### PR TITLE
Remove deprecated defaultProps from several components (part 2)

### DIFF
--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -1,44 +1,38 @@
 import { Gridicon } from '@automattic/components';
-import { translate } from 'i18n-calypso';
-import { omitBy } from 'lodash';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { createElement } from 'react';
 import { connect } from 'react-redux';
 import { getPostTotalCommentsCount } from 'calypso/state/comments/selectors';
 
 import './style.scss';
 
-const noop = () => {};
-
 function CommentButton( {
 	commentCount = 0,
-	href = null,
-	onClick = noop,
 	size = 24,
-	tagName = 'li',
-	target = null,
-	icon = null,
+	tagName: TagName = 'li',
+	onClick,
+	href,
+	target,
+	icon,
 	defaultLabel,
 } ) {
+	const translate = useTranslate();
 	const showLabel = commentCount > 0 || defaultLabel;
 	const label = commentCount || defaultLabel;
 
-	return createElement(
-		tagName,
-		omitBy(
-			{
-				className: 'comment-button',
-				href: 'a' === tagName ? href : null,
-				onClick,
-				target: 'a' === tagName ? target : null,
-				title: translate( 'Comment' ),
-			},
-			( prop ) => prop === null
-		),
-		icon || <Gridicon icon="comment" size={ size } className="comment-button__icon" />,
-		<span className="comment-button__label">
-			{ showLabel && <span className="comment-button__label-count">{ label }</span> }
-		</span>
+	return (
+		<TagName
+			className="comment-button"
+			title={ translate( 'Comment' ) }
+			onClick={ onClick }
+			href={ 'a' === TagName ? href : undefined }
+			target={ 'a' === TagName ? target : undefined }
+		>
+			{ icon || <Gridicon icon="comment" size={ size } className="comment-button__icon" /> }
+			<span className="comment-button__label">
+				{ showLabel && <span className="comment-button__label-count">{ label }</span> }
+			</span>
+		</TagName>
 	);
 }
 

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -10,9 +10,16 @@ import './style.scss';
 
 const noop = () => {};
 
-function CommentButton( props ) {
-	const { commentCount, href, onClick, tagName, target, icon, defaultLabel } = props;
-
+function CommentButton( {
+	commentCount = 0,
+	href = null,
+	onClick = noop,
+	size = 24,
+	tagName = 'li',
+	target = null,
+	icon = null,
+	defaultLabel,
+} ) {
 	const showLabel = commentCount > 0 || defaultLabel;
 	const label = commentCount || defaultLabel;
 
@@ -28,7 +35,7 @@ function CommentButton( props ) {
 			},
 			( prop ) => prop === null
 		),
-		icon || <Gridicon icon="comment" size={ props.size } className="comment-button__icon" />,
+		icon || <Gridicon icon="comment" size={ size } className="comment-button__icon" />,
 		<span className="comment-button__label">
 			{ showLabel && <span className="comment-button__label-count">{ label }</span> }
 		</span>
@@ -37,26 +44,13 @@ function CommentButton( props ) {
 
 CommentButton.propTypes = {
 	commentCount: PropTypes.number,
-	defaultLabel: PropTypes.string,
 	href: PropTypes.string,
 	onClick: PropTypes.func,
 	post: PropTypes.object,
-	showLabel: PropTypes.bool,
 	tagName: PropTypes.string,
 	target: PropTypes.string,
 	icon: PropTypes.object,
-};
-
-CommentButton.defaultProps = {
-	commentCount: 0,
-	href: null,
-	onClick: noop,
-	post: {},
-	showLabel: true,
-	size: 24,
-	tagName: 'li',
-	target: null,
-	icon: null,
+	defaultLabel: PropTypes.string,
 };
 
 const mapStateToProps = ( state, ownProps ) => {

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -1,6 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import ShareButton from 'calypso/blocks/reader-share';
 import { shouldShowReblog } from 'calypso/blocks/reader-share/helper';
 import { useSelector } from 'calypso/state';
@@ -9,13 +9,10 @@ import CommentLikeButtonContainer from './comment-likes';
 
 import './comment-actions.scss';
 
-const noop = () => {};
-
 const CommentActions = ( {
 	post,
 	comment,
 	comment: { isPlaceholder },
-	translate,
 	activeReplyCommentId,
 	commentId,
 	handleReply,
@@ -24,6 +21,7 @@ const CommentActions = ( {
 	onReadMore,
 	onLikeToggle,
 } ) => {
+	const translate = useTranslate();
 	const showReplyButton = post && post.discussion && post.discussion.comments_open === true;
 	const showCancelReplyButton = activeReplyCommentId === commentId;
 	const hasSites = !! useSelector( getPrimarySiteId );
@@ -80,8 +78,4 @@ const CommentActions = ( {
 	);
 };
 
-CommentActions.defaultProps = {
-	onReadMore: noop,
-};
-
-export default localize( CommentActions );
+export default CommentActions;

--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -63,7 +63,7 @@ const ReaderFeaturedImage = ( {
 	canonicalMedia,
 	href,
 	children,
-	onClick,
+	onClick = noop,
 	className,
 	fetched,
 	imageUrl,
@@ -193,10 +193,6 @@ ReaderFeaturedImage.propTypes = {
 	canonicalMedia: PropTypes.object,
 	href: PropTypes.string,
 	onClick: PropTypes.func,
-};
-
-ReaderFeaturedImage.defaultProps = {
-	onClick: noop,
 };
 
 const mapStateToProps = ( state, ownProps ) => {

--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -11,8 +11,6 @@ import {
 } from 'calypso/state/reader/posts/sizes';
 import './style.scss';
 
-const noop = () => {};
-
 const getFeaturedImageType = (
 	canonicalMedia,
 	imageWidth,
@@ -63,7 +61,7 @@ const ReaderFeaturedImage = ( {
 	canonicalMedia,
 	href,
 	children,
-	onClick = noop,
+	onClick,
 	className,
 	fetched,
 	imageUrl,

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -6,7 +6,7 @@ const FeaturedAsset = ( {
 	post,
 	canonicalMedia,
 	postUrl,
-	allowVideoPlaying,
+	allowVideoPlaying = true,
 	onVideoThumbnailClick,
 	isVideoExpanded,
 	isCompactPost,
@@ -49,10 +49,6 @@ FeaturedAsset.propTypes = {
 	onVideoThumbnailClick: PropTypes.func,
 	isVideoExpanded: PropTypes.bool,
 	hasExcerpt: PropTypes.bool,
-};
-
-FeaturedAsset.defaultProps = {
-	allowVideoPlaying: true,
 };
 
 export default FeaturedAsset;

--- a/client/components/action-card/index.jsx
+++ b/client/components/action-card/index.jsx
@@ -14,9 +14,9 @@ const ActionCard = ( {
 	buttonHref,
 	buttonOnClick,
 	children,
-	compact,
+	compact = true,
 	classNames,
-	buttonDisabled,
+	buttonDisabled = false,
 	illustration,
 } ) => (
 	<Card className={ clsx( 'action-card', classNames ) } compact={ compact }>
@@ -61,11 +61,6 @@ ActionCard.propTypes = {
 	compact: PropTypes.bool,
 	illustration: PropTypes.string,
 	classNames: PropTypes.string,
-};
-
-ActionCard.defaultProps = {
-	compact: true,
-	buttonDisabled: false,
 };
 
 export default ActionCard;

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -10,7 +10,6 @@ import BarContainer from './bar-container';
 
 import './style.scss';
 
-const noop = () => {};
 const isTouch = hasTouch();
 
 /**
@@ -43,7 +42,7 @@ function getYAxisMax( values ) {
 
 // The Chart component.
 function Chart( {
-	barClick = noop,
+	barClick,
 	children,
 	data,
 	isPlaceholder = false,

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -43,21 +43,21 @@ function getYAxisMax( values ) {
 
 // The Chart component.
 function Chart( {
-	barClick,
+	barClick = noop,
 	children,
 	data,
-	isPlaceholder,
+	isPlaceholder = false,
 	isRtl,
-	minBarWidth,
-	minTouchBarWidth,
+	minBarWidth = 15,
+	minTouchBarWidth = 42,
 	numberFormat,
 	translate,
-	chartXPadding,
-	sliceFromBeginning,
+	chartXPadding = 20,
+	sliceFromBeginning = true,
 	onChangeMaxBars,
 	minBarsToBeShown,
-	hideYAxis,
-	hideXAxis,
+	hideYAxis = false,
+	hideXAxis = false,
 } ) {
 	const [ tooltip, setTooltip ] = useState( { isTooltipVisible: false } );
 	const [ sizing, setSizing ] = useState( { clientWidth: 0, hasResized: false } );
@@ -235,17 +235,6 @@ Chart.propTypes = {
 	minBarsToBeShown: PropTypes.number,
 	hideYAxis: PropTypes.bool,
 	hideXAxis: PropTypes.bool,
-};
-
-Chart.defaultProps = {
-	barClick: noop,
-	isPlaceholder: false,
-	minBarWidth: 15,
-	minTouchBarWidth: 42,
-	chartXPadding: 20,
-	sliceFromBeginning: true,
-	hideYAxis: false,
-	hideXAxis: false,
 };
 
 export default withRtl( localize( Chart ) );

--- a/client/components/email-verification/email-verification-gate/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-verification-gate/email-unverified-notice.jsx
@@ -19,11 +19,6 @@ class EmailUnverifiedNotice extends Component {
 		noticeStatus: PropTypes.string,
 	};
 
-	static defaultProps = {
-		noticeText: null,
-		noticeStatus: '',
-	};
-
 	handleDismiss = () => {
 		this.setState( { error: null, emailSent: false } );
 	};

--- a/client/components/email-verification/email-verification-gate/index.jsx
+++ b/client/components/email-verification/email-verification-gate/index.jsx
@@ -16,15 +16,10 @@ export class EmailVerificationGate extends Component {
 		allowUnlaunched: PropTypes.bool,
 		noticeText: PropTypes.node,
 		noticeStatus: PropTypes.string,
-		children: PropTypes.Node,
+		children: PropTypes.node,
 		//connected
 		userEmail: PropTypes.string,
 		needsVerification: PropTypes.bool,
-	};
-
-	static defaultProps = {
-		noticeText: null,
-		noticeStatus: '',
 	};
 
 	handleFocus = ( e ) => {

--- a/client/components/marketing-message/index.tsx
+++ b/client/components/marketing-message/index.tsx
@@ -8,11 +8,8 @@ import { useMarketingMessage } from './use-marketing-message';
 import './style.scss';
 
 type NudgeProps = {
-	useMockData: boolean;
-	siteId: number | null;
-	className?: string;
-	path: string;
-	withDiscount: string;
+	siteId?: number | null;
+	path?: string;
 };
 
 type JITMTProps = {
@@ -29,7 +26,7 @@ type JITMTProps = {
 	} >;
 };
 
-const Container = styled.div< Pick< NudgeProps, 'path' > >`
+const Container = styled.div`
 	display: flex;
 
 	&.is-signup-plans {
@@ -78,7 +75,7 @@ const Message = styled.div< { isPlansStep: boolean } >`
 	}
 `;
 
-const Text = styled.p< Pick< NudgeProps, 'path' > >`
+const Text = styled.p`
 	white-space: pre-wrap;
 	text-indent: -1.5em;
 	margin: 0;
@@ -107,8 +104,8 @@ const limitedTimeOfferDiscountNudge = () => {
 	);
 };
 
-export default function MarketingMessage( { siteId, useMockData, ...props }: NudgeProps ) {
-	const [ isFetching, messages, removeMessage ] = useMarketingMessage( siteId, useMockData );
+export default function MarketingMessage( { siteId = null, path = '' }: NudgeProps ) {
+	const [ isFetching, messages, removeMessage ] = useMarketingMessage( siteId );
 	const hasNudge = ! isFetching && messages.length > 0;
 
 	useEffect( () => {
@@ -122,13 +119,13 @@ export default function MarketingMessage( { siteId, useMockData, ...props }: Nud
 		return null;
 	}
 
-	const classNames = clsx( 'nudge-container', props.className, `is-${ slugify( props.path ) }` );
+	const classNames = clsx( 'nudge-container', { [ `is-${ slugify( path ) }` ]: path } );
 
 	return (
-		<Container path={ props.path } className={ classNames } role="status">
+		<Container className={ classNames } role="status">
 			{ messages.map( ( msg ) => (
-				<Message key={ msg.id } isPlansStep={ props.path === 'signup/plans' }>
-					<Text path={ props.path }>{ msg.text }</Text>
+				<Message key={ msg.id } isPlansStep={ path === 'signup/plans' }>
+					<Text>{ msg.text }</Text>
 					<Button compact borderless onClick={ () => removeMessage( msg.id ) }>
 						<Gridicon icon="cross" size={ 24 } />
 					</Button>
@@ -137,10 +134,3 @@ export default function MarketingMessage( { siteId, useMockData, ...props }: Nud
 		</Container>
 	);
 }
-
-MarketingMessage.defaultProps = {
-	useMockData: false,
-	siteId: null,
-	path: '',
-	withDiscount: null,
-};

--- a/client/components/support-info/index.jsx
+++ b/client/components/support-info/index.jsx
@@ -5,7 +5,7 @@ import InfoPopover from 'calypso/components/info-popover';
 
 import './style.scss';
 
-function makePrivacyLink( privacyLink, link ) {
+function makePrivacyLink( privacyLink = true, link = '' ) {
 	if ( privacyLink ) {
 		if ( typeof privacyLink === 'string' ) {
 			return privacyLink;
@@ -18,10 +18,10 @@ function makePrivacyLink( privacyLink, link ) {
 }
 
 function SupportInfo( {
-	children = <></>,
-	text = '',
+	children,
+	text,
 	link,
-	position,
+	position = 'left',
 	privacyLink,
 	popoverClassName = '',
 } ) {
@@ -32,11 +32,12 @@ function SupportInfo( {
 		<div className="support-info">
 			<InfoPopover
 				className={ popoverClassName }
-				position={ position || 'left' }
+				position={ position }
 				screenReaderText={ translate( 'Learn more' ) }
 			>
-				{ text + ' ' }
+				{ text }
 				{ children }
+				{ link || filteredPrivacyLink ? ' ' : null }
 				{ link && (
 					<span className="support-info__learn-more">
 						<ExternalLink href={ link } target="_blank" rel="noopener noreferrer">
@@ -56,13 +57,8 @@ function SupportInfo( {
 	);
 }
 
-SupportInfo.defaultProps = {
-	text: '',
-	link: '',
-	privacyLink: true,
-};
-
 SupportInfo.propTypes = {
+	children: PropTypes.node,
 	text: PropTypes.string,
 	link: PropTypes.string,
 	position: PropTypes.string,

--- a/client/my-sites/github-deployments/components/deployment-style/index.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/index.tsx
@@ -49,7 +49,7 @@ export const DeploymentStyle = ( {
 			</p>
 			<p>
 				{ __(
-					' Advanced deployments allow you to use a workflow script, enabling custom build steps such as installing Composer dependencies, conducting pre-deployment code testing, and controlling file deployment. '
+					' Advanced deployments allow you to use a workflow script, enabling custom build steps such as installing Composer dependencies, conducting pre-deployment code testing, and controlling file deployment.'
 				) }
 			</p>
 		</>

--- a/client/my-sites/github-deployments/components/deployment-style/index.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/index.tsx
@@ -49,7 +49,7 @@ export const DeploymentStyle = ( {
 			</p>
 			<p>
 				{ __(
-					' Advanced deployments allow you to use a workflow script, enabling custom build steps such as installing Composer dependencies, conducting pre-deployment code testing, and controlling file deployment.'
+					'Advanced deployments allow you to use a workflow script, enabling custom build steps such as installing Composer dependencies, conducting pre-deployment code testing, and controlling file deployment.'
 				) }
 			</p>
 		</>

--- a/client/my-sites/people/team-invite/index.tsx
+++ b/client/my-sites/people/team-invite/index.tsx
@@ -84,8 +84,6 @@ function TeamInvite( props: Props ) {
 				if ( ! site || ! isJetpack || needsVerification ) {
 					return (
 						<Card>
-							{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
-							{ /* @ts-ignore */ }
 							<EmailVerificationGate>
 								<InviteForm onInviteSuccess={ goBack } />
 							</EmailVerificationGate>

--- a/client/my-sites/site-settings/site-tools/link.jsx
+++ b/client/my-sites/site-settings/site-tools/link.jsx
@@ -2,9 +2,7 @@ import { CompactCard } from '@automattic/components';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 
-const noop = () => {};
-
-const SiteToolsLink = ( { description, href, isWarning, onClick = noop, title } ) => {
+const SiteToolsLink = ( { description, href, isWarning, onClick, title } ) => {
 	const titleClasses = clsx( 'site-tools__section-title', {
 		'is-warning': isWarning,
 	} );
@@ -21,7 +19,7 @@ const SiteToolsLink = ( { description, href, isWarning, onClick = noop, title } 
 
 SiteToolsLink.propTypes = {
 	description: PropTypes.string,
-	href: PropTypes.string,
+	href: PropTypes.string.isRequired,
 	isWarning: PropTypes.bool,
 	onClick: PropTypes.func,
 	title: PropTypes.string,

--- a/client/my-sites/site-settings/site-tools/link.jsx
+++ b/client/my-sites/site-settings/site-tools/link.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 const noop = () => {};
 
-const SiteToolsLink = ( { description, href, isWarning, onClick, title } ) => {
+const SiteToolsLink = ( { description, href, isWarning, onClick = noop, title } ) => {
 	const titleClasses = clsx( 'site-tools__section-title', {
 		'is-warning': isWarning,
 	} );
@@ -25,11 +25,6 @@ SiteToolsLink.propTypes = {
 	isWarning: PropTypes.bool,
 	onClick: PropTypes.func,
 	title: PropTypes.string,
-};
-
-SiteToolsLink.defaultProps = {
-	isWarning: false,
-	onClick: noop,
 };
 
 export default SiteToolsLink;

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
 import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import ReactDOM from 'react-dom';
@@ -25,73 +25,68 @@ const Sso = ( {
 	selectedSiteId,
 	ssoModuleActive,
 	ssoModuleUnavailable,
-	translate,
 } ) => {
+	const translate = useTranslate();
 	const localeSlug = useLocale();
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 
 	return (
-		<>
-			<div>
-				<QueryJetpackConnection siteId={ selectedSiteId } />
+		<div>
+			<QueryJetpackConnection siteId={ selectedSiteId } />
+			<Card className="sso__card site-settings__security-settings">
+				<FormFieldset>
+					<SupportInfo
+						text={ translate(
+							'Allows registered users to log in to your site with their WordPress.com accounts.'
+						) }
+						link={
+							isAtomic
+								? localizeUrl( 'https://wordpress.com/support/wordpress-com-secure-sign-on-sso/' )
+								: 'https://jetpack.com/support/sso/'
+						}
+						privacyLink={ ! isAtomic }
+					/>
 
-				<Card className="sso__card site-settings__security-settings">
-					<FormFieldset>
-						<SupportInfo
-							text={ translate(
-								'Allows registered users to log in to your site with their WordPress.com accounts.'
-							) }
-							link={
-								isAtomic
-									? localizeUrl( 'https://wordpress.com/support/wordpress-com-secure-sign-on-sso/' )
-									: 'https://jetpack.com/support/sso/'
+					<JetpackModuleToggle
+						siteId={ selectedSiteId }
+						moduleSlug="sso"
+						label={ translate( 'Allow users to log in to this site using WordPress.com accounts' ) }
+						description={ translate( "Use WordPress.com's secure authentication" ) }
+						disabled={ isRequestingSettings || isSavingSettings || ssoModuleUnavailable }
+						onChange={ ( enabled ) => {
+							if ( ! enabled ) {
+								setIsModalVisible( true );
 							}
-							privacyLink={ ! isAtomic }
+						} }
+					/>
+
+					<div className="sso__module-settings site-settings__child-settings">
+						<ToggleControl
+							checked={ !! fields.jetpack_sso_match_by_email }
+							disabled={
+								isRequestingSettings ||
+								isSavingSettings ||
+								! ssoModuleActive ||
+								ssoModuleUnavailable
+							}
+							onChange={ handleAutosavingToggle( 'jetpack_sso_match_by_email' ) }
+							label={ translate( 'Match accounts using email addresses' ) }
 						/>
 
-						<JetpackModuleToggle
-							siteId={ selectedSiteId }
-							moduleSlug="sso"
-							label={ translate(
-								'Allow users to log in to this site using WordPress.com accounts'
-							) }
-							description={ translate( "Use WordPress.com's secure authentication" ) }
-							disabled={ isRequestingSettings || isSavingSettings || ssoModuleUnavailable }
-							onChange={ ( enabled ) => {
-								if ( ! enabled ) {
-									setIsModalVisible( true );
-								}
-							} }
+						<ToggleControl
+							checked={ !! fields.jetpack_sso_require_two_step }
+							disabled={
+								isRequestingSettings ||
+								isSavingSettings ||
+								! ssoModuleActive ||
+								ssoModuleUnavailable
+							}
+							onChange={ handleAutosavingToggle( 'jetpack_sso_require_two_step' ) }
+							label={ translate( 'Require two-step authentication' ) }
 						/>
-
-						<div className="sso__module-settings site-settings__child-settings">
-							<ToggleControl
-								checked={ !! fields.jetpack_sso_match_by_email }
-								disabled={
-									isRequestingSettings ||
-									isSavingSettings ||
-									! ssoModuleActive ||
-									ssoModuleUnavailable
-								}
-								onChange={ handleAutosavingToggle( 'jetpack_sso_match_by_email' ) }
-								label={ translate( 'Match accounts using email addresses' ) }
-							/>
-
-							<ToggleControl
-								checked={ !! fields.jetpack_sso_require_two_step }
-								disabled={
-									isRequestingSettings ||
-									isSavingSettings ||
-									! ssoModuleActive ||
-									ssoModuleUnavailable
-								}
-								onChange={ handleAutosavingToggle( 'jetpack_sso_require_two_step' ) }
-								label={ translate( 'Require two-step authentication' ) }
-							/>
-						</div>
-					</FormFieldset>
-				</Card>
-			</div>
+					</div>
+				</FormFieldset>
+			</Card>
 			{ localeSlug === 'en' &&
 				isModalVisible &&
 				ReactDOM.createPortal(
@@ -109,14 +104,8 @@ const Sso = ( {
 					/>,
 					document.body
 				) }
-		</>
+		</div>
 	);
-};
-
-Sso.defaultProps = {
-	isSavingSettings: false,
-	isRequestingSettings: true,
-	fields: {},
 };
 
 Sso.propTypes = {
@@ -141,4 +130,4 @@ export default connect( ( state ) => {
 		ssoModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'sso' ),
 		ssoModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 	};
-} )( localize( Sso ) );
+} )( Sso );

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -110,8 +110,4 @@ const Button: ForwardRefRenderFunction<
  */
 const ButtonWithForwardedRef = forwardRef( Button );
 
-ButtonWithForwardedRef.defaultProps = {
-	type: 'button',
-};
-
 export default ButtonWithForwardedRef;

--- a/packages/components/src/count/index.jsx
+++ b/packages/components/src/count/index.jsx
@@ -5,16 +5,18 @@ import formatNumberCompact from './format-number-compact';
 
 import './style.scss';
 
-export const Count = ( { count, compact, numberFormat, forwardRef, primary, ...rest } ) => {
-	// Omit props passed from the `localize` higher-order component that we don't need.
-	const { translate, moment, ...inheritProps } = rest;
-
+export const Count = ( {
+	count,
+	primary = false,
+	compact = false,
+	forwardRef,
+	numberFormat,
+	translate,
+	locale,
+	...props
+} ) => {
 	return (
-		<span
-			ref={ forwardRef }
-			className={ clsx( 'count', { 'is-primary': primary } ) }
-			{ ...inheritProps }
-		>
+		<span ref={ forwardRef } className={ clsx( 'count', { 'is-primary': primary } ) } { ...props }>
 			{ compact ? formatNumberCompact( count ) || numberFormat( count ) : numberFormat( count ) }
 		</span>
 	);
@@ -25,12 +27,6 @@ Count.propTypes = {
 	numberFormat: PropTypes.func,
 	primary: PropTypes.bool,
 	compact: PropTypes.bool,
-	refProp: PropTypes.oneOfType( [ PropTypes.func, PropTypes.shape( { current: PropTypes.any } ) ] ),
-};
-
-Count.defaultProps = {
-	primary: false,
-	compact: false,
 };
 
 export default localize( Count );

--- a/packages/components/src/notice-banner/index.tsx
+++ b/packages/components/src/notice-banner/index.tsx
@@ -39,29 +39,16 @@ const getIconByLevel = ( level: NoticeBannerProps[ 'level' ] ) => {
 	}
 };
 
-/**
- * NoticeBanner component
- * @param {Object} props                    - The component properties.
- * @param {string} props.level              - The notice level: error, warning, info, success.
- * @param {boolean} props.hideCloseButton   - Whether to hide the close button.
- * @param {Function} props.onClose          - The function to call when the close button is clicked.
- * @param {string} props.title              - The title of the notice.
- * @param {React.ReactNode[]} props.actions - Actions to show across the bottom of the bar.
- * @param {React.Component} props.children  - The notice content.
- * @returns {React.ReactElement}              The `NoticeBanner` component.
- */
-const NoticeBanner: React.FC< NoticeBannerProps > = ( {
-	level,
+export default function NoticeBanner( {
+	level = 'info',
 	title,
 	children,
 	actions,
-	hideCloseButton,
+	hideCloseButton = false,
 	onClose,
-} ) => {
-	const classes = clsx( 'notice-banner', `is-${ level }` );
-
+}: NoticeBannerProps ) {
 	return (
-		<div className={ classes }>
+		<div className={ clsx( 'notice-banner', `is-${ level }` ) }>
 			<div className="notice-banner__icon-wrapper">
 				<Icon icon={ getIconByLevel( level ) } className="notice-banner__icon" />
 			</div>
@@ -86,11 +73,4 @@ const NoticeBanner: React.FC< NoticeBannerProps > = ( {
 			) }
 		</div>
 	);
-};
-
-NoticeBanner.defaultProps = {
-	level: 'info',
-	hideCloseButton: false,
-};
-
-export default NoticeBanner;
+}


### PR DESCRIPTION
Followup to #93666, removing some more deprecated `defaultProps`, as I was encountering the console warnings while using Calypso.

See details in inline comments.