### PR TITLE
Stats: Add new floating feedback panel

### DIFF
--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -35,6 +35,16 @@ function StatsFeedbackCard() {
 				</div>
 				<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
 			</div>
+			<FeedbackPanel />
+		</div>
+	);
+}
+
+function FeedbackPanel() {
+	return (
+		<div className="stats-feedback-panel">
+			<p>floating panel content here</p>
+			<p>buttons here</p>
 		</div>
 	);
 }

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -5,15 +5,20 @@ import FeedbackModal from './modal';
 
 import './style.scss';
 
+const FEEDBACK_ACTION_LEAVE_REVIEW = 'feedback-action-leave-review';
+const FEEDBACK_ACTION_SEND_FEEDBACK = 'feedback-action-send-feedback';
+
 interface FeedbackProps {
-	clickHandler: () => void;
+	clickHandler: ( action: string ) => void;
 }
 
 function StatsFeedbackController() {
 	const [ isOpen, setIsOpen ] = useState( false );
 
-	const handleButtonClick = () => {
-		setIsOpen( true );
+	const handleButtonClick = ( action: string ) => {
+		if ( action === FEEDBACK_ACTION_SEND_FEEDBACK ) {
+			setIsOpen( true );
+		}
 	};
 
 	return (
@@ -48,21 +53,23 @@ function FeedbackContent( { clickHandler }: FeedbackProps ) {
 	const primaryButtonText = translate( 'Love it? Leave a review' );
 	const secondaryButtonText = translate( 'Not a fan? Help us improve' );
 
-	const handleButtonClick = () => {
-		if ( clickHandler ) {
-			clickHandler();
-		}
+	const handleLeaveReview = () => {
+		clickHandler( FEEDBACK_ACTION_LEAVE_REVIEW );
+	};
+
+	const handleSendFeedback = () => {
+		clickHandler( FEEDBACK_ACTION_SEND_FEEDBACK );
 	};
 
 	return (
 		<div className="stats-feedback-card__content">
 			<div className="stats-feedback-card__cta">{ ctaText }</div>
 			<div className="stats-feedback-card__actions">
-				<Button variant="secondary" onClick={ handleButtonClick }>
+				<Button variant="secondary" onClick={ handleLeaveReview }>
 					<span className="stats-feedback-card__emoji">😍</span>
 					{ primaryButtonText }
 				</Button>
-				<Button variant="secondary" onClick={ handleButtonClick }>
+				<Button variant="secondary" onClick={ handleSendFeedback }>
 					<span className="stats-feedback-card__emoji">😠</span>
 					{ secondaryButtonText }
 				</Button>

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -5,6 +5,10 @@ import FeedbackModal from './modal';
 
 import './style.scss';
 
+interface FeedbackProps {
+	clickHandler: () => void;
+}
+
 function StatsFeedbackCard() {
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -23,7 +27,7 @@ function StatsFeedbackCard() {
 	);
 }
 
-function FeedbackPanel( { clickHandler } ) {
+function FeedbackPanel( { clickHandler }: FeedbackProps ) {
 	return (
 		<div className="stats-feedback-panel">
 			<FeedbackContent clickHandler={ clickHandler } />
@@ -31,7 +35,7 @@ function FeedbackPanel( { clickHandler } ) {
 	);
 }
 
-function FeedbackContent( { clickHandler } ) {
+function FeedbackContent( { clickHandler }: FeedbackProps ) {
 	const translate = useTranslate();
 
 	const ctaText = translate( 'How do you rate your overall experience with Jetpack Stats?' );

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -8,14 +8,14 @@ import './style.scss';
 function StatsFeedbackCard() {
 	const [ isOpen, setIsOpen ] = useState( false );
 
-	// const handleClickSendFeedback = () => {
-	// 	setIsOpen( true );
-	// };
+	const handleButtonClick = () => {
+		setIsOpen( true );
+	};
 
 	return (
 		<div className="stats-feedback-container">
 			<div className="stats-feedback-card">
-				<FeedbackContent />
+				<FeedbackContent clickhandler={ handleButtonClick } />
 				<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
 			</div>
 			<FeedbackPanel />
@@ -32,7 +32,7 @@ function FeedbackPanel() {
 	);
 }
 
-function FeedbackContent() {
+function FeedbackContent( { clickhandler } ) {
 	const translate = useTranslate();
 
 	const ctaText = translate( 'How do you rate your overall experience with Jetpack Stats?' );
@@ -41,6 +41,9 @@ function FeedbackContent() {
 
 	const handleButtonClick = () => {
 		console.log( 'button clicked' );
+		if ( clickhandler ) {
+			clickhandler();
+		}
 	};
 
 	return (

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -14,22 +14,28 @@ interface FeedbackProps {
 	clickHandler: ( action: string ) => void;
 }
 
+interface FeedbackPanelProps {
+	clickHandler: ( action: string ) => void;
+	isOpen: boolean;
+}
+
 function StatsFeedbackController() {
 	const [ isOpen, setIsOpen ] = useState( false );
+	const [ isFloatingPanelOpen, setIsFloatingPanelOpen ] = useState( true );
 
 	const handleButtonClick = ( action: string ) => {
 		if ( action === FEEDBACK_ACTION_SEND_FEEDBACK ) {
 			setIsOpen( true );
 		}
 		if ( action === FEEDBACK_ACTION_DISMISS_FLOATING_PANEL ) {
-			console.log( 'dismiss floating panel' );
+			setIsFloatingPanelOpen( false );
 		}
 	};
 
 	return (
 		<div className="stats-feedback-container">
 			<FeedbackCard clickHandler={ handleButtonClick } />
-			<FeedbackPanel clickHandler={ handleButtonClick } />
+			<FeedbackPanel isOpen={ isFloatingPanelOpen } clickHandler={ handleButtonClick } />
 			<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
 		</div>
 	);
@@ -43,12 +49,16 @@ function FeedbackCard( { clickHandler }: FeedbackProps ) {
 	);
 }
 
-function FeedbackPanel( { clickHandler }: FeedbackProps ) {
+function FeedbackPanel( { isOpen, clickHandler }: FeedbackPanelProps ) {
 	const translate = useTranslate();
 
 	const handleCloseButtonClicked = () => {
 		clickHandler( FEEDBACK_ACTION_DISMISS_FLOATING_PANEL );
 	};
+
+	if ( ! isOpen ) {
+		return null;
+	}
 
 	return (
 		<div className="stats-feedback-panel">

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FeedbackModal from './modal';
@@ -39,8 +40,20 @@ function FeedbackCard( { clickHandler }: FeedbackProps ) {
 }
 
 function FeedbackPanel( { clickHandler }: FeedbackProps ) {
+	const translate = useTranslate();
+
+	const handleCloseButtonClicked = () => {
+		console.log( 'close button cicked' );
+	};
+
 	return (
 		<div className="stats-feedback-panel">
+			<Button
+				className="stats-feedback-panel__close-button"
+				onClick={ handleCloseButtonClicked }
+				icon={ close }
+				label={ translate( 'Close' ) }
+			/>
 			<FeedbackContent clickHandler={ clickHandler } />
 		</div>
 	);

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -62,15 +62,15 @@ function FeedbackContent( { clickHandler }: FeedbackProps ) {
 	};
 
 	return (
-		<div className="stats-feedback-card__content">
-			<div className="stats-feedback-card__cta">{ ctaText }</div>
-			<div className="stats-feedback-card__actions">
+		<div className="stats-feedback-content">
+			<div className="stats-feedback-content__cta">{ ctaText }</div>
+			<div className="stats-feedback-content__actions">
 				<Button variant="secondary" onClick={ handleLeaveReview }>
-					<span className="stats-feedback-card__emoji">😍</span>
+					<span className="stats-feedback-content__emoji">😍</span>
 					{ primaryButtonText }
 				</Button>
 				<Button variant="secondary" onClick={ handleSendFeedback }>
-					<span className="stats-feedback-card__emoji">😠</span>
+					<span className="stats-feedback-content__emoji">😠</span>
 					{ secondaryButtonText }
 				</Button>
 			</div>

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -43,7 +43,6 @@ function FeedbackContent( { clickHandler }: FeedbackProps ) {
 	const secondaryButtonText = translate( 'Not a fan? Help us improve' );
 
 	const handleButtonClick = () => {
-		console.log( 'button clicked' );
 		if ( clickHandler ) {
 			clickHandler();
 		}

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -20,9 +20,9 @@ function StatsFeedbackCard() {
 		<div className="stats-feedback-container">
 			<div className="stats-feedback-card">
 				<FeedbackContent clickHandler={ handleButtonClick } />
-				<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
 			</div>
 			<FeedbackPanel clickHandler={ handleButtonClick } />
+			<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
 		</div>
 	);
 }

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -15,7 +15,7 @@ function StatsFeedbackCard() {
 	return (
 		<div className="stats-feedback-container">
 			<div className="stats-feedback-card">
-				<FeedbackContent clickhandler={ handleButtonClick } />
+				<FeedbackContent clickHandler={ handleButtonClick } />
 				<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
 			</div>
 			<FeedbackPanel />
@@ -32,7 +32,7 @@ function FeedbackPanel() {
 	);
 }
 
-function FeedbackContent( { clickhandler } ) {
+function FeedbackContent( { clickHandler } ) {
 	const translate = useTranslate();
 
 	const ctaText = translate( 'How do you rate your overall experience with Jetpack Stats?' );
@@ -41,8 +41,8 @@ function FeedbackContent( { clickhandler } ) {
 
 	const handleButtonClick = () => {
 		console.log( 'button clicked' );
-		if ( clickhandler ) {
-			clickhandler();
+		if ( clickHandler ) {
+			clickHandler();
 		}
 	};
 

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -9,7 +9,7 @@ interface FeedbackProps {
 	clickHandler: () => void;
 }
 
-function StatsFeedbackCard() {
+function StatsFeedbackController() {
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const handleButtonClick = () => {
@@ -71,4 +71,4 @@ function FeedbackContent( { clickHandler }: FeedbackProps ) {
 	);
 }
 
-export default StatsFeedbackCard;
+export default StatsFeedbackController;

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -18,11 +18,17 @@ function StatsFeedbackCard() {
 
 	return (
 		<div className="stats-feedback-container">
-			<div className="stats-feedback-card">
-				<FeedbackContent clickHandler={ handleButtonClick } />
-			</div>
+			<FeedbackCard clickHandler={ handleButtonClick } />
 			<FeedbackPanel clickHandler={ handleButtonClick } />
 			<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
+		</div>
+	);
+}
+
+function FeedbackCard( { clickHandler }: FeedbackProps ) {
+	return (
+		<div className="stats-feedback-card">
+			<FeedbackContent clickHandler={ clickHandler } />
 		</div>
 	);
 }

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -6,33 +6,16 @@ import FeedbackModal from './modal';
 import './style.scss';
 
 function StatsFeedbackCard() {
-	const translate = useTranslate();
 	const [ isOpen, setIsOpen ] = useState( false );
 
-	const ctaText = translate( 'How do you rate your overall experience with Jetpack Stats?' );
-	const primaryButtonText = translate( 'Love it? Leave a review' );
-	const secondaryButtonText = translate( 'Not a fan? Help us improve' );
-
-	const handleClickWriteReview = () => {};
-
-	const handleClickSendFeedback = () => {
-		setIsOpen( true );
-	};
+	// const handleClickSendFeedback = () => {
+	// 	setIsOpen( true );
+	// };
 
 	return (
 		<div className="stats-feedback-container">
 			<div className="stats-feedback-card">
-				<div className="stats-feedback-card__cta">{ ctaText }</div>
-				<div className="stats-feedback-card__actions">
-					<Button variant="secondary" onClick={ handleClickWriteReview }>
-						<span className="stats-feedback-card__emoji">😍</span>
-						{ primaryButtonText }
-					</Button>
-					<Button variant="secondary" onClick={ handleClickSendFeedback }>
-						<span className="stats-feedback-card__emoji">😠</span>
-						{ secondaryButtonText }
-					</Button>
-				</div>
+				<FeedbackContent />
 				<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
 			</div>
 			<FeedbackPanel />
@@ -45,6 +28,34 @@ function FeedbackPanel() {
 		<div className="stats-feedback-panel">
 			<p>floating panel content here</p>
 			<p>buttons here</p>
+		</div>
+	);
+}
+
+function FeedbackContent() {
+	const translate = useTranslate();
+
+	const ctaText = translate( 'How do you rate your overall experience with Jetpack Stats?' );
+	const primaryButtonText = translate( 'Love it? Leave a review' );
+	const secondaryButtonText = translate( 'Not a fan? Help us improve' );
+
+	const handleButtonClick = () => {
+		console.log( 'button clicked' );
+	};
+
+	return (
+		<div className="stats-feedback-card__content">
+			<div className="stats-feedback-card__cta">{ ctaText }</div>
+			<div className="stats-feedback-card__actions">
+				<Button variant="secondary" onClick={ handleButtonClick }>
+					<span className="stats-feedback-card__emoji">😍</span>
+					{ primaryButtonText }
+				</Button>
+				<Button variant="secondary" onClick={ handleButtonClick }>
+					<span className="stats-feedback-card__emoji">😠</span>
+					{ secondaryButtonText }
+				</Button>
+			</div>
 		</div>
 	);
 }

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -8,6 +8,7 @@ import './style.scss';
 
 const FEEDBACK_ACTION_LEAVE_REVIEW = 'feedback-action-leave-review';
 const FEEDBACK_ACTION_SEND_FEEDBACK = 'feedback-action-send-feedback';
+const FEEDBACK_ACTION_DISMISS_FLOATING_PANEL = 'feedback-action-dismiss-floating-panel';
 
 interface FeedbackProps {
 	clickHandler: ( action: string ) => void;
@@ -19,6 +20,9 @@ function StatsFeedbackController() {
 	const handleButtonClick = ( action: string ) => {
 		if ( action === FEEDBACK_ACTION_SEND_FEEDBACK ) {
 			setIsOpen( true );
+		}
+		if ( action === FEEDBACK_ACTION_DISMISS_FLOATING_PANEL ) {
+			console.log( 'dismiss floating panel' );
 		}
 	};
 
@@ -43,7 +47,7 @@ function FeedbackPanel( { clickHandler }: FeedbackProps ) {
 	const translate = useTranslate();
 
 	const handleCloseButtonClicked = () => {
-		console.log( 'close button cicked' );
+		clickHandler( FEEDBACK_ACTION_DISMISS_FLOATING_PANEL );
 	};
 
 	return (

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -19,60 +19,6 @@ interface FeedbackPanelProps {
 	isOpen: boolean;
 }
 
-function StatsFeedbackController() {
-	const [ isOpen, setIsOpen ] = useState( false );
-	const [ isFloatingPanelOpen, setIsFloatingPanelOpen ] = useState( true );
-
-	const handleButtonClick = ( action: string ) => {
-		if ( action === FEEDBACK_ACTION_SEND_FEEDBACK ) {
-			setIsOpen( true );
-		}
-		if ( action === FEEDBACK_ACTION_DISMISS_FLOATING_PANEL ) {
-			setIsFloatingPanelOpen( false );
-		}
-	};
-
-	return (
-		<div className="stats-feedback-container">
-			<FeedbackCard clickHandler={ handleButtonClick } />
-			<FeedbackPanel isOpen={ isFloatingPanelOpen } clickHandler={ handleButtonClick } />
-			<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
-		</div>
-	);
-}
-
-function FeedbackCard( { clickHandler }: FeedbackProps ) {
-	return (
-		<div className="stats-feedback-card">
-			<FeedbackContent clickHandler={ clickHandler } />
-		</div>
-	);
-}
-
-function FeedbackPanel( { isOpen, clickHandler }: FeedbackPanelProps ) {
-	const translate = useTranslate();
-
-	const handleCloseButtonClicked = () => {
-		clickHandler( FEEDBACK_ACTION_DISMISS_FLOATING_PANEL );
-	};
-
-	if ( ! isOpen ) {
-		return null;
-	}
-
-	return (
-		<div className="stats-feedback-panel">
-			<Button
-				className="stats-feedback-panel__close-button"
-				onClick={ handleCloseButtonClicked }
-				icon={ close }
-				label={ translate( 'Close' ) }
-			/>
-			<FeedbackContent clickHandler={ clickHandler } />
-		</div>
-	);
-}
-
 function FeedbackContent( { clickHandler }: FeedbackProps ) {
 	const translate = useTranslate();
 
@@ -101,6 +47,60 @@ function FeedbackContent( { clickHandler }: FeedbackProps ) {
 					{ secondaryButtonText }
 				</Button>
 			</div>
+		</div>
+	);
+}
+
+function FeedbackPanel( { isOpen, clickHandler }: FeedbackPanelProps ) {
+	const translate = useTranslate();
+
+	const handleCloseButtonClicked = () => {
+		clickHandler( FEEDBACK_ACTION_DISMISS_FLOATING_PANEL );
+	};
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<div className="stats-feedback-panel">
+			<Button
+				className="stats-feedback-panel__close-button"
+				onClick={ handleCloseButtonClicked }
+				icon={ close }
+				label={ translate( 'Close' ) }
+			/>
+			<FeedbackContent clickHandler={ clickHandler } />
+		</div>
+	);
+}
+
+function FeedbackCard( { clickHandler }: FeedbackProps ) {
+	return (
+		<div className="stats-feedback-card">
+			<FeedbackContent clickHandler={ clickHandler } />
+		</div>
+	);
+}
+
+function StatsFeedbackController() {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ isFloatingPanelOpen, setIsFloatingPanelOpen ] = useState( true );
+
+	const handleButtonClick = ( action: string ) => {
+		if ( action === FEEDBACK_ACTION_SEND_FEEDBACK ) {
+			setIsOpen( true );
+		}
+		if ( action === FEEDBACK_ACTION_DISMISS_FLOATING_PANEL ) {
+			setIsFloatingPanelOpen( false );
+		}
+	};
+
+	return (
+		<div className="stats-feedback-container">
+			<FeedbackCard clickHandler={ handleButtonClick } />
+			<FeedbackPanel isOpen={ isFloatingPanelOpen } clickHandler={ handleButtonClick } />
+			<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
 		</div>
 	);
 }

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -18,16 +18,15 @@ function StatsFeedbackCard() {
 				<FeedbackContent clickHandler={ handleButtonClick } />
 				<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
 			</div>
-			<FeedbackPanel />
+			<FeedbackPanel clickHandler={ handleButtonClick } />
 		</div>
 	);
 }
 
-function FeedbackPanel() {
+function FeedbackPanel( { clickHandler } ) {
 	return (
 		<div className="stats-feedback-panel">
-			<p>floating panel content here</p>
-			<p>buttons here</p>
+			<FeedbackContent clickHandler={ clickHandler } />
 		</div>
 	);
 }

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -78,7 +78,7 @@
 
 .stats-feedback-panel {
 	position: fixed;
-	bottom: 16px;
+	bottom: 24px;
 	right: 24px;
 	z-index: 10;
 
@@ -94,8 +94,8 @@
 
 .stats-feedback-panel__close-button {
 	position: absolute;
-	top: 6px;
-	right: 6px;
+	top: 10px;
+	right: 10px;
 
 	svg {
 		width: 14px;

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -24,7 +24,7 @@
 }
 
 .stats-feedback-content__cta {
-	margin-bottom: 12px;
+	margin-bottom: 16px;
 }
 
 .stats-feedback-content__emoji {

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -24,7 +24,7 @@
 }
 
 .stats-feedback-content__cta {
-	margin-bottom: 16px;
+	margin: 0 16px 16px 0;
 }
 
 .stats-feedback-content__emoji {

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -7,7 +7,7 @@
 	font-weight: 400;
 	line-height: 21px;
 	letter-spacing: -0.24px;
-    color: var(--studio-gray-100);
+	color: var(--studio-gray-100);
 }
 
 .stats-feedback-content__actions {
@@ -17,9 +17,9 @@
 	.components-button {
 		margin-bottom: 6px;
 		width: fit-content;
-        font-weight: 500;
-        font-size: $font-body-small;
-        border-radius: 4px;
+		font-weight: 500;
+		font-size: $font-body-small;
+		border-radius: 4px;
 	}
 }
 
@@ -83,11 +83,11 @@
 	z-index: 10;
 
 	border: 1px solid var(--studio-gray-5);
-	border-radius: 8px;
+	border-radius: 8px; // stylelint-disable-line scales/radii
 	padding: 24px;
 	width: 300px;
 	box-sizing: border-box;
-	box-shadow: 0px 10px 20px 0px #00000014;
+	box-shadow: 0 10px 20px 0 #00000014;
 
 	background-color: var(--studio-white);
 }

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -85,3 +85,14 @@
 
 	background-color: var(--studio-white);
 }
+
+.stats-feedback-panel__close-button {
+	position: absolute;
+	top: 6px;
+	right: 6px;
+
+	svg {
+		width: 14px;
+		height: 14px;
+	}
+}

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -81,7 +81,7 @@
 
 	border: 1px solid var(--studio-gray-5);
 	border-radius: 10px; // stylelint-disable-line scales/radii
-	padding: 18px;
+	padding: 24px;
 	max-width: 230px;
 
 	background-color: var(--studio-white);

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -82,7 +82,9 @@
 	border: 1px solid var(--studio-gray-5);
 	border-radius: 10px; // stylelint-disable-line scales/radii
 	padding: 24px;
-	max-width: 230px;
+	width: 300px;
+	box-sizing: border-box;
+	box-shadow: 0px 10px 20px 0px #00000014;
 
 	background-color: var(--studio-white);
 }

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -59,3 +59,13 @@
 	font-size: larger;
 	margin-right: 6px;
 }
+
+.stats-feedback-panel {
+	position: fixed;
+	bottom: 64px;
+	right: 16px;
+	z-index: 10;
+
+	background-color: green;
+	// background-color: var(--studio-white);
+}

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -17,6 +17,9 @@
 	.components-button {
 		margin-bottom: 6px;
 		width: fit-content;
+        font-weight: 500;
+        font-size: $font-body-small;
+        border-radius: 4px;
 	}
 }
 

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -9,6 +9,25 @@
 	letter-spacing: -0.24px;
 }
 
+.stats-feedback-content__actions {
+	display: flex;
+	flex-direction: column;
+
+	.components-button {
+		margin-bottom: 6px;
+		width: fit-content;
+	}
+}
+
+.stats-feedback-content__cta {
+	margin-bottom: 12px;
+}
+
+.stats-feedback-content__emoji {
+	font-size: larger;
+	margin-right: 6px;
+}
+
 .stats-feedback-card {
 	background: var(--studio-white);
 	border: 1px solid var(--studio-gray-5);
@@ -35,33 +54,22 @@
 	}
 
 	.stats-feedback-content__cta {
-		@media (max-width: $break-wide) {
-			margin-bottom: 12px;
+		@media (min-width: $break-wide) {
+			margin-right: 12px;
+			margin-bottom: 0;
 		}
 	}
 
 	.stats-feedback-content__actions {
-		display: flex;
-		flex-direction: column;
-
-		.components-button {
-			margin: 6px 0;
-			width: fit-content;
-		}
-
 		@media (min-width: $break-wide) {
 			flex-direction: row;
 
 			.components-button {
-				margin: 0 6px;
+				margin-left: 6px;
+				margin-bottom: 0;
 			}
 		}
 	}
-}
-
-.stats-feedback-content__emoji {
-	font-size: larger;
-	margin-right: 6px;
 }
 
 .stats-feedback-panel {
@@ -76,18 +84,4 @@
 	max-width: 230px;
 
 	background-color: var(--studio-white);
-
-	.stats-feedback-content__cta {
-		margin-bottom: 12px;
-	}
-
-	.stats-feedback-content__actions {
-		display: flex;
-		flex-direction: column;
-
-		.components-button {
-			margin-bottom: 6px;
-			width: fit-content;
-		}
-	}
 }

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -74,7 +74,7 @@
 
 .stats-feedback-panel {
 	position: fixed;
-	bottom: 64px;
+	bottom: 16px;
 	right: 16px;
 	z-index: 10;
 

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -7,6 +7,7 @@
 	font-weight: 400;
 	line-height: 21px;
 	letter-spacing: -0.24px;
+    color: var(--studio-gray-100);
 }
 
 .stats-feedback-content__actions {

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -70,6 +70,24 @@
 	right: 16px;
 	z-index: 10;
 
-	background-color: green;
-	// background-color: var(--studio-white);
+	border: 1px solid var(--studio-gray-5);
+	border-radius: 10px; // stylelint-disable-line scales/radii
+	padding: 18px;
+	max-width: 230px;
+
+	background-color: var(--studio-white);
+
+	.stats-feedback-content__cta {
+		margin-bottom: 12px;
+	}
+
+	.stats-feedback-content__actions {
+		display: flex;
+		flex-direction: column;
+
+		.components-button {
+			margin-bottom: 6px;
+			width: fit-content;
+		}
+	}
 }

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -1,6 +1,14 @@
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
 
+.stats-feedback-content {
+	font-family: $font-sf-pro-text;
+	font-size: $font-body-small;
+	font-weight: 400;
+	line-height: 21px;
+	letter-spacing: -0.24px;
+}
+
 .stats-feedback-card {
 	background: var(--studio-white);
 	border: 1px solid var(--studio-gray-5);
@@ -15,47 +23,43 @@
 		border-right: none;
 	}
 
-	display: flex;
-	flex-direction: column;
+	.stats-feedback-content {
+		display: flex;
+		flex-direction: column;
 
-	@media (min-width: $break-wide) {
-		flex-direction: row;
-		justify-content: space-between;
-		align-items: center;
+		@media (min-width: $break-wide) {
+			flex-direction: row;
+			justify-content: space-between;
+			align-items: center;
+		}
 	}
 
-	font-family: $font-sf-pro-text;
-	font-size: $font-body-small;
-	font-weight: 400;
-	line-height: 21px;
-	letter-spacing: -0.24px;
-}
-
-.stats-feedback-card__cta {
-	@media (max-width: $break-wide) {
-		margin-bottom: 12px;
-	}
-}
-
-.stats-feedback-card__actions {
-	display: flex;
-	flex-direction: column;
-
-	.components-button {
-		margin: 6px 0;
-		width: fit-content;
+	.stats-feedback-content__cta {
+		@media (max-width: $break-wide) {
+			margin-bottom: 12px;
+		}
 	}
 
-	@media (min-width: $break-wide) {
-		flex-direction: row;
+	.stats-feedback-content__actions {
+		display: flex;
+		flex-direction: column;
 
 		.components-button {
-			margin: 0 6px;
+			margin: 6px 0;
+			width: fit-content;
+		}
+
+		@media (min-width: $break-wide) {
+			flex-direction: row;
+
+			.components-button {
+				margin: 0 6px;
+			}
 		}
 	}
 }
 
-.stats-feedback-card__emoji {
+.stats-feedback-content__emoji {
 	font-size: larger;
 	margin-right: 6px;
 }

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -83,7 +83,7 @@
 	z-index: 10;
 
 	border: 1px solid var(--studio-gray-5);
-	border-radius: 10px; // stylelint-disable-line scales/radii
+	border-radius: 8px;
 	padding: 24px;
 	width: 300px;
 	box-sizing: border-box;

--- a/client/my-sites/stats/feedback/style.scss
+++ b/client/my-sites/stats/feedback/style.scss
@@ -79,7 +79,7 @@
 .stats-feedback-panel {
 	position: fixed;
 	bottom: 16px;
-	right: 16px;
+	right: 24px;
 	z-index: 10;
 
 	border: 1px solid var(--studio-gray-5);

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -58,7 +58,7 @@ import StatsModuleSearch from './features/modules/stats-search';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
 import StatsModuleUTM, { StatsModuleUTMOverlay } from './features/modules/stats-utm';
 import StatsModuleVideos from './features/modules/stats-videos';
-import StatsFeedbackCard from './feedback';
+import StatsFeedbackController from './feedback';
 import HighlightsSection from './highlights-section';
 import { shouldGateStats } from './hooks/use-should-gate-stats';
 import MiniCarousel from './mini-carousel';
@@ -242,7 +242,7 @@ class StatsSite extends Component {
 			shouldForceDefaultDateRange,
 		} = this.props;
 		const isNewStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
-		const isFeedbackCardEnabled = config.isEnabled( 'stats/user-feedback' );
+		const isUserFeedbackEnabled = config.isEnabled( 'stats/user-feedback' );
 		let defaultPeriod = PAST_SEVEN_DAYS;
 
 		const shouldShowUpsells = isOdysseyStats && ! isAtomic;
@@ -810,7 +810,7 @@ class StatsSite extends Component {
 					<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />
 				) }
 				<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
-				{ isFeedbackCardEnabled && <StatsFeedbackCard /> }
+				{ isUserFeedbackEnabled && <StatsFeedbackController /> }
 				<JetpackColophon />
 				<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
 				{ this.props.upsellModalView && <StatsUpsellModal siteId={ siteId } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related:

https://github.com/Automattic/red-team/issues/154

## Proposed Changes

Adds a new floating feedback panel to the Traffic page.

Does not implement button behaviours (although hooks are in place for this and for tracks) nor does it intelligently display the panel. It can be dismissed but it will reappear on each render cycle. Button behaviours, tracks, and controlled display will be addressed in separate issues.

<img width="743" alt="SCR-20240903-paak" src="https://github.com/user-attachments/assets/d6f46af7-217d-48cc-a7a6-e4f555e020ec">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of the User Feedback project.

pejTkB-1Ce-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Calypso Live site.
* Visit the Traffic page.
* Enable the feature flag: `?flags=stats/user-feedback`
* Confirm the floating panel is visible at the bottom of the window (not the page).
* Confirm it displays correctly when scrolling or resizing the view.
* Confirm the dismiss button works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?