### PR TITLE
Select Design Step: Highlight selected theme

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -45,7 +45,7 @@ import {
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgrade-modal';
 import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
-import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
+import { ActiveTheme, useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
 import { urlToSlug } from 'calypso/lib/url';
@@ -128,6 +128,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const siteTitle = site?.name;
 	const siteDescription = site?.description;
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
+	const { data: siteActiveTheme } = useActiveThemeQuery( site?.ID ?? 0, !! site?.ID );
 
 	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'design-picker' );
 
@@ -927,6 +928,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			getBadge={ getBadge }
 			oldHighResImageLoading={ oldHighResImageLoading }
 			isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
+			siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
 		/>
 	);
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -317,8 +317,12 @@
 			}
 		}
 
-		.theme-card__image-container {
-			border-color: rgba(0, 0, 0, 0.12);
+		&.theme-card--is-active {
+			order: 0;
+		}
+
+		&:not(.theme-card--is-active) {
+			order: 1;
 		}
 	}
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -310,10 +310,12 @@
 	}
 
 	.theme-card {
-		&:hover,
-		&:focus-within {
-			.theme-card__image-container {
-				border-color: #a7aaad;
+		.theme-card--is-active {
+			&:hover,
+			&:focus-within {
+				.theme-card__image-container {
+					border-color: #a7aaad;
+				}
 			}
 		}
 
@@ -327,7 +329,7 @@
 	}
 
 	.design-button-container .design-picker__design-option .design-picker__image-frame:hover::after,
-	.theme-card .theme-card__image:hover::after {
+	.theme-card--is-actionable .theme-card__image:hover::after {
 		background-color: rgba(255, 255, 255, 0.72);
 	}
 }

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -33,7 +33,7 @@ const ActiveBadge = () => {
 	return (
 		<div className="theme-card__info-badge-container">
 			<div className="theme-card__info-badge theme-card__info-badge-active">
-				<svg fill="none" height="16" width="16" viewBox="0 0 14 14">
+				<svg fill="none" height="14" width="14" viewBox="0 0 14 14">
 					<clipPath id="a">
 						<path d="m0 .5h14v14h-14z" />
 					</clipPath>

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -29,6 +29,28 @@ interface ThemeCardProps {
 	onStyleVariationMoreClick?: () => void;
 }
 
+const ActiveBadge = () => {
+	return (
+		<div className="theme-card__info-badge-container">
+			<div className="theme-card__info-badge theme-card__info-badge-active">
+				<svg fill="none" height="16" width="16" viewBox="0 0 14 14">
+					<clipPath id="a">
+						<path d="m0 .5h14v14h-14z" />
+					</clipPath>
+					<g>
+						<path d="m11.6992 3.1001-6.29998 8.5-3.3-2.5-.9 1.2 4.5 3.4 7.19998-9.7z" fill="#fff" />
+					</g>
+				</svg>
+				<span>
+					{ translate( 'Active', {
+						context: 'singular noun, the currently active theme',
+					} ) }
+				</span>
+			</div>
+		</div>
+	);
+};
+
 const ThemeCard = forwardRef(
 	(
 		{
@@ -123,13 +145,6 @@ const ThemeCard = forwardRef(
 						<h2 className="theme-card__info-title">
 							<span>{ name }</span>
 						</h2>
-						{ isActive && (
-							<span className="theme-card__info-badge theme-card__info-badge-active">
-								{ translate( 'Active', {
-									context: 'singular noun, the currently active theme',
-								} ) }
-							</span>
-						) }
 						{ ! isActive && styleVariations.length > 0 && (
 							<div className="theme-card__info-style-variations">
 								<StyleVariationBadges
@@ -141,6 +156,7 @@ const ThemeCard = forwardRef(
 							</div>
 						) }
 						{ ! isActive && <>{ badge }</> }
+						{ isActive && <ActiveBadge /> }
 						{ optionsMenu && <div className="theme-card__info-options">{ optionsMenu }</div> }
 					</div>
 				</div>

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -55,6 +55,24 @@ $theme-card-info-margin-top: 16px;
 	position: relative;
 }
 
+.theme-card--is-actionable {
+	.theme-card__image {
+		&:hover,
+		&:focus {
+			opacity: 0.9;
+
+			.theme-card__image-label {
+				opacity: 1;
+				animation: theme-card__image-label 150ms ease-in-out;
+			}
+		}
+
+		.accessible-focus &:focus &-label {
+			box-shadow: 0 0 0 2px var(--color-primary-light);
+		}
+	}
+}
+
 .theme-card__image {
 	cursor: default;
 	height: 100%;
@@ -64,20 +82,6 @@ $theme-card-info-margin-top: 16px;
 	top: 0;
 	transition: all 200ms ease-in-out;
 	width: 100%;
-
-	&:hover,
-	&:focus {
-		opacity: 0.9;
-
-		.theme-card__image-label {
-			opacity: 1;
-			animation: theme-card__image-label 150ms ease-in-out;
-		}
-	}
-
-	.accessible-focus &:focus &-label {
-		box-shadow: 0 0 0 2px var(--color-primary-light);
-	}
 
 	&-label {
 		background: var(--color-surface);

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -14,34 +14,29 @@ $theme-card-info-margin-top: 16px;
 
 	&--is-active {
 		.theme-card__image-container {
-			border: 0;
-		}
-
-		.theme-card__info {
-			align-items: center;
-			background: var(--color-primary);
-			border-bottom-left-radius: 2px;
-			border-bottom-right-radius: 2px;
-			box-sizing: initial;
-			flex-direction: row;
-			gap: 16px;
-			margin-top: 0;
-			padding: 8px 24px;
-
-			.theme-card__info-options,
-			.theme-card__info-options .theme__more-button {
-				position: relative;
-			}
-		}
-
-		.theme-card__info-title {
-			color: var(--color-text-inverted);
+			border: 2px solid var(--color-primary);
+			border-radius: 4px;
 		}
 	}
 
 	&--is-actionable {
 		.theme-card__image {
 			cursor: pointer;
+		}
+	}
+
+	.theme-card__info-badge-container {
+		display: flex;
+		flex-basis: 100%;
+	}
+
+	.theme-card__info-badge-active {
+		display: flex;
+		background-color: var(--color-primary);
+		color: var(--studio-white);
+
+		svg {
+			margin-right: 6px;
 		}
 	}
 }

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -34,9 +34,11 @@ $theme-card-info-margin-top: 16px;
 		display: flex;
 		background-color: var(--color-primary);
 		color: var(--studio-white);
+		font-weight: 400;
 
 		svg {
-			margin-right: 6px;
+			margin-right: 3px;
+			margin-top: 1px;
 		}
 	}
 }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -205,6 +205,10 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 		shouldLimitGlobalStyles,
 	} );
 
+	const conditionalProps = ! isActive
+		? { onImageClick: () => onPreview( design, selectedStyleVariation ) }
+		: {};
+
 	return (
 		<ThemeCard
 			className="design-button-container"
@@ -223,13 +227,13 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 			badge={ getBadge( design.slug, isLocked ) }
 			styleVariations={ style_variations }
 			selectedStyleVariation={ selectedStyleVariation }
-			onImageClick={ () => onPreview( design, selectedStyleVariation ) }
 			onStyleVariationClick={ ( variation ) => {
 				onChangeVariation( design, variation );
 				setSelectedStyleVariation( variation );
 			} }
 			onStyleVariationMoreClick={ () => onPreview( design ) }
 			isActive={ isActive }
+			{ ...conditionalProps }
 		/>
 	);
 };

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -178,6 +178,7 @@ interface DesignCardProps {
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test.
+	isActive: boolean;
 }
 
 const DesignCard: React.FC< DesignCardProps > = ( {
@@ -190,6 +191,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 	onPreview,
 	getBadge,
 	oldHighResImageLoading,
+	isActive,
 } ) => {
 	const [ selectedStyleVariation, setSelectedStyleVariation ] = useState< StyleVariation >();
 
@@ -227,6 +229,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 				setSelectedStyleVariation( variation );
 			} }
 			onStyleVariationMoreClick={ () => onPreview( design ) }
+			isActive={ isActive }
 		/>
 	);
 };
@@ -244,6 +247,7 @@ interface DesignPickerProps {
 	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test
 	isSiteAssemblerEnabled?: boolean; // Temporary for A/B test
+	siteActiveTheme?: string | null;
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -259,6 +263,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	getBadge,
 	oldHighResImageLoading,
 	isSiteAssemblerEnabled,
+	siteActiveTheme = null,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const filteredDesigns = useMemo( () => {
@@ -268,6 +273,8 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 
 		return designs;
 	}, [ designs, categorization?.selection ] );
+
+	// Pick design
 
 	const assemblerCtaData = usePatternAssemblerCtaData();
 
@@ -312,6 +319,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 							onPreview={ onPreview }
 							getBadge={ getBadge }
 							oldHighResImageLoading={ oldHighResImageLoading }
+							isActive={ design.recipe?.stylesheet === siteActiveTheme }
 						/>
 					);
 				} ) }
@@ -338,6 +346,7 @@ export interface UnifiedDesignPickerProps {
 	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test
 	isSiteAssemblerEnabled?: boolean; // Temporary for A/B test
+	siteActiveTheme?: string | null;
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -355,6 +364,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	getBadge,
 	oldHighResImageLoading,
 	isSiteAssemblerEnabled,
+	siteActiveTheme = null,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 
@@ -389,6 +399,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					getBadge={ getBadge }
 					oldHighResImageLoading={ oldHighResImageLoading }
 					isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
+					siteActiveTheme={ siteActiveTheme }
 				/>
 				{ bottomAnchorContent }
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/8776

## Proposed Changes

* We now show the active badge on the Design Picker (DP).
* The implemented design is the same as the one proposed on the parent task.
* The design applies to both the DP and the Theme Showcase (TS).
* The selected design will be placed as the first item on the list on the DP.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Customers who are working on onboarding do not have a clear indication of what theme they've currently selected for their site. This is confusing and not optimal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link and create a new site.
* Create a new site and pick a design.
* Once on the onboarding flow check that if you click on the "Select Design" step you see that the selected theme is in the first place, and has the corresponding "Active" badge. 
* Also check on the Theme Showcase (once you reach wp-admin/Calypso) for a consistent behaviour.

### Design Picker
![Screenshot 2024-09-02 at 19 42 51](https://github.com/user-attachments/assets/1331ec72-95e1-4635-bcfb-403e5b6b4a3d)

### Theme Showcase
![Screenshot 2024-09-02 at 19 44 05](https://github.com/user-attachments/assets/d6c068e9-a1b3-43f5-8543-a10e6b129a9f)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
