### PR TITLE
Fix Notifications UI broken by pre-formatted block 

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -787,6 +787,7 @@ $with-sidebar-min-page-width: 1114px;
 				border: 1px solid var(--color-neutral-10);
 				border-radius: 3px;
 				padding: 4px;
+				white-space: normal;
 
 				code {
 					border: none;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/93937

## Proposed Changes

* Add `white-space: normal` to the `wp-block-preformatted` to break the lines in notifications panel

|BEFORE|AFTER|
|-|-|
|<img width="428" alt="Screenshot 2567-08-27 at 18 37 20" src="https://github.com/user-attachments/assets/a5797878-7ada-4090-9ce0-199ee4072ff2">|<img width="540" alt="Screenshot 2567-08-27 at 16 35 57" src="https://github.com/user-attachments/assets/3fe157f7-5454-45aa-84e0-330ba2ff6782">|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix for Notifications UI broken by pre-formatted block 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Subscribe to a blog of another account
* Create a post with a pre-formatted block
```
<!-- wp:preformatted -->
<pre class="wp-block-preformatted"><strong>Name</strong>: Name<br><strong>Interview Date:</strong> August 26, 2024<br><strong>Memorable Quote:</strong> “It was this easy!” - Although she had setbacks understanding the features of blocks<br><strong>Persona:</strong> Complete beginner with no technical background.</pre>
<!-- /wp:preformatted -->
```
- Publish it
- Go to the Notification panel on the subscriber user account
- Verify the text in the pre-formatted block is completely displayed and the Notifications UI is not broken

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
