### PR TITLE
Overview panel: Remove upgrade buttons "primary" and "compact" styling

### DIFF
--- a/client/hosting/overview/components/plan-card.tsx
+++ b/client/hosting/overview/components/plan-card.tsx
@@ -128,8 +128,6 @@ const PricingSection: FC = () => {
 					<div className="hosting-overview__plan-cta">
 						{ isFreePlan && (
 							<Button
-								primary
-								compact
 								href={ `/plans/${ site?.slug }` }
 								onClick={ () =>
 									dispatch( recordTracksEvent( 'calypso_hosting_overview_upgrade_plan_click' ) )

--- a/client/hosting/overview/components/site-backup-card/index.js
+++ b/client/hosting/overview/components/site-backup-card/index.js
@@ -67,8 +67,6 @@ const SiteBackupCard = ( { lastGoodBackup, requestBackups, siteId, siteSlug } ) 
 						) }
 					</p>
 					<Button
-						primary
-						compact
 						href={ addQueryArgs( `/plans/${ siteSlug }`, {
 							feature: WPCOM_FEATURES_BACKUPS,
 							plan: PLAN_BUSINESS,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8783

## Proposed Changes

* Remove upgrade buttons "primary" and "compact" styling on /overview/[siteSlug]

Before | After
--|--
<img width="1719" alt="Screenshot 2024-09-03 at 4 38 44 PM" src="https://github.com/user-attachments/assets/39bf8418-c2ae-4d52-b334-800e6c590825">  | <img width="1720" alt="Screenshot 2024-09-03 at 4 38 30 PM" src="https://github.com/user-attachments/assets/40ea90f5-1346-4d89-8a37-c1b509414c31">





## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Decrease competition for the user's attention with too many call-to-action styled buttons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /overview/[siteSlug]
* Ensure the buttons look like the After image above.
* Try clicking them.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
