### PR TITLE
Improved copy clarity

### DIFF
--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -127,12 +127,12 @@ class ConfirmCancelDomain extends Component {
 					getLocaleSlug() === 'en' ||
 					getLocaleSlug() === 'en-gb' ||
 					i18n.hasTranslation(
-						'Unable to cancel your purchase. Please try again later {{a}}or contact support{{/a}}.'
+						'Unable to cancel your purchase. Please try again later or {{a}}contact support{{/a}}.'
 					)
 				) {
 					this.props.errorNotice(
 						translate(
-							'Unable to cancel your purchase. Please try again later {{a}}or contact support{{/a}}.',
+							'Unable to cancel your purchase. Please try again later or {{a}}contact support{{/a}}.',
 							{
 								components: {
 									a: <ActionPanelLink href="/help/contact" />,


### PR DESCRIPTION
Follow-up of https://github.com/Automattic/wp-calypso/pull/94041

## Proposed Changes

* Improved copy clarity

<img width="1265" alt="image" src="https://github.com/user-attachments/assets/6d2fbf66-d503-4fa1-bc2c-c88c45fc9285">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
