### PR TITLE
Stats: Apply the notice mechanism to prevent feedback form submission spamming

### DIFF
--- a/client/my-sites/stats/components/stats-button/stats-button.tsx
+++ b/client/my-sites/stats/components/stats-button/stats-button.tsx
@@ -8,6 +8,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 interface StatsButtonProps extends React.ButtonHTMLAttributes< HTMLButtonElement > {
 	children?: React.ReactNode;
 	primary?: boolean;
+	busy?: boolean;
 }
 
 const StatsButton: React.FC< StatsButtonProps > = ( { children, primary, ...rest } ) => {

--- a/client/my-sites/stats/components/stats-button/stats-button.tsx
+++ b/client/my-sites/stats/components/stats-button/stats-button.tsx
@@ -24,6 +24,7 @@ const StatsButton: React.FC< StatsButtonProps > = ( { children, primary, ...rest
 				} ) }
 				variant="primary"
 				primary={ isWPCOMSite ? true : undefined }
+				isBusy={ rest.busy }
 				{ ...rest }
 			>
 				{ children }

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -3,7 +3,7 @@ import FeedbackModal from './modal';
 
 import './style.scss';
 
-function StatsFeedbackCard() {
+function StatsFeedbackCard( { siteId }: { siteId: number } ) {
 	// A simple card component with feedback buttons.
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -16,7 +16,7 @@ function StatsFeedbackCard() {
 				<button>one</button>
 				<button onClick={ () => setIsOpen( true ) }>two</button>
 			</div>
-			<FeedbackModal isOpen={ isOpen } onClose={ () => setIsOpen( false ) } />
+			{ isOpen && <FeedbackModal siteId={ siteId } onClose={ () => setIsOpen( false ) } /> }
 		</div>
 	);
 }

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -88,7 +88,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 					<StatsButton
 						primary
 						onClick={ onFormSubmit }
-						busy={ isSubmittingFeedback || isSubmissionSuccessful }
+						busy={ isSubmittingFeedback }
 						disabled={ isSubmittingFeedback || isSubmissionSuccessful || ! content }
 					>
 						{ translate( 'Submit' ) }

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -1,32 +1,61 @@
 import { Button, Modal, TextareaControl } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import React, { useState } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import StatsButton from 'calypso/my-sites/stats/components/stats-button';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
+import useSubmitProductFeedback from './use-submit-product-feedback';
 
 import './style.scss';
 
 interface ModalProps {
-	isOpen: boolean;
+	siteId: number;
 	onClose: () => void;
 }
 
-const FeedbackModal: React.FC< ModalProps > = ( { isOpen, onClose } ) => {
+const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 	const translate = useTranslate();
-	const [ isAnimating, setIsAnimating ] = useState( false );
+	const dispatch = useDispatch();
 	const [ content, setContent ] = useState( '' );
 
-	const handleClose = () => {
-		setIsAnimating( true );
+	const { isSubmittingFeedback, submitFeedback, isSubmissionSuccessful } =
+		useSubmitProductFeedback( siteId );
+
+	const handleClose = useCallback( () => {
 		setTimeout( () => {
-			setIsAnimating( false );
 			onClose();
 		}, 200 );
-	};
+	}, [ onClose ] );
 
-	if ( ! isOpen && ! isAnimating ) {
-		return null;
-	}
+	const onFormSubmit = useCallback( () => {
+		if ( ! content ) {
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_stats_user_feedback_form_submit', {
+				feedback: content,
+			} )
+		);
+
+		const sourceUrl = `${ window.location.origin }${ window.location.pathname }`;
+		submitFeedback( { source_url: sourceUrl, product_name: 'Jetpack Stats', feedback: content } );
+	}, [ dispatch, content, submitFeedback ] );
+
+	useEffect( () => {
+		if ( isSubmissionSuccessful ) {
+			dispatch(
+				successNotice( translate( 'Thank you for your feedback!' ), {
+					id: 'submit-product-feedback-success',
+					duration: 5000,
+				} )
+			);
+
+			handleClose();
+		}
+	}, [ dispatch, isSubmissionSuccessful, handleClose, translate ] );
 
 	return (
 		<Modal className="stats-feedback-modal" onRequestClose={ handleClose } __experimentalHideHeader>
@@ -56,7 +85,14 @@ const FeedbackModal: React.FC< ModalProps > = ( { isOpen, onClose } ) => {
 					onChange={ setContent }
 				/>
 				<div className="stats-feedback-modal__button">
-					<StatsButton primary>{ translate( 'Submit' ) }</StatsButton>
+					<StatsButton
+						primary
+						onClick={ onFormSubmit }
+						busy={ isSubmittingFeedback || isSubmissionSuccessful }
+						disabled={ isSubmittingFeedback || isSubmissionSuccessful || ! content }
+					>
+						{ translate( 'Submit' ) }
+					</StatsButton>
 				</div>
 			</div>
 		</Modal>

--- a/client/my-sites/stats/feedback/modal/style.scss
+++ b/client/my-sites/stats/feedback/modal/style.scss
@@ -44,12 +44,18 @@
 }
 
 .stats-feedback-modal__button {
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
 	margin-top: 24px;
 	font-family: $font-sf-pro-text;
 	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 20px;
-	text-align: right;
+
+	small {
+		margin-right: 8px;
+	}
 
 	button {
 		padding: 10px 16px;

--- a/client/my-sites/stats/feedback/modal/use-submit-product-feedback-mutation.ts
+++ b/client/my-sites/stats/feedback/modal/use-submit-product-feedback-mutation.ts
@@ -1,0 +1,29 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import type { SubmitJetpackStatsFeedbackParams } from './use-submit-product-feedback';
+import type { APIError } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+interface APIResponse {
+	success: boolean;
+}
+
+function mutationSubmitProductFeedback(
+	params: SubmitJetpackStatsFeedbackParams,
+	siteId?: number
+): Promise< APIResponse > {
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ siteId }/jetpack-stats/user-feedback`,
+		body: params,
+	} );
+}
+
+export default function useSubmitProductFeedbackMutation< TContext = unknown >(
+	siteId?: number,
+	options?: UseMutationOptions< APIResponse, APIError, SubmitJetpackStatsFeedbackParams, TContext >
+): UseMutationResult< APIResponse, APIError, SubmitJetpackStatsFeedbackParams, TContext > {
+	return useMutation< APIResponse, APIError, SubmitJetpackStatsFeedbackParams, TContext >( {
+		...options,
+		mutationFn: ( params ) => mutationSubmitProductFeedback( params, siteId ),
+	} );
+}

--- a/client/my-sites/stats/feedback/modal/use-submit-product-feedback.ts
+++ b/client/my-sites/stats/feedback/modal/use-submit-product-feedback.ts
@@ -1,0 +1,47 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useDispatch } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
+import useSubmitProductFeedbackMutation from './use-submit-product-feedback-mutation';
+
+export interface SubmitJetpackStatsFeedbackParams {
+	source_url: string;
+	product_name: string;
+	feedback: string;
+}
+
+export default function useSubmitProductFeedback( siteId: number ): {
+	isSubmittingFeedback: boolean;
+	submitFeedback: ( params: SubmitJetpackStatsFeedbackParams ) => void;
+	isSubmissionSuccessful: boolean;
+	resetMutation: () => void;
+} {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const {
+		isError,
+		isSuccess,
+		mutate,
+		isPending: isSubmittingFeedback,
+		reset,
+	} = useSubmitProductFeedbackMutation( siteId );
+
+	useEffect( () => {
+		if ( isError ) {
+			dispatch(
+				errorNotice( translate( 'Something went wrong. Please try again.' ), {
+					id: 'submit-product-feedback-failure',
+					duration: 5000,
+				} )
+			);
+		}
+	}, [ translate, isError, dispatch ] );
+
+	return {
+		isSubmittingFeedback,
+		submitFeedback: mutate,
+		isSubmissionSuccessful: isSuccess,
+		resetMutation: reset,
+	};
+}

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -12,6 +12,7 @@ const DEFAULT_SERVER_NOTICES_VISIBILITY = {
 	// TODO: Check if the site needs to be upgraded to a higher tier on the back end.
 	tier_upgrade: true,
 	gdpr_cookie_consent: false,
+	able_to_submit_user_feedback: false,
 };
 const DEFAULT_CLIENT_NOTICES_VISIBILITY = {
 	client_paid_plan_purchase_success: true,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -810,7 +810,7 @@ class StatsSite extends Component {
 					<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />
 				) }
 				<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
-				{ isFeedbackCardEnabled && <StatsFeedbackCard /> }
+				{ isFeedbackCardEnabled && <StatsFeedbackCard siteId={ siteId } /> }
 				<JetpackColophon />
 				<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
 				{ this.props.upsellModalView && <StatsUpsellModal siteId={ siteId } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/157

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the Diff D160350-code and sandbox `public-api.wordpress.com`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?