### PR TITLE
Highlight themes in sidebar when viewing individual theme

### DIFF
--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -104,5 +104,10 @@ export const itemLinkMatches = ( path, currentPath ) => {
 		return path.startsWith( '/stats/' );
 	}
 
+	// For `/theme/*` paths, show Themes menu as selected.
+	if ( pathIncludes( currentPath, 'theme', 1 ) ) {
+		return pathIncludes( path, 'themes', 1 );
+	}
+
 	return fragmentIsEqual( path, currentPath, 1 );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92645

## Proposed Changes

* Highlight the "Themes" menu item in the sidebar when viewing individual theme pages, at both the global and site levels.

Before | After
---- | ----
<img width="808" alt="Screen Shot 2024-08-29 at 11 56 28 AM" src="https://github.com/user-attachments/assets/815a8759-40f3-4567-bff9-d8e88055666b"> | <img width="638" alt="Screen Shot 2024-08-29 at 11 56 15 AM" src="https://github.com/user-attachments/assets/24052e7b-8be3-41db-a1a3-2746dd6717b8">
<img width="911" alt="Screen Shot 2024-08-29 at 11 55 43 AM" src="https://github.com/user-attachments/assets/09df832d-256c-4803-9aa6-a3270595f5d5"> | <img width="651" alt="Screen Shot 2024-08-29 at 2 08 12 PM" src="https://github.com/user-attachments/assets/8de5fa70-ba4b-4b34-a15d-3c4a54468925">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To keep the interface consistent between the themes showcase and clicking a theme.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites and click Themes. 
* Check that Themes is highlighted or has a `selected` class.
* Click on an individual theme.
* Check that Themes is still highlighted.
* Go to /home and click Appearance > Themes.
* Check that Appearance > Themes is open and highlighted.
* Click on an individual theme.
* Check that Themes is still highlighted.
* Check that there are no regressions on logged-out /themes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
