### PR TITLE
Domains Step: Fix missing use-your-domain step back button on new user signup

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1337,8 +1337,17 @@ export class RenderDomainsStep extends Component {
 		let backLabelText;
 		let isExternalBackUrl = false;
 
-		// Hide "Back" button in domains step if the user has no sites.
-		const shouldHideBack = ! userSiteCount && previousStepName?.startsWith( 'user' );
+		/**
+		 * Hide "Back" button in domains step if:
+		 *   1. The user has no sites
+		 *   2. This step was rendered immediately after account creation
+		 *   3. The user is on the root domains step and not a child step section like use-your-domain
+		 */
+		const shouldHideBack =
+			! userSiteCount &&
+			previousStepName?.startsWith( 'user' ) &&
+			stepSectionName !== 'use-your-domain';
+
 		const hideBack = flowName === 'domain' || shouldHideBack;
 
 		const previousStepBackUrl = this.getPreviousStepUrl();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92999

## Proposed Changes

* Prevents back button from being hidden if the user is on the `user-your-domain` step

![2024-08-30 13 04 32](https://github.com/user-attachments/assets/17524830-55f4-444a-a9d8-98414eaa3264)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Previously, there was a patch meant to hide an unnecessary back button on the domains step if a new user had just signed up for WordPress.com. https://github.com/Automattic/wp-calypso/pull/88663
* This patch missed an edge case where the `use-your-domain` step section would have its back button hidden as well.
* It's worth noting a few things here:
  * Like the author of the original patch, I, myself, would've made the same mistake. I would've expected the `use-your-domain` section to be its own, independent step. It, however, is not. It's a _**step section**_. The fact that both the pick-your-domain and use-your-domain views are _both_ classified as the `domains` step will probably cause more confusion in the future.
  * My recommendation is to look into making it more obvious that the `use-your-domain` step is a **step section**, and not a **step**. I'd also explore making the `use-your-domain` step section its own, full-fledged step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test this PR with calypso.live.
* Visit /start as a logged out user
* Sign up as a new user
* Once redirected to /domains, you should see no back button
* Click on the "Use a domain I own" hyperlink
* Verify that the back button for the `use-your-domain` step is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
