### PR TITLE
Server: Add noindex meta tags for /start/[sub-page] and /setup/*

### DIFF
--- a/client/landing/stepper/section.ts
+++ b/client/landing/stepper/section.ts
@@ -4,4 +4,5 @@ export const STEPPER_SECTION_DEFINITION = {
 	module: 'stepper',
 	group: 'stepper',
 	enableLoggedOut: false,
+	meta: [ { name: 'robots', content: 'noindex' } ], // The stepper pages should not be indexed. See 3065-gh-Automattic/martech.
 };

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -46,7 +46,8 @@ import getBootstrappedUser from 'calypso/server/user-bootstrap';
 import { createReduxStore } from 'calypso/state';
 import { LOCALE_SET } from 'calypso/state/action-types';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
-import { setDocumentHeadLink } from 'calypso/state/document-head/actions';
+import { setDocumentHeadLink, setDocumentHeadMeta } from 'calypso/state/document-head/actions';
+import { getDocumentHeadMeta } from 'calypso/state/document-head/selectors';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
 import { deserialize } from 'calypso/state/utils';
@@ -603,6 +604,12 @@ const setUpSectionContext = ( section, entrypoint ) => ( req, res, next ) => {
 
 	if ( Array.isArray( section.links ) ) {
 		section.links.forEach( ( link ) => req.context.store.dispatch( setDocumentHeadLink( link ) ) );
+	}
+
+	if ( Array.isArray( section.meta ) ) {
+		// Append section specific meta tags.
+		const meta = getDocumentHeadMeta( req.context.store.getState() ).concat( section.meta );
+		req.context.store.dispatch( setDocumentHeadMeta( meta ) );
 	}
 	next();
 };

--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -1,4 +1,6 @@
 import { getLanguage, getLanguageRouteParam } from '@automattic/i18n-utils';
+import { setDocumentHeadMeta } from 'calypso/state/document-head/actions';
+import { getDocumentHeadMeta } from 'calypso/state/document-head/selectors';
 
 export default function ( router ) {
 	const lang = getLanguageRouteParam();
@@ -10,7 +12,8 @@ export default function ( router ) {
 			`/start/:flowName/:stepName/${ lang }`,
 			`/start/:flowName/:stepName/:stepSectionName/${ lang }`,
 		],
-		setUpLocale
+		setUpLocale,
+		setupMetaTags
 	);
 }
 
@@ -19,6 +22,20 @@ function setUpLocale( context, next ) {
 	const language = getLanguage( context.params.lang );
 	if ( language ) {
 		context.lang = context.params.lang;
+	}
+
+	next();
+}
+
+// Set up meta tags.
+function setupMetaTags( context, next ) {
+	// All `/start/*` sub-pages should be noindex. See 3065-gh-Automattic/martech.
+	if ( ! /^\/start\/?$/.test( context.pathname ) ) {
+		const meta = getDocumentHeadMeta( context.store.getState() ).concat( {
+			name: 'robots',
+			content: 'noindex',
+		} );
+		context.store.dispatch( setDocumentHeadMeta( meta ) );
 	}
 
 	next();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 3065-gh-Automattic/martech

## Proposed Changes

* Handle meta tags from section definitions.
* Add `noindex` meta tag to the Stepper section definition.
* Add `noindex` meta tag for `/start` sub-pages using a middleware.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `/setup/*` and `/start/[sub-page]/*` routes should not be indexed to prevent cannibalizing traffic from the main `/start` page. See 3065-gh-Automattic/martech for more details.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code reveiw.
* Inspect the page source of any Stepper page, for example `/setup/link-in-bio` or `/setup/blog`, and verify the `<meta name="robots" content="noindex"/>` is present.
* Inspect the page source of any `/start/` sub-page, for example `/start/account` or `/start/domains` and verify the  `<meta name="robots" content="noindex"/>` is present.
* Inspect the source of the main `/start` page and verify the `<meta name="robots" content="noindex"/>` is **NOT** present.
* Test other server routes for regression.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
