### PR TITLE
Partner Directory: Update links and statuses for approved directories

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -294,11 +294,8 @@ const PartnerDirectoryDashboard = () => {
 			<div className="partner-directory-dashboard__completed-section">
 				<div className="partner-directory-dashboard__heading">
 					{ translate(
-						'Thank you! You’ll be notified when the partner directory is live.',
-						'Thank you! You’ll be notified when the partner directories are live.',
-						// todo: Once the partner directory are live use the copy below:
-						//'Congratulations! Your agency is now listed in our partner directory.',
-						//'Congratulations! Your agency is now listed in our partner directories.',
+						'Congratulations! Your agency is now listed in our partner directory.',
+						'Congratulations! Your agency is now listed in our partner directories.',
 						{
 							count: directoryApplicationStatuses.filter( ( { key } ) => key === 'approved' )
 								.length,

--- a/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
@@ -37,7 +37,7 @@ export const getBrandMeta = ( brand: string, agency?: Agency | null ): BrandMeta
 				className: 'partner-directory-dashboard__woo-icon',
 				url: 'https://woocommerce.com/development-services/',
 				urlProfile: `https://woocommerce.com/development-services/${ agencySlug }/${ agencyId }`,
-				isAvailable: false,
+				isAvailable: true,
 			};
 		case 'Pressable.com':
 			return {
@@ -45,7 +45,7 @@ export const getBrandMeta = ( brand: string, agency?: Agency | null ): BrandMeta
 				icon: <img src={ pressableIcon } alt="" />,
 				url: 'https://pressable.com/development-services/',
 				urlProfile: `https://pressable.com/development-services/${ agencySlug }/${ agencyId }`,
-				isAvailable: false,
+				isAvailable: true,
 			};
 		case 'Jetpack.com':
 			return {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1007

## Proposed Changes

This PR updates some existing verbiage and statuses to better communicate with agencies when their agency is approved for a specific partner directory.

Before | After
--|--
<img width="1215" alt="image" src="https://github.com/user-attachments/assets/59964c27-446b-41dc-bd80-a20855249bb9">| <img width="1217" alt="image" src="https://github.com/user-attachments/assets/8ff6d890-3c41-4000-96d4-c76353d3b603">


## Testing Instructions

- Open the Automattic for Agencies live link and visit the Partner Directory Link.
- If your agency is approved for specific, verify that it's displayed correctly and the copy changes make sense, and also that the links to the directory and your directory listing are correct.
- If you need to approve your agency, please make sure you disapprove it by removing the sticker after you are done.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
