### PR TITLE
Hosting Overview: Remove nested links in plan storage

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -16,7 +16,8 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { ComponentType, FC, PropsWithChildren, ReactNode, useRef, useState } from 'react'; // eslint-disable-line no-unused-vars -- used in the jsdoc types
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import hasWpcomStagingSite from 'calypso/state/selectors/has-wpcom-staging-site';
 import isLegacySiteWithHigherLimits from 'calypso/state/selectors/is-legacy-site-with-higher-limits';
@@ -63,6 +64,8 @@ export function PlanStorage( {
 	);
 	const [ isTooltipVisible, setTooltipVisible ] = useState( false );
 	const tooltipAnchorRef = useRef( null );
+
+	const dispatch = useDispatch();
 
 	if ( ( jetpackSite && ! atomicSite ) || ! canViewBar || ! sitePlanSlug ) {
 		return null;
@@ -143,6 +146,9 @@ export function PlanStorage( {
 					onMouseLeave={ hideTooltip }
 					onFocus={ showTooltip }
 					onBlur={ hideTooltip }
+					onClick={ () => {
+						dispatch( recordTracksEvent( 'calypso_hosting_overview_need_more_storage_click' ) );
+					} }
 				>
 					{ planStorageComponents }
 				</a>

--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -1,6 +1,8 @@
 .plan-storage {
 	display: flex;
 	color: var(--studio-gray-80);
+
+	&:hover,
 	&:visited {
 		color: inherit;
 	}

--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -1,6 +1,6 @@
 .plan-storage {
 	display: flex;
-	color: var(--studio-gray-80);
+	color: inherit;
 
 	&:hover,
 	&:visited {

--- a/client/hosting/overview/components/plan-card.tsx
+++ b/client/hosting/overview/components/plan-card.tsx
@@ -158,7 +158,6 @@ const PricingSection: FC = () => {
 };
 
 const PlanCard: FC = () => {
-	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const site = useSelector( getSelectedSite );
 	const planDetails = site?.plan;
@@ -256,18 +255,9 @@ const PlanCard: FC = () => {
 						>
 							{ storageAddons.length > 0 && ! isAgencyPurchase && (
 								<div className="hosting-overview__plan-storage-footer">
-									<Button
-										className="hosting-overview__link-button"
-										plain
-										href={ `/add-ons/${ site?.slug }` }
-										onClick={ () => {
-											dispatch(
-												recordTracksEvent( 'calypso_hosting_overview_need_more_storage_click' )
-											);
-										} }
-									>
+									<span className="hosting-overview__storage-footer-text">
 										{ translate( 'Need more storage?' ) }
-									</Button>
+									</span>
 								</div>
 							) }
 						</PlanStorage>

--- a/client/hosting/overview/components/style.scss
+++ b/client/hosting/overview/components/style.scss
@@ -263,10 +263,14 @@ $blueberry-color: #3858e9;
 
 .hosting-overview__plan-storage-footer {
 	text-align: left;
-}
 
-.hosting-overview__link-button {
-	color: var(--color-link);
+	.hosting-overview__storage-footer-text {
+		color: var(--color-link);
+
+		&:hover {
+			color: var(--color-link-dark);
+		}
+	}
 }
 
 .hosting-overview__plan-storage-value,

--- a/client/hosting/overview/components/style.scss
+++ b/client/hosting/overview/components/style.scss
@@ -261,15 +261,11 @@ $blueberry-color: #3858e9;
 	text-transform: uppercase;
 }
 
-.hosting-overview__plan-storage-footer {
-	text-align: left;
+.hosting-overview__storage-footer-text {
+	color: var(--color-link);
 
-	.hosting-overview__storage-footer-text {
-		color: var(--color-link);
-
-		&:hover {
-			color: var(--color-link-dark);
-		}
+	&:hover {
+		color: var(--color-link-dark);
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8917-gh-Automattic/dotcom-forge

## Proposed Changes

Replaces the nested link in the Plan Storage block with a `span`, while preserving the visual appearance of the "Need more storage" CTA. Rather than this CTA being a separate link to addons, it is now just part of the larger link to a plan upgrade.

Also fixes a small bug that caused the text above the progress bar to change color when the block is hovered for sites where `/plans` hasn't been visited yet.

## Why are these changes being made?

Nested links aren't valid HTML. We also had two different, competing CTAs in this block for free sites. The block itself leading to plan upgrades, the text link to add-ons. Simplifying to one CTA allows to focus user attention on plan upgrades while ensuring valid markup at the same time.

## Testing Instructions

Updated markup:

- Use a free site to trigger the correct flow
- Inspect markup and confirm there is now just one `a` wrapping the plan storage block without any nested links. Confirm that the element wrapping "**Need more storage?**" is now a `span`.
- Test hovering the link **"Need more storage"** text. Confirm that it does not change color when the block surrounding it is hovered, but it does take on a darker blue when the text itself is hovered. It should look and behave like a link as it did before this change.
- Click on the Plan Storage block to visit the plans page. Then return to the hosting overview and confirm that the color isn't impacted by the fact that this link is now `:visited`

Styling fix:

- Use a new free site (so you know `/plans` is not a `:visited` link). This bug only applies to cases where that url won't trigger `:visited` styling that's already in place.
- Hover over the Plan Storage block and confirm that the text above the progress bar ("Plan Storage" and the current usage on the right) does not change color when hovering over the block, both before and after visiting the plans page by clicking on the block. The color of the text above the progress bar should never change.