### PR TITLE
Campaign Search Input error

### DIFF
--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -44,7 +44,7 @@ const SORT_OPTIONS_CLICKS_LOW_HIGH = 'clicks_total|asc';
 const SORT_OPTIONS_CREATED_AT = 'created_at';
 
 export const SORT_OPTIONS_DEFAULT = {
-	orderBy: SORT_OPTIONS_BY_TITLE,
+	orderBy: SORT_OPTIONS_LAST_PUBLISHED,
 	order: 'desc',
 };
 

--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -32,8 +32,7 @@ export type DropdownOption = {
 };
 
 const SORT_OPTIONS_BY_TITLE = 'post_title';
-const SORT_OPTIONS_LAST_PUBLISHED = 'date';
-
+const SORT_OPTIONS_LAST_PUBLISHED = 'post_date';
 const SORT_OPTIONS_RECENTLY_UPDATED = 'modified';
 const SORT_OPTIONS_MOST_LIKED = 'like_count';
 const SORT_OPTIONS_MOST_COMMENTED = 'comment_count';

--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -33,6 +33,7 @@ export type DropdownOption = {
 
 const SORT_OPTIONS_BY_TITLE = 'post_title';
 const SORT_OPTIONS_LAST_PUBLISHED = 'date';
+
 const SORT_OPTIONS_RECENTLY_UPDATED = 'modified';
 const SORT_OPTIONS_MOST_LIKED = 'like_count';
 const SORT_OPTIONS_MOST_COMMENTED = 'comment_count';

--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -44,7 +44,7 @@ const SORT_OPTIONS_CLICKS_LOW_HIGH = 'clicks_total|asc';
 const SORT_OPTIONS_CREATED_AT = 'created_at';
 
 export const SORT_OPTIONS_DEFAULT = {
-	orderBy: SORT_OPTIONS_LAST_PUBLISHED,
+	orderBy: SORT_OPTIONS_BY_TITLE,
 	order: 'desc',
 };
 

--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -32,7 +32,7 @@ export type DropdownOption = {
 };
 
 const SORT_OPTIONS_BY_TITLE = 'post_title';
-const SORT_OPTIONS_LAST_PUBLISHED = 'post_date';
+const SORT_OPTIONS_LAST_PUBLISHED = 'date';
 const SORT_OPTIONS_RECENTLY_UPDATED = 'modified';
 const SORT_OPTIONS_MOST_LIKED = 'like_count';
 const SORT_OPTIONS_MOST_COMMENTED = 'comment_count';
@@ -204,7 +204,7 @@ export default function SearchBar( props: Props ) {
 		setSearchInput( search );
 		handleSetSearch( {
 			search: search,
-			order: sortOption,
+			order: mode === 'posts' ? sortOption : campaignSortOption,
 			filter: filterOption,
 		} );
 	};


### PR DESCRIPTION
related to tumblr dsp ticket 1255

## Proposed Changes

this is a duplicate of https://github.com/Automattic/wp-calypso/pull/93920/
please check the above link for details 


this task was a bit more complex than I thought.. changing the value from `date` to 'post_date` simply broke the posts page 

investigating more I figured out that we actually have 2 endpoints that we consume to bring search results

https://public-api.wordpress.com/wpcom/v2/sites/47799514/blaze/posts?page=1&title=sdfsfs&order_by=date&order=desc&_envelope=1

this is the endpoint for the posts page (where a user can check their posts and click to promote them) and this endpoint is expecting date (not post_date - and this is the reason why the tests were failing)

then we have this one

https://public-api.wordpress.com/wpcom/v2/sites/47799514/wordads/dsp/api/v1/search/campaigns/site/47799514?page=1&title=sdfsdfsdfsdfsf&order=desc&order_by=date&_envelope=1

where order_by should not be date but post_date.

trying to figure this out I noticed that we use the same sorting values for both the campaigns and posts page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

Please test this PR thorogly as it is more complex than I first imagined..

1. checkout the branch (or visit the preview link) 
2. go to advertising page. in the posts view.. ensure that everything is loading ok
3. try to search by using the search bar and check the network that everything loads (and the queries are what is expected)
4. go to the campaign view. ensure that everything is loading ok
5. search by using the search bar and check the network.. ensure that everything is loading and that the query is what is expected)
you are it


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?