### PR TITLE
A4A: Create invite member link routing 

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -38,6 +38,7 @@ export const A4A_PARTNER_DIRECTORY_LINK = '/partner-directory';
 export const A4A_PARTNER_DIRECTORY_DASHBOARD_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/dashboard`;
 export const A4A_TEAM_LINK = '/team';
 export const A4A_TEAM_INVITE_LINK = '/team/invite';
+export const A4A_TEAM_ACCEPT_INVITE_LINK = '/team/invite/accept';
 export const EXTERNAL_A4A_KNOWLEDGE_BASE = 'http://automattic.com/for-agencies/help';
 
 // Client

--- a/client/a8c-for-agencies/data/team/use-activate-member.ts
+++ b/client/a8c-for-agencies/data/team/use-activate-member.ts
@@ -1,0 +1,36 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface APIError {
+	status: number;
+	code: string | null;
+	message: string;
+}
+
+interface Params {
+	agencyId: number;
+	inviteId: number;
+	secret: string;
+}
+
+interface APIResponse {
+	success: boolean;
+}
+
+function activateMemberMutation( params: Params ): Promise< APIResponse > {
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ params.agencyId }/user-invites/${ params.inviteId }`,
+		method: 'POST',
+		body: params,
+	} );
+}
+
+export default function useActivateMemberMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, Params, TContext >
+): UseMutationResult< APIResponse, APIError, Params, TContext > {
+	return useMutation< APIResponse, APIError, Params, TContext >( {
+		...options,
+		mutationFn: ( args ) => activateMemberMutation( args ),
+	} );
+}

--- a/client/a8c-for-agencies/data/team/use-activate-member.ts
+++ b/client/a8c-for-agencies/data/team/use-activate-member.ts
@@ -31,6 +31,6 @@ export default function useActivateMemberMutation< TContext = unknown >(
 ): UseMutationResult< APIResponse, APIError, Params, TContext > {
 	return useMutation< APIResponse, APIError, Params, TContext >( {
 		...options,
-		mutationFn: ( args ) => activateMemberMutation( args ),
+		mutationFn: activateMemberMutation,
 	} );
 }

--- a/client/a8c-for-agencies/sections/team/controller.tsx
+++ b/client/a8c-for-agencies/sections/team/controller.tsx
@@ -1,6 +1,7 @@
 import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import MainSidebar from '../../components/sidebar-menu/main';
+import TeamAcceptInvite from './primary/team-accept-invite';
 import TeamInvite from './primary/team-invite';
 import TeamList from './primary/team-list';
 
@@ -22,6 +23,19 @@ export const teamInviteContext: Callback = ( context, next ) => {
 		<>
 			<PageViewTracker title="Manage team > Invite a team member" path={ context.path } />
 			<TeamInvite />
+		</>
+	);
+
+	next();
+};
+
+export const teamAcceptInviteContext: Callback = ( context, next ) => {
+	const { agency_id: agencyId, invite_id: inviteId, secret: secret } = context.query;
+
+	context.primary = (
+		<>
+			<PageViewTracker title="Accept team invite" path={ context.path } />
+			<TeamAcceptInvite agencyId={ agencyId } inviteId={ inviteId } secret={ secret } />
 		</>
 	);
 

--- a/client/a8c-for-agencies/sections/team/index.tsx
+++ b/client/a8c-for-agencies/sections/team/index.tsx
@@ -1,14 +1,17 @@
 import page from '@automattic/calypso-router';
 import {
+	A4A_TEAM_ACCEPT_INVITE_LINK,
 	A4A_TEAM_INVITE_LINK,
 	A4A_TEAM_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { teamContext, teamInviteContext } from './controller';
+import { teamAcceptInviteContext, teamContext, teamInviteContext } from './controller';
 
 export default function () {
 	page( A4A_TEAM_LINK, requireAccessContext, teamContext, makeLayout, clientRender );
 
 	page( A4A_TEAM_INVITE_LINK, requireAccessContext, teamInviteContext, makeLayout, clientRender );
+
+	page( A4A_TEAM_ACCEPT_INVITE_LINK, teamAcceptInviteContext, makeLayout, clientRender );
 }

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/index.tsx
@@ -70,7 +70,7 @@ export default function TeamAcceptInvite( { agencyId, inviteId, secret }: Props 
 	}, [ activateMember, agencyId, dispatch, inviteId, secret ] );
 
 	useEffect( () => {
-		if ( agency && agency.id === agencyId ) {
+		if ( agency && agency.id === Number( agencyId ) ) {
 			// If current agency is the same as the one in the URL, redirect to the overview page
 			page( A4A_OVERVIEW_LINK );
 		}

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/index.tsx
@@ -1,0 +1,105 @@
+import page from '@automattic/calypso-router';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo, useState } from 'react';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import { A4A_OVERVIEW_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useActivateMemberMutation from 'calypso/a8c-for-agencies/data/team/use-activate-member';
+import { useDispatch, useSelector } from 'calypso/state';
+import { fetchAgencies } from 'calypso/state/a8c-for-agencies/agency/actions';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+import './style.scss';
+
+type Props = {
+	agencyId?: number;
+	inviteId?: number;
+	secret?: string;
+};
+
+function PlaceHolder() {
+	return (
+		<div className="team-accept-invite__section-placeholder">
+			<div className="team-accept-invite__section-placeholder-title"></div>
+			<div className="team-accept-invite__section-placeholder-body"></div>
+			<div className="team-accept-invite__section-placeholder-footer"></div>
+		</div>
+	);
+}
+
+function ErrorMessage( { error }: { error: string } ) {
+	return <div className="team-accept-invite__error">{ error }</div>;
+}
+
+export default function TeamAcceptInvite( { agencyId, inviteId, secret }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const agency = useSelector( getActiveAgency );
+
+	const { mutate: activateMember } = useActivateMemberMutation();
+
+	const [ error, setError ] = useState( '' );
+
+	useEffect( () => {
+		// FIXME: Check if current user is not member of any agency. If so, display some instructions on how to join to the new agency.
+
+		if ( agencyId && inviteId && secret ) {
+			setError( '' );
+
+			activateMember(
+				{
+					agencyId,
+					inviteId,
+					secret,
+				},
+				{
+					onSuccess: () => {
+						dispatch( fetchAgencies() );
+					},
+					onError: ( error ) => {
+						setError( error.message );
+					},
+				}
+			);
+		}
+	}, [ activateMember, agencyId, dispatch, inviteId, secret ] );
+
+	useEffect( () => {
+		if ( agency && agency.id === agencyId ) {
+			// If current agency is the same as the one in the URL, redirect to the overview page
+			page( A4A_OVERVIEW_LINK );
+		}
+	}, [ agency, agencyId ] );
+
+	const title = translate( 'Accepting team invite' );
+
+	const content = useMemo( () => {
+		if ( error ) {
+			return <ErrorMessage error={ error } />;
+		}
+
+		return <PlaceHolder />;
+	}, [ error ] );
+
+	return (
+		<Layout className="team-accept-invite" title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>
+						{ error ? (
+							translate( 'Invalid invite link' )
+						) : (
+							<div className="team-accept-invite__title-placeholder"></div>
+						) }
+					</Title>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>{ content }</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/style.scss
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/style.scss
@@ -1,0 +1,40 @@
+@mixin loading-effect {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background: var(--color-neutral-10);
+}
+
+.team-accept-invite__title-placeholder {
+	@include loading-effect;
+
+	width: 300px;
+	height: 43px;
+}
+
+.team-accept-invite__section-placeholder {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.team-accept-invite__section-placeholder-title {
+	@include loading-effect;
+
+	width: 100%;
+	height: 32px;
+}
+
+
+.team-accept-invite__section-placeholder-body {
+	@include loading-effect;
+
+	width: 100%;
+	height: 200px;
+}
+
+.team-accept-invite__section-placeholder-footer {
+	@include loading-effect;
+
+	width: 20%;
+	min-width: 100px;
+	height: 43px;
+}


### PR DESCRIPTION
This pull request implements the routing for the magic link to redirect users (`https://agencies.automattic.com/team/invite/accept`) and triggers a POST request to the accept invite endpoint. 


In case there is an error with the invite link (e.g., invalid secret, expired invite), the following screen will be displayed. **Note that the error message will be different for each error.**

<img width="1726" alt="Screenshot 2024-08-26 at 10 13 06 PM" src="https://github.com/user-attachments/assets/4bd03a95-3263-4a71-9ee2-1a5921fb05b6">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/991

## Proposed Changes

* Implement the `/team/invite/accept` route that requires an authenticated user. The route uses a similar loading visual as the landing page. If the activation is successful, the user is redirected to the overview page. Otherwise if error is detected, the message is displayed.

## Testing Instructions

* Create a WP account and log in to the Incognito tab. Keep note of the email.
* Now follow the instructions on how to create an invite and get the secret in this diff: D159237-code
* Once you have the Agency ID, Invite ID, and secret, spin up this branch locally and go to the following path: `http://agencies.localhost:3000/team/invite/accept?agency_id=${AGENCY_ID}&invite_id=${INVITE_ID}&secret=${SECRET}`
* Make sure you replace the correct query parameter values and open it in the same Incognito tab where you login the new user. **_We want the user to be logged in so we have an authenticated user session, and the path is accessible._**
* Confirm that after accessing the path, the user is redirected to the overview page and is added to the agency. You can verify this is correct by inspecting the `/agency` endpoint and check it returns the correct agency ID.

https://github.com/user-attachments/assets/2edae291-cf70-4964-afaf-1a6f40ab97fb



## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?