### PR TITLE
LPM API Migration: Begin replacing the Source API version of WeChat Pay with PaymentIntent API version

### DIFF
--- a/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
@@ -6,6 +6,7 @@ const isAlipayRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-ali
 const isBancontactRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-bancontact' );
 const isIdealRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-ideal' );
 const isP24RedirectEnabled = config.isEnabled( 'stripe-redirect-migration-p24' );
+const StripeRedirectMigrationWechat = config.isEnabled( 'stripe-redirect-migration-wechat' );
 
 /**
  * Convert a WPCOM payment method class name to a checkout payment method slug
@@ -47,6 +48,7 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 		case 'WPCOM_Billing_Stripe_Source_Three_D_Secure':
 			return 'stripe-three-d-secure';
 		case 'WPCOM_Billing_Stripe_Source_Wechat':
+		case 'WPCOM_Billing_Stripe_Wechat':
 			return 'wechat';
 		case 'WPCOM_Billing_Dlocal_Redirect_India_Netbanking':
 			return 'netbanking';
@@ -111,6 +113,9 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 		case 'stripe-three-d-secure':
 			return 'WPCOM_Billing_Stripe_Source_Three_D_Secure';
 		case 'wechat':
+			if ( StripeRedirectMigrationWechat ) {
+				return 'WPCOM_Billing_Stripe_Wechat';
+			}
 			return 'WPCOM_Billing_Stripe_Source_Wechat';
 		case 'apple-pay':
 		case 'google-pay':
@@ -137,6 +142,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 		case 'WPCOM_Billing_Stripe_Bancontact':
 		case 'WPCOM_Billing_Stripe_Ideal':
 		case 'WPCOM_Billing_Stripe_P24':
+		case 'WPCOM_Billing_Stripe_Wechat':
 		case 'WPCOM_Billing_Stripe_Source_Alipay':
 		case 'WPCOM_Billing_Stripe_Source_Bancontact':
 		case 'WPCOM_Billing_Stripe_Source_Eps':

--- a/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
@@ -6,7 +6,7 @@ const isAlipayRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-ali
 const isBancontactRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-bancontact' );
 const isIdealRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-ideal' );
 const isP24RedirectEnabled = config.isEnabled( 'stripe-redirect-migration-p24' );
-const StripeRedirectMigrationWechat = config.isEnabled( 'stripe-redirect-migration-wechat' );
+const isWechatRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-wechat' );
 
 /**
  * Convert a WPCOM payment method class name to a checkout payment method slug
@@ -113,7 +113,7 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 		case 'stripe-three-d-secure':
 			return 'WPCOM_Billing_Stripe_Source_Three_D_Secure';
 		case 'wechat':
-			if ( StripeRedirectMigrationWechat ) {
+			if ( isWechatRedirectEnabled ) {
 				return 'WPCOM_Billing_Stripe_Wechat';
 			}
 			return 'WPCOM_Billing_Stripe_Source_Wechat';

--- a/config/development.json
+++ b/config/development.json
@@ -224,6 +224,7 @@
 		"stripe-redirect-migration-bancontact": true,
 		"stripe-redirect-migration-ideal": true,
 		"stripe-redirect-migration-p24": true,
+		"stripe-redirect-migration-wechat": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/development.json
+++ b/config/development.json
@@ -224,7 +224,7 @@
 		"stripe-redirect-migration-bancontact": true,
 		"stripe-redirect-migration-ideal": true,
 		"stripe-redirect-migration-p24": true,
-		"stripe-redirect-migration-wechat": false,
+		"stripe-redirect-migration-wechat": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -149,6 +149,7 @@
 		"stripe-redirect-migration-bancontact": false,
 		"stripe-redirect-migration-ideal": false,
 		"stripe-redirect-migration-p24": false,
+		"stripe-redirect-migration-wechat": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/production.json
+++ b/config/production.json
@@ -195,6 +195,7 @@
 		"stripe-redirect-migration-bancontact": false,
 		"stripe-redirect-migration-ideal": false,
 		"stripe-redirect-migration-p24": false,
+		"stripe-redirect-migration-wechat": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -188,7 +188,7 @@
 		"stripe-redirect-migration-bancontact": true,
 		"stripe-redirect-migration-ideal": true,
 		"stripe-redirect-migration-p24": true,
-		"stripe-redirect-migration-wechat": false,
+		"stripe-redirect-migration-wechat": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -188,6 +188,7 @@
 		"stripe-redirect-migration-bancontact": true,
 		"stripe-redirect-migration-ideal": true,
 		"stripe-redirect-migration-p24": true,
+		"stripe-redirect-migration-wechat": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -188,6 +188,7 @@
 		"stripe-redirect-migration-bancontact": false,
 		"stripe-redirect-migration-ideal": false,
 		"stripe-redirect-migration-p24": false,
+		"stripe-redirect-migration-wechat": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -348,6 +348,7 @@ export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_Stripe_Bancontact'
 	| 'WPCOM_Billing_Stripe_Ideal'
 	| 'WPCOM_Billing_Stripe_P24'
+	| 'WPCOM_Billing_Stripe_Wechat'
 	| 'WPCOM_Billing_Stripe_Source_Alipay'
 	| 'WPCOM_Billing_Stripe_Source_Bancontact'
 	| 'WPCOM_Billing_Stripe_Source_Eps'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/payments-shilling#2976

## Proposed Changes

In D161587-code, we enabled a new version of the WeChat Pay payment method which, unlike the currently available one, uses the Stripe redirect API with a Payment Intent instead of the Stripe Sources API, the latter of which is deprecated and will be disabled soon.

This PR enables the new payment method in calypso checkout, but only for local development (calypso.localhost) and staging (proxied WordPress.com) environments.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the API so that the purchase will be made in test mode.
* Add a product to your cart and visit checkout using localhost calypso (the calypso.live links won't work for this since that environment is not enabled).
* Inside checkout, set your country code to "China" and any valid postal code (like 510000).
* In the payment method step, verify that you see "WeChat Pay" as an option.
* Select `WeChat Pay`, enter any name in the field, and submit the payment.
* When you see the Stripe confirmation page, verify that at the top of the page it reads "WeChat Pay" and mentions "payment_intent" somewhere.
* Authorize the purchase and verify that you are taken back to calypso with a successful purchase (it may take a while).
* Verify on the backend that the order was _not_ made with "stripe-source".

