### PR TITLE
Stats: Add feedback form modal

### DIFF
--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -3,7 +3,7 @@ import FeedbackModal from './modal';
 
 import './style.scss';
 
-const StatsFeedbackCard = () => {
+function StatsFeedbackCard() {
 	// A simple card component with feedback buttons.
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -19,6 +19,6 @@ const StatsFeedbackCard = () => {
 			<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
 		</div>
 	);
-};
+}
 
 export default StatsFeedbackCard;

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -1,7 +1,12 @@
+import { useState } from 'react';
+import FeedbackModal from './modal';
+
 import './style.scss';
 
-function StatsFeedbackCard() {
+const StatsFeedbackCard = () => {
 	// A simple card component with feedback buttons.
+	const [ isOpen, setIsOpen ] = useState( false );
+
 	return (
 		<div className="stats-feedback-card">
 			<div className="stats-feedback-card__cta">
@@ -9,10 +14,11 @@ function StatsFeedbackCard() {
 			</div>
 			<div className="stats-feedback-card__actions">
 				<button>one</button>
-				<button>two</button>
+				<button onClick={ () => setIsOpen( true ) }>two</button>
 			</div>
+			<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
 		</div>
 	);
-}
+};
 
 export default StatsFeedbackCard;

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -1,0 +1,66 @@
+import { Button, Modal, TextareaControl } from '@wordpress/components';
+import { close } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import React, { useState } from 'react';
+import StatsButton from 'calypso/my-sites/stats/components/stats-button';
+
+import './style.scss';
+
+interface ModalProps {
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+const FeedbackModal: React.FC< ModalProps > = ( { isOpen, onClose } ) => {
+	const translate = useTranslate();
+	const [ isAnimating, setIsAnimating ] = useState( false );
+	const [ content, setContent ] = useState( '' );
+
+	const handleClose = () => {
+		setIsAnimating( true );
+		setTimeout( () => {
+			setIsAnimating( false );
+			onClose();
+		}, 200 );
+	};
+
+	if ( ! isOpen && ! isAnimating ) {
+		return null;
+	}
+
+	return (
+		<Modal className="stats-feedback-modal" onRequestClose={ handleClose } __experimentalHideHeader>
+			<Button
+				className="stats-feedback-modal__close-button"
+				onClick={ handleClose }
+				icon={ close }
+				label={ translate( 'Close' ) }
+			/>
+			<div className="stats-feedback-modal__wrapper">
+				<h1 className="stats-feedback-modal__title">
+					{ translate( 'Help us make Jetpack Stats better' ) }
+				</h1>
+
+				<div className="stats-feedback-modal__text">
+					{ translate(
+						'We value your opinion and would love to hear more about your experience. Please share any specific thoughts or suggestions you have to improve Jetpack Stats.'
+					) }
+				</div>
+				<TextareaControl
+					rows={ 5 }
+					cols={ 40 }
+					className="stats-feedback-modal__form"
+					placeholder={ translate( 'Add your feedback here' ) }
+					name="content"
+					value={ content }
+					onChange={ setContent }
+				/>
+				<div className="stats-feedback-modal__button">
+					<StatsButton primary>{ translate( 'Submit' ) }</StatsButton>
+				</div>
+			</div>
+		</Modal>
+	);
+};
+
+export default FeedbackModal;

--- a/client/my-sites/stats/feedback/modal/style.scss
+++ b/client/my-sites/stats/feedback/modal/style.scss
@@ -1,0 +1,57 @@
+@import "@automattic/components/src/styles/typography";
+
+.stats-feedback-modal {
+	width: 685px;
+	background-color: var(--studio-white);
+	text-align: left;
+}
+
+.stats-feedback-modal__close-button {
+	position: absolute;
+	top: 16px;
+	right: 16px;
+}
+
+.stats-feedback-modal__title {
+	font-family: $font-sf-pro-display;
+	font-size: rem(26px);
+	font-weight: 600;
+	line-height: 32px;
+	margin-bottom: 16px;
+}
+
+.stats-feedback-modal__text {
+	font-family: $font-sf-pro-text;
+	font-size: $font-body-small;
+	font-weight: 400;
+	line-height: 21px;
+	letter-spacing: -0.24px;
+}
+
+.stats-feedback-modal__form {
+	margin-top: 24px;
+
+	textarea {
+		padding: 8px 16px;
+		resize: none;
+		font-family: $font-sf-pro-text;
+		font-size: $font-body-small;
+		font-weight: 400;
+		line-height: 21px;
+		letter-spacing: -0.24px;
+
+	}
+}
+
+.stats-feedback-modal__button {
+	margin-top: 24px;
+	font-family: $font-sf-pro-text;
+	font-size: $font-body-small;
+	font-weight: 400;
+	line-height: 20px;
+	text-align: right;
+
+	button {
+		padding: 10px 16px;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/156

## Proposed Changes

* Add a feedback form modal according to the design.

> Note: The submit action is still not working for now.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A part of project pejTkB-1Ce-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page with the feature flag: `flags=stats/user-feedback`.
* Click on the second button of the permanent feedback section.

<img width="1296" alt="截圖 2024-08-28 下午11 30 43" src="https://github.com/user-attachments/assets/50f17b26-c424-4def-b3ec-0cb0c78e8baf">

* Ensure the feedback form modal shows according to the design.

<img width="869" alt="截圖 2024-08-28 下午11 31 36" src="https://github.com/user-attachments/assets/f45fc54b-2a51-4cec-8ddd-00c3a794df8c">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?