### PR TITLE
WIP: Show fewer differentiating features per plan

### DIFF
--- a/packages/calypso-products/src/constants/feature-group.ts
+++ b/packages/calypso-products/src/constants/feature-group.ts
@@ -27,4 +27,8 @@ export const FEATURE_GROUP_SHIPPING = 'feature-group-shipping';
 /* END: Woo Express Feature Groups */
 
 export const FEATURE_GROUP_STORAGE = 'feature-group-storage';
+export const FEATURE_GROUP_DOMAIN = 'feature-group-domain';
+export const FEATURE_GROUP_THEMES = 'feature-group-themes';
+export const FEATURE_GROUP_PERFORMANCE = 'feature-group-performance';
+
 export const FEATURE_GROUP_ALL_FEATURES = 'feature-group-all-freatures';

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -486,3 +486,7 @@ export const FEATURE_TYPE_JETPACK_SOCIAL = 'jetpack_social';
 export const FEATURE_TYPE_JETPACK_SEARCH = 'jetpack_search';
 export const FEATURE_TYPE_JETPACK_STATS = 'jetpack_stats';
 export const FEATURE_TYPE_JETPACK_VIDEOPRESS = 'jetpack_videopress';
+
+// Zzz
+export const FEATURE_DNS_SSL_CACHING = 'feature-dns-ssl-caching';
+export const FEATURE_DNS_SSL_CACHING_CDN = 'feature-dns-ssl-caching-cdn';

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -119,6 +119,12 @@ import {
 	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 	FEATURE_PRIORITY_24_7_SUPPORT,
 	FEATURE_FAST_SUPPORT_FROM_EXPERTS,
+	FEATURE_GROUP_DOMAIN,
+	FEATURE_GROUP_THEMES,
+	FEATURE_GROUP_PERFORMANCE,
+	FEATURE_GROUP_SUPPORT,
+	FEATURE_DNS_SSL_CACHING,
+	FEATURE_DNS_SSL_CACHING_CDN,
 } from './constants';
 import { FeatureGroupMap } from './types';
 
@@ -132,6 +138,30 @@ export const featureGroups: Partial< FeatureGroupMap > = {
 		slug: FEATURE_GROUP_STORAGE,
 		getTitle: () => i18n.translate( 'Storage' ),
 		getFeatures: () => [], // Intentionally empty for now. We will include a fixed list of feature slugs in a follow-up.
+	},
+	[ FEATURE_GROUP_DOMAIN ]: {
+		slug: FEATURE_GROUP_DOMAIN,
+		getTitle: () => i18n.translate( 'Domain' ),
+		getFeatures: () => [ FEATURE_CUSTOM_DOMAIN ],
+	},
+	[ FEATURE_GROUP_SUPPORT ]: {
+		slug: FEATURE_GROUP_SUPPORT,
+		getTitle: () => i18n.translate( 'Support' ),
+		getFeatures: () => [ FEATURE_FAST_SUPPORT_FROM_EXPERTS, FEATURE_PRIORITY_24_7_SUPPORT ],
+	},
+	[ FEATURE_GROUP_THEMES ]: {
+		slug: FEATURE_GROUP_THEMES,
+		getTitle: () => i18n.translate( 'Themes' ),
+		getFeatures: () => [
+			FEATURE_BEAUTIFUL_THEMES,
+			FEATURE_PREMIUM_THEMES,
+			WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+		],
+	},
+	[ FEATURE_GROUP_PERFORMANCE ]: {
+		slug: FEATURE_GROUP_PERFORMANCE,
+		getTitle: () => i18n.translate( 'Performance' ),
+		getFeatures: () => [ FEATURE_DNS_SSL_CACHING, FEATURE_DNS_SSL_CACHING_CDN ],
 	},
 	[ FEATURE_GROUP_ESSENTIAL_FEATURES ]: {
 		slug: FEATURE_GROUP_ESSENTIAL_FEATURES,
@@ -341,10 +371,18 @@ export const featureGroups: Partial< FeatureGroupMap > = {
 };
 
 export function resolveFeatureGroupsForFeaturesGrid(): Partial< FeatureGroupMap > {
-	return {
-		[ FEATURE_GROUP_ALL_FEATURES ]: featureGroups[ FEATURE_GROUP_ALL_FEATURES ],
-		[ FEATURE_GROUP_STORAGE ]: featureGroups[ FEATURE_GROUP_STORAGE ],
-	};
+	if ( true ) {
+		return {
+			[ FEATURE_GROUP_DOMAIN ]: featureGroups[ FEATURE_GROUP_DOMAIN ],
+			[ FEATURE_GROUP_THEMES ]: featureGroups[ FEATURE_GROUP_THEMES ],
+			[ FEATURE_GROUP_PERFORMANCE ]: featureGroups[ FEATURE_GROUP_PERFORMANCE ],
+			// [ FEATURE_GROUP_THINGS ]: featureGroups[ FEATURE_GROUP_THINGS ],
+			[ FEATURE_GROUP_SUPPORT ]: featureGroups[ FEATURE_GROUP_SUPPORT ],
+			// [ FEATURE_GROUP_THEMES_AND_CUSTOMIZATION ]:
+			// 	featureGroups[ FEATURE_GROUP_THEMES_AND_CUSTOMIZATION ],
+			[ FEATURE_GROUP_STORAGE ]: featureGroups[ FEATURE_GROUP_STORAGE ],
+		};
+	}
 }
 
 export function resolveFeatureGroupsForComparisonGrid(): Partial< FeatureGroupMap > {

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -313,6 +313,8 @@ import {
 	FEATURE_SOCIAL_SHARES_1000,
 	FEATURE_SOCIAL_ENHANCED_PUBLISHING,
 	FEATURE_SOCIAL_IMAGE_GENERATOR,
+	FEATURE_DNS_SSL_CACHING,
+	FEATURE_DNS_SSL_CACHING_CDN,
 } from './constants';
 import type { FeatureList } from './types';
 
@@ -658,9 +660,11 @@ const FEATURES_LIST: FeatureList = {
 				} );
 			}
 
-			return i18n.translate( 'Free domain for one year', {
-				context: 'title',
-			} );
+			return true
+				? 'Free domain'
+				: i18n.translate( 'Free domain for one year', {
+						context: 'title',
+				  } );
 		},
 		getAlternativeTitle: () => i18n.translate( 'Free custom domain' ),
 		getDescription: ( { domainName = undefined } = {} ) => {
@@ -2604,6 +2608,16 @@ const FEATURES_LIST: FeatureList = {
 		getTitle: () => i18n.translate( 'Advanced Jetpack features' ),
 	},
 	/* END: Sensei Features */
+
+	[ FEATURE_DNS_SSL_CACHING ]: {
+		getSlug: () => FEATURE_DNS_SSL_CACHING,
+		getTitle: () => i18n.translate( 'Extremely fast DNS with SSL & global edge caching' ),
+	},
+	[ FEATURE_DNS_SSL_CACHING_CDN ]: {
+		getSlug: () => FEATURE_DNS_SSL_CACHING_CDN,
+		getTitle: () =>
+			i18n.translate( 'High performance with global CDN with 28+ locations and more' ),
+	},
 };
 
 export { FEATURES_LIST };

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -432,6 +432,8 @@ import {
 	FEATURE_SECURITY_VULNERABILITY_NOTIFICATIONS,
 	FEATURE_WOOCOMMERCE_HOSTING,
 	FEATURE_PRIORITY_24_7_SUPPORT,
+	FEATURE_DNS_SSL_CACHING,
+	FEATURE_DNS_SSL_CACHING_CDN,
 } from './constants';
 import {
 	getPlanBusinessTitle,
@@ -567,6 +569,7 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_SMART_REDIRECTS,
 			FEATURE_ALWAYS_ONLINE,
 			FEATURE_PAYMENT_TRANSACTION_FEES_10,
+			...( true && [ FEATURE_DNS_SSL_CACHING ] ),
 		];
 	},
 
@@ -594,15 +597,19 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 		];
 	},
-	get2023PricingGridSignupJetpackFeatures: () => [
-		FEATURE_PAID_SUBSCRIBERS_JP,
-		FEATURE_PREMIUM_CONTENT_JP,
-		FEATURE_DONATIONS_AND_TIPS_JP,
-		FEATURE_PAYMENT_BUTTONS_JP,
-		FEATURE_STATS_JP,
-		FEATURE_LTD_SOCIAL_MEDIA_JP,
-		FEATURE_CONTACT_FORM_JP,
-	],
+	get2023PricingGridSignupJetpackFeatures: () => {
+		return true
+			? []
+			: [
+					FEATURE_PAID_SUBSCRIBERS_JP,
+					FEATURE_PREMIUM_CONTENT_JP,
+					FEATURE_DONATIONS_AND_TIPS_JP,
+					FEATURE_PAYMENT_BUTTONS_JP,
+					FEATURE_STATS_JP,
+					FEATURE_LTD_SOCIAL_MEDIA_JP,
+					FEATURE_CONTACT_FORM_JP,
+			  ];
+	},
 	get2023PlanComparisonJetpackFeatureOverride: () => [
 		FEATURE_PAID_SUBSCRIBERS_JP,
 		FEATURE_DONATIONS_AND_TIPS_JP,
@@ -783,9 +790,11 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		return [
 			FEATURE_CUSTOM_DOMAIN,
 			WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
+			FEATURE_BEAUTIFUL_THEMES,
 			FEATURE_AD_FREE_EXPERIENCE,
 			FEATURE_FAST_DNS,
 			FEATURE_PAYMENT_TRANSACTION_FEES_8,
+			...( true && [ FEATURE_DNS_SSL_CACHING ] ),
 		];
 	},
 	get2023PlanComparisonFeatureOverride: () => {
@@ -967,6 +976,12 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_SELL_60_COUNTRIES,
 			FEATURE_SHIPPING_INTEGRATIONS,
 			FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL,
+			...( true && [
+				FEATURE_CUSTOM_DOMAIN,
+				FEATURE_PRIORITY_24_7_SUPPORT,
+				WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+				FEATURE_DNS_SSL_CACHING_CDN,
+			] ),
 		];
 	},
 	get2023PlanComparisonFeatureOverride: () => {
@@ -1317,6 +1332,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_WORDADS,
 			FEATURE_STYLE_CUSTOMIZATION,
 			FEATURE_PAYMENT_TRANSACTION_FEES_4,
+			...( true && [ FEATURE_DNS_SSL_CACHING_CDN ] ),
 		];
 	},
 	get2023PlanComparisonFeatureOverride: () => {
@@ -1333,12 +1349,15 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
 		FEATURE_SITE_ACTIVITY_LOG_JP,
 	],
-	get2023PricingGridSignupJetpackFeatures: () => [
-		FEATURE_VIDEOPRESS_JP,
-		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
-		FEATURE_SITE_ACTIVITY_LOG_JP,
-		FEATURE_STATS_PAID,
-	],
+	get2023PricingGridSignupJetpackFeatures: () =>
+		true
+			? []
+			: [
+					FEATURE_VIDEOPRESS_JP,
+					FEATURE_UNLTD_SOCIAL_MEDIA_JP,
+					FEATURE_SITE_ACTIVITY_LOG_JP,
+					FEATURE_STATS_PAID,
+			  ],
 	getStorageFeature: () => FEATURE_13GB_STORAGE,
 	getPlanComparisonFeatureLabels: () => ( {
 		[ FEATURE_PREMIUM_THEMES ]: i18n.translate( 'Unlimited premium themes' ),

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -45,6 +45,9 @@ import {
 	FEATURE_200GB_STORAGE,
 	FEATURE_P2_13GB_STORAGE,
 	FEATURE_P2_3GB_STORAGE,
+	FEATURE_GROUP_DOMAIN,
+	FEATURE_GROUP_THEMES,
+	FEATURE_GROUP_PERFORMANCE,
 } from './constants';
 import { PriceTierEntry } from './get-price-tier-for-units';
 import type { TranslateResult } from 'i18n-calypso';
@@ -247,6 +250,9 @@ export type FeatureGroupSlug =
 	| typeof FEATURE_GROUP_MARKETING_EMAIL
 	| typeof FEATURE_GROUP_SHIPPING
 	| typeof FEATURE_GROUP_STORAGE
+	| typeof FEATURE_GROUP_DOMAIN
+	| typeof FEATURE_GROUP_THEMES
+	| typeof FEATURE_GROUP_PERFORMANCE
 	| typeof FEATURE_GROUP_ALL_FEATURES;
 
 export interface FeatureFootnotes {

--- a/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
@@ -78,6 +78,12 @@ const PlanFeaturesList = ( {
 							( feature ) => featureGroup?.getFeatures().includes( feature.getSlug() )
 					  );
 
+			console.debug(
+				'zzz',
+				planSlug,
+				featureGroup?.slug,
+				filteredWpcomFeatures.map( ( f ) => f.getSlug() )
+			);
 			/**
 			 * 1. Storage group is still it's own thing, with no actual features associated. It will join the rest in a follow-up.
 			 */


### PR DESCRIPTION
Spike for the project 'Show fewer differentiating features per plan': p5uIfZ-fIN-p2

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?