### PR TITLE
wpcom-block-editor: Track the preview dropdown selected

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -14,6 +14,7 @@ import wpcomBlockEditorTemplatePartDetachBlocks from './wpcom-block-editor-templ
 import wpcomBlockPremiumContentStripeConnect from './wpcom-block-premium-content-stripe-connect';
 import wpcomInserterInlineSearchTerm from './wpcom-inserter-inline-search-term';
 import wpcomInserterTabPanelSelected from './wpcom-inserter-tab-panel-selected';
+import wpcomPreviewDropdownSelected from './wpcom-preview-dropdown-selected';
 import {
 	wpcomSiteEditorDocumentActionsDropdownOpen,
 	wpcomSiteEditorDocumentActionsTemplateAreaClick,
@@ -85,6 +86,7 @@ const EVENTS_MAPPING = [
 	wpcomSiteEditorSidebarPatternsClick(),
 	wpcomSiteEditorSidebarStylesClick(),
 	wpcomSiteEditorSidebarTemplatesClick(),
+	wpcomPreviewDropdownSelected(),
 ];
 const EVENTS_MAPPING_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => capture );
 const EVENTS_MAPPING_NON_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => ! capture );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-preview-dropdown-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-preview-dropdown-selected.js
@@ -17,6 +17,7 @@ export default () => ( {
 			[ __( 'Tablet' ) ]: 'tablet',
 			[ __( 'Mobile' ) ]: 'mobile',
 			[ `${ __( 'View site' ) }\n${ __( '(opens in a new tab)' ) }` ]: 'view-site',
+			[ __( 'Preview in new tab' ) ]: 'preview',
 		};
 
 		const item = target.querySelector( '.components-menu-item__item' );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-preview-dropdown-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-preview-dropdown-selected.js
@@ -7,7 +7,16 @@ import tracksRecordEvent from './track-record-event';
  */
 export default () => ( {
 	id: 'wpcom-preview-dropdown-selected',
-	selector: '.components-menu-item__button',
+	selector: [
+		'.components-menu-item__button',
+		// The “Preview in new tab” item in the post/page editor
+		'.editor-preview-dropdown__button-external',
+	]
+		.map(
+			( className ) =>
+				`.components-dropdown-menu__menu[aria-label="${ __( 'View options' ) }"] ${ className }`
+		)
+		.join( ',' ),
 	type: 'click',
 	capture: true,
 	handler: ( _event, target ) => {
@@ -16,12 +25,11 @@ export default () => ( {
 			[ __( 'Desktop (50%)' ) ]: 'zoom-out',
 			[ __( 'Tablet' ) ]: 'tablet',
 			[ __( 'Mobile' ) ]: 'mobile',
-			[ `${ __( 'View site' ) }\n${ __( '(opens in a new tab)' ) }` ]: 'view-site',
+			[ [ __( 'View site' ), __( '(opens in a new tab)' ) ].join( '\n' ) ]: 'view-site',
 			[ __( 'Preview in new tab' ) ]: 'preview',
 		};
 
-		const item = target.querySelector( '.components-menu-item__item' );
-		const previewMode = mapTextToPreviewMode[ item?.innerText ];
+		const previewMode = mapTextToPreviewMode[ target.innerText ];
 		if ( previewMode ) {
 			tracksRecordEvent( 'wpcom_editor_preview_dropdown_selected', {
 				preview_mode: previewMode,

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-preview-dropdown-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-preview-dropdown-selected.js
@@ -1,0 +1,30 @@
+import { __ } from '@wordpress/i18n';
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom_block_editor_template_part_detach_blocks`.
+ * @returns {import('./types').DelegateEventHandler} event object definition.
+ */
+export default () => ( {
+	id: 'wpcom-preview-dropdown-selected',
+	selector: '.components-menu-item__button',
+	type: 'click',
+	capture: true,
+	handler: ( _event, target ) => {
+		const mapTextToPreviewMode = {
+			[ __( 'Desktop' ) ]: 'desktop',
+			[ __( 'Desktop (50%)' ) ]: 'zoom-out',
+			[ __( 'Tablet' ) ]: 'tablet',
+			[ __( 'Mobile' ) ]: 'mobile',
+			[ `${ __( 'View site' ) }\n${ __( '(opens in a new tab)' ) }` ]: 'view-site',
+		};
+
+		const item = target.querySelector( '.components-menu-item__item' );
+		const previewMode = mapTextToPreviewMode[ item?.innerText ];
+		if ( previewMode ) {
+			tracksRecordEvent( 'wpcom_preview_dropdown_selected', {
+				preview_mode: previewMode,
+			} );
+		}
+	},
+} );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-preview-dropdown-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-preview-dropdown-selected.js
@@ -22,7 +22,7 @@ export default () => ( {
 		const item = target.querySelector( '.components-menu-item__item' );
 		const previewMode = mapTextToPreviewMode[ item?.innerText ];
 		if ( previewMode ) {
-			tracksRecordEvent( 'wpcom_preview_dropdown_selected', {
+			tracksRecordEvent( 'wpcom_editor_preview_dropdown_selected', {
 				preview_mode: previewMode,
 			} );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1724787351598199-slack-C048CUFRGFQ

## Proposed Changes

Introduce the `wpcom_editor_preview_dropdown_selected ` event to track the preview dropdown selected. The selected item will be recorded as the `preview_mode`

Note that the event is renamed from `wpcom_preview_dropdown_selected` to `wpcom_editor_preview_dropdown_selected` as suggested.
| Item | Event |
| - | - |
| Desktop |  <img width="252" alt="image" src="https://github.com/user-attachments/assets/d92b583a-0752-4fb1-a867-ce23988d57a2"> |
| Desktop (50%) | <img width="253" alt="image" src="https://github.com/user-attachments/assets/7be9e263-c022-4bcb-b7f7-f3a6851aeac3"> |
| Tablet | <img width="252" alt="image" src="https://github.com/user-attachments/assets/3585334a-c005-48d2-b3d8-83a979e5745d"> |
| Mobile | <img width="250" alt="image" src="https://github.com/user-attachments/assets/ab4ffa14-ad7d-49b2-81e7-53f1e097840f"> |
| View site | <img width="251" alt="image" src="https://github.com/user-attachments/assets/d376d8f1-2631-4c71-b502-bbdbbf8f8ba2"> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It would be great how user preview their site/page/post in the editor

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `widgets.wp.com`
* Apply changes to your sandbox as below
  ```
  cd apps/wpcom-block-editor
  yarn dev --sync
  ```
* Go to the editor
* Open the preview dropdown
* Select different item
* Make sure the track event, `wpcom_editor_preview_dropdown_selected`, is sent with the `preview_mode` property

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?