### PR TITLE
Plugin Marketplace: Fix menu highlight on plugins details page

### DIFF
--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -40,11 +40,11 @@ export const itemLinkMatches = ( path, currentPath ) => {
 	}
 
 	if ( pathIncludes( currentPath, 'plugins', 1 ) ) {
-		if ( pathIncludes( currentPath, 'browse', 2 ) ) {
-			return pathIncludes( path, 'plugins', 1 ) && ! pathIncludes( path, 'scheduled-updates', 2 );
+		if ( pathIncludes( currentPath, 'scheduled-updates', 2 ) ) {
+			return pathIncludes( path, 'plugins', 1 ) && pathIncludes( path, 'scheduled-updates', 2 );
 		}
 
-		return pathIncludes( path, 'plugins', 1 ) && fragmentIsEqual( path, currentPath, 2 );
+		return pathIncludes( path, 'plugins', 1 ) && fragmentIsEqual( path, currentPath, 1 );
 	}
 
 	if ( pathIncludes( currentPath, 'settings', 1 ) ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93424

## Proposed Changes

* Highlight the Plugins menu when the user is in the plugin detail page

| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2024-09-03 at 13 17 10](https://github.com/user-attachments/assets/ef2a6d7e-9bf6-40e0-8a65-b796c1222cac) |  ![Screenshot 2024-09-03 at 13 16 50](https://github.com/user-attachments/assets/1ab481a8-ef7f-41af-ae9b-4aeab3bf57d9) |



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* bugfix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link
* Go to /plugins/site-name with an **Atomic** site
* Notice that the Add new plugin submenu is highlighted the following cases:
* * Click on a category
* * Click on a plugin (details page)
* * Click on upload plugin button
* Notice that the Scheduled updates is highlighted only when you're on the scheduled updates page
* Untangle the site and notice that now we have a `Marketplace` submenu
* Repeat the steps again
* Go to a **Simple Site**
* Notice that Plugins menu remains active when:
* * A plugin category is selected
* * On the main page
* * On the plugin details page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
