### PR TITLE
Handles the new suspended campaign status for PromotePost

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -51,6 +51,12 @@ export type CampaignResponse = {
 		total: number;
 		card_name: string;
 		orders: Order[];
+		debt_amount?: number;
+		payment_links?: {
+			date: string;
+			amount: number;
+			url: string;
+		}[];
 	};
 	is_evergreen?: boolean;
 };

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -479,7 +479,7 @@ export default function CampaignItemDetails( props: Props ) {
 					</Notice>
 				) }
 
-				{ status === 'suspended' && payment_links && (
+				{ status === 'suspended' && payment_links && payment_links.length > 0 && (
 					<>
 						<Notice
 							isReskinned
@@ -496,7 +496,7 @@ export default function CampaignItemDetails( props: Props ) {
 
 				<section className="campaign-item-details__wrapper">
 					<div className="campaign-item-details__main">
-						{ status === 'suspended' && payment_links && (
+						{ status === 'suspended' && payment_links && payment_links.length > 0 && (
 							<div className="campaign-item-details__payment-links-container">
 								<div className="campaign-item-details__payment-links">
 									<div className="campaign-item-details__payment-link-row">

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -9,6 +9,7 @@ import { Icon, chevronLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment/moment';
 import { useState } from 'react';
+import ExternalLink from 'calypso/components/external-link';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
@@ -135,7 +136,7 @@ export default function CampaignItemDetails( props: Props ) {
 		conversion_last_currency_found,
 	} = campaign_stats || {};
 
-	const { card_name, payment_method, credits, total, orders } = billing_data || {};
+	const { card_name, payment_method, credits, total, orders, payment_links } = billing_data || {};
 	const { title, clickUrl } = content_config || {};
 	const canDisplayPaymentSection =
 		orders && orders.length > 0 && ( payment_method || ! isNaN( total || 0 ) );
@@ -478,8 +479,47 @@ export default function CampaignItemDetails( props: Props ) {
 					</Notice>
 				) }
 
+				{ status === 'suspended' && payment_links && (
+					<>
+						<Notice
+							isReskinned
+							showDismiss={ false }
+							status="is-error"
+							icon="notice-outline"
+							className="promote-post-notice campaign-item-details__notice campaign-suspended"
+							text={ translate(
+								'Your campaigns are suspended due to exceeding the credit limit. Please complete the payments using the provided links to resume your campaigns.'
+							) }
+						/>
+					</>
+				) }
+
 				<section className="campaign-item-details__wrapper">
 					<div className="campaign-item-details__main">
+						{ status === 'suspended' && payment_links && (
+							<div className="campaign-item-details__payment-links-container">
+								<div className="campaign-item-details__payment-links">
+									<div className="campaign-item-details__payment-link-row">
+										<div className="payment-link__label">{ translate( 'Date' ) }</div>
+										<div className="payment-link__label">{ translate( 'Amount' ) }</div>
+										<div>&nbsp;</div>
+									</div>
+									{ payment_links.map( ( info, index ) => (
+										<div key={ index } className="campaign-item-details__payment-link-row">
+											<div>{ moment( info.date ).format( 'MMMM DD, YYYY' ) }</div>
+											<div>${ formatNumber( info.amount ) }</div>
+											<div className="payment-link__link">
+												<ExternalLink href={ info.url } target="_blank">
+													{ translate( 'Pay' ) }
+													{ getExternalLinkIcon() }
+												</ExternalLink>
+											</div>
+										</div>
+									) ) }
+								</div>
+							</div>
+						) }
+
 						<div className="campaign-item-details__main-stats-container">
 							{ shouldShowStats && (
 								<div className="campaign-item-details__main-stats campaign-item-details__impressions">

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -161,6 +161,10 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 		.campaign-item-details__notice {
 			margin-bottom: 24px;
+
+			&.campaign-suspended {
+				margin-bottom: 16px;
+			}
 		}
 
 		.campaign-item-details__wrapper {
@@ -170,7 +174,39 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				color: var(--studio-gray-100);
 				line-height: 1.25;
 			}
+		}
 
+		.campaign-item-details__payment-links {
+			display: flex;
+			flex-direction: column;
+			gap: 8px;
+			padding: 16px;
+
+			.campaign-item-details__payment-link-row {
+				display: grid;
+				grid-template-columns: 40% 40% 20%;
+
+				.payment-link__label {
+					font-size: 0.875rem;
+					font-weight: 500;
+				}
+
+				.payment-link__link {
+					justify-self: flex-end;
+					a {
+						display: flex;
+						align-items: center;
+						gap: 2px;
+
+
+						svg {
+							path {
+								fill: var(--color-primary);
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 
@@ -214,6 +250,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 			}
 		}
 		.campaign-item-details__main-stats-container,
+		.campaign-item-details__payment-links-container,
 		.campaign-item-details__payment-container {
 			border: 1px solid #ddd;
 			border-radius: 4px;
@@ -256,6 +293,10 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 					}
 				}
 			}
+		}
+		.campaign-item-details__payment-links-container {
+			background: var(--studio-gray-0);
+			border: none;
 		}
 
 		.campaign-item-details__main-stats-row {
@@ -883,6 +924,13 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 		.campaign-item-details .campaign-item-details__notice {
 			margin-bottom: 32px;
+
+			&.campaign-suspended {
+				margin-bottom: 0;
+				border-bottom: 1px solid #ddd;
+				border-bottom-left-radius: 0;
+				border-bottom-right-radius: 0;
+			}
 		}
 
 		.campaign-item-details__secondary-stats-interests-mobile {

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -22,6 +22,7 @@ export const campaignStatus = {
 	CANCELED: 'canceled',
 	FINISHED: 'finished',
 	PROCESSING: 'processing',
+	SUSPENDED: 'suspended',
 };
 
 export const getPostType = ( type: string ) => {
@@ -63,6 +64,9 @@ export const getCampaignStatusBadgeColor = ( status?: string ) => {
 		case campaignStatus.FINISHED: {
 			return 'info-blue';
 		}
+		case campaignStatus.SUSPENDED: {
+			return 'error';
+		}
 		default:
 			return 'warning';
 	}
@@ -93,6 +97,9 @@ export const getCampaignStatus = ( status?: string ) => {
 		}
 		case campaignStatus.PROCESSING: {
 			return __( 'Creating' );
+		}
+		case campaignStatus.SUSPENDED: {
+			return __( 'Suspended' );
 		}
 		default:
 			return status;


### PR DESCRIPTION
## Proposed Changes

This PR adds the necessary code to handle the new Suspended status for Promote Post campaigns.
The main idea here is to notify the user and display links to correct the situation.

![Screenshot 2024-08-27 at 3 18 56 PM](https://github.com/user-attachments/assets/90e82508-01a5-4c88-80fd-38bc25cad2c7)

![Screenshot 2024-08-27 at 3 18 50 PM](https://github.com/user-attachments/assets/d0a3beef-26ef-40f8-b434-0dbb71a2026e)

## Why are these changes being made?

We want to display additional information in the campaign details page in case the system suspends any of their campaigns. The user can now correct the situation by paying the debt they collected.

## Testing Instructions

* Checkout this branch
* Modify the file client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx, and add this at line 143:
```
const status = 'suspended';
const ui_status = 'suspended';
const payment_links = [
  {
    date: '2024-08-02T16:11:43.000Z',
    amount: 1224.56,
    url: 'https://www.google.com',
  },
  {
    date: '2024-07-02T16:11:43.000Z',
    amount: 24.56,
    url: 'https://www.google.com',
  },
  {
    date: '2023-01-02T16:11:43.000Z',
    amount: 2324.56,
    url: 'https://www.google.com',
  },
];
```
* You must also delete the previous variables for `status`, `ui_status` and `payment_links` (We just hardcoded those values to simulate the case).
* Start Calypso and navigate to the Tools->Advertising page
* Go to Campaign details, for any of your campaigns
* Verify that you see the new notice, and section displaying the payment links.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
