### PR TITLE
Stepper: Disable signup form during loading

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -188,7 +188,8 @@ class PasswordlessSignupForm extends Component {
 	};
 
 	submitStep = ( data ) => {
-		const { flowName, stepName, goToNextStep, submitCreateAccountStep } = this.props;
+		const { flowName, stepName, goToNextStep, submitCreateAccountStep, passDataToNextStep } =
+			this.props;
 		submitCreateAccountStep(
 			{
 				flowName,
@@ -201,7 +202,11 @@ class PasswordlessSignupForm extends Component {
 			data
 		);
 		this.submitTracksEvent( true, { action_message: 'Successful login', username: data.username } );
-		goToNextStep( data );
+		if ( passDataToNextStep ) {
+			goToNextStep( data );
+		} else {
+			goToNextStep();
+		}
 	};
 
 	handleAcceptDomainSuggestion = ( newEmail, newDomain, oldDomain ) => {

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -39,6 +39,7 @@ interface SignupFormSocialFirst {
 	userEmail: string;
 	notice: JSX.Element | false;
 	isSocialFirst: boolean;
+	passDataToNextStep?: boolean;
 }
 
 const options = {
@@ -72,6 +73,7 @@ const SignupFormSocialFirst = ( {
 	userEmail,
 	notice,
 	isSocialFirst,
+	passDataToNextStep,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState( 'initial' );
 	const { __ } = useI18n();
@@ -158,6 +160,7 @@ const SignupFormSocialFirst = ( {
 						submitButtonLabel={ __( 'Continue' ) }
 						userEmail={ userEmail }
 						renderTerms={ renderEmailStepTermsOfService }
+						passDataToNextStep={ passDataToNextStep }
 						onCreateAccountError={ ( error: { error: string }, email: string ) => {
 							if ( isExistingAccountError( error.error ) ) {
 								window.location.assign(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -72,6 +72,7 @@ const UserStepComponent: Step = function UserStep( {
 						stepName={ stepName }
 						flowName={ flow }
 						goToNextStep={ setWpAccountCreateResponse }
+						passDataToNextStep
 						logInUrl={ loginLink }
 						handleSocialResponse={ handleSocialResponse }
 						socialServiceResponse={ socialServiceResponse }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
@@ -3,8 +3,11 @@
 import { useMutation } from '@tanstack/react-query';
 import { createAccount } from 'calypso/lib/signup/api/account';
 import { useDispatch } from 'calypso/state';
-import { LOGIN_AUTH_ACCOUNT_TYPE_REQUESTING } from 'calypso/state/action-types';
-import { receiveSuccess } from 'calypso/state/data-layer/wpcom/users/auth-options';
+import {
+	SOCIAL_LOGIN_REQUEST,
+	SOCIAL_LOGIN_REQUEST_FAILURE,
+	SOCIAL_LOGIN_REQUEST_SUCCESS,
+} from 'calypso/state/action-types';
 
 export function useCreateAccountMutation() {
 	const dispatch = useDispatch();
@@ -12,14 +15,22 @@ export function useCreateAccountMutation() {
 	return useMutation( {
 		mutationKey: [ 'create' ],
 		mutationFn: createAccount,
-		onMutate: ( variables ) => {
+		onMutate: () => {
 			dispatch( {
-				type: LOGIN_AUTH_ACCOUNT_TYPE_REQUESTING,
-				usernameOrEmail: variables.userData?.email,
+				type: SOCIAL_LOGIN_REQUEST,
 			} );
 		},
 		onSuccess: ( data ) => {
-			dispatch( receiveSuccess( null, data ) );
+			dispatch( {
+				type: SOCIAL_LOGIN_REQUEST_SUCCESS,
+				data: data,
+			} );
+		},
+		onError: ( error ) => {
+			dispatch( {
+				type: SOCIAL_LOGIN_REQUEST_FAILURE,
+				error,
+			} );
 		},
 	} );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
@@ -2,10 +2,24 @@
 // import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 import { useMutation } from '@tanstack/react-query';
 import { createAccount } from 'calypso/lib/signup/api/account';
+import { useDispatch } from 'calypso/state';
+import { LOGIN_AUTH_ACCOUNT_TYPE_REQUESTING } from 'calypso/state/action-types';
+import { receiveSuccess } from 'calypso/state/data-layer/wpcom/users/auth-options';
 
 export function useCreateAccountMutation() {
+	const dispatch = useDispatch();
+
 	return useMutation( {
 		mutationKey: [ 'create' ],
 		mutationFn: createAccount,
+		onMutate: ( variables ) => {
+			dispatch( {
+				type: LOGIN_AUTH_ACCOUNT_TYPE_REQUESTING,
+				usernameOrEmail: variables.userData?.email,
+			} );
+		},
+		onSuccess: ( data ) => {
+			dispatch( receiveSuccess( null, data ) );
+		},
 	} );
 }


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/91824

## Proposed Changes

- Disable the sign up form during loading. 
- Don't pass data to `goToNextStep` unless asked to. This is extra safety to avoid breaking /start. 

## Why are these changes being made?
Better UX.

## Testing Instructions

1. Run `yarn start-mock-wordpress-com`.
2. Login via Apple. 
3. After logging in via Apple, the form should be disabled during verification.