### PR TITLE
replace date with post_date in search query of search/campaigns endpoint to not get validation error

### DIFF
--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -32,7 +32,7 @@ export type DropdownOption = {
 };
 
 const SORT_OPTIONS_BY_TITLE = 'post_title';
-const SORT_OPTIONS_LAST_PUBLISHED = 'date';
+const SORT_OPTIONS_LAST_PUBLISHED = 'post_date';
 const SORT_OPTIONS_RECENTLY_UPDATED = 'modified';
 const SORT_OPTIONS_MOST_LIKED = 'like_count';
 const SORT_OPTIONS_MOST_COMMENTED = 'comment_count';


### PR DESCRIPTION
related to tumblr dsp ticket 1255



The issue.. in advertising -> campaigns list page, if you search for a term you will get a validation error and the UI gets broken
(the term I used was my personal email - but you can use any search query that will not return any results)

the result is as shown below
<img width="712" alt="Screenshot 2024-08-26 at 17 02 55" src="https://github.com/user-attachments/assets/b55cb69d-ff68-4cdb-820c-ad4f38345668">

## Proposed Changes

trying to figure this out. (and thanks to Oleg) we figured out that the query for order_by should be post_date instead of date


## Testing Instructions

test in trunk .. open the campaigns list page and enter a query.. you should get something similar to the above ss

checkout the branch and do the same step.. you should get something like this
<img width="840" alt="Screenshot 2024-08-26 at 17 07 00" src="https://github.com/user-attachments/assets/1c92662c-4454-426a-a869-6c27f754c8cc">


do a CR (it is just a one-liner fix)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?