### PR TITLE
Update color-studio package to 3.0.1

### DIFF
--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -29,7 +29,7 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",
-		"@automattic/color-studio": "2.6.0",
+		"@automattic/color-studio": "^3.0.1",
 		"@automattic/components": "workspace:^",
 		"@automattic/format-currency": "workspace:^",
 		"@automattic/typography": "workspace:^",

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
 		"@automattic/calypso-sentry": "workspace:^",
 		"@automattic/calypso-stripe": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
-		"@automattic/color-studio": "2.6.0",
+		"@automattic/color-studio": "^3.0.1",
 		"@automattic/command-palette": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-razorpay": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
-		"@automattic/color-studio": "2.6.0",
+		"@automattic/color-studio": "^3.0.1",
 		"@automattic/command-palette": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -28,7 +28,7 @@
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@automattic/color-studio": "2.6.0",
+		"@automattic/color-studio": "^3.0.1",
 		"postcss": "^8.4.5",
 		"postcss-custom-properties": "^11.0.0",
 		"sass": "^1.37.5"

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -46,7 +46,7 @@
 	"devDependencies": {
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@automattic/color-studio": "2.6.0",
+		"@automattic/color-studio": "^3.0.1",
 		"@storybook/cli": "^7.6.19",
 		"@storybook/react": "^7.6.19",
 		"@testing-library/dom": "^10.1.0",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -27,7 +27,7 @@
 	],
 	"types": "dist/types",
 	"dependencies": {
-		"@automattic/color-studio": "2.6.0",
+		"@automattic/color-studio": "^3.0.1",
 		"@automattic/typography": "1.0.0",
 		"@wordpress/base-styles": "5.2.0",
 		"@wordpress/block-editor": "^13.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,7 +322,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/color-studio": "npm:2.6.0"
+    "@automattic/color-studio": "npm:^3.0.1"
     postcss: "npm:^8.4.5"
     postcss-custom-properties: "npm:^11.0.0"
     sass: "npm:^1.37.5"
@@ -545,10 +545,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/color-studio@npm:2.6.0":
-  version: 2.6.0
-  resolution: "@automattic/color-studio@npm:2.6.0"
-  checksum: 1171df1d9b92b2734950239eb82250fe53f45d09485fd18b2aa62a40aaabbaa1c127898da97319f871e137254aae9ed7141e2aae30ec09f0151f515af8516510
+"@automattic/color-studio@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@automattic/color-studio@npm:3.0.1"
+  checksum: 1fed9e35e5a4cf283055d323661bf94f8836fbe762c3a1ff7c514407c9cffcae9b05791fb2d4904050c097e939b745c8f2bc13cc84c9963d35c9d1aa57f1fbd8
   languageName: node
   linkType: hard
 
@@ -673,7 +673,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/color-studio": "npm:2.6.0"
+    "@automattic/color-studio": "npm:^3.0.1"
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@storybook/cli": "npm:^7.6.19"
@@ -1592,7 +1592,7 @@ __metadata:
   resolution: "@automattic/page-pattern-modal@workspace:packages/page-pattern-modal"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/color-studio": "npm:2.6.0"
+    "@automattic/color-studio": "npm:^3.0.1"
     "@automattic/typography": "npm:1.0.0"
     "@testing-library/react": "npm:^15.0.7"
     "@wordpress/base-styles": "npm:5.2.0"
@@ -12661,7 +12661,7 @@ __metadata:
     "@automattic/calypso-sentry": "workspace:^"
     "@automattic/calypso-stripe": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
-    "@automattic/color-studio": "npm:2.6.0"
+    "@automattic/color-studio": "npm:^3.0.1"
     "@automattic/command-palette": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
@@ -19287,7 +19287,7 @@ __metadata:
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-products": "workspace:^"
-    "@automattic/color-studio": "npm:2.6.0"
+    "@automattic/color-studio": "npm:^3.0.1"
     "@automattic/components": "workspace:^"
     "@automattic/format-currency": "workspace:^"
     "@automattic/typography": "workspace:^"
@@ -34502,7 +34502,7 @@ __metadata:
     "@automattic/calypso-razorpay": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
-    "@automattic/color-studio": "npm:2.6.0"
+    "@automattic/color-studio": "npm:^3.0.1"
     "@automattic/command-palette": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"


### PR DESCRIPTION
## Background

I was [researching](https://github.com/Automattic/payments-shilling/issues/3060) why the buttons in checkout are a different shade of blue than other parts of calypso and found that the `@automattic/color-studio` package is out-of-date everywhere.

For example, see the color difference between these two buttons:

Outside checkout             |  Checkout
:-------------------------:|:-------------------------:
<img width="676" alt="Screenshot 2024-09-03 at 10 45 43 AM" src="https://github.com/user-attachments/assets/28b97c53-bb70-4f50-95aa-6e68422c49d6"> | <img width="636" alt="Screenshot 2024-09-03 at 10 59 29 AM" src="https://github.com/user-attachments/assets/105575a9-d33c-4c99-963c-4bb1379d236d">

It turns out that checkout is actually doing the right thing and [using the color directly](https://github.com/Automattic/wp-calypso/blob/66c1aea529d734ee3cab9f5a1a877bd2ee5b963e/packages/composite-checkout/src/lib/theme.ts#L63) from the `@automattic/color-studio` package (which [is outdated as version 2.6](https://github.com/Automattic/wp-calypso/blob/66c1aea529d734ee3cab9f5a1a877bd2ee5b963e/package.json#L151) everywhere in calypso) but some parts of calypso are using the [deprecated](https://github.com/Automattic/wp-calypso/blob/66c1aea529d734ee3cab9f5a1a877bd2ee5b963e/packages/components/src/button/index.tsx#L107-L111) button in the `@automattic/components` package which has [a hard-coded color](https://github.com/Automattic/wp-calypso/blob/66c1aea529d734ee3cab9f5a1a877bd2ee5b963e/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss#L14) (from the `@automattic/calypso-color-schemes` package) that happens to match the one in color-studio 3.0.

## Proposed changes

In this PR I'm updating all versions of `@automattic/color-studio` to the latest version (3.0.1) so that the colors will be the same everywhere.

> [!NOTE]
> Checkout currently [uses the color](https://github.com/Automattic/color-studio/blob/trunk/dist/colors.json#L26) `Blue 50` for its buttons, but [the blue used by the "correct" color scheme](https://github.com/Automattic/color-studio/blob/trunk/dist/colors.json#L143) is actually `WordPress Blue 50`. So to get the correct color in checkout we need to also update the composite-checkout package to use WordPress Blue instead which will happen in https://github.com/Automattic/wp-calypso/pull/94147.

## Screenshot

With https://github.com/Automattic/wp-calypso/pull/94147 applied also:

Before             |  After
:-------------------------:|:-------------------------:
<img width="446" alt="Screenshot 2024-09-03 at 11 29 05 AM" src="https://github.com/user-attachments/assets/30048ef5-9066-4de9-833b-3f7856bc09aa"> | <img width="439" alt="Screenshot 2024-09-03 at 11 43 27 AM" src="https://github.com/user-attachments/assets/b78c6603-5e2d-4faf-924b-f7a3832036b3">

## Testing Instructions

This will affect the colors all over calypso so testing a lot of different pages is important. That said, I'm not sure the best way to verify the safety of this change since it's so wide-spread. Suggestions are welcome! 

You can at least see how it affects checkout by also applying https://github.com/Automattic/wp-calypso/pull/94147 (see screenshots above).
