### PR TITLE
Stats: Revert date input changes which broke the typing input of the calendar

### DIFF
--- a/client/components/stats-date-control/stats-date-control-date-input.tsx
+++ b/client/components/stats-date-control/stats-date-control-date-input.tsx
@@ -1,6 +1,4 @@
-import config from '@automattic/calypso-config';
 import moment from 'moment';
-import React, { useEffect, useState } from 'react';
 
 interface Props {
 	id: string;
@@ -9,58 +7,17 @@ interface Props {
 	max?: string;
 }
 
-const isNewCalendar = config.isEnabled( 'stats/date-picker-calendar' );
-
 const DateInput: React.FC< Props > = ( {
 	value,
 	onChange,
 	id,
 	max = moment().format( 'YYYY-MM-DD' ),
 } ) => {
-	const [ inputValue, setInputValue ] = useState( value );
-
-	useEffect( () => {
-		setInputValue( value );
-	}, [ value ] );
-
 	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
-		// track value internally
-		setInputValue( event?.target?.value );
+		onChange && onChange( event?.target?.value );
 	};
 
-	const handleBlur = ( event: React.FocusEvent< HTMLInputElement > ) => {
-		const value = event?.target?.value;
-
-		if ( isNewCalendar ) {
-			const isValid = moment( value, 'YYYY-MM-DD', true ).isValid();
-
-			if ( ! isValid ) {
-				setInputValue( moment().format( 'YYYY-MM-DD' ) );
-			} else {
-				onChange?.( value );
-			}
-		}
-	};
-
-	return (
-		<>
-			{ isNewCalendar ? (
-				<input
-					id={ id }
-					className="stats-date-control-picker-dates__input"
-					type="text"
-					value={ inputValue }
-					onChange={ handleChange }
-					onBlur={ handleBlur } // Add onBlur event for validation
-					placeholder="YYYY-MM-DD" // Placeholder text in input field
-					title="Date format: YYYY-MM-DD" // tooltip for format
-					max={ max }
-				/>
-			) : (
-				<input id={ id } type="date" value={ value } onChange={ handleChange } max={ max } /> // original date type input pre-feature flag
-			) }
-		</>
-	);
+	return <input id={ id } type="date" value={ value } onChange={ handleChange } max={ max } />;
 };
 
 export default DateInput;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/93547
P2: pejTkB-1Ds-p2

## Proposed Changes

* Revert change over the DateInput, which we are not going to use anymore

## Why are these changes being made?

* Bugfix

## Testing Instructions


* Open Calypso Live Branch
* Open Date picker
* Ensure you can enter dates instead of only selecting

<img width="564" alt="image" src="https://github.com/user-attachments/assets/d3a64a14-0205-4b94-81bc-534ef43cc0a7">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?