### PR TITLE
A4A Dev Sites: Add `Allow clients to use the WordPress.com Help Center and hosting features setting` (`is_fully_managed_agency_site`) toggle

### DIFF
--- a/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
+++ b/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
@@ -25,6 +25,7 @@ export function A4AFullyManagedSiteSetting( {
 	disabled,
 }: Props ) {
 	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
+	const isDevSite = site.is_a4a_dev_site;
 	const isAtomicSite = site.is_wpcom_atomic;
 
 	const { data: agencySite } = useFetchAgencyFromBlog( site?.ID, { enabled: !! site?.ID } );
@@ -35,6 +36,27 @@ export function A4AFullyManagedSiteSetting( {
 		return null;
 	}
 
+	const translationComponents = {
+		HcLink: (
+			<a
+				target="_blank"
+				href={ localizeUrl(
+					'https://wordpress.com/support/help-support-options/#how-to-contact-us'
+				) }
+				rel="noreferrer"
+			/>
+		),
+		HfLink: (
+			<a
+				target="_blank"
+				href={ localizeUrl(
+					'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
+				) }
+				rel="noreferrer"
+			/>
+		),
+	};
+
 	return (
 		<div className="site-settings__a4a-fully-managed-container">
 			<SettingsSectionHeader
@@ -43,40 +65,32 @@ export function A4AFullyManagedSiteSetting( {
 				disabled={ disabled }
 				isSaving={ isSaving }
 				onButtonClick={ onSaveSetting }
-				showButton
+				showButton={ ! isDevSite }
 			/>
 			<CompactCard className="site-settings__a4a-fully-managed-content">
-				<ToggleControl
-					disabled={ disabled }
-					className="site-settings__a4a-fully-managed-toggle"
-					label={ translate(
-						'Allow clients to use the {{HcLink}}WordPress.com Help Center{{/HcLink}} and {{HfLink}}hosting features.{{/HfLink}}',
-						{
-							components: {
-								HcLink: (
-									<a
-										target="_blank"
-										href={ localizeUrl(
-											'https://wordpress.com/support/help-support-options/#how-to-contact-us'
-										) }
-										rel="noreferrer"
-									/>
-								),
-								HfLink: (
-									<a
-										target="_blank"
-										href={ localizeUrl(
-											'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
-										) }
-										rel="noreferrer"
-									/>
-								),
-							},
-						}
-					) }
-					checked={ ! isFullyManagedAgencySite }
-					onChange={ ( checked ) => onChange( ! checked ) }
-				/>
+				{ isDevSite ? (
+					<p className="form-setting-explanation">
+						{ translate(
+							"Clients can't access the {{HcLink}}WordPress.com Help Center{{/HcLink}} or {{HfLink}}hosting features{{/HfLink}} on development sites. Once the site is launched, enable access in Site Settings.",
+							{
+								components: translationComponents,
+							}
+						) }
+					</p>
+				) : (
+					<ToggleControl
+						disabled={ disabled }
+						className="site-settings__a4a-fully-managed-toggle"
+						label={ translate(
+							'Allow clients to use the {{HcLink}}WordPress.com Help Center{{/HcLink}} and {{HfLink}}hosting features.{{/HfLink}}',
+							{
+								components: translationComponents,
+							}
+						) }
+						checked={ ! isFullyManagedAgencySite }
+						onChange={ ( checked ) => onChange( ! checked ) }
+					/>
+				) }
 			</CompactCard>
 		</div>
 	);

--- a/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
+++ b/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
@@ -1,12 +1,29 @@
 import config from '@automattic/calypso-config';
+import { CompactCard } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { ToggleControl } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
 import useFetchAgencyFromBlog from 'calypso/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import type { SiteDetails } from '@automattic/data-stores';
 
 type Props = {
 	site: SiteDetails;
+	checked: boolean;
+	onChange: ( value: boolean ) => void;
+	isSaving?: boolean;
+	onSaveSetting: () => void;
+	disabled: boolean;
 };
 
-export function A4AFullyManagedSiteSetting( { site }: Props ) {
+export function A4AFullyManagedSiteSetting( {
+	site,
+	checked,
+	onChange,
+	isSaving,
+	onSaveSetting,
+	disabled,
+}: Props ) {
 	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 	const isAtomicSite = site.is_wpcom_atomic;
 
@@ -18,5 +35,49 @@ export function A4AFullyManagedSiteSetting( { site }: Props ) {
 		return null;
 	}
 
-	return <div>Toogle</div>;
+	return (
+		<div className="site-settings__a4a-fully-managed-container">
+			<SettingsSectionHeader
+				title={ translate( 'Help Center and hosting features visibility' ) }
+				id="site-settings__a4a-fully-managed-header"
+				disabled={ disabled }
+				isSaving={ isSaving }
+				onButtonClick={ onSaveSetting }
+				showButton
+			/>
+			<CompactCard className="site-settings__a4a-fully-managed-content">
+				<ToggleControl
+					disabled={ disabled }
+					className="site-settings__a4a-fully-managed-toggle"
+					label={ translate(
+						'Allow clients to use the {{HcLink}}WordPress.com Help Center{{/HcLink}} and {{HfLink}}hosting features.{{/HfLink}}',
+						{
+							components: {
+								HcLink: (
+									<a
+										target="_blank"
+										href={ localizeUrl(
+											'https://wordpress.com/support/help-support-options/#how-to-contact-us'
+										) }
+										rel="noreferrer"
+									/>
+								),
+								HfLink: (
+									<a
+										target="_blank"
+										href={ localizeUrl(
+											'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
+										) }
+										rel="noreferrer"
+									/>
+								),
+							},
+						}
+					) }
+					checked={ checked }
+					onChange={ onChange }
+				/>
+			</CompactCard>
+		</div>
+	);
 }

--- a/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
+++ b/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
@@ -9,7 +9,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 type Props = {
 	site: SiteDetails;
-	checked: boolean;
+	isFullyManagedAgencySite: boolean;
 	onChange: ( value: boolean ) => void;
 	isSaving?: boolean;
 	onSaveSetting: () => void;
@@ -18,7 +18,7 @@ type Props = {
 
 export function A4AFullyManagedSiteSetting( {
 	site,
-	checked,
+	isFullyManagedAgencySite,
 	onChange,
 	isSaving,
 	onSaveSetting,
@@ -74,8 +74,8 @@ export function A4AFullyManagedSiteSetting( {
 							},
 						}
 					) }
-					checked={ checked }
-					onChange={ onChange }
+					checked={ ! isFullyManagedAgencySite }
+					onChange={ ( checked ) => onChange( ! checked ) }
 				/>
 			</CompactCard>
 		</div>

--- a/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
+++ b/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
@@ -1,0 +1,23 @@
+import config from '@automattic/calypso-config';
+import useFetchAgencyFromBlog from 'calypso/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog';
+import type { SiteDetails } from '@automattic/data-stores';
+
+type Props = {
+	site: SiteDetails;
+};
+
+export function A4AFullyManagedSiteSetting( { site }: Props ) {
+	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
+	const isDevSite = site.is_a4a_dev_site;
+	const isAtomicSite = site.is_wpcom_atomic;
+
+	const { data: agencySite } = useFetchAgencyFromBlog( site?.ID, { enabled: !! site?.ID } );
+
+	const shouldShowToggle = devSitesEnabled && agencySite && isAtomicSite && ! isDevSite;
+
+	if ( ! shouldShowToggle ) {
+		return null;
+	}
+
+	return <div>Toogle</div>;
+}

--- a/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
+++ b/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
@@ -8,12 +8,11 @@ type Props = {
 
 export function A4AFullyManagedSiteSetting( { site }: Props ) {
 	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
-	const isDevSite = site.is_a4a_dev_site;
 	const isAtomicSite = site.is_wpcom_atomic;
 
 	const { data: agencySite } = useFetchAgencyFromBlog( site?.ID, { enabled: !! site?.ID } );
 
-	const shouldShowToggle = devSitesEnabled && agencySite && isAtomicSite && ! isDevSite;
+	const shouldShowToggle = devSitesEnabled && agencySite && isAtomicSite;
 
 	if ( ! shouldShowToggle ) {
 		return null;

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -565,6 +565,7 @@ export class SiteSettingsFormGeneral extends Component {
 	render() {
 		const {
 			customizerUrl,
+			fields,
 			handleSubmitForm,
 			hasNoWpcomBranding,
 			isRequestingSettings,
@@ -621,7 +622,14 @@ export class SiteSettingsFormGeneral extends Component {
 				) : (
 					this.privacySettings()
 				) }
-				<A4AFullyManagedSiteSetting site={ site } />
+				<A4AFullyManagedSiteSetting
+					site={ site }
+					checked={ fields.wpcom_gifting_subscription }
+					onChange={ this.props.handleToggle( 'wpcom_gifting_subscription' ) }
+					isSaving={ isSavingSettings }
+					onSaveSetting={ handleSubmitForm }
+					disabled={ isRequestingSettings || isSavingSettings }
+				/>
 				{ this.enhancedOwnershipSettings() }
 				<DIFMUpsell
 					site={ site }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -65,6 +65,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import { A4AFullyManagedSiteSetting } from './a4a-fully-managed-site-setting';
 import { DIFMUpsell } from './difm-upsell-banner';
 import Masterbar from './masterbar';
 import SiteAdminInterface from './site-admin-interface';
@@ -620,6 +621,7 @@ export class SiteSettingsFormGeneral extends Component {
 				) : (
 					this.privacySettings()
 				) }
+				<A4AFullyManagedSiteSetting site={ site } isWpcomStagingSite={ isWpcomStagingSite } />
 				{ this.enhancedOwnershipSettings() }
 				<DIFMUpsell
 					site={ site }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -624,7 +624,7 @@ export class SiteSettingsFormGeneral extends Component {
 				) }
 				<A4AFullyManagedSiteSetting
 					site={ site }
-					checked={ fields.is_fully_managed_agency_site }
+					isFullyManagedAgencySite={ fields.is_fully_managed_agency_site }
 					onChange={ this.props.handleToggle( 'is_fully_managed_agency_site' ) }
 					isSaving={ isSavingSettings }
 					onSaveSetting={ handleSubmitForm }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -624,8 +624,8 @@ export class SiteSettingsFormGeneral extends Component {
 				) }
 				<A4AFullyManagedSiteSetting
 					site={ site }
-					checked={ fields.wpcom_gifting_subscription }
-					onChange={ this.props.handleToggle( 'wpcom_gifting_subscription' ) }
+					checked={ fields.is_fully_managed_agency_site }
+					onChange={ this.props.handleToggle( 'is_fully_managed_agency_site' ) }
 					isSaving={ isSavingSettings }
 					onSaveSetting={ handleSubmitForm }
 					disabled={ isRequestingSettings || isSavingSettings }
@@ -758,6 +758,7 @@ const getFormSettings = ( settings ) => {
 		wpcom_public_coming_soon: '',
 		wpcom_gifting_subscription: false,
 		admin_url: '',
+		is_fully_managed_agency_site: false,
 	};
 
 	if ( ! settings ) {
@@ -771,6 +772,8 @@ const getFormSettings = ( settings ) => {
 		lang_id: settings.lang_id,
 		blog_public: settings.blog_public,
 		timezone_string: settings.timezone_string,
+
+		is_fully_managed_agency_site: settings.is_fully_managed_agency_site,
 
 		wpcom_coming_soon: settings.wpcom_coming_soon,
 		wpcom_data_sharing_opt_out: !! settings.wpcom_data_sharing_opt_out,

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -621,7 +621,7 @@ export class SiteSettingsFormGeneral extends Component {
 				) : (
 					this.privacySettings()
 				) }
-				<A4AFullyManagedSiteSetting site={ site } isWpcomStagingSite={ isWpcomStagingSite } />
+				<A4AFullyManagedSiteSetting site={ site } />
 				{ this.enhancedOwnershipSettings() }
 				<DIFMUpsell
 					site={ site }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -628,7 +628,8 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	margin-bottom: 16px;
 }
 
-.site-settings__gifting-container {
+.site-settings__gifting-container,
+.site-settings__a4a-fully-managed-container {
 	margin-bottom: 16px;
 	p {
 		font-style: italic;

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -89,6 +89,7 @@ const props = {
 	selectedSite: {},
 	translate: ( x ) => x,
 	onChangeField: () => ( z ) => z,
+	handleToggle: () => ( z ) => z,
 	eventTracker: () => ( z ) => z,
 	trackEvent: () => ( z ) => z,
 	updateFields: () => ( z ) => z,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8922.

## Proposed Changes

* introduce `A4AFullyManagedSiteSetting` component and related toggle
* mock `handleToggle` function for related unit tests

![Markup on 2024-09-04 at 12:04:28](https://github.com/user-attachments/assets/fd09565b-753f-40a4-8496-7fa7b87bcc42)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

We will need to test the changes with different kind of sites:

- Simple site
- Atomic agency site
- Atomic agency dev site
- Atomic non-agency site
- Jetpack-connected site

---

1. Check out this PR and build the app.
2. When testing with Atomic or Jetpack sites, install the Jetpack Beta Tester plugin and checkout the latest Jetpack trunk. Related PR: https://github.com/Automattic/jetpack/pull/39223.
3. Navigate to the General Settings in Calypso at `http://calypso.localhost:3000/settings/general/{site-slug}?flags=a4a-dev-sites`. Please note the feature flag.
4. When testing with Atomic agency sites, there's should be a new toggle (as can be seen in the screenshot above) - unless the site is a free dev site.
5. If the toggle is displayed, it should be fully operational and change the `is_fully_managed_agency_site` setting / blog option.
6. If the site a dev site, the toggle shouldn't be available, but an explanation text should be displayed instead.
7. The toggle should not be available on other sites (e.g. Simple sites, Jetpack-connected sites).

You can also create a new WPCOM agency site (or dev site) and check whether the `is_fully_managed_agency_site` setting is correctly reflected in the toggle.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?