### PR TITLE
dont show the budget left in campaigns list when campaign has status rejected

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -76,7 +76,7 @@ export default function CampaignItem( props: Props ) {
 
 	let budgetString = '-';
 	let budgetStringMobile = '';
-	if ( is_evergreen && campaignDays ) {
+	if ( is_evergreen && campaignDays && ui_status !== campaignStatus.REJECTED ) {
 		/* translators: Daily average spend. dailyAverageSpending is the budget */
 		budgetString = sprintf(
 			/* translators: %s is a formatted amount */
@@ -88,7 +88,7 @@ export default function CampaignItem( props: Props ) {
 			translate( '$%s weekly budget' ),
 			totalBudget
 		);
-	} else if ( campaignDays ) {
+	} else if ( campaignDays && ui_status !== campaignStatus.REJECTED ) {
 		budgetString = `$${ formatCents( totalBudget ) }`;
 		budgetStringMobile = sprintf(
 			/* translators: %s is a formatted amount */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1036 (tumblr github dsp ticket)

## Proposed Changes

in advertising pages, in the campaign list we don't want to show the budget left (in the table) when the campaign has status of rejected


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

checkout this branch, and start the calypso (or checkout the preview link) 

you should have a few campaigns (its good to have a few active, a few scheduled, canceled and rejected so you can test all cases)

ensure that in next to the rejected campaigns you don't get a budget number and you get a '-' instead (as in the below ss)

<img width="1130" alt="Screenshot 2024-08-26 at 14 07 37" src="https://github.com/user-attachments/assets/c23a61d9-fd44-4015-bf3d-7035b445f956">


do a CR

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?