### PR TITLE
Update/paid newsletter subscriber importer

### DIFF
--- a/client/data/paid-newsletter/use-subscriber-import-mutation.ts
+++ b/client/data/paid-newsletter/use-subscriber-import-mutation.ts
@@ -48,11 +48,11 @@ export const useSubscriberImportMutation = (
 
 	const { mutate } = mutation;
 
-	const enqueSubscriberImport = useCallback(
+	const enqueueSubscriberImport = useCallback(
 		( siteId: number, engine: string, currentStep: string ) =>
 			mutate( { siteId, engine, currentStep } ),
 		[ mutate ]
 	);
 
-	return { enqueSubscriberImport, ...mutation };
+	return { enqueueSubscriberImport, ...mutation };
 };

--- a/client/data/paid-newsletter/use-subscriber-import-mutation.ts
+++ b/client/data/paid-newsletter/use-subscriber-import-mutation.ts
@@ -1,0 +1,58 @@
+import {
+	DefaultError,
+	useMutation,
+	UseMutationOptions,
+	useQueryClient,
+} from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wp from 'calypso/lib/wp';
+
+interface MutationVariables {
+	siteId: number;
+	engine: string;
+	currentStep: string;
+}
+
+export const useSubscriberImportMutation = (
+	options: UseMutationOptions< unknown, DefaultError, MutationVariables > = {}
+) => {
+	const queryClient = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: async ( { siteId, engine, currentStep }: MutationVariables ) => {
+			const response = await wp.req.post(
+				{
+					path: `/sites/${ siteId }/site-importer/paid-newsletter/subscriber-import`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					engine: engine,
+					current_step: currentStep,
+				}
+			);
+
+			if ( ! response.current_step ) {
+				throw new Error( 'unsuccsefully skipped step', response );
+			}
+
+			return response;
+		},
+		...options,
+		onSuccess( ...args ) {
+			const [ , { siteId, engine, currentStep } ] = args;
+			queryClient.invalidateQueries( {
+				queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
+			} );
+			options.onSuccess?.( ...args );
+		},
+	} );
+
+	const { mutate } = mutation;
+
+	const enqueSubscriberImport = useCallback(
+		( siteId: number, engine: string, currentStep: string ) =>
+			mutate( { siteId, engine, currentStep } ),
+		[ mutate ]
+	);
+
+	return { enqueSubscriberImport, ...mutation };
+};

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -15,7 +15,7 @@ type ContentProps = {
 	selectedSite?: SiteDetails;
 	siteSlug: string;
 	fromSite: QueryArgParsed;
-	content: any;
+	cardData: any;
 	skipNextStep: () => void;
 };
 

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -99,6 +99,9 @@
 .subscriber-upload-form__modal li {
 	display: flex;
 }
+.subscriber-upload-form__modal strong {
+	margin-right: 8px;
+}
 .subscriber-upload-form__modal svg {
 	fill: var(--studio-gray-50);
 	margin-right: 8px;

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -40,10 +40,18 @@
 		box-shadow: none;
 	}
 
-	.summary__content p {
-		display: flex;
-		gap: 8px;
+
+	.summary__content input[type="checkbox"] {
+		margin-right: 8px;
 	}
+
+	.summary__content svg {
+		float: left;
+		margin-right: 6px;
+		margin-top: -1px;
+		fill: var(--studio-gray-50);
+	}
+
 
 	.stripe-logo {
 		width: 48px;

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -85,7 +85,7 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 			if ( status === 'done' ) {
 				stepsProgress[ index ].indicator = <Icon icon={ check } />;
 			}
-			if ( status === 'processing' ) {
+			if ( status === 'importing' ) {
 				stepsProgress[ index ].indicator = <Spinner style={ { color: '#3858e9' } } />;
 			}
 		}
@@ -98,7 +98,12 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 
 	let stepContent = {};
 	if ( paidNewsletterData?.steps ) {
-		stepContent = paidNewsletterData?.steps[ step ]?.content ?? {};
+		// This is useful for the summary step.
+		if ( ! paidNewsletterData?.steps[ step ] ) {
+			stepContent = paidNewsletterData.steps;
+		} else {
+			stepContent = paidNewsletterData.steps[ step ]?.content ?? {};
+		}
 	}
 
 	useEffect( () => {

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -148,7 +148,6 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 					cardData={ stepContent }
 					engine={ engine }
 					isFetchingContent={ isFetchingPaidNewsletter }
-					content={ stepContent }
 				/>
 			) }
 		</div>

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -85,7 +85,7 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 			if ( status === 'done' || status === 'imported' ) {
 				stepsProgress[ index ].indicator = <Icon icon={ check } />;
 			}
-			if ( status === 'importing' || status === 'processing' ) {
+			if ( status === 'importing' || status === 'awaiting' ) {
 				stepsProgress[ index ].indicator = <Spinner style={ { color: '#3858e9' } } />;
 			}
 		}

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -82,10 +82,10 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 
 		if ( paidNewsletterData?.steps ) {
 			const status = paidNewsletterData?.steps[ stepName ]?.status ?? '';
-			if ( status === 'done' || status === 'imported' ) {
+			if ( status === 'done' ) {
 				stepsProgress[ index ].indicator = <Icon icon={ check } />;
 			}
-			if ( status === 'importing' || status === 'awaiting' ) {
+			if ( status === 'importing' ) {
 				stepsProgress[ index ].indicator = <Spinner style={ { color: '#3858e9' } } />;
 			}
 		}

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -82,10 +82,10 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 
 		if ( paidNewsletterData?.steps ) {
 			const status = paidNewsletterData?.steps[ stepName ]?.status ?? '';
-			if ( status === 'done' ) {
+			if ( status === 'done' || status === 'imported' ) {
 				stepsProgress[ index ].indicator = <Icon icon={ check } />;
 			}
-			if ( status === 'importing' ) {
+			if ( status === 'importing' || status === 'processing' ) {
 				stepsProgress[ index ].indicator = <Spinner style={ { color: '#3858e9' } } />;
 			}
 		}

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.scss
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.scss
@@ -12,10 +12,11 @@
 .map-plan__info {
 	min-height: 80px;
 	display: flex;
-	align-items: center;
 	min-width: 230px;
+	align-items: center;
 }
 .map-plan__info {
+	align-items: start;
 	flex-direction: column;
 	justify-content: center;
 	p {
@@ -30,7 +31,7 @@
 .map-plan__select-product .map-plan__selected {
 	display: flex;
 	height: auto;
-
+	text-align: right;
 	p {
 		margin: 0;
 	}

--- a/client/my-sites/importer/newsletter/subscriber-upload-form.tsx
+++ b/client/my-sites/importer/newsletter/subscriber-upload-form.tsx
@@ -1,11 +1,10 @@
 import { FormInputValidation } from '@automattic/components';
 import { Subscriber } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { useActiveJobRecognition } from '@automattic/subscriber';
-import { Button, ProgressBar, Modal } from '@wordpress/components';
+import { ProgressBar } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Icon, cloudUpload, people, currencyEuro } from '@wordpress/icons';
-import { useCallback, useState, useEffect, useRef, FormEvent } from 'react';
+import { Icon, cloudUpload } from '@wordpress/icons';
+import { useCallback, useState, FormEvent } from 'react';
 import DropZone from 'calypso/components/drop-zone';
 import FilePicker from 'calypso/components/file-picker';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -16,13 +15,13 @@ type Props = {
 	nextStepUrl: string;
 	siteId: number;
 	skipNextStep: () => void;
+	cardData: any;
 };
 
 export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextStep }: Props ) {
 	const [ selectedFile, setSelectedFile ] = useState< File >();
-	const [ isOpen, setIsOpen ] = useState( false );
 
-	const { importCsvSubscribers, getSubscribersImports } = useDispatch( Subscriber.store );
+	const { importCsvSubscribers } = useDispatch( Subscriber.store );
 	const { importSelector } = useSelect( ( select ) => {
 		const subscriber = select( Subscriber.store );
 
@@ -32,13 +31,11 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 		};
 	}, [] );
 
-	const prevInProgress = useRef( importSelector?.inProgress );
-
 	const [ isSelectedFileValid, setIsSelectedFileValid ] = useState( false );
 	const onSubmit = useCallback(
 		async ( event: FormEvent< HTMLFormElement > ) => {
 			event.preventDefault();
-			selectedFile && importCsvSubscribers( siteId, selectedFile );
+			selectedFile && importCsvSubscribers( siteId, selectedFile, [], true );
 		},
 		[ siteId, selectedFile ]
 	);
@@ -59,19 +56,6 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 		return validExtensions.includes( match?.groups?.extension.toLowerCase() as string );
 	}
 
-	useActiveJobRecognition( siteId );
-
-	useEffect( () => {
-		getSubscribersImports( siteId );
-	}, [ siteId, getSubscribersImports ] );
-
-	useEffect( () => {
-		if ( prevInProgress.current ) {
-			setIsOpen( true );
-		}
-		prevInProgress.current = importSelector?.inProgress;
-	}, [ importSelector?.inProgress ] );
-
 	const importSubscribersUrl =
 		'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/';
 
@@ -82,39 +66,6 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 				<p>Uploading...</p>
 				<ProgressBar />
 			</div>
-		);
-	}
-
-	if ( isOpen ) {
-		return (
-			<Modal
-				title="All done!"
-				isDismissible={ false }
-				onRequestClose={ () => setIsOpen( false ) }
-				className="subscriber-upload-form__modal"
-				size="medium"
-			>
-				<div>
-					We’ve found 100 subscribers, where:
-					<ul>
-						<li>
-							<Icon icon={ people } />
-							<strong>82</strong> are free subscribers
-						</li>
-						<li>
-							<Icon icon={ people } />
-							<strong>1</strong> have a complimentary
-						</li>
-						<li>
-							<Icon icon={ currencyEuro } />
-							subscription <strong>18</strong> are paying subscribers
-						</li>
-					</ul>
-				</div>
-				<Button variant="primary" href={ nextStepUrl }>
-					Continue
-				</Button>
-			</Modal>
 		);
 	}
 

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -21,7 +21,8 @@ export default function Subscribers( {
 	skipNextStep,
 	cardData,
 }: Props ) {
-	const [ isOpen, setIsOpen ] = useState( false );
+	const open = cardData.meta.paid_subscribers_count || false;
+	const [ isOpen, setIsOpen ] = useState( open );
 
 	return (
 		<>

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -1,13 +1,17 @@
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Card, Gridicon } from '@automattic/components';
+import { Modal, Button } from '@wordpress/components';
+import { Icon, people, currencyEuro } from '@wordpress/icons';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
+import { useState } from 'react';
 import SubscriberUploadForm from './subscriber-upload-form';
 import type { SiteDetails } from '@automattic/data-stores';
 
 type Props = {
 	nextStepUrl: string;
-	selectedSite?: SiteDetails;
+	selectedSite: SiteDetails;
 	fromSite: QueryArgParsed;
 	skipNextStep: () => void;
+	cardData: any;
 };
 
 export default function Subscribers( {
@@ -15,33 +19,67 @@ export default function Subscribers( {
 	selectedSite,
 	fromSite,
 	skipNextStep,
+	cardData,
 }: Props ) {
-	if ( ! selectedSite ) {
-		return null;
-	}
+	const [ isOpen, setIsOpen ] = useState( false );
+
 	return (
-		<Card>
-			<h2>Step 1: Export your subscribers from Substack</h2>
-			<p>
-				To generate a CSV file of all your Substack subscribers, go to the Subscribers tab and click
-				'Export.' Once the CSV file is downloaded, upload it in the next step.
-			</p>
-			<Button
-				href={ `https://${ fromSite }/publish/subscribers` }
-				target="_blank"
-				rel="noreferrer noopener"
-			>
-				Export subscribers <Gridicon icon="external" />
-			</Button>
-			<hr />
-			<h2>Step 2: Import your subscribers to WordPress.com</h2>
-			{ selectedSite.ID && (
-				<SubscriberUploadForm
-					siteId={ selectedSite.ID }
-					nextStepUrl={ nextStepUrl }
-					skipNextStep={ skipNextStep }
-				/>
+		<>
+			<Card>
+				<h2>Step 1: Export your subscribers from Substack</h2>
+				<p>
+					To generate a CSV file of all your Substack subscribers, go to the Subscribers tab and
+					click 'Export.' Once the CSV file is downloaded, upload it in the next step.
+				</p>
+				<Button
+					variant="secondary"
+					href={ `https://${ fromSite }/publish/subscribers` }
+					target="_blank"
+					rel="noreferrer noopener"
+				>
+					Export subscribers <Gridicon icon="external" />
+				</Button>
+				<hr />
+				<h2>Step 2: Import your subscribers to WordPress.com</h2>
+				{ selectedSite.ID && (
+					<SubscriberUploadForm
+						siteId={ selectedSite.ID }
+						nextStepUrl={ nextStepUrl }
+						skipNextStep={ skipNextStep }
+						cardData={ cardData }
+					/>
+				) }
+			</Card>
+			{ isOpen && (
+				<Modal
+					title="All done!"
+					isDismissible={ false }
+					onRequestClose={ () => setIsOpen( false ) }
+					className="subscriber-upload-form__modal"
+					size="medium"
+				>
+					<div>
+						We’ve found 100 subscribers, where:
+						<ul>
+							<li>
+								<Icon icon={ people } />
+								<strong>82</strong> are free subscribers
+							</li>
+							<li>
+								<Icon icon={ people } />
+								<strong>1</strong> have a complimentary
+							</li>
+							<li>
+								<Icon icon={ currencyEuro } />
+								subscription <strong>18</strong> are paying subscribers
+							</li>
+						</ul>
+					</div>
+					<Button variant="primary" href={ nextStepUrl }>
+						Continue
+					</Button>
+				</Modal>
 			) }
-		</Card>
+		</>
 	);
 }

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -3,7 +3,7 @@ import { Subscriber } from '@automattic/data-stores';
 import { useQueryClient } from '@tanstack/react-query';
 import { Modal, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { Icon, people, currencyEuro, external } from '@wordpress/icons';
+import { Icon, people, currencyDollar, external } from '@wordpress/icons';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
 import { useEffect, useRef } from 'react';
 import SubscriberUploadForm from './subscriber-upload-form';
@@ -101,8 +101,8 @@ export default function Subscribers( {
 							) }
 							{ paid_emails !== 0 && (
 								<li>
-									<Icon icon={ currencyEuro } />
-									subscription <strong>{ paid_emails }</strong> are paying subscribers
+									<Icon icon={ currencyDollar } />
+									<strong>{ paid_emails }</strong> are paying subscribers
 								</li>
 							) }
 						</ul>

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -2,7 +2,6 @@ import { Card, Gridicon } from '@automattic/components';
 import { Modal, Button } from '@wordpress/components';
 import { Icon, people, currencyEuro } from '@wordpress/icons';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
-import { useState } from 'react';
 import SubscriberUploadForm from './subscriber-upload-form';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -21,8 +20,11 @@ export default function Subscribers( {
 	skipNextStep,
 	cardData,
 }: Props ) {
-	const open = cardData.meta.paid_subscribers_count || false;
-	const [ isOpen, setIsOpen ] = useState( open );
+	const open = cardData?.meta?.status === 'pending' || false;
+
+	const all_emails = cardData?.meta?.email_count || 0;
+	const paid_emails = cardData?.meta?.paid_subscribers_count || 0;
+	const free_emails = all_emails - paid_emails;
 
 	return (
 		<>
@@ -51,29 +53,29 @@ export default function Subscribers( {
 					/>
 				) }
 			</Card>
-			{ isOpen && (
+			{ open && (
 				<Modal
 					title="All done!"
 					isDismissible={ false }
-					onRequestClose={ () => setIsOpen( false ) }
+					onRequestClose={ () => {} }
 					className="subscriber-upload-form__modal"
 					size="medium"
 				>
 					<div>
-						We’ve found 100 subscribers, where:
+						We’ve found { all_emails } subscribers.
 						<ul>
-							<li>
-								<Icon icon={ people } />
-								<strong>82</strong> are free subscribers
-							</li>
-							<li>
-								<Icon icon={ people } />
-								<strong>1</strong> have a complimentary
-							</li>
-							<li>
-								<Icon icon={ currencyEuro } />
-								subscription <strong>18</strong> are paying subscribers
-							</li>
+							{ free_emails !== 0 && (
+								<li>
+									<Icon icon={ people } />
+									<strong>{ free_emails }</strong> are free subscribers
+								</li>
+							) }
+							{ paid_emails !== 0 && (
+								<li>
+									<Icon icon={ currencyEuro } />
+									subscription <strong>{ paid_emails }</strong> are paying subscribers
+								</li>
+							) }
 						</ul>
 					</div>
 					<Button variant="primary" href={ nextStepUrl }>

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -1,28 +1,42 @@
 import { Card, ConfettiAnimation } from '@automattic/components';
-import { Icon, post, people, currencyDollar } from '@wordpress/icons';
+import ContentSummary from './summary/content';
+import SubscribersSummary from './summary/subscribers';
+import type { SiteDetails } from '@automattic/data-stores';
 
-export default function Summary() {
+type Props = {
+	cardData: any;
+	selectedSite: SiteDetails;
+};
+
+export default function Summary( { cardData, selectedSite }: Props ) {
 	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 
+	function shouldRenderConfetti( contentStatus: string, subscriberStatue: string ) {
+		if ( contentStatus === 'done' && subscriberStatue === 'done' ) {
+			return true;
+		}
+		if ( contentStatus === 'done' && subscriberStatue === 'skipped' ) {
+			return true;
+		}
+
+		if ( contentStatus === 'skipped' && subscriberStatue === 'done' ) {
+			return true;
+		}
+
+		return false;
+	}
 	return (
 		<Card>
-			<ConfettiAnimation trigger={ ! prefersReducedMotion } />
-			<h2>Success!</h2>
-			<div className="summary__content">
-				<p>Here's an overview of what you'll migrate:</p>
-				<p>
-					<Icon icon={ post } />
-					<strong>47</strong> posts
-				</p>
-				<p>
-					<Icon icon={ people } />
-					<strong>99</strong> subscribers
-				</p>
-				<p>
-					<Icon icon={ currencyDollar } />
-					<strong>17</strong>paid subscribers
-				</p>
-			</div>
+			{ shouldRenderConfetti( cardData.content.status, cardData.subscribers.status ) && (
+				<ConfettiAnimation trigger={ ! prefersReducedMotion } />
+			) }
+			<ContentSummary cardData={ cardData.content.content } status={ cardData.content.status } />
+			<SubscribersSummary
+				cardData={ cardData.subscribers.content }
+				status={ cardData.subscribers.status }
+				proStatus={ cardData[ 'paid-subscribers' ].status }
+				siteId={ selectedSite.ID }
+			/>
 		</Card>
 	);
 }

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -12,14 +12,14 @@ export default function Summary( { cardData, selectedSite }: Props ) {
 	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 
 	function shouldRenderConfetti( contentStatus: string, subscriberStatue: string ) {
-		if ( contentStatus === 'done' && subscriberStatue === 'done' ) {
+		if ( contentStatus === 'done' && subscriberStatue === 'imported' ) {
 			return true;
 		}
 		if ( contentStatus === 'done' && subscriberStatue === 'skipped' ) {
 			return true;
 		}
 
-		if ( contentStatus === 'skipped' && subscriberStatue === 'done' ) {
+		if ( contentStatus === 'skipped' && subscriberStatue === 'imported' ) {
 			return true;
 		}
 

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -53,7 +53,7 @@ export default function ContentSummary( { status, cardData }: Props ) {
 		);
 	}
 
-	if ( status === 'importing' ) {
+	if ( status === 'importing' || status === 'processing' ) {
 		return (
 			<div className="summary__content">
 				<p>

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -1,0 +1,67 @@
+import { Icon, post, media, comment, page } from '@wordpress/icons';
+
+type Props = {
+	cardData: any;
+	status: string;
+};
+
+export default function ContentSummary( { status, cardData }: Props ) {
+	if ( status === 'skipped' ) {
+		return (
+			<div className="summary__content">
+				<p>
+					<Icon icon={ post } /> Content importing was <strong>skipped!</strong>
+				</p>
+			</div>
+		);
+	}
+
+	if ( status === 'done' ) {
+		const progress = cardData.progress;
+		return (
+			<div className="summary__content">
+				<p>We imported:</p>
+
+				{ progress.post.completed !== 0 && (
+					<p>
+						<Icon icon={ post } />
+						<strong>{ progress.post.completed }</strong> posts
+					</p>
+				) }
+
+				{ progress.page.completed !== 0 && (
+					<p>
+						<Icon icon={ page } />
+						<strong>{ progress.page.completed }</strong> pages
+					</p>
+				) }
+
+				{ progress.attachment.completed !== 0 && (
+					<p>
+						<Icon icon={ media } />
+						<strong>{ progress.attachment.completed }</strong> media
+					</p>
+				) }
+
+				{ progress.comment.completed !== 0 && (
+					<p>
+						<Icon icon={ comment } />
+						<strong>{ progress.comment.completed }</strong> comments
+					</p>
+				) }
+			</div>
+		);
+	}
+
+	if ( status === 'importing' ) {
+		return (
+			<div className="summary__content">
+				<p>
+					<Icon icon={ post } /> Content is importing...
+				</p>
+			</div>
+		);
+	}
+
+	return;
+}

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -17,10 +17,10 @@ export default function SubscriberSummary( { status, proStatus, cardData, siteId
 	const hasPaidSubscribers = proStatus !== 'skipped' && parseInt( paidSubscribers ) > 0;
 	const [ isDisabled, setIsDisabled ] = useState( ! hasPaidSubscribers );
 
-	const { enqueSubscriberImport } = useSubscriberImportMutation();
+	const { enqueueSubscriberImport } = useSubscriberImportMutation();
 
 	const importSubscribers = () => {
-		enqueSubscriberImport( siteId, 'substack', 'summary' );
+		enqueueSubscriberImport( siteId, 'substack', 'summary' );
 	};
 
 	const onChange = ( { target: { checked } }: ChangeEvent< HTMLInputElement > ) =>

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -13,8 +13,8 @@ type Props = {
 	siteId: number;
 };
 export default function SubscriberSummary( { status, proStatus, cardData, siteId }: Props ) {
-	const hasPaidSubscribers =
-		proStatus !== 'skipped' && parseInt( cardData.meta.paid_subscribers_count ) > 0;
+	const paidSubscribers = cardData?.meta?.paid_subscribers_count ?? 0;
+	const hasPaidSubscribers = proStatus !== 'skipped' && parseInt( paidSubscribers ) > 0;
 	const [ isDisabled, setIsDisabled ] = useState( ! hasPaidSubscribers );
 
 	const { enqueSubscriberImport } = useSubscriberImportMutation();
@@ -42,12 +42,12 @@ export default function SubscriberSummary( { status, proStatus, cardData, siteId
 				<p>Here's an overview of what you'll migrate:</p>
 				<p>
 					<Icon icon={ people } />
-					<strong>{ cardData.meta.email_count }</strong> subscribers
+					<strong>{ cardData?.meta?.email_count }</strong> subscribers
 				</p>
 				{ hasPaidSubscribers && (
 					<p>
 						<Icon icon={ currencyDollar } />
-						<strong>{ cardData.meta.paid_subscribers_count }</strong> paid subscribers
+						<strong>{ cardData?.meta?.paid_subscribers_count }</strong> paid subscribers
 					</p>
 				) }
 				{ hasPaidSubscribers && (
@@ -81,7 +81,7 @@ export default function SubscriberSummary( { status, proStatus, cardData, siteId
 		);
 	}
 
-	if ( status === 'importing' || status === 'processing' ) {
+	if ( status === 'importing' || status === 'awaiting' ) {
 		return (
 			<div className="summary__content">
 				<p>
@@ -92,8 +92,8 @@ export default function SubscriberSummary( { status, proStatus, cardData, siteId
 	}
 
 	if ( status === 'imported' ) {
-		const paid_subscribers = cardData.meta.paid_subscribers_count;
-		const free_subscribers = cardData.meta.subscribed_count - paid_subscribers;
+		const paid_subscribers = cardData?.meta?.paid_subscribers_count ?? 0;
+		const free_subscribers = cardData?.meta?.subscribed_count - paid_subscribers;
 		return (
 			<div className="summary__content">
 				<p>We migrated { cardData.meta.subscribed_count } subscribers</p>

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -81,7 +81,7 @@ export default function SubscriberSummary( { status, proStatus, cardData, siteId
 		);
 	}
 
-	if ( status === 'importing' || status === 'awaiting' ) {
+	if ( status === 'importing' ) {
 		return (
 			<div className="summary__content">
 				<p>
@@ -91,7 +91,7 @@ export default function SubscriberSummary( { status, proStatus, cardData, siteId
 		);
 	}
 
-	if ( status === 'imported' ) {
+	if ( status === 'done' ) {
 		const paid_subscribers = cardData?.meta?.paid_subscribers_count ?? 0;
 		const free_subscribers = cardData?.meta?.subscribed_count - paid_subscribers;
 		return (

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -19,6 +19,10 @@ export default function SubscriberSummary( { status, proStatus, cardData, siteId
 
 	const { enqueSubscriberImport } = useSubscriberImportMutation();
 
+	const importSubscribers = () => {
+		enqueSubscriberImport( siteId, 'substack', 'summary' );
+	};
+
 	const onChange = ( { target: { checked } }: ChangeEvent< HTMLInputElement > ) =>
 		setIsDisabled( checked );
 
@@ -31,10 +35,6 @@ export default function SubscriberSummary( { status, proStatus, cardData, siteId
 			</div>
 		);
 	}
-
-	const importSubscribers = () => {
-		enqueSubscriberImport( siteId, 'substack', 'summary' );
-	};
 
 	if ( status === 'pending' ) {
 		return (
@@ -81,13 +81,25 @@ export default function SubscriberSummary( { status, proStatus, cardData, siteId
 		);
 	}
 
-	if ( status === 'imported' ) {
+	if ( status === 'importing' || status === 'processing' ) {
 		return (
 			<div className="summary__content">
-				<p>We migrated</p>
+				<p>
+					<Icon icon={ people } /> Importing subscribers...
+				</p>
+			</div>
+		);
+	}
+
+	if ( status === 'imported' ) {
+		const paid_subscribers = cardData.meta.paid_subscribers_count;
+		const free_subscribers = cardData.meta.subscribed_count - paid_subscribers;
+		return (
+			<div className="summary__content">
+				<p>We migrated { cardData.meta.subscribed_count } subscribers</p>
 				<p>
 					<Icon icon={ people } />
-					<strong>{ cardData.meta.email_count }</strong> subscribers
+					<strong>{ free_subscribers }</strong> free subscribers
 				</p>
 				{ hasPaidSubscribers && (
 					<p>

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,0 +1,101 @@
+import { FormLabel } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { Icon, people, currencyDollar, atSymbol } from '@wordpress/icons';
+import { ChangeEvent } from 'react';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import { useSubscriberImportMutation } from 'calypso/data/paid-newsletter/use-subscriber-import-mutation';
+
+type Props = {
+	cardData: any;
+	status: string;
+	proStatus: string;
+	siteId: number;
+};
+export default function SubscriberSummary( { status, proStatus, cardData, siteId }: Props ) {
+	const hasPaidSubscribers =
+		proStatus !== 'skipped' && parseInt( cardData.meta.paid_subscribers_count ) > 0;
+	const [ isDisabled, setIsDisabled ] = useState( ! hasPaidSubscribers );
+
+	const { enqueSubscriberImport } = useSubscriberImportMutation();
+
+	const onChange = ( { target: { checked } }: ChangeEvent< HTMLInputElement > ) =>
+		setIsDisabled( checked );
+
+	if ( status === 'skipped' ) {
+		return (
+			<div className="summary__content">
+				<p>
+					<Icon icon={ atSymbol } /> Subscriber importing was <strong>skipped!</strong>
+				</p>
+			</div>
+		);
+	}
+
+	const importSubscribers = () => {
+		enqueSubscriberImport( siteId, 'substack', 'summary' );
+	};
+
+	if ( status === 'pending' ) {
+		return (
+			<div className="summary__content">
+				<p>Here's an overview of what you'll migrate:</p>
+				<p>
+					<Icon icon={ people } />
+					<strong>{ cardData.meta.email_count }</strong> subscribers
+				</p>
+				{ hasPaidSubscribers && (
+					<p>
+						<Icon icon={ currencyDollar } />
+						<strong>{ cardData.meta.paid_subscribers_count }</strong> paid subscribers
+					</p>
+				) }
+				{ hasPaidSubscribers && (
+					<>
+						<p>
+							<strong>Before we import your newsletter</strong>
+						</p>
+
+						<p>
+							<strong>To prevent any unexpected actions by your old provider</strong>, go to your
+							Stripe dashboard and click “Revoke access” for any service previously associated with
+							this subscription.
+						</p>
+
+						<p>
+							<FormLabel>
+								<FormCheckbox
+									checked={ isDisabled }
+									defaultChecked={ false }
+									onChange={ onChange }
+								/>
+								I’ve disconnected other providers from the Stripe account
+							</FormLabel>
+						</p>
+					</>
+				) }
+				<Button variant="primary" disabled={ ! isDisabled } onClick={ importSubscribers }>
+					Import subscribers
+				</Button>
+			</div>
+		);
+	}
+
+	if ( status === 'imported' ) {
+		return (
+			<div className="summary__content">
+				<p>We migrated</p>
+				<p>
+					<Icon icon={ people } />
+					<strong>{ cardData.meta.email_count }</strong> subscribers
+				</p>
+				{ hasPaidSubscribers && (
+					<p>
+						<Icon icon={ currencyDollar } />
+						<strong>{ cardData.meta.paid_subscribers_count }</strong> paid subscribers
+					</p>
+				) }
+			</div>
+		);
+	}
+}

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -39,7 +39,12 @@ export function createActions() {
 		job,
 	} );
 
-	function* importCsvSubscribers( siteId: number, file?: File, emails: string[] = [] ) {
+	function* importCsvSubscribers(
+		siteId: number,
+		file?: File,
+		emails: string[] = [],
+		parseOnly?: boolean = false
+	) {
 		yield importCsvSubscribersStart( siteId, file, emails );
 
 		try {
@@ -52,7 +57,7 @@ export function createActions() {
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				formData: file && [ [ 'import', file, file.name ] ],
-				body: { emails },
+				body: { emails, parse_only: parseOnly },
 			} );
 
 			yield importCsvSubscribersStartSuccess( siteId, data.upload_id );

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -43,7 +43,7 @@ export function createActions() {
 		siteId: number,
 		file?: File,
 		emails: string[] = [],
-		parseOnly?: boolean = false
+		parseOnly: boolean = false
 	) {
 		yield importCsvSubscribersStart( siteId, file, emails );
 


### PR DESCRIPTION
Update the subscriptions import + summary components to enqueue the subscriber in one step and then import the subscribers. 

## Proposed Changes

* Update the summary cards to show again what we subscribe. 
* Only enque the subscriber in the first step. 
* Let the user click the next step to start the process. 

## Why are these changes being made?
* So that the flow matches more as designed.

## Testing Instructions

Add D159234-code to your .com sandbox. 
Sandbox public-api.wordpress.com 
 

* Go thought the subscriber import flow. 
/visits /import/newsletter/substack/example.com/ 

and you can skip the first part (content importing) 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?