### PR TITLE
Migration: Add migration experiment link

### DIFF
--- a/client/hosting/sites/components/link-with-redirect/index.tsx
+++ b/client/hosting/sites/components/link-with-redirect/index.tsx
@@ -1,0 +1,36 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { type HTMLProps, useEffect, useState } from 'react';
+
+interface Props extends Omit< HTMLProps< HTMLAnchorElement >, 'href' > {
+	href: string | null | undefined;
+}
+
+export const LinkWithRedirect = ( props: Props ) => {
+	const [ delayedEvent, setDelayedEvent ] =
+		useState< React.MouseEvent< HTMLAnchorElement > | null >( null );
+	const { __ } = useI18n();
+
+	const { children, href, onClick } = props;
+
+	const onClickHandler = ( e: React.MouseEvent< HTMLAnchorElement > ) => {
+		e.preventDefault();
+		if ( ! href ) {
+			setDelayedEvent( e );
+		} else {
+			onClick?.( e );
+		}
+	};
+
+	useEffect( () => {
+		if ( href && delayedEvent ) {
+			onClick?.( delayedEvent );
+			window.location.assign( href );
+		}
+	}, [ href, delayedEvent, onClick ] );
+
+	return (
+		<a { ...props } href={ href ?? '#' } onClick={ onClickHandler }>
+			{ delayedEvent ? __( 'Redirecting...' ) : children }
+		</a>
+	);
+};

--- a/client/hosting/sites/components/link-with-redirect/index.tsx
+++ b/client/hosting/sites/components/link-with-redirect/index.tsx
@@ -30,7 +30,7 @@ export const LinkWithRedirect = ( props: Props ) => {
 
 	return (
 		<a { ...props } href={ href ?? '#' } onClick={ onClickHandler }>
-			{ delayedEvent ? __( 'Redirecting...' ) : children }
+			{ delayedEvent ? __( 'Redirecting' ) : children }
 		</a>
 	);
 };

--- a/client/hosting/sites/components/link-with-redirect/test/index.tsx
+++ b/client/hosting/sites/components/link-with-redirect/test/index.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { LinkWithRedirect } from '../';
+
+const originalLocation = window.location;
+
+describe( 'LinkWithRedirect', () => {
+	beforeEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: { ...originalLocation, assign: jest.fn(), replace: jest.fn() },
+		} );
+	} );
+
+	afterAll( () => {
+		Object.defineProperty( window, 'location', originalLocation );
+	} );
+
+	it( 'renders the link when it is available', () => {
+		const { getByRole } = render(
+			<LinkWithRedirect href="https://example.com">Click me</LinkWithRedirect>
+		);
+
+		expect( getByRole( 'link' ) ).toHaveAttribute( 'href', 'https://example.com' );
+	} );
+
+	it( 'renders `redirecting` when the user clicks but the link is not available', async () => {
+		const { getByText, findByText } = render(
+			<LinkWithRedirect href={ null }>Click me</LinkWithRedirect>
+		);
+
+		userEvent.click( getByText( 'Click me' ) );
+
+		expect( await findByText( 'Redirecting...' ) ).toBeVisible();
+	} );
+
+	it( 'redirects user to the link when is available after the redirecting state', async () => {
+		const { getByText, rerender, findByText } = render(
+			<LinkWithRedirect href={ null }>Click me</LinkWithRedirect>
+		);
+
+		userEvent.click( getByText( 'Click me' ) );
+
+		expect( await findByText( 'Redirecting...' ) ).toBeVisible();
+
+		rerender( <LinkWithRedirect href="https://example.com">Click me</LinkWithRedirect> );
+
+		await waitFor( () => expect( window.location.assign ).toHaveBeenCalled() );
+	} );
+} );

--- a/client/hosting/sites/components/link-with-redirect/test/index.tsx
+++ b/client/hosting/sites/components/link-with-redirect/test/index.tsx
@@ -35,7 +35,7 @@ describe( 'LinkWithRedirect', () => {
 
 		userEvent.click( getByText( 'Click me' ) );
 
-		expect( await findByText( 'Redirecting...' ) ).toBeVisible();
+		expect( await findByText( 'Redirecting' ) ).toBeVisible();
 	} );
 
 	it( 'redirects user to the link when is available after the redirecting state', async () => {
@@ -45,7 +45,7 @@ describe( 'LinkWithRedirect', () => {
 
 		userEvent.click( getByText( 'Click me' ) );
 
-		expect( await findByText( 'Redirecting...' ) ).toBeVisible();
+		expect( await findByText( 'Redirecting' ) ).toBeVisible();
 
 		rerender( <LinkWithRedirect href="https://example.com">Click me</LinkWithRedirect> );
 

--- a/client/hosting/sites/components/sites-dashboard-header.tsx
+++ b/client/hosting/sites/components/sites-dashboard-header.tsx
@@ -8,10 +8,10 @@ import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
-import { useExperiment } from 'calypso/lib/explat';
 import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
 import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
+import { LinkWithRedirect } from './link-with-redirect';
 
 const PageHeader = styled.div( {
 	backgroundColor: 'var( --studio-white )',
@@ -108,8 +108,6 @@ const SitesDashboardHeader = () => {
 		ref: 'topbar',
 	} );
 
-	const [ isLoadingExperiment ] = useExperiment( 'EXPERIMENT_NAME_HERE' );
-
 	return (
 		<PageHeader>
 			<HeaderControls>
@@ -143,15 +141,10 @@ const SitesDashboardHeader = () => {
 							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
 						} }
 						href={ importSiteUrl }
+						itemComponent={ LinkWithRedirect }
 					>
-						{ isLoadingExperiment ? (
-							'LOADING STATE HERE...'
-						) : (
-							<>
-								<DownloadIcon icon={ download } size={ 18 } />
-								<span>{ __( 'Import an existing site' ) }</span>
-							</>
-						) }
+						<DownloadIcon icon={ download } size={ 18 } />
+						<span>{ __( 'Import an existing site' ) }</span>
 					</PopoverMenuItem>
 				</AddNewSiteSplitButton>
 			</HeaderControls>

--- a/client/hosting/sites/components/sites-dashboard-header.tsx
+++ b/client/hosting/sites/components/sites-dashboard-header.tsx
@@ -8,6 +8,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
+import { useExperiment } from 'calypso/lib/explat';
 import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
 import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
@@ -107,6 +108,8 @@ const SitesDashboardHeader = () => {
 		ref: 'topbar',
 	} );
 
+	const [ isLoadingExperiment ] = useExperiment( 'EXPERIMENT_NAME_HERE' );
+
 	return (
 		<PageHeader>
 			<HeaderControls>
@@ -141,8 +144,14 @@ const SitesDashboardHeader = () => {
 						} }
 						href={ importSiteUrl }
 					>
-						<DownloadIcon icon={ download } size={ 18 } />
-						<span>{ __( 'Import an existing site' ) }</span>
+						{ isLoadingExperiment ? (
+							'LOADING STATE HERE...'
+						) : (
+							<>
+								<DownloadIcon icon={ download } size={ 18 } />
+								<span>{ __( 'Import an existing site' ) }</span>
+							</>
+						) }
 					</PopoverMenuItem>
 				</AddNewSiteSplitButton>
 			</HeaderControls>

--- a/client/hosting/sites/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/hosting/sites/hooks/use-sites-dashboard-import-site-url.ts
@@ -1,15 +1,27 @@
 import { Primitive } from 'utility-types';
+import { useExperiment } from 'calypso/lib/explat';
 import { addQueryArgs } from 'calypso/lib/url';
 import { TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
 
 export const useSitesDashboardImportSiteUrl = (
 	additionalParameters: Record< string, Primitive >
 ) => {
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( 'EXPERIMENT_NAME_HERE' );
+
+	if ( isLoadingExperiment ) {
+		return '#';
+	}
+
+	const path =
+		experimentAssignment?.variationName === 'treatment'
+			? '/setup/hosted-site-migration'
+			: '/setup/migration';
+
 	return addQueryArgs(
 		{
 			source: TRACK_SOURCE_NAME,
 			...additionalParameters,
 		},
-		'/setup/hosted-site-migration'
+		path
 	);
 };

--- a/client/hosting/sites/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/hosting/sites/hooks/use-sites-dashboard-import-site-url.ts
@@ -6,10 +6,12 @@ import { TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
 export const useSitesDashboardImportSiteUrl = (
 	additionalParameters: Record< string, Primitive >
 ) => {
-	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( 'EXPERIMENT_NAME_HERE' );
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
+		'calypso_optimized_migration_flow'
+	);
 
 	if ( isLoadingExperiment ) {
-		return '#';
+		return null;
 	}
 
 	const path =

--- a/client/hosting/sites/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/hosting/sites/hooks/use-sites-dashboard-import-site-url.ts
@@ -16,8 +16,8 @@ export const useSitesDashboardImportSiteUrl = (
 
 	const path =
 		experimentAssignment?.variationName === 'treatment'
-			? '/setup/hosted-site-migration'
-			: '/setup/migration';
+			? '/setup/migration'
+			: '/setup/hosted-site-migration';
 
 	return addQueryArgs(
 		{


### PR DESCRIPTION
Related to #93881

## Proposed Changes
* Integrate the link to the new migration based on the experiment config
* Shows a "Redirecting" message while the experiment is not fully loaded and the user tries to click.  ( it is hard to reproduce, so automated tests are testing ).

## Testing Instructions

Scenario 1: Going to the new behavior 
* Go to `/site`
* Click on `Add new site` > Import an existing site
* Check if you were redirected to `/setup/migration`

Scenario 2: Old behavior
* Go to `/site`
* Using the Developer Tools check the local storage already have the key   `explat-experiment--calypso_optimized_migration_flow` 
* The value will contain a JSON;
* Update the  `variationName` field to `"treatment"` instead of null; 
* Reload the page
* Click on `Add new site` > Import an existing site
* Check if you were redirected to `/setup/hosted-site-migration`

NOTE: Maybe you will need to repeat the local storage steps sometimes because there is a logic on the exPlat framework recreating it. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
