### PR TITLE
Hosting Configuration: Avoid accessing  “Server Settings” to the “Hosting Features” if the plan is expired

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -305,7 +305,7 @@ export function redirectToHostingPromoIfNotAtomic( context, next ) {
 	const site = getSelectedSite( state );
 	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
 
-	if ( ! isAtomicSite ) {
+	if ( ! isAtomicSite || site.plan?.expired ) {
 		return page.redirect( `/hosting-features/${ site?.slug }` );
 	}
 

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -64,7 +64,8 @@ const HostingFeatures = () => {
 	// `siteTransferData?.isTransferring` is not a fully reliable indicator by itself, which is why
 	// we also look at `siteTransferData.status`
 	const isTransferInProgress =
-		siteTransferData?.isTransferring || siteTransferData?.status === transferStates.COMPLETED;
+		( siteTransferData?.isTransferring || siteTransferData?.status === transferStates.COMPLETED ) &&
+		! isPlanExpired;
 
 	useEffect( () => {
 		if ( ! siteId ) {

--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -28,6 +28,8 @@ const WOOCOMMERCE_ICON = `data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3
 
 export default function buildFallbackResponse( {
 	siteDomain = '',
+	isAtomic,
+	isPlanExpired,
 	shouldShowMailboxes = false,
 	shouldShowLinks = false,
 	shouldShowTestimonials = false,
@@ -600,7 +602,10 @@ export default function buildFallbackResponse( {
 				{
 					parent: 'options-general.php',
 					slug: 'options-hosting-configuration-php',
-					title: translate( 'Hosting Configuration' ),
+					title:
+						isAtomic && ! isPlanExpired
+							? translate( 'Server Settings' )
+							: translate( 'Hosting Features' ),
 					type: 'submenu-item',
 					url: `/hosting-config/${ siteDomain }`,
 				},

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -16,7 +16,7 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { requestAdminMenu } from '../../state/admin-menu/actions';
 import allSitesMenu from './static-data/all-sites-menu';
 import buildFallbackResponse from './static-data/fallback-menu';
@@ -32,6 +32,7 @@ const useSiteMenuItems = () => {
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSiteId ) );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, selectedSiteId ) );
 	const isStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, selectedSiteId ) );
+	const isPlanExpired = useSelector( ( state ) => !! getSelectedSite( state )?.plan?.expired );
 	const locale = useLocale();
 	const isAllDomainsView = '/domains/manage' === currentRoute;
 	const { currentSection } = useCurrentRoute();
@@ -109,6 +110,8 @@ const useSiteMenuItems = () => {
 	 */
 	const fallbackDataOverrides = {
 		siteDomain,
+		isAtomic,
+		isPlanExpired,
 		shouldShowWooCommerce,
 		shouldShowThemes,
 		shouldShowMailboxes,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8252

## Proposed Changes

* Rename the “Hosting Configuration” to either “Hosting Features” or “Server Settings” based on the capacity of the current site
* Redirect the “Server Settings” to the “Hosting Features” if the plan is expired
* Don't show the transferring message if the plan has expired

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We have to change the fallback message and avoid the site with expired plan accessing the Server Settings

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/home/:site` on your atomic site with the expired plan
* Click `Settings > Hosting Configuration`
* Make sure it opens the “Hosting Features”
* Make sure the “Hosting Features” page won't display the “Activating hosting features”

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
