### PR TITLE
A4A Dev Sites: Refetch dev licenses count after creating a new dev site and other minor fixes

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/use-random-site-name.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/use-random-site-name.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 
 export const getRandomSiteBaseUrl = async ( title: string ) => {
@@ -38,7 +38,8 @@ const getRandomSiteName = async () => {
 export const useRandomSiteName = () => {
 	const [ randomSiteName, setRandomSiteName ] = useState( '' );
 	const [ isRandomSiteNameLoading, setIsRandomSiteNameLoading ] = useState( true );
-	useEffect( () => {
+
+	const fetchRandomSiteName = useCallback( async () => {
 		getRandomSiteName()
 			.then( ( randomSiteName ) => {
 				setRandomSiteName( randomSiteName );
@@ -50,5 +51,9 @@ export const useRandomSiteName = () => {
 			} );
 	}, [] );
 
-	return { randomSiteName, isRandomSiteNameLoading };
+	useEffect( () => {
+		fetchRandomSiteName();
+	}, [ fetchRandomSiteName ] );
+
+	return { randomSiteName, isRandomSiteNameLoading, refetchRandomSiteName: fetchRandomSiteName };
 };

--- a/client/a8c-for-agencies/data/purchases/use-fetch-dev-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-dev-licenses.ts
@@ -3,11 +3,13 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
+const getFetchDevLicensesQueryKey = ( agencyId?: number ) => [ 'a4a-dev-licenses', agencyId ];
+
 export default function useFetchDevLicenses() {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	return useQuery( {
-		queryKey: [ 'a4a-dev-licenses', agencyId ],
+		queryKey: getFetchDevLicensesQueryKey( agencyId ),
 		queryFn: () =>
 			wpcom.req.get(
 				{
@@ -28,3 +30,5 @@ export default function useFetchDevLicenses() {
 		refetchOnWindowFocus: false,
 	} );
 }
+
+export { getFetchDevLicensesQueryKey };

--- a/client/a8c-for-agencies/data/sites/use-create-wpcom-dev-site.ts
+++ b/client/a8c-for-agencies/data/sites/use-create-wpcom-dev-site.ts
@@ -1,7 +1,13 @@
-import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import {
+	useMutation,
+	UseMutationOptions,
+	UseMutationResult,
+	useQueryClient,
+} from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { getFetchDevLicensesQueryKey } from '../purchases/use-fetch-dev-licenses';
 
 export interface APIError {
 	status: number;
@@ -43,10 +49,16 @@ function createWPCOMDevSiteMutation(
 export default function useCreateWPCOMDevSiteMutation< TContext = unknown >(
 	options?: UseMutationOptions< APIResponse, APIError, CreateDevSiteParams, TContext >
 ): UseMutationResult< APIResponse, APIError, CreateDevSiteParams, TContext > {
+	const queryClient = useQueryClient();
 	const agencyId = useSelector( getActiveAgencyId );
 
 	return useMutation< APIResponse, APIError, CreateDevSiteParams, TContext >( {
 		...options,
 		mutationFn: ( args ) => createWPCOMDevSiteMutation( args, agencyId ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( {
+				queryKey: getFetchDevLicensesQueryKey( agencyId ),
+			} );
+		},
 	} );
 }

--- a/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
@@ -1,10 +1,20 @@
+import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback, useContext, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
-import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_MARKETPLACE_PRODUCTS_LINK,
+	A4A_SITES_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
+import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
+import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import SitesDashboardContext from '../../sites/sites-dashboard-context';
 
 import './style.scss';
 
@@ -12,10 +22,40 @@ export default function OverviewHeaderActions() {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const isNarrowView = useBreakpoint( '<660px' );
+	const { randomSiteName, isRandomSiteNameLoading, refetchRandomSiteName } = useRandomSiteName();
+	const { refetch: refetchPendingSites } = useFetchPendingSites();
+	const [ showConfigurationModal, setShowConfigurationModal ] = useState( false );
+
+	const toggleDevSiteConfigurationsModal = useCallback( () => {
+		setShowConfigurationModal( ! showConfigurationModal );
+	}, [ showConfigurationModal ] );
+
+	const { setRecentlyCreatedSiteId } = useContext( SitesDashboardContext );
+
+	const onCreateSiteSuccess = useCallback(
+		( id: number ) => {
+			refetchPendingSites();
+			refetchRandomSiteName();
+			setRecentlyCreatedSiteId( id );
+			page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
+		},
+		[ refetchPendingSites, refetchRandomSiteName, setRecentlyCreatedSiteId ]
+	);
 
 	return (
 		<div className="overview-header__actions">
-			<AddNewSiteButton showMainButtonLabel={ ! isNarrowView } />
+			{ showConfigurationModal && (
+				<SiteConfigurationsModal
+					closeModal={ toggleDevSiteConfigurationsModal }
+					randomSiteName={ randomSiteName }
+					isRandomSiteNameLoading={ isRandomSiteNameLoading }
+					onCreateSiteSuccess={ onCreateSiteSuccess }
+				/>
+			) }
+			<AddNewSiteButton
+				showMainButtonLabel={ ! isNarrowView }
+				toggleDevSiteConfigurationsModal={ toggleDevSiteConfigurationsModal }
+			/>
 			{ ! isNarrowView && (
 				<Button
 					primary

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -41,7 +41,7 @@ type NeedsSetupSite = {
 };
 
 export default function NeedSetup( { licenseKey }: Props ) {
-	const { randomSiteName, isRandomSiteNameLoading } = useRandomSiteName();
+	const { randomSiteName, isRandomSiteNameLoading, refetchRandomSiteName } = useRandomSiteName();
 	const translate = useTranslate();
 	const [ currentSiteConfigurationId, setCurrentSiteConfigurationId ] = useState< number | null >(
 		null
@@ -138,9 +138,10 @@ export default function NeedSetup( { licenseKey }: Props ) {
 	const onCreateSiteSuccess = useCallback(
 		( id: number ) => {
 			refetchPendingSites();
+			refetchRandomSiteName();
 			page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
 		},
-		[ refetchPendingSites ]
+		[ refetchPendingSites, refetchRandomSiteName ]
 	);
 
 	const onCreateSiteWithConfig = useCallback(

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -28,7 +28,7 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const isMobile = useMobileBreakpoint();
-	const { randomSiteName, isRandomSiteNameLoading } = useRandomSiteName();
+	const { randomSiteName, isRandomSiteNameLoading, refetchRandomSiteName } = useRandomSiteName();
 	const { refetch: refetchPendingSites } = useFetchPendingSites();
 
 	const [ tourStepRef, setTourStepRef ] = useState< HTMLElement | null >( null );
@@ -43,10 +43,11 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 	const onCreateSiteSuccess = useCallback(
 		( id: number ) => {
 			refetchPendingSites();
+			refetchRandomSiteName();
 			setRecentlyCreatedSiteId( id );
 			page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
 		},
-		[ refetchPendingSites ]
+		[ refetchPendingSites, refetchRandomSiteName, setRecentlyCreatedSiteId ]
 	);
 
 	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );


### PR DESCRIPTION
## Proposed Changes

* Refetch dev licenses count after creating a new dev site 
* Refetch random site name after creating a new site
* Fix missing site creation modal on Overview page

## Why are these changes being made?

pdDOJh-3Cl-p2

## Testing Instructions

* Apply this PR to your local
* Run `yarn start-a8c-for-agencies`
* Go to the Overview page
* Click on Add Sites > Development Site
* Create a new dev site
* Click again on Add Sites
* Verify if the count was updated (subtracting the new site)
* Click again on the Development Site
* The site name suggestion should be different
* Perform regression tests on Site Creation, purchasing a license, and creating a site afterward

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?