### PR TITLE
Help Center: Fix the icon size in the post editor

### DIFF
--- a/apps/help-center/help-center-gutenberg-disconnected.js
+++ b/apps/help-center/help-center-gutenberg-disconnected.js
@@ -22,7 +22,7 @@ function HelpCenterContent() {
 				href="https://wordpress.com/help"
 				icon={ <HelpIcon /> }
 				label="Help"
-				size={ canvasMode === 'edit' ? 'compact' : undefined }
+				size={ ! canvasMode || canvasMode === 'edit' ? 'compact' : undefined }
 				target="_blank"
 			/>
 		</>

--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -61,9 +61,9 @@ function HelpCenterContent() {
 				onClick={ handleToggleHelpCenter }
 				icon={ <HelpIcon /> }
 				label="Help"
-				aria-pressed={ canvasMode === 'edit' && show ? true : false }
+				aria-pressed={ ( ! canvasMode || canvasMode === 'edit' ) && show ? true : false }
 				aria-expanded={ show ? true : false }
-				size={ canvasMode === 'edit' ? 'compact' : undefined }
+				size={ ! canvasMode || canvasMode === 'edit' ? 'compact' : undefined }
 			/>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93976

## Proposed Changes

* Fix the icon size of the Help Center is not configured to `compact` because the `canvasMode` is available only in the Site Editor

| Before | After |
| - | - |
| <img width="293" alt="image" src="https://github.com/user-attachments/assets/665f0c60-3b3e-485a-b220-bf79ceaf8292"> | <img width="311" alt="image" src="https://github.com/user-attachments/assets/d80fd9e7-19f2-415d-b025-8a40285cd990"> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The icon size of the Help Center is different from others

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Point `widgets.wp.com` to your sandbox
* Apply changes to your sandbox
  * `cd apps/help-center`
  * `yarn dev --sync`
* Go to the post editor
* Make sure the icon size is correct, that is, `32px`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
