### PR TITLE
Stats: Replace calendar with Calypso component for the Traffic page

### DIFF
--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -45,6 +45,7 @@ export class DateRange extends Component {
 		renderTrigger: PropTypes.func,
 		renderHeader: PropTypes.func,
 		renderInputs: PropTypes.func,
+		rootClass: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -56,6 +57,7 @@ export class DateRange extends Component {
 		renderTrigger: ( props ) => <DateRangeTrigger { ...props } />,
 		renderHeader: ( props ) => <DateRangeHeader { ...props } />,
 		renderInputs: ( props ) => <DateRangeInputs { ...props } />,
+		rootClass: '',
 	};
 
 	constructor( props ) {
@@ -672,10 +674,13 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the DateRange component
 	 */
 	render() {
-		const rootClassNames = clsx( {
-			'date-range': true,
-			'toggle-visible': this.state.popoverVisible,
-		} );
+		const rootClassNames = clsx(
+			{
+				'date-range': true,
+				'toggle-visible': this.state.popoverVisible,
+			},
+			this.props.rootClass
+		);
 
 		const triggerProps = {
 			startDate: this.state.startDate,

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -1,6 +1,11 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
+import { Button } from '@wordpress/components';
+import { Icon, calendar } from '@wordpress/icons';
+import { Moment } from 'moment';
 import qs from 'qs';
+import { RefObject } from 'react';
+import DateRange from 'calypso/components/date-range';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import DateControlPicker from './stats-date-control-picker';
@@ -8,6 +13,7 @@ import { StatsDateControlProps, DateControlPickerShortcut } from './types';
 import './style.scss';
 
 const COMPONENT_CLASS_NAME = 'stats-date-control';
+const isCalendarEnabled = config.isEnabled( 'stats/date-picker-calendar' );
 
 const StatsDateControl = ( {
 	slug,
@@ -115,16 +121,46 @@ const StatsDateControl = ( {
 
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
-			<DateControlPicker
-				buttonLabel={ getButtonLabel() }
-				dateRange={ dateRange }
-				shortcutList={ shortcutList }
-				selectedShortcut={ getShortcutForRange()?.id }
-				onShortcut={ onShortcutHandler }
-				onApply={ onApplyButtonHandler }
-				onGatedHandler={ onGatedHandler }
-				overlay={ overlay }
-			/>
+			{ isCalendarEnabled ? (
+				<DateRange
+					selectedStartDate={ moment( dateRange.chartStart ) }
+					selectedEndDate={ moment( dateRange.chartEnd ) }
+					lastSelectableDate={ moment().toDate() }
+					// TODO: We should use probably the create date of the site here?
+					firstSelectableDate={ moment( '2005-01-01' ).toDate() }
+					onDateCommit={ ( startDate: Moment, endDate: Moment ) =>
+						startDate &&
+						endDate &&
+						onApplyButtonHandler( startDate.format( 'YYYY-MM-DD' ), endDate.format( 'YYYY-MM-DD' ) )
+					}
+					renderTrigger={ ( {
+						onTriggerClick,
+						buttonRef,
+					}: {
+						onTriggerClick: () => void;
+						buttonRef: RefObject< typeof Button >;
+					} ) => {
+						return (
+							<Button onClick={ onTriggerClick } ref={ buttonRef }>
+								{ getButtonLabel() }
+								<Icon className="gridicon" icon={ calendar } />
+							</Button>
+						);
+					} }
+					rootClass="stats-date-control-picker"
+				/>
+			) : (
+				<DateControlPicker
+					buttonLabel={ getButtonLabel() }
+					dateRange={ dateRange }
+					shortcutList={ shortcutList }
+					selectedShortcut={ getShortcutForRange()?.id }
+					onShortcut={ onShortcutHandler }
+					onApply={ onApplyButtonHandler }
+					onGatedHandler={ onGatedHandler }
+					overlay={ overlay }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -126,8 +126,6 @@ const StatsDateControl = ( {
 					selectedStartDate={ moment( dateRange.chartStart ) }
 					selectedEndDate={ moment( dateRange.chartEnd ) }
 					lastSelectableDate={ moment().toDate() }
-					// TODO: We should use probably the create date of the site here?
-					firstSelectableDate={ moment( '2005-01-01' ).toDate() }
 					onDateCommit={ ( startDate: Moment, endDate: Moment ) =>
 						startDate &&
 						endDate &&


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/161

## Proposed Changes

* Use Calypso date range componet as a drop in replacement for the existing calendar on the Traffic page

## Why are these changes being made?

* Make calendar available for date range picking

## Testing Instructions

* Open `/stats/week/:siteSlug?flags=stats%2Fdate-picker-calendar` on Calypso Live or locally
* Ensure the calendar works *mostly
* Ensure the trigger (date display) is the same as the old one
* Ensure you are able to select a date range and apply

<img width="736" alt="image" src="https://github.com/user-attachments/assets/ce5ee971-40f0-46e5-ab7a-3335b6e59f6a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
