### PR TITLE
Plans Grid: fix frequent recreation of ResizeObserver in useGridSize

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -1121,6 +1121,14 @@ const ComparisonGrid = ( {
 	);
 };
 
+const GRID_BREAKPOINTS = new Map( [
+	[ 'small', 0 ],
+	[ 'smedium', 686 ],
+	[ 'medium', 835 ], // enough to fit Enterpreneur plan. was 686
+	[ 'large', 1005 ], // enough to fit Enterpreneur plan. was 870
+	[ 'xlarge', 1180 ],
+] );
+
 // TODO
 // Now that everything under is functional component, we can deprecate this wrapper and only keep ComparisonGrid instead.
 // More details can be found in https://github.com/Automattic/wp-calypso/issues/87047
@@ -1147,18 +1155,12 @@ const WrappedComparisonGrid = ( {
 	featureGroupMap,
 	...otherProps
 }: ComparisonGridExternalProps ) => {
-	const gridContainerRef = useRef< HTMLDivElement | null >( null );
+	const gridContainerRef = useRef< HTMLDivElement >( null );
 
 	// TODO: this will be deprecated along side removing the wrapper component
 	const gridSize = useGridSize( {
 		containerRef: gridContainerRef,
-		containerBreakpoints: new Map( [
-			[ 'small', 0 ],
-			[ 'smedium', 686 ],
-			[ 'medium', 835 ], // enough to fit Enterpreneur plan. was 686
-			[ 'large', 1005 ], // enough to fit Enterpreneur plan. was 870
-			[ 'xlarge', 1180 ],
-		] ),
+		containerBreakpoints: GRID_BREAKPOINTS,
 	} );
 
 	const classNames = clsx( 'plans-grid-next', className, {

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -339,16 +339,22 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		featureGroupMap = {},
 	} = props;
 
-	const gridContainerRef = useRef< HTMLDivElement | null >( null );
+	const gridContainerRef = useRef< HTMLDivElement >( null );
+
+	const gridBreakpoints = useMemo(
+		() =>
+			new Map( [
+				[ 'small', 0 ],
+				[ 'medium', 740 ],
+				[ 'large', isInAdmin ? 1180 : 1320 ], // 1320 to fit Enterpreneur plan, 1180 to work in admin
+			] ),
+		[ isInAdmin ]
+	);
 
 	// TODO: this will be deprecated along side removing the wrapper component
 	const gridSize = useGridSize( {
 		containerRef: gridContainerRef,
-		containerBreakpoints: new Map( [
-			[ 'small', 0 ],
-			[ 'medium', 740 ],
-			[ 'large', isInAdmin ? 1180 : 1320 ], // 1320 to fit Enterpreneur plan, 1180 to work in admin
-		] ),
+		containerBreakpoints: gridBreakpoints,
 	} );
 
 	const classNames = clsx( 'plans-grid-next', className, {

--- a/packages/plans-grid-next/src/hooks/use-grid-size.ts
+++ b/packages/plans-grid-next/src/hooks/use-grid-size.ts
@@ -16,37 +16,31 @@ interface Props {
  * useGridSize returns the current grid size based on the width of the container
  * and the breakpoints passed through as props.
  */
-const useGridSize = ( { containerRef, containerBreakpoints }: Props ) => {
+export default function useGridSize( { containerRef, containerBreakpoints }: Props ) {
 	const [ gridSize, setGridSize ] = useState< string | null >( null );
 
 	useLayoutEffect( () => {
-		if ( ! containerRef?.current ) {
+		if ( ! containerRef.current ) {
 			return;
 		}
 
-		const observer = new ResizeObserver(
-			( [ entry ]: Parameters< ResizeObserverCallback >[ 0 ] ) => {
-				const width = entry.contentRect.width;
+		const observer = new ResizeObserver( ( [ entry ] ) => {
+			const { width } = entry.contentRect;
 
-				if ( width ) {
-					for ( const [ key, value ] of [ ...containerBreakpoints ].reverse() ) {
-						if ( width >= value ) {
-							if ( gridSize !== key ) {
-								setGridSize( key );
-							}
-							break;
-						}
+			if ( width ) {
+				for ( const [ key, value ] of [ ...containerBreakpoints ].reverse() ) {
+					if ( width >= value ) {
+						setGridSize( key );
+						break;
 					}
 				}
 			}
-		);
+		} );
 
 		observer.observe( containerRef.current );
 
 		return () => observer.disconnect();
-	}, [ containerBreakpoints, containerRef, gridSize ] );
+	}, [ containerRef, containerBreakpoints ] );
 
 	return gridSize;
-};
-
-export default useGridSize;
+}


### PR DESCRIPTION
We get many Sentry reports where a `ResizeObserver` fails with error:
```
ResizeObserver loop completed with undelivered notifications.
```
and many of them are on pages that display the Plans Grid. So I started looking at the code and noticed that the `useGridSize` hook is doing silly things: the effect that creates and destroys the `ResizeObserver` has dependencies that triggers re-creation on every `size` change, and also on every `containerBreakpoints` change. Because `containerBreakpoints` is a map created from scratch on every render, the `ResizeObserver` is re-created all the time!

This PR fixes that:
- the `containerBreakpoints` value is extracted to a static constant or memoized
- we don't use `size` inside the effect because `setSize()` with an identical value is already detected as noop by React