### PR TITLE
Stats: Fix page flickering due to api query

### DIFF
--- a/client/my-sites/stats/pages/insights/controller.tsx
+++ b/client/my-sites/stats/pages/insights/controller.tsx
@@ -1,13 +1,12 @@
 import AsyncLoad from 'calypso/components/async-load';
-import LoadStatsPage from '../../stats-redirect/load-stats-page';
 import PageLoading from '../shared/page-loading';
 import type { Context } from '@automattic/calypso-router';
 
+setTimeout( () => import( 'calypso/my-sites/stats/pages/insights' ), 3000 );
+
 function insights( context: Context, next: () => void ) {
 	context.primary = (
-		<LoadStatsPage>
-			<AsyncLoad require="calypso/my-sites/stats/pages/insights" placeholder={ PageLoading } />
-		</LoadStatsPage>
+		<AsyncLoad require="calypso/my-sites/stats/pages/insights" placeholder={ PageLoading } />
 	);
 	next();
 }

--- a/client/my-sites/stats/pages/subscribers/controller.tsx
+++ b/client/my-sites/stats/pages/subscribers/controller.tsx
@@ -5,6 +5,8 @@ import { getSiteFilters, rangeOfPeriod, type SiteFilterType } from '../shared/he
 import PageLoading from '../shared/page-loading';
 import type { Context } from '@automattic/calypso-router';
 
+setTimeout( () => import( 'calypso/my-sites/stats/pages/subscribers' ), 3000 );
+
 function subscribers( context: Context, next: () => void ) {
 	const givenSiteId = context.params.site;
 	const filters = getSiteFilters( givenSiteId );

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -25,8 +25,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
-	const { hasLoadedSitePurchases, isRequestingSitePurchases, hasAnyPlan } =
-		useStatsPurchases( siteId );
+	const { hasLoadedSitePurchases, hasAnyPlan } = useStatsPurchases( siteId );
 
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
@@ -48,7 +47,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		canUserManageOptions
 	);
 
-	const isLoading = ! hasLoadedSitePurchases || isRequestingSitePurchases || isLoadingNotices;
+	const isLoading = ! hasLoadedSitePurchases || isLoadingNotices;
 	const { isNewSite, shouldShowPaywall } = useSiteCompulsoryPlanSelectionQualifiedCheck( siteId );
 	// to redirect the user can't have a plan purached and can't have the flag true, if either is true the user either has a plan or is postponing
 	const redirectToPurchase =


### PR DESCRIPTION
Related P2: pejTkB-1vF-p2
Related to https://github.com/Automattic/red-team/issues/94

## Proposed Changes

* Stop showing full page loading status when loading purchases
* Always load subscribers and insights page chunks to prevent the flickering

## Testing Instructions

Please test primarily in Odyssey Stats

- Build and run Odyssey Stats locally
- Open `/wp-admin/admin.php?page=stats#!/stats/day/:siteSlug`
- Click Insights
- Ensure the page doesn't flicker
- Click Subscribers
- Ensure the page doesn't flicker
- Switch the tabs multiple times 
- Ensure the pages don't flicker
- Make sure Calypso Stats still works okay

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?