### PR TITLE
Fix iframe error when accessing Add new Page on post command palette

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1113,6 +1113,25 @@ function handleAddPage( calypsoPort ) {
 	addCommandsInputListener( selector, callback );
 }
 
+function handleAddPost( calypsoPort ) {
+	const selector = `[data-value="${ __( 'Add new post' ) }"]`;
+
+	const callback = ( e ) => {
+		e.preventDefault();
+
+		calypsoPort.postMessage( {
+			action: 'addNewPost',
+			payload: {
+				destinationUrl: '/wp-admin/post-new.php',
+				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
+			},
+		} );
+	};
+
+	addEditorListener( selector, callback );
+	addCommandsInputListener( selector, callback );
+}
+
 function initPort( message ) {
 	if ( 'initPort' !== message.data.action ) {
 		return;
@@ -1217,6 +1236,8 @@ function initPort( message ) {
 		handlePatterns( calypsoPort );
 
 		handleAddPage( calypsoPort );
+
+		handleAddPost( calypsoPort );
 	}
 
 	window.removeEventListener( 'message', initPort, false );

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1075,8 +1075,8 @@ function handleAppBannerShowing( calypsoPort ) {
 	};
 }
 
-function handlePatterns( calypsoPort ) {
-	const selector = `[data-value="${ __( 'Patterns' ) }"]`;
+function handleWpAdminRedirect( { calypsoPort, path, title } ) {
+	const selector = `[data-value="${ title }"]`;
 
 	const callback = ( e ) => {
 		e.preventDefault();
@@ -1084,7 +1084,7 @@ function handlePatterns( calypsoPort ) {
 		calypsoPort.postMessage( {
 			action: 'wpAdminRedirect',
 			payload: {
-				destinationUrl: '/wp-admin/site-editor.php?postType=wp_block',
+				destinationUrl: `/wp-admin/${ path }`,
 				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
 			},
 		} );
@@ -1092,44 +1092,26 @@ function handlePatterns( calypsoPort ) {
 
 	addEditorListener( selector, callback );
 	addCommandsInputListener( selector, callback );
+}
+
+function handlePatterns( calypsoPort ) {
+	handleWpAdminRedirect( {
+		calypsoPort,
+		path: 'site-editor.php?postType=wp_block',
+		title: __( 'Patterns' ),
+	} );
 }
 
 function handleAddPage( calypsoPort ) {
-	const selector = `[data-value="${ __( 'Add new page' ) }"]`;
-
-	const callback = ( e ) => {
-		e.preventDefault();
-
-		calypsoPort.postMessage( {
-			action: 'wpAdminRedirect',
-			payload: {
-				destinationUrl: '/wp-admin/post-new.php?post_type=page',
-				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
-			},
-		} );
-	};
-
-	addEditorListener( selector, callback );
-	addCommandsInputListener( selector, callback );
+	handleWpAdminRedirect( {
+		calypsoPort,
+		path: 'post-new.php?post_type=page',
+		title: __( 'Add new page' ),
+	} );
 }
 
 function handleAddPost( calypsoPort ) {
-	const selector = `[data-value="${ __( 'Add new post' ) }"]`;
-
-	const callback = ( e ) => {
-		e.preventDefault();
-
-		calypsoPort.postMessage( {
-			action: 'wpAdminRedirect',
-			payload: {
-				destinationUrl: '/wp-admin/post-new.php',
-				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
-			},
-		} );
-	};
-
-	addEditorListener( selector, callback );
-	addCommandsInputListener( selector, callback );
+	handleWpAdminRedirect( { calypsoPort, path: 'post-new.php', title: __( 'Add new post' ) } );
 }
 
 function initPort( message ) {

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1094,6 +1094,25 @@ function handlePatterns( calypsoPort ) {
 	addCommandsInputListener( selector, callback );
 }
 
+function handleAddPage( calypsoPort ) {
+	const selector = `[data-value="${ __( 'Add new page' ) }"]`;
+
+	const callback = ( e ) => {
+		e.preventDefault();
+
+		calypsoPort.postMessage( {
+			action: 'addNewPage',
+			payload: {
+				destinationUrl: '/wp-admin/post-new.php?post_type=page',
+				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
+			},
+		} );
+	};
+
+	addEditorListener( selector, callback );
+	addCommandsInputListener( selector, callback );
+}
+
 function initPort( message ) {
 	if ( 'initPort' !== message.data.action ) {
 		return;
@@ -1196,6 +1215,8 @@ function initPort( message ) {
 		handleAppBannerShowing( calypsoPort );
 
 		handlePatterns( calypsoPort );
+
+		handleAddPage( calypsoPort );
 	}
 
 	window.removeEventListener( 'message', initPort, false );

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1082,7 +1082,7 @@ function handlePatterns( calypsoPort ) {
 		e.preventDefault();
 
 		calypsoPort.postMessage( {
-			action: 'goToPatterns',
+			action: 'wpAdminRedirect',
 			payload: {
 				destinationUrl: '/wp-admin/site-editor.php?postType=wp_block',
 				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
@@ -1101,7 +1101,7 @@ function handleAddPage( calypsoPort ) {
 		e.preventDefault();
 
 		calypsoPort.postMessage( {
-			action: 'addNewPage',
+			action: 'wpAdminRedirect',
 			payload: {
 				destinationUrl: '/wp-admin/post-new.php?post_type=page',
 				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
@@ -1120,7 +1120,7 @@ function handleAddPost( calypsoPort ) {
 		e.preventDefault();
 
 		calypsoPort.postMessage( {
-			action: 'addNewPost',
+			action: 'wpAdminRedirect',
 			payload: {
 				destinationUrl: '/wp-admin/post-new.php',
 				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -114,6 +114,7 @@ enum EditorActions {
 	TrackPerformance = 'trackPerformance',
 	GetIsAppBannerVisible = 'getIsAppBannerVisible',
 	NavigateToHome = 'navigateToHome',
+	AddNewPage = 'addNewPage',
 }
 
 type ComponentProps = Props &
@@ -383,7 +384,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			this.navigate( destinationUrl, unsavedChanges );
 		}
 
-		if ( EditorActions.GoToPatterns === action ) {
+		if ( EditorActions.GoToPatterns === action || EditorActions.AddNewPage === action ) {
 			const { destinationUrl, unsavedChanges } = payload;
 
 			this.navigate( `https://${ this.props.siteSlug }${ destinationUrl }`, unsavedChanges );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -95,7 +95,7 @@ enum WindowActions {
 
 enum EditorActions {
 	GoToAllPosts = 'goToAllPosts', // Unused action in favor of CloseEditor. Maintained here to support cached scripts.
-	GoToPatterns = 'goToPatterns',
+	WpAdminRedirect = 'wpAdminRedirect',
 	CloseEditor = 'closeEditor',
 	OpenMediaModal = 'openMediaModal',
 	OpenCheckoutModal = 'openCheckoutModal',
@@ -114,8 +114,6 @@ enum EditorActions {
 	TrackPerformance = 'trackPerformance',
 	GetIsAppBannerVisible = 'getIsAppBannerVisible',
 	NavigateToHome = 'navigateToHome',
-	AddNewPage = 'addNewPage',
-	AddNewPost = 'addNewPost',
 }
 
 type ComponentProps = Props &
@@ -385,11 +383,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			this.navigate( destinationUrl, unsavedChanges );
 		}
 
-		if (
-			EditorActions.GoToPatterns === action ||
-			EditorActions.AddNewPage === action ||
-			EditorActions.AddNewPost === action
-		) {
+		if ( EditorActions.WpAdminRedirect === action ) {
 			const { destinationUrl, unsavedChanges } = payload;
 
 			this.navigate( `https://${ this.props.siteSlug }${ destinationUrl }`, unsavedChanges );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -115,6 +115,7 @@ enum EditorActions {
 	GetIsAppBannerVisible = 'getIsAppBannerVisible',
 	NavigateToHome = 'navigateToHome',
 	AddNewPage = 'addNewPage',
+	AddNewPost = 'addNewPost',
 }
 
 type ComponentProps = Props &
@@ -384,7 +385,11 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			this.navigate( destinationUrl, unsavedChanges );
 		}
 
-		if ( EditorActions.GoToPatterns === action || EditorActions.AddNewPage === action ) {
+		if (
+			EditorActions.GoToPatterns === action ||
+			EditorActions.AddNewPage === action ||
+			EditorActions.AddNewPost === action
+		) {
 			const { destinationUrl, unsavedChanges } = payload;
 
 			this.navigate( `https://${ this.props.siteSlug }${ destinationUrl }`, unsavedChanges );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93979

## Proposed Changes

* Add two new handlers to post messages for `Add new post` and `Add new page` to the `calypsoify-iframe` to avoid iframe errors
* The new handler will handle the `Add new page` and `Add new post` commands in the Command palette

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the IFrame error described in https://github.com/Automattic/wp-calypso/issues/93979

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Execute `cd apps/wpcom-block-editor/ && yarn dev --sync`
- Sandbox your simple site and `widgets.wp.com`
- Apply this patch and navigate to your local edit post page, `http://calypso.localhost:3000/post/<your simple site>`, e.g. ` http://calypso.localhost:3000/post/mytestsimplesite.wordpress.com`
- Open Command Palette by clicking on the top bar or pressing `Cmd+K`
- Select `Add new page` or `Add new post`
- Check you are correctly redirected and no iframe errors are displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
