### PR TITLE
Point "Edit Profile" to profile.php when Site-Level Profile is enabled

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -462,6 +462,10 @@ class MasterbarLoggedIn extends Component {
 
 	renderProfileMenu() {
 		const { translate, user, siteUrl, isClassicView } = this.props;
+		const editProfileLink =
+			config.isEnabled( 'layout/site-level-user-profile' ) || isClassicView
+				? siteUrl + '/wp-admin/profile.php'
+				: '/me';
 		const profileActions = [
 			{
 				label: (
@@ -478,10 +482,7 @@ class MasterbarLoggedIn extends Component {
 						</div>
 					</div>
 				),
-				url:
-					config.isEnabled( 'layout/site-level-user-profile' ) || isClassicView
-						? siteUrl + '/wp-admin/profile.php'
-						: '/me',
+				url: editProfileLink,
 			},
 			{
 				label: translate( 'My Account' ),
@@ -499,7 +500,7 @@ class MasterbarLoggedIn extends Component {
 		return (
 			<Item
 				tipTarget="me"
-				url="/me"
+				url={ editProfileLink }
 				onClick={ this.clickMe }
 				isActive={ this.isActive( 'me', true ) }
 				className="masterbar__item-howdy"

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -478,7 +478,10 @@ class MasterbarLoggedIn extends Component {
 						</div>
 					</div>
 				),
-				url: isClassicView ? siteUrl + '/wp-admin/profile.php' : '/me',
+				url:
+					config.isEnabled( 'layout/site-level-user-profile' ) || isClassicView
+						? siteUrl + '/wp-admin/profile.php'
+						: '/me',
 			},
 			{
 				label: translate( 'My Account' ),

--- a/config/development.json
+++ b/config/development.json
@@ -127,7 +127,7 @@
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
-		"layout/site-level-user-profile": false,
+		"layout/site-level-user-profile": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": true,
 		"livechat_solution": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 
- https://github.com/Automattic/dotcom-forge/issues/8697
- https://github.com/Automattic/jetpack/pull/39091

## Proposed Changes

This PR points "Edit Profile" and "Howdy, .." to profile.php for Simple Default sites when Site-Level Profile is enabled.

<img width="271" alt="Screenshot 2024-08-29 at 15 42 15" src="https://github.com/user-attachments/assets/829b78dd-ee37-4382-876c-7c2a1acfe453">

| before link | after link |
|--------|--------|
| /me | <site>/wp-admin/profile.php | 

This PR complements the implementation of the site front-end: https://github.com/Automattic/jetpack/pull/39091.

With these changes, profile links should follow the simple rule; 

- point to /me when the user is not a member of the site
- point to profile.php when the user is a member of the site

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When the SIte Level Profile is shipped, those links should follow the above rule. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live
* Prepare an account (**Account A**)
	* Prepare a Simple Default site or an Atomic Default site
	* Set `wpcom_site_level_user_profile=1` to the site
		* Simple Default: `switch_to_blog($blog_id)` & `update_option("wpcom_site_level_user_profile", 1)`
		* Atomic Default: Open _cli and `wp option update wpcom_site_level_user_profile 1`
	* Patch this PR: https://github.com/Automattic/jetpack/pull/39091#issuecomment-2311848884
	* Confirm that the links point to profile.php both in wp-admin and Calypso
* Prepare another account (**Account B**)
	* Go to the frontend of the site with **Account B**
	* Confirm that the links point to /me both in wp-admin and Calypso (On Atomic Default, there should be no Edit Profile menu)
* Invite Account B to the site
	* Go to the frontend of the site with **Account B**
	* Confirm that the links point to profile.php both in wp-admin and Calypso
* [optional regression testing] Test the following combinations as much as possible

|Type|Admin<br>interface|Is user<br>member of site|Before|After|
|-|-|-|-|-|
|Simple|Default|Yes|`/me?origin_site=xxx`|`profile.php`|
|Simple|Default|No|`/me`|(no change)|
|Simple|Classic|Yes|`profile.php`|(no change)|
|Simple|Classic|No|`/me`|(no change)|
|Atomic|Default|Yes|`/me?origin_site=xxx`|`profile.php`|
|Atomic|Default|No|(no Edit Profile menu)|(no change)|
|Atomic|Classic|Yes|`profile.php`|(no change)|
|Atomic|Classic|No|(no Edit Profile menu)|(no change)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
