### PR TITLE
Performance Profiler: Keep the same visualization on header tabs on mobile

### DIFF
--- a/client/performance-profiler/components/header/index.tsx
+++ b/client/performance-profiler/components/header/index.tsx
@@ -69,7 +69,7 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 				</div>
 				{ showNavigationTabs && (
 					<SectionNav className="profiler-navigation-tabs">
-						<NavTabs>
+						<NavTabs enforceTabsView>
 							<NavItem
 								onClick={ () => onTabChange( TabType.mobile ) }
 								selected={ activeTab === TabType.mobile }

--- a/client/performance-profiler/components/header/style.scss
+++ b/client/performance-profiler/components/header/style.scss
@@ -80,6 +80,18 @@
 		box-shadow: none;
 		margin: 0;
 
+		.section-nav__mobile-header {
+			display: none;
+		}
+
+		.section-nav__panel {
+			display: flex;
+			align-items: center;
+			flex-wrap: nowrap;
+			overflow-wrap: normal;
+			justify-content: space-between;
+		}
+
 		.section-nav-tabs__list {
 			// Add padding to display the rounded border and remove the same distance to keep it aligned vertically
 			padding-left: 6px;
@@ -115,6 +127,7 @@
 					padding: 0 16px;
 					align-items: center;
 					gap: 10px;
+					width: auto;
 
 					span {
 						font-size: $font-body-small;
@@ -168,6 +181,7 @@
 			align-items: center;
 			gap: 16px;
 			font-size: $font-body-small;
+			margin-left: 25px;
 
 			.report-site-details {
 				display: flex;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8915

## Proposed Changes

Avoid collapsing tabs on mobile view on the Performance Profiler dashboard


## Why are these changes being made?
https://github.com/Automattic/dotcom-forge/issues/8915

## Testing Instructions

* Go to `/speed-test-tool?url=wordpress.com`
* Resize the window and test mobile sizes on the browser 
* The tabs should NOT turn into a dropdown

| Before  | After |
| ------------- | ------------- |
|![image](https://github.com/user-attachments/assets/c3d2c051-6e73-4b53-88e7-030f06b76452)|![CleanShot 2024-09-02 at 18 13 39@2x](https://github.com/user-attachments/assets/2a2abfde-70b9-459f-acc7-24a111014c72)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
