### PR TITLE
Fix broken badge and text in migration flow step in mobile view

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
@@ -4,6 +4,10 @@
 .import-or-migrate {
 	max-width: 602px;
 
+	&.site-migration-import-or-migrate .step-container__header {
+		padding: 25px;
+	}
+
 	.onboarding-title {
 		font-size: 2.75rem;
 		text-align: center;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
@@ -4,8 +4,8 @@
 .import-or-migrate {
 	max-width: 602px;
 
-	&.site-migration-import-or-migrate .step-container__header {
-		padding: 25px;
+	&.site-migration-import-or-migrate.step-container .step-container__header {
+		padding: 36px;
 	}
 
 	.onboarding-title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
@@ -3,7 +3,6 @@
 
 .import-or-migrate {
 	max-width: 602px;
-	padding: 0 12px;
 
 	.onboarding-title {
 		font-size: 2.75rem;
@@ -29,6 +28,12 @@
 
 		.flow-question {
 			max-width: none;
+			margin: 0 0 18px;
+			&__heading {
+				flex-wrap: wrap-reverse;
+				min-width: min-content;
+				white-space: nowrap;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93927

## Proposed Changes

When going through the migration flow in the mobile view, the text and the badge in the "Migrate Site" button looks broken. We've fixed the design so that it looks good in all screen sizes. A broken design in migration flow can potentially give a negative impression to a user on the way to conversion.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix broken text in mobile views

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Start the flow from `calypso.localhost:3000/start`
- Go through the domain selection step
- Select the free plan on the Plans page
- On the Goals step, select the "Import existing content or website" option and click continue
- Input the source site URL in the Identify step
- You should reach the "What do you want to do?" (import or migrate) step
- Check the page in all screen sizes

### iPhone 13/14/15 Pro
<img width="513" alt="Screenshot 2024-08-27 at 1 24 08 PM" src="https://github.com/user-attachments/assets/7bf03fc0-0f09-4eef-9608-9dd29e3e57c6">

### iPhone 13/14/15 Pro Max
<img width="513" alt="Screenshot 2024-08-27 at 1 25 28 PM" src="https://github.com/user-attachments/assets/3cc727b8-e06c-4287-8af3-df1589fcd5d1">

### Bigger screens (Shouldn't see any change)
<img width="767" alt="Screenshot 2024-08-27 at 1 32 31 PM" src="https://github.com/user-attachments/assets/bb197b2c-01ce-4a27-992d-80cc77951e92">


### Before
<img width="654" alt="Screenshot 2024-08-27 at 1 40 12 AM" src="https://github.com/user-attachments/assets/5e82d495-0286-4071-a81a-54aa9c417b47">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
