### PR TITLE
Admin bar: Observe reader tooltip announcement position

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -128,6 +128,9 @@ class MasterbarLoggedIn extends Component {
 	};
 
 	setupReaderPositionObserver() {
+		if ( this.props.sectionName !== 'home' && this.props.sectionGroup !== 'sites-dashboard' ) {
+			return;
+		}
 		const readerItem = document.querySelector( '.masterbar__reader' );
 		this.resizeObserver = new ResizeObserver(
 			debounce( () => {

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -81,6 +81,7 @@ class MasterbarLoggedIn extends Component {
 		// making the ref a state triggers a re-render when it changes (needed for popover)
 		menuBtnRef: null,
 		readerBtnRef: null,
+		readerPosition: null,
 	};
 
 	static propTypes = {
@@ -138,12 +139,36 @@ class MasterbarLoggedIn extends Component {
 		};
 		document.addEventListener( 'keydown', this.actionSearchShortCutListener );
 		this.subscribeToViewPortChanges();
+
+		// Observe if the position of the reader item has changed.
+		this.observer = new window.MutationObserver( () => {
+			const readerItem = document.querySelector( '.masterbar__reader' );
+			if ( readerItem ) {
+				const rect = readerItem.getBoundingClientRect();
+				if ( this.state.readerPosition ) {
+					if (
+						rect.left !== this.lastReaderPosition.left ||
+						rect.top !== this.lastReaderPosition.top
+					) {
+						this.setState( { readerPosition: rect } );
+					}
+				} else {
+					this.setState( { readerPosition: rect } );
+				}
+				this.lastReaderPosition = rect;
+			}
+		} );
+		this.observer.observe( document.body, { attributes: true, childList: true, subtree: true } );
 	}
 
 	componentWillUnmount() {
 		document.removeEventListener( 'keydown', this.actionSearchShortCutListener );
 		this.unsubscribeToViewPortChanges?.();
 		this.unsubscribeResponsiveMenuViewPortChanges?.();
+
+		if ( this.observer ) {
+			this.observer.disconnect();
+		}
 	}
 
 	handleToggleMobileMenu = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/93972

## Proposed Changes

* Observe reader icon position changes and re-render if needed.

https://github.com/user-attachments/assets/39bdfd78-02cd-454c-8e53-cd6436c0730e


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See p1725383088956799-slack-C03NLNTPZ2T -- the Help Center occasionally loads late enough to move the Reader icon over, which makes the tooltip look like it's pointing to the Help Center.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally.
* Add a timeout to `renderHelpCenter()` in /client/layout/masterbar/logged-in.jsx:

```
renderHelpCenter() {
		const { siteId, translate } = this.props;

		// Set a timeout before rendering the help center.
		setTimeout( () => {
			console.log( 'masterbar rect', this.masterbarRef.current.getBoundingClientRect() );
		}, 1000 );

		return (
			...
```
* Check that the Reader tooltip position adjusts after the Help Center icon loads.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?