### PR TITLE
Help Center: Align 'X' close button with Help Center icon

### DIFF
--- a/packages/help-center/src/hooks/use-opening-coordinates.ts
+++ b/packages/help-center/src/hooks/use-opening-coordinates.ts
@@ -25,8 +25,9 @@ export const calculateOpeningPosition = ( element: HTMLElement ) => {
 	}
 
 	// This takes into account the '?' button's padding and align the close button with the help center icon
-	const computedStyle = window.getComputedStyle( element );
-	const helpCenterPaddingRight = parseInt( computedStyle.paddingRight, 10 );
+	const helpCenterIconPaddingRight =
+		parseInt( element.style.paddingRight, 10 ) ||
+		parseInt( element.getAttribute( 'data-padding-right' ) || '0', 10 );
 
 	// Return an empty object in mobile view.
 	if ( innerWidth <= 480 ) {
@@ -36,7 +37,7 @@ export const calculateOpeningPosition = ( element: HTMLElement ) => {
 	const { x, y, width, height } = element.getBoundingClientRect();
 
 	const buttonLeftEdge = x;
-	const buttonRightEdge = x + width + helpCenterPaddingRight;
+	const buttonRightEdge = x + width + helpCenterIconPaddingRight;
 
 	const buttonTopEdge = y;
 	const buttonBottomEdge = y + height;
@@ -99,6 +100,12 @@ export function useOpeningCoordinates( disabled: boolean = false, isMinimized: b
 							element instanceof HTMLButtonElement || element instanceof HTMLAnchorElement
 					) || path[ 0 ] ) as HTMLElement;
 
+					// Cache the computed padding-right if not already done
+					// This will be used to align the help center close button with the "?" icon
+					if ( ! openingElement.hasAttribute( 'data-padding-right' ) ) {
+						const computedStyle = window.getComputedStyle( openingElement );
+						openingElement.setAttribute( 'data-padding-right', computedStyle.paddingRight );
+					}
 					setOpeningCoordinates( calculateOpeningPosition( openingElement ) );
 				} catch ( e ) {
 					// In case something weird is clicked. e.g something without `getBoundingClientRect`.

--- a/packages/help-center/src/hooks/use-opening-coordinates.ts
+++ b/packages/help-center/src/hooks/use-opening-coordinates.ts
@@ -24,6 +24,10 @@ export const calculateOpeningPosition = ( element: HTMLElement ) => {
 		return defaultPosition;
 	}
 
+	// This takes into account the '?' button's padding and align the close button with the help center icon
+	const computedStyle = window.getComputedStyle( element );
+	const helpCenterPaddingRight = parseInt( computedStyle.paddingRight, 10 );
+
 	// Return an empty object in mobile view.
 	if ( innerWidth <= 480 ) {
 		return {};
@@ -32,7 +36,7 @@ export const calculateOpeningPosition = ( element: HTMLElement ) => {
 	const { x, y, width, height } = element.getBoundingClientRect();
 
 	const buttonLeftEdge = x;
-	const buttonRightEdge = x + width;
+	const buttonRightEdge = x + width + helpCenterPaddingRight;
 
 	const buttonTopEdge = y;
 	const buttonBottomEdge = y + height;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8829
Fixes https://github.com/Automattic/dotcom-forge/issues/8829

## Proposed Changes

* Align the Help Center 'X' with the '?' icon, now it considers the question mark's padding in the alignment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix https://github.com/Automattic/dotcom-forge/issues/8829

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link
* Make sure when the HC is open, it is aligned like this
<img width="492" alt="image" src="https://github.com/user-attachments/assets/0490788c-2941-473f-a6d4-6d5af5df4d30">

* Test also other locations where HC is not placed on the header, for instance `my home`, it should be positioned as before


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
