### PR TITLE
Stepper: Apply extended props to `calypso_signup_start`. Update `tailored-ecommerce` flow

### DIFF
--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -38,7 +38,7 @@ To create a flow, you only have to implement `useSteps` and `useStepNavigation`.
 
 There is also an optional `useSideEffect` hook. You can implement this hook to run any side-effects to the flow. You can prefetch information, send track events when something changes, etc...
 
-There is a required `isSignupFlow` flag that _MUST be `true` for signup flows_ (generally where a new site may be created), and should be `false` for other flows. The `isSignupFlow` flag controls whether we'll trigger a `calypso_signup_start` Tracks event when the flow starts. For signup flows, you can also supply additional event props to the `calypso_signup_start` event by implementing the optional `useSignupStartEventProps()` hook on the flow.
+There is a required `isSignupFlow` flag that _MUST be `true` for signup flows_ (generally where a new site may be created), and should be `false` for other flows. The `isSignupFlow` flag controls whether we'll trigger a `calypso_signup_start` Tracks event when the flow starts. For signup flows, you can also supply additional event props to the `calypso_signup_start` event by implementing the optional `useTracksEventProps()` hook on the flow.
 
 ```tsx
 // prettier-ignore

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import recordSignupStart from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-signup-start';
+import useSnakeCasedKeys from 'calypso/landing/stepper/utils/use-snake-cased-keys';
 import { adTrackSignupStart } from 'calypso/lib/analytics/ad-tracking';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { setSignupStartTime } from 'calypso/signup/storageUtils';

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -19,12 +19,10 @@ export const useSignUpStartTracking = ( { flow }: Props ) => {
 	const [ queryParams ] = useSearchParams();
 	const ref = queryParams.get( 'ref' ) || '';
 	const flowName = flow.name;
+	const flowVariant = flow.variantSlug;
 	const isSignupFlow = flow.isSignupFlow;
-	const extraProps = useSnakeCasedKeys( {
-		input: {
-			flowVariant: flow.variantSlug,
-			...flow.useTracksEventProps?.()[ STEPPER_TRACKS_EVENT_SIGNUP_START ],
-		},
+	const signupStartEventProps = useSnakeCasedKeys( {
+		input: flow.useTracksEventProps?.()[ STEPPER_TRACKS_EVENT_SIGNUP_START ],
 	} );
 
 	/**
@@ -50,6 +48,13 @@ export const useSignUpStartTracking = ( { flow }: Props ) => {
 			return;
 		}
 
-		recordSignupStart( { flow: flowName, ref, optionalProps: extraProps || {} } );
-	}, [ isSignupFlow, flowName, ref, extraProps ] );
+		recordSignupStart( {
+			flow: flowName,
+			ref,
+			optionalProps: {
+				...signupStartEventProps,
+				...( flowVariant && { flow_variant: flowVariant } ),
+			},
+		} );
+	}, [ isSignupFlow, flowName, ref, signupStartEventProps, flowVariant ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { STEPPER_TRACKS_EVENT_SIGNUP_START } from 'calypso/landing/stepper/constants';
 import recordSignupStart from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-signup-start';
 import useSnakeCasedKeys from 'calypso/landing/stepper/utils/use-snake-cased-keys';
 import { adTrackSignupStart } from 'calypso/lib/analytics/ad-tracking';

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import recordSignupStart from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-signup-start';
 import { adTrackSignupStart } from 'calypso/lib/analytics/ad-tracking';
@@ -16,17 +16,14 @@ interface Props {
 export const useSignUpStartTracking = ( { flow }: Props ) => {
 	const [ queryParams ] = useSearchParams();
 	const ref = queryParams.get( 'ref' ) || '';
-	const flowVariant = flow.variantSlug;
 	const flowName = flow.name;
 	const isSignupFlow = flow.isSignupFlow;
-	const signupStartEventProps = flow.useSignupStartEventProps?.();
-	const extraProps = useMemo(
-		() => ( {
-			...signupStartEventProps,
-			...( flowVariant && { flow_variant: flowVariant } ),
-		} ),
-		[ signupStartEventProps, flowVariant ]
-	);
+	const extraProps = useSnakeCasedKeys( {
+		input: {
+			flowVariant: flow.variantSlug,
+			...flow.useTracksEventProps?.()[ STEPPER_TRACKS_EVENT_SIGNUP_START ],
+		},
+	} );
 
 	/**
 	 * Timers and other analytics

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -135,7 +135,9 @@ describe( 'useSignUpTracking', () => {
 			const { rerender } = render( {
 				flow: {
 					...signUpFlow,
-					useSignupStartEventProps: () => ( { extra: 'props' } ),
+					useTracksEventProps: () => ( {
+						[ STEPPER_TRACKS_EVENT_SIGNUP_START ]: { extra: 'props' },
+					} ),
 				} satisfies Flow,
 			} );
 

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -10,6 +10,7 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { setSignupStartTime } from 'calypso/signup/storageUtils';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
 import { useSignUpStartTracking } from '../';
+import { STEPPER_TRACKS_EVENT_SIGNUP_START } from '../../../../../constants';
 import type { Flow, StepperStep } from '../../../types';
 
 const steps = [ { slug: 'step-1' }, { slug: 'step-2' } ] as StepperStep[];
@@ -86,7 +87,9 @@ describe( 'useSignUpTracking', () => {
 			render( {
 				flow: {
 					...signUpFlow,
-					useSignupStartEventProps: () => ( { extra: 'props' } ),
+					useTracksEventProps: () => ( {
+						[ STEPPER_TRACKS_EVENT_SIGNUP_START ]: { extra: 'props' },
+					} ),
 				} satisfies Flow,
 				queryParams: { ref: 'another-flow-or-cta' },
 			} );

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -138,8 +138,6 @@ export type Flow = {
 	 * Required flag to indicate if the flow is a signup flow.
 	 */
 	isSignupFlow: boolean;
-	useSignupStartEventProps?: () => Record< string, string | number >;
-
 	/**
 	 *  You can use this hook to configure the login url.
 	 * @returns An object describing the configuration.

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -7,6 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { ECOMMERCE_FLOW, ecommerceFlowRecurTypes } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
@@ -14,6 +15,7 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
+import { STEPPER_TRACKS_EVENT_SIGNUP_START } from '../constants';
 import { useSite } from '../hooks/use-site';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
@@ -46,13 +48,13 @@ function getPlanFromRecurType( recurType: string ) {
 const ecommerceFlow: Flow = {
 	name: ECOMMERCE_FLOW,
 	isSignupFlow: true,
-	useSignupStartEventProps() {
+	useTracksEventProps() {
 		const recur = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
 			[]
 		);
 
-		return { recur };
+		return useMemo( () => ( { [ STEPPER_TRACKS_EVENT_SIGNUP_START ]: { recur } } ), [ recur ] );
 	},
 	useSteps() {
 		const steps = [

--- a/client/landing/stepper/utils/test/use-snake-cased-keys.ts
+++ b/client/landing/stepper/utils/test/use-snake-cased-keys.ts
@@ -16,9 +16,31 @@ describe( 'useSnakeCasedKeys', () => {
 		expect( result.current ).toBe( previous );
 	} );
 
-	test( 'given an object with mixture of snake_cased/camelCased keys it will convert correctly', () => {
-		const input = { fooBar: 'fooBar', foo_not_bar: 'foo_not_bar', foo123: 'foo123' };
-		const expectedOutput = { foo_bar: 'fooBar', foo_not_bar: 'foo_not_bar', foo123: 'foo123' };
+	test( 'given fooBar it will convert correctly', () => {
+		const input = { fooBar: 'fooBar' };
+		const expectedOutput = { foo_bar: 'fooBar' };
+
+		const { result } = renderHook( ( params ) => useSnakeCasedKeys( params ), {
+			initialProps: { input },
+		} );
+
+		expect( result.current ).toEqual( expectedOutput );
+	} );
+
+	test( 'given foo_bar it will convert correctly', () => {
+		const input = { foo_bar: 'fooBar' };
+		const expectedOutput = { foo_bar: 'fooBar' };
+
+		const { result } = renderHook( ( params ) => useSnakeCasedKeys( params ), {
+			initialProps: { input },
+		} );
+
+		expect( result.current ).toEqual( expectedOutput );
+	} );
+
+	test( 'given foo123 it will convert correctly', () => {
+		const input = { foo123bar: 'fooBar' };
+		const expectedOutput = { foo_123_bar: 'fooBar' };
 
 		const { result } = renderHook( ( params ) => useSnakeCasedKeys( params ), {
 			initialProps: { input },

--- a/client/landing/stepper/utils/test/use-snake-cased-keys.ts
+++ b/client/landing/stepper/utils/test/use-snake-cased-keys.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import useSnakeCasedKeys from '../use-snake-cased-keys';
+
+describe( 'useSnakeCasedKeys', () => {
+	test( 'ensures reference equality given same input', () => {
+		const input = { fooBar: 'fooBar' };
+		const { result, rerender } = renderHook( ( params ) => useSnakeCasedKeys( params ), {
+			initialProps: { input },
+		} );
+		const previous = result.current;
+
+		rerender( { input } );
+		expect( result.current ).toBe( previous );
+	} );
+
+	test( 'given an object with mixture of snake_cased/camelCased keys it will convert correctly', () => {
+		const input = { fooBar: 'fooBar', foo_not_bar: 'foo_not_bar', foo123: 'foo123' };
+		const expectedOutput = { foo_bar: 'fooBar', foo_not_bar: 'foo_not_bar', foo123: 'foo123' };
+
+		const { result } = renderHook( ( params ) => useSnakeCasedKeys( params ), {
+			initialProps: { input },
+		} );
+
+		expect( result.current ).toEqual( expectedOutput );
+	} );
+} );

--- a/client/landing/stepper/utils/use-snake-cased-keys.ts
+++ b/client/landing/stepper/utils/use-snake-cased-keys.ts
@@ -1,0 +1,12 @@
+import { useMemo } from '@wordpress/element';
+import { convertToSnakeCase } from 'calypso/state/data-layer/utils';
+
+interface Params {
+	input?: Record< string, unknown >;
+}
+
+const useSnakeCasedKeys = ( { input }: Params ) => {
+	return useMemo( () => input && ( convertToSnakeCase( input ) as Params[ 'input' ] ), [ input ] );
+};
+
+export default useSnakeCasedKeys;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/94108

## Proposed Changes

- Updates usage of `useSignupStartEventProps` to be replaced by `useTracksEventProps`, as per intended use to cover all signup framework events.
- Updates Stepper event slugs with `STEPPER_TRACKS_EVENT_SIGNUP_START`
- Introduces a utility hook `useSnakeCasedKeys` to help pass props in their snake_cased form, allowing consuming end (flows) to work with camelCased variables.
  - This was motivated by similar logic happening in `recordSubmitStep` for the additional-props
  - It is still questionable whether we need this or whether this is the right place and form to define, or whether we could have a `recordTracksEvent` wrapper in Stepper that would do this instead. We can remove and not bother i.e. for the few rare cases where a flow needs to pass additional props, it can do it in snake_case form and so be it.

DO NOT MERGE - depended on ongoing discussions in https://github.com/Automattic/wp-calypso/issues/94175

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The `useSignupStartEventProps` prop/hook was defined for flows to extend the props recorded by `calypso_signup_start`. The newer hook `useTracksEventProps` was built to serve this need more generally (across all framework events, including `calypso_signup_start`).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure `calypso_signup_start` is recorded correctly for `isSignupFlow` flows
* Ensure `tailored-ecommerce` flow passes the `recur` prop to the `calypso_signup_start` Tracks event
* Ensure `flow_variant` is passed correctly for any sub/child flow to the `calypso_signup_start` Tracks event

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
