### PR TITLE
A4A Dev Sites: Make create dev site not hoverable when 0 sites are available

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -71,6 +71,7 @@ export default function AddNewSiteButton( {
 		heading,
 		description,
 		isBanner,
+		disabled,
 		buttonProps,
 		extraContent,
 	}: {
@@ -79,13 +80,17 @@ export default function AddNewSiteButton( {
 		heading: string;
 		description: string | TranslateResult;
 		isBanner?: boolean;
+		disabled?: boolean;
 		buttonProps?: React.ComponentProps< typeof Button >;
 		extraContent?: JSX.Element;
 	} ) => {
 		return (
 			<Button
 				{ ...buttonProps }
-				className={ clsx( 'site-selector-and-importer__popover-button', { banner: isBanner } ) }
+				className={ clsx( 'site-selector-and-importer__popover-button', {
+					banner: isBanner,
+					disabled,
+				} ) }
 				borderless
 			>
 				<div className={ clsx( 'site-selector-and-importer__popover-button-icon', iconClassName ) }>
@@ -211,6 +216,7 @@ export default function AddNewSiteButton( {
 								comment: 'br is a line break',
 							}
 						),
+						disabled: ! hasAvailableDevSites,
 						isBanner: true,
 						buttonProps: {
 							onClick: () => {

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -86,6 +86,11 @@
 		background-color: var(--color-neutral-0);
 	}
 
+	&.disabled {
+		cursor: not-allowed;
+		background-color: var(--color-neutral-0);
+	}
+
 	@include break-large {
 		display: flex;
 		gap: 8px;


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/8907

## Proposed Changes

#### Before
![Image](https://github.com/user-attachments/assets/25132585-274e-42b5-981d-f12e5a39d853)

#### After
![Image](https://github.com/user-attachments/assets/b59a2c92-f3e3-4423-b743-1bfa147a9ec3)


## Testing Instructions

- Create enough sites until you don't have any more dev sites available.
- Navigate to sites page.
- Click on Add site -> the `WordPress.com Development Site` should not be hoverable.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
