### PR TITLE
Migration: Enable hotjar on migration flows

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -4,7 +4,12 @@ import { initializeAnalytics } from '@automattic/calypso-analytics';
 import { CurrentUser } from '@automattic/calypso-analytics/dist/types/utils/current-user';
 import config from '@automattic/calypso-config';
 import { User as UserStore } from '@automattic/data-stores';
-import { IMPORT_HOSTED_SITE_FLOW } from '@automattic/onboarding';
+import {
+	HOSTED_SITE_MIGRATION_FLOW,
+	MIGRATION_FLOW,
+	MIGRATION_SIGNUP_FLOW,
+	SITE_MIGRATION_FLOW,
+} from '@automattic/onboarding';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
@@ -76,8 +81,15 @@ const getFlowFromURL = () => {
 	return fromPath || fromQuery;
 };
 
+const HOTJAR_ENABLED_FLOWS = [
+	MIGRATION_FLOW,
+	SITE_MIGRATION_FLOW,
+	HOSTED_SITE_MIGRATION_FLOW,
+	MIGRATION_SIGNUP_FLOW,
+];
+
 const initializeHotJar = ( flowName: string ) => {
-	if ( flowName === IMPORT_HOSTED_SITE_FLOW ) {
+	if ( HOTJAR_ENABLED_FLOWS.includes( flowName ) ) {
 		addHotJarScript();
 	}
 };


### PR DESCRIPTION
Related https://github.com/Automattic/dotcom-forge/issues/8978

## Proposed Changes
* Enable hot jar scripts loading on all migration flows.

## Why are these changes being made?
* We want to use Hotjar features like surveys to get more inputs from users

## Testing Instructions
* Enable the flags  [hotjar and ad-tracking] `sessionStorage.setItem('flags', 'hotjar_enabled,ad-tracking');` 
* Create a cookie with the name `sensitive_pixel_options` and value `"%7B%22ok%22%3Atrue%2C%22buckets%22%3A%7B%22essential%22%3Atrue%2C%22analytics%22%3Atrue%2C%22advertising%22%3Atrue%7D%7D"`  via Developer tools
<img width="738" alt="image" src="https://github.com/user-attachments/assets/fc621b85-d3e1-43a8-a835-000d536eaba8">
* Go to the /setup/migration flow
* Check all requests Developer Tools > Network
* Check if there are hotjar requests.

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/59904f99-6b74-4205-9687-440933cdd4a4">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
