### PR TITLE
Update the agency billing copy when launching A4A dev site.

### DIFF
--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -117,11 +117,9 @@ const LaunchSite = () => {
 						{ isDevelopmentSite && (
 							<p>
 								{ agencyLoading || agencyError
-									? translate(
-											'Once the site is launched, your agency will be billed for this site in the next billing cycle.'
-									  )
+									? translate( 'After launch, we’ll bill your agency in the next billing cycle.' )
 									: translate(
-											'Once the site is launched, {{strong}}%(agencyName)s{{/strong}} will be billed for this site in the next billing cycle.',
+											'After launch, we’ll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle.',
 											{
 												args: {
 													agencyName: agencyName,


### PR DESCRIPTION
## Proposed Changes

Due to some feedback, we are updating the copy on agency billing at the launch page to:
`After launch, we’ll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle.`

### Before
![image](https://github.com/user-attachments/assets/8dc862fd-71f7-41e6-86f7-2b7d023f8d17)


### After
![image](https://github.com/user-attachments/assets/f7f624b7-2dd5-4179-9181-c3d863eede76)


## Testing Instructions

Have a development site created on A4A.
Go to `http://calypso.localhost:3000/settings/general/{site-id}`
Check that you get the new copy.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
