### PR TITLE
Remove Stripe "cardNetworks" object from redux store

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
@@ -45,7 +45,6 @@ export default function CreditCardFields( {
 	const { __ } = useI18n();
 	const theme = useTheme();
 	const [ isStripeFullyLoaded, setIsStripeFullyLoaded ] = useState( false );
-
 	const fields: CardFieldState = useSelect(
 		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getFields(),
 		[]
@@ -64,7 +63,6 @@ export default function CreditCardFields( {
 	const {
 		setFieldValue,
 		changeBrand,
-		changeCardNetworks,
 		setCardDataError,
 		setCardDataComplete,
 		setUseForAllSubscriptions,
@@ -152,7 +150,6 @@ export default function CreditCardFields( {
 						<CreditCardNumberField
 							setIsStripeFullyLoaded={ setIsStripeFullyLoaded }
 							handleStripeFieldChange={ handleStripeFieldChange }
-							changeCardNetworks={ changeCardNetworks }
 							stripeElementStyle={ stripeElementStyle }
 							shouldUseEbanx={ shouldUseEbanx }
 							getErrorMessagesForField={ getErrorMessagesForField }

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -12,7 +12,6 @@ import type { StripeElementStyle } from '@stripe/stripe-js';
 export default function CreditCardNumberField( {
 	setIsStripeFullyLoaded,
 	handleStripeFieldChange,
-	changeCardNetworks,
 	stripeElementStyle,
 	shouldUseEbanx = false,
 	getErrorMessagesForField,
@@ -21,7 +20,6 @@ export default function CreditCardNumberField( {
 }: {
 	setIsStripeFullyLoaded: ( isLoaded: boolean ) => void;
 	handleStripeFieldChange: ( input: StripeFieldChangeInput ) => void;
-	changeCardNetworks: ( networks: [] ) => void;
 	stripeElementStyle: StripeElementStyle;
 	shouldUseEbanx?: boolean;
 	getErrorMessagesForField: ( key: string ) => string[];
@@ -35,7 +33,6 @@ export default function CreditCardNumberField( {
 		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getBrand(),
 		[]
 	);
-
 	const { cardNumber: cardNumberError } = useSelect(
 		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getCardDataErrors(),
 		[]
@@ -80,22 +77,6 @@ export default function CreditCardNumberField( {
 					} }
 					onChange={ ( input ) => {
 						handleStripeFieldChange( input );
-					} }
-					/* Note, the onNetworksChange event is deprecated and will be removed at some point
-					 * This will need to be updated before we upgrade Stripe beyond v3
-					 */
-					onNetworksChange={ ( event ) => {
-						// @ts-expect-error: The onNetworksChange method is deprecated, but is necessary for cobrand compliance
-						switch ( event.networks ) {
-							case null:
-							case undefined:
-								break;
-							default: {
-								// @ts-expect-error: The onNetworksChange method is deprecated, but is necessary for cobrand compliance
-								changeCardNetworks( event.networks );
-								break;
-							}
-						}
 					} }
 				/>
 				<PaymentLogo brand={ brand } />

--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -42,9 +42,9 @@ function CreditCardSummary() {
 	);
 }
 
-const CreditCardLabel: React.FC< {
-	hasExistingCardMethods: boolean | undefined;
-} > = ( { hasExistingCardMethods } ) => {
+const CreditCardLabel: React.FC< { hasExistingCardMethods: boolean | undefined } > = ( {
+	hasExistingCardMethods,
+} ) => {
 	const { __ } = useI18n();
 	return (
 		<Fragment>

--- a/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
@@ -18,9 +18,6 @@ export const actions = {
 	changeBrand( payload: string ): CardStoreAction {
 		return { type: 'BRAND_SET', payload };
 	},
-	changeCardNetworks( payload: { brand: string }[] ): CardStoreAction {
-		return { type: 'CARD_NETWORKS_SET', payload };
-	},
 	setCardDataError( type: CardElementType, message: string | null ): CardStoreAction {
 		return { type: 'CARD_DATA_ERROR_SET', payload: { type, message } };
 	},
@@ -47,9 +44,6 @@ export const actions = {
 export const selectors = {
 	getBrand( state: CardStoreState ): string {
 		return state.brand || '';
-	},
-	getCardNetworks( state: CardStoreState ): { brand: string }[] {
-		return state.cardNetworks || [];
 	},
 	getCardDataErrors( state: CardStoreState ) {
 		return state.cardDataErrors;
@@ -158,18 +152,6 @@ export function createCreditCardPaymentMethodStore( {
 		}
 	}
 
-	function cardNetworksReducer(
-		state: { brand: string }[] | null | undefined = null,
-		action?: CardStoreAction
-	) {
-		switch ( action?.type ) {
-			case 'CARD_NETWORKS_SET':
-				return action.payload;
-			default:
-				return state;
-		}
-	}
-
 	function allSubscriptionsReducer( state: boolean, action?: CardStoreAction ) {
 		switch ( action?.type ) {
 			case 'USE_FOR_ALL_SUBSCRIPTIONS_SET':
@@ -197,7 +179,6 @@ export function createCreditCardPaymentMethodStore( {
 					cardDataErrors: cardDataErrorsReducer(),
 					cardDataComplete: cardDataCompleteReducer(),
 					brand: brandReducer(),
-					cardNetworks: cardNetworksReducer(),
 					useForAllSubscriptions: getInitialUseForAllSubscriptionsValue(),
 				},
 				action: AnyAction
@@ -207,7 +188,6 @@ export function createCreditCardPaymentMethodStore( {
 					cardDataErrors: cardDataErrorsReducer( state.cardDataErrors, action ),
 					cardDataComplete: cardDataCompleteReducer( state.cardDataComplete, action ),
 					brand: brandReducer( state.brand, action ),
-					cardNetworks: cardNetworksReducer( state.cardNetworks, action ),
 					useForAllSubscriptions: allowUseForAllSubscriptions
 						? allSubscriptionsReducer( state.useForAllSubscriptions, action )
 						: false,

--- a/client/my-sites/checkout/src/payment-methods/credit-card/types.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/types.ts
@@ -19,7 +19,6 @@ export type CardDataCompleteState = Record< CardElementType, boolean >;
 
 export interface CardStoreState {
 	brand: string | null | undefined;
-	cardNetworks: { brand: string }[];
 	fields: CardFieldState;
 	cardDataErrors: Record< string, string | null >;
 	cardDataComplete: CardDataCompleteState;
@@ -35,7 +34,6 @@ export type CardElementType = CardNumberElementType | CardExpiryElementType | Ca
 
 export type CardStoreAction =
 	| { type: 'BRAND_SET'; payload: string }
-	| { type: 'CARD_NETWORKS_SET'; payload: { brand: string }[] }
 	| { type: 'CARD_DATA_ERROR_SET'; payload: { type: CardElementType; message: string | null } }
 	| { type: 'CARD_DATA_COMPLETE_SET'; payload: { type: CardElementType; complete: boolean } }
 	| { type: 'FIELD_VALUE_SET'; payload: { key: string; value: string } }


### PR DESCRIPTION
As detailed in the August 26 update in the [original issue](https://github.com/Automattic/payments-shilling/issues/3045#issue-2464480037), we are opting to use the included Stripe card network selector instead of building our own. Trying to work around the Stripe API and deprecated functions proved to be too great of a lift for this feature just so that we could control the UI/UX of the payment logos. 

We are removing the `cardNetworks` object from the redux store and instead will work to pass all card network and brand related information from the server to maintain a single source of truth.

### Testing

- This doesn't really require much to test since it it simply listening for network changes and adding them to the redux store
- What we would want to check is that the other store items for `wpcom-credit-card` still work as expected, this can be done from within Checkout using the Redux Devtools extension, and also with general usability of the new card form in Checkout

Reverts Automattic/wp-calypso#93703