### PR TITLE
Plugins Marketplace: Fix Manage Sites inconsistent states

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -33,6 +33,7 @@ import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/a
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import {
 	isRequestingForSites,
+	isRequestingForAllSites,
 	getSiteObjectsWithPlugin,
 	getPluginOnSite,
 } from 'calypso/state/plugins/installed/selectors';
@@ -495,6 +496,8 @@ function GetStartedButton( { onClick, plugin, isMarketplaceProduct, startFreeTri
 function ManageSitesButton( { plugin, installedOnSitesQuantity } ) {
 	const translate = useTranslate();
 	const [ displayManageSitePluginsModal, setDisplayManageSitePluginsModal ] = useState( false );
+	const isRequestingPlugins = useSelector( ( state ) => isRequestingForAllSites( state ) );
+
 	const toggleDisplayManageSitePluginsModal = useCallback( () => {
 		setDisplayManageSitePluginsModal( ( value ) => ! value );
 	}, [] );
@@ -525,6 +528,7 @@ function ManageSitesButton( { plugin, installedOnSitesQuantity } ) {
 			<Button
 				className="plugin-details-cta__manage-button"
 				onClick={ toggleDisplayManageSitePluginsModal }
+				busy={ isRequestingPlugins }
 			>
 				{ translate( 'Manage sites' ) }
 			</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/93807

https://github.com/user-attachments/assets/b06a65a3-0530-4554-ae5e-992bc96acbb0


## Proposed Changes

* Use a selector to check if plugins are being retrieved
* Set the `Manage sites` button to loading so it is disabled while plugins are retrieved

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The user can see different states for the Managing Sites dialog when opening it when the plugins are not yet fully loaded

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Open calypso and navigate to `/plugins`,
* Select one plugin
* Check the `Manage sites` button is in a loading state, try to click it
* Confirm the button is disabled so it can only be clicked when the plugins are fully loaded
* Check the `Manage sites` modal always displays the same values

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
