### PR TITLE
desktop: Bump version to 8.0.4-beta3

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "8.0.4-beta2",
+	"version": "8.0.4-beta3",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/",


### PR DESCRIPTION
Routine PR to track the latest beta build for WordPress Desktop on `trunk`.

Reminder: The beta itself is distributed independently from this PR being merged. It depends on the `desktop-v8.0.4-beta3` tag. This PR is simply to ensure the version in `package.json` is up to date.