### PR TITLE
i18n: Fix passing the locale when fetching alphabetic tags on /tags

### DIFF
--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -94,7 +94,7 @@ export const fetchAlphabeticTags = ( context: PageJSContext, next: ( e?: Error )
 	}
 	performanceMark( context as PartialContext, 'fetchAlphabeticTags' );
 
-	const currentUserLocale = getCurrentUserLocale( context.store.getState() );
+	const currentUserLocale = getCurrentUserLocale( context.store.getState() ) || context.lang;
 
 	context.queryClient
 		.fetchQuery( {
@@ -102,7 +102,7 @@ export const fetchAlphabeticTags = ( context: PageJSContext, next: ( e?: Error )
 			queryFn: () => {
 				return wpcom.req.get( '/read/tags/alphabetic', {
 					apiVersion: '1.2',
-					lang: currentUserLocale, // Note: undefined will be omitted by the query string builder.
+					locale: currentUserLocale, // Note: undefined will be omitted by the query string builder.
 				} );
 			},
 			staleTime: 86400000, // 24 hours


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Use `locale` instead of `lang` when fetching the tags. The WPCOM endpoint doesn't use `lang`. Using `locale` makes sure the endpoint correctly sets the locale to be able to return translated tags.
* Add ` || context.lang` to `currentUserLocale` to use the locale from the URL when logged out.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of an effort to localize the tags on `/[locale]/tags`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See D159997-code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
