### PR TITLE
Some improvements to the paid newsletter importer

### DIFF
--- a/client/my-sites/importer/newsletter/content-upload/file-importer.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/file-importer.jsx
@@ -44,6 +44,7 @@ class FileImporter extends PureComponent {
 			icon: PropTypes.string.isRequired,
 			description: PropTypes.node.isRequired,
 			uploadDescription: PropTypes.node,
+			acceptedFileTypes: PropTypes.array,
 		} ).isRequired,
 		importerStatus: PropTypes.shape( {
 			errorData: PropTypes.shape( {
@@ -80,7 +81,8 @@ class FileImporter extends PureComponent {
 	};
 
 	render() {
-		const { title, overrideDestination, uploadDescription, optionalUrl } = this.props.importerData;
+		const { title, overrideDestination, uploadDescription, optionalUrl, acceptedFileTypes } =
+			this.props.importerData;
 		const { importerStatus, site, fromSite, nextStepUrl, skipNextStep } = this.props;
 		const { errorData, importerState, summaryModalOpen } = importerStatus;
 		const isEnabled = appStates.DISABLED !== importerState;
@@ -153,6 +155,7 @@ class FileImporter extends PureComponent {
 						site={ site }
 						optionalUrl={ optionalUrl }
 						fromSite={ fromSite }
+						acceptedFileTypes={ acceptedFileTypes }
 						nextStepUrl={ nextStepUrl }
 						skipNextStep={ skipNextStep }
 					/>

--- a/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
@@ -48,6 +48,7 @@ export class UploadingPane extends PureComponent {
 			validate: PropTypes.func,
 		} ),
 		fromSite: PropTypes.string,
+		acceptedFileTypes: PropTypes.array,
 		nextStepUrl: PropTypes.string,
 		skipNextStep: PropTypes.func,
 	};
@@ -237,7 +238,7 @@ export class UploadingPane extends PureComponent {
 	};
 
 	render() {
-		const { importerStatus, fromSite, nextStepUrl, skipNextStep } = this.props;
+		const { importerStatus, fromSite, acceptedFileTypes, nextStepUrl, skipNextStep } = this.props;
 		const isReadyForImport = this.isReadyForImport();
 		const importerStatusClasses = clsx(
 			'importer__upload-content',
@@ -275,6 +276,7 @@ export class UploadingPane extends PureComponent {
 							type="file"
 							name="exportFile"
 							onChange={ this.initiateFromForm }
+							accept={ acceptedFileTypes ? acceptedFileTypes.join( ',' ) : undefined }
 						/>
 					) }
 					<DropZone onFilesDrop={ isReadyForImport ? this.initiateFromDrop : noop } />

--- a/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
@@ -276,7 +276,7 @@ export class UploadingPane extends PureComponent {
 							type="file"
 							name="exportFile"
 							onChange={ this.initiateFromForm }
-							accept={ acceptedFileTypes ? acceptedFileTypes.join( ',' ) : undefined }
+							accept={ acceptedFileTypes?.length ? acceptedFileTypes.join( ',' ) : undefined }
 						/>
 					) }
 					<DropZone onFilesDrop={ isReadyForImport ? this.initiateFromDrop : noop } />

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -1,4 +1,6 @@
-import { Card, Button, Gridicon } from '@automattic/components';
+import { Card } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { external } from '@wordpress/icons';
 import { useEffect } from 'react';
 import importerConfig from 'calypso/lib/importer/importer-config';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
@@ -72,8 +74,10 @@ export default function Content( {
 						href={ `https://${ fromSite }/publish/settings?search=export` }
 						target="_blank"
 						rel="noreferrer noopener"
+						icon={ external }
+						variant="secondary"
 					>
-						Export content <Gridicon icon="external" />
+						Export content
 					</Button>
 					<hr />
 					<h2>Step 2: Import your content to WordPress.com</h2>

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -1,5 +1,4 @@
 import { Card, Button, Gridicon } from '@automattic/components';
-import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
 import { useEffect } from 'react';
 import importerConfig from 'calypso/lib/importer/importer-config';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
@@ -12,10 +11,9 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 type ContentProps = {
 	nextStepUrl: string;
-	selectedSite?: SiteDetails;
+	selectedSite: SiteDetails;
 	siteSlug: string;
-	fromSite: QueryArgParsed;
-	cardData: any;
+	fromSite: string;
 	skipNextStep: () => void;
 };
 
@@ -26,8 +24,8 @@ export default function Content( {
 	fromSite,
 	skipNextStep,
 }: ContentProps ) {
-	const siteTitle = selectedSite?.title;
-	const siteId = selectedSite?.ID;
+	const siteTitle = selectedSite.title;
+	const siteId = selectedSite.ID;
 
 	const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
 
@@ -39,10 +37,6 @@ export default function Content( {
 
 	useEffect( fetchImporters, [ siteId, dispatch ] );
 	useEffect( startImporting, [ siteId, dispatch, siteImports ] );
-
-	if ( ! selectedSite ) {
-		return null;
-	}
 
 	function startImporting() {
 		siteId && siteImports.length === 0 && dispatch( startImport( siteId ) );
@@ -90,7 +84,7 @@ export default function Content( {
 					site={ selectedSite }
 					importerStatus={ importerStatus }
 					importerData={ importerData }
-					fromSite={ fromSite as string }
+					fromSite={ fromSite }
 					nextStepUrl={ nextStepUrl }
 					skipNextStep={ skipNextStep }
 				/>

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -61,6 +61,7 @@
 
 .select-newsletter-form__help {
 	margin-top: 8px;
+	margin-bottom: 0;
 	font-size: 0.75rem;
 
 	&.is-error {
@@ -113,4 +114,5 @@
 
 .select-newsletter-form .is-loading {
 	@include placeholder( --color-neutral-10 );
+	margin-bottom: 0;
 }

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -52,20 +52,19 @@
 		fill: var(--studio-gray-50);
 	}
 
-
 	.stripe-logo {
 		width: 48px;
 		padding-left: 8px;
 	}
-}
 
-.select-newsletter-form__help {
-	margin-top: 8px;
-	margin-bottom: 0;
-	font-size: 0.75rem;
+	.select-newsletter-form__help {
+		margin-top: 8px;
+		margin-bottom: 0;
+		font-size: 0.75rem;
 
-	&.is-error {
-		color: var(--color-error) !important;
+		&.is-error {
+			color: var(--color-error);
+		}
 	}
 }
 

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -64,7 +64,7 @@
 	font-size: 0.75rem;
 
 	&.is-error {
-		color: var(--color-error);
+		color: var(--color-error) !important;
 	}
 }
 
@@ -82,6 +82,7 @@
 	padding-top: 50px;
 	color: var(--studio-gray-50);
 }
+
 .subscriber-upload-form__in-progress svg,
 .subscriber-upload-form .file-picker svg {
 	width: 48px;
@@ -96,16 +97,20 @@
 	padding: 0;
 	list-style: none;
 }
+
 .subscriber-upload-form__modal li {
 	display: flex;
 }
+
 .subscriber-upload-form__modal strong {
 	margin-right: 8px;
 }
+
 .subscriber-upload-form__modal svg {
 	fill: var(--studio-gray-50);
 	margin-right: 8px;
 }
+
 .select-newsletter-form .is-loading {
 	@include placeholder( --color-neutral-10 );
 }

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -150,7 +150,6 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 					stepUrl={ stepUrl }
 					urlData={ urlData }
 					isLoading={ isFetching || isResetPaidNewsletterPending }
-					validFromSite={ validFromSite }
 				/>
 			) }
 

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -10,16 +10,10 @@ type Props = {
 	stepUrl: string;
 	urlData?: UrlData;
 	isLoading: boolean;
-	validFromSite: boolean;
 };
 
-export default function SelectNewsletterForm( {
-	stepUrl,
-	urlData,
-	isLoading,
-	validFromSite,
-}: Props ) {
-	const [ hasError, setHasError ] = useState( ! validFromSite );
+export default function SelectNewsletterForm( { stepUrl, urlData, isLoading }: Props ) {
+	const [ hasError, setHasError ] = useState( false );
 
 	const handleAction = ( fromSite: string ) => {
 		if ( ! isValidUrl( fromSite ) ) {

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -48,12 +48,12 @@ export default function SelectNewsletterForm( { stepUrl, urlData, isLoading }: P
 				/>
 				{ hasError && (
 					<p className="select-newsletter-form__help is-error">
-						Please enter a valid substack URL.
+						Please enter a valid Substack URL.
 					</p>
 				) }
 				{ ! hasError && (
 					<p className="select-newsletter-form__help">
-						Enter the URL of the substack newsletter that you wish to import.
+						Enter the URL of the Substack newsletter that you wish to import.
 					</p>
 				) }
 			</div>

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -1,9 +1,9 @@
-import { Card } from '@automattic/components';
+import { Card, Button, Gridicon } from '@automattic/components';
 import { Subscriber } from '@automattic/data-stores';
 import { useQueryClient } from '@tanstack/react-query';
-import { Modal, Button } from '@wordpress/components';
+import { Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { Icon, people, currencyDollar, external } from '@wordpress/icons';
+import { Icon, people, currencyDollar } from '@wordpress/icons';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
 import { useEffect, useRef } from 'react';
 import SubscriberUploadForm from './subscriber-upload-form';
@@ -62,14 +62,11 @@ export default function Subscribers( {
 					click 'Export.' Once the CSV file is downloaded, upload it in the next step.
 				</p>
 				<Button
-					variant="secondary"
 					href={ `https://${ fromSite }/publish/subscribers` }
 					target="_blank"
 					rel="noreferrer noopener"
-					iconPosition="right"
-					icon={ external }
 				>
-					Export subscribers
+					Export subscribers <Gridicon icon="external" />
 				</Button>
 				<hr />
 				<h2>Step 2: Import your subscribers to WordPress.com</h2>
@@ -107,9 +104,7 @@ export default function Subscribers( {
 							) }
 						</ul>
 					</div>
-					<Button variant="primary" href={ nextStepUrl }>
-						Continue
-					</Button>
+					<Button href={ nextStepUrl }>Continue</Button>
 				</Modal>
 			) }
 		</>

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -1,9 +1,9 @@
-import { Card, Button, Gridicon } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { Subscriber } from '@automattic/data-stores';
 import { useQueryClient } from '@tanstack/react-query';
-import { Modal } from '@wordpress/components';
+import { Modal, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { Icon, people, currencyDollar } from '@wordpress/icons';
+import { Icon, people, currencyDollar, external } from '@wordpress/icons';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
 import { useEffect, useRef } from 'react';
 import SubscriberUploadForm from './subscriber-upload-form';
@@ -65,8 +65,10 @@ export default function Subscribers( {
 					href={ `https://${ fromSite }/publish/subscribers` }
 					target="_blank"
 					rel="noreferrer noopener"
+					icon={ external }
+					variant="secondary"
 				>
-					Export subscribers <Gridicon icon="external" />
+					Export subscribers
 				</Button>
 				<hr />
 				<h2>Step 2: Import your subscribers to WordPress.com</h2>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93150

## Proposed Changes

It:
- handles the `acceptedFileTypes` config in the content upload form
- fixes the error rendered when the Substack URL is not correct
- fixes some spacing for the `SelectNewsletterForm` component
- cleanups some code

<img width="748" alt="Screenshot 2024-09-02 at 12 43 15" src="https://github.com/user-attachments/assets/45e05163-007e-4751-ba42-193b38703186">

<img width="748" alt="Screenshot 2024-09-02 at 12 43 19" src="https://github.com/user-attachments/assets/d49aad73-ada6-45d0-9b40-f894151db85a">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
