### PR TITLE
Migration: Add credentials step

### DIFF
--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -272,17 +272,13 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 
 				return navigateWithQueryParams(
 					SITE_MIGRATION_ASSISTED_MIGRATION,
-					[ 'siteId', 'siteSlug', 'from', 'credentials' ],
+					[ 'credentials' ],
 					{ ...props, ...extraPrams },
 					{ replaceHistory: true }
 				);
 			},
 			goBack: ( props?: ProvidedDependencies ) => {
-				return navigateWithQueryParams(
-					MIGRATION_HOW_TO_MIGRATE,
-					[ 'siteId', 'siteSlug', 'from' ],
-					props
-				);
+				return navigateWithQueryParams( MIGRATION_HOW_TO_MIGRATE, [], props );
 			},
 		},
 	};


### PR DESCRIPTION
## Proposed Changes
* Add the new CREDENTIAL STEP on the migration flow


## Testing Instructions
Scenario 1: No FROM information
* Go to `/setup/migration` 
* Select `WordPress` 
* Make the upgrade and payment
* On the `Need a hand?` select `Do it for me` 
* Check if you can see the credential screen instead
* Fill the credentials
* Click on continue. 
* Check if you reach the end of the flow
* Check if a ticket was created.

Scenario 2:  From is available
* Go to `/setup/migration?from=[WORDPRESS_SITE]` 
* Make the upgrade and payment
* On the `Need a hand?` select `Do it for me` 
* Check if you can see the credential screen instead
* Check if the Site Address field was already populated. 


Scenario 3:  Skip
Follow all steps described in Scenario 1 until the step `Tell us about your site.`
* Click on `Skip, I need help providing access` 
* Check if you can see the `/migrateMessage` step. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
