### PR TITLE
Theme Showcase: Make the search bar and categories sticky for logged-in users

### DIFF
--- a/client/my-sites/themes/controller-logged-in.jsx
+++ b/client/my-sites/themes/controller-logged-in.jsx
@@ -17,7 +17,7 @@ export function loggedIn( context, next ) {
 	}
 
 	// Scroll to the top
-	if ( typeof window !== 'undefined' ) {
+	if ( typeof window !== 'undefined' && context.init ) {
 		window.scrollTo( 0, 0 );
 	}
 

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -25,7 +25,15 @@ jest.mock( 'calypso/components/data/query-themes', () =>
 	require( 'calypso/components/empty-component' )
 );
 
-window.IntersectionObserver = jest.fn( () => ( { observe: jest.fn(), disconnect: jest.fn() } ) );
+window.IntersectionObserver = jest.fn( () => ( {
+	observe: jest.fn(),
+	disconnect: jest.fn(),
+	root: null,
+	rootMargin: '',
+	thresholds: [],
+	takeRecords: jest.fn(),
+	unobserve: jest.fn(),
+} ) );
 
 const themes = [
 	{

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -9,6 +9,7 @@ import { localize, translate } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
+import { InView } from 'react-intersection-observer';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -592,6 +593,8 @@ class ThemeShowcase extends Component {
 		window.scrollTo( { top: 0 } );
 	};
 
+	shouldThemeControlsSticky = ( inView ) => this.props.isLoggedIn && ! inView;
+
 	render() {
 		const {
 			siteId,
@@ -681,57 +684,70 @@ class ThemeShowcase extends Component {
 						<div className="themes__showcase">{ this.renderBanner() }</div>
 					) }
 					{ ! isCollectionView && (
-						<div className="themes__controls">
-							<div className="theme__search">
-								<div className="theme__search-input">
-									{ isSearchV2 ? (
-										<SearchThemesV2
-											query={ featureStringFilter + search }
-											onSearch={ this.doSearch }
-										/>
-									) : (
-										<SearchThemes
-											query={ filterString + search }
-											onSearch={ this.doSearch }
-											recordTracksEvent={ this.recordSearchThemesTracksEvent }
-										/>
-									) }
-								</div>
-								{ tabFilters && premiumThemesEnabled && ! isMultisite && (
-									<>
-										<SelectDropdown
-											className="section-nav-tabs__dropdown"
-											onSelect={ this.onTierSelectFilter }
-											selectedText={ translate( 'View: %s', {
-												args: getOptionLabel( tiers, tier ) || '',
+						<InView rootMargin="-180px 0px 0px 0px" fallbackInView>
+							{ ( { inView, ref } ) => (
+								<>
+									<div
+										className={ clsx( 'themes__controls', {
+											'is-sticky': this.shouldThemeControlsSticky( inView ),
+										} ) }
+									>
+										<div className="theme__search">
+											<div className="theme__search-input">
+												{ isSearchV2 ? (
+													<SearchThemesV2
+														query={ featureStringFilter + search }
+														onSearch={ this.doSearch }
+													/>
+												) : (
+													<SearchThemes
+														query={ filterString + search }
+														onSearch={ this.doSearch }
+														recordTracksEvent={ this.recordSearchThemesTracksEvent }
+													/>
+												) }
+											</div>
+											{ tabFilters && premiumThemesEnabled && ! isMultisite && (
+												<>
+													<SelectDropdown
+														className="section-nav-tabs__dropdown"
+														onSelect={ this.onTierSelectFilter }
+														selectedText={ translate( 'View: %s', {
+															args: getOptionLabel( tiers, tier ) || '',
+														} ) }
+														options={ tiers }
+														initialSelected={ tier }
+													></SelectDropdown>
+												</>
+											) }
+										</div>
+										<div
+											className={ clsx( 'themes__filters', {
+												'is-woo-express': isSiteWooExpress,
 											} ) }
-											options={ tiers }
-											initialSelected={ tier }
-										></SelectDropdown>
-									</>
-								) }
-							</div>
-							<div
-								className={ clsx( 'themes__filters', {
-									'is-woo-express': isSiteWooExpress,
-								} ) }
-							>
-								{ tabFilters && ! isSiteECommerceFreeTrial && (
-									<ThemesToolbarGroup
-										items={ Object.values( tabFilters ) }
-										selectedKey={ this.getSelectedTabFilter().key }
-										onSelect={ ( key ) =>
-											this.onFilterClick(
-												Object.values( tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
-											)
-										}
-									/>
-								) }
-								{ ! isLoggedIn && tabFilters && (
-									<PatternAssemblerButton onClick={ this.onDesignYourOwnClick } />
-								) }
-							</div>
-						</div>
+										>
+											{ tabFilters && ! isSiteECommerceFreeTrial && (
+												<ThemesToolbarGroup
+													items={ Object.values( tabFilters ) }
+													selectedKey={ this.getSelectedTabFilter().key }
+													onSelect={ ( key ) =>
+														this.onFilterClick(
+															Object.values( tabFilters ).find(
+																( tabFilter ) => tabFilter.key === key
+															)
+														)
+													}
+												/>
+											) }
+											{ ! isLoggedIn && tabFilters && (
+												<PatternAssemblerButton onClick={ this.onDesignYourOwnClick } />
+											) }
+										</div>
+									</div>
+									<div className="themes__controls-placeholder" ref={ ref } />
+								</>
+							) }
+						</InView>
 					) }
 					{ isCollectionView && (
 						<ThemeCollectionViewHeader

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -96,6 +96,7 @@ class ThemeShowcase extends Component {
 	state = {
 		isDesignThemeModalVisible: false,
 		isSiteSelectorModalVisible: false,
+		shouldThemeControlsSticky: false,
 	};
 
 	constructor( props ) {
@@ -593,7 +594,9 @@ class ThemeShowcase extends Component {
 		window.scrollTo( { top: 0 } );
 	};
 
-	shouldThemeControlsSticky = ( inView ) => this.props.isLoggedIn && ! inView;
+	onShouldThemeControlsStickyChange = ( inView ) => {
+		this.setState( { shouldThemeControlsSticky: this.props.isLoggedIn && ! inView } );
+	};
 
 	render() {
 		const {
@@ -684,75 +687,75 @@ class ThemeShowcase extends Component {
 						<div className="themes__showcase">{ this.renderBanner() }</div>
 					) }
 					{ ! isCollectionView && (
-						<InView rootMargin="-32px 0px 0px 0px" threshold={ 1 } fallbackInView>
-							{ ( { inView, ref } ) => (
-								<>
-									<div
-										className={ clsx( 'themes__controls-placeholder', {
-											'is-sticky': this.shouldThemeControlsSticky( inView ),
-										} ) }
-										ref={ ref }
-									/>
-									<div
-										className={ clsx( 'themes__controls', {
-											'is-sticky': this.shouldThemeControlsSticky( inView ),
-										} ) }
-									>
-										<div className="theme__search">
-											<div className="theme__search-input">
-												{ isSearchV2 ? (
-													<SearchThemesV2
-														query={ featureStringFilter + search }
-														onSearch={ this.doSearch }
-													/>
-												) : (
-													<SearchThemes
-														query={ filterString + search }
-														onSearch={ this.doSearch }
-														recordTracksEvent={ this.recordSearchThemesTracksEvent }
-													/>
-												) }
-											</div>
-											{ tabFilters && premiumThemesEnabled && ! isMultisite && (
-												<>
-													<SelectDropdown
-														className="section-nav-tabs__dropdown"
-														onSelect={ this.onTierSelectFilter }
-														selectedText={ translate( 'View: %s', {
-															args: getOptionLabel( tiers, tier ) || '',
-														} ) }
-														options={ tiers }
-														initialSelected={ tier }
-													></SelectDropdown>
-												</>
-											) }
-										</div>
-										<div
-											className={ clsx( 'themes__filters', {
-												'is-woo-express': isSiteWooExpress,
-											} ) }
-										>
-											{ tabFilters && ! isSiteECommerceFreeTrial && (
-												<ThemesToolbarGroup
-													items={ Object.values( tabFilters ) }
-													selectedKey={ this.getSelectedTabFilter().key }
-													onSelect={ ( key ) =>
-														this.onFilterClick(
-															Object.values( tabFilters ).find(
-																( tabFilter ) => tabFilter.key === key
-															)
-														)
-													}
-												/>
-											) }
-											{ ! isLoggedIn && tabFilters && (
-												<PatternAssemblerButton onClick={ this.onDesignYourOwnClick } />
-											) }
-										</div>
-									</div>
-								</>
+						<>
+							{ isLoggedIn && (
+								<InView
+									as="div"
+									className={ clsx( 'themes__controls-placeholder', {
+										'is-sticky': this.state.shouldThemeControlsSticky,
+									} ) }
+									rootMargin="-32px 0px 0px 0px"
+									threshold={ 1 }
+									fallbackInView
+									onChange={ this.onShouldThemeControlsStickyChange }
+								/>
 							) }
-						</InView>
+							<div
+								className={ clsx( 'themes__controls', {
+									'is-sticky': this.state.shouldThemeControlsSticky,
+								} ) }
+							>
+								<div className="theme__search">
+									<div className="theme__search-input">
+										{ isSearchV2 ? (
+											<SearchThemesV2
+												query={ featureStringFilter + search }
+												onSearch={ this.doSearch }
+											/>
+										) : (
+											<SearchThemes
+												query={ filterString + search }
+												onSearch={ this.doSearch }
+												recordTracksEvent={ this.recordSearchThemesTracksEvent }
+											/>
+										) }
+									</div>
+									{ tabFilters && premiumThemesEnabled && ! isMultisite && (
+										<>
+											<SelectDropdown
+												className="section-nav-tabs__dropdown"
+												onSelect={ this.onTierSelectFilter }
+												selectedText={ translate( 'View: %s', {
+													args: getOptionLabel( tiers, tier ) || '',
+												} ) }
+												options={ tiers }
+												initialSelected={ tier }
+											></SelectDropdown>
+										</>
+									) }
+								</div>
+								<div
+									className={ clsx( 'themes__filters', {
+										'is-woo-express': isSiteWooExpress,
+									} ) }
+								>
+									{ tabFilters && ! isSiteECommerceFreeTrial && (
+										<ThemesToolbarGroup
+											items={ Object.values( tabFilters ) }
+											selectedKey={ this.getSelectedTabFilter().key }
+											onSelect={ ( key ) =>
+												this.onFilterClick(
+													Object.values( tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
+												)
+											}
+										/>
+									) }
+									{ ! isLoggedIn && tabFilters && (
+										<PatternAssemblerButton onClick={ this.onDesignYourOwnClick } />
+									) }
+								</div>
+							</div>
+						</>
 					) }
 					{ isCollectionView && (
 						<ThemeCollectionViewHeader

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -684,9 +684,15 @@ class ThemeShowcase extends Component {
 						<div className="themes__showcase">{ this.renderBanner() }</div>
 					) }
 					{ ! isCollectionView && (
-						<InView rootMargin="-180px 0px 0px 0px" fallbackInView>
+						<InView rootMargin="-32px 0px 0px 0px" threshold={ 1 } fallbackInView>
 							{ ( { inView, ref } ) => (
 								<>
+									<div
+										className={ clsx( 'themes__controls-placeholder', {
+											'is-sticky': this.shouldThemeControlsSticky( inView ),
+										} ) }
+										ref={ ref }
+									/>
 									<div
 										className={ clsx( 'themes__controls', {
 											'is-sticky': this.shouldThemeControlsSticky( inView ),
@@ -744,7 +750,6 @@ class ThemeShowcase extends Component {
 											) }
 										</div>
 									</div>
-									<div className="themes__controls-placeholder" ref={ ref } />
 								</>
 							) }
 						</InView>

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -518,6 +518,30 @@
 			padding: 0 16px;
 		}
 	}
+
+	.themes__controls.is-sticky {
+		@include break-medium {
+			position: fixed;
+			left: var(--sidebar-width-max);
+			top: var(--masterbar-height);
+			width: calc(100vw - var(--sidebar-width-max) - 2 * 2rem);
+			padding: 24px 32px 8px;
+			border-bottom: 1px solid var(--studio-gray-5);
+			box-sizing: content-box;
+			background: var(--studio-white);
+			z-index: 20;
+
+			& + .themes__controls-placeholder {
+				height: 101px;
+			}
+
+			.is-global-sidebar-visible & {
+				top: calc(var(--masterbar-height) + 16px);
+				width: calc(100% - var(--sidebar-width-max) - 31px);
+				box-sizing: border-box;
+			}
+		}
+	}
 }
 
 .theme-showcase__open-showcase-button-holder {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -548,14 +548,14 @@
 	}
 
 	.themes__controls-placeholder {
+		.is-logged-out & {
+			display: none;
+		}
+
 		@include break-medium {
 			padding-top: 24px;
 			margin-top: -24px;
 			box-sizing: content-box;
-
-			.is-logged-out & {
-				display: none;
-			}
 
 			.is-global-sidebar-visible & {
 				padding-top: 40px;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -524,21 +524,34 @@
 			position: fixed;
 			left: var(--sidebar-width-max);
 			top: var(--masterbar-height);
-			width: calc(100vw - var(--sidebar-width-max) - 2 * 2rem);
-			padding: 24px 32px 8px;
+			width: calc(100vw - var(--sidebar-width-max) - 16px);
+			padding: 24px 32px 8px 33px;
 			border-bottom: 1px solid var(--studio-gray-5);
-			box-sizing: content-box;
+			box-sizing: border-box;
 			background: var(--studio-white);
 			z-index: 20;
-
-			& + .themes__controls-placeholder {
-				height: 101px;
-			}
 
 			.is-global-sidebar-visible & {
 				top: calc(var(--masterbar-height) + 16px);
 				width: calc(100% - var(--sidebar-width-max) - 31px);
-				box-sizing: border-box;
+				padding: 40px 32px 8px;
+			}
+		}
+	}
+
+	.themes__controls-placeholder {
+		@include break-medium {
+			padding-top: 24px;
+			margin-top: -24px;
+			box-sizing: content-box;
+
+			.is-global-sidebar-visible & {
+				padding-top: 40px;
+				margin-top: -40px;
+			}
+
+			&.is-sticky {
+				height: 101px;
 			}
 		}
 	}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -535,6 +535,14 @@
 				top: calc(var(--masterbar-height) + 16px);
 				width: calc(100% - var(--sidebar-width-max) - 31px);
 				padding: 40px 32px 8px;
+
+
+				// Make the scroll behavior works on the top of the fixed element.
+				pointer-events: none;
+
+				> * {
+					pointer-events: auto;
+				}
 			}
 		}
 	}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -553,6 +553,10 @@
 			margin-top: -24px;
 			box-sizing: content-box;
 
+			.is-logged-out & {
+				display: none;
+			}
+
 			.is-global-sidebar-visible & {
 				padding-top: 40px;
 				margin-top: -40px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92601

## Proposed Changes

* Make the search bar and categories sticky on the Theme Showcase screen for logged-in users. Note that this PR is focusing on the sticky behavior, and we can continue to update the layout in the follow-up PR.

**Global Theme Showcase**

https://github.com/user-attachments/assets/7c2e1e85-eda0-4631-b977-edaa4336f38b

**Site Theme Showcase**

https://github.com/user-attachments/assets/f3dcfd08-0dac-4fca-8551-0ea5cf30e85a

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/themes` or `/themes/:site`
* Scroll down
* Make sure the search bar and categories are sticky to the top

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
