### PR TITLE
A4A: Implement the 'Remove member' action.

### DIFF
--- a/client/a8c-for-agencies/data/team/use-remove-member.ts
+++ b/client/a8c-for-agencies/data/team/use-remove-member.ts
@@ -19,7 +19,7 @@ interface APIResponse {
 
 function removeMemberMutation( params: Params, agencyId?: number ): Promise< APIResponse > {
 	if ( ! agencyId ) {
-		throw new Error( 'Agency ID is required to assign a license' );
+		throw new Error( 'Agency ID is required to remove a team member' );
 	}
 
 	return wpcom.req.post( {

--- a/client/a8c-for-agencies/data/team/use-remove-member.ts
+++ b/client/a8c-for-agencies/data/team/use-remove-member.ts
@@ -1,0 +1,41 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+interface APIError {
+	status: number;
+	code: string | null;
+	message: string;
+}
+
+export interface Params {
+	id: number;
+}
+
+interface APIResponse {
+	success: boolean;
+}
+
+function removeMemberMutation( params: Params, agencyId?: number ): Promise< APIResponse > {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to assign a license' );
+	}
+
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/users/${ params.id }`,
+		method: 'DELETE',
+	} );
+}
+
+export default function useRemoveMemberMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, Params, TContext >
+): UseMutationResult< APIResponse, APIError, Params, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< APIResponse, APIError, Params, TContext >( {
+		...options,
+		mutationFn: ( args ) => removeMemberMutation( args, agencyId ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
@@ -47,7 +47,7 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 					{
 						onSuccess: () => {
 							dispatch(
-								successNotice( translate( 'The user has been successfully removed.' ), {
+								successNotice( translate( 'The member has been successfully removed.' ), {
 									id: 'remove-user-success',
 									duration: 5000,
 								} )

--- a/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
@@ -35,7 +35,12 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 						},
 
 						onError: ( error ) => {
-							dispatch( errorNotice( error.message ) );
+							dispatch(
+								errorNotice( error.message, {
+									id: 'cancel-user-invite-error',
+									duration: 5000,
+								} )
+							);
 						},
 					}
 				);
@@ -56,7 +61,12 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 						},
 
 						onError: ( error ) => {
-							dispatch( errorNotice( error.message ) );
+							dispatch(
+								errorNotice( error.message, {
+									id: 'remove-user-error',
+									duration: 5000,
+								} )
+							);
 						},
 					}
 				);

--- a/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
@@ -1,0 +1,43 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import useCancelMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-cancel-member-invite';
+import { useDispatch } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { TeamMember } from '../types';
+
+type Props = {
+	onRefetchList?: () => void;
+};
+
+export default function useHandleMemberAction( { onRefetchList }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { mutate: cancelMemberInvite } = useCancelMemberInviteMutation();
+
+	return useCallback(
+		( action: string, item: TeamMember ) => {
+			if ( action === 'cancel-user-invite' ) {
+				cancelMemberInvite(
+					{ id: item.id },
+					{
+						onSuccess: () => {
+							dispatch(
+								successNotice( translate( 'The invitation has been successfully cancelled.' ), {
+									id: 'cancel-user-invite-success',
+									duration: 5000,
+								} )
+							);
+							onRefetchList?.();
+						},
+
+						onError: ( error ) => {
+							dispatch( errorNotice( error.message ) );
+						},
+					}
+				);
+			}
+		},
+		[ cancelMemberInvite, dispatch, onRefetchList, translate ]
+	);
+}

--- a/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import useCancelMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-cancel-member-invite';
+import useRemoveMemberMutation from 'calypso/a8c-for-agencies/data/team/use-remove-member';
 import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { TeamMember } from '../types';
@@ -14,6 +15,8 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 	const dispatch = useDispatch();
 
 	const { mutate: cancelMemberInvite } = useCancelMemberInviteMutation();
+
+	const { mutate: removeMember } = useRemoveMemberMutation();
 
 	return useCallback(
 		( action: string, item: TeamMember ) => {
@@ -37,7 +40,28 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 					}
 				);
 			}
+
+			if ( action === 'delete-user' ) {
+				removeMember(
+					{ id: item.id },
+					{
+						onSuccess: () => {
+							dispatch(
+								successNotice( translate( 'The user has been successfully removed.' ), {
+									id: 'remove-user-success',
+									duration: 5000,
+								} )
+							);
+							onRefetchList?.();
+						},
+
+						onError: ( error ) => {
+							dispatch( errorNotice( error.message ) );
+						},
+					}
+				);
+			}
 		},
-		[ cancelMemberInvite, dispatch, onRefetchList, translate ]
+		[ cancelMemberInvite, dispatch, onRefetchList, removeMember, translate ]
 	);
 }

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -115,7 +115,7 @@ export const ActionColumn = ( {
 					{
 						name: 'password-reset',
 						label: translate( 'Send password reset' ),
-						isEnabled: true,
+						isEnabled: false, // FIXME: Implement this action
 					},
 					{
 						name: 'delete-user',

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode, useCallback, useMemo, useState } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
@@ -14,13 +14,12 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import { A4A_TEAM_INVITE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useCancelMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-cancel-member-invite';
 import { useDispatch, useSelector } from 'calypso/state';
 import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import useHandleMemberAction from '../../hooks/use-handle-member-action';
 import { useMemberList } from '../../hooks/use-member-list';
 import { TeamMember } from '../../types';
 import GetStarted from '../get-started';
@@ -38,8 +37,6 @@ export default function TeamList() {
 
 	const { members, hasMembers, isPending, refetch } = useMemberList();
 
-	const { mutate: cancelMemberInvite } = useCancelMemberInviteMutation();
-
 	const title = translate( 'Manage team members' );
 
 	const onInviteClick = () => {
@@ -47,31 +44,7 @@ export default function TeamList() {
 		page( A4A_TEAM_INVITE_LINK );
 	};
 
-	const handleAction = useCallback(
-		( action: string, item: TeamMember ) => {
-			if ( action === 'cancel-user-invite' ) {
-				cancelMemberInvite(
-					{ id: item.id },
-					{
-						onSuccess: () => {
-							dispatch(
-								successNotice( 'The invitation has been successfully cancelled.', {
-									id: 'cancel-user-invite-success',
-									duration: 5000,
-								} )
-							);
-							refetch();
-						},
-
-						onError: ( error ) => {
-							dispatch( errorNotice( error.message ) );
-						},
-					}
-				);
-			}
-		},
-		[ cancelMemberInvite, dispatch, refetch ]
-	);
+	const handleAction = useHandleMemberAction( { onRefetchList: refetch } );
 
 	const canRemove = useSelector( ( state: A4AStore ) =>
 		hasAgencyCapability( state, 'a4a_remove_users' )


### PR DESCRIPTION
This PR implements the handler for the 'Remove member' CTA.

<img width="330" alt="Screenshot 2024-09-02 at 6 06 16 PM" src="https://github.com/user-attachments/assets/fa910bbd-d55f-4b47-bd9d-931d9ee737d8">



Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1052

## Proposed Changes

* Move all member action handlers to a separate hook to separate concerns and make the presentational layer easier to read.
* Implement the Mutation hook that is linked to the `/users` DELETE endpoint.
* Additional: Disable the 'Password reset' action as it is not required for MVP.

## Why are these changes being made?

*

## Testing Instructions

* Use the A4A live link and go to the `/team` page.
* Add some few members and create some few invites.
* Test that the **Cancel invite** and **Remove member** actions work as expected.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
