### PR TITLE
Themes global view: Show global sidebar on theme

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -117,7 +117,7 @@ body.command-palette-modal-open {
 			padding-left: 24px;
 		}
 
-		.is-section-theme &,
+		.is-section-theme.has-no-sidebar &,
 		.is-section-themes.has-no-sidebar & {
 			padding: 0;
 			margin: 0;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -74,9 +74,9 @@ body.command-palette-modal-open {
 	}
 
 	// Themes sets it own padding/margin
-	.is-section-theme &,
+	.is-section-theme.has-no-sidebar &,
 	.is-section-themes.has-no-sidebar &,
-	.theme-default .layout.is-section-theme &,
+	.theme-default .layout.is-section-theme.has-no-sidebar &,
 	.theme-default .layout.is-section-themes.has-no-sidebar &,
 	.theme-default .layout.is-section-themes:not(.is-logged-in) & {
 		padding: 0;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -73,7 +73,7 @@ body.command-palette-modal-open {
 		margin: 0;
 	}
 
-	// Themes sets it own padding/margin
+	// Themes sets its own padding/margin when there is no sidebar
 	.is-section-theme.has-no-sidebar &,
 	.is-section-themes.has-no-sidebar &,
 	.theme-default .layout.is-section-theme.has-no-sidebar &,

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1014,11 +1014,6 @@ $font-size: rem(14px);
 					overflow: initial;
 				}
 			}
-			.is-section-theme {
-				.layout__secondary {
-					transform: translateX(-100%);
-				}
-			}
 		}
 
 		.sidebar__menu.is-togglable:not(.is-toggle-open).hovered {

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -5,6 +5,7 @@ import {
 	noSite,
 	redirectToLoginIfSiteRequested,
 	selectSiteOrSkipIfLoggedInWithMultipleSites,
+	addNavigationIfLoggedIn,
 } from 'calypso/my-sites/controller';
 import { getTheme } from 'calypso/state/themes/selectors';
 import { details, fetchThemeDetailsData } from './controller';
@@ -36,6 +37,7 @@ export default function ( router ) {
 		noSite,
 		fetchThemeDetailsData,
 		details,
+		addNavigationIfLoggedIn,
 		makeLayout
 	);
 }

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -1,6 +1,10 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
-import { makeLayout, redirectWithoutLocaleParamIfLoggedIn } from 'calypso/controller';
+import {
+	makeLayout,
+	redirectWithoutLocaleParamIfLoggedIn,
+	render as clientRender,
+} from 'calypso/controller';
 import {
 	noSite,
 	redirectToLoginIfSiteRequested,
@@ -38,6 +42,7 @@ export default function ( router ) {
 		fetchThemeDetailsData,
 		details,
 		addNavigationIfLoggedIn,
-		makeLayout
+		makeLayout,
+		clientRender
 	);
 }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -18,6 +18,10 @@ $button-border: 4px;
 	.layout.is-logged-in .layout__content {
 		overflow: clip;
 
+		@media screen and (min-width: 782px) {
+			padding-left: calc(var(--sidebar-width-max) + 32px + 1px);
+		}
+
 		.theme__sheet-screenshot,
 		.theme__sheet-web-preview {
 			@include breakpoint-deprecated( ">960px" ) {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -15,6 +15,23 @@ $button-border: 4px;
 		--color-surface-backdrop: var(--studio-white);
 	}
 
+	.layout.is-logged-in .layout__content {
+		overflow: clip;
+
+		.theme__sheet-screenshot,
+		.theme__sheet-web-preview {
+			@include breakpoint-deprecated( ">960px" ) {
+				top: calc(var(--masterbar-height) + 16px);
+			}
+		}
+
+		.theme__sheet-web-preview .theme-preview__frame-wrapper {
+			@include breakpoint-deprecated( ">960px" ) {
+				max-height: calc(100vh - 32px - var(--masterbar-height));
+			}
+		}
+	}
+
 	.layout__primary .main {
 		@include breakpoint-deprecated( "<960px" ) {
 			padding-bottom: 40px;
@@ -137,7 +154,8 @@ $button-border: 4px;
 		display: flex;
 		gap: 16px;
 		flex-direction: column;
-		padding: 0;
+		padding-top: 0;
+		padding-bottom: 0;
 
 		.theme__sheet-column-left {
 			padding: 0 24px;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -15,29 +15,6 @@ $button-border: 4px;
 		--color-surface-backdrop: var(--studio-white);
 	}
 
-	.layout.is-logged-in .layout__content {
-		overflow: clip;
-		padding-top: var(--masterbar-height);
-
-		@include breakpoint-deprecated( "<960px" ) {
-			padding-left: 0;
-			padding-right: 0;
-		}
-
-		.theme__sheet-screenshot,
-		.theme__sheet-web-preview {
-			@include breakpoint-deprecated( ">960px" ) {
-				top: calc(var(--masterbar-height) + 16px);
-			}
-		}
-
-		.theme__sheet-web-preview .theme-preview__frame-wrapper {
-			@include breakpoint-deprecated( ">960px" ) {
-				max-height: calc(100vh - 32px - var(--masterbar-height));
-			}
-		}
-	}
-
 	.layout__primary .main {
 		@include breakpoint-deprecated( "<960px" ) {
 			padding-bottom: 40px;
@@ -46,6 +23,26 @@ $button-border: 4px;
 
 	.empty-content {
 		margin-bottom: 20px;
+	}
+
+	&.is-global-sidebar-visible {
+		background: var(--studio-gray-0);
+
+		.layout__content {
+			min-height: 100vh;
+			@media screen and (min-width: 782px) {
+				padding: calc(var(--masterbar-height) + var(--content-padding-top)) 16px var(--content-padding-bottom) var(--sidebar-width-max);
+			}
+		}
+
+		.layout__primary > * {
+			background-color: var(--color-surface);
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
+			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
+			max-width: none;
+			overflow-y: auto;
+		}
 	}
 }
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -18,10 +18,6 @@ $button-border: 4px;
 	.layout.is-logged-in .layout__content {
 		overflow: clip;
 
-		@media screen and (min-width: 782px) {
-			padding-left: calc(var(--sidebar-width-max) + 32px + 1px);
-		}
-
 		.theme__sheet-screenshot,
 		.theme__sheet-web-preview {
 			@include breakpoint-deprecated( ">960px" ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92645

## Proposed Changes

* Frame the individual /theme page the same way as the /themes showcase, at both the /sites and individual site level.

- Planned follow-ups: 
    - Highlight Themes in the sidebar while on a theme page, like plugins.
    - Use breadcrumbs in header, like plugins.

Before | After
---- | -----
<img width="1275" alt="Screen Shot 2024-08-27 at 11 52 11 AM" src="https://github.com/user-attachments/assets/d82e3c6b-c34f-45c2-a8ec-72c0ab433871"> | <img width="1255" alt="Screen Shot 2024-08-27 at 11 51 37 AM" src="https://github.com/user-attachments/assets/bcfdd8d9-f4f6-418e-9302-876cbd8ff1e2">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To keep the interface consistent between the themes showcase and clicking a theme.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open /themes and click on a theme.
* Verify that the global sidebar and gray frame are visible.
* Test for regressions on mobile screen sizes and different browsers.
* Open /themes **while logged out** and click on a theme.
* Verify that there are no changes (no new sidebar and frame) and test for regressions.
* Open themes from My Home > Appearance > Themes and click on a theme. 
* Verify that the sidebar is visible, and that there aren't regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
