### PR TITLE
Add Payment Method: Remove unused div nesting

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/credit-card/contact-fields.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/contact-fields.tsx
@@ -37,7 +37,7 @@ export default function ContactFields( {
 	};
 
 	return (
-		<div className="contact-fields">
+		<>
 			{ shouldUseEbanx && ! shouldShowTaxFields && (
 				<CountrySpecificPaymentFields
 					countryCode={ getFieldValue( 'countryCode' ) }
@@ -57,6 +57,6 @@ export default function ContactFields( {
 					isDisabled={ isDisabled }
 				/>
 			) }
-		</div>
+		</>
 	);
 }


### PR DESCRIPTION
It looks like a 'contact-fields' class was added with a wrapper `div` element, but the class doesn't appear to be used or referenced anywhere.

Adding this div element turns the contact fields into their own nested block, which triggers Field-Row styling: 
```
.css-18nem30-GridRow-FieldRow:first-of-type {
    margin-top: 0;
}
```
Changing the div into a fragment and removing the class fixes this styling issue. If someone wishes to add it back in the future they will need to handle the first-of-type styling at that point.

| Before | After |
| ----- | ----- |
| <img width="630" alt="image" src="https://github.com/user-attachments/assets/b28749f2-d598-498f-a84e-4c38e9bc9e2e"> | <img width="630" alt="image" src="https://github.com/user-attachments/assets/70708993-87c3-475f-b665-cc7600d233e8"> |

## Testing Instructions

* Go to http://calypso.localhost:3000/me/purchases/add-payment-method
* Make sure the Country field shows correctly spaced
* Also check any sub fields of Country
