### PR TITLE
Fix payment method logo spacing

### DIFF
--- a/client/my-sites/checkout/src/components/payment-method-logos.js
+++ b/client/my-sites/checkout/src/components/payment-method-logos.js
@@ -6,7 +6,6 @@ export const PaymentMethodLogos = styled.span`
 	text-align: right;
 	align-items: center;
 	justify-content: flex-end;
-	padding-inline-end: 24px;
 
 	.rtl & {
 		text-align: left;

--- a/packages/wpcom-checkout/src/payment-method-logos.tsx
+++ b/packages/wpcom-checkout/src/payment-method-logos.tsx
@@ -9,7 +9,6 @@ export const PaymentMethodLogos = styled.span`
 	text-align: right;
 	align-items: center;
 	justify-content: flex-end;
-	padding-inline-end: 24px;
 
 	.rtl & {
 		text-align: left;

--- a/packages/wpcom-checkout/src/payment-method-logos.tsx
+++ b/packages/wpcom-checkout/src/payment-method-logos.tsx
@@ -15,7 +15,7 @@ export const PaymentMethodLogos = styled.span`
 	}
 
 	svg {
-		display: block;
+		display: inline-block;
 		&.has-background {
 			padding-inline-end: 5px;
 		}


### PR DESCRIPTION
This is a follow up to the cobadge work. It looks like we serve the `payment-method-logos` from two places, wpcom-checkout and my-sites/checkout. Because of this, we have two similar PaymentMethodLogos wrapper components that apply styling to the payment methods found in Checkout and the Add Payment Method sections. 

While one had styling to set the PaymentLogo `svg` to `inline-block`, the other had set the `svg` styling to `block` which caused the logos to become left align.

| Before | After |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/aa3f93aa-cc57-4495-bd40-bf7ea38724ba) | ![image](https://github.com/user-attachments/assets/31cbeb67-b95d-4a8c-9f49-b5614f860fef) |

Related to #94123

## Proposed Changes

- Update the svg display property in both styled components to `inline-block`
- Additional changes: updated missing translation functions on some of the payment logo labels

## Testing Instructions

* Open up a Calypso.live link below and go to Checkout
* Ensure you have Google or Apple Pay set up
* Check that the payment logos for these methods are right aligned like the existing credit card methods

