### PR TITLE
Calypso Component DateRange improvement: Add Shortcuts Menu

### DIFF
--- a/client/components/date-range/README.md
+++ b/client/components/date-range/README.md
@@ -34,6 +34,7 @@ Props are displayed as a table with Name, Type, Default, and Description as head
 | `onDateCommit(startDate, endDate)`          | `Function`                  | `undefined`         | callback function called when a date is _committed_ (ie: "Applied").                                                                                                                               |
 | `onDateSelect(startDate, endDate)`          | `Function`                  | `undefined`         | callback function called when a date is _selected_ (but not committed ie: "Applied")                                                                                                               |
 | `triggerText( startDateText, endDateText )` | `Function`                  | `undefined`         | function to generate the text displayed in the trigger button. Passed the start/end date text in `MM/DD/YYYY` format (or locale specific alternative)                                              |
+| `displayShortcuts`                          | `Boolean`                   | `false`             | determines whether to display the shortcuts menu alongside the calendar                                                                                                                            |
 
 #### Render Props
 

--- a/client/components/date-range/docs/example.jsx
+++ b/client/components/date-range/docs/example.jsx
@@ -64,6 +64,11 @@ class DateRangeExample extends Component {
 
 				<h3>Custom Inputs Component</h3>
 				<Card>{ this.withCustomInputs() }</Card>
+
+				<h3>With Shortcuts Menu Displayed</h3>
+				<Card>
+					<DateRange shouldRenderShortcuts />
+				</Card>
 			</Fragment>
 		);
 	}

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -45,7 +45,7 @@ export class DateRange extends Component {
 		renderTrigger: PropTypes.func,
 		renderHeader: PropTypes.func,
 		renderInputs: PropTypes.func,
-		renderShortcuts: PropTypes.bool,
+		shouldRenderShortcuts: PropTypes.bool,
 		rootClass: PropTypes.string,
 	};
 
@@ -58,7 +58,7 @@ export class DateRange extends Component {
 		renderTrigger: ( props ) => <DateRangeTrigger { ...props } />,
 		renderHeader: ( props ) => <DateRangeHeader { ...props } />,
 		renderInputs: ( props ) => <DateRangeInputs { ...props } />,
-		renderShortcuts: false,
+		shouldRenderShortcuts: false,
 		rootClass: '',
 	};
 
@@ -433,10 +433,10 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the Popover component
 	 */
 	renderPopover() {
-		const { renderShortcuts } = this.props;
+		const { shouldRenderShortcuts } = this.props;
 
-		// Only render shortcuts if renderShortcuts is true
-		const shortcuts = renderShortcuts ? this.renderShortcutsComponent() : null;
+		// Only render shortcuts if shouldRenderShortcuts is true
+		const shortcuts = shouldRenderShortcuts ? this.shouldRenderShortcutsComponent() : null;
 
 		const headerProps = {
 			onApplyClick: this.commitDates,
@@ -487,7 +487,9 @@ export class DateRange extends Component {
 						/>
 					</div>
 					{ shortcuts && (
-						<div className="date-control-picker-shortcuts">{ this.renderShortcutsComponent() }</div>
+						<div className="date-control-picker-shortcuts">
+							{ this.shouldRenderShortcutsComponent() }
+						</div>
 					) }
 				</div>
 			</Popover>
@@ -498,7 +500,7 @@ export class DateRange extends Component {
 	 * Renders the Shortcuts component
 	 * @returns {import('react').Element} the Shortcuts component
 	 */
-	renderShortcutsComponent() {
+	shouldRenderShortcutsComponent() {
 		return <Shortcuts onClick={ this.handleShortcutClick } />;
 	}
 

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -527,6 +527,8 @@ export class DateRange extends Component {
 		this.setState( {
 			startDate: newFromDate,
 			endDate: newToDate,
+			textInputStartDate: this.toDateString( newFromDate ),
+			textInputEndDate: this.toDateString( newToDate ),
 		} );
 	};
 }

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -478,6 +478,7 @@ export class DateRange extends Component {
 						numberOfMonths={ this.getNumberOfMonths() }
 					/>
 				</div>
+				{ showShortcuts && <Shortcuts onClick={ this.handleShortcutClick } /> }
 			</Popover>
 		);
 	}
@@ -515,6 +516,13 @@ export class DateRange extends Component {
 			</div>
 		);
 	}
+
+	handleShortcutClick = ( { newFromDate, newToDate } ) => {
+		this.setState( {
+			startDate: newFromDate,
+			endDate: newToDate,
+		} );
+	};
 }
 
 export default localize( withLocalizedMoment( DateRange ) );

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -390,7 +390,7 @@ export class DateRange extends Component {
 		return window.matchMedia( '(min-width: 480px)' ).matches ? 2 : 1;
 	}
 
-	onDateRangeChange( startDate, endDate ) {
+	handleDateRangeChange( startDate, endDate ) {
 		this.setState( {
 			startDate,
 			endDate,
@@ -486,7 +486,9 @@ export class DateRange extends Component {
 	renderShortcuts() {
 		return (
 			<div className="date-control-picker-shortcuts">
-				<Shortcuts onClick={ this.handleShortcutClick } />
+				<Shortcuts
+					onClick={ ( startDate, endDate ) => this.handleDateRangeChange( startDate, endDate ) }
+				/>
 			</div>
 		);
 	}
@@ -502,7 +504,9 @@ export class DateRange extends Component {
 				lastSelectableDate={ this.props.lastSelectableDate }
 				selectedStartDate={ this.state.startDate }
 				selectedEndDate={ this.state.endDate }
-				onDateRangeChange={ ( startDate, endDate ) => this.onDateRangeChange( startDate, endDate ) }
+				onDateRangeChange={ ( startDate, endDate ) =>
+					this.handleDateRangeChange( startDate, endDate )
+				}
 				focusedMonth={ this.state.focusedMonth }
 				numberOfMonths={ this.getNumberOfMonths() }
 			/>
@@ -542,15 +546,6 @@ export class DateRange extends Component {
 			</div>
 		);
 	}
-
-	handleShortcutClick = ( { newFromDate, newToDate } ) => {
-		this.setState( {
-			startDate: newFromDate,
-			endDate: newToDate,
-			textInputStartDate: this.toDateString( newFromDate ),
-			textInputEndDate: this.toDateString( newToDate ),
-		} );
-	};
 }
 
 export default localize( withLocalizedMoment( DateRange ) );

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -433,11 +433,6 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the Popover component
 	 */
 	renderPopover() {
-		const { displayShortcuts } = this.props;
-
-		// Only render shortcuts if displayShortcuts is true
-		const shortcuts = displayShortcuts ? this.displayShortcutsComponent() : null;
-
 		const headerProps = {
 			onApplyClick: this.commitDates,
 			onCancelClick: this.closePopoverAndRevert,
@@ -486,11 +481,7 @@ export class DateRange extends Component {
 							numberOfMonths={ this.getNumberOfMonths() }
 						/>
 					</div>
-					{ shortcuts && (
-						<div className="date-control-picker-shortcuts">
-							{ this.displayShortcutsComponent() }
-						</div>
-					) }
+					{ this.props.displayShortcuts && this.renderShortcuts() }
 				</div>
 			</Popover>
 		);
@@ -500,8 +491,12 @@ export class DateRange extends Component {
 	 * Renders the Shortcuts component
 	 * @returns {import('react').Element} the Shortcuts component
 	 */
-	displayShortcutsComponent() {
-		return <Shortcuts onClick={ this.handleShortcutClick } />;
+	renderShortcuts() {
+		return (
+			<div className="date-control-picker-shortcuts">
+				<Shortcuts onClick={ this.handleShortcutClick } />
+			</div>
+		);
 	}
 
 	/**

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -45,6 +45,7 @@ export class DateRange extends Component {
 		renderTrigger: PropTypes.func,
 		renderHeader: PropTypes.func,
 		renderInputs: PropTypes.func,
+		renderShortcuts: PropTypes.bool,
 		rootClass: PropTypes.string,
 	};
 
@@ -57,6 +58,7 @@ export class DateRange extends Component {
 		renderTrigger: ( props ) => <DateRangeTrigger { ...props } />,
 		renderHeader: ( props ) => <DateRangeHeader { ...props } />,
 		renderInputs: ( props ) => <DateRangeInputs { ...props } />,
+		renderShortcuts: false,
 		rootClass: '',
 	};
 
@@ -431,6 +433,11 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the Popover component
 	 */
 	renderPopover() {
+		const { renderShortcuts } = this.props;
+
+		// Only render shortcuts if renderShortcuts is true
+		const shortcuts = renderShortcuts ? this.renderShortcutsComponent() : null;
+
 		const headerProps = {
 			onApplyClick: this.commitDates,
 			onCancelClick: this.closePopoverAndRevert,
@@ -479,13 +486,77 @@ export class DateRange extends Component {
 							numberOfMonths={ this.getNumberOfMonths() }
 						/>
 					</div>
-					{ showShortcuts && (
-						<div className="date-control-picker-shortcuts">
-							<Shortcuts onClick={ this.handleShortcutClick } />
-						</div>
+					{ shortcuts && (
+						<div className="date-control-picker-shortcuts">{ this.renderShortcutsComponent() }</div>
 					) }
 				</div>
 			</Popover>
+		);
+	}
+
+	/**
+	 * Renders the Shortcuts component
+	 * @returns {import('react').Element} the Shortcuts component
+	 */
+	renderShortcutsComponent() {
+		return <Shortcuts onClick={ this.handleShortcutClick } />;
+	}
+
+	/**
+	 * Renders the DatePicker component
+	 * @returns {import('react').Element} the DatePicker component
+	 */
+	renderDatePicker() {
+		const fromDate = this.momentDateToJsDate( this.state.startDate );
+		const toDate = this.momentDateToJsDate( this.state.endDate );
+
+		// Add "Range" modifier classes to Day component
+		// within Date Picker to aid "range" styling
+		// http://react-day-picker.js.org/api/DayPicker/#modifiers
+		const modifiers = {
+			start: fromDate,
+			end: toDate,
+			'range-start': fromDate,
+			'range-end': toDate,
+			range: {
+				from: fromDate,
+				to: toDate,
+			},
+		};
+
+		// Dates to be "selected" in Picker
+		const selected = [
+			fromDate,
+			{
+				from: fromDate,
+				to: toDate,
+			},
+		];
+
+		const rootClassNames = {
+			'date-range__picker': true,
+		};
+
+		const calendarInitialDate =
+			this.props.firstSelectableDate ||
+			( this.props.lastSelectableDate &&
+				moment( this.props.lastSelectableDate ).subtract( 1, 'month' ) ) ||
+			this.state.startDate;
+
+		return (
+			<DatePicker
+				calendarViewDate={ this.state.focusedMonth }
+				calendarInitialDate={ this.momentDateToJsDate( calendarInitialDate ) ?? null }
+				rootClassNames={ rootClassNames }
+				modifiers={ modifiers }
+				showOutsideDays={ false }
+				fromMonth={ this.momentDateToJsDate( this.props.firstSelectableDate ) }
+				toMonth={ this.momentDateToJsDate( this.props.lastSelectableDate ) }
+				onSelectDay={ this.onSelectDate }
+				selectedDays={ selected }
+				numberOfMonths={ this.getNumberOfMonths() }
+				disabledDays={ this.getDisabledDaysConfig() }
+			/>
 		);
 	}
 

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -8,6 +8,7 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import DateRangePicker from './date-range-picker';
 import DateRangeHeader from './header';
 import DateRangeInputs from './inputs';
+import Shortcuts from './shortcuts';
 import DateRangeTrigger from './trigger';
 
 import './style.scss';

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -462,23 +462,29 @@ export class DateRange extends Component {
 				position="bottom"
 				onClose={ this.closePopoverAndCommit }
 			>
-				<div className="date-range__popover-inner">
-					<div className="date-range__controls">
-						{ this.props.renderHeader( headerProps ) }
-						{ this.renderDateHelp() }
+				<div className="date-range__popover-content">
+					<div className="date-range__popover-inner">
+						<div className="date-range__controls">
+							{ this.props.renderHeader( headerProps ) }
+							{ this.renderDateHelp() }
+						</div>
+						{ this.props.renderInputs( inputsProps ) }
+						<DateRangePicker
+							firstSelectableDate={ this.props.firstSelectableDate }
+							lastSelectableDate={ this.props.lastSelectableDate }
+							selectedStartDate={ this.state.startDate }
+							selectedEndDate={ this.state.endDate }
+							onDateRangeChange={ onDateRangeChange }
+							focusedMonth={ this.state.focusedMonth }
+							numberOfMonths={ this.getNumberOfMonths() }
+						/>
 					</div>
-					{ this.props.renderInputs( inputsProps ) }
-					<DateRangePicker
-						firstSelectableDate={ this.props.firstSelectableDate }
-						lastSelectableDate={ this.props.lastSelectableDate }
-						selectedStartDate={ this.state.startDate }
-						selectedEndDate={ this.state.endDate }
-						onDateRangeChange={ onDateRangeChange }
-						focusedMonth={ this.state.focusedMonth }
-						numberOfMonths={ this.getNumberOfMonths() }
-					/>
+					{ showShortcuts && (
+						<div className="date-control-picker-shortcuts">
+							<Shortcuts onClick={ this.handleShortcutClick } />
+						</div>
+					) }
 				</div>
-				{ showShortcuts && <Shortcuts onClick={ this.handleShortcutClick } /> }
 			</Popover>
 		);
 	}

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -45,7 +45,7 @@ export class DateRange extends Component {
 		renderTrigger: PropTypes.func,
 		renderHeader: PropTypes.func,
 		renderInputs: PropTypes.func,
-		shouldRenderShortcuts: PropTypes.bool,
+		displayShortcuts: PropTypes.bool,
 		rootClass: PropTypes.string,
 	};
 
@@ -58,7 +58,7 @@ export class DateRange extends Component {
 		renderTrigger: ( props ) => <DateRangeTrigger { ...props } />,
 		renderHeader: ( props ) => <DateRangeHeader { ...props } />,
 		renderInputs: ( props ) => <DateRangeInputs { ...props } />,
-		shouldRenderShortcuts: false,
+		displayShortcuts: false,
 		rootClass: '',
 	};
 
@@ -433,10 +433,10 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the Popover component
 	 */
 	renderPopover() {
-		const { shouldRenderShortcuts } = this.props;
+		const { displayShortcuts } = this.props;
 
-		// Only render shortcuts if shouldRenderShortcuts is true
-		const shortcuts = shouldRenderShortcuts ? this.shouldRenderShortcutsComponent() : null;
+		// Only render shortcuts if displayShortcuts is true
+		const shortcuts = displayShortcuts ? this.displayShortcutsComponent() : null;
 
 		const headerProps = {
 			onApplyClick: this.commitDates,
@@ -488,7 +488,7 @@ export class DateRange extends Component {
 					</div>
 					{ shortcuts && (
 						<div className="date-control-picker-shortcuts">
-							{ this.shouldRenderShortcutsComponent() }
+							{ this.displayShortcutsComponent() }
 						</div>
 					) }
 				</div>
@@ -500,7 +500,7 @@ export class DateRange extends Component {
 	 * Renders the Shortcuts component
 	 * @returns {import('react').Element} the Shortcuts component
 	 */
-	shouldRenderShortcutsComponent() {
+	displayShortcutsComponent() {
 		return <Shortcuts onClick={ this.handleShortcutClick } />;
 	}
 

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -544,7 +544,7 @@ export class DateRange extends Component {
 			this.state.startDate;
 
 		return (
-			<DatePicker
+			<DateRangePicker
 				calendarViewDate={ this.state.focusedMonth }
 				calendarInitialDate={ this.momentDateToJsDate( calendarInitialDate ) ?? null }
 				rootClassNames={ rootClassNames }

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -390,6 +390,16 @@ export class DateRange extends Component {
 		return window.matchMedia( '(min-width: 480px)' ).matches ? 2 : 1;
 	}
 
+	onDateRangeChange( startDate, endDate ) {
+		this.setState( {
+			startDate,
+			endDate,
+			textInputStartDate: this.toDateString( startDate ),
+			textInputEndDate: this.toDateString( endDate ),
+		} );
+		this.props.onDateSelect && this.props.onDateSelect( startDate, endDate );
+	}
+
 	renderDateHelp() {
 		const { startDate, endDate } = this.state;
 
@@ -446,16 +456,6 @@ export class DateRange extends Component {
 			onInputFocus: this.handleInputFocus,
 		};
 
-		const onDateRangeChange = ( startDate, endDate ) => {
-			this.setState( {
-				startDate,
-				endDate,
-				textInputStartDate: this.toDateString( startDate ),
-				textInputEndDate: this.toDateString( endDate ),
-			} );
-			this.props.onDateSelect && this.props.onDateSelect( startDate, endDate );
-		};
-
 		return (
 			<Popover
 				className="date-range__popover"
@@ -471,15 +471,7 @@ export class DateRange extends Component {
 							{ this.renderDateHelp() }
 						</div>
 						{ this.props.renderInputs( inputsProps ) }
-						<DateRangePicker
-							firstSelectableDate={ this.props.firstSelectableDate }
-							lastSelectableDate={ this.props.lastSelectableDate }
-							selectedStartDate={ this.state.startDate }
-							selectedEndDate={ this.state.endDate }
-							onDateRangeChange={ onDateRangeChange }
-							focusedMonth={ this.state.focusedMonth }
-							numberOfMonths={ this.getNumberOfMonths() }
-						/>
+						{ this.renderDatePicker() }
 					</div>
 					{ this.props.displayShortcuts && this.renderShortcuts() }
 				</div>
@@ -504,55 +496,15 @@ export class DateRange extends Component {
 	 * @returns {import('react').Element} the DatePicker component
 	 */
 	renderDatePicker() {
-		const fromDate = this.momentDateToJsDate( this.state.startDate );
-		const toDate = this.momentDateToJsDate( this.state.endDate );
-
-		// Add "Range" modifier classes to Day component
-		// within Date Picker to aid "range" styling
-		// http://react-day-picker.js.org/api/DayPicker/#modifiers
-		const modifiers = {
-			start: fromDate,
-			end: toDate,
-			'range-start': fromDate,
-			'range-end': toDate,
-			range: {
-				from: fromDate,
-				to: toDate,
-			},
-		};
-
-		// Dates to be "selected" in Picker
-		const selected = [
-			fromDate,
-			{
-				from: fromDate,
-				to: toDate,
-			},
-		];
-
-		const rootClassNames = {
-			'date-range__picker': true,
-		};
-
-		const calendarInitialDate =
-			this.props.firstSelectableDate ||
-			( this.props.lastSelectableDate &&
-				moment( this.props.lastSelectableDate ).subtract( 1, 'month' ) ) ||
-			this.state.startDate;
-
 		return (
 			<DateRangePicker
-				calendarViewDate={ this.state.focusedMonth }
-				calendarInitialDate={ this.momentDateToJsDate( calendarInitialDate ) ?? null }
-				rootClassNames={ rootClassNames }
-				modifiers={ modifiers }
-				showOutsideDays={ false }
-				fromMonth={ this.momentDateToJsDate( this.props.firstSelectableDate ) }
-				toMonth={ this.momentDateToJsDate( this.props.lastSelectableDate ) }
-				onSelectDay={ this.onSelectDate }
-				selectedDays={ selected }
+				firstSelectableDate={ this.props.firstSelectableDate }
+				lastSelectableDate={ this.props.lastSelectableDate }
+				selectedStartDate={ this.state.startDate }
+				selectedEndDate={ this.state.endDate }
+				onDateRangeChange={ ( startDate, endDate ) => this.onDateRangeChange( startDate, endDate ) }
+				focusedMonth={ this.state.focusedMonth }
 				numberOfMonths={ this.getNumberOfMonths() }
-				disabledDays={ this.getDisabledDaysConfig() }
 			/>
 		);
 	}

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso'; // Ensure this import is present
 import moment from 'moment'; // Assuming moment is used for date calculations
 import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react'; // Add useState and useEffect
 
 const DATERANGE_PERIOD = {
 	DAY: 'day',
@@ -18,6 +19,11 @@ const DateRangePickerShortcuts = ( {
 	onClick: ( shortcut: any ) => void;
 } ) => {
 	const translate = useTranslate();
+	const [ selectedShortcut, setSelectedShortcut ] = useState( currentShortcut ); // Track selected shortcut
+
+	useEffect( () => {
+		setSelectedShortcut( currentShortcut ); // Update state when currentShortcut changes
+	}, [ currentShortcut ] );
 
 	const generateShortcutList = () => {
 		return [
@@ -61,6 +67,7 @@ const DateRangePickerShortcuts = ( {
 		range: any;
 		period?: string;
 	} ) => {
+		setSelectedShortcut( shortcut.id ); // Update selected shortcut on click
 		const { offset, range } = shortcut; // Assuming these are part of the shortcut structure
 		const newToDate = moment().subtract( offset, 'days' ); // Ensure this is a Moment object
 		const newFromDate = moment().subtract( offset + range, 'days' ); // Ensure this is a Moment object
@@ -72,7 +79,7 @@ const DateRangePickerShortcuts = ( {
 		<div className="date-control-picker-shortcuts__inner">
 			<ul className="date-control-picker-shortcuts__list">
 				{ shortcutList.map( ( shortcut, idx ) => {
-					const isSelected = shortcut.id === currentShortcut;
+					const isSelected = shortcut.id === selectedShortcut; // Use state for selection
 
 					return (
 						<li

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -16,13 +16,7 @@ const DateRangePickerShortcuts = ( {
 	onClick,
 }: {
 	currentShortcut?: string;
-	onClick: ( shortcut: {
-		id?: string;
-		label?: string;
-		offset: number;
-		range: number;
-		period?: string;
-	} ) => void;
+	onClick: ( shortcut: { newFromDate: moment.Moment; newToDate: moment.Moment } ) => void;
 } ) => {
 	const translate = useTranslate();
 	const [ selectedShortcut, setSelectedShortcut ] = useState( currentShortcut );

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -4,13 +4,13 @@ import { useTranslate } from 'i18n-calypso'; // Ensure this import is present
 import moment from 'moment'; // Assuming moment is used for date calculations
 import PropTypes from 'prop-types';
 
-const STATS_PERIOD = {
+const DATERANGE_PERIOD = {
 	DAY: 'day',
 	WEEK: 'week',
 	MONTH: 'month',
 };
 
-const DateControlPickerShortcuts = ( {
+const DateRangePickerShortcuts = ( {
 	currentShortcut,
 	onClick,
 }: {
@@ -26,28 +26,28 @@ const DateControlPickerShortcuts = ( {
 				label: translate( 'Last 7 Days' ),
 				offset: 0,
 				range: 6,
-				period: STATS_PERIOD.DAY,
+				period: DATERANGE_PERIOD.DAY,
 			},
 			{
 				id: 'last_30_days',
 				label: translate( 'Last 30 Days' ),
 				offset: 0,
 				range: 29,
-				period: STATS_PERIOD.DAY,
+				period: DATERANGE_PERIOD.DAY,
 			},
 			{
 				id: 'last_3_months',
 				label: translate( 'Last 90 Days' ),
 				offset: 0,
 				range: 89,
-				period: STATS_PERIOD.WEEK,
+				period: DATERANGE_PERIOD.WEEK,
 			},
 			{
 				id: 'last_year',
 				label: translate( 'Last Year' ),
 				offset: 0,
 				range: 364, // ranges are zero based!
-				period: STATS_PERIOD.MONTH,
+				period: DATERANGE_PERIOD.MONTH,
 			},
 		];
 	};
@@ -97,9 +97,9 @@ const DateControlPickerShortcuts = ( {
 	);
 };
 
-DateControlPickerShortcuts.propTypes = {
+DateRangePickerShortcuts.propTypes = {
 	currentShortcut: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
 };
 
-export default DateControlPickerShortcuts;
+export default DateRangePickerShortcuts;

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { Icon, check, lock } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso'; // Ensure this import is present
 import moment from 'moment'; // Assuming moment is used for date calculations
@@ -70,7 +69,7 @@ const DateControlPickerShortcuts = ( {
 	};
 
 	return (
-		<div className="date-control-picker-shortcuts">
+		<div className="date-control-picker-shortcuts__inner">
 			<ul className="date-control-picker-shortcuts__list">
 				{ shortcutList.map( ( shortcut, idx ) => {
 					const isSelected = shortcut.id === currentShortcut;
@@ -89,8 +88,6 @@ const DateControlPickerShortcuts = ( {
 								aria-label={ `Time range ${ shortcut.label }. Click to select.` }
 							>
 								<span>{ shortcut.label }</span>
-								{ isSelected && <Icon icon={ check } /> }
-								{ ! isSelected && <Icon icon={ lock } /> }
 							</Button>
 						</li>
 					);

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -74,7 +74,11 @@ const DateRangePickerShortcuts = ( {
 					>
 						<Button
 							onClick={ () => handleClick( shortcut ) }
-							aria-label={ `Time range ${ shortcut.label }. Click to select.` }
+							aria-label={ translate( `Time range %(label)s. Click to select.`, {
+								args: {
+									label: shortcut.label,
+								},
+							} ) }
 						>
 							<span>{ shortcut.label }</span>
 						</Button>

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -72,14 +72,7 @@ const DateRangePickerShortcuts = ( {
 						} ) }
 						key={ shortcut.id || idx }
 					>
-						<Button
-							onClick={ () => handleClick( shortcut ) }
-							aria-label={ translate( `Time range %(label)s. Click to select.`, {
-								args: {
-									label: shortcut.label,
-								},
-							} ) }
-						>
+						<Button onClick={ () => handleClick( shortcut ) }>
 							<span>{ shortcut.label }</span>
 						</Button>
 					</li>

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -1,0 +1,108 @@
+import { Button } from '@wordpress/components';
+import { Icon, check, lock } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso'; // Ensure this import is present
+import moment from 'moment'; // Assuming moment is used for date calculations
+import PropTypes from 'prop-types';
+
+const STATS_PERIOD = {
+	DAY: 'day',
+	WEEK: 'week',
+	MONTH: 'month',
+};
+
+const DateControlPickerShortcuts = ( {
+	currentShortcut,
+	onClick,
+}: {
+	currentShortcut?: string;
+	onClick: ( shortcut: any ) => void;
+} ) => {
+	const translate = useTranslate();
+
+	const generateShortcutList = () => {
+		return [
+			{
+				id: 'last_7_days',
+				label: translate( 'Last 7 Days' ),
+				offset: 0,
+				range: 6,
+				period: STATS_PERIOD.DAY,
+			},
+			{
+				id: 'last_30_days',
+				label: translate( 'Last 30 Days' ),
+				offset: 0,
+				range: 29,
+				period: STATS_PERIOD.DAY,
+			},
+			{
+				id: 'last_3_months',
+				label: translate( 'Last 90 Days' ),
+				offset: 0,
+				range: 89,
+				period: STATS_PERIOD.WEEK,
+			},
+			{
+				id: 'last_year',
+				label: translate( 'Last Year' ),
+				offset: 0,
+				range: 364, // ranges are zero based!
+				period: STATS_PERIOD.MONTH,
+			},
+		];
+	};
+
+	const shortcutList = generateShortcutList(); // Generate the shortcut list if one isn't provided
+
+	const handleClick = ( shortcut: {
+		id?: string;
+		label?: any;
+		offset: any;
+		range: any;
+		period?: string;
+	} ) => {
+		const { offset, range } = shortcut; // Assuming these are part of the shortcut structure
+		const newToDate = moment().subtract( offset, 'days' ); // Ensure this is a Moment object
+		const newFromDate = moment().subtract( offset + range, 'days' ); // Ensure this is a Moment object
+
+		onClick( { newFromDate, newToDate } ); // Pass both dates back to the parent
+	};
+
+	return (
+		<div className="date-control-picker-shortcuts">
+			<ul className="date-control-picker-shortcuts__list">
+				{ shortcutList.map( ( shortcut, idx ) => {
+					const isSelected = shortcut.id === currentShortcut;
+
+					return (
+						<li
+							className={ clsx( 'date-control-picker-shortcuts__shortcut', {
+								'is-selected': isSelected,
+							} ) }
+							key={ shortcut.id || idx }
+						>
+							<Button
+								onClick={ () => {
+									handleClick( shortcut );
+								} }
+								aria-label={ `Time range ${ shortcut.label }. Click to select.` }
+							>
+								<span>{ shortcut.label }</span>
+								{ isSelected && <Icon icon={ check } /> }
+								{ ! isSelected && <Icon icon={ lock } /> }
+							</Button>
+						</li>
+					);
+				} ) }
+			</ul>
+		</div>
+	);
+};
+
+DateControlPickerShortcuts.propTypes = {
+	currentShortcut: PropTypes.string,
+	onClick: PropTypes.func.isRequired,
+};
+
+export default DateControlPickerShortcuts;

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@wordpress/components';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso'; // Ensure this import is present
-import moment from 'moment'; // Assuming moment is used for date calculations
+import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react'; // Add useState and useEffect
+import { useEffect, useState } from 'react';
 
 const DATERANGE_PERIOD = {
 	DAY: 'day',
@@ -16,89 +16,80 @@ const DateRangePickerShortcuts = ( {
 	onClick,
 }: {
 	currentShortcut?: string;
-	onClick: ( shortcut: any ) => void;
+	onClick: ( shortcut: {
+		id?: string;
+		label?: string;
+		offset: number;
+		range: number;
+		period?: string;
+	} ) => void;
 } ) => {
 	const translate = useTranslate();
-	const [ selectedShortcut, setSelectedShortcut ] = useState( currentShortcut ); // Track selected shortcut
+	const [ selectedShortcut, setSelectedShortcut ] = useState( currentShortcut );
 
 	useEffect( () => {
-		setSelectedShortcut( currentShortcut ); // Update state when currentShortcut changes
+		setSelectedShortcut( currentShortcut );
 	}, [ currentShortcut ] );
 
-	const generateShortcutList = () => {
-		return [
-			{
-				id: 'last_7_days',
-				label: translate( 'Last 7 Days' ),
-				offset: 0,
-				range: 6,
-				period: DATERANGE_PERIOD.DAY,
-			},
-			{
-				id: 'last_30_days',
-				label: translate( 'Last 30 Days' ),
-				offset: 0,
-				range: 29,
-				period: DATERANGE_PERIOD.DAY,
-			},
-			{
-				id: 'last_3_months',
-				label: translate( 'Last 90 Days' ),
-				offset: 0,
-				range: 89,
-				period: DATERANGE_PERIOD.WEEK,
-			},
-			{
-				id: 'last_year',
-				label: translate( 'Last Year' ),
-				offset: 0,
-				range: 364, // ranges are zero based!
-				period: DATERANGE_PERIOD.MONTH,
-			},
-		];
-	};
+	const getShortcutList = () => [
+		{
+			id: 'last_7_days',
+			label: translate( 'Last 7 Days' ),
+			offset: 0,
+			range: 6,
+			period: DATERANGE_PERIOD.DAY,
+		},
+		{
+			id: 'last_30_days',
+			label: translate( 'Last 30 Days' ),
+			offset: 0,
+			range: 29,
+			period: DATERANGE_PERIOD.DAY,
+		},
+		{
+			id: 'last_3_months',
+			label: translate( 'Last 90 Days' ),
+			offset: 0,
+			range: 89,
+			period: DATERANGE_PERIOD.WEEK,
+		},
+		{
+			id: 'last_year',
+			label: translate( 'Last Year' ),
+			offset: 0,
+			range: 364, // ranges are zero based!
+			period: DATERANGE_PERIOD.MONTH,
+		},
+	];
 
-	const shortcutList = generateShortcutList(); // Generate the shortcut list if one isn't provided
+	const shortcutList = getShortcutList();
 
-	const handleClick = ( shortcut: {
-		id?: string;
-		label?: any;
-		offset: any;
-		range: any;
-		period?: string;
-	} ) => {
-		setSelectedShortcut( shortcut.id ); // Update selected shortcut on click
-		const { offset, range } = shortcut; // Assuming these are part of the shortcut structure
-		const newToDate = moment().subtract( offset, 'days' ); // Ensure this is a Moment object
-		const newFromDate = moment().subtract( offset + range, 'days' ); // Ensure this is a Moment object
+	const handleClick = ( { id, offset, range }: { id?: string; offset: number; range: number } ) => {
+		setSelectedShortcut( id );
+		const newToDate = moment().subtract( offset, 'days' );
+		const newFromDate = moment().subtract( offset + range, 'days' );
 
-		onClick( { newFromDate, newToDate } ); // Pass both dates back to the parent
+		onClick( { newFromDate, newToDate } );
 	};
 
 	return (
 		<div className="date-control-picker-shortcuts__inner">
 			<ul className="date-control-picker-shortcuts__list">
-				{ shortcutList.map( ( shortcut, idx ) => {
-					const isSelected = shortcut.id === selectedShortcut; // Use state for selection
-
-					return (
-						<li
-							className={ clsx( 'date-control-picker-shortcuts__shortcut', {
-								'is-selected': isSelected,
-							} ) }
-							key={ shortcut.id || idx }
+				{ shortcutList.map( ( shortcut, idx ) => (
+					<li
+						className={ clsx( 'date-control-picker-shortcuts__shortcut', {
+							'is-selected': shortcut.id === selectedShortcut,
+						} ) }
+						key={ shortcut.id || idx }
+					>
+						<Button
+							onClick={ () => handleClick( shortcut ) }
+							aria-label={ `Time range ${ shortcut.label }. Click to select.` }
 						>
-							<Button
-								onClick={ () => {
-									handleClick( shortcut );
-								} }
-								aria-label={ `Time range ${ shortcut.label }. Click to select.` }
-							>
-								<span>{ shortcut.label }</span>
-							</Button>
-						</li>
-					);
-				} ) }
+							<span>{ shortcut.label }</span>
+						</Button>
+					</li>
+				) ) }
 			</ul>
 		</div>
 	);

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 const DATERANGE_PERIOD = {
 	DAY: 'day',
@@ -20,10 +20,6 @@ const DateRangePickerShortcuts = ( {
 } ) => {
 	const translate = useTranslate();
 	const [ selectedShortcut, setSelectedShortcut ] = useState( currentShortcut );
-
-	useEffect( () => {
-		setSelectedShortcut( currentShortcut );
-	}, [ currentShortcut ] );
 
 	const getShortcutList = () => [
 		{

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -16,7 +16,7 @@ const DateRangePickerShortcuts = ( {
 	onClick,
 }: {
 	currentShortcut?: string;
-	onClick: ( shortcut: { newFromDate: moment.Moment; newToDate: moment.Moment } ) => void;
+	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment ) => void;
 } ) => {
 	const translate = useTranslate();
 	const [ selectedShortcut, setSelectedShortcut ] = useState( currentShortcut );
@@ -63,7 +63,7 @@ const DateRangePickerShortcuts = ( {
 		const newToDate = moment().subtract( offset, 'days' );
 		const newFromDate = moment().subtract( offset + range, 'days' );
 
-		onClick( { newFromDate, newToDate } );
+		onClick( newFromDate, newToDate );
 	};
 
 	return (

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -268,3 +268,8 @@
 		border-radius: 200px !important;
 	}
 }
+
+.date-range__popover-content { // Styling to fit optional shortcuts sidebar
+	display: flex;
+	align-items: stretch; // Ensure children stretch to full height
+}

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -146,7 +146,7 @@ const StatsDateControl = ( {
 						);
 					} }
 					rootClass="stats-date-control-picker"
-					shouldRenderShortcuts
+					displayShortcuts
 				/>
 			) : (
 				<DateControlPicker

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -146,7 +146,7 @@ const StatsDateControl = ( {
 						);
 					} }
 					rootClass="stats-date-control-picker"
-					renderShortcuts
+					shouldRenderShortcuts
 				/>
 			) : (
 				<DateControlPicker

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -146,6 +146,7 @@ const StatsDateControl = ( {
 						);
 					} }
 					rootClass="stats-date-control-picker"
+					renderShortcuts
 				/>
 			) : (
 				<DateControlPicker


### PR DESCRIPTION
## Proposed Changes

This PR adds an optional date range shortcuts menu to the side of the DateRange component. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**To test component in use in Stats**

* Open live branch
* Navigate to traffic page
* Add flag `stats/date-picker-calendar`
* Open date range picker and try selecting various date ranges, and using the shortcuts menu on the right
* Check on different size displays, browsers, mobile etc. 
* test out that daterange picker works and looks exactly as before when the shortcuts menu is not displayed
* confirm the readme and docs example are updated sufficiently for the component 

![image](https://github.com/user-attachments/assets/1d10f8b5-a90a-417c-83c8-30d7dd25159b)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
