### PR TITLE
A4A: Restrict destructive operations to members with no capabilities.

### DIFF
--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -37,6 +37,8 @@ import {
 	A4A_PAYMENT_METHODS_LINK,
 	A4A_PAYMENT_METHODS_ADD_LINK,
 	A4A_MIGRATIONS_LINK,
+	A4A_TEAM_LINK,
+	A4A_TEAM_INVITE_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import type { Agency } from 'calypso/state/a8c-for-agencies/types';
 
@@ -79,6 +81,8 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_PAYMENT_METHODS_LINK ]: [ 'a4a_jetpack_licensing' ],
 	[ A4A_PAYMENT_METHODS_ADD_LINK ]: [ 'a4a_jetpack_licensing' ],
 	[ A4A_MIGRATIONS_LINK ]: [ 'a4a_read_migrations' ],
+	[ A4A_TEAM_LINK ]: [ 'a4a_read_users' ],
+	[ A4A_TEAM_INVITE_LINK ]: [ 'a4a_edit_user_invites' ],
 };
 
 export const isPathAllowed = ( pathname: string, agency: Agency | null ) => {

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -9,7 +9,8 @@ import {
 	LicenseType,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { addQueryArgs } from 'calypso/lib/url';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import RevokeLicenseDialog from '../revoke-license-dialog';
@@ -36,6 +37,8 @@ export default function LicenseDetailsActions( {
 }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+
+	const isOwner = useSelector( isAgencyOwner );
 
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
@@ -107,9 +110,10 @@ export default function LicenseDetailsActions( {
 				</Button>
 			) }
 
-			{ ( isChildLicense
-				? licenseState === LicenseState.Attached
-				: licenseState !== LicenseState.Revoked ) &&
+			{ isOwner &&
+				( isChildLicense
+					? licenseState === LicenseState.Attached
+					: licenseState !== LicenseState.Revoked ) &&
 				licenseType === LicenseType.Partner && (
 					<Button compact onClick={ openRevokeDialog } scary>
 						{ translate( 'Revoke' ) }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -40,7 +40,7 @@ export default function LicenseDetailsActions( {
 	const translate = useTranslate();
 
 	const canRevoke = useSelector( ( state: A4AStore ) =>
-		hasAgencyCapability( state, 'a4a_revoke_license' )
+		hasAgencyCapability( state, 'a4a_revoke_licenses' )
 	);
 
 	const [ revokeDialog, setRevokeDialog ] = useState( false );

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -10,7 +10,8 @@ import {
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch, useSelector } from 'calypso/state';
-import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import RevokeLicenseDialog from '../revoke-license-dialog';
@@ -38,7 +39,9 @@ export default function LicenseDetailsActions( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const isOwner = useSelector( isAgencyOwner );
+	const canRevoke = useSelector( ( state: A4AStore ) =>
+		hasAgencyCapability( state, 'a4a_revoke_license' )
+	);
 
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
@@ -110,7 +113,7 @@ export default function LicenseDetailsActions( {
 				</Button>
 			) }
 
-			{ isOwner &&
+			{ canRevoke &&
 				( isChildLicense
 					? licenseState === LicenseState.Attached
 					: licenseState !== LicenseState.Revoked ) &&

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
@@ -22,7 +22,7 @@ export default function LicenseBundleDropDown( { licenseKey, product, bundleSize
 	const dispatch = useDispatch();
 
 	const canRevoke = useSelector( ( state: A4AStore ) =>
-		hasAgencyCapability( state, 'a4a_revoke_license' )
+		hasAgencyCapability( state, 'a4a_revoke_licenses' )
 	);
 
 	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
@@ -6,7 +6,8 @@ import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { LicenseRole } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { useDispatch, useSelector } from 'calypso/state';
-import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import RevokeLicenseDialog from '../revoke-license-dialog';
 
@@ -20,7 +21,9 @@ export default function LicenseBundleDropDown( { licenseKey, product, bundleSize
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const isOwner = useSelector( isAgencyOwner );
+	const canRevoke = useSelector( ( state: A4AStore ) =>
+		hasAgencyCapability( state, 'a4a_revoke_license' )
+	);
 
 	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );
 	const [ showContextMenu, setShowContextMenu ] = useState( false );
@@ -44,7 +47,7 @@ export default function LicenseBundleDropDown( { licenseKey, product, bundleSize
 		setShowRevokeDialog( false );
 	}, [ dispatch ] );
 
-	if ( ! isOwner ) {
+	if ( ! canRevoke ) {
 		return null;
 	}
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
@@ -5,7 +5,8 @@ import { useCallback, useRef, useState } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { LicenseRole } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import RevokeLicenseDialog from '../revoke-license-dialog';
 
@@ -18,6 +19,8 @@ type Props = {
 export default function LicenseBundleDropDown( { licenseKey, product, bundleSize }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const isOwner = useSelector( isAgencyOwner );
 
 	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );
 	const [ showContextMenu, setShowContextMenu ] = useState( false );
@@ -40,6 +43,10 @@ export default function LicenseBundleDropDown( { licenseKey, product, bundleSize
 		dispatch( recordTracksEvent( 'calypso_a4a_license_list_revoke_bundle_dialog_close' ) );
 		setShowRevokeDialog( false );
 	}, [ dispatch ] );
+
+	if ( ! isOwner ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -23,7 +23,7 @@ export default function useLicenseActions(
 	const dispatch = useDispatch();
 
 	const canRevoke = useSelector( ( state: A4AStore ) =>
-		hasAgencyCapability( state, 'a4a_revoke_license' )
+		hasAgencyCapability( state, 'a4a_revoke_licenses' )
 	);
 
 	return useMemo( () => {

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -7,7 +7,8 @@ import {
 	LicenseType,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export default function useLicenseActions(
@@ -19,6 +20,8 @@ export default function useLicenseActions(
 ): LicenseAction[] {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const isOwner = useSelector( isAgencyOwner );
 
 	return useMemo( () => {
 		if ( ! siteUrl ) {
@@ -75,11 +78,22 @@ export default function useLicenseActions(
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_hosting_configuration_click' ),
 				type: 'revoke',
 				isEnabled:
+					isOwner &&
 					( isChildLicense
 						? licenseState === LicenseState.Attached
-						: licenseState !== LicenseState.Revoked ) && licenseType === LicenseType.Partner,
+						: licenseState !== LicenseState.Revoked ) &&
+					licenseType === LicenseType.Partner,
 				className: 'is-destructive',
 			},
 		];
-	}, [ attachedAt, dispatch, isChildLicense, licenseType, revokedAt, siteUrl, translate ] );
+	}, [
+		attachedAt,
+		dispatch,
+		isChildLicense,
+		isOwner,
+		licenseType,
+		revokedAt,
+		siteUrl,
+		translate,
+	] );
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -8,7 +8,8 @@ import {
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch, useSelector } from 'calypso/state';
-import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export default function useLicenseActions(
@@ -21,7 +22,9 @@ export default function useLicenseActions(
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const isOwner = useSelector( isAgencyOwner );
+	const canRevoke = useSelector( ( state: A4AStore ) =>
+		hasAgencyCapability( state, 'a4a_revoke_license' )
+	);
 
 	return useMemo( () => {
 		if ( ! siteUrl ) {
@@ -78,7 +81,7 @@ export default function useLicenseActions(
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_hosting_configuration_click' ),
 				type: 'revoke',
 				isEnabled:
-					isOwner &&
+					canRevoke &&
 					( isChildLicense
 						? licenseState === LicenseState.Attached
 						: licenseState !== LicenseState.Revoked ) &&
@@ -88,9 +91,9 @@ export default function useLicenseActions(
 		];
 	}, [
 		attachedAt,
+		canRevoke,
 		dispatch,
 		isChildLicense,
-		isOwner,
 		licenseType,
 		revokedAt,
 		siteUrl,

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/credit-card-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/credit-card-actions.tsx
@@ -22,6 +22,8 @@ export default function CreditCardActions( {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const dispatch = useDispatch();
 
+	const availableActions = cardActions.filter( ( action ) => action.isEnabled );
+
 	const showActions = () => {
 		setIsOpen( true );
 		dispatch( recordTracksEvent( 'calypso_a4a_payments_card_actions_button_click' ) );
@@ -30,6 +32,10 @@ export default function CreditCardActions( {
 	const closeDropdown = () => {
 		setIsOpen( false );
 	};
+
+	if ( availableActions.length === 0 ) {
+		return null;
+	}
 
 	return (
 		<>
@@ -50,17 +56,15 @@ export default function CreditCardActions( {
 				onClose={ closeDropdown }
 				position="bottom left"
 			>
-				{ cardActions
-					.filter( ( action ) => action.isEnabled )
-					.map( ( action ) => (
-						<PopoverMenuItem
-							className={ clsx( action.className ) }
-							key={ action.name }
-							onClick={ action.onClick }
-						>
-							{ action.name }
-						</PopoverMenuItem>
-					) ) }
+				{ availableActions.map( ( action ) => (
+					<PopoverMenuItem
+						className={ clsx( action.className ) }
+						key={ action.name }
+						onClick={ action.onClick }
+					>
+						{ action.name }
+					</PopoverMenuItem>
+				) ) }
 			</PopoverMenu>
 		</>
 	);

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
@@ -3,7 +3,8 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
-import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { PaymentMethodOverviewContext } from '../../context';
 import { useDeleteCard } from '../../hooks/use-delete-card';
@@ -42,7 +43,9 @@ export default function StoredCreditCard( {
 
 	const { paging } = useContext( PaymentMethodOverviewContext );
 
-	const isOwner = useSelector( isAgencyOwner );
+	const canRemove = useSelector( ( state: A4AStore ) =>
+		hasAgencyCapability( state, 'a4a_remove_payment_method' )
+	);
 
 	// Fetch the stored cards from the cache if they are available.
 	const {
@@ -67,7 +70,7 @@ export default function StoredCreditCard( {
 		},
 		{
 			name: translate( 'Delete' ),
-			isEnabled: isOwner,
+			isEnabled: canRemove,
 			onClick: () => {
 				setIsDeleteDialogVisible( true );
 				dispatch( recordTracksEvent( 'calypso_a4a_payments_card_actions_delete_click' ) );

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
@@ -2,7 +2,8 @@ import { PaymentLogo } from '@automattic/wpcom-checkout';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { PaymentMethodOverviewContext } from '../../context';
 import { useDeleteCard } from '../../hooks/use-delete-card';
@@ -41,6 +42,8 @@ export default function StoredCreditCard( {
 
 	const { paging } = useContext( PaymentMethodOverviewContext );
 
+	const isOwner = useSelector( isAgencyOwner );
+
 	// Fetch the stored cards from the cache if they are available.
 	const {
 		data: { allStoredCards },
@@ -64,7 +67,7 @@ export default function StoredCreditCard( {
 		},
 		{
 			name: translate( 'Delete' ),
-			isEnabled: true,
+			isEnabled: isOwner,
 			onClick: () => {
 				setIsDeleteDialogVisible( true );
 				dispatch( recordTracksEvent( 'calypso_a4a_payments_card_actions_delete_click' ) );

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/index.tsx
@@ -44,7 +44,7 @@ export default function StoredCreditCard( {
 	const { paging } = useContext( PaymentMethodOverviewContext );
 
 	const canRemove = useSelector( ( state: A4AStore ) =>
-		hasAgencyCapability( state, 'a4a_remove_payment_method' )
+		hasAgencyCapability( state, 'a4a_remove_payment_methods' )
 	);
 
 	// Fetch the stored cards from the cache if they are available.

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -6,7 +6,8 @@ import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashbo
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch, useSelector } from 'calypso/state';
-import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -44,7 +45,9 @@ export default function useSiteActions( {
 	const isWPCOMSimpleSite = ! isJetpack && ! isA4AClient;
 	const isWPCOMSite = isWPCOMSimpleSite || isWPCOMAtomicSite;
 
-	const isOwner = useSelector( isAgencyOwner );
+	const canRemove = useSelector( ( state: A4AStore ) =>
+		hasAgencyCapability( state, 'a4a_remove_managed_sites' )
+	);
 
 	return useMemo( () => {
 		if ( ! siteValue ) {
@@ -165,14 +168,14 @@ export default function useSiteActions( {
 				onClick: () => handleClickMenuItem( 'remove_site' ),
 				icon: 'trash',
 				className: 'is-error',
-				isEnabled: isOwner,
+				isEnabled: canRemove,
 			},
 		];
 	}, [
+		canRemove,
 		dispatch,
 		isDevSite,
 		isLargeScreen,
-		isOwner,
 		isWPCOMSimpleSite,
 		isWPCOMSite,
 		onSelect,

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -6,6 +6,7 @@ import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashbo
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch, useSelector } from 'calypso/state';
+import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -42,6 +43,8 @@ export default function useSiteActions( {
 	const isA4AClient = useSelector( ( state ) => isA4AClientSite( state, siteValue?.blog_id ) );
 	const isWPCOMSimpleSite = ! isJetpack && ! isA4AClient;
 	const isWPCOMSite = isWPCOMSimpleSite || isWPCOMAtomicSite;
+
+	const isOwner = useSelector( isAgencyOwner );
 
 	return useMemo( () => {
 		if ( ! siteValue ) {
@@ -162,17 +165,20 @@ export default function useSiteActions( {
 				onClick: () => handleClickMenuItem( 'remove_site' ),
 				icon: 'trash',
 				className: 'is-error',
-				isEnabled: true,
+				isEnabled: isOwner,
 			},
 		];
 	}, [
 		dispatch,
+		isDevSite,
 		isLargeScreen,
+		isOwner,
 		isWPCOMSimpleSite,
 		isWPCOMSite,
 		onSelect,
+		setDataViewsState,
 		setSelectedSiteFeature,
-		site?.value?.sticker,
+		site?.value,
 		siteError,
 		siteValue,
 		translate,

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -77,11 +77,11 @@ export const DateColumn = ( { date }: { date?: string } ): ReactNode => {
 export const ActionColumn = ( {
 	member,
 	onMenuSelected,
-	asOwner = true,
+	withDelete = true,
 }: {
 	member: TeamMember;
 	onMenuSelected?: ( action: string ) => void;
-	asOwner?: boolean;
+	withDelete?: boolean;
 } ): ReactNode => {
 	const translate = useTranslate();
 
@@ -121,7 +121,7 @@ export const ActionColumn = ( {
 						name: 'delete-user',
 						label: translate( 'Delete user' ),
 						className: 'is-danger',
-						isEnabled: asOwner,
+						isEnabled: withDelete,
 					},
 			  ];
 

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -77,11 +77,11 @@ export const DateColumn = ( { date }: { date?: string } ): ReactNode => {
 export const ActionColumn = ( {
 	member,
 	onMenuSelected,
-	withDelete = true,
+	canRemove = true,
 }: {
 	member: TeamMember;
 	onMenuSelected?: ( action: string ) => void;
-	withDelete?: boolean;
+	canRemove?: boolean;
 } ): ReactNode => {
 	const translate = useTranslate();
 
@@ -121,7 +121,7 @@ export const ActionColumn = ( {
 						name: 'delete-user',
 						label: translate( 'Delete user' ),
 						className: 'is-danger',
-						isEnabled: withDelete,
+						isEnabled: canRemove,
 					},
 			  ];
 

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -15,8 +15,11 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import { A4A_TEAM_INVITE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useCancelMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-cancel-member-invite';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { useMemberList } from '../../hooks/use-member-list';
 import { TeamMember } from '../../types';
@@ -70,6 +73,12 @@ export default function TeamList() {
 		[ cancelMemberInvite, dispatch, refetch ]
 	);
 
+	const canRemove = useSelector( ( state: A4AStore ) =>
+		hasAgencyCapability( state, 'a4a_remove_users' )
+	);
+
+	const currentUser = useSelector( getCurrentUser );
+
 	const fields = useMemo(
 		() => [
 			{
@@ -111,6 +120,7 @@ export default function TeamList() {
 						<ActionColumn
 							member={ item }
 							onMenuSelected={ ( action ) => handleAction( action, item ) }
+							withDelete={ canRemove || item.email === currentUser?.email }
 						/>
 					);
 				},
@@ -119,7 +129,7 @@ export default function TeamList() {
 				enableSorting: false,
 			},
 		],
-		[ handleAction, isDesktop, translate ]
+		[ canRemove, currentUser?.email, handleAction, isDesktop, translate ]
 	);
 
 	if ( isPending ) {

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -120,7 +120,7 @@ export default function TeamList() {
 						<ActionColumn
 							member={ item }
 							onMenuSelected={ ( action ) => handleAction( action, item ) }
-							withDelete={ canRemove || item.email === currentUser?.email }
+							canRemove={ canRemove || item.email === currentUser?.email }
 						/>
 					);
 				},

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -1,5 +1,6 @@
 // Required for modular state.
 import 'calypso/state/a8c-for-agencies/init';
+import { isEnabled } from '@automattic/calypso-config';
 import { A4AStore, APIError, Agency } from '../types';
 
 export function getActiveAgency( state: A4AStore ): Agency | null {
@@ -36,6 +37,11 @@ export function isAgencyClientUser( state: A4AStore ): boolean {
 }
 
 export function hasAgencyCapability( state: A4AStore, capability: string ): boolean {
+	if ( ! isEnabled( 'a4a-multi-user-support' ) ) {
+		// This is always true if the feature is not enabled to bypass restrictions.
+		return true;
+	}
+
 	const agency = getActiveAgency( state );
-	return !! agency && agency?.user?.capabilities?.includes( capability );
+	return agency?.user?.capabilities?.includes( capability ) ?? false;
 }

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -35,7 +35,7 @@ export function isAgencyClientUser( state: A4AStore ): boolean {
 	return state.a8cForAgencies.agencies.isAgencyClientUser;
 }
 
-export function isAgencyOwner( state: A4AStore ): boolean {
+export function hasAgencyCapability( state: A4AStore, capability: string ): boolean {
 	const agency = getActiveAgency( state );
-	return !! agency && agency.user.role === 'a4a_administrator';
+	return !! agency && agency?.user?.capabilities?.includes( capability );
 }

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -34,3 +34,8 @@ export function hasAgency( state: A4AStore ): boolean {
 export function isAgencyClientUser( state: A4AStore ): boolean {
 	return state.a8cForAgencies.agencies.isAgencyClientUser;
 }
+
+export function isAgencyOwner( state: A4AStore ): boolean {
+	const agency = getActiveAgency( state );
+	return !! agency && agency.user.role === 'a4a_administrator';
+}


### PR DESCRIPTION
 This PR restricts some of the destructive operations to team members. The following operations are deemed destructive and shall be restricted to team members:

- Remove member (Except self)
- Remove Sites
- Remove Payment methods
- Cancel/Revoke licenses

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/956

**NOTE: Please refrain from merging this pull request until the D160175-code is merged.**

## Proposed Changes

* Define a new set of A4A capabilities that map to the restrictive operations. See D160175-code 
* Create a `hasAgencyCapability` selector as a helper function to check if the current agency has certain capabilities.
* For each destructive operations, add some guards using the new selector to determine when to show/hide few of the CTA buttons.

## Why are these changes being made?

* It is important to limit any destructive operations to non-owners to avoid potential damage caused by malicious intent.

## Testing Instructions

* Apply D160175-code to your sandbox and point public-api.wordpress.com. (This is necessary to have the new set of capabilities that maps to restrictive operations.
* Login with a team member account.
* Use the A4A live link and test the restrictive operations that are not accessible.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?