### PR TITLE
Site setup: Update image in mobile design choice step

### DIFF
--- a/client/components/themes-list/test/__snapshots__/index.jsx.snap
+++ b/client/components/themes-list/test/__snapshots__/index.jsx.snap
@@ -20,7 +20,7 @@ exports[`ThemesList should render a div with a className of "themes-list" 1`] = 
         <img
           alt="Pattern Assembler"
           class="pattern-assembler-cta__image"
-          src="assembler-illustration.png"
+          src="assembler-illustration-v2.png"
         />
       </div>
       <div

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
-import assemblerIllustrationImage from '../assets/images/assembler-illustration.png';
+import assemblerIllustrationV2Image from '../assets/images/assembler-illustration-v2.png';
 import './style.scss';
 
 type PatternAssemblerCtaData = {
@@ -49,7 +49,7 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 			<div className="pattern-assembler-cta__image-wrapper">
 				<img
 					className="pattern-assembler-cta__image"
-					src={ assemblerIllustrationImage }
+					src={ assemblerIllustrationV2Image }
 					alt="Pattern Assembler"
 				/>
 			</div>

--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -132,7 +132,6 @@
 	}
 
 	.pattern-assembler-cta__image-wrapper {
-		padding-left: 35px;
 		text-align: right;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8872

Follow up to https://github.com/Automattic/wp-calypso/pull/94135

## Proposed Changes

* Update the image used in design choice step on mobile

## Before
<img width="1049" alt="Screenshot 2024-09-03 at 9 55 18 AM" src="https://github.com/user-attachments/assets/c68997ee-7d12-4c84-87f4-8bfe466f31d6">

## After
<img width="1163" alt="Screenshot 2024-09-03 at 17 01 21" src="https://github.com/user-attachments/assets/c8d3cd81-83d9-4f18-87b4-98a1868ffbcf">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Logical flows project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new test site in mobile device (using dev tools)
* Select free plan, then `Promote myself or business` site goal
* Scroll to bottom of design choice to see new image introduced in https://github.com/Automattic/wp-calypso/pull/94135
* Confirm looks ok

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
