### PR TITLE
Stats: Help center should only be available for WPCOM site on Calypso

### DIFF
--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -29,7 +29,7 @@ const extraPath = browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv;
 const cachePath = path.resolve( '.cache', extraPath );
 
 const excludedPackages = [
-	// /^calypso\/components\/inline-support-link$/,
+	/^calypso\/components\/inline-support-link$/,
 	/^calypso\/components\/web-preview.*$/,
 	/^calypso\/blocks\/upsell-nudge.*$/,
 	/^calypso\/my-sites\/stats\/mini-carousel.*$/,

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -29,7 +29,7 @@ const extraPath = browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv;
 const cachePath = path.resolve( '.cache', extraPath );
 
 const excludedPackages = [
-	/^calypso\/components\/inline-support-link$/,
+	// /^calypso\/components\/inline-support-link$/,
 	/^calypso\/components\/web-preview.*$/,
 	/^calypso\/blocks\/upsell-nudge.*$/,
 	/^calypso\/my-sites\/stats\/mini-carousel.*$/,

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -10,7 +10,6 @@ import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
@@ -162,7 +161,7 @@ const DoYouLoveJetpackStatsNotice = ( {
 						target="_blank"
 						rel="noreferrer"
 						onClick={ ( event ) => {
-							if ( ! isJetpackCloud() ) {
+							if ( ! isOdysseyStats && isWPCOMSite ) {
 								event.preventDefault();
 								openHelpCenter();
 							}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/93960

## Proposed Changes

* Help center doens't seem to work for non-wpcom help docs and it doesn't work for Odyssey as well. So we are limiting the change only to wpcom sites + non Odyssey Stats.

Hi @Addison-Stavlo, thanks for improving the how the doc work for dotcom sites. As exactly the same code runs in Jetpack as well, so it'll be great if wpcom changes on Stats could be gated only to WPCOM sites. I'll try to give PRs more timely reviews too. Thanks!


## Testing Instructions

*  https://github.com/Automattic/wp-calypso/pull/93960 Still works as expected
* Open a jetpack self hosted site on Calysp, ensure the learn more link works as an external link

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
