### PR TITLE
A4A: Address feedback before call for testing

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -10,12 +10,14 @@ type CardContentProps = {
 	onAddClick: () => void;
 	isButtonDisabled: boolean;
 	showQuotaError: boolean;
+	isDevelopmentSite?: boolean;
 };
 
 export const NewStagingSiteCardContent = ( {
 	onAddClick,
 	isButtonDisabled,
 	showQuotaError,
+	isDevelopmentSite,
 }: CardContentProps ) => {
 	{
 		const translate = useTranslate();
@@ -65,6 +67,10 @@ export const NewStagingSiteCardContent = ( {
 							) }
 						</p>
 					</div>
+				) }
+				{ isDevelopmentSite && (
+					// Not wrapped in translation to avoid request unconfirmed copy
+					<p>The staging feature will be available once the site is launched.</p>
 				) }
 				<Button primary disabled={ isButtonDisabled } onClick={ onAddClick }>
 					<span>{ translate( 'Add staging site' ) }</span>

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -57,6 +57,7 @@ export const StagingSiteCard = ( {
 	isJetpack,
 	isPossibleJetpackConnectionProblem,
 	dispatch,
+	isDevelopmentSite,
 	isBorderless,
 } ) => {
 	const { __ } = useI18n();
@@ -503,13 +504,15 @@ export const StagingSiteCard = ( {
 		stagingSiteCardContent = (
 			<NewStagingSiteCardContent
 				onAddClick={ onAddClick }
+				isDevelopmentSite={ isDevelopmentSite }
 				isButtonDisabled={
 					disabled ||
 					isLoadingAddStagingSite ||
 					isLoadingQuotaValidation ||
 					! hasValidQuota ||
 					isSyncInProgress ||
-					isPossibleJetpackConnectionProblem
+					isPossibleJetpackConnectionProblem ||
+					isDevelopmentSite
 				}
 				showQuotaError={ ! hasValidQuota && ! isLoadingQuotaValidation }
 			/>
@@ -532,6 +535,7 @@ export default connect( ( state ) => {
 	const currentUserId = getCurrentUserId( state );
 	const siteId = getSelectedSiteId( state );
 	const siteOwnerId = getSelectedSite( state )?.site_owner;
+	const isDevelopmentSite = getSelectedSite( state )?.is_a4a_dev_site || false;
 
 	return {
 		currentUserId,
@@ -539,5 +543,6 @@ export default connect( ( state ) => {
 		isPossibleJetpackConnectionProblem: isJetpackConnectionProblem( state, siteId ),
 		siteId,
 		siteOwnerId,
+		isDevelopmentSite,
 	};
 } )( localize( StagingSiteCard ) );

--- a/client/my-sites/site-settings/site-visibility/launch-confirmation-modal.tsx
+++ b/client/my-sites/site-settings/site-visibility/launch-confirmation-modal.tsx
@@ -1,0 +1,51 @@
+import { Button } from '@automattic/components';
+import styled from '@emotion/styled';
+import { Modal } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
+
+const ActionButtons = styled.div( {
+	display: 'flex',
+	gap: '1em',
+	justifyContent: 'flex-end',
+} );
+
+type LaunchConfirmationModalProps = {
+	onConfirmation: () => void;
+	closeModal: () => void;
+	billingAgencyMessage: string;
+};
+
+export function LaunchConfirmationModal( {
+	closeModal,
+	billingAgencyMessage,
+	onConfirmation,
+}: LaunchConfirmationModalProps ) {
+	// Not wrapped in translation to avoid request unconfirmed copy
+	const modalTitle = 'You’re about to update your production site';
+
+	return (
+		<>
+			<Modal title={ modalTitle } onRequestClose={ closeModal }>
+				{ billingAgencyMessage && (
+					<p>
+						{ billingAgencyMessage }
+						<br />
+						Are you sure you want to proceed?
+					</p>
+				) }
+				<ActionButtons>
+					<Button
+						onClick={ () => {
+							closeModal();
+						} }
+					>
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button primary onClick={ onConfirmation }>
+						{ translate( 'Yes, launch site' ) }
+					</Button>
+				</ActionButtons>
+			</Modal>
+		</>
+	);
+}


### PR DESCRIPTION
## Proposed Changes


### Creates a confirmation modal before launching development sites
![image](https://github.com/user-attachments/assets/49432960-9ff8-46d1-8299-71cfe945d4da)

### Disable staging sites for sites under development
![image](https://github.com/user-attachments/assets/b51fc866-fae3-4eff-be39-10d8add5d142)


## Testing Instructions

Create a development site on A4A
https://agencies.automattic.com/overview?flags=a4a-dev-sites

Open the staging configurations of your dev site:
`http://calypso.localhost:3000/staging-site/{your-dev-site-url}`
The `Add staging site` button should be disabled.
There is a new message above it, `The staging feature will be available once the site is launched.`

The button should be enabled for sites that are not A4A development.

Open the launch panel on the settings page:
`http://calypso.localhost:3000/settings/general/{you-dev-site-id}`
The Launch button should be primary (blue).
Clicking on it should not launch the site immediately, but open the confirmation modal.
Clicking on the confirmation should publish the site.

The modal should not be present on sites that are not development.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
