### PR TITLE
Migration: Integrate the Migration offer modal

### DIFF
--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -222,8 +222,6 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 						? MIGRATION_SOURCE_URL
 						: MIGRATION_HOW_TO_MIGRATE;
 
-					// console.log( 'GoToCheckout', props );
-
 					return navigateToCheckout( { siteId, siteSlug, plan, from, props, destinationStep } );
 				}
 			},

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -64,7 +64,7 @@ describe( `${ flow.name }`, () => {
 		runUseStepNavigationGoBack( {
 			currentStep: from.slug,
 			dependencies: dependencies,
-			currentURL: addQueryArgs( query, `/setup/${ from.slug }` ),
+			currentURL: addQueryArgs( query, `/${ flow.name }/${ from.slug }` ),
 		} );
 
 		const destination = getFlowLocation();
@@ -318,6 +318,24 @@ describe( `${ flow.name }`, () => {
 					)
 				);
 			} );
+
+			it( 'redirects user from MIGRATION_UPGRADE_PLAN using SOURCE_URL_STEP as destination when they accept the offer', () => {
+				runNavigation( {
+					from: STEPS.MIGRATION_UPGRADE_PLAN,
+					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
+					dependencies: { goToCheckout: true, plan: 'business', userAcceptedDeal: true },
+				} );
+
+				expect( goToCheckout ).toHaveBeenCalledWith( {
+					destination: `/setup/migration/migration-source-url?siteId=123&siteSlug=example.wordpress.com`,
+					extraQueryParams: undefined,
+					flowName: 'migration',
+					siteSlug: 'example.wordpress.com',
+					stepName: STEPS.MIGRATION_UPGRADE_PLAN.slug,
+					cancelDestination: `/setup/migration/migration-upgrade-plan?siteId=123&siteSlug=example.wordpress.com`,
+					plan: 'business',
+				} );
+			} );
 		} );
 
 		describe( 'MIGRATION_HOW_TO_MIGRATE STEP', () => {
@@ -383,7 +401,7 @@ describe( `${ flow.name }`, () => {
 	} );
 
 	describe( 'useStepNavigation > goBack', () => {
-		it( 'redirects back user from SOURCE URL TO HOW TO MIGRATE', () => {
+		it( 'redirects back user from SOURCE URL > HOW TO MIGRATE', () => {
 			const destination = runNavigationBack( {
 				from: STEPS.MIGRATION_SOURCE_URL,
 				query: { siteId: 123, siteSlug: 'example.wordpress.com' },
@@ -395,15 +413,41 @@ describe( `${ flow.name }`, () => {
 			} );
 		} );
 
-		it( 'redirects back user from MIGRATION_UPGRADE_PLAN > PLATFORM_IDENTIFICATION', () => {
+		it( 'retain user on the step and set the assisted migration modal query param when the modal query param is not set', () => {
 			const destination = runNavigationBack( {
 				from: STEPS.MIGRATION_UPGRADE_PLAN,
 				query: { siteId: 123, siteSlug: 'example.wordpress.com', plan: 'business' },
 			} );
 
 			expect( destination ).toMatchDestination( {
+				step: STEPS.MIGRATION_UPGRADE_PLAN,
+				query: {
+					siteId: 123,
+					siteSlug: 'example.wordpress.com',
+					plan: 'business',
+					showModal: 'true',
+				},
+			} );
+		} );
+
+		it( 'redirects back user from MIGRATION_HOW_TO_MIGRATE URL > PLATFORM_IDENTIFICATION STEP when the assisted modal query param is set', () => {
+			const destination = runNavigationBack( {
+				from: STEPS.MIGRATION_UPGRADE_PLAN,
+				query: {
+					siteId: 123,
+					siteSlug: 'example.wordpress.com',
+					plan: 'business',
+					showModal: 'true',
+				},
+			} );
+
+			expect( destination ).toMatchDestination( {
 				step: STEPS.PLATFORM_IDENTIFICATION,
-				query: { siteId: 123, siteSlug: 'example.wordpress.com', plan: 'business' },
+				query: {
+					siteId: 123,
+					siteSlug: 'example.wordpress.com',
+					plan: 'business',
+				},
 			} );
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/test/helpers/index.tsx
+++ b/client/landing/stepper/declarative-flow/test/helpers/index.tsx
@@ -47,9 +47,10 @@ export const renderFlow = ( flow: Flow ) => {
 			}
 		}, [] );
 
+		const pathname = location.pathname.replace( `${ flow.name }/`, '' );
 		return (
 			<>
-				<p data-testid="pathname">{ `${ location.pathname }${ location.search }` }</p>
+				<p data-testid="pathname">{ `${ pathname }${ location.search }` }</p>
 				<p data-testid="search">{ location.search }</p>
 				<p data-testid="state">{ JSON.stringify( location.state ) }</p>
 				{ assertionConditionResult && (
@@ -118,6 +119,7 @@ declare global {
 
 expect.extend( {
 	toMatchDestination( destination, expected: MatchDestinationParams ) {
+		// console.log( 'OIE', destination.step, expected.step.slug)
 		const isSameStep = destination.step === expected.step.slug;
 
 		if ( expected.query instanceof URLSearchParams === false ) {
@@ -138,7 +140,11 @@ expect.extend( {
 		if ( ! isSameStep ) {
 			return {
 				message: () =>
-					`expected ${ destination.step } to match ${ expected.step.slug } but the step is different`,
+					`Expected step: ${ this.utils.printExpected(
+						decodeURIComponent( expected.step.slug )
+					) } \nReceived step: ${ this.utils.printReceived(
+						decodeURIComponent( destination.step )
+					) }`,
 				pass: false,
 			};
 		}

--- a/client/landing/stepper/declarative-flow/test/helpers/index.tsx
+++ b/client/landing/stepper/declarative-flow/test/helpers/index.tsx
@@ -119,7 +119,6 @@ declare global {
 
 expect.extend( {
 	toMatchDestination( destination, expected: MatchDestinationParams ) {
-		// console.log( 'OIE', destination.step, expected.step.slug)
 		const isSameStep = destination.step === expected.step.slug;
 
 		if ( expected.query instanceof URLSearchParams === false ) {


### PR DESCRIPTION
Related to #93956

## Proposed Changes
* Integrate the Assisted Migration offer. 

<img width="1120" alt="image" src="https://github.com/user-attachments/assets/e748ad39-2af1-442c-88ae-5094419d6339">



## Testing Instructions
Scenario 1: Skip How to Migrate screen
* Go to `/migration` 
* Select WordPress
* On the Upgrade Plan step, click  "Back" 
* Could you check if you can see the modal?
* Click on "Take the deal."
* Make the payment
*  Check if you were redirected to the  `Let’s migrate your site` step


Scenario 2: Back to platform identification screen
* Go to `/migration` 
* Select WordPress
* On the Upgrade Plan step, click  "Back" 
* Could you check if you can see the modal
* Click on "No Thanks"
*  Check if you were redirected to the  `Move your site to WordPress.com` step



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
