### PR TITLE
Stats upsell banner improvements - update copy and open learn more in help center.

### DIFF
--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -107,16 +107,19 @@ const DoYouLoveJetpackStatsNotice = ( {
 		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing';
 
 	const paidStatsRemoveHardcoding = hasEnTranslation(
-		'Finesse your scaling-up strategy with detailed insights and data. Upgrade to a %s plan for a richer understanding and smarter decision-making.'
+		'Finesse your scaling-up strategy with detailed insights and data. Upgrade to the %s plan for a richer understanding and smarter decision-making.'
 	)
 		? translate(
-				'Finesse your scaling-up strategy with detailed insights and data. Upgrade to a %s plan for a richer understanding and smarter decision-making.',
+				'Finesse your scaling-up strategy with detailed insights and data. Upgrade to the %s plan for a richer understanding and smarter decision-making.',
 				{
 					args: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
 				}
 		  )
 		: translate(
-				'Finesse your scaling-up strategy with detailed insights and data. Upgrade to an Explorer plan for a richer understanding and smarter decision-making.'
+				'Finesse your scaling-up strategy with detailed insights and data. Upgrade to a %s plan for a richer understanding and smarter decision-making.',
+				{
+					args: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
+				}
 		  );
 
 	const description = isWPCOMPaidStatsFlow

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -3,11 +3,14 @@ import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import NoticeBanner from '@automattic/components/src/notice-banner';
+import { HelpCenter } from '@automattic/data-stores';
 import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
@@ -15,6 +18,8 @@ import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions
 import { STATS_DO_YOU_LOVE_JETPACK_STATS_NOTICE } from '../constants';
 import { trackStatsAnalyticsEvent } from '../utils';
 import { StatsNoticeProps } from './types';
+
+const HELP_CENTER_STORE = HelpCenter.register();
 
 const getStatsPurchaseURL = (
 	siteId: number | null,
@@ -46,6 +51,7 @@ const DoYouLoveJetpackStatsNotice = ( {
 		'postponed',
 		30 * 24 * 3600
 	);
+	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const dismissNotice = () => {
 		isOdysseyStats
@@ -128,6 +134,12 @@ const DoYouLoveJetpackStatsNotice = ( {
 
 	const CTAText = isWPCOMPaidStatsFlow ? translate( 'Upgrade' ) : translate( 'Upgrade my Stats' );
 
+	const localizedLearnMoreLink = localizeUrl( learnMoreLink );
+	const openHelpCenter = () => {
+		setShowHelpCenter( true );
+		setShowSupportDoc( localizedLearnMoreLink );
+	};
+
 	return (
 		<div
 			className={ `inner-notice-container has-odyssey-stats-bg-color ${
@@ -146,9 +158,15 @@ const DoYouLoveJetpackStatsNotice = ( {
 					</button>
 					<a
 						className="notice-banner__action-link"
-						href={ localizeUrl( learnMoreLink ) }
+						href={ localizedLearnMoreLink }
 						target="_blank"
 						rel="noreferrer"
+						onClick={ ( event ) => {
+							if ( ! isJetpackCloud() ) {
+								event.preventDefault();
+								openHelpCenter();
+							}
+						} }
 					>
 						{ translate( 'Learn more' ) }
 						<Icon className="stats-icon" icon={ external } size={ 24 } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#8780

## Proposed Changes

* Opens the learn more link in the help center if possible.
* Changes the copy to say "the {planName}" instead of "a {planName}"

BEFORE
![banner-copy-old](https://github.com/user-attachments/assets/842e116c-b1fd-48fb-84b3-9b5a892893fa)


AFTER

![banner-copy-new](https://github.com/user-attachments/assets/574cf1d8-477b-49f8-94c6-46186c39e7b4)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to open docs in the help center if possible.
* It was advised to refer to plans as "the planType" instead of "a planType".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch locally.
* Go to a newer site that would still get the upsell banner.
    * Note - we updated to hide this banner if a site has less than 100 views. You can update[ this constant](https://github.com/Automattic/wp-calypso/blob/453b8b2e3cdf43e2a763725a835b0e6ea7aeced0/client/my-sites/stats/stats-notices/index.tsx#L33) locally to have the banner show up at lower view counts.
* Verify the banner copy reads correctly.
* Verify the "learn more" link opens the help center. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
