### PR TITLE
Pie chart - make legend responsive

### DIFF
--- a/client/components/pie-chart/style.scss
+++ b/client/components/pie-chart/style.scss
@@ -93,6 +93,7 @@
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
+	flex-wrap: wrap;
 
 	.legend-item:not(:first-child) {
 		margin-top: 20px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#8086

## Proposed Changes

* Adds flex wrap property to the pie chart legend so that it wraps on mobile and doesn't bleed out of the parent element and content area.

BEFORE (mobile) - legend bleeds off page
<img width="428" alt="Screenshot 2024-08-27 at 9 38 09 AM" src="https://github.com/user-attachments/assets/c864beb3-b9df-4ccf-a1bd-163af81f9994">

BEFORE (mid-width) - chart widths are unbalanced to accomadate the wide legend.
<img width="985" alt="Screenshot 2024-08-27 at 9 37 29 AM" src="https://github.com/user-attachments/assets/702db777-d18c-4c07-9948-b8b99fa805e5">


AFTER (mobile) - legend wraps
<img width="513" alt="Screenshot 2024-08-27 at 9 38 05 AM" src="https://github.com/user-attachments/assets/922e3790-38c8-4a6b-a38a-d829a5edec77">

AFTER (mid-width) - chart widths are even and the legend wraps.
<img width="984" alt="Screenshot 2024-08-27 at 9 37 22 AM" src="https://github.com/user-attachments/assets/f2a3fcbd-cad3-4417-a69f-a436ada94297">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Indeed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/site-monitoring/  
* Look at the pie charts.
* Verify they look the same on desktop.
* Inspect dev tools and try various mobile device widths
* verify the legend wraps and does not break off the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
