### PR TITLE
Help Center: Align close button position

### DIFF
--- a/packages/help-center/src/hooks/use-opening-coordinates.ts
+++ b/packages/help-center/src/hooks/use-opening-coordinates.ts
@@ -5,7 +5,7 @@ const AESTHETIC_OFFSET = 20;
 const HELP_CENTER_POSITION_MASTERBAR = 11;
 const HELP_CENTER_POSITION_EDITOR = 15;
 
-const getPosition = ( element: HTMLElement ) => {
+const originElementOffset = ( element: HTMLElement ) => {
 	if ( element.classList.contains( 'masterbar__item' ) ) {
 		return HELP_CENTER_POSITION_MASTERBAR;
 	}
@@ -44,17 +44,10 @@ export const calculateOpeningPosition = ( element: HTMLElement ) => {
 
 	const { x, y, width, height } = element.getBoundingClientRect();
 
-	const position = getPosition( element );
+	const position = originElementOffset( element );
 
 	// handle RTL languages
 	const buttonLeftEdge = x - position;
-
-	const buttonRightEdge =
-		x +
-		width +
-		( element.classList.contains( 'masterbar__item' )
-			? HELP_CENTER_POSITION_MASTERBAR
-			: HELP_CENTER_POSITION_EDITOR );
 
 	const buttonTopEdge = y;
 	const buttonBottomEdge = y + height;
@@ -73,6 +66,7 @@ export const calculateOpeningPosition = ( element: HTMLElement ) => {
 
 	if ( buttonLeftEdge + helpCenterWidth + AESTHETIC_OFFSET > innerWidth ) {
 		// Align right edge of the help center with the right edge of the button
+		const buttonRightEdge = x + width + position;
 		coords.left = buttonRightEdge - helpCenterWidth;
 		coords.transformOrigin += ' right';
 	} else {

--- a/packages/help-center/src/hooks/use-opening-coordinates.ts
+++ b/packages/help-center/src/hooks/use-opening-coordinates.ts
@@ -2,6 +2,19 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useState, useEffect } from 'react';
 
 const AESTHETIC_OFFSET = 20;
+const HELP_CENTER_POSITION_MASTERBAR = 11;
+const HELP_CENTER_POSITION_EDITOR = 15;
+
+const getPosition = ( element: HTMLElement ) => {
+	if ( element.classList.contains( 'masterbar__item' ) ) {
+		return HELP_CENTER_POSITION_MASTERBAR;
+	}
+	if ( element.classList.contains( 'entry-point-button' ) ) {
+		return HELP_CENTER_POSITION_EDITOR;
+	}
+	// opening it from another location, example `my home`
+	return 0;
+};
 
 /**
  * This function calculates the position of the Help Center based on the last click event.
@@ -31,8 +44,17 @@ export const calculateOpeningPosition = ( element: HTMLElement ) => {
 
 	const { x, y, width, height } = element.getBoundingClientRect();
 
-	const buttonLeftEdge = x;
-	const buttonRightEdge = x + width;
+	const position = getPosition( element );
+
+	// handle RTL languages
+	const buttonLeftEdge = x - position;
+
+	const buttonRightEdge =
+		x +
+		width +
+		( element.classList.contains( 'masterbar__item' )
+			? HELP_CENTER_POSITION_MASTERBAR
+			: HELP_CENTER_POSITION_EDITOR );
 
 	const buttonTopEdge = y;
 	const buttonBottomEdge = y + height;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8829
Fixes https://github.com/Automattic/dotcom-forge/issues/8829

## Proposed Changes

* Fix https://github.com/Automattic/dotcom-forge/issues/8829

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix https://github.com/Automattic/dotcom-forge/issues/8829

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link
* Make sure when the HC is open, it is aligned like this
<img width="492" alt="image" src="https://github.com/user-attachments/assets/0490788c-2941-473f-a6d4-6d5af5df4d30">

* Test also other locations where HC is not placed on the header, for instance `my home`, it should be positioned as before
* Test RTL languages

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
