### PR TITLE
Stripe: Enable network selector for CreditCardNumberField

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -1,5 +1,4 @@
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
-import { PaymentLogo } from '@automattic/wpcom-checkout';
 import { CardNumberElement } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -29,10 +28,7 @@ export default function CreditCardNumberField( {
 	const { __ } = useI18n();
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
-	const brand: string = useSelect(
-		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getBrand(),
-		[]
-	);
+
 	const { cardNumber: cardNumberError } = useSelect(
 		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getCardDataErrors(),
 		[]
@@ -71,6 +67,7 @@ export default function CreditCardNumberField( {
 					options={ {
 						style: stripeElementStyle,
 						disabled: isDisabled,
+						showIcon: true,
 					} }
 					onReady={ () => {
 						setIsStripeFullyLoaded( true );
@@ -79,7 +76,6 @@ export default function CreditCardNumberField( {
 						handleStripeFieldChange( input );
 					} }
 				/>
-				<PaymentLogo brand={ brand } />
 
 				{ cardNumberError && <StripeErrorMessage>{ cardNumberError }</StripeErrorMessage> }
 			</StripeFieldWrapper>


### PR DESCRIPTION
As described in the title, this PR simply sets the CreditCardNumberField's `showIcon` option to true, which will display the [card network selector](https://docs.stripe.com/js/elements_object/create_element?type=cardNumber#elements_create-options-showIcon) in the Stripe Element.

Related to https://github.com/Automattic/payments-shilling/issues/3015

## Testing Instructions

* Proxy from the cdg server
* Go to checkout, type in the following test card number `4000002500001001`
* The icon to the left of the card number should now be a dropdown and you should be able to select Cartes Bancaires
