### PR TITLE
Add copies for incoming Staging Site Syncing for WooCommerce project.

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
@@ -19,6 +20,7 @@ export const NewStagingSiteCardContent = ( {
 	{
 		const translate = useTranslate();
 		const hasEnTranslation = useHasEnTranslation();
+		const stagingSiteSyncWoo = config.isEnabled( 'staging-site-sync-woo' );
 
 		return (
 			<>
@@ -47,6 +49,23 @@ export const NewStagingSiteCardContent = ( {
 								}
 						  ) }
 				</HostingCardDescription>
+				{ stagingSiteSyncWoo && (
+					<div>
+						<p>{ translate( 'WooCommerce Site' ) }</p>
+						<p>
+							{ translate(
+								'Syncing staging database to production overwrites posts, pages, products and orders. {{a}}Learn more{{/a}}.',
+								{
+									components: {
+										a: (
+											<InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />
+										),
+									},
+								}
+							) }
+						</p>
+					</div>
+				) }
 				<Button primary disabled={ isButtonDisabled } onClick={ onAddClick }>
 					<span>{ translate( 'Add staging site' ) }</span>
 				</Button>

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { FormLabel } from '@automattic/components';
 import styled from '@emotion/styled';
 import { translate, useTranslate } from 'i18n-calypso';
@@ -206,6 +207,9 @@ const StagingToProductionSync = ( {
 		],
 		[ translate ]
 	);
+
+	const stagingSiteSyncWoo = config.isEnabled( 'staging-site-sync-woo' );
+
 	return (
 		<>
 			{ showSyncPanel && (
@@ -239,6 +243,16 @@ const StagingToProductionSync = ( {
 									return <li key={ item.name }>{ item.label }</li>;
 								} ) }
 							</ConfirmationModalList>
+							{ stagingSiteSyncWoo && (
+								<div>
+									<p>{ translate( 'Warning' ) }</p>
+									<p>
+										{ translate(
+											'We do not recommend syncing or pushing data from a staging site to live production news sites or sites that use eCommerce plugins, such as WooCommerce, without proper planning and testing. Keep in mind that data on the destination site could have newer transactions, such as customers and orders, and would be lost when overwritten by the staging site’s data.'
+										) }
+									</p>
+								</div>
+							) }
 							<ConfirmationModalInputTitle>
 								{ translate( "Enter your site's name {{span}}%(siteSlug)s{{/span}} to confirm.", {
 									args: {

--- a/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
+++ b/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
@@ -1,7 +1,9 @@
+import config from '@automattic/calypso-config';
 import styled from '@emotion/styled';
 import { ToggleControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { useState, useEffect, useMemo } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 const DangerousItemsContainer = styled.div( {
 	marginTop: '16px',
@@ -138,6 +140,8 @@ export default function SyncOptionsPanel( {
 		onChange( selectedItems );
 	}, [ optionItemsMap, onChange ] );
 
+	const stagingSiteSyncWoo = config.isEnabled( 'staging-site-sync-woo' );
+
 	return (
 		<>
 			{ nonDangerousItems.map( ( item ) => {
@@ -185,6 +189,23 @@ export default function SyncOptionsPanel( {
 						</div>
 					);
 				} ) }
+				{ stagingSiteSyncWoo && (
+					<div>
+						<p>
+							{ translate(
+								'This site has WooCommerce installed. All orders in the production database will be overwritten. {{a}}Learn more{{/a}}.',
+								{
+									components: {
+										a: (
+											<InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />
+										),
+									},
+								}
+							) }
+						</p>
+						<p>{ translate( 'Confirm I want to proceed with database synchronization ' ) }</p>
+					</div>
+				) }
 			</DangerousItemsContainer>
 		</>
 	);


### PR DESCRIPTION
## Proposed Changes

Add copies for incoming pdDOJh-3GF-p2 project. This will avoid us getting blocked by translations if project move quickly. All copies are under `staging-site-sync-woo` feature flag, we should not worry about designs at the moment.

### Before creating staging site
![image](https://github.com/user-attachments/assets/f51ba0f6-6564-4b3f-92e0-88b027398f6e)

### Info on the Danger zone box before sync
![image](https://github.com/user-attachments/assets/681ad899-eb72-4ff7-a374-e335ad207da6)

### Final warning before sync
![image](https://github.com/user-attachments/assets/f0666f85-0e24-49db-b815-d786ae600e06)

## Testing Instructions

- Access http://calypso.localhost:3000/sites?flags=staging-site-sync-woo
- Find a site that does not have staging site setup, check if the text is present like in the **first** image.
- Find a site that has staging site, click on `Staging into production` radio button. It should open the Danger zone box, and it should include the text like the **second** image.
- Tag any option from the `Synchronize this data:` toggles, click on Synchronise button. It should open the final confirmation modal. Check if the new text is present like in the **third** image.

**Feel free and incentivized if any of the copies has any misspelling**

- Test all three cases **without** the feature flag. Copies should not be available to main audience.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?