### PR TITLE
A4A: Partner Directory: Add hint text for logo upload field

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -230,11 +230,9 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 					label={ translate( 'Company logo' ) }
 					description={ translate( 'Need help? {{a}}View our logo guidelines.{{/a}}', {
 						components: {
-							// @TODO: Update the link when we have it.
-							// eslint-disable-next-line jsx-a11y/anchor-is-valid
 							a: (
 								<a
-									href="https://agencieshelp.automattic.com/"
+									href="https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings"
 									target="_blank"
 									rel="noreferrer noopener"
 								/>

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -232,7 +232,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 						components: {
 							a: (
 								<a
-									href="https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings"
+									href="https://agencieshelp.automattic.com/knowledge-base/adding-a-logo-to-the-partner-directory-agency-profile/"
 									target="_blank"
 									rel="noreferrer noopener"
 								/>

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -228,6 +228,19 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 				</FormField>
 				<FormField
 					label={ translate( 'Company logo' ) }
+					description={ translate( 'Need help? {{a}}View our logo guidelines.{{/a}}', {
+						components: {
+							// @TODO: Update the link when we have it.
+							// eslint-disable-next-line jsx-a11y/anchor-is-valid
+							a: (
+								<a
+									href="https://agencieshelp.automattic.com/"
+									target="_blank"
+									rel="noreferrer noopener"
+								/>
+							),
+						},
+					} ) }
 					sub={ translate(
 						'Upload your agency logo sized at 800px by 320px. Format allowed: JPG, PNG'
 					) }

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/logo-picker.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/logo-picker.tsx
@@ -4,6 +4,7 @@ import A4AImagePicker from 'calypso/a8c-for-agencies/components/a4a-image-picker
 
 const LOGO_SIZE_WIDTH = 800;
 const LOGO_SIZE_HEIGHT = 320;
+const LOGO_SIZE_TOLERANCE = 5;
 
 type Props = {
 	logo?: string | null;
@@ -37,7 +38,11 @@ const LogoPicker = ( { logo, onPick }: Props ) => {
 		setError( null );
 
 		getImage( file ).then( ( img ) => {
-			if ( img.width !== LOGO_SIZE_WIDTH || img.height !== LOGO_SIZE_HEIGHT ) {
+			// Check against the allowed deviation in pixels from the required logo dimensions
+			const isWidthValid = Math.abs( img.width - LOGO_SIZE_WIDTH ) <= LOGO_SIZE_TOLERANCE;
+			const isHeightValid = Math.abs( img.height - LOGO_SIZE_HEIGHT ) <= LOGO_SIZE_TOLERANCE;
+
+			if ( ! isWidthValid || ! isHeightValid ) {
 				setError( translate( 'Company logo must have 800px width and 320px height.' ) );
 				return;
 			}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/credit-card-element-field.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/credit-card-element-field.tsx
@@ -1,5 +1,5 @@
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
-import { CardElement } from '@stripe/react-stripe-js';
+import { CardNumberElement } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -26,16 +26,17 @@ export default function CreditCardElementField( {
 	return (
 		<div className="credit-card-fields__input-field">
 			<label className="credit-card-fields__label">
-				<span className="credit-card-fields__label-text">{ translate( 'Card details' ) }</span>
+				<span className="credit-card-fields__label-text">{ translate( 'Card details!' ) }</span>
 				<span
 					className={ clsx( 'credit-card-fields__stripe-element', 'number', {
 						'credit-card-fields__stripe-element--has-error': cardError,
 					} ) }
 				>
-					<CardElement
+					<CardNumberElement
 						options={ {
 							disabled: isDisabled,
 							style: stripeElementStyle,
+							showIcon: true,
 						} }
 						onReady={ () => {
 							setIsStripeFullyLoaded( true );


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/921

## Proposed Changes

This PR adds a little hint text next to the logo upload field with a link to our guidelines for logos (WIP). In addition, it adds a 5px tolerance to the required image size (which preserves the aspect ratio) to allow images off by a few pixels.

**Screenshot**: 

<img width="716" alt="image" src="https://github.com/user-attachments/assets/2dc5f1da-84e4-428f-8119-fd3b009785b1">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Visit the Calypso Live link for Automattic for Agencies environment
* Visit the Partner Directory (`/partner-directory/agency-details`)
* Verify the image upload accepts the required image size + sizes off by 5 pixels. You can use tools like `https://placehold.it/805x320.png` to generate precise image sizes
* Verify the hint text below the field is displayed correctly and the copy make sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?