### PR TITLE
Show breadcrumbs in individual theme header

### DIFF
--- a/client/components/breadcrumb/README.md
+++ b/client/components/breadcrumb/README.md
@@ -29,6 +29,6 @@ const BreadcrumbExamples = () => {
 
 ## Props
 
-- `items` (`{ label: string; href?: string }[]`) - The Navigations items to be shown
+- `items` (`{ label: string; href?: string; helpBubble?: React.ReactElement; onClick?: () => void }[]`) - The Navigations items to be shown
 - `compact` (`boolean`) - Displays only the previous item URL (optional)
 - `mobileItem` (`string`) - In compact version, displays this value. If not passed defaults to "Back" (optional)

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -61,7 +61,7 @@ const StyledGridicon = styled( Gridicon )`
 	color: var( --color-neutral-10 );
 `;
 
-const HelpBuble = styled( InfoPopover )`
+const HelpBubble = styled( InfoPopover )`
 	margin-left: 7px;
 	display: flex;
 	align-items: center;
@@ -79,13 +79,18 @@ const renderHelpBubble = ( item: Item ) => {
 	}
 
 	return (
-		<HelpBuble icon="help-outline" position="right">
+		<HelpBubble icon="help-outline" position="right">
 			{ item.helpBubble }
-		</HelpBuble>
+		</HelpBubble>
 	);
 };
 
-export type Item = { label: string; href?: string; helpBubble?: React.ReactElement };
+export type Item = {
+	label: string;
+	href?: string;
+	helpBubble?: React.ReactElement;
+	onClick?: () => void;
+};
 interface Props {
 	items: Item[];
 	mobileItem?: Item;
@@ -127,11 +132,13 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 
 	return (
 		<StyledUl className="breadcrumbs">
-			{ items.map( ( item: { href?: string; label: string }, index: Key ) => (
+			{ items.map( ( item: Item, index: Key ) => (
 				<StyledLi key={ index }>
 					{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 14 } /> }
 					{ item.href && index !== items.length - 1 ? (
-						<a href={ item.href }>{ item.label }</a>
+						<a href={ item.href } onClick={ item.onClick }>
+							{ item.label }
+						</a>
 					) : (
 						<span>{ item.label }</span>
 					) }

--- a/client/components/navigation-header/README.md
+++ b/client/components/navigation-header/README.md
@@ -2,6 +2,7 @@
 
 This component displays a header with a breadcrumb.
 It can also include children items which will be positioned to the far right.
+It will not show less than 2 items.
 
 ## How to use
 
@@ -20,7 +21,7 @@ function render() {
 
 ## Props
 
-- `navigationItems` (`{ label: string; href: string }[]`) - The Navigations items to be shown
+- `navigationItems` (`{ label: string; href?: string; helpBubble?: React.ReactElement; onClick?: () => void }[]`) - The Navigations items to be shown
 - `id` (`string`) - ID for the header (optional)
 - `className` (`string`) - A class name for the wrapped component (optional)
 - `children` (`nodes`) – Any children elements which are being rendered to the far right (optional)

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1216,10 +1216,13 @@ class ThemeSheet extends Component {
 	};
 
 	getBackLink = () => {
-		const { backPath, locale, isLoggedIn, themeId } = this.props;
-		this.props.recordTracksEvent( 'calypso_theme_sheet_back_click', { theme_name: themeId } );
-
+		const { backPath, locale, isLoggedIn } = this.props;
 		return localizeThemesPath( backPath, locale, ! isLoggedIn );
+	};
+
+	handleBackLinkClick = () => {
+		const { themeId } = this.props;
+		this.props.recordTracksEvent( 'calypso_theme_sheet_back_click', { theme_name: themeId } );
 	};
 
 	getBannerUpsellTitle = () => <BannerUpsellTitle { ...this.props } />;
@@ -1370,7 +1373,10 @@ class ThemeSheet extends Component {
 			'is-removed': isRemoved,
 		} );
 
-		const navigationItems = [ { label: 'Themes', href: this.getBackLink() }, { label: title } ];
+		const navigationItems = [
+			{ label: 'Themes', href: this.getBackLink(), onClick: this.handleBackLinkClick },
+			{ label: title },
+		];
 
 		return (
 			<Main className="theme__sheet">

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1215,18 +1215,11 @@ class ThemeSheet extends Component {
 		return styleVariations.find( ( variation ) => variation.slug === selectedStyleVariationSlug );
 	};
 
-	goBack = () => {
+	getBackLink = () => {
 		const { backPath, locale, isLoggedIn, themeId } = this.props;
 		this.props.recordTracksEvent( 'calypso_theme_sheet_back_click', { theme_name: themeId } );
 
-		// Use history back when coming from customize your store screen.
-		const urlParams = new URLSearchParams( window.location.search );
-		if ( urlParams.has( 'from', 'customize-store' ) && window.history.length > 1 ) {
-			window.history.back();
-			return;
-		}
-
-		page( localizeThemesPath( backPath, locale, ! isLoggedIn ) );
+		return localizeThemesPath( backPath, locale, ! isLoggedIn );
 	};
 
 	getBannerUpsellTitle = () => <BannerUpsellTitle { ...this.props } />;
@@ -1377,10 +1370,7 @@ class ThemeSheet extends Component {
 			'is-removed': isRemoved,
 		} );
 
-		const navigationItems = [
-			{ label: 'Themes', href: siteSlug ? `/themes/${ siteSlug }` : '/themes' },
-			{ label: title },
-		];
+		const navigationItems = [ { label: 'Themes', href: this.getBackLink() }, { label: title } ];
 
 		return (
 			<Main className="theme__sheet">

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -39,9 +39,9 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import SyncActiveTheme from 'calypso/components/data/sync-active-theme';
-import HeaderCake from 'calypso/components/header-cake';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import ThemeSiteSelectorModal from 'calypso/components/theme-site-selector-modal';
 import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
@@ -1377,6 +1377,11 @@ class ThemeSheet extends Component {
 			'is-removed': isRemoved,
 		} );
 
+		const navigationItems = [
+			{ label: 'Themes', href: siteSlug ? `/themes/${ siteSlug }` : '/themes' },
+			{ label: title },
+		];
+
 		return (
 			<Main className="theme__sheet">
 				<QueryCanonicalTheme themeId={ this.props.themeId } siteId={ siteId } />
@@ -1426,14 +1431,7 @@ class ThemeSheet extends Component {
 				/>
 				<ThanksModal source="details" themeId={ this.props.themeId } />
 				<ActivationModal source="details" />
-				<div className="theme__sheet-action-bar-container">
-					<HeaderCake
-						className="theme__sheet-action-bar"
-						backText={ translate( 'Back to themes' ) }
-						onClick={ this.goBack }
-						alwaysShowBackText
-					/>
-				</div>
+				<NavigationHeader navigationItems={ navigationItems } />
 				<div className={ columnsClassName }>
 					<div className="theme__sheet-column-header">
 						{ this.renderStagingPaidThemeNotice() }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1374,7 +1374,7 @@ class ThemeSheet extends Component {
 		} );
 
 		const navigationItems = [
-			{ label: 'Themes', href: this.getBackLink(), onClick: this.handleBackLinkClick },
+			{ label: translate( 'Themes' ), href: this.getBackLink(), onClick: this.handleBackLinkClick },
 			{ label: title },
 		];
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -70,10 +70,7 @@ $button-border: 4px;
 
 		@media screen and (min-width: 960px) {
 			padding: 24px 20px;
-		}
-
-		@media screen and (min-width: 1806px) {
-			padding: 24px 0;
+			box-sizing: initial;
 		}
 	}
 }
@@ -301,25 +298,6 @@ $button-border: 4px;
 
 .theme__sheet-column-right {
 	grid-area: preview;
-}
-
-.header-cake.card.theme__sheet-action-bar {
-	box-shadow: none;
-	box-sizing: content-box;
-	margin: 0 auto;
-	max-width: $theme-sheet-content-max-width;
-	min-height: 70px;
-	padding: 0 20px;
-	position: relative;
-
-	@include breakpoint-deprecated( "<960px" ) {
-		margin: 0 0 32px 0;
-		min-height: 60px;
-	}
-}
-
-.is-mobile-app-view .header-cake.card.theme__sheet-action-bar {
-	display: none;
 }
 
 .theme__sheet-primary-button {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -61,6 +61,20 @@ $button-border: 4px;
 			overflow-y: auto;
 		}
 	}
+
+	.theme__sheet .navigation-header {
+		margin: 0 auto;
+		max-width: $theme-sheet-content-max-width;
+		padding: 24px 44px;
+
+		@media screen and (min-width: 960px) {
+			padding: 24px 20px;
+		}
+
+		@media screen and (min-width: 1806px) {
+			padding: 24px 0;
+		}
+	}
 }
 
 .main.theme__sheet {
@@ -286,10 +300,6 @@ $button-border: 4px;
 
 .theme__sheet-column-right {
 	grid-area: preview;
-}
-
-.theme__sheet-action-bar-container {
-	box-shadow: 0 1px var(--color-border-subtle);
 }
 
 .header-cake.card.theme__sheet-action-bar {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -17,6 +17,7 @@ $button-border: 4px;
 
 	.layout.is-logged-in .layout__content {
 		overflow: clip;
+		padding-top: 47px;
 
 		.theme__sheet-screenshot,
 		.theme__sheet-web-preview {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/92645

## Proposed Changes

* Use the `NavigationHeader` component for individual themes.
* Update the `Breadcrumb` and `NavigationHeader` components to take an `onClick` prop.

Before | After
---- | -----
<img width="235" alt="Screen Shot 2024-08-29 at 4 21 34 PM" src="https://github.com/user-attachments/assets/b87021f1-f2ac-4c56-95a8-5b06ca97d87a"> | <img width="229" alt="Screen Shot 2024-08-29 at 4 21 43 PM" src="https://github.com/user-attachments/assets/c5526de0-2ab7-48d5-bbf6-906a93e56f9b">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To keep the page header consistent with other pages, especially the theme showcase and individual plugin pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /themes.
* Click on a theme.
* Verify that the breadcrumb text is correct (Themes > title of the theme).
* Use the header to navigate back to Themes.
* Repeat at site level (Appearance > Themes).
* Repeat while logged out.
* Test at different screen sizes.
* Regression test another page with breadcrumbs, like Stats and individual Plugins pages.

Known issue: there's some variation in padding on the page. I'm aligning with the theme title.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
