### PR TITLE
A4A: Wire 'User invites' endpoint to the UI. 

### DIFF
--- a/client/a8c-for-agencies/data/team/use-cancel-member-invite.ts
+++ b/client/a8c-for-agencies/data/team/use-cancel-member-invite.ts
@@ -1,0 +1,44 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+interface APIError {
+	status: number;
+	code: string | null;
+	message: string;
+}
+
+export interface cancelMemberInviteParams {
+	id: number;
+}
+
+interface APIResponse {
+	success: boolean;
+}
+
+function cancelMemberInviteMutation(
+	params: cancelMemberInviteParams,
+	agencyId?: number
+): Promise< APIResponse > {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to assign a license' );
+	}
+
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/user-invites/${ params.id }`,
+		method: 'DELETE',
+	} );
+}
+
+export default function useCancelMemberInviteMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, cancelMemberInviteParams, TContext >
+): UseMutationResult< APIResponse, APIError, cancelMemberInviteParams, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< APIResponse, APIError, cancelMemberInviteParams, TContext >( {
+		...options,
+		mutationFn: ( args ) => cancelMemberInviteMutation( args, agencyId ),
+	} );
+}

--- a/client/a8c-for-agencies/data/team/use-fetch-member-invite.ts
+++ b/client/a8c-for-agencies/data/team/use-fetch-member-invite.ts
@@ -1,0 +1,33 @@
+import { UseQueryResult, useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+type MemberInvite = {
+	id: number;
+	email: string;
+	status: string;
+	expires_at: number;
+};
+
+export default function useFetchMemberInvites(): UseQueryResult< MemberInvite[], unknown > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery( {
+		queryKey: [ 'a4a-member-invites', agencyId ],
+		queryFn: () =>
+			wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/${ agencyId }/user-invites`,
+			} ),
+		select: ( data ) => {
+			return data?.map( ( invite: MemberInvite ) => ( {
+				id: invite.id,
+				email: invite.email,
+				status: invite.status,
+				expires_at: new Date( invite.expires_at ),
+			} ) );
+		},
+		enabled: !! agencyId,
+	} );
+}

--- a/client/a8c-for-agencies/data/team/use-send-team-member-invite.ts
+++ b/client/a8c-for-agencies/data/team/use-send-team-member-invite.ts
@@ -27,10 +27,10 @@ function mutationSendTeamMemberInvite(
 
 	return wpcom.req.put( {
 		apiNamespace: 'wpcom/v2',
-		path: `/agency/${ agencyId }/team/invite`,
-		method: 'PUT',
+		path: `/agency/${ agencyId }/user-invites`,
+		method: 'POST',
 		body: {
-			username: inviteDetails.username,
+			email: inviteDetails.username,
 			message: inviteDetails.message,
 		},
 	} );

--- a/client/a8c-for-agencies/data/team/use-send-team-member-invite.ts
+++ b/client/a8c-for-agencies/data/team/use-send-team-member-invite.ts
@@ -25,7 +25,7 @@ function mutationSendTeamMemberInvite(
 		throw new Error( 'Agency ID is required to send team member invite' );
 	}
 
-	return wpcom.req.put( {
+	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
 		path: `/agency/${ agencyId }/user-invites`,
 		method: 'POST',

--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -32,7 +32,7 @@ export default function GetStarted() {
 				<LayoutHeader>
 					<Title>{ title }</Title>
 					<Actions>
-						<Button variant="primary" onClick={ onInviteClick }>
+						<Button variant="primary" onClick={ onInviteClick } href={ A4A_TEAM_INVITE_LINK }>
 							{ translate( 'Invite a team member' ) }
 						</Button>
 					</Actions>

--- a/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
@@ -41,7 +41,12 @@ export default function TeamInvite() {
 			{ username, message },
 			{
 				onSuccess: () => {
-					dispatch( successNotice( 'The invitation has been successfully sent.' ) );
+					dispatch(
+						successNotice( 'The invitation has been successfully sent.', {
+							id: 'submit-user-invite-success',
+							duration: 5000,
+						} )
+					);
 					page( A4A_TEAM_LINK );
 				},
 

--- a/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
@@ -110,7 +110,12 @@ export default function TeamInvite() {
 					</div>
 
 					<div className="team-invite-form__footer">
-						<Button variant="primary" onClick={ onSendInvite } disabled={ isSending }>
+						<Button
+							variant="primary"
+							onClick={ onSendInvite }
+							disabled={ isSending }
+							isBusy={ isSending }
+						>
 							{ translate( 'Send invite' ) }
 						</Button>
 					</div>

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -10,7 +10,7 @@ import { TeamMember } from '../../types';
 export const RoleStatusColumn = ( { member }: { member: TeamMember } ): ReactNode => {
 	const translate = useTranslate();
 
-	const getRoleLabel = ( role: string ): string => {
+	const getRoleLabel = ( role?: string ): string => {
 		// Currently, we only have two roles: 'owner' and 'member'. Later, we will have more roles.
 		return role === 'owner' ? translate( 'Agency owner' ) : translate( 'Team member' );
 	};
@@ -100,19 +100,29 @@ export const ActionColumn = ( {
 		return null;
 	}
 
-	const actions = [
-		{
-			name: 'password-reset',
-			label: translate( 'Send password reset' ),
-			isEnabled: true,
-		},
-		{
-			name: 'delete-user',
-			label: translate( 'Delete user' ),
-			className: 'is-danger',
-			isEnabled: asOwner,
-		},
-	];
+	const actions =
+		member.status === 'pending'
+			? [
+					{
+						name: 'cancel-user-invite',
+						label: translate( 'Cancel invite' ),
+						className: 'is-danger',
+						isEnabled: true,
+					},
+			  ]
+			: [
+					{
+						name: 'password-reset',
+						label: translate( 'Send password reset' ),
+						isEnabled: true,
+					},
+					{
+						name: 'delete-user',
+						label: translate( 'Delete user' ),
+						className: 'is-danger',
+						isEnabled: asOwner,
+					},
+			  ];
 
 	return (
 		<>

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode, useMemo, useState } from 'react';
+import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
@@ -14,9 +14,11 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import { A4A_TEAM_INVITE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useCancelMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-cancel-member-invite';
 import useFetchMemberInvites from 'calypso/a8c-for-agencies/data/team/use-fetch-member-invite';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { TeamMember } from '../../types';
 import GetStarted from '../get-started';
 import { ActionColumn, DateColumn, MemberColumn, RoleStatusColumn } from './columns';
@@ -31,7 +33,13 @@ export default function TeamList() {
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( initialDataViewsState );
 
-	const { data: memberInvites, isPending: isMemberInvitesPending } = useFetchMemberInvites();
+	const {
+		data: memberInvites,
+		isPending: isMemberInvitesPending,
+		refetch: refetchMemberInvites,
+	} = useFetchMemberInvites();
+
+	const { mutate: cancelMemberInvite } = useCancelMemberInviteMutation();
 
 	const title = translate( 'Manage team members' );
 
@@ -40,10 +48,31 @@ export default function TeamList() {
 		page( A4A_TEAM_INVITE_LINK );
 	};
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const handleAction = ( action: string, item: TeamMember ) => {
-		// FIXME: Implement action handling
-	};
+	const handleAction = useCallback(
+		( action: string, item: TeamMember ) => {
+			if ( action === 'cancel-user-invite' ) {
+				cancelMemberInvite(
+					{ id: item.id },
+					{
+						onSuccess: () => {
+							dispatch(
+								successNotice( 'The invitation has been successfully cancelled.', {
+									id: 'cancel-user-invite-success',
+									duration: 5000,
+								} )
+							);
+							refetchMemberInvites();
+						},
+
+						onError: ( error ) => {
+							dispatch( errorNotice( error.message ) );
+						},
+					}
+				);
+			}
+		},
+		[ cancelMemberInvite, dispatch, refetchMemberInvites ]
+	);
 
 	const fields = useMemo(
 		() => [
@@ -94,13 +123,14 @@ export default function TeamList() {
 				enableSorting: false,
 			},
 		],
-		[ isDesktop, translate ]
+		[ handleAction, isDesktop, translate ]
 	);
 
 	const members: TeamMember[] = useMemo( () => {
 		const activeMembers: TeamMember[] = [
 			// FIXME: Fetch team members
 			{
+				id: 0,
 				displayName: 'Owner',
 				email: 'owner@automattic.com',
 				role: 'owner',

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -14,6 +14,7 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import { A4A_TEAM_INVITE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchMemberInvites from 'calypso/a8c-for-agencies/data/team/use-fetch-member-invite';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { TeamMember } from '../../types';
@@ -29,6 +30,8 @@ export default function TeamList() {
 	const isDesktop = useDesktopBreakpoint();
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( initialDataViewsState );
+
+	const { data: memberInvites, isPending: isMemberInvitesPending } = useFetchMemberInvites();
 
 	const title = translate( 'Manage team members' );
 
@@ -94,36 +97,32 @@ export default function TeamList() {
 		[ isDesktop, translate ]
 	);
 
-	// FIXME: Fetch team members
-	const members: TeamMember[] = [
-		{
-			displayName: 'Owner',
-			email: 'owner@automattic.com',
-			role: 'owner',
-			status: 'active',
-		},
-		{
-			displayName: 'User 1',
-			email: 'user1@automattic.com',
-			role: 'member',
-			status: 'active',
-			dateAdded: new Date().toDateString(),
-		},
-		{
-			displayName: 'User 2',
-			email: 'user2@automattic.com',
-			role: 'member',
-			status: 'pending',
-			dateAdded: new Date().toDateString(),
-		},
-		{
-			email: 'user3@automattic.com',
-			role: 'member',
-			status: 'expired',
-		},
-	];
+	const members: TeamMember[] = useMemo( () => {
+		const activeMembers: TeamMember[] = [
+			// FIXME: Fetch team members
+			{
+				displayName: 'Owner',
+				email: 'owner@automattic.com',
+				role: 'owner',
+				status: 'active',
+			},
+		];
+
+		const pendingMembers: TeamMember[] =
+			memberInvites?.map( ( invite ) => ( {
+				id: invite.id,
+				email: invite.email,
+				status: 'pending',
+			} ) ) ?? [];
+
+		return [ ...activeMembers, ...pendingMembers ];
+	}, [ memberInvites ] );
 
 	const isEmpty = members.length <= 1; // We always have one member (owner) so we exclude it from count.
+
+	if ( isMemberInvitesPending ) {
+		// FIXME: Add placeholder when UI is pending
+	}
 
 	if ( isEmpty ) {
 		return <GetStarted />;

--- a/client/a8c-for-agencies/sections/team/types.ts
+++ b/client/a8c-for-agencies/sections/team/types.ts
@@ -1,5 +1,5 @@
 export interface TeamMember {
-	id?: number;
+	id: number;
 	email: string;
 	displayName?: string;
 	role?: string;

--- a/client/a8c-for-agencies/sections/team/types.ts
+++ b/client/a8c-for-agencies/sections/team/types.ts
@@ -1,7 +1,8 @@
 export interface TeamMember {
+	id?: number;
 	email: string;
 	displayName?: string;
-	role: string;
+	role?: string;
 	avatar?: string;
 	dateAdded?: string;
 	status: 'active' | 'pending' | 'expired';


### PR DESCRIPTION
This PR wires the User invites endpoint to the UI.


Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/943

## Proposed Changes

* Implement query and mutation hooks that point to the User invites endpoint.
* Implement the 'Send invite' handler.
* Implement the 'Fetch invite' logic.
* Implement the 'Cancel invite' handler. 

## Why are these changes being made?

*

## Testing Instructions

1. Use the A4A live link to access the `/team` page.
2. Verify that the Team list page fetches from the User invite endpoint to generate the pending member list.
3. Navigate to the `/team/invite` page.
4. Ensure that the form is functional and create a member invite. Upon completion, the page should redirect back to the 'Team' page.
5. Test the cancellation of pending member invites as well.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
