### PR TITLE
A4A Dev Sites: Fix loading referral product when current type is regular and other minor fixes

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-dev-license.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-dev-license.ts
@@ -25,7 +25,7 @@ export default function useFetchDevLicense( blogId?: number ) {
 			productId: data?.product_id,
 			siteUrl: data?.site_url,
 		} ),
-		enabled: !! agencyId,
+		enabled: !! agencyId && !! blogId,
 		refetchOnWindowFocus: false,
 	} );
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -219,12 +219,16 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 						<h1 className="checkout__main-title">{ title }</h1>
 
 						<div className="checkout__main-list">
-							{ checkoutItems.map( ( items ) => (
+							{ referralBlogId && isLoadingReferralDevSite ? (
+								<div className="product-info__placeholder"></div>
+							) : (
+								checkoutItems.map( ( items ) => (
 									<ProductInfo
 										key={ `product-info-${ items.product_id }-${ items.quantity }` }
 										product={ items }
 									/>
-							) ) }
+								) )
+							) }
 						</div>
 					</div>
 					<div

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -45,7 +45,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const { marketplaceType, setMarketplaceType } = useContext( MarketplaceTypeContext );
 	const isAutomatedReferrals = marketplaceType === MARKETPLACE_TYPE_REFERRAL;
 
 	const { selectedCartItems, onRemoveCartItem, onClearCart, setSelectedCartItems } =
@@ -133,6 +133,14 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 	);
 
 	useEffect( () => {
+		// On mount, set the marketplace type to referral if the referralBlogId is present.
+		if ( referralBlogId ) {
+			setMarketplaceType( MARKETPLACE_TYPE_REFERRAL );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	useEffect( () => {
 		// When the referralBlogId is present, add the referral plan to the cart.
 		if ( referralBlogId && ! isLoadingReferralDevSite ) {
 			addReferralPlanToCart();
@@ -212,10 +220,10 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 
 						<div className="checkout__main-list">
 							{ checkoutItems.map( ( items ) => (
-								<ProductInfo
-									key={ `product-info-${ items.product_id }-${ items.quantity }` }
-									product={ items }
-								/>
+									<ProductInfo
+										key={ `product-info-${ items.product_id }-${ items.quantity }` }
+										product={ items }
+									/>
 							) ) }
 						</div>
 					</div>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -65,11 +65,12 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 		);
 
 		siteUrls = product.siteUrls?.length
-			? translate( 'Site: %(sitesList)s', {
+			? translate( 'Site: %(sitesList)s', 'Sites: %(sitesList)s', {
+					count: product.siteUrls.length,
 					args: {
 						sitesList: formattedSiteUrls?.join( ',' ) ?? '',
 					},
-					context: 'product description',
+					context: 'site URLs in the plan description',
 					comment: 'The `sitesList` is the list of site URLs in the plan description.',
 			  } )
 			: '';

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -1,6 +1,11 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+@mixin loading-effect {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background: var(--color-sidebar-menu-selected-background);
+}
+
 .checkout .a4a-layout__body,
 .checkout .a4a-layout__body-wrapper {
 	/* stylelint-disable-next-line scales/radii */
@@ -256,6 +261,15 @@
 		margin-block: 4px 0;
 		color: var(--color-neutral-40);
 	}
+}
+
+.product-info__placeholder {
+	@include loading-effect();
+
+	width: 100%;
+	height: 48px;
+	background-color: var(--color-neutral-0);
+	border-radius: 4px;
 }
 
 .checkout__client-referral-form {

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -9,6 +9,7 @@ import {
 import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
 import Checkout from './checkout';
+import { MARKETPLACE_TYPE_REFERRAL, MARKETPLACE_TYPE_REGULAR } from './hoc/with-marketplace-type';
 import HostingOverview from './hosting-overview';
 import { getValidHostingSection } from './lib/hosting';
 import { getValidBrand } from './lib/product-brand';
@@ -95,7 +96,12 @@ export const checkoutContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Checkout" path={ context.path } />
-			<Checkout referralBlogId={ referralBlogId } />
+			<Checkout
+				referralBlogId={ referralBlogId }
+				defaultMarketplaceType={
+					referralBlogId ? MARKETPLACE_TYPE_REFERRAL : MARKETPLACE_TYPE_REGULAR
+				}
+			/>
 		</>
 	);
 	next();

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-referral-dev-site.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-referral-dev-site.ts
@@ -32,7 +32,10 @@ export default function useReferralDevSite(
 				siteUrls: [ license.siteUrl ],
 			};
 
-			setSelectedCartItems( [ cartProduct ] );
+			// Wait for the next tick to set the selected cart items, to avoid outdated marketplace type
+			setTimeout( () => {
+				setSelectedCartItems( [ cartProduct ] );
+			}, 0 );
 		}
 	}, [ license, product, referralPlanAdded, setSelectedCartItems ] );
 

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-referral-dev-site.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-referral-dev-site.ts
@@ -1,8 +1,6 @@
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import useFetchDevLicense from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-license';
-import { MarketplaceTypeContext } from 'calypso/a8c-for-agencies/sections/marketplace/context';
-import { MARKETPLACE_TYPE_REFERRAL } from 'calypso/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type';
 import { ShoppingCartItem } from '../types';
 
 export default function useReferralDevSite(
@@ -12,7 +10,6 @@ export default function useReferralDevSite(
 ) {
 	const { data: allProducts, isLoading: isLoadingProducts } = useProductsQuery();
 	const { data: license, isLoading: isLoadingLicense } = useFetchDevLicense( referralBlogId );
-	const { setMarketplaceType } = useContext( MarketplaceTypeContext );
 
 	const product = useMemo(
 		() => allProducts?.find( ( p ) => p.product_id === license?.productId ),
@@ -26,8 +23,6 @@ export default function useReferralDevSite(
 
 	const addReferralPlanToCart = useCallback( () => {
 		if ( product && license && ! referralPlanAdded ) {
-			setMarketplaceType( MARKETPLACE_TYPE_REFERRAL );
-
 			const cartProduct: ShoppingCartItem = {
 				...product,
 				quantity: 1,
@@ -37,7 +32,7 @@ export default function useReferralDevSite(
 
 			setSelectedCartItems( [ cartProduct ] );
 		}
-	}, [ license, product, referralPlanAdded, setMarketplaceType, setSelectedCartItems ] );
+	}, [ license, product, referralPlanAdded, setSelectedCartItems ] );
 
 	return { addReferralPlanToCart, isLoading: isLoadingProducts || isLoadingLicense };
 }

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-referral-dev-site.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-referral-dev-site.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import useFetchDevLicense from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-license';
+import useGetTipaltiPayee from 'calypso/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee';
 import { ShoppingCartItem } from '../types';
 
 export default function useReferralDevSite(
@@ -10,6 +11,7 @@ export default function useReferralDevSite(
 ) {
 	const { data: allProducts, isLoading: isLoadingProducts } = useProductsQuery();
 	const { data: license, isLoading: isLoadingLicense } = useFetchDevLicense( referralBlogId );
+	const { isLoading: isLoadingTipalti } = useGetTipaltiPayee();
 
 	const product = useMemo(
 		() => allProducts?.find( ( p ) => p.product_id === license?.productId ),
@@ -34,5 +36,8 @@ export default function useReferralDevSite(
 		}
 	}, [ license, product, referralPlanAdded, setSelectedCartItems ] );
 
-	return { addReferralPlanToCart, isLoading: isLoadingProducts || isLoadingLicense };
+	return {
+		addReferralPlanToCart,
+		isLoading: isLoadingProducts || isLoadingLicense || isLoadingTipalti,
+	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add `defaultMarketplaceType` to the Checkout page on the first render
  * Also sets marketplace type to `referral` on Checkout page mount (these are complementary things)
  * Remove `setMarketplaceType` from `useReferralDevSite` hook. It didn't have the proposed effect, doing it on a mount is more effective.
  * Add setTimeout due to some scenarios where the storage key is still outdated
* Include useGetTipaltiPayee as a loading dependency, to hold adding the referral product to the cart until we have all the data ready
* Add loading state to product info on checkout page, to make it clearer to the user that the page isn't stuck and the data is still loading
* Disable fetch dev license when missing blogId
* Add plural to sites list translation

## Why are these changes being made?

On the referral dev site flow, when opening the referral checkout page with a referral_blog_id on a fresh loading (empty sessionStorage), the cart stays empty. This is because, in the previous implementation, we set the marketplace type and added the referral product to the cart using the same useEffect. Making the add referral product action point to the regular cart, not the referral cart, due to the outdated value. To fix that, we need to set the defaultMarketplaceType to referral, call the setMarketplaceType on mount, and use setTimeout to ensure the product will be added to the correct cart.

pdDOJh-3Cl-p2

## Testing Instructions

* Apply this PR to your local
* Run `yarn start-a8c-for-agencies`
* Create a new dev site and get the wpcom blog_id
* Clean up the cache, sessionStorage, and IndexedDB for `agencies.localhost:3000`
* Go to `http://agencies.localhost:3000/marketplace/checkout?referral_blog_id={blog_id}`
* You should see a loading placeholder in the products list while fetching the required data
* Try different scenarios with different blog_ids to make sure the correct product is rendered (with the site URL)
* Perform regression tests on the checkout page, doing regular referrals and regular purchases (without using development sites)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?