### PR TITLE
Performance Profiler: Show TBT tab

### DIFF
--- a/client/data/site-profiler/metrics-dictionaries.ts
+++ b/client/data/site-profiler/metrics-dictionaries.ts
@@ -91,6 +91,7 @@ export function getBasicMetricsFromPerfReport( metrics?: any ): BasicMetricsScor
 		fcp: metrics.fcp,
 		ttfb: metrics.ttfb,
 		inp: metrics.inp,
+		tbt: metrics.tbt,
 	};
 	return getBasicMetricsScored( basicMetrics );
 }

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -92,7 +92,7 @@ export interface HostingProviderQueryResponse {
 	hosting_provider: HostingProvider;
 }
 
-export type Metrics = 'cls' | 'lcp' | 'fcp' | 'ttfb' | 'inp';
+export type Metrics = 'cls' | 'lcp' | 'fcp' | 'ttfb' | 'inp' | 'tbt';
 
 export type Scores = 'good' | 'needs-improvement' | 'poor';
 
@@ -140,6 +140,7 @@ export type PerformanceMetricsHistory = {
 		lcp?: number[];
 		cls?: number[];
 		inp?: number[];
+		tbt?: number[];
 	};
 };
 

--- a/client/performance-profiler/components/core-web-vitals-display/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/index.tsx
@@ -39,7 +39,7 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 			return translate( 's', { comment: 'Used for displaying a time range in seconds, eg. 1-2s' } );
 		}
 
-		if ( [ 'inp' ].includes( activeTab ) ) {
+		if ( [ 'inp', 'tbt' ].includes( activeTab ) ) {
 			return translate( 'ms', {
 				comment: 'Used for displaying a range in milliseconds, eg. 100-200ms',
 			} );

--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -19,7 +19,7 @@ export const PerformanceProfilerDashboardContent = ( {
 	performanceReport,
 	url,
 }: PerformanceProfilerDashboardContentProps ) => {
-	const { overall_score, fcp, lcp, cls, inp, ttfb, audits, history, screenshots, is_wpcom } =
+	const { overall_score, fcp, lcp, cls, inp, ttfb, tbt, audits, history, screenshots, is_wpcom } =
 		performanceReport;
 
 	return (
@@ -38,6 +38,7 @@ export const PerformanceProfilerDashboardContent = ( {
 					cls={ cls }
 					inp={ inp }
 					ttfb={ ttfb }
+					tbt={ tbt }
 					history={ history }
 				/>
 				<NewsletterBanner />

--- a/client/performance-profiler/components/metric-tab-bar/index.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/index.tsx
@@ -22,6 +22,12 @@ export const MetricTabBar = ( props: Props ) => {
 				if ( props[ key as Metrics ] === undefined || props[ key as Metrics ] === null ) {
 					return null;
 				}
+
+				// Only display TBT if INP is not available
+				if ( key === 'tbt' && props[ 'inp' ] !== undefined && props[ 'inp' ] !== null ) {
+					return null;
+				}
+
 				return (
 					<button
 						key={ key }

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -20,6 +20,10 @@ export const metricsNames = {
 		displayName: translate( 'Server responsiveness' ),
 		name: translate( 'Time to First Byte' ),
 	},
+	tbt: {
+		displayName: translate( 'Wait time' ),
+		name: translate( 'Total Blocking Time' ),
+	},
 };
 
 export const metricValuations = {
@@ -73,6 +77,16 @@ export const metricValuations = {
 			'Server responsiveness reflects the time taken for a user’s browser to receive the first byte of data from the server after making a request. The best sites load around 800 milliseconds or less.'
 		),
 	},
+	tbt: {
+		good: translate( "Your site's wait time is good" ),
+		needsImprovement: translate( "Your site's wait time is moderate" ),
+		bad: translate( "Your site's wait time needs improvement" ),
+		heading: translate( 'What is wait time?' ),
+		aka: translate( '(aka Total Blocking Time)' ),
+		explanation: translate(
+			'Wait time measures the total amount of time that a page is blocked from responding to user input, such as mouse clicks, screen taps, or keyboard presses. The best sites have a wait time of less than 200 milliseconds.'
+		),
+	},
 };
 
 // bad values are only needed as a maximum value on the scales
@@ -102,6 +116,11 @@ export const metricsTresholds = {
 		needsImprovement: 500,
 		bad: 1000,
 	},
+	tbt: {
+		good: 200,
+		needsImprovement: 600,
+		bad: 1000,
+	},
 };
 
 export const mapThresholdsToStatus = ( metric: Metrics, value: number ): Valuation => {
@@ -129,7 +148,7 @@ export const displayValue = ( metric: Metrics, value: number ): string => {
 		return `${ max2Decimals( value / 1000 ) }s`;
 	}
 
-	if ( [ 'inp', 'fid' ].includes( metric ) ) {
+	if ( [ 'inp', 'fid', 'tbt' ].includes( metric ) ) {
 		return `${ max2Decimals( value ) }ms`;
 	}
 


### PR DESCRIPTION
Fixes [Performance Profiler: Include TBT metric when CrUX data is not available](https://github.com/Automattic/dotcom-forge/issues/8855)

## Proposed Changes

* Add a `Wait time` tab
* Only displays it when `Interactivity` data is not available

## Why are these changes being made?

[Performance Profiler: Include TBT metric when CrUX data is not available](https://github.com/Automattic/dotcom-forge/issues/8855)


## Testing Instructions

* Go to a site with CRUX data available. Ex: `/speed-test-tool?url=wordpress.com`
* Check if `Interactivity` is displayed
* Go to a site without CRUX data available. Ex: `/speed-test-tool?url=www.s7coworking.co`
* Check if the `Wait time` is displayed

| Interactivity  | Wait time |
| ------------- | ------------- |
|![CleanShot 2024-08-28 at 12 43 05@2x](https://github.com/user-attachments/assets/9d263ed0-d11b-40b2-b889-3b877f9f6391)|![CleanShot 2024-08-28 at 12 34 35@2x](https://github.com/user-attachments/assets/b7f1f196-782e-43c5-9689-0231bf53ee7c)|




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
