### PR TITLE
Date Range Picker: Refactor the calendar to a standalone component

### DIFF
--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -1,5 +1,5 @@
 import moment, { Moment } from 'moment';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { DateUtils } from 'react-day-picker';
 import DatePicker from 'calypso/components/date-picker';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -23,31 +23,6 @@ interface DateRangePickerProps {
 const NO_DATE_SELECTED_VALUE = null;
 const noop = () => {};
 
-/**
- * Enforces that given date is within the bounds of the
- * range specified
- * @param  {import('moment').Moment}  date             momentJS instance
- * @param  {Object} options          date range
- * @param  {import('moment').Moment | Date}  options.dateFrom the start of the date range
- * @param  {import('moment').Moment | Date}  options.dateTo   the end of the date range
- * @returns {import('moment').Moment}                  the date clamped to be within the range
- */
-const clampDateToRange = (
-	date: Moment,
-	{ dateFrom, dateTo }: { dateFrom: MomentOrNull; dateTo: MomentOrNull }
-) => {
-	// Ensure endDate is within bounds of firstSelectableDate
-	if ( dateFrom && date.isBefore( dateFrom ) ) {
-		date = dateFrom;
-	}
-
-	if ( dateTo && date.isAfter( dateTo ) ) {
-		date = dateTo;
-	}
-
-	return date;
-};
-
 const DateRangePicker = ( {
 	firstSelectableDate,
 	lastSelectableDate,
@@ -58,61 +33,6 @@ const DateRangePicker = ( {
 	onDateRangeChange = noop,
 	numberOfMonths = 2,
 }: DateRangePickerProps ) => {
-	const [ focusedMonthCalendar, setFocusedMonthCalendar ] = useState< Date | undefined >(
-		focusedMonth
-	);
-
-	useEffect( () => {
-		const initStartEndDates = ( {
-			firstSelectableDate,
-			lastSelectableDate,
-			selectedStartDate,
-			selectedEndDate,
-		}: Partial< DateRangePickerProps > ) => {
-			// Define the date range that is selectable (ie: not disabled)
-			firstSelectableDate = firstSelectableDate ? moment( firstSelectableDate ) : null;
-			lastSelectableDate = lastSelectableDate ? moment( lastSelectableDate ) : null;
-
-			// Clamp start/end dates to ranges (if specified)
-			let startDate =
-				selectedStartDate == null
-					? NO_DATE_SELECTED_VALUE
-					: clampDateToRange( moment( selectedStartDate ), {
-							dateFrom: firstSelectableDate,
-							dateTo: lastSelectableDate,
-					  } );
-
-			let endDate =
-				selectedEndDate == null
-					? NO_DATE_SELECTED_VALUE
-					: clampDateToRange( moment( selectedEndDate ), {
-							dateFrom: firstSelectableDate,
-							dateTo: lastSelectableDate,
-					  } );
-
-			// Ensure start is before end otherwise flip the values
-			if ( startDate && endDate && endDate.isBefore( startDate ) ) {
-				// flip values via array destructuring (think about it...)
-				[ startDate, endDate ] = [ endDate, startDate ];
-			}
-			return [ startDate, endDate ];
-		};
-
-		const [ startDate, endDate ] = initStartEndDates( {
-			firstSelectableDate,
-			lastSelectableDate,
-			selectedStartDate,
-			selectedEndDate,
-		} );
-
-		// Set calendar focus to the start or end date
-		if ( startDate ) {
-			setFocusedMonthCalendar( startDate.toDate() );
-		} else if ( endDate ) {
-			setFocusedMonthCalendar( endDate.toDate() );
-		}
-	}, [ firstSelectableDate, lastSelectableDate, selectedStartDate, selectedEndDate ] );
-
 	/**
 	 * Converts a moment date to a native JS Date object
 	 * @param  {import('moment').Moment} momentDate a momentjs date object to convert
@@ -274,7 +194,7 @@ const DateRangePicker = ( {
 
 	return (
 		<DatePicker
-			calendarViewDate={ focusedMonthCalendar }
+			calendarViewDate={ focusedMonth }
 			calendarInitialDate={ momentDateToJsDate( calendarInitialDate ) }
 			rootClassNames={ rootClassNames }
 			modifiers={ modifiers }

--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -1,0 +1,326 @@
+import moment from 'moment';
+import React, { useState } from 'react';
+import { DateUtils } from 'react-day-picker';
+import DatePicker from 'calypso/components/date-picker';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+
+type DateType = Date | moment.Moment | null; //TODO: fix this
+
+interface DateRangePickerProps {
+	firstSelectableDate: DateType;
+	lastSelectableDate: DateType;
+	selectedStartDate?: DateType; //?
+	selectedEndDate: DateType; //?
+	moment: typeof moment;
+	onDateRangeChange?: ( startDate: DateType, endDate: DateType ) => void;
+	focusedMonthProp?: Date | null;
+}
+
+/**
+ * Module variables
+ */
+const NO_DATE_SELECTED_VALUE = null;
+const noop = () => {};
+
+/**
+ * Enforces that given date is within the bounds of the
+ * range specified
+ * @param  {import('moment').Moment}  date             momentJS instance
+ * @param  {Object} options          date range
+ * @param  {import('moment').Moment | Date}  options.dateFrom the start of the date range
+ * @param  {import('moment').Moment | Date}  options.dateTo   the end of the date range
+ * @returns {import('moment').Moment}                  the date clamped to be within the range
+ */
+const clampDateToRange = ( date, { dateFrom, dateTo } ) => {
+	// Ensure endDate is within bounds of firstSelectableDate
+	if ( dateFrom && date.isBefore( dateFrom ) ) {
+		date = dateFrom;
+	}
+
+	if ( dateTo && date.isAfter( dateTo ) ) {
+		date = dateTo;
+	}
+
+	return date;
+};
+
+const initStartEndDates = ( {
+	firstSelectableDate,
+	lastSelectableDate,
+	selectedStartDate,
+	selectedEndDate,
+}: Partial< DateRangePickerProps > ) => {
+	// Define the date range that is selectable (ie: not disabled)
+	firstSelectableDate = firstSelectableDate && moment( firstSelectableDate );
+	lastSelectableDate = lastSelectableDate && moment( lastSelectableDate );
+
+	// Clamp start/end dates to ranges (if specified)
+	let startDate =
+		selectedStartDate == null
+			? NO_DATE_SELECTED_VALUE
+			: clampDateToRange( moment( selectedStartDate ), {
+					dateFrom: firstSelectableDate,
+					dateTo: lastSelectableDate,
+			  } );
+
+	let endDate =
+		selectedEndDate == null
+			? NO_DATE_SELECTED_VALUE
+			: clampDateToRange( moment( selectedEndDate ), {
+					dateFrom: firstSelectableDate,
+					dateTo: lastSelectableDate,
+			  } );
+
+	// Ensure start is before end otherwise flip the values
+	if ( startDate && endDate && endDate.isBefore( startDate ) ) {
+		// flip values via array destructuring (think about it...)
+		[ startDate, endDate ] = [ endDate, startDate ];
+	}
+	return [ startDate, endDate ];
+};
+
+const DateRangePicker = ( {
+	firstSelectableDate,
+	lastSelectableDate,
+	selectedStartDate,
+	selectedEndDate,
+	moment,
+	focusedMonthProp = null,
+	onDateRangeChange = noop,
+}: DateRangePickerProps ) => {
+	const [ initialStartDate, initialEndDate ] = initStartEndDates( {
+		firstSelectableDate,
+		lastSelectableDate,
+		selectedStartDate,
+		selectedEndDate,
+	} );
+	// const [ startDate, setStartDate ] = useState< DateType >( initialStartDate );
+	// const [ endDate, setEndDate ] = useState< DateType >( initialEndDate );
+	const [ focusedMonth, setFocusedMonth ] = useState< DateType >( focusedMonthProp );
+	const [ staleStartDate, setStaleStartDate ] = useState< DateType >( null );
+	const [ staleEndDate, setStaleEndDate ] = useState< DateType >( null );
+	const [ staleDatesSaved, setStaleDatesSaved ] = useState( false );
+
+	// this needs to be independent from startDate because we must independently validate them
+	// before updating the central source of truth (ie: startDate)
+	// textInputStartDate: this.toDateString( startDate ),
+	// textInputEndDate: this.toDateString( endDate ),
+	// initialStartDate: startDate, // cache values in case we need to reset to them
+	// initialEndDate: endDate, // cache values in case we need to reset to them
+	// focusedMonth: this.props.focusedMonth,
+
+	/**
+	 * Converts a moment date to a native JS Date object
+	 * @param  {import('moment').Moment} momentDate a momentjs date object to convert
+	 * @returns {Date}            the converted JS Date object
+	 */
+	function momentDateToJsDate( momentDate ) {
+		return moment.isMoment( momentDate ) ? momentDate.toDate() : momentDate;
+	}
+
+	/**
+	 * 	Gets the locale appropriate date format (eg: "MM/DD/YYYY")
+	 * @returns {string} date format as a string
+	 */
+	const getLocaleDateFormat = () => {
+		return moment.localeData().longDateFormat( 'L' );
+	};
+
+	const isValidDate = ( date ) => {
+		const epoch = moment( '01/01/1970', getLocaleDateFormat() );
+
+		// By default check
+		// 1. Looks like a valid date
+		// 2. after 01/01/1970 (avoids bugs when really stale dates are treated as valid)
+		if ( ! date.isValid() || ! date.isSameOrAfter( epoch ) ) {
+			return false;
+		}
+
+		// Check not before the first selectable date
+		// https://momentjs.com/docs/#/query/is-same-or-before/
+		if ( firstSelectableDate && date.isBefore( firstSelectableDate ) ) {
+			return false;
+		}
+
+		// Check not before the last selectable date
+		// https://momentjs.com/docs/#/query/is-same-or-before/
+		if ( lastSelectableDate && date.isAfter( lastSelectableDate ) ) {
+			return false;
+		}
+
+		return true;
+	};
+
+	/**
+	 * Converts moment dates to a DateRange
+	 * as required by Day Picker DateUtils
+	 * @param  {import('moment').Moment} startDate the start date for the range
+	 * @param  {import('moment').Moment} endDate   the end date for the range
+	 * @returns {Object}           the date range object
+	 */
+	const toDateRange = ( startDate, endDate ) => {
+		return {
+			from: momentDateToJsDate( startDate ),
+			to: momentDateToJsDate( endDate ),
+		};
+	};
+
+	/**
+	 * Converts a native JS Date object to a MomentJS Date object
+	 * @param  {Date} nativeDate date to be converted
+	 * @returns {import('moment').Moment}            the converted Date
+	 */
+	const nativeDateToMoment = ( nativeDate ) => {
+		return moment( nativeDate );
+	};
+
+	/**
+	 * Formats a given date to the appropriate format for the
+	 * current locale
+	 * @param  {import('moment').Moment | Date} date the date to be converted
+	 * @returns {string}      the date as a formatted locale string
+	 */
+	const formatDateToLocale = ( date ) => {
+		return moment( date ).format( 'L' );
+	};
+
+	/**
+	 * Converts date-like object to a string suitable
+	 * for display in a text input. Also converts
+	 * to locale appropriate format.
+	 * @param  {import('moment').Moment | Date} date the date for conversion
+	 * @returns {string}      the date expressed as a locale appropriate string or if null
+	 *                       then returns the locale format (eg: MM/DD/YYYY)
+	 */
+	const toDateString = ( date ) => {
+		if ( moment.isMoment( date ) || moment.isDate( date ) ) {
+			return formatDateToLocale( moment( date ) );
+		}
+
+		return getLocaleDateFormat(); // "MM/DD/YYY" or locale equivalent
+	};
+
+	/**
+	 * Handles selection (only) of new dates persisting
+	 * the values to state. Note that if the user does not
+	 * commit the dates (eg: clicking "Apply") then the `revertDates`
+	 * method is triggered which restores the previous ("stale") dates.
+	 *
+	 * Dates are only persisted via the commitDates method.
+	 * @param  {import('moment').Moment} date the newly selected date object
+	 */
+	const selectDate = ( date ) => {
+		if ( ! isValidDate( date ) ) {
+			return;
+		}
+
+		// DateUtils requires a range object with this shape
+		const range = toDateRange( selectedStartDate, selectedEndDate );
+
+		const rawDay = momentDateToJsDate( date );
+
+		// Calculate the new Date range
+		const newRange = DateUtils.addDayToRange( rawDay, range );
+
+		// Update to date or `null` which means "not date"
+		const newStartDate =
+			newRange.from === null ? NO_DATE_SELECTED_VALUE : nativeDateToMoment( newRange.from );
+		const newEndDate =
+			newRange.to === null ? NO_DATE_SELECTED_VALUE : nativeDateToMoment( newRange.to );
+
+		// For first date selection only: "cache" previous dates
+		// just in case user doesn't "Apply" and we need to revert
+		// to the original dates
+		if ( ! staleDatesSaved ) {
+			setStaleStartDate( selectedStartDate );
+			setStaleEndDate( selectedEndDate );
+			setStaleDatesSaved( true ); // marks that we have saved stale dates
+		}
+		// setStartDate( newStartDate );
+		// setEndDate( newEndDate );
+
+		onDateRangeChange( newStartDate, newEndDate );
+	};
+
+	const getNumberOfMonths = () => {
+		return window.matchMedia( '(min-width: 480px)' ).matches ? 2 : 1;
+	};
+
+	/**
+	 * Builds an appropriate disabledDays prop for DatePicker
+	 * based on firstSelectableDate and lastSelectableDate
+	 * config props
+	 *
+	 * See:
+	 * http://react-day-picker.js.org/api/DayPicker/#disabledDays
+	 * http://react-day-picker.js.org/docs/matching-days
+	 * @returns {Array} configuration to be passed to DatePicker as disabledDays prop
+	 */
+	const getDisabledDaysConfig = () => {
+		const config: { before?: Date; after?: Date } = {};
+
+		if ( firstSelectableDate ) {
+			config.before = momentDateToJsDate( firstSelectableDate ); // disable all days before today
+		}
+
+		if ( lastSelectableDate ) {
+			config.after = momentDateToJsDate( lastSelectableDate ); // disable all days before today
+		}
+
+		// Requires a wrapping Array
+		return [ config ];
+	};
+
+	const fromDate = momentDateToJsDate( selectedStartDate );
+	const toDate = momentDateToJsDate( selectedEndDate );
+
+	// Add "Range" modifier classes to Day component
+	// within Date Picker to aid "range" styling
+	// http://react-day-picker.js.org/api/DayPicker/#modifiers
+	const modifiers = {
+		start: fromDate,
+		end: toDate,
+		'range-start': fromDate,
+		'range-end': toDate,
+		range: {
+			from: fromDate,
+			to: toDate,
+		},
+	};
+
+	// Dates to be "selected" in Picker
+	const selected = [
+		fromDate,
+		{
+			from: fromDate,
+			to: toDate,
+		},
+	];
+
+	const rootClassNames = {
+		'date-range__picker': true,
+	};
+
+	const calendarInitialDate =
+		firstSelectableDate ||
+		( lastSelectableDate && moment( lastSelectableDate ).subtract( 1, 'month' ) ) ||
+		selectedStartDate;
+
+	return (
+		<DatePicker
+			calendarViewDate={ focusedMonth }
+			calendarInitialDate={ momentDateToJsDate( calendarInitialDate ) ?? null }
+			rootClassNames={ rootClassNames }
+			modifiers={ modifiers }
+			showOutsideDays={ false }
+			fromMonth={ momentDateToJsDate( firstSelectableDate ) }
+			toMonth={ momentDateToJsDate( lastSelectableDate ) }
+			onSelectDay={ selectDate }
+			selectedDays={ selected }
+			numberOfMonths={ getNumberOfMonths() }
+			disabledDays={ getDisabledDaysConfig() }
+		/>
+	);
+};
+
+export default withLocalizedMoment( DateRangePicker );

--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -157,14 +157,14 @@ const DateRangePicker = ( {
 		return [ config ];
 	};
 
-	const fromDate = momentDateToJsDate( selectedStartDate );
-	const toDate = momentDateToJsDate( selectedEndDate );
-
 	useEffect( () => {
-		if ( selectedStartDate && selectedEndDate && selectedStartDate.isAfter() ) {
-			onDateRangeChange( selectedEndDate, selectedStartDate );
+		if ( selectedStartDate && selectedEndDate && selectedStartDate.isAfter( selectedEndDate ) ) {
+			onDateRangeChange?.( selectedEndDate, selectedStartDate );
 		}
 	}, [ selectedStartDate?.format(), selectedEndDate?.format() ] );
+
+	const fromDate = momentDateToJsDate( selectedStartDate );
+	const toDate = momentDateToJsDate( selectedEndDate );
 
 	// Add "Range" modifier classes to Day component
 	// within Date Picker to aid "range" styling

--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -14,6 +14,7 @@ interface DateRangePickerProps {
 	moment: typeof moment;
 	onDateRangeChange?: ( startDate: DateType, endDate: DateType ) => void;
 	focusedMonthProp?: Date | null;
+	numberOfMonths?: number;
 }
 
 /**
@@ -87,6 +88,7 @@ const DateRangePicker = ( {
 	moment,
 	focusedMonthProp = null,
 	onDateRangeChange = noop,
+	numberOfMonths = 2,
 }: DateRangePickerProps ) => {
 	const [ initialStartDate, initialEndDate ] = initStartEndDates( {
 		firstSelectableDate,
@@ -185,22 +187,6 @@ const DateRangePicker = ( {
 	};
 
 	/**
-	 * Converts date-like object to a string suitable
-	 * for display in a text input. Also converts
-	 * to locale appropriate format.
-	 * @param  {import('moment').Moment | Date} date the date for conversion
-	 * @returns {string}      the date expressed as a locale appropriate string or if null
-	 *                       then returns the locale format (eg: MM/DD/YYYY)
-	 */
-	const toDateString = ( date ) => {
-		if ( moment.isMoment( date ) || moment.isDate( date ) ) {
-			return formatDateToLocale( moment( date ) );
-		}
-
-		return getLocaleDateFormat(); // "MM/DD/YYY" or locale equivalent
-	};
-
-	/**
 	 * Handles selection (only) of new dates persisting
 	 * the values to state. Note that if the user does not
 	 * commit the dates (eg: clicking "Apply") then the `revertDates`
@@ -240,10 +226,6 @@ const DateRangePicker = ( {
 		// setEndDate( newEndDate );
 
 		onDateRangeChange( newStartDate, newEndDate );
-	};
-
-	const getNumberOfMonths = () => {
-		return window.matchMedia( '(min-width: 480px)' ).matches ? 2 : 1;
 	};
 
 	/**
@@ -317,7 +299,7 @@ const DateRangePicker = ( {
 			toMonth={ momentDateToJsDate( lastSelectableDate ) }
 			onSelectDay={ selectDate }
 			selectedDays={ selected }
-			numberOfMonths={ getNumberOfMonths() }
+			numberOfMonths={ numberOfMonths }
 			disabledDays={ getDisabledDaysConfig() }
 		/>
 	);

--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -1,5 +1,5 @@
 import moment, { Moment } from 'moment';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { DateUtils } from 'react-day-picker';
 import DatePicker from 'calypso/components/date-picker';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -159,6 +159,12 @@ const DateRangePicker = ( {
 
 	const fromDate = momentDateToJsDate( selectedStartDate );
 	const toDate = momentDateToJsDate( selectedEndDate );
+
+	useEffect( () => {
+		if ( selectedStartDate && selectedEndDate && selectedStartDate.isAfter() ) {
+			onDateRangeChange( selectedEndDate, selectedStartDate );
+		}
+	}, [ selectedStartDate?.format(), selectedEndDate?.format() ] );
 
 	// Add "Range" modifier classes to Day component
 	// within Date Picker to aid "range" styling

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -463,8 +463,8 @@ export class DateRange extends Component {
 					</div>
 					{ this.props.renderInputs( inputsProps ) }
 					<DateRangePicker
-						firstSelectableDate={ this.state.initialStartDate }
-						lastSelectableDate={ this.state.initialEndDate }
+						firstSelectableDate={ this.props.firstSelectableDate }
+						lastSelectableDate={ this.props.lastSelectableDate }
 						selectedStartDate={ this.state.startDate }
 						selectedEndDate={ this.state.endDate }
 						onDateRangeChange={ onDateRangeChange }

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -190,7 +190,7 @@ export class DateRange extends Component {
 		if ( isSameDate ) {
 			return;
 		}
-
+		// Should we juggle the dates more??
 		if ( ! this.state.startDate ) {
 			this.setState( {
 				startDate: date,

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -191,6 +191,13 @@ export class DateRange extends Component {
 			return;
 		}
 
+		if ( ! this.state.startDate ) {
+			this.setState( {
+				startDate: date,
+			} );
+			return;
+		}
+
 		this.setState( {
 			[ stateKey ]: date,
 		} );

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -5,8 +5,8 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { DateUtils } from 'react-day-picker';
-import DatePicker from 'calypso/components/date-picker';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import DateRangePicker from './date-range-picker';
 import DateRangeHeader from './header';
 import DateRangeInputs from './inputs';
 import DateRangeTrigger from './trigger';
@@ -591,6 +591,16 @@ export class DateRange extends Component {
 			onInputFocus: this.handleInputFocus,
 		};
 
+		const onDateRangeChange = ( startDate, endDate ) => {
+			this.setState( {
+				startDate,
+				endDate,
+				textInputStartDate: this.toDateString( startDate ),
+				textInputEndDate: this.toDateString( endDate ),
+			} );
+			this.props.onDateSelect && this.props.onDateSelect( startDate, endDate );
+		};
+
 		return (
 			<Popover
 				className="date-range__popover"
@@ -605,67 +615,16 @@ export class DateRange extends Component {
 						{ this.renderDateHelp() }
 					</div>
 					{ this.props.renderInputs( inputsProps ) }
-					{ this.renderDatePicker() }
+					<DateRangePicker
+						firstSelectableDate={ this.state.initialStartDate }
+						lastSelectableDate={ this.state.initialEndDate }
+						selectedStartDate={ this.state.startDate }
+						selectedEndDate={ this.state.endDate }
+						onDateRangeChange={ onDateRangeChange }
+						focusedMonthProp={ this.state.focusedMonth }
+					/>
 				</div>
 			</Popover>
-		);
-	}
-
-	/**
-	 * Renders the DatePicker component
-	 * @returns {import('react').Element} the DatePicker component
-	 */
-	renderDatePicker() {
-		const fromDate = this.momentDateToJsDate( this.state.startDate );
-		const toDate = this.momentDateToJsDate( this.state.endDate );
-
-		// Add "Range" modifier classes to Day component
-		// within Date Picker to aid "range" styling
-		// http://react-day-picker.js.org/api/DayPicker/#modifiers
-		const modifiers = {
-			start: fromDate,
-			end: toDate,
-			'range-start': fromDate,
-			'range-end': toDate,
-			range: {
-				from: fromDate,
-				to: toDate,
-			},
-		};
-
-		// Dates to be "selected" in Picker
-		const selected = [
-			fromDate,
-			{
-				from: fromDate,
-				to: toDate,
-			},
-		];
-
-		const rootClassNames = {
-			'date-range__picker': true,
-		};
-
-		const calendarInitialDate =
-			this.props.firstSelectableDate ||
-			( this.props.lastSelectableDate &&
-				moment( this.props.lastSelectableDate ).subtract( 1, 'month' ) ) ||
-			this.state.startDate;
-
-		return (
-			<DatePicker
-				calendarViewDate={ this.state.focusedMonth }
-				calendarInitialDate={ this.momentDateToJsDate( calendarInitialDate ) ?? null }
-				rootClassNames={ rootClassNames }
-				modifiers={ modifiers }
-				showOutsideDays={ false }
-				fromMonth={ this.momentDateToJsDate( this.props.firstSelectableDate ) }
-				toMonth={ this.momentDateToJsDate( this.props.lastSelectableDate ) }
-				onSelectDay={ this.onSelectDate }
-				selectedDays={ selected }
-				numberOfMonths={ this.getNumberOfMonths() }
-				disabledDays={ this.getDisabledDaysConfig() }
-			/>
 		);
 	}
 

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -191,11 +191,9 @@ export class DateRange extends Component {
 			return;
 		}
 
-		// this.onSelectDate( date );//????
-		// TODO!!
-		// this.setState({
-
-		// });
+		this.setState( {
+			[ stateKey ]: date,
+		} );
 	};
 
 	/**

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -468,7 +468,7 @@ export class DateRange extends Component {
 						selectedStartDate={ this.state.startDate }
 						selectedEndDate={ this.state.endDate }
 						onDateRangeChange={ onDateRangeChange }
-						focusedMonthProp={ this.state.focusedMonth }
+						focusedMonth={ this.state.focusedMonth }
 						numberOfMonths={ this.getNumberOfMonths() }
 					/>
 				</div>


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/159

## Proposed Changes

* Extract date range picker to a standalone component
* Add typing for the component

## Why are these changes being made?

* Make the date range picker reusable

## Testing Instructions

* Run Jetpack Cloud locally `yarn start-jetpack-cloud`
* Open a site on Jetpack cloud with Complete plan `http://jetpack.cloud.localhost:3000/activity-log/:siteSlug`
* Open live env along side `https://cloud.jetpack.com/activity-log/:siteSlug`
* Ensure the date range picker still works as it does on live

<img width="843" alt="image" src="https://github.com/user-attachments/assets/0127e92c-5ce7-4378-9d72-ad822ac92cc1">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


cc @annacmc 
