### PR TITLE
Site Logs: Fix Pagination Page Number Tabs

### DIFF
--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -137,13 +137,13 @@ export const LogsTab = ( {
 		}
 
 		const nextPageIndex = nextPageNumber - 1;
-		if ( nextPageIndex < currentPageIndex && currentPageIndex > 0 ) {
-			setCurrentPageIndex( currentPageIndex - 1 );
+		if ( nextPageIndex < currentPageIndex && nextPageIndex >= 0 ) {
+			setCurrentPageIndex( nextPageIndex );
 		} else if (
 			nextPageIndex > currentPageIndex &&
-			( currentPageIndex + 1 ) * pageSize < ( data?.total_results ?? 0 )
+			nextPageIndex * pageSize < ( data?.total_results ?? 0 )
 		) {
-			setCurrentPageIndex( currentPageIndex + 1 );
+			setCurrentPageIndex( nextPageIndex );
 		}
 
 		setAutoRefresh( false );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #92668

## Proposed Changes

* Allows updating the currentPageIndex to the nextPageIndex instead of only incrementing or decrementing by one.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* On the Site Logs page, clicking on a pagination tab will presently only increment or decrement the current page by one. However, a user could reasonably expect that clicking on a pagination tab will take them to that page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Site Logs screen: `https://wordpress.com/site-logs/{site-url}/php`
* Ensure that there are at least 3 pages of logs. Additional logs can be added to the screen by changing the date range.
* Verify that pagination arrows will increment or decrement the current page by 1 (unless the current page is the first or last page).
* Verify that clicking on a pagination tab other than the current page tab will update the current page to the selected page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
