### PR TITLE
Theme upload dropzone - remove active styles when disabled.

### DIFF
--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -57,7 +57,7 @@ class UploadDropZone extends Component {
 		return (
 			<div className={ className }>
 				<div className="upload-drop-zone__dropzone">
-					<DropZone onFilesDrop={ this.onFileSelect } />
+					<DropZone onFilesDrop={ this.onFileSelect } disabled={ disabled } />
 					<FilePicker accept="application/zip" onPick={ this.onFileSelect }>
 						<Gridicon className="upload-drop-zone__icon" icon="cloud-upload" size={ 48 } />
 						{ dropText }

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -22,6 +22,7 @@ export class DropZone extends Component {
 		textLabel: TranslatableString,
 		translate: PropTypes.func,
 		dropZoneName: PropTypes.string,
+		disabled: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -32,6 +33,7 @@ export class DropZone extends Component {
 		fullScreen: false,
 		icon: <Gridicon icon="cloud-upload" size={ 48 } />,
 		dropZoneName: null,
+		disabled: false,
 	};
 
 	state = {
@@ -211,7 +213,9 @@ export class DropZone extends Component {
 
 	render() {
 		const classes = clsx( 'drop-zone', this.props.className, {
-			'is-active': this.state.isDraggingOverDocument || this.state.isDraggingOverElement,
+			'is-active':
+				! this.props.disabled &&
+				( this.state.isDraggingOverDocument || this.state.isDraggingOverElement ),
 			'is-dragging-over-document': this.state.isDraggingOverDocument,
 			'is-dragging-over-element': this.state.isDraggingOverElement,
 			'is-full-screen': this.props.fullScreen,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/93579

## Proposed Changes

* Passes the disabled prop to the DropZone component.
* Prevents .is-active class from being set when the component is disabled.

BEFORE (inactive dropzone responds like it can be used, when it can't)
![dropzone-indicates](https://github.com/user-attachments/assets/de78606f-cc06-45c2-933c-c11436ff33c8)


AFTER (inactive dropzone remains inactive)
![dropzone-no-indicates](https://github.com/user-attachments/assets/70d49395-bf88-4069-a1e0-7a72f8425044)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The component shows styles when hovering to drop a file as if it would work, even when it is disabled for plan tiers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to themes -> upload in calypso for a free site.
* Drag a file over the dropzone, notice no styles happen on hovering a file.
* I don't think we can access this dropzone from sites that actually can upload themes currently. This is a separate issue in discussion Automattic/dotcom-forge#2540 and previously discussed here https://github.com/Automattic/wp-calypso/issues/93594#issuecomment-2297002461 - but it seems the upload field in calypso does not support re-uploads (to update new versions) so users are currently always sent to wp-admin for this.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
