### PR TITLE
Checkout: Update color themes to use WordPress blue colors

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -534,9 +534,9 @@ export default function CheckoutMain( {
 				primaryOver: colors[ 'Jetpack Green 60' ],
 				success: colors[ 'Jetpack Green' ],
 				discount: colors[ 'Jetpack Green' ],
-				highlight: colors[ 'Blue 50' ],
-				highlightBorder: colors[ 'Blue 80' ],
-				highlightOver: colors[ 'Blue 60' ],
+				highlight: colors[ 'WordPress Blue 50' ],
+				highlightBorder: colors[ 'WordPress Blue 80' ],
+				highlightOver: colors[ 'WordPress Blue 60' ],
 		  }
 		: {};
 	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };

--- a/packages/composite-checkout/src/lib/theme.ts
+++ b/packages/composite-checkout/src/lib/theme.ts
@@ -60,9 +60,9 @@ const theme: Theme = {
 	colors: {
 		background: swatches.gray0,
 		surface: swatches.white,
-		primary: colorStudio.colors[ 'Blue 50' ],
+		primary: colorStudio.colors[ 'WordPress Blue 50' ],
 		primaryBorder: swatches.pink80,
-		primaryOver: colorStudio.colors[ 'Blue 60' ],
+		primaryOver: colorStudio.colors[ 'WordPress Blue 60' ],
 		highlight: swatches.blue50,
 		highlightBorder: swatches.blue80,
 		highlightOver: swatches.blue60,


### PR DESCRIPTION
## Background

I was [researching](https://github.com/Automattic/payments-shilling/issues/3060) why the buttons in checkout are a different shade of blue than other parts of calypso.

For example, see the color difference between these two buttons:

Outside checkout             |  Checkout
:-------------------------:|:-------------------------:
<img width="676" alt="Screenshot 2024-09-03 at 10 45 43 AM" src="https://github.com/user-attachments/assets/28b97c53-bb70-4f50-95aa-6e68422c49d6"> | <img width="636" alt="Screenshot 2024-09-03 at 10 59 29 AM" src="https://github.com/user-attachments/assets/105575a9-d33c-4c99-963c-4bb1379d236d">

It turns out that checkout is [using the color directly](https://github.com/Automattic/wp-calypso/blob/66c1aea529d734ee3cab9f5a1a877bd2ee5b963e/packages/composite-checkout/src/lib/theme.ts#L63) from the `@automattic/color-studio` package (which [is outdated as version 2.6](https://github.com/Automattic/wp-calypso/blob/66c1aea529d734ee3cab9f5a1a877bd2ee5b963e/package.json#L151) everywhere in calypso) but some parts of calypso are using the [deprecated](https://github.com/Automattic/wp-calypso/blob/66c1aea529d734ee3cab9f5a1a877bd2ee5b963e/packages/components/src/button/index.tsx#L107-L111) button in the @automattic/components package which has [a hard-coded color](https://github.com/Automattic/wp-calypso/blob/66c1aea529d734ee3cab9f5a1a877bd2ee5b963e/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss#L14) (from the `@automattic/calypso-color-schemes` package) that happens to match the one in color-studio 3.0. In https://github.com/Automattic/wp-calypso/pull/94148 I'm updating all of calypso to use the latest version of the color-studio package.

However, checkout currently [uses the color](https://github.com/Automattic/color-studio/blob/trunk/dist/colors.json#L26) `Blue 50` for its buttons, and [the blue used by the "correct" color scheme](https://github.com/Automattic/color-studio/blob/trunk/dist/colors.json#L143) is actually `WordPress Blue 50`. So to get the correct color in checkout we need to also update the `@automattic/composite-checkout` package to be use `WordPress Blue` instead.

## Proposed changes

In this PR I'm updating the colors used by the `@automattic/composite-checkout` package theme (and the Jetpack variant) to use "WordPress Blue" instead of "Blue".

## Screenshot

This change by itself:


Before             |  After
:-------------------------:|:-------------------------:
<img width="446" alt="Screenshot 2024-09-03 at 11 29 05 AM" src="https://github.com/user-attachments/assets/30048ef5-9066-4de9-833b-3f7856bc09aa"> | <img width="446" alt="Screenshot 2024-09-03 at 11 59 33 AM" src="https://github.com/user-attachments/assets/0e2a8022-28f1-4c75-8e6c-e711026d0cff">


With https://github.com/Automattic/wp-calypso/pull/94148 also applied:

Before             |  After
:-------------------------:|:-------------------------:
<img width="446" alt="Screenshot 2024-09-03 at 11 29 05 AM" src="https://github.com/user-attachments/assets/30048ef5-9066-4de9-833b-3f7856bc09aa"> | <img width="439" alt="Screenshot 2024-09-03 at 11 43 27 AM" src="https://github.com/user-attachments/assets/b78c6603-5e2d-4faf-924b-f7a3832036b3">

## Testing Instructions

- Add a product to your cart and visit checkout.
- If the steps are collapsed (auto-completed), click to "Edit" the tax information step ("Billing details" or "Contact details").
- Examine the color of the "Continue to payment" button and verify it is `#006088` (previously`#0675c4`).
- Optional: also apply https://github.com/Automattic/wp-calypso/pull/94148 and verify that the color has changed to `#3858e9`.