### PR TITLE
Notifications: convert linkInterceptor to thunk

### DIFF
--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -459,7 +459,7 @@ class Layout extends Component {
 			// element itself. There may be better ways to handle this, but
 			// let's disable eslint here for now to avoid refactoring older code.
 			// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-			<div onClick={ interceptLinks }>
+			<div onClick={ this.props.interceptLinks }>
 				{ this.props.error && <AppError error={ this.props.error } /> }
 
 				{ ! this.props.error && (
@@ -553,6 +553,7 @@ const mapDispatchToProps = {
 	selectNote: actions.ui.selectNote,
 	unselectNote: actions.ui.unselectNote,
 	enableKeyboardShortcuts: actions.ui.enableKeyboardShortcuts,
+	interceptLinks,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( Layout );

--- a/apps/notifications/src/panel/utils/link-interceptor.js
+++ b/apps/notifications/src/panel/utils/link-interceptor.js
@@ -1,5 +1,3 @@
-import { store } from '../state';
-
 const openLink = ( href, tracksEvent ) => ( { type: 'OPEN_LINK', href, tracksEvent } );
 const openSite = ( { siteId, href } ) => ( { type: 'OPEN_SITE', siteId, href } );
 const openPost = ( siteId, postId, href ) => ( { type: 'OPEN_POST', siteId, postId, href } );
@@ -11,11 +9,11 @@ const openComment = ( { siteId, postId, href, commentId } ) => ( {
 	commentId,
 } );
 
-export const interceptLinks = ( event ) => {
+export const interceptLinks = ( event ) => ( dispatch ) => {
 	const { target } = event;
 
 	if ( 'A' !== target.tagName && 'A' !== target.parentNode.tagName ) {
-		return true;
+		return;
 	}
 
 	const node = 'A' === target.tagName ? target : target.parentNode;
@@ -23,7 +21,7 @@ export const interceptLinks = ( event ) => {
 	const { linkType, postId, siteId, commentId, tracksEvent } = dataset;
 
 	if ( ! linkType ) {
-		return true;
+		return;
 	}
 
 	// we don't want to interfere with the click
@@ -31,23 +29,19 @@ export const interceptLinks = ( event ) => {
 	// normal behavior already by holding down
 	// one of the modifier keys.
 	if ( event.ctrlKey || event.metaKey ) {
-		return true;
+		return;
 	}
 
 	event.stopPropagation();
 	event.preventDefault();
 
 	if ( 'post' === linkType ) {
-		store.dispatch( openPost( siteId, postId, href ) );
+		dispatch( openPost( siteId, postId, href ) );
 	} else if ( 'comment' === linkType ) {
-		store.dispatch( openComment( { siteId, postId, href, commentId } ) );
+		dispatch( openComment( { siteId, postId, href, commentId } ) );
 	} else if ( 'site' === linkType ) {
-		store.dispatch( openSite( { siteId, href } ) );
+		dispatch( openSite( { siteId, href } ) );
 	} else {
-		store.dispatch( openLink( href, tracksEvent ) );
+		dispatch( openLink( href, tracksEvent ) );
 	}
-
-	return false;
 };
-
-export default interceptLinks;


### PR DESCRIPTION
Converts the `linkInterceptor` function to a Redux thunk, avoiding a direct import of `store`. The thunk will get the store from context instead. This removes one of the few remaining `store` imports.

**How to test:**
In the notifications panel, open some post or likes so that the slide-out panel is displayed:

<img width="497" alt="Screenshot 2024-08-27 at 13 14 35" src="https://github.com/user-attachments/assets/a9b773a9-2f1a-45fc-8994-96f433c50a44">

Under the people's names, there are links either to their posts or home sites. These are `<a href>` links that link to the site's URL, but when you click on them, the `linkInterceptor` opens the links in Reader instead. It uses the `data-link-type` and `data-site-id` and `data-post-id` HTML attributes to construct the right Reader URL.

Verify that this open-in-Reader functionality still works.