### PR TITLE
[WIP] A4A Dev Sites: Update provisioning notification for Development sites 

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -18,7 +18,7 @@ import './style.scss';
 
 type SiteConfigurationsModalProps = {
 	closeModal: () => void;
-	onCreateSiteSuccess: ( id: number ) => void;
+	onCreateSiteSuccess: ( id: number, isDevSite?: boolean ) => void;
 	randomSiteName: string;
 	isRandomSiteNameLoading: boolean;
 	siteId?: number;
@@ -95,7 +95,7 @@ export default function SiteConfigurationsModal( {
 		if ( isDevSite ) {
 			createWPCOMDevSite( params, {
 				onSuccess: ( response ) => {
-					onCreateSiteSuccess( response.site.id );
+					onCreateSiteSuccess( response.site.id, true );
 					closeModal();
 				},
 				onError: async ( error ) => {

--- a/client/a8c-for-agencies/hooks/use-site-created-callback.ts
+++ b/client/a8c-for-agencies/hooks/use-site-created-callback.ts
@@ -1,0 +1,25 @@
+import page from '@automattic/calypso-router';
+import { addQueryArgs } from '@wordpress/url';
+import { useCallback, useContext } from 'react';
+import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
+import SitesDashboardContext from '../sections/sites/sites-dashboard-context';
+
+const useSiteCreatedCallback = ( refetchRandomSiteName: () => Promise< void > ) => {
+	const { setRecentlyCreatedSiteId } = useContext( SitesDashboardContext );
+	const { refetch: refetchPendingSites } = useFetchPendingSites();
+
+	return useCallback(
+		( id: number, isDevSite?: boolean ) => {
+			refetchPendingSites();
+			refetchRandomSiteName();
+			setRecentlyCreatedSiteId( id );
+
+			const queryParams = isDevSite ? { created_dev_site: id } : { created_site: id };
+			page( addQueryArgs( A4A_SITES_LINK, queryParams ) );
+		},
+		[ refetchPendingSites, refetchRandomSiteName, setRecentlyCreatedSiteId ]
+	);
+};
+
+export default useSiteCreatedCallback;

--- a/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
@@ -1,20 +1,14 @@
-import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
-import {
-	A4A_MARKETPLACE_PRODUCTS_LINK,
-	A4A_SITES_LINK,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
-import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
+import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import SitesDashboardContext from '../../sites/sites-dashboard-context';
 
 import './style.scss';
 
@@ -23,24 +17,13 @@ export default function OverviewHeaderActions() {
 	const translate = useTranslate();
 	const isNarrowView = useBreakpoint( '<660px' );
 	const { randomSiteName, isRandomSiteNameLoading, refetchRandomSiteName } = useRandomSiteName();
-	const { refetch: refetchPendingSites } = useFetchPendingSites();
 	const [ showConfigurationModal, setShowConfigurationModal ] = useState( false );
 
 	const toggleDevSiteConfigurationsModal = useCallback( () => {
 		setShowConfigurationModal( ! showConfigurationModal );
 	}, [ showConfigurationModal ] );
 
-	const { setRecentlyCreatedSiteId } = useContext( SitesDashboardContext );
-
-	const onCreateSiteSuccess = useCallback(
-		( id: number ) => {
-			refetchPendingSites();
-			refetchRandomSiteName();
-			setRecentlyCreatedSiteId( id );
-			page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
-		},
-		[ refetchPendingSites, refetchRandomSiteName, setRecentlyCreatedSiteId ]
-	);
+	const onCreateSiteSuccess = useSiteCreatedCallback( refetchRandomSiteName );
 
 	return (
 		<div className="overview-header__actions">

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -18,6 +18,7 @@ import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-co
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
 import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
+import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
 import SitesHeaderActions from '../sites-header-actions';
 import ClientSite from './client-site';
 import { AvailablePlans } from './plan-field';
@@ -135,14 +136,7 @@ export default function NeedSetup( { licenseKey }: Props ) {
 				features.wpcom_atomic.state === 'provisioning' && !! features.wpcom_atomic.license_key
 		);
 
-	const onCreateSiteSuccess = useCallback(
-		( id: number ) => {
-			refetchPendingSites();
-			refetchRandomSiteName();
-			page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
-		},
-		[ refetchPendingSites, refetchRandomSiteName ]
-	);
+	const onCreateSiteSuccess = useSiteCreatedCallback( refetchRandomSiteName );
 
 	const onCreateSiteWithConfig = useCallback(
 		( id: number ) => {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -51,7 +51,10 @@ export default function SitesDashboard() {
 
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const recentlyCreatedSite = getQueryArg( window.location.href, 'created_site' ) ?? null;
+	const createdSiteId = getQueryArg( window.location.href, 'created_site' ) ?? null;
+	const createdDevSiteId = getQueryArg( window.location.href, 'created_dev_site' ) ?? null;
+
+	const recentlyCreatedSite = createdSiteId || createdDevSiteId;
 	const migrationIntent = getQueryArg( window.location.href, 'migration' ) ?? null;
 
 	const {
@@ -237,11 +240,16 @@ export default function SitesDashboard() {
 							<ProvisioningSiteNotification
 								siteId={ Number( recentlyCreatedSiteId ) }
 								migrationIntent={ !! migrationIntent }
+								isDevSite={ !! createdDevSiteId }
 							/>
 						) }
 
 						<LayoutHeader>
-							<Title>{ translate( 'Sites' ) }</Title>
+							<Title>
+								{ showOnlyDevelopmentSites
+									? translate( 'Development Sites' )
+									: translate( 'Sites' ) }
+							</Title>
 							<Actions>
 								<MobileSidebarNavigation />
 								<SitesHeaderActions onWPCOMImport={ () => refetch() } />

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -8,9 +8,14 @@ import { addQueryArgs } from 'calypso/lib/url';
 type Props = {
 	siteId: number;
 	migrationIntent: boolean;
+	isDevSite?: boolean;
 };
 
-export default function ProvisioningSiteNotification( { siteId, migrationIntent }: Props ) {
+export default function ProvisioningSiteNotification( {
+	siteId,
+	migrationIntent,
+	isDevSite,
+}: Props ) {
 	const { isReady, site } = useIsSiteReady( { siteId } );
 	const [ showBanner, setShowBanner ] = useState( true );
 
@@ -32,17 +37,46 @@ export default function ProvisioningSiteNotification( { siteId, migrationIntent 
 		'https://wordpress.com/setup/hosted-site-migration/site-migration-identify'
 	);
 
+	let title = translate( 'Setting up your new WordPress.com site' );
+	let content = translate(
+		"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
+	);
+
+	if ( isReady ) {
+		if ( isDevSite ) {
+			title = translate( 'Your WordPress.com development site is ready!' );
+			content = translate(
+				'{{a}}%(siteURL)s{{/a}} is now ready. Get started by configuring your new development site. It may take a few minutes for it to show up in the site list below.',
+				{
+					args: { siteURL: site?.url ?? '' },
+					components: {
+						a: <a href={ wpOverviewUrl } target="_blank" rel="noreferrer" />,
+					},
+					comment: 'The %(siteURL)s is the URL of the site that has been provisioned.',
+				}
+			);
+		} else {
+			title = translate( 'Your WordPress.com site is ready!' );
+			content = translate(
+				'{{a}}%(siteURL)s{{/a}} is now ready. Get started by configuring your new site. It may take a few minutes for it to show up in the site list below.',
+				{
+					args: { siteURL: site?.url ?? '' },
+					components: {
+						a: <a href={ wpOverviewUrl } target="_blank" rel="noreferrer" />,
+					},
+					comment: 'The %(siteURL)s is the URL of the site that has been provisioned.',
+				}
+			);
+		}
+	}
+
 	return (
 		showBanner && (
 			<NoticeBanner
 				level={ isReady ? 'success' : 'warning' }
 				hideCloseButton={ ! isReady }
 				onClose={ () => setShowBanner( false ) }
-				title={
-					isReady
-						? translate( 'Your WordPress.com site is ready!' )
-						: translate( 'Setting up your new WordPress.com site' )
-				}
+				title={ title }
 				actions={
 					isReady
 						? [
@@ -59,20 +93,7 @@ export default function ProvisioningSiteNotification( { siteId, migrationIntent 
 						: undefined
 				}
 			>
-				{ isReady
-					? translate(
-							'{{a}}%(siteURL)s{{/a}} is now ready. Get started by configuring your new site. It may take a few minutes for it to show up in the site list below.',
-							{
-								args: { siteURL: site?.url ?? '' },
-								components: {
-									a: <a href={ wpOverviewUrl } target="_blank" rel="noreferrer" />,
-								},
-								comment: 'The %(siteURL)s is the URL of the site that has been provisioned.',
-							}
-					  )
-					: translate(
-							"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
-					  ) }
+				{ content }
 			</NoticeBanner>
 		)
 	);

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -1,22 +1,17 @@
 import config from '@automattic/calypso-config';
-import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
-import {
-	A4A_MARKETPLACE_PRODUCTS_LINK,
-	A4A_SITES_LINK,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
-import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
+import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import SitesDashboardContext from '../sites-dashboard-context';
 
 import './style.scss';
 
@@ -29,7 +24,6 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 	const translate = useTranslate();
 	const isMobile = useMobileBreakpoint();
 	const { randomSiteName, isRandomSiteNameLoading, refetchRandomSiteName } = useRandomSiteName();
-	const { refetch: refetchPendingSites } = useFetchPendingSites();
 
 	const [ tourStepRef, setTourStepRef ] = useState< HTMLElement | null >( null );
 	const [ showConfigurationModal, setShowConfigurationModal ] = useState( false );
@@ -38,17 +32,7 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 		setShowConfigurationModal( ! showConfigurationModal );
 	}, [ showConfigurationModal ] );
 
-	const { setRecentlyCreatedSiteId } = useContext( SitesDashboardContext );
-
-	const onCreateSiteSuccess = useCallback(
-		( id: number ) => {
-			refetchPendingSites();
-			refetchRandomSiteName();
-			setRecentlyCreatedSiteId( id );
-			page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
-		},
-		[ refetchPendingSites, refetchRandomSiteName, setRecentlyCreatedSiteId ]
-	);
+	const onCreateSiteSuccess = useSiteCreatedCallback( refetchRandomSiteName );
 
 	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
