### PR TITLE
Perfromance Profiler: keep showing loader if report is not ready.

### DIFF
--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import './style.scss';
 import DocumentHead from 'calypso/components/data/document-head';
 import { PerformanceReport } from 'calypso/data/site-profiler/types';
@@ -20,7 +20,7 @@ type PerformanceProfilerDashboardProps = {
 export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboardProps ) => {
 	const translate = useTranslate();
 	const { url, tab, hash } = props;
-	const [ isSavedReport ] = useState( !! hash );
+	const isSavedReport = useRef( !! hash );
 	const [ activeTab, setActiveTab ] = React.useState< TabType >( tab );
 	const { data: basicMetrics } = useUrlBasicMetricsQuery( url, hash, true );
 	const { final_url: finalUrl, token } = basicMetrics || {};
@@ -84,7 +84,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 					'is-loading': ! mobileLoaded,
 				} ) }
 			>
-				<LoadingScreen isSavedReport={ isSavedReport } key="mobile-loading" />
+				<LoadingScreen isSavedReport={ isSavedReport.current } key="mobile-loading" />
 			</div>
 
 			<div
@@ -93,7 +93,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 					'is-loading': ! desktopLoaded,
 				} ) }
 			>
-				<LoadingScreen isSavedReport={ isSavedReport } key="desktop-loading" />
+				<LoadingScreen isSavedReport={ isSavedReport.current } key="desktop-loading" />
 			</div>
 
 			{ ( ( activeTab === TabType.mobile && mobileLoaded ) ||

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import './style.scss';
 import DocumentHead from 'calypso/components/data/document-head';
 import { PerformanceReport } from 'calypso/data/site-profiler/types';
@@ -20,13 +20,13 @@ type PerformanceProfilerDashboardProps = {
 export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboardProps ) => {
 	const translate = useTranslate();
 	const { url, tab, hash } = props;
+	const [ isSavedReport ] = useState( !! hash );
 	const [ activeTab, setActiveTab ] = React.useState< TabType >( tab );
 	const { data: basicMetrics } = useUrlBasicMetricsQuery( url, hash, true );
 	const { final_url: finalUrl, token } = basicMetrics || {};
 	const { data: performanceInsights } = useUrlPerformanceInsightsQuery( url, hash );
 	const desktopLoaded = 'completed' === performanceInsights?.status;
 	const mobileLoaded = typeof performanceInsights?.mobile === 'object';
-	const isSavedReport = desktopLoaded && mobileLoaded && !! hash;
 
 	const updateQueryParams = ( params: Record< string, string >, forceReload = false ) => {
 		const queryParams = new URLSearchParams( window.location.search );

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -26,6 +26,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 	const { data: performanceInsights } = useUrlPerformanceInsightsQuery( url, hash );
 	const desktopLoaded = 'completed' === performanceInsights?.status;
 	const mobileLoaded = typeof performanceInsights?.mobile === 'object';
+	const isSavedReport = desktopLoaded && mobileLoaded && !! hash;
 
 	const updateQueryParams = ( params: Record< string, string >, forceReload = false ) => {
 		const queryParams = new URLSearchParams( window.location.search );
@@ -83,7 +84,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 					'is-loading': ! mobileLoaded,
 				} ) }
 			>
-				<LoadingScreen isSavedReport={ !! hash } key="mobile-loading" />
+				<LoadingScreen isSavedReport={ isSavedReport } key="mobile-loading" />
 			</div>
 
 			<div
@@ -92,7 +93,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 					'is-loading': ! desktopLoaded,
 				} ) }
 			>
-				<LoadingScreen isSavedReport={ !! hash } key="desktop-loading" />
+				<LoadingScreen isSavedReport={ isSavedReport } key="desktop-loading" />
 			</div>
 
 			{ ( ( activeTab === TabType.mobile && mobileLoaded ) ||


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes a regression from https://github.com/Automattic/wp-calypso/pull/93861

## Proposed Changes

* use the initial state of the `hash` as initially there isn't one for new tests but it's appended to the URL once we start running the tests resulting in showing `Getting your report…` while waiting for the tests to run

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

New Test
- Go to `http://calypso.localhost:3000/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F`
- Verify the loader appears

Existing Test
- Refresh your page
- Verify the `Getting your report…` loader appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
