### PR TITLE
A4A > Team: Implement team member permissions

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -12,7 +12,10 @@ import {
 } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { isPathAllowed } from 'calypso/a8c-for-agencies/lib/permission';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import {
 	A4A_MARKETPLACE_LINK,
 	A4A_LICENSES_LINK,
@@ -31,6 +34,8 @@ import { createItem } from '../lib/utils';
 
 const useMainMenuItems = ( path: string ) => {
 	const translate = useTranslate();
+
+	const agency = useSelector( getActiveAgency );
 
 	const menuItems = useMemo( () => {
 		const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
@@ -170,8 +175,13 @@ const useMainMenuItems = ( path: string ) => {
 						},
 				  ]
 				: [] ),
-		].map( ( item ) => createItem( item, path ) );
-	}, [ path, translate ] );
+		]
+			.map( ( item ) => createItem( item, path ) )
+			.filter( ( item ) =>
+				// If multi-user support is enabled, we need to check if the user has access to the current path
+				config.isEnabled( 'a4a-multi-user-support' ) ? isPathAllowed( item.link, agency ) : true
+			);
+	}, [ agency, path, translate ] );
 	return menuItems;
 };
 

--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 import { getQueryArgs, addQueryArgs } from '@wordpress/url';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
@@ -6,7 +7,13 @@ import {
 	hasAgency,
 	hasFetchedAgency,
 } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { A4A_CLIENT_LANDING_LINK, A4A_LANDING_LINK } from './components/sidebar-menu/lib/constants';
+import {
+	A4A_CLIENT_LANDING_LINK,
+	A4A_LANDING_LINK,
+	A4A_OVERVIEW_LINK,
+} from './components/sidebar-menu/lib/constants';
+import { isPathAllowed } from './lib/permission';
+import type { Agency } from 'calypso/state/a8c-for-agencies/types';
 
 export const redirectToLandingContext: Callback = () => {
 	if ( isA8CForAgencies() ) {
@@ -18,13 +25,30 @@ export const redirectToLandingContext: Callback = () => {
 	return;
 };
 
+// This function is used to check if the user has access to the current path
+const handleMultiUserSupport = ( agency: Agency, pathname: string, next: () => void ) => {
+	if ( isPathAllowed( pathname, agency ) ) {
+		next();
+		return;
+	}
+	window.location.href = A4A_OVERVIEW_LINK;
+	return;
+};
+
 export const requireAccessContext: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const agency = getActiveAgency( state );
 	const { pathname, search, hash } = window.location;
 
+	const isMultiUserSupportEnabled = config.isEnabled( 'a4a-multi-user-support' );
+
 	if ( agency ) {
-		next();
+		if ( ! isMultiUserSupportEnabled ) {
+			next();
+			return;
+		}
+		// If multi-user support is enabled, we need to check if the user has access to the current path
+		handleMultiUserSupport( agency, pathname, next );
 		return;
 	}
 

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -1,0 +1,110 @@
+import {
+	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
+	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
+	PARTNER_DIRECTORY_DASHBOARD_SLUG,
+} from 'calypso/a8c-for-agencies/sections/partner-directory/constants';
+import {
+	A4A_LANDING_LINK,
+	A4A_OVERVIEW_LINK,
+	A4A_SITES_LINK,
+	A4A_SITES_LINK_NEEDS_ATTENTION,
+	A4A_SITES_LINK_NEEDS_SETUP,
+	A4A_SITES_LINK_FAVORITE,
+	A4A_SITES_LINK_DEVELOPMENT,
+	A4A_SITES_LINK_WALKTHROUGH_TOUR,
+	A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
+	A4A_SITES_CONNECT_URL_LINK,
+	A4A_MARKETPLACE_LINK,
+	A4A_MARKETPLACE_PRODUCTS_LINK,
+	A4A_MARKETPLACE_HOSTING_LINK,
+	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+	A4A_MARKETPLACE_CHECKOUT_LINK,
+	A4A_MARKETPLACE_ASSIGN_LICENSE_LINK,
+	A4A_MARKETPLACE_DOWNLOAD_PRODUCTS_LINK,
+	A4A_REFERRALS_LINK,
+	A4A_REFERRALS_BANK_DETAILS_LINK,
+	A4A_REFERRALS_COMMISSIONS_LINK,
+	A4A_REFERRALS_DASHBOARD,
+	A4A_REFERRALS_PAYMENT_SETTINGS,
+	A4A_REFERRALS_FAQ,
+	A4A_PARTNER_DIRECTORY_LINK,
+	A4A_PURCHASES_LINK,
+	A4A_LICENSES_LINK,
+	A4A_UNASSIGNED_LICENSES_LINK,
+	A4A_BILLING_LINK,
+	A4A_INVOICES_LINK,
+	A4A_PAYMENT_METHODS_LINK,
+	A4A_PAYMENT_METHODS_ADD_LINK,
+	A4A_MIGRATIONS_LINK,
+} from '../components/sidebar-menu/lib/constants';
+import type { Agency } from 'calypso/state/a8c-for-agencies/types';
+
+const A4A_PARTNER_DIRECTORY_DASHBOARD_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_DASHBOARD_SLUG }`;
+const A4A_PARTNER_DIRECTORY_AGENCY_DETAILS_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`;
+const A4A_PARTNER_DIRECTORY_AGENCY_EXPERTISE_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }`;
+
+const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
+	[ A4A_SITES_LINK ]: [ 'a4a_read_managed_sites' ],
+	[ A4A_SITES_LINK_NEEDS_ATTENTION ]: [ 'a4a_read_managed_sites' ],
+	[ A4A_SITES_LINK_NEEDS_SETUP ]: [ 'a4a_read_managed_sites' ],
+	[ A4A_SITES_LINK_FAVORITE ]: [ 'a4a_read_managed_sites' ],
+	[ A4A_SITES_LINK_DEVELOPMENT ]: [ 'a4a_read_managed_sites' ],
+	[ A4A_SITES_LINK_WALKTHROUGH_TOUR ]: [ 'a4a_read_managed_sites' ],
+	[ A4A_SITES_LINK_ADD_NEW_SITE_TOUR ]: [ 'a4a_read_managed_sites' ],
+	[ A4A_SITES_CONNECT_URL_LINK ]: [ 'a4a_read_managed_sites' ],
+	[ A4A_MARKETPLACE_LINK ]: [ 'a4a_read_marketplace' ],
+	[ A4A_MARKETPLACE_PRODUCTS_LINK ]: [ 'a4a_read_marketplace' ],
+	[ A4A_MARKETPLACE_HOSTING_LINK ]: [ 'a4a_read_marketplace' ],
+	[ A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK ]: [ 'a4a_read_marketplace' ],
+	[ A4A_MARKETPLACE_HOSTING_WPCOM_LINK ]: [ 'a4a_read_marketplace' ],
+	[ A4A_MARKETPLACE_CHECKOUT_LINK ]: [ 'a4a_read_marketplace' ],
+	[ A4A_MARKETPLACE_ASSIGN_LICENSE_LINK ]: [ 'a4a_read_marketplace' ],
+	[ A4A_MARKETPLACE_DOWNLOAD_PRODUCTS_LINK ]: [ 'a4a_read_marketplace' ],
+	[ A4A_REFERRALS_LINK ]: [ 'a4a_read_referrals' ],
+	[ A4A_REFERRALS_BANK_DETAILS_LINK ]: [ 'a4a_read_referrals' ],
+	[ A4A_REFERRALS_COMMISSIONS_LINK ]: [ 'a4a_read_referrals' ],
+	[ A4A_REFERRALS_DASHBOARD ]: [ 'a4a_read_referrals' ],
+	[ A4A_REFERRALS_PAYMENT_SETTINGS ]: [ 'a4a_read_referrals' ],
+	[ A4A_REFERRALS_FAQ ]: [ 'a4a_read_referrals' ],
+	[ A4A_PARTNER_DIRECTORY_LINK ]: [ 'a4a_read_partner_directory' ],
+	[ A4A_PARTNER_DIRECTORY_DASHBOARD_LINK ]: [ 'a4a_read_partner_directory' ],
+	[ A4A_PARTNER_DIRECTORY_AGENCY_DETAILS_LINK ]: [ 'a4a_read_partner_directory' ],
+	[ A4A_PARTNER_DIRECTORY_AGENCY_EXPERTISE_LINK ]: [ 'a4a_read_partner_directory' ],
+	[ A4A_PURCHASES_LINK ]: [ 'a4a_jetpack_licensing' ],
+	[ A4A_LICENSES_LINK ]: [ 'a4a_jetpack_licensing' ],
+	[ A4A_UNASSIGNED_LICENSES_LINK ]: [ 'a4a_jetpack_licensing' ],
+	[ A4A_BILLING_LINK ]: [ 'a4a_jetpack_licensing' ],
+	[ A4A_INVOICES_LINK ]: [ 'a4a_jetpack_licensing' ],
+	[ A4A_PAYMENT_METHODS_LINK ]: [ 'a4a_jetpack_licensing' ],
+	[ A4A_PAYMENT_METHODS_ADD_LINK ]: [ 'a4a_jetpack_licensing' ],
+	[ A4A_MIGRATIONS_LINK ]: [ 'a4a_read_migrations' ],
+};
+
+export const isPathAllowed = ( pathname: string, agency: Agency | null ) => {
+	if ( ! agency ) {
+		return false;
+	}
+
+	// Admins can access all paths
+	const role = agency?.user?.role;
+	// For some cases, the role isn't set, so we default to 'a4a_administrator'
+	// FIXME: This should be removed after the role is set for all users
+	if ( ! role || role === 'a4a_administrator' ) {
+		return true;
+	}
+
+	// Everyone can access the landing page and the overview page
+	if ( [ A4A_LANDING_LINK, A4A_OVERVIEW_LINK ].includes( pathname ) ) {
+		return true;
+	}
+
+	// Check if the user has the required capability to access the current path
+	const capabilities = agency?.user?.capabilities;
+	if ( capabilities ) {
+		const permissions = MEMBER_ACCESSIBLE_PATHS?.[ pathname ];
+		return permissions
+			? capabilities.some( ( capability: string ) => permissions.includes( capability ) )
+			: false;
+	}
+};

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -62,6 +62,10 @@ export interface Agency {
 		};
 	};
 	partner_directory_allowed: boolean;
+	user: {
+		role: 'a4a_administrator' | 'a4a_manager';
+		capabilities: string[];
+	};
 }
 
 export interface AgencyStore {


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/955

## Proposed Changes

This PR implements team member permissions, allowing them only to route and show the nav items that are accessible according to their permissions.

## Why are these changes being made?

* These changes are being made so that we can restrict the users to only accessible routes. 

## Testing Instructions

* Switch to this branch locally and start the server.
* Login as an agency and invite a new member.
* Accept the invitation as a team member and log in using an incognito window. 
* Apply this patch: D159147-code
* Now refresh the page where the agency owner is logged in and verify you can access all the routes as expected and that nothing has changed by comparing it with the production version.
* Refresh the page where the agency team member is logged in and verify you can access only the following routes and only the allowed menu items are shown as per this issue: https://github.com/Automattic/automattic-for-agencies-dev/issues/955
* Update the permissions on the diff and verify if it works as expected. 

Agency owner view:

<img width="1725" alt="Screenshot 2024-08-29 at 1 32 03 PM" src="https://github.com/user-attachments/assets/ba273de0-c8b8-4266-9177-a5e077cc8b4c">

Agency team member view:

<img width="1725" alt="Screenshot 2024-08-29 at 1 31 55 PM" src="https://github.com/user-attachments/assets/64a3d7b9-83ec-487c-b2e8-bbfb979cb1a1">

- Append the URL on the team member view with ?flags=-a4a-multi-user-support and verify it matches the production version.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?