### PR TITLE
Update copy for connected domains

### DIFF
--- a/client/lib/domains/get-domain-type-text.js
+++ b/client/lib/domains/get-domain-type-text.js
@@ -23,11 +23,10 @@ export function getDomainTypeText(
 ) {
 	switch ( domain.type ) {
 		case domainTypes.MAPPED:
-			if ( context === domainInfoContext.PAGE_TITLE ) {
-				return __( 'Connected Domain' );
+			if ( domain.isSubdomain ) {
+				return __( 'Connected subdomain' );
 			}
-
-			return __( 'Registered with an external provider' );
+			return __( 'Connected domain' );
 
 		case domainTypes.REGISTERED:
 			if ( domain?.isPremium ) {

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -92,7 +92,10 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 		}
 
 		if ( type === DomainType.MAPPED ) {
-			return renderNeutralBadge( __( 'Registered with an external provider' ) );
+			if ( domain.isSubdomain ) {
+				return renderNeutralBadge( __( 'Connected subdomain' ) );
+			}
+			return renderNeutralBadge( __( 'Connected domain' ) );
 		}
 
 		return renderNeutralBadge( __( 'Domain Transfer' ) );

--- a/packages/domains-table/src/utils/get-domain-type-text.tsx
+++ b/packages/domains-table/src/utils/get-domain-type-text.tsx
@@ -11,11 +11,10 @@ export function getDomainTypeText(
 	const domainText = () => {
 		switch ( domain.type ) {
 			case domainTypes.MAPPED:
-				if ( context === domainInfoContext.PAGE_TITLE ) {
-					return __( 'Connected domain', __i18n_text_domain__ );
+				if ( domain.isSubdomain ) {
+					return __( 'Connected subdomain', __i18n_text_domain__ );
 				}
-
-				return __( 'Registered with an external provider', __i18n_text_domain__ );
+				return __( 'Connected domain', __i18n_text_domain__ );
 
 			case domainTypes.REGISTERED:
 				if ( domain?.isPremium ) {


### PR DESCRIPTION
## Proposed Changes

This PR updates the copy we used to show for connected domains/subdomains. 

![connected-domain-before](https://github.com/user-attachments/assets/98451d7e-2aea-4fd1-a6ce-520fb52021ec)
![connected-subadomain-before](https://github.com/user-attachments/assets/a41e1ce0-75b5-4cf0-b464-5d454391cb2d)
![connected-domain-after](https://github.com/user-attachments/assets/de0d0515-f416-47ff-8301-cf92f1b178d5)
![connected-subdomain-after](https://github.com/user-attachments/assets/00d494a4-2b9a-4081-860b-ee8b7bced5ed)

## Why are these changes being made?
Before this PR, we showed `Registered with an external provider`, even for subdomains which root domain was registered with us.

To simplify and avoid confusion, we decided to show a simpler label: Connected domain` (or `Connected subdomain`) 

## Testing Instructions
 Apply this patch and verify that the copy for connected domains/subdomains appears as in the screenshots above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
