### PR TITLE
Help Center: clean-up a leftover variable

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -59,12 +59,6 @@ const HelpCenterContainer: React.FC< Container > = ( {
 		recordTracksEvent( `calypso_inlinehelp_close` );
 	}, [ handleClose ] );
 
-	const animationProps = {
-		style: {
-			...openingCoordinates,
-		},
-	};
-
 	const focusReturnRef = useFocusReturn();
 
 	const cardMergeRefs = useMergeRefs( [ nodeRef, focusReturnRef ] );
@@ -99,7 +93,7 @@ const HelpCenterContainer: React.FC< Container > = ( {
 					handle=".help-center__container-header"
 					bounds="body"
 				>
-					<Card className={ classNames } { ...animationProps } ref={ cardMergeRefs }>
+					<Card className={ classNames } style={ { ...openingCoordinates } } ref={ cardMergeRefs }>
 						<HelpCenterHeader
 							isMinimized={ isMinimized }
 							onMinimize={ () => setIsMinimized( true ) }


### PR DESCRIPTION
## Proposed Changes

Remove `animationProps` as it was leftover from and put the styles directly into the component.

## Why are these changes being made?

Just general clean-up.

## Testing Instructions

Open Help Center from Live Link. It should open exactly the same as production.