### PR TITLE
Help Center: Remove check that prevents it from loading

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/help-center/async.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/help-center/async.tsx
@@ -1,21 +1,16 @@
-import { HelpCenter, HelpCenterSelect } from '@automattic/data-stores';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { HelpCenter } from '@automattic/data-stores';
+import { useDispatch } from '@wordpress/data';
+import { useCallback } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
 const AsyncHelpCenter = () => {
 	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
-	const isShowingHelpCenter = useSelect(
-		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
-		[]
-	);
 
-	const handleClose = () => setShowHelpCenter( false );
-
-	if ( ! isShowingHelpCenter ) {
-		return null;
-	}
+	const handleClose = useCallback( () => {
+		setShowHelpCenter( false );
+	}, [ setShowHelpCenter ] );
 
 	return (
 		<AsyncLoad require="@automattic/help-center" placeholder={ null } handleClose={ handleClose } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/94027
Fixes https://github.com/Automattic/wp-calypso/issues/94027

## Proposed Changes

* The Help Center was using its visibility state to determine whether it should be loaded or not. The shown state is used to render or not the help center, not to control whether it should be loaded or not.
* Internally, [the help center already deals with whether it should be visible](https://github.com/Automattic/wp-calypso/blob/fix/migration_flow_checkout_helpcenter/packages/help-center/src/components/help-center-container.tsx#L83) or not based on it's state.
* This PR removes this check that was preventing the help center to loading properly and also uses `useCallback` to memoizes the function `handleClose`, meaning it will only recreate the function if its dependencies change.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes https://github.com/Automattic/wp-calypso/issues/94027

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start any migration flow (/setup/migration, /setup/site-migration, /setup/hosted-site-migration)
* Follow all steps until you reach the checkout step 
* On top right, there is a 'Visit help center' link button
* Also more towards to the bottom, by clicking, the Help center should open as normally 
<img width="799" alt="image" src="https://github.com/user-attachments/assets/212cd0b5-ceda-4811-8365-233594cb00f1">


TIP:
When reaching
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/62e41fff-12db-42d3-9891-ffbbcb3dd419">

Click back and take the deal to go directly to checkout

<img width="826" alt="image" src="https://github.com/user-attachments/assets/4303c500-9cdc-420f-ba48-e467c2a7b9d2">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
