### PR TITLE
Add Cartes Bancaires logo as payment logo for methods

### DIFF
--- a/client/assets/images/upgrades/cc-cb.svg
+++ b/client/assets/images/upgrades/cc-cb.svg
@@ -1,1 +1,73 @@
-<svg viewBox="0 0 26.47 18.16" xmlns="http://www.w3.org/2000/svg" width="2500" height="1715"><radialGradient id="b" cx="1.47" cy="18.27" gradientTransform="matrix(1 0 0 .94 0 .5)" gradientUnits="userSpaceOnUse" r="26.83"><stop offset=".09" stop-color="#009245"/><stop offset=".23" stop-color="#049552" stop-opacity=".89"/><stop offset=".52" stop-color="#0d9e74" stop-opacity=".59"/><stop offset=".91" stop-color="#1bacab" stop-opacity=".12"/><stop offset="1" stop-color="#1fb0b8" stop-opacity="0"/></radialGradient><radialGradient id="c" cx="5.89" cy="19.23" gradientUnits="userSpaceOnUse" r="34.42"><stop offset=".15" stop-color="#1fb0b8" stop-opacity="0"/><stop offset=".35" stop-color="#1c7491" stop-opacity=".4"/><stop offset=".56" stop-color="#1a4471" stop-opacity=".73"/><stop offset=".74" stop-color="#18265e" stop-opacity=".93"/><stop offset=".87" stop-color="#181b57"/></radialGradient><g><path d="M0 0h26.47v18.16H0z" fill="#29abe2"/><path d="M0 0h26.47v18.16H0z" fill="url(#b)"/><path d="M0 0h26.47v18.16H0z" fill="url(#c)"/></g><g fill="#fff"><path d="M14.39 3.86h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V3.86zM14.39 9.36h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V9.36zM8.23 9.36V8.8h5.69a5.51 5.51 0 0 0-5.69-4.94 5.47 5.47 0 0 0-5.69 5.22 5.47 5.47 0 0 0 5.69 5.22 5.51 5.51 0 0 0 5.69-4.94z"/></g></svg>
+<svg
+  viewBox="0 0 60 38"
+  width="60"
+  height="38"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <defs>
+    <!-- Define the clipping path -->
+    <clipPath id="paths">
+      <!-- Adjust the coordinates of the paths to fit the viewBox -->
+      <rect
+        xmlns="http://www.w3.org/2000/svg"
+        x="0.5"
+        y="0.5"
+        width="59"
+        height="37"
+        rx="3"
+        fill="none"
+      />
+    </clipPath>
+    <!-- Adjusted gradients to fit the viewBox -->
+    <radialGradient
+      id="b"
+      cx="-5"
+      cy="70"
+      gradientUnits="userSpaceOnUse"
+      r="140"
+    >
+      <stop offset=".09" stop-color="#009245" />
+      <stop offset=".23" stop-color="#049552" stop-opacity=".89" />
+      <stop offset=".52" stop-color="#0d9e74" stop-opacity=".59" />
+      <stop offset=".91" stop-color="#1bacab" stop-opacity=".12" />
+      <stop offset="1" stop-color="#1fb0b8" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient
+      id="c"
+      cx="-5"
+      cy="70"
+      gradientUnits="userSpaceOnUse"
+      r="140"
+    >
+      <stop offset=".15" stop-color="#1fb0b8" stop-opacity="0" />
+      <stop offset=".35" stop-color="#1c7491" stop-opacity=".4" />
+      <stop offset=".56" stop-color="#1a4471" stop-opacity=".73" />
+      <stop offset=".74" stop-color="#18265e" stop-opacity=".93" />
+      <stop offset=".87" stop-color="#181b57" />
+    </radialGradient>
+  </defs>
+
+  <g clip-path="url(#paths)">
+    <!-- Background paths adjusted to fit the viewBox -->
+    <path d="M0 0h60v38H0z" fill="#29abe2" />
+    <path d="M0 0h60v38H0z" fill="url(#b)" />
+    <path d="M0 0h60v38H0z" fill="url(#c)" />
+  </g>
+  <rect
+    x="1"
+    y="1"
+    width="58"
+    height="36"
+    rx="2.5"
+    fill="none"
+    stroke-width="1"
+    stroke="#DCDCDE"
+  />
+
+  <!-- Adjusted position and scaling for the foreground paths -->
+  <g fill="#fff" transform="scale(1.8) translate(3, 1.5)">
+    <path
+      d="M14.39 3.86h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V3.86zM14.39 9.36h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V9.36zM8.23 9.36V8.8h5.69a5.51 5.51 0 0 0-5.69-4.94 5.47 5.47 0 0 0-5.69 5.22 5.47 5.47 0 0 0 5.69 5.22 5.51 5.51 0 0 0 5.69-4.94z"
+    />
+  </g>
+</svg>

--- a/client/assets/images/upgrades/cc-cb.svg
+++ b/client/assets/images/upgrades/cc-cb.svg
@@ -20,7 +20,7 @@
     </clipPath>
     <!-- Adjusted gradients to fit the viewBox -->
     <radialGradient
-      id="b"
+      id="cbb"
       cx="-5"
       cy="70"
       gradientUnits="userSpaceOnUse"
@@ -33,7 +33,7 @@
       <stop offset="1" stop-color="#1fb0b8" stop-opacity="0" />
     </radialGradient>
     <radialGradient
-      id="c"
+      id="cbc"
       cx="-5"
       cy="70"
       gradientUnits="userSpaceOnUse"
@@ -50,20 +50,9 @@
   <g clip-path="url(#paths)">
     <!-- Background paths adjusted to fit the viewBox -->
     <path d="M0 0h60v38H0z" fill="#29abe2" />
-    <path d="M0 0h60v38H0z" fill="url(#b)" />
-    <path d="M0 0h60v38H0z" fill="url(#c)" />
+    <path d="M0 0h60v38H0z" fill="url(#cbb)" />
+    <path d="M0 0h60v38H0z" fill="url(#cbc)" />
   </g>
-  <rect
-    x="1"
-    y="1"
-    width="58"
-    height="36"
-    rx="2.5"
-    fill="none"
-    stroke-width="1"
-    stroke="#DCDCDE"
-  />
-
   <!-- Adjusted position and scaling for the foreground paths -->
   <g fill="#fff" transform="scale(1.8) translate(3, 1.5)">
     <path

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -17,7 +17,7 @@ import './style.scss';
 
 const LOGO_PATHS = {
 	amex: creditCardAmexImage,
-	cb: creditCardCartesBancairesImage,
+	cartes_bancaires: creditCardCartesBancairesImage,
 	diners: creditCardDinersImage,
 	discover: creditCardDiscoverImage,
 	jcb: creditCardJCBImage,
@@ -32,7 +32,7 @@ const ALT_TEXT = {
 	amex: 'American Express',
 	'apple-pay': 'Apple Pay',
 	bancontact: 'Bancontact',
-	cb: 'Cartes Bancaires',
+	cartes_bancaires: 'Cartes Bancaires',
 	diners: 'Diners Club',
 	discover: 'Discover',
 	eps: 'eps',

--- a/client/lib/checkout/payment-methods.tsx
+++ b/client/lib/checkout/payment-methods.tsx
@@ -65,7 +65,7 @@ export interface StoredPaymentMethodCard extends StoredPaymentMethodBase {
 	card_iin: string;
 	card_last_4: string;
 	card_zip: string;
-	display_brand: string;
+	display_brand: string | null;
 }
 
 export interface StoredPaymentMethodEbanx extends StoredPaymentMethodBase {
@@ -162,7 +162,6 @@ export const PaymentMethodSummary = ( {
 			break;
 
 		case 'cartes_bancaires':
-		case 'cb':
 			displayType = translate( 'Cartes Bancaires' );
 			break;
 

--- a/client/lib/checkout/payment-methods.tsx
+++ b/client/lib/checkout/payment-methods.tsx
@@ -65,6 +65,7 @@ export interface StoredPaymentMethodCard extends StoredPaymentMethodBase {
 	card_iin: string;
 	card_last_4: string;
 	card_zip: string;
+	display_brand: string;
 }
 
 export interface StoredPaymentMethodEbanx extends StoredPaymentMethodBase {
@@ -117,7 +118,7 @@ interface ImagePathsMap {
 
 const CREDIT_CARD_SELECTED_PATHS: ImagePathsMap = {
 	amex: creditCardAmexImage,
-	cb: creditCardCartesBancairesImage,
+	cartes_bancaires: creditCardCartesBancairesImage,
 	diners: creditCardDinersImage,
 	discover: creditCardDiscoverImage,
 	jcb: creditCardJCBImage,
@@ -160,7 +161,7 @@ export const PaymentMethodSummary = ( {
 			displayType = translate( 'American Express' );
 			break;
 
-		case 'cartes bancaires':
+		case 'cartes_bancaires':
 		case 'cb':
 			displayType = translate( 'Cartes Bancaires' );
 			break;

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -851,12 +851,15 @@ export function subscribedWithinPastWeek( purchase: Purchase ) {
 
 /**
  * Returns the payment logo to display based on the payment method
+ * 'displayBrand' respects the customer's card brand choice if available
  * @param {Object} purchase - the purchase with which we are concerned
  * @returns {string|null} the payment logo type, or null if no payment type is set.
  */
 export function paymentLogoType( purchase: Purchase ): string | null | undefined {
 	if ( isPaidWithCreditCard( purchase ) ) {
-		return purchase.payment.creditCard?.type;
+		return purchase.payment.creditCard?.displayBrand
+			? purchase.payment.creditCard?.displayBrand
+			: purchase.payment.creditCard?.type;
 	}
 
 	if ( isPaidWithPayPalDirect( purchase ) ) {

--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -19,6 +19,7 @@ import { paymentMethods } from 'calypso/me/purchases/paths';
 import titles from 'calypso/me/purchases/titles';
 import { useCreateCreditCard } from 'calypso/my-sites/checkout/src/hooks/use-create-payment-methods';
 import { useSelector, useDispatch } from 'calypso/state';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { PaymentMethodSelectorSubmitButtonContent } from '../manage-purchase/payment-method-selector/payment-method-selector-submit-button-content';
@@ -26,10 +27,12 @@ import { PaymentMethodSelectorSubmitButtonContent } from '../manage-purchase/pay
 function AddNewPaymentMethod() {
 	const goToPaymentMethods = () => page( paymentMethods );
 	const addPaymentMethodTitle = String( titles.addPaymentMethod );
+	const currency = useSelector( getCurrentUserCurrencyCode );
 
 	const translate = useTranslate();
 	const { isStripeLoading, stripeLoadingError } = useStripe();
 	const stripeMethod = useCreateCreditCard( {
+		currency,
 		isStripeLoading,
 		stripeLoadingError,
 		shouldUseEbanx: false,

--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.tsx
@@ -9,6 +9,8 @@ import {
 } from 'calypso/my-sites/checkout/src/hooks/use-create-payment-methods';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/src/lib/translate-payment-method-names';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { PaymentMethodSelectorSubmitButtonContent } from '../payment-method-selector/payment-method-selector-submit-button-content';
 import useFetchAvailablePaymentMethods from './use-fetch-available-payment-methods';
 import type { PaymentMethod } from '@automattic/composite-checkout';
@@ -26,6 +28,7 @@ export default function useCreateAssignablePaymentMethods(
 ): PaymentMethod[] {
 	const translate = useTranslate();
 	const { isStripeLoading, stripeLoadingError } = useStripe();
+	const currency = useSelector( getCurrentUserCurrencyCode );
 
 	const {
 		isFetching: isLoadingAllowedPaymentMethods,
@@ -47,6 +50,7 @@ export default function useCreateAssignablePaymentMethods(
 	} );
 	const hasExistingCardMethods = existingCardMethods && existingCardMethods.length > 0;
 	const stripeMethod = useCreateCreditCard( {
+		currency,
 		isStripeLoading,
 		stripeLoadingError,
 		shouldUseEbanx: false,

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -342,6 +342,7 @@
 
 	.payment-logo {
 		margin-right: 5px;
+		border-radius: 2px;
 	}
 
 	a {

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -12,6 +12,7 @@ import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface Props {
 	lastDigits?: string;
+	displayBrand?: string;
 	cardType?: string;
 	name: string;
 	expiry?: string;
@@ -24,6 +25,7 @@ interface Props {
 
 const PaymentMethodDetails: FunctionComponent< Props > = ( {
 	lastDigits,
+	displayBrand,
 	cardType,
 	name,
 	expiry,
@@ -39,7 +41,7 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 	const expirationDate = expiry ? moment( expiry, moment.ISO_8601, true ) : null;
 	const displayExpirationDate = expirationDate?.isValid() ? expirationDate.format( 'MM/YY' ) : null;
 
-	const type = cardType?.toLocaleLowerCase() || paymentPartner || '';
+	const type = displayBrand ?? ( cardType?.toLocaleLowerCase() || paymentPartner || '' );
 
 	return (
 		<div className="payment-method-details">

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -12,7 +12,7 @@ import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface Props {
 	lastDigits?: string;
-	displayBrand?: string;
+	displayBrand?: string | null;
 	cardType?: string;
 	name: string;
 	expiry?: string;

--- a/client/me/purchases/payment-methods/payment-method.tsx
+++ b/client/me/purchases/payment-methods/payment-method.tsx
@@ -21,6 +21,9 @@ export default function PaymentMethod( { paymentMethod }: { paymentMethod: Store
 				<PaymentMethodDetails
 					lastDigits={ 'card_last_4' in paymentMethod ? paymentMethod.card_last_4 : undefined }
 					email={ paymentMethod.email }
+					displayBrand={
+						'display_brand' in paymentMethod ? paymentMethod.display_brand : undefined
+					}
 					cardType={ 'card_type' in paymentMethod ? paymentMethod.card_type : undefined }
 					paymentPartner={ paymentMethod.payment_partner }
 					name={ paymentMethod.name }

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -441,6 +441,10 @@ class PurchaseItem extends Component {
 
 	getPaymentMethod() {
 		const { purchase, translate } = this.props;
+		const paymentMethodType =
+			purchase.payment.creditCard.displayBrand?.trim() !== ''
+				? purchase.payment.creditCard.displayBrand
+				: purchase.payment.creditCard.type || purchase.payment.paymentPartner || '';
 
 		if ( isIncludedWithPlan( purchase ) ) {
 			return translate( 'Included with Plan' );
@@ -487,8 +491,8 @@ class PurchaseItem extends Component {
 				return (
 					<>
 						<img
-							src={ getPaymentMethodImageURL( purchase.payment.creditCard.type ) }
-							alt={ purchase.payment.creditCard.type }
+							src={ getPaymentMethodImageURL( paymentMethodType ) }
+							alt={ paymentMethodType }
 							className="purchase-item__payment-method-card"
 						/>
 						{ purchase.payment.creditCard.number }

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -441,10 +441,6 @@ class PurchaseItem extends Component {
 
 	getPaymentMethod() {
 		const { purchase, translate } = this.props;
-		const paymentMethodType =
-			purchase.payment.creditCard.displayBrand?.trim() !== ''
-				? purchase.payment.creditCard.displayBrand
-				: purchase.payment.creditCard.type || purchase.payment.paymentPartner || '';
 
 		if ( isIncludedWithPlan( purchase ) ) {
 			return translate( 'Included with Plan' );
@@ -488,6 +484,10 @@ class PurchaseItem extends Component {
 
 		if ( isRenewing( purchase ) ) {
 			if ( purchase.payment.type === 'credit_card' ) {
+				const paymentMethodType = purchase.payment.creditCard.displayBrand
+					? purchase.payment.creditCard.displayBrand
+					: purchase.payment.creditCard.type || purchase.payment.paymentPartner || '';
+
 				return (
 					<>
 						<img

--- a/client/my-sites/checkout/src/components/payment-logos.js
+++ b/client/my-sites/checkout/src/components/payment-logos.js
@@ -29,6 +29,8 @@ VisaLogo.propTypes = {
 };
 
 export function CBLogo( { className } ) {
+	// We need to provide a unique ID to any svg that uses an id prop
+	// especially if we expect multiple instances of the component to render on the page
 	const uniqueID = `${ Math.floor( 10000 + Math.random() * 90000 ) }`;
 
 	return (

--- a/client/my-sites/checkout/src/components/payment-logos.js
+++ b/client/my-sites/checkout/src/components/payment-logos.js
@@ -29,44 +29,63 @@ VisaLogo.propTypes = {
 };
 
 export function CBLogo( { className } ) {
+	const uniqueID = `${ Math.floor( 10000 + Math.random() * 90000 ) }`;
+
 	return (
 		<svg
 			className={ className }
-			width="41"
-			height="17"
-			viewBox="0 0 41 17"
-			fill="none"
-			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			focusable="false"
+			viewBox="0 0 60 38"
+			width="42"
+			height="26.6"
+			xmlns="http://www.w3.org/2000/svg"
 		>
-			<radialGradient
-				id="b"
-				cx="1.47"
-				cy="18.27"
-				gradientTransform="matrix(1 0 0 .94 0 .5)"
-				gradientUnits="userSpaceOnUse"
-				r="26.83"
-			>
-				<stop offset=".09" stopColor="#009245" />
-				<stop offset=".23" stopColor="#049552" stopOpacity=".89" />
-				<stop offset=".52" stopColor="#0d9e74" stopOpacity=".59" />
-				<stop offset=".91" stopColor="#1bacab" stopOpacity=".12" />
-				<stop offset="1" stopColor="#1fb0b8" stopOpacity="0" />
-			</radialGradient>
-			<radialGradient id="c" cx="5.89" cy="19.23" gradientUnits="userSpaceOnUse" r="34.42">
-				<stop offset=".15" stopColor="#1fb0b8" stopOpacity="0" />
-				<stop offset=".35" stopColor="#1c7491" stopOpacity=".4" />
-				<stop offset=".56" stopColor="#1a4471" stopOpacity=".73" />
-				<stop offset=".74" stopColor="#18265e" stopOpacity=".93" />
-				<stop offset=".87" stopColor="#181b57" />
-			</radialGradient>
-			<g>
-				<path d="M0 0h26.47v18.16H0z" fill="#29abe2" />
-				<path d="M0 0h26.47v18.16H0z" fill="url(#b)" />
-				<path d="M0 0h26.47v18.16H0z" fill="url(#c)" />
+			<defs>
+				<clipPath id={ `${ uniqueID }paths` }>
+					<rect
+						xmlns="http://www.w3.org/2000/svg"
+						x="0.5"
+						y="0.5"
+						width="59"
+						height="37"
+						rx="3"
+						fill="none"
+					/>
+				</clipPath>
+				<radialGradient
+					id={ `${ uniqueID }b` }
+					cx="-5"
+					cy="70"
+					gradientUnits="userSpaceOnUse"
+					r="140"
+				>
+					<stop offset=".09" stopColor="#009245" />
+					<stop offset=".23" stopColor="#049552" stopOpacity=".89" />
+					<stop offset=".52" stopColor="#0d9e74" stopOpacity=".59" />
+					<stop offset=".91" stopColor="#1bacab" stopOpacity=".12" />
+					<stop offset="1" stopColor="#1fb0b8" stopOpacity="0" />
+				</radialGradient>
+				<radialGradient
+					id={ `${ uniqueID }c` }
+					cx="-5"
+					cy="70"
+					gradientUnits="userSpaceOnUse"
+					r="140"
+				>
+					<stop offset=".15" stopColor="#1fb0b8" stopOpacity="0" />
+					<stop offset=".35" stopColor="#1c7491" stopOpacity=".4" />
+					<stop offset=".56" stopColor="#1a4471" stopOpacity=".73" />
+					<stop offset=".74" stopColor="#18265e" stopOpacity=".93" />
+					<stop offset=".87" stopColor="#181b57" />
+				</radialGradient>
+			</defs>
+			<g clipPath={ `url(#${ uniqueID }paths)` }>
+				<path d="M0 0h60v38H0z" fill="#29abe2" />
+				<path d="M0 0h60v38H0z" fill={ `url(#${ uniqueID }b)` } />
+				<path d="M0 0h60v38H0z" fill={ `url(#${ uniqueID }c)` } />
 			</g>
-			<g fill="#fff">
+			<g fill="#fff" transform="scale(1.8) translate(3, 1.5)">
 				<path d="M14.39 3.86h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V3.86zM14.39 9.36h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V9.36zM8.23 9.36V8.8h5.69a5.51 5.51 0 0 0-5.69-4.94 5.47 5.47 0 0 0-5.69 5.22 5.47 5.47 0 0 0 5.69 5.22 5.51 5.51 0 0 0 5.69-4.94z" />
 			</g>
 		</svg>

--- a/client/my-sites/checkout/src/components/payment-method-logos.js
+++ b/client/my-sites/checkout/src/components/payment-method-logos.js
@@ -1,25 +1,22 @@
 import styled from '@emotion/styled';
 
 export const PaymentMethodLogos = styled.span`
-	&.payment-logos {
-		display: flex;
-		flex: 1;
-		transform: translateY( 3px );
-		text-align: right;
-		align-items: center;
-		justify-content: flex-end;
-		padding-inline-end: 24px;
+	display: flex;
+	flex: 1;
+	text-align: right;
+	align-items: center;
+	justify-content: flex-end;
+	padding-inline-end: 24px;
 
-		.rtl & {
-			text-align: left;
-		}
+	.rtl & {
+		text-align: left;
+	}
 
-		svg {
-			display: inline-block;
+	svg {
+		display: inline-block;
 
-			&.has-background {
-				padding-inline-end: 5px;
-			}
+		&.has-background {
+			padding-inline-end: 5px;
 		}
 	}
 `;

--- a/client/my-sites/checkout/src/components/payment-method-logos.js
+++ b/client/my-sites/checkout/src/components/payment-method-logos.js
@@ -1,15 +1,25 @@
 import styled from '@emotion/styled';
 
 export const PaymentMethodLogos = styled.span`
-	flex: 1;
-	transform: translateY( 3px );
-	text-align: right;
+	&.payment-logos {
+		display: flex;
+		flex: 1;
+		transform: translateY( 3px );
+		text-align: right;
+		align-items: center;
+		justify-content: flex-end;
+		padding-inline-end: 24px;
 
-	.rtl & {
-		text-align: left;
-	}
+		.rtl & {
+			text-align: left;
+		}
 
-	svg {
-		display: inline-block;
+		svg {
+			display: inline-block;
+
+			&.has-background {
+				padding-inline-end: 5px;
+			}
+		}
 	}
 `;

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -65,6 +65,7 @@ export function useCreatePayPal( {
 }
 
 export function useCreateCreditCard( {
+	currency,
 	isStripeLoading,
 	stripeLoadingError,
 	shouldUseEbanx,
@@ -74,6 +75,7 @@ export function useCreateCreditCard( {
 	allowUseForAllSubscriptions,
 	hasExistingCardMethods,
 }: {
+	currency: string;
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	shouldUseEbanx: boolean;
@@ -96,6 +98,7 @@ export function useCreateCreditCard( {
 		() =>
 			shouldLoadStripeMethod
 				? createCreditCardMethod( {
+						currency,
 						store: stripePaymentMethodStore,
 						shouldUseEbanx,
 						shouldShowTaxFields,
@@ -399,7 +402,7 @@ export default function useCreatePaymentMethods( {
 } ): PaymentMethod[] {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
-
+	const { currency } = responseCart;
 	const paypalMethod = useCreatePayPal( {} );
 
 	const idealMethod = useCreateIdeal( {
@@ -459,6 +462,7 @@ export default function useCreatePaymentMethods( {
 	// in the credit card form instead.
 	const shouldShowTaxFields = contactDetailsType === 'none';
 	const stripeMethod = useCreateCreditCard( {
+		currency,
 		shouldShowTaxFields,
 		isStripeLoading,
 		stripeLoadingError,

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -75,7 +75,7 @@ export function useCreateCreditCard( {
 	allowUseForAllSubscriptions,
 	hasExistingCardMethods,
 }: {
-	currency: string;
+	currency: string | null;
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	shouldUseEbanx: boolean;
@@ -108,6 +108,7 @@ export function useCreateCreditCard( {
 				  } )
 				: null,
 		[
+			currency,
 			shouldLoadStripeMethod,
 			stripePaymentMethodStore,
 			shouldUseEbanx,

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
@@ -47,7 +47,9 @@ export default function useCreateExistingCards( {
 					id: `existingCard-${ storedDetails.stored_details_id }`,
 					cardholderName: storedDetails.name,
 					cardExpiry: storedDetails.expiry,
-					brand: storedDetails.card_type,
+					brand: storedDetails?.display_brand
+						? storedDetails.display_brand
+						: storedDetails.card_type,
 					last4: storedDetails.card_last_4,
 					storedDetailsId: storedDetails.stored_details_id,
 					paymentMethodToken: storedDetails.mp_ref,

--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -62,7 +62,7 @@ const CreditCardLabel: React.FC< {
 
 function CreditCardLogos( { currency }: { currency: string } ) {
 	return (
-		<PaymentMethodLogos className="credit-card__logo payment-logos">
+		<PaymentMethodLogos className="credit-card__logo">
 			{ currency === 'EUR' && <CBLogo className="has-background" /> }
 			<VisaLogo />
 			<MastercardLogo />

--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -45,7 +45,7 @@ function CreditCardSummary() {
 
 const CreditCardLabel: React.FC< {
 	hasExistingCardMethods: boolean | undefined;
-	currency: string;
+	currency: string | null;
 } > = ( { hasExistingCardMethods, currency } ) => {
 	const { __ } = useI18n();
 	return (
@@ -60,7 +60,7 @@ const CreditCardLabel: React.FC< {
 	);
 };
 
-function CreditCardLogos( { currency }: { currency: string } ) {
+function CreditCardLogos( { currency }: { currency: string | null } ) {
 	return (
 		<PaymentMethodLogos className="credit-card__logo">
 			{ currency === 'EUR' && <CBLogo className="has-background" /> }
@@ -80,7 +80,7 @@ export function createCreditCardMethod( {
 	allowUseForAllSubscriptions,
 	hasExistingCardMethods,
 }: {
-	currency: string;
+	currency: string | null;
 	store: CardStoreType;
 	shouldUseEbanx?: boolean;
 	shouldShowTaxFields?: boolean;

--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -3,6 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { Fragment } from 'react';
 import {
+	CBLogo,
 	VisaLogo,
 	MastercardLogo,
 	AmexLogo,
@@ -42,9 +43,10 @@ function CreditCardSummary() {
 	);
 }
 
-const CreditCardLabel: React.FC< { hasExistingCardMethods: boolean | undefined } > = ( {
-	hasExistingCardMethods,
-} ) => {
+const CreditCardLabel: React.FC< {
+	hasExistingCardMethods: boolean | undefined;
+	currency: string;
+} > = ( { hasExistingCardMethods, currency } ) => {
 	const { __ } = useI18n();
 	return (
 		<Fragment>
@@ -53,14 +55,15 @@ const CreditCardLabel: React.FC< { hasExistingCardMethods: boolean | undefined }
 			) : (
 				<span>{ __( 'Credit or debit card' ) }</span>
 			) }
-			<CreditCardLogos />
+			<CreditCardLogos currency={ currency } />
 		</Fragment>
 	);
 };
 
-function CreditCardLogos() {
+function CreditCardLogos( { currency }: { currency: string } ) {
 	return (
 		<PaymentMethodLogos className="credit-card__logo payment-logos">
+			{ currency === 'EUR' && <CBLogo className="has-background" /> }
 			<VisaLogo />
 			<MastercardLogo />
 			<AmexLogo />
@@ -69,6 +72,7 @@ function CreditCardLogos() {
 }
 
 export function createCreditCardMethod( {
+	currency,
 	store,
 	shouldUseEbanx,
 	shouldShowTaxFields,
@@ -76,6 +80,7 @@ export function createCreditCardMethod( {
 	allowUseForAllSubscriptions,
 	hasExistingCardMethods,
 }: {
+	currency: string;
 	store: CardStoreType;
 	shouldUseEbanx?: boolean;
 	shouldShowTaxFields?: boolean;
@@ -86,7 +91,9 @@ export function createCreditCardMethod( {
 	return {
 		id: 'card',
 		paymentProcessorId: 'card',
-		label: <CreditCardLabel hasExistingCardMethods={ hasExistingCardMethods } />,
+		label: (
+			<CreditCardLabel hasExistingCardMethods={ hasExistingCardMethods } currency={ currency } />
+		),
 		hasRequiredFields: true,
 		activeContent: (
 			<CreditCardFields

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -26,6 +26,7 @@ import { useCreateCreditCard } from 'calypso/my-sites/checkout/src/hooks/use-cre
 import { logStashLoadErrorEvent } from 'calypso/my-sites/checkout/src/lib/analytics';
 import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 import { useDispatch, useSelector } from 'calypso/state';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getAddNewPaymentMethodUrlFor, getPaymentMethodsUrlFor } from '../paths';
@@ -84,9 +85,11 @@ function SiteLevelAddNewPaymentMethodForm( { siteSlug }: { siteSlug: string } ) 
 	const logPaymentMethodsError = useLogPaymentMethodsError(
 		'site level add new payment method load error'
 	);
+	const currency = useSelector( getCurrentUserCurrencyCode );
 
 	const { isStripeLoading, stripeLoadingError } = useStripe();
 	const stripeMethod = useCreateCreditCard( {
+		currency,
 		isStripeLoading,
 		stripeLoadingError,
 		shouldUseEbanx: false,

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -32,7 +32,6 @@ export interface BillingTransaction {
 	cc_name: string;
 	cc_num: string;
 	cc_type: string;
-	display_brand: string;
 	credit: string;
 	date: string;
 	desc: string;

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -32,6 +32,7 @@ export interface BillingTransaction {
 	cc_name: string;
 	cc_num: string;
 	cc_type: string;
+	display_brand: string;
 	credit: string;
 	date: string;
 	desc: string;

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -126,6 +126,7 @@ export function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditC
 		object.payment.creditCard = {
 			id: Number( purchase.payment_card_id ),
 			type: purchase.payment_card_type,
+			displayBrand: purchase.payment_display_brand,
 			processor: purchase.payment_card_processor,
 			number: purchase.payment_details,
 			expiryDate: purchase.payment_expiry,

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -126,7 +126,7 @@ export function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditC
 		object.payment.creditCard = {
 			id: Number( purchase.payment_card_id ),
 			type: purchase.payment_card_type,
-			displayBrand: purchase.payment_display_brand,
+			displayBrand: purchase.payment_card_display_brand,
 			processor: purchase.payment_card_processor,
 			number: purchase.payment_details,
 			expiryDate: purchase.payment_expiry,

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -224,6 +224,7 @@ export interface RawPurchase {
 		| 'emergent-paywall'
 		| 'brazil-tef'
 		| string;
+	payment_display_brand: string | null;
 	payment_country_name: string;
 	payment_country_code: string | null;
 	stored_details_id: string | null;
@@ -337,12 +338,14 @@ export type PurchasePaymentWithCreditCard = PurchasePayment & {
 	countryName: string | undefined;
 	storedDetailsId: string | number;
 	type: string;
+	displayBrand: string | null;
 	creditCard: PurchasePaymentCreditCard;
 };
 
 export interface PurchasePaymentCreditCard {
 	id: number;
 	type: string;
+	displayBrand: string | null;
 	processor: string;
 	number: string;
 	expiryDate: string;

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -270,7 +270,7 @@ export interface RawPurchase {
 export type RawPurchaseCreditCard = RawPurchase & {
 	payment_type: 'credit_card';
 	payment_card_type: string;
-	payment_card_display_brand: string;
+	payment_card_display_brand: string | null;
 	payment_card_processor: string;
 	payment_details: string | number;
 	payment_expiry: string;

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -224,7 +224,7 @@ export interface RawPurchase {
 		| 'emergent-paywall'
 		| 'brazil-tef'
 		| string;
-	payment_display_brand: string | null;
+	payment_card_display_brand: string | null;
 	payment_country_name: string;
 	payment_country_code: string | null;
 	stored_details_id: string | null;
@@ -270,6 +270,7 @@ export interface RawPurchase {
 export type RawPurchaseCreditCard = RawPurchase & {
 	payment_type: 'credit_card';
 	payment_card_type: string;
+	payment_card_display_brand: string;
 	payment_card_processor: string;
 	payment_details: string | number;
 	payment_expiry: string;

--- a/packages/wpcom-checkout/src/payment-method-logos.tsx
+++ b/packages/wpcom-checkout/src/payment-method-logos.tsx
@@ -4,14 +4,22 @@ import styled from '@emotion/styled';
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
 export const PaymentMethodLogos = styled.span`
+	display: flex;
+	flex: 1;
 	text-align: right;
-	transform: translateY( 3px );
+	align-items: center;
+	justify-content: flex-end;
+	padding-inline-end: 24px;
+
 	.rtl & {
 		text-align: left;
 	}
 
 	svg {
 		display: block;
+		&.has-background {
+			padding-inline-end: 5px;
+		}
 	}
 
 	&.google-pay__logo svg {
@@ -162,6 +170,8 @@ export function VisaLogo( { className }: { className?: string } ) {
 }
 
 export function CBLogo( { className }: { className?: string } ) {
+	// We need to provide a unique ID to any svg that uses an id prop
+	// especially if we expect multiple instances of the component to render on the page
 	const uniqueID = `${ Math.floor( 10000 + Math.random() * 90000 ) }`;
 
 	return (

--- a/packages/wpcom-checkout/src/payment-method-logos.tsx
+++ b/packages/wpcom-checkout/src/payment-method-logos.tsx
@@ -162,44 +162,63 @@ export function VisaLogo( { className }: { className?: string } ) {
 }
 
 export function CBLogo( { className }: { className?: string } ) {
+	const uniqueID = `${ Math.floor( 10000 + Math.random() * 90000 ) }`;
+
 	return (
 		<svg
 			className={ className }
-			width="41"
-			height="17"
-			viewBox="0 0 41 17"
-			fill="none"
-			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			focusable="false"
+			viewBox="0 0 60 38"
+			width="42"
+			height="26.6"
+			xmlns="http://www.w3.org/2000/svg"
 		>
-			<radialGradient
-				id="b"
-				cx="1.47"
-				cy="18.27"
-				gradientTransform="matrix(1 0 0 .94 0 .5)"
-				gradientUnits="userSpaceOnUse"
-				r="26.83"
-			>
-				<stop offset=".09" stopColor="#009245" />
-				<stop offset=".23" stopColor="#049552" stopOpacity=".89" />
-				<stop offset=".52" stopColor="#0d9e74" stopOpacity=".59" />
-				<stop offset=".91" stopColor="#1bacab" stopOpacity=".12" />
-				<stop offset="1" stopColor="#1fb0b8" stopOpacity="0" />
-			</radialGradient>
-			<radialGradient id="c" cx="5.89" cy="19.23" gradientUnits="userSpaceOnUse" r="34.42">
-				<stop offset=".15" stopColor="#1fb0b8" stopOpacity="0" />
-				<stop offset=".35" stopColor="#1c7491" stopOpacity=".4" />
-				<stop offset=".56" stopColor="#1a4471" stopOpacity=".73" />
-				<stop offset=".74" stopColor="#18265e" stopOpacity=".93" />
-				<stop offset=".87" stopColor="#181b57" />
-			</radialGradient>
-			<g>
-				<path d="M0 0h26.47v18.16H0z" fill="#29abe2" />
-				<path d="M0 0h26.47v18.16H0z" fill="url(#b)" />
-				<path d="M0 0h26.47v18.16H0z" fill="url(#c)" />
+			<defs>
+				<clipPath id={ `${ uniqueID }paths` }>
+					<rect
+						xmlns="http://www.w3.org/2000/svg"
+						x="0.5"
+						y="0.5"
+						width="59"
+						height="37"
+						rx="3"
+						fill="none"
+					/>
+				</clipPath>
+				<radialGradient
+					id={ `${ uniqueID }b` }
+					cx="-5"
+					cy="70"
+					gradientUnits="userSpaceOnUse"
+					r="140"
+				>
+					<stop offset=".09" stopColor="#009245" />
+					<stop offset=".23" stopColor="#049552" stopOpacity=".89" />
+					<stop offset=".52" stopColor="#0d9e74" stopOpacity=".59" />
+					<stop offset=".91" stopColor="#1bacab" stopOpacity=".12" />
+					<stop offset="1" stopColor="#1fb0b8" stopOpacity="0" />
+				</radialGradient>
+				<radialGradient
+					id={ `${ uniqueID }c` }
+					cx="-5"
+					cy="70"
+					gradientUnits="userSpaceOnUse"
+					r="140"
+				>
+					<stop offset=".15" stopColor="#1fb0b8" stopOpacity="0" />
+					<stop offset=".35" stopColor="#1c7491" stopOpacity=".4" />
+					<stop offset=".56" stopColor="#1a4471" stopOpacity=".73" />
+					<stop offset=".74" stopColor="#18265e" stopOpacity=".93" />
+					<stop offset=".87" stopColor="#181b57" />
+				</radialGradient>
+			</defs>
+			<g clipPath={ `url(#${ uniqueID }paths)` }>
+				<path d="M0 0h60v38H0z" fill="#29abe2" />
+				<path d="M0 0h60v38H0z" fill={ `url(#${ uniqueID }b)` } />
+				<path d="M0 0h60v38H0z" fill={ `url(#${ uniqueID }c)` } />
 			</g>
-			<g fill="#fff">
+			<g fill="#fff" transform="scale(1.8) translate(3, 1.5)">
 				<path d="M14.39 3.86h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V3.86zM14.39 9.36h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V9.36zM8.23 9.36V8.8h5.69a5.51 5.51 0 0 0-5.69-4.94 5.47 5.47 0 0 0-5.69 5.22 5.47 5.47 0 0 0 5.69 5.22 5.51 5.51 0 0 0 5.69-4.94z" />
 			</g>
 		</svg>

--- a/packages/wpcom-checkout/src/payment-method-logos.tsx
+++ b/packages/wpcom-checkout/src/payment-method-logos.tsx
@@ -38,7 +38,6 @@ export function PaymentLogo( { brand, isSummary }: { brand: string; isSummary?: 
 				</BrandLogo>
 			);
 			break;
-		case 'cb':
 		case 'cartes_bancaires':
 			cardFieldIcon = (
 				<BrandLogo isSummary={ isSummary }>


### PR DESCRIPTION
This PR implements the display_brand string value across various payment logo components in /checkout and /purchases. It also updates the CB logo to better match the style of the other payment brands.

Related to: 
- https://github.com/Automattic/payments-shilling/issues/3035
- pbOQVh-52g-p2

## Proposed Changes

- Add a new Cartes Bancaires svg to different asset stores (which handle access from different places and also set two separate display sizes)
- Add a CBLogo component in line with our other brand logo React components
- Assemble `display_brand` and `displayBrand` when passed from the /purchases endpoint
- Update instances of card logo across components to return the `display_brand` if available, otherwise default to the `card_type` instead.
- Update payment details to use display_brand when possible. For instance, `VISA****1001` would become `Cartes Bancaires****1001` when display_brand is available.

## Testing Instructions

### Checkout changes

**Inactive Payment Methods**
<img width="619" alt="image" src="https://github.com/user-attachments/assets/9fd6b933-c128-4908-afe7-2a7c596a5b8a">

**Active credit card method**
<img width="586" alt="image" src="https://github.com/user-attachments/assets/a414f452-f1c8-4578-a334-9a2599b32dc3">

**Note:** Ignore the Payment logo in the CardNumberField for now, it will be removed in this PR https://github.com/Automattic/wp-calypso/pull/93932

### Purchases 

**Active Payments tab**

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/f44360ad-bb59-4cfb-a194-fddddb8d4cf6">

**Purchase Settings** (click through from Active Payments tab)

<img width="614" alt="image" src="https://github.com/user-attachments/assets/87dc7d4e-004b-4c0b-b2a1-8ac62fb3c528">

**Change Payment method** 
- Click through from Purchase Settings (at the bottom), these changes should look the Checkout experience. (Note, I am aware we are missing the CB logo in the payment method logos for the add card form, adding this shortly)

**Billing History tab**
- We display the card details in the individual receipt, but this will require a bit more work to either use a selector here, or, pass the details through the receipts endpoint (which we'll need to do for email receipts I suspect).
- Will be included in a follow up diff and PR

**Payment Methods tab**
<img width="691" alt="image" src="https://github.com/user-attachments/assets/2519525e-5ee1-461a-bf67-0d36c134b6a5">

**Add new card**
- Similar to the change payment method, this checkout form doesn't include the CB changes, will update this shortly!


Other testing steps:
Since Checkout is imported in some ways to other projects like [a8c-for-agencies](https://github.com/Automattic/wp-calypso/blob/trunk/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/index.tsx), we'll need to check that these changes haven't affected their work too.

I believe Jetpack Cloud also uses some formulation of composite-checkout and wpcom-checkout too.