### PR TITLE
Dissalow adding ns*.wordpress.com as NS record

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -282,11 +282,11 @@ class DnsAddNew extends React.Component {
 			return true;
 		}
 
-		// Specific to NS records, avoid invalid state by checking if the target Host field is a WordPress.com nameserver
+		// Specific to NS records, avoid invalid state by checking if the target Host field is at *.wordpress.com
 		if (
 			this.state.fields.type.value === 'NS' &&
 			fieldName === 'data' &&
-			/^ns\d+\.wordpress\.com$/.test( this.state.fields.data.value ) // ns1.wordpress.com, ns2.wordpress.com, etc.
+			/\.wordpress\.com$/i.test( this.state.fields.data.value ) // matches on ns1.wordpress.com, ns2.wordpress.com, *.wordpress.com, etc.
 		) {
 			return false;
 		}

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -282,6 +282,15 @@ class DnsAddNew extends React.Component {
 			return true;
 		}
 
+		// Specific to NS records, avoid invalid state by checking if the target Host field is a WordPress.com nameserver
+		if (
+			this.state.fields.type.value === 'NS' &&
+			fieldName === 'data' &&
+			/^ns\d+\.wordpress\.com$/.test( this.state.fields.data.value ) // ns1.wordpress.com, ns2.wordpress.com, etc.
+		) {
+			return false;
+		}
+
 		return ! formState.isFieldInvalid( this.state.fields, fieldName );
 	};
 


### PR DESCRIPTION
Internal bug: 978-gh-Automattic/nomado-issues

## Proposed Changes
* Sets the Hosts field as 'invalid' if setting NS record to *.wordpress.com

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As a user, I should not be able to add NS records pointing to our nameservers.
* NS records pointing to ns?.wordpress.com  doesn't make sense since we are hosting the root zone anyway
* Fixes a bug that results in a UI issue where the added NS record shows as Handled by WordPress.com and the user can't edit or delete them anymore

It makes the most sense to block <*>.wordpress.com

Discussed introducing validation checks in the API too, as well as additional output/guidance for the user, but it was determined to be unnessesary at the moment. Can open new tasks to for either if requested.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch and run
* Navigate to 'Add a New DNS Record'
  * http://calypso.localhost:3000/domains/manage/<your.domain>/add-dns-record/<your.domain>
* Specify 'NS' as the type
* Add any 'Name'
* Test different combinations for 'Hosts', the only disallowed Hosts would match <*>.wordpress.com NS server structure
  * ns<any number>.wordpress.com
  * Valid: ns1wordpress.com, ns1.anythingelse.com
  * Invalid: ns1337.wordpress.com, ns1.wordpress.com 

```
not valid: ns1.wordpress.com
not valid: ns2.WoRdPrEsS.com
not valid: ns3.wordpress.com
not valid: nsone.wordpress.com
not valid: ns999999.wordpress.com
not valid: mysite.wordpress.com
not valid: *.wordpress.com

valid: ns1wordpress.com
valid: wordpress.com
valid: ns1.wardpress.com
valid: ns1.WoRdPrEsS.edu
valid: ns2.wordpress.org
valid: ns3.wordpress.co
```

Regexr.com
![image](https://github.com/user-attachments/assets/fdebda9b-69b9-4dc1-beac-596d7c95a5f7)

Screenshot from local dev:
![image](https://github.com/user-attachments/assets/71a64ff8-8f05-43d9-988b-fb6b9d6ff8ff)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
