### PR TITLE
ToS screenshots: Fix failing screenshots for the checkout page

### DIFF
--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -33,6 +33,10 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		await page.reload( { waitUntil: 'domcontentloaded', timeout: EXTENDED_TIMEOUT } );
 	} );
 
+	it( 'See Home', async function () {
+		await page.waitForURL( /home/ );
+	} );
+
 	it( 'Add WordPress.com Business plan to cart', async function () {
 		await Promise.all( [
 			page.waitForURL( /.*checkout.*/ ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Follow-up to https://github.com/Automattic/wp-calypso/pull/93765. Wait for the Home page before loading checkout.

