### PR TITLE
Performance Profiler: Make tab header responsive

### DIFF
--- a/client/performance-profiler/components/header/index.tsx
+++ b/client/performance-profiler/components/header/index.tsx
@@ -29,6 +29,24 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 	const { url, activeTab, onTabChange, showNavigationTabs, timestamp, showWPcomBadge } = props;
 	const urlParts = new URL( url );
 
+	const renderTimestampAndBadge = () => (
+		<>
+			{ timestamp && (
+				<span>
+					{ translate( 'Tested on %(date)s', {
+						args: { date: moment( timestamp ).format( 'MMMM Do, YYYY h:mm:ss A' ) },
+					} ) }
+				</span>
+			) }
+			{ showWPcomBadge && (
+				<span className="wpcom-badge">
+					<img src={ WPcomBadge } alt={ translate( 'WordPress.com badge' ) } />
+					<span>{ translate( 'Hosted on WordPress.com' ) }</span>
+				</span>
+			) }
+		</>
+	);
+
 	return (
 		<div className="profiler-header">
 			<div className="l-block-wrapper">
@@ -46,19 +64,7 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 						</Button>
 					</div>
 					<div className="profiler-header__report-site-details show-on-mobile">
-						{ timestamp && (
-							<span>
-								{ translate( 'Tested on %(date)s', {
-									args: { date: moment( timestamp ).format( 'MMMM Do, YYYY h:mm:ss A' ) },
-								} ) }
-							</span>
-						) }
-						{ showWPcomBadge && (
-							<span className="wpcom-badge">
-								<img src={ WPcomBadge } alt={ translate( 'WordPress.com badge' ) } />
-								<span>{ translate( 'Hosted on WordPress.com' ) }</span>
-							</span>
-						) }
+						{ renderTimestampAndBadge() }
 					</div>
 				</div>
 				{ showNavigationTabs && (
@@ -82,19 +88,7 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 
 						<div className="profiler-header__navbar-right">
 							<div className="report-site-details hide-on-mobile">
-								{ timestamp && (
-									<span>
-										{ translate( 'Tested on %(date)s', {
-											args: { date: moment( timestamp ).format( 'MMMM Do, YYYY h:mm:ss A' ) },
-										} ) }
-									</span>
-								) }
-								{ showWPcomBadge && (
-									<span className="wpcom-badge">
-										<img src={ WPcomBadge } alt={ translate( 'WordPress.com badge' ) } />
-										<span>{ translate( 'Hosted on WordPress.com' ) }</span>
-									</span>
-								) }
+								{ renderTimestampAndBadge() }
 							</div>
 							<div
 								className="share-option"

--- a/client/performance-profiler/components/header/index.tsx
+++ b/client/performance-profiler/components/header/index.tsx
@@ -45,6 +45,21 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 							{ translate( 'Test another site' ) }
 						</Button>
 					</div>
+					<div className="profiler-header__report-site-details show-on-mobile">
+						{ timestamp && (
+							<span>
+								{ translate( 'Tested on %(date)s', {
+									args: { date: moment( timestamp ).format( 'MMMM Do, YYYY h:mm:ss A' ) },
+								} ) }
+							</span>
+						) }
+						{ showWPcomBadge && (
+							<span className="wpcom-badge">
+								<img src={ WPcomBadge } alt={ translate( 'WordPress.com badge' ) } />
+								<span>{ translate( 'Hosted on WordPress.com' ) }</span>
+							</span>
+						) }
+					</div>
 				</div>
 				{ showNavigationTabs && (
 					<SectionNav className="profiler-navigation-tabs">
@@ -66,7 +81,7 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 						</NavTabs>
 
 						<div className="profiler-header__navbar-right">
-							<div className="report-site-details">
+							<div className="report-site-details hide-on-mobile">
 								{ timestamp && (
 									<span>
 										{ translate( 'Tested on %(date)s', {

--- a/client/performance-profiler/components/header/style.scss
+++ b/client/performance-profiler/components/header/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .profiler-header {
 	color: #fff;
 	padding-top: 40px;
@@ -49,6 +51,26 @@
 				color: var(--studio-gray-5);
 			}
 		}
+	}
+
+	.profiler-header__report-site-details {
+		display: flex;
+		flex-direction: column;
+		gap: 14px;
+
+		&.show-on-mobile {
+			@media (min-width: $break-large) {
+				display: none;
+			}
+		}
+
+
+	}
+
+	.wpcom-badge {
+		display: flex;
+		align-items: center;
+		gap: 6px;
 	}
 
 	.profiler-navigation-tabs.section-nav {
@@ -138,6 +160,7 @@
 			}
 		}
 
+
 		.profiler-header__navbar-right {
 			display: flex;
 			align-items: center;
@@ -149,10 +172,10 @@
 				align-items: center;
 				gap: 32px;
 
-				.wpcom-badge {
-					display: flex;
-					align-items: center;
-					gap: 6px;
+				&.hide-on-mobile {
+					@media (max-width: $break-large) {
+						display: none;
+					}
 				}
 			}
 

--- a/client/performance-profiler/components/header/style.scss
+++ b/client/performance-profiler/components/header/style.scss
@@ -1,4 +1,5 @@
 @import "@wordpress/base-styles/breakpoints";
+@import "@automattic/typography/styles/variables";
 
 .profiler-header {
 	color: #fff;
@@ -57,6 +58,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 14px;
+		font-size: $font-body-small;
 
 		&.show-on-mobile {
 			@media (min-width: $break-large) {

--- a/client/performance-profiler/components/screenshot-thumbnail.tsx
+++ b/client/performance-profiler/components/screenshot-thumbnail.tsx
@@ -2,10 +2,8 @@ import styled from '@emotion/styled';
 import { translate } from 'i18n-calypso';
 
 const Container = styled.div`
-	width: 370px;
 	height: 255px;
 	display: flex;
-	justify-content: flex-end;
 	align-items: center;
 
 	& > * {

--- a/client/performance-profiler/pages/dashboard/style.scss
+++ b/client/performance-profiler/pages/dashboard/style.scss
@@ -19,7 +19,11 @@ $blueberry-color: #3858e9;
 		display: flex;
 		justify-content: space-between;
 		width: 100%;
+		flex-wrap: wrap;
 		column-gap: 35px;
+		@media (max-width: 550px) {
+			justify-content: center;
+		}
 	}
 }
 

--- a/client/performance-profiler/pages/dashboard/style.scss
+++ b/client/performance-profiler/pages/dashboard/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 $blueberry-color: #3858e9;
 
 .is-group-performance-profiler .layout__content {
@@ -21,7 +23,7 @@ $blueberry-color: #3858e9;
 		width: 100%;
 		flex-wrap: wrap;
 		column-gap: 35px;
-		@media (max-width: 550px) {
+		@media (max-width: $break-small) {
 			justify-content: center;
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/8914
Resolves https://github.com/Automattic/dotcom-forge/issues/8910


https://github.com/user-attachments/assets/c759f102-cf84-405a-aa13-0e1adbe88d56




## Proposed Changes

* Add a media query to move the timestamp and badge components to the header top section for small screens
* Add `flex-wrap` functionality to the top section. Use media query here to avoid fiddling with min and max sizes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make responsive those sections. 
I have decided to use media queries in both changes because:
- In the header top section, the components were being moved to different sections
- In the top section with the screenshot, because it would require using min and max sizes, and the resulting code seemed more complex.
- I have also avoided using `isMobile` because the screen sizes affected were not the mobile `480px` but bigger ones, and the standard breakpoints applied nicely.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Resize the screen and use the developer tools for different mobile screens and check:
  * The behavior of the timestamp and badge are correct, and the style matches Figma
  * The behavior of the top section and the screenshot are correct in both `Mobile` and `Desktop`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
