### PR TITLE
LPM API Migration: Begin replacing the Source API version of P24 with PaymentIntent API version

### DIFF
--- a/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { camelToSnakeCase } from '@automattic/js-utils';
 import type { CheckoutPaymentMethodSlug, WPCOMPaymentMethod } from '@automattic/wpcom-checkout';
 
-const StripeRedirectMigrationP24 = config.isEnabled( 'stripe-redirect-migration-p24' );
+const isP24RedirectEnabled = config.isEnabled( 'stripe-redirect-migration-p24' );
 
 /**
  * Convert a WPCOM payment method class name to a checkout payment method slug
@@ -86,7 +86,7 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 		case 'ideal':
 			return 'WPCOM_Billing_Stripe_Source_Ideal';
 		case 'p24':
-			if ( StripeRedirectMigrationP24 ) {
+			if ( isP24RedirectEnabled ) {
 				return 'WPCOM_Billing_Stripe_P24';
 			}
 			return 'WPCOM_Billing_Stripe_Source_P24';

--- a/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
@@ -1,5 +1,8 @@
+import config from '@automattic/calypso-config';
 import { camelToSnakeCase } from '@automattic/js-utils';
 import type { CheckoutPaymentMethodSlug, WPCOMPaymentMethod } from '@automattic/wpcom-checkout';
+
+const StripeRedirectMigrationP24 = config.isEnabled( 'stripe-redirect-migration-p24' );
 
 /**
  * Convert a WPCOM payment method class name to a checkout payment method slug
@@ -31,6 +34,7 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 		case 'WPCOM_Billing_Stripe_Source_Ideal':
 			return 'ideal';
 		case 'WPCOM_Billing_Stripe_Source_P24':
+		case 'WPCOM_Billing_Stripe_P24':
 			return 'p24';
 		case 'WPCOM_Billing_Stripe_Source_Sofort':
 			return 'sofort';
@@ -82,6 +86,9 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 		case 'ideal':
 			return 'WPCOM_Billing_Stripe_Source_Ideal';
 		case 'p24':
+			if ( StripeRedirectMigrationP24 ) {
+				return 'WPCOM_Billing_Stripe_P24';
+			}
 			return 'WPCOM_Billing_Stripe_Source_P24';
 		case 'sofort':
 			return 'WPCOM_Billing_Stripe_Source_Sofort';
@@ -110,6 +117,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 		case 'WPCOM_Billing_PayPal_Direct':
 		case 'WPCOM_Billing_PayPal_Express':
 		case 'WPCOM_Billing_Stripe_Payment_Method':
+		case 'WPCOM_Billing_Stripe_P24':
 		case 'WPCOM_Billing_Stripe_Source_Alipay':
 		case 'WPCOM_Billing_Stripe_Source_Bancontact':
 		case 'WPCOM_Billing_Stripe_Source_Eps':

--- a/config/development.json
+++ b/config/development.json
@@ -219,6 +219,7 @@
 		"stats/user-feedback": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
+		"stripe-redirect-migration-p24": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/development.json
+++ b/config/development.json
@@ -219,7 +219,7 @@
 		"stats/user-feedback": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
-		"stripe-redirect-migration-p24": false,
+		"stripe-redirect-migration-p24": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -144,6 +144,7 @@
 		"stats/user-feedback": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
+		"stripe-redirect-migration-p24": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/production.json
+++ b/config/production.json
@@ -190,6 +190,7 @@
 		"stats/user-feedback": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
+		"stripe-redirect-migration-p24": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -184,6 +184,7 @@
 		"stats/user-feedback": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
+		"stripe-redirect-migration-p24": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -183,6 +183,7 @@
 		"stats/user-feedback": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
+		"stripe-redirect-migration-p24": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -344,6 +344,7 @@ export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_PayPal_Direct'
 	| 'WPCOM_Billing_PayPal_Express'
 	| 'WPCOM_Billing_Stripe_Payment_Method'
+	| 'WPCOM_Billing_Stripe_P24'
 	| 'WPCOM_Billing_Stripe_Source_Alipay'
 	| 'WPCOM_Billing_Stripe_Source_Bancontact'
 	| 'WPCOM_Billing_Stripe_Source_Eps'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/payments-shilling#2976

## Proposed Changes

*In order to use P24 with the PaymentIntent API, the Stripe Elements for P24 in the payment selector form needs to be directed to use the class `WPCOM_Billing_Stripe_P24` when processing the transaction.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Stripe is retiring their Sources API in favor of the PaymentIntent API.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Setup: 
* Enable Store Sandbox
* Start up local Calypso with this PR applied
* Apply D160900-code to your sandbox and sandbox `public-api`
* Enable a Stripe listener on your local machine
* Make sure your user account currency is set to EUR or PLN

* Add a product to your cart and proceed to Checkout
* Use the country `Poland` and the postal code `59-703`
* In the Payment Options section, select `Przelewy24` and fill in your name and email
* You should be redirected to an Authorization page. It should mention `payment_intent` on it

![Screenshot 2024-09-10 at 11 09 47](https://github.com/user-attachments/assets/122aab98-c530-4927-9742-79fb32431936)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
