### PR TITLE
remove instances of `var(--studio-pink`

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -60,7 +60,7 @@
 			color: var(--studio-gray-20);
 
 			&::before {
-				border-top: 3px solid var(--studio-pink-50);
+				border-top: 3px solid var(--studio-wordpress-blue);
 				border-radius: 3px;
 				transform: initial;
 			}
@@ -204,7 +204,7 @@
 	}
 
 	&__expiration-date {
-		color: var(--studio-pink-50);
+		color: var(--studio-red);
 	}
 
 	&__standalone-card-price {

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -5,18 +5,6 @@
 
 	@include jetpack-cloud-sections-shared-styles();
 
-	// On cloud.jetpack.com, we want to override the primary color, used on
-	// the featured product card, with --studio-pink-50.
-	.jetpack-product-card.is-featured {
-		.jetpack-product-card__header {
-			background-color: var(--studio-pink-50);
-		}
-
-		.jetpack-product-card__body {
-			border: solid 2px var(--studio-pink-50);
-		}
-	}
-
 	.layout__content {
 		overflow: clip;
 	}

--- a/client/jetpack-connect/colors.scss
+++ b/client/jetpack-connect/colors.scss
@@ -20,9 +20,9 @@
 
 @mixin woocommerce-colors() {
 	// Override accent variables with WooCommerce colors
-	--color-accent: var(--studio-pink-50);
-	--color-accent-light: var(--studio-pink-30);
-	--color-accent-dark: var(--studio-pink-70);
+	--color-accent: var(--studio-woocommerce-purple);
+	--color-accent-light: var(--studio-woocommerce-purple-30);
+	--color-accent-dark: var(--studio-woocommerce-purple-70);
 
 	--color-woocommerce-onboarding-background: #f6f7f7;
 	--color-woocommerce-header-border: #dcdcde;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -973,8 +973,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		.auth-form__social,
 		.login__form-social {
 			.social-buttons__button {
-				border-color: var(--studio-pink-50);
-				color: var(--studio-pink-50);
+				border-color: var(--studio-woocommerce-purple);
+				color: var(--studio-woocommerce-purple);
 
 				&.disabled {
 					border-color: var(--studio-gray-30);

--- a/client/layout/masterbar/crowdsignal.scss
+++ b/client/layout/masterbar/crowdsignal.scss
@@ -5,8 +5,8 @@
 
 	--color-primary: var(--studio-wordpress-blue-90);
 	--color-primary-dark: var(--studio-wordpress-blue-100);
-	--color-accent: var(--studio-pink-50);
-	--color-accent-dark: var(--studio-pink-70);
+	--color-accent: var(--studio-wordpress-blue);
+	--color-accent-dark: var(--studio-wordpress-blue-70);
 
 	--color-border: var(--studio-gray-5);
 	--color-surface: var(--studio-white);

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -261,8 +261,8 @@ $image-height: 47px;
 
 	.auth-form__social-buttons {
 		.social-buttons__button {
-			border: 1px solid var(--studio-pink-50);
-			color: var(--studio-pink-50);
+			border: 1px solid var(--studio-wordpress-blue);
+			color: var(--studio-wordpress-blue);
 			box-shadow: none;
 		}
 	}

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -355,7 +355,7 @@
 	}
 
 	&.is-expiring .manage-purchase__detail-date-span {
-		color: var(--studio-pink-50);
+		color: var(--studio-red);
 	}
 }
 

--- a/client/my-sites/domains/components/domain-and-plan-package/navigation/style.scss
+++ b/client/my-sites/domains/components/domain-and-plan-package/navigation/style.scss
@@ -90,7 +90,7 @@
 		}
 
 		ol &__active {
-			color: var(--studio-pink-50);
+			color: var(--studio-wordpress-blue);
 		}
 	}
 }

--- a/client/my-sites/marketplace/components/progressbar/index.tsx
+++ b/client/my-sites/marketplace/components/progressbar/index.tsx
@@ -104,7 +104,7 @@ export default function MarketplaceProgressBar( {
 			<Title className="progressbar__title wp-brand-font">{ stepValue }</Title>
 			<StyledProgressBar
 				value={ simulatedProgressPercentage }
-				color="var( --studio-pink-50 )"
+				color="var( --studio-wordpress-blue )"
 				compact
 			/>
 			{ steps.length > 1 && <div>{ stepIndication }</div> }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -368,8 +368,8 @@ body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow) .formatted-h
 		}
 
 		.social-buttons__button {
-			border: 1px solid var(--studio-pink-50);
-			color: var(--studio-pink-50);
+			border: 1px solid var(--studio-wordpress-blue);
+			color: var(--studio-wordpress-blue);
 			box-shadow: none;
 			max-width: 250px;
 			height: 48px;

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -59,7 +59,7 @@
 				display: inline-block;
 				margin-left: 8px;
 				padding: 2px 8px;
-				background: var(--studio-wordpress-blue);
+				background: var(--color-masterbar-unread-dot-background);
 				border-radius: 50%;
 				font-size: $font-body-extra-small;
 				color: #fff;

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -59,7 +59,7 @@
 				display: inline-block;
 				margin-left: 8px;
 				padding: 2px 8px;
-				background: var(--studio-pink-50);
+				background: var(--studio-wordpress-blue);
 				border-radius: 50%;
 				font-size: $font-body-extra-small;
 				color: #fff;

--- a/packages/help-center/src/components/help-center-more-resources.scss
+++ b/packages/help-center/src/components/help-center-more-resources.scss
@@ -11,7 +11,7 @@
 			button {
 				&.help-center-more-resources__institution {
 					> svg:first-child {
-						fill: var(--studio-pink-50);
+						fill: var(--studio-green);
 					}
 				}
 


### PR DESCRIPTION
## Description

This is one in a series of issues to remove old instances of pink as an accent color throughout the app. All we're doing in this PR is making updates to accent colors in a few different spots. See https://github.com/Automattic/dotcom-forge/issues/9002 for the full list of PRs.

## How to test

This PR is going to be a little tricky to test.

It's probably going to be easiest to go into the diff and raise any concerns or issues that you see vs. trying to test each of these changes individually.

Mostly, we just want to make sure that there are no syntax errors. 