### PR TITLE
Add a back link to plugin collections

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,4 +1,6 @@
+import { Gridicon } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
+import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -152,6 +154,32 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 		);
 	};
 
+	const renderBackLink = () => {
+		const StyledBackLink = styled.a`
+			display: flex;
+			alignitems: center;
+			font-size: 13px;
+			&,
+			&:link,
+			&:visited,
+			&:hover,
+			&:active {
+				color: var( --studio-gray-80 );
+			}
+			> svg {
+				margin-right: 5px;
+			}
+		`;
+		return (
+			<div className="plugins-browser__back">
+				<StyledBackLink href="/plugins">
+					<Gridicon icon="chevron-left" size={ 18 } />
+					{ __( 'Back' ) }
+				</StyledBackLink>
+			</div>
+		);
+	};
+
 	if ( ! isRequestingSitesData && noPermissionsError ) {
 		return <NoPermissionsError title={ __( 'Plugins' ) } />;
 	}
@@ -188,6 +216,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 				search={ search }
 			/>
 			<div className="plugins-browser__content-wrapper">
+				{ ( category || search ) && renderBackLink() }
 				{ selectedSite && isJetpack && isPossibleJetpackConnectionProblem && (
 					<JetpackConnectionHealthBanner siteId={ siteId } />
 				) }

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-$search-categories-padding-top: 40px;
+$search-categories-padding-top: 20px;
 
 .search-categories {
 	display: flex;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -25,6 +25,13 @@
 		}
 	}
 
+	.plugins-browser__back {
+		padding-top: 25px;
+		@include breakpoint-deprecated("<660px") {
+			padding: 16px;
+		}
+	}
+
 	.upsell-nudge {
 		margin-top: 16px;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #93588

## Proposed Changes

Adds a Back link from the collections (e.g. plugins/browse/paid) that goes to /plugins.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There's no obvious way back from plugin collections (e.g. a category or "Must-have"). The only visible back button leaves /plugins entirely.

## Testing Instructions

 1. Use Calypso live link
 2. Go to /plugins/browse/paid
 3. See Back link, press it
 4. You should be on /plugins
 5. Repeat at a variety of screen sizes

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before | After
-------|------
 <img width="1210" alt="Screenshot 2024-08-28 at 12 13 57" src="https://github.com/user-attachments/assets/d0047ba1-bff5-44ce-9609-9b77fcec23d8"> | <img width="1210" alt="Screenshot 2024-08-28 at 12 13 13" src="https://github.com/user-attachments/assets/039089d1-e8d6-4c85-a458-e1417f2bd2c2">

## Pre-merge Checklist



<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
