### PR TITLE
A4A Dev Sites: Remove unnecessary `?referer=a4a-dashboard` Launch link URL parameter

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -67,7 +67,7 @@ export default function useSiteActions( {
 		return [
 			{
 				name: translate( 'Prepare for launch' ),
-				href: `https://wordpress.com/settings/general/${ blog_id }?referer=a4a-dashboard`,
+				href: `https://wordpress.com/settings/general/${ blog_id }`,
 				onClick: () => handleClickMenuItem( 'prepare_for_launch' ),
 				isExternalLink: true,
 				isEnabled: isDevSite,

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -93,7 +93,7 @@ const PrepareForLaunchItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	return (
 		<MenuItem
 			onClick={ () => {
-				window.location.href = `https://wordpress.com/settings/general/${ site.ID }?referer=a4a-dashboard`;
+				window.location.href = `https://wordpress.com/settings/general/${ site.ID }`;
 				recordTracks( 'calypso_sites_dashboard_site_action_prepare_for_launch_click' );
 			} }
 		>


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/8900.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* remove unnecessary `?referer=a4a-dashboard` "Prepare for launch" link URL parameter; it can be removed since we are now relying on the site information available in the related component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Testing the change in the Agency portal:**

1. Check out this PR locally and build the app with `yarn start-a8c-for-agencies`.
2. Head over to the Sites section at http://agencies.localhost:3000/sites/?flags=a4a-dev-sites.
3. Find one of your development sites that haven't been launched yet. Open the menu on the side of the row and click on the "Prepare for launch" link.
4. The link should take you to the `https://wordpress.com/settings/general/{blog-id}` page (without the referer URL parameter). There should be two buttons: `Launch site` and `Refer to client`, plus the agency name should be loaded in the copy as well.

**Testing the change in the "normal WPCOM" Sites page:**
1. Build the app with `yarn start`.
2. Head over to the Sites page at http://calypso.localhost:3000/sites.
3. Follow the steps 3 and 4 from the previous section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?