### PR TITLE
Include coupon code as query param in stepper onboarding checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -45,10 +45,11 @@ const onboarding: Flow = {
 	useStepNavigation( currentStepSlug, navigate ) {
 		const flowName = this.name;
 
-		const { domainCartItem, planCartItem } = useSelect(
+		const { domainCartItem, planCartItem, couponCode } = useSelect(
 			( select: ( key: string ) => OnboardSelect ) => ( {
 				domainCartItem: select( ONBOARD_STORE ).getDomainCartItem(),
 				planCartItem: select( ONBOARD_STORE ).getPlanCartItem(),
+				couponCode: select( ONBOARD_STORE ).getCouponCode(),
 			} ),
 			[]
 		);
@@ -86,6 +87,7 @@ const onboarding: Flow = {
 							addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
 								redirect_to: destination,
 								signup: 1,
+								coupon: couponCode,
 							} )
 						);
 					} else {


### PR DESCRIPTION
## Proposed Changes

Coupons applied in Stepper Onboarding flow are not applied to final price in Checkout. 
This PR applies the coupon code to the final price in Checkout 

## Testing Instructions

1. Checkout branch 
2. Launch Stepper onboard flow and include a coupon code `calypso.localhost:3000/setup/onboarding/?coupon={code}`
3. Complete onboard flow 
4. Discount seen at pricing page should be reflected in checkout total
