### PR TITLE
Sites: hide header and tab navigation on mobile

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -4,6 +4,7 @@ import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import ItemPreviewPaneContent from './item-preview-pane-content';
 import ItemPreviewPaneHeader from './item-preview-pane-header';
 import { FeaturePreviewInterface, PreviewPaneProps } from './types';
@@ -79,7 +80,9 @@ export default function ItemPreviewPane( {
 		);
 	} );
 
-	const shouldHideNav = hideNavIfSingleTab && featureTabs.length <= 1;
+	const isMobileApp = isWpMobileApp();
+
+	const shouldHideNav = ( hideNavIfSingleTab && featureTabs.length <= 1 ) || isMobileApp;
 
 	return (
 		<div className={ clsx( 'item-preview__pane', className ) }>

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -8,6 +8,7 @@ import { translate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
 import QuerySitePhpVersion from 'calypso/components/data/query-site-php-version';
 import QuerySiteWpVersion from 'calypso/components/data/query-site-wp-version';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getAtomicHostingPhpVersion } from 'calypso/state/selectors/get-atomic-hosting-php-version';
@@ -48,6 +49,7 @@ export default function ItemPreviewPaneHeader( {
 	const wpVersion = selectedSite?.options?.software_version?.match( /^\d+(\.\d+){0,2}/ )?.[ 0 ]; // Some times it can be `6.6.1-alpha-58760`, so we strip the `-alpha-58760` part
 	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
 	const isStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
+	const isMobileApp = isWpMobileApp();
 
 	const focusRef = useRef< HTMLButtonElement >( null );
 
@@ -81,101 +83,105 @@ export default function ItemPreviewPaneHeader( {
 			{ isAtomic && <QuerySiteWpVersion siteId={ siteId } /> }
 			<div className={ clsx( 'item-preview__header', className ) }>
 				<div className="item-preview__header-content">
-					{ !! itemData?.withIcon && (
-						<SiteFavicon
-							blogId={ itemData.blogId }
-							fallback={ siteIconFallback }
-							color={ itemData.color }
-							className="item-preview__header-favicon"
-							size={ size }
-						/>
-					) }
-					<div className="item-preview__header-info">
-						<div className="item-preview__header-title-summary">
-							<div className="item-preview__header-title">{ itemData.title }</div>
-							<div className="item-preview__header-summary">
-								{ itemData?.url ? (
-									<Button
-										variant="link"
-										className="item-preview__header-summary-link"
-										href={ itemData.url }
-										target="_blank"
-									>
-										<span>
-											{ itemData.subtitle }
-											<Icon
-												className="sidebar-v2__external-icon"
-												icon={ external }
-												size={ extraProps?.externalIconSize || ICON_SIZE_SMALL }
-											/>
-										</span>
-									</Button>
-								) : (
-									itemData.subtitle
-								) }
-
-								{ extraProps && extraProps.subtitleExtra ? (
-									<span>
-										<extraProps.subtitleExtra />
-									</span>
-								) : (
-									''
-								) }
-							</div>
-
-							{ shouldDisplayVersionNumbers && (
-								<div className="item-preview__header-env-data">
-									{ wpVersion && (
-										<div className="item-preview__header-env-data-item">
-											WordPress{ ' ' }
-											<a
-												className="item-preview__header-env-data-item-link"
-												href={ `/hosting-config/${ selectedSite?.domain }#wp` }
-												onClick={ handleWpVersionClick }
+					{ ! isMobileApp && (
+						<>
+							{ !! itemData?.withIcon && (
+								<SiteFavicon
+									blogId={ itemData.blogId }
+									fallback={ siteIconFallback }
+									color={ itemData.color }
+									className="item-preview__header-favicon"
+									size={ size }
+								/>
+							) }
+							<div className="item-preview__header-info">
+								<div className="item-preview__header-title-summary">
+									<div className="item-preview__header-title">{ itemData.title }</div>
+									<div className="item-preview__header-summary">
+										{ itemData?.url ? (
+											<Button
+												variant="link"
+												className="item-preview__header-summary-link"
+												href={ itemData.url }
+												target="_blank"
 											>
-												{ wpVersion }
-												{ wpVersionName && isStagingSite && <span> ({ wpVersionName })</span> }
-											</a>
-										</div>
-									) }
+												<span>
+													{ itemData.subtitle }
+													<Icon
+														className="sidebar-v2__external-icon"
+														icon={ external }
+														size={ extraProps?.externalIconSize || ICON_SIZE_SMALL }
+													/>
+												</span>
+											</Button>
+										) : (
+											itemData.subtitle
+										) }
 
-									{ phpVersion && (
-										<div className="item-preview__header-env-data-item">
-											PHP{ ' ' }
-											<a
-												className="item-preview__header-env-data-item-link"
-												onClick={ handlePhpVersionClick }
-												href={ `/hosting-config/${ selectedSite?.domain }#php` }
-											>
-												{ phpVersion }
-											</a>
+										{ extraProps && extraProps.subtitleExtra ? (
+											<span>
+												<extraProps.subtitleExtra />
+											</span>
+										) : (
+											''
+										) }
+									</div>
+
+									{ shouldDisplayVersionNumbers && (
+										<div className="item-preview__header-env-data">
+											{ wpVersion && (
+												<div className="item-preview__header-env-data-item">
+													WordPress{ ' ' }
+													<a
+														className="item-preview__header-env-data-item-link"
+														href={ `/hosting-config/${ selectedSite?.domain }#wp` }
+														onClick={ handleWpVersionClick }
+													>
+														{ wpVersion }
+														{ wpVersionName && isStagingSite && <span> ({ wpVersionName })</span> }
+													</a>
+												</div>
+											) }
+
+											{ phpVersion && (
+												<div className="item-preview__header-env-data-item">
+													PHP{ ' ' }
+													<a
+														className="item-preview__header-env-data-item-link"
+														onClick={ handlePhpVersionClick }
+														href={ `/hosting-config/${ selectedSite?.domain }#php` }
+													>
+														{ phpVersion }
+													</a>
+												</div>
+											) }
 										</div>
 									) }
 								</div>
-							) }
-						</div>
 
-						{ isPreviewLoaded && (
-							<div className="item-preview__header-actions">
-								{ extraProps?.headerButtons ? (
-									<extraProps.headerButtons
-										focusRef={ focusRef }
-										itemData={ itemData }
-										closeSitePreviewPane={ closeItemPreviewPane || ( () => {} ) }
-									/>
-								) : (
-									<Button
-										onClick={ closeItemPreviewPane }
-										className="item-preview__close-preview"
-										aria-label={ translate( 'Close Preview' ) }
-										ref={ focusRef }
-									>
-										<Gridicon icon="cross" size={ ICON_SIZE_REGULAR } />
-									</Button>
+								{ isPreviewLoaded && (
+									<div className="item-preview__header-actions">
+										{ extraProps?.headerButtons ? (
+											<extraProps.headerButtons
+												focusRef={ focusRef }
+												itemData={ itemData }
+												closeSitePreviewPane={ closeItemPreviewPane || ( () => {} ) }
+											/>
+										) : (
+											<Button
+												onClick={ closeItemPreviewPane }
+												className="item-preview__close-preview"
+												aria-label={ translate( 'Close Preview' ) }
+												ref={ focusRef }
+											>
+												<Gridicon icon="cross" size={ ICON_SIZE_REGULAR } />
+											</Button>
+										) }
+									</div>
 								) }
 							</div>
-						) }
-					</div>
+						</>
+					) }
 				</div>
 			</div>
 		</>

--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -710,3 +710,11 @@
 		}
 	}
 }
+
+.is-mobile-app-view {
+	.wpcom-site .a4a-layout.sites-dashboard .site-preview-pane {
+		.item-preview__header {
+			padding: 0;
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8864

## Proposed Changes

* Hides the site management preview header and tabs when rendered in mobile app

## Demo

https://github.com/user-attachments/assets/f9de9697-6753-45d4-9dfc-fcbc5a985397


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix issue with navigation on mobile

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the `/site-monitoring` site management view for an atomic site
* Confirm you see the header and tab navigation
<img width="390" alt="Screenshot 2024-08-29 at 21 33 10" src="https://github.com/user-attachments/assets/d4344ebf-5b6d-4046-b816-612cffb587ea">
* Update the network user agent to use `wp-iphone` and refresh the page
* Confirm the header and tab navigation is no longer rendered
<img width="382" alt="Screenshot 2024-08-29 at 21 35 03" src="https://github.com/user-attachments/assets/3968f4b0-3733-47b4-a458-ebc960e36202">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
