### PR TITLE
Paid Newsletter: Improve UI consistancy

### DIFF
--- a/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
@@ -157,7 +157,7 @@ class AuthorMappingPane extends PureComponent {
 					} ) }
 				</div>
 				<ImporterActionButtonContainer noSpacing>
-					<ImporterActionButton disabled={ ! canStartImport } onClick={ onStartImport }>
+					<ImporterActionButton primary disabled={ ! canStartImport } onClick={ onStartImport }>
 						Continue import
 					</ImporterActionButton>
 				</ImporterActionButtonContainer>

--- a/client/my-sites/importer/newsletter/content-upload/import-summary-modal.tsx
+++ b/client/my-sites/importer/newsletter/content-upload/import-summary-modal.tsx
@@ -80,15 +80,12 @@ export default function ImportSummaryModal( {
 	return (
 		<Modal title="All set!" isDismissible={ false } onRequestClose={ onRequestClose } size="medium">
 			{ getContent( postsNumber, pagesNumber, attachmentsNumber ) }
-			<p>
-				{ authorsNumber && (
-					<>
-						<br />
-						Your Substack publication has <strong>{ authorsNumber } authors</strong>. Next, you can
-						match them with existing site users.
-					</>
-				) }
-			</p>
+			{ authorsNumber && (
+				<p>
+					Your Substack publication has <strong>{ authorsNumber } authors</strong>. Next, you can
+					match them with existing site users.
+				</p>
+			) }
 			<Button variant="primary" onClick={ onRequestClose }>
 				Continue
 			</Button>

--- a/client/my-sites/importer/newsletter/content-upload/import-summary-modal.tsx
+++ b/client/my-sites/importer/newsletter/content-upload/import-summary-modal.tsx
@@ -8,6 +8,68 @@ interface ImportSummaryModalProps {
 	authorsNumber?: number;
 }
 
+function getContent( postsNumber: number, pagesNumber: number, attachmentsNumber: number ) {
+	if ( postsNumber > 0 && pagesNumber > 0 && attachmentsNumber > 0 ) {
+		return (
+			<p>
+				We’ve found <strong>{ postsNumber } posts</strong>, <strong>{ pagesNumber } pages</strong>
+				and <strong>{ attachmentsNumber } media</strong> to import.
+			</p>
+		);
+	}
+
+	if ( postsNumber > 0 && pagesNumber > 0 ) {
+		return (
+			<p>
+				We’ve found <strong>{ postsNumber } posts</strong> and{ ' ' }
+				<strong>{ pagesNumber } pages</strong> to import.
+			</p>
+		);
+	}
+
+	if ( postsNumber > 0 && attachmentsNumber > 0 ) {
+		return (
+			<p>
+				We’ve found <strong>{ postsNumber } posts</strong> and{ ' ' }
+				<strong>{ attachmentsNumber } media</strong> to import.
+			</p>
+		);
+	}
+
+	if ( pagesNumber > 0 && attachmentsNumber > 0 ) {
+		return (
+			<p>
+				We’ve found <strong>{ pagesNumber } pages</strong> and{ ' ' }
+				<strong>{ attachmentsNumber } media</strong> to import.
+			</p>
+		);
+	}
+
+	if ( postsNumber > 0 ) {
+		return (
+			<p>
+				We’ve found <strong>{ postsNumber } posts</strong> to import.
+			</p>
+		);
+	}
+
+	if ( pagesNumber > 0 ) {
+		return (
+			<p>
+				We’ve found <strong>{ pagesNumber } pages</strong> to import.
+			</p>
+		);
+	}
+
+	if ( attachmentsNumber > 0 ) {
+		return (
+			<p>
+				We’ve found <strong>{ attachmentsNumber } media</strong> to import.
+			</p>
+		);
+	}
+}
+
 export default function ImportSummaryModal( {
 	onRequestClose,
 	postsNumber,
@@ -17,9 +79,8 @@ export default function ImportSummaryModal( {
 }: ImportSummaryModalProps ) {
 	return (
 		<Modal title="All set!" isDismissible={ false } onRequestClose={ onRequestClose } size="medium">
+			{ getContent( postsNumber, pagesNumber, attachmentsNumber ) }
 			<p>
-				We’ve found <strong>{ postsNumber } posts</strong>, <strong>{ pagesNumber } pages</strong>{ ' ' }
-				and <strong>{ attachmentsNumber } media</strong> to import.
 				{ authorsNumber && (
 					<>
 						<br />

--- a/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
@@ -1,4 +1,6 @@
-import { ProgressBar, FormInputValidation, FormLabel, Gridicon } from '@automattic/components';
+import { FormInputValidation, FormLabel } from '@automattic/components';
+import { ProgressBar } from '@wordpress/components';
+import { Icon, cloudUpload } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { truncate } from 'lodash';
@@ -107,9 +109,7 @@ export class UploadingPane extends PureComponent {
 			case appStates.UPLOAD_PROCESSING:
 			case appStates.UPLOADING: {
 				const uploadPercent = percentComplete;
-				const progressClasses = clsx( 'importer__upload-progress', {
-					'is-complete': uploadPercent > 95,
-				} );
+
 				const uploaderPrompt =
 					importerState === appStates.UPLOADING && uploadPercent < 99
 						? this.props.translate( 'Uploading %(filename)s\u2026', {
@@ -118,14 +118,9 @@ export class UploadingPane extends PureComponent {
 						: this.props.translate( 'Processing uploaded file\u2026' );
 
 				return (
-					<div>
+					<div className="content-upload-form__in-progress">
 						<p>{ uploaderPrompt }</p>
-						<ProgressBar
-							className={ progressClasses }
-							value={ uploadPercent }
-							total={ 100 }
-							isPulsing={ uploadPercent > 99 || importerState === appStates.UPLOAD_PROCESSING }
-						/>
+						<ProgressBar />
 					</div>
 				);
 			}
@@ -261,13 +256,7 @@ export class UploadingPane extends PureComponent {
 					onKeyPress={ isReadyForImport ? this.handleKeyPress : null }
 				>
 					<div className={ importerStatusClasses }>
-						<Gridicon
-							size="48"
-							className="importer__upload-icon"
-							icon={
-								this.props.optionalUrl && this.state.fileToBeUploaded ? 'checkmark' : 'cloud-upload'
-							}
-						/>
+						<Icon icon={ cloudUpload } viewBox="4 4 16 16" size={ 48 } />
 						{ this.getMessage() }
 					</div>
 					{ isReadyForImport && (

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -67,20 +67,26 @@
 		}
 	}
 }
-
+.content-upload-form__in-progress,
 .subscriber-upload-form__in-progress,
 .subscriber-upload-form .file-picker {
-	background: #f6f7f7;
-	height: 180px;
 	width: 100%;
-	border: 1px dashed var(--studio-gray-50);
-	border-radius: 4px;
 	display: flex;
 	flex-direction: column;
 	margin-bottom: 16px;
 	align-items: center;
-	padding-top: 50px;
 	color: var(--studio-gray-50);
+}
+
+.subscriber-upload-form__dropzone {
+	background: #f6f7f7;
+	padding-top: 50px;
+	cursor: pointer;
+	position: relative;
+	height: 180px;
+	border: 1px dashed var(--studio-gray-50);
+	border-radius: 4px;
+	margin-bottom: 20px;
 }
 
 .subscriber-upload-form__in-progress svg,
@@ -89,7 +95,7 @@
 	height: 48px;
 	text-align: center;
 	padding: 8px;
-	fill: var(--studio-gray-50);
+	fill: var(--studio-gray-20);
 }
 
 .subscriber-upload-form__modal ul {

--- a/client/my-sites/importer/newsletter/subscriber-upload-form.tsx
+++ b/client/my-sites/importer/newsletter/subscriber-upload-form.tsx
@@ -61,10 +61,12 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 
 	if ( importSelector?.inProgress ) {
 		return (
-			<div className="subscriber-upload-form__in-progress">
-				<Icon icon={ cloudUpload } viewBox="4 4 16 16" size={ 16 } />
-				<p>Uploading...</p>
-				<ProgressBar />
+			<div className="subscriber-upload-form__dropzone">
+				<div className="subscriber-upload-form__in-progress">
+					<Icon icon={ cloudUpload } viewBox="4 4 16 16" size={ 16 } />
+					<p>Uploading...</p>
+					<ProgressBar />
+				</div>
 			</div>
 		);
 	}
@@ -76,17 +78,19 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 					Sorry, you can only upload CSV files. Please try again with a valid file.
 				</FormInputValidation>
 			) }
-			<DropZone onFilesDrop={ onFileSelect } fullScreen />
-			<FilePicker accept="text/csv" onPick={ onFileSelect } multiple={ false }>
-				<Icon icon={ cloudUpload } viewBox="4 4 16 16" size={ 16 } />
-				{ ! selectedFile && <p>Drag a file, or click to upload a file.</p> }
-				{ selectedFile && (
-					<p>
-						To replace this <em className="file-name">{ selectedFile?.name }</em>
-						<br /> drag a file, or click to upload different one.
-					</p>
-				) }
-			</FilePicker>
+			<div className="subscriber-upload-form__dropzone">
+				<DropZone onFilesDrop={ onFileSelect } />
+				<FilePicker accept="text/csv" onPick={ onFileSelect } multiple={ false }>
+					<Icon icon={ cloudUpload } viewBox="4 4 16 16" size={ 16 } />
+					{ ! selectedFile && <p>Drag a file, or click to upload a file.</p> }
+					{ selectedFile && (
+						<p>
+							To replace this <em className="file-name">{ selectedFile?.name }</em>
+							<br /> drag a file, or click to upload different one.
+						</p>
+					) }
+				</FilePicker>
+			</div>
 			{ isSelectedFileValid && selectedFile && (
 				<p>
 					By clicking "Continue," you represent that you've obtained the appropriate consent to

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -106,7 +106,9 @@ export default function Subscribers( {
 							) }
 						</ul>
 					</div>
-					<Button href={ nextStepUrl }>Continue</Button>
+					<Button variant="primary" href={ nextStepUrl }>
+						Continue
+					</Button>
 				</Modal>
 			) }
 		</>

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -29,7 +29,7 @@ export default function Summary( { cardData, selectedSite }: Props ) {
 		<Card>
 			{ shouldRenderConfetti( cardData.content.status, cardData.subscribers.status ) && (
 				<>
-					<ConfettiAnimation trigger={ ! prefersReducedMotion } /> <h1>Success! 🎉</h1>
+					<ConfettiAnimation trigger={ ! prefersReducedMotion } /> <h2>Success! 🎉</h2>
 				</>
 			) }
 			<ContentSummary cardData={ cardData.content.content } status={ cardData.content.status } />


### PR DESCRIPTION
This PR fixes a number of minor issues with the current Paid Newsletter Importer UI.



## Proposed Changes
1. Submit buttons should be primary. 
2. We should use the new WP ProgressBar component. 
3. We should use the Icon from Core vs Gridicon. 
4. Updates the copy to be more exact. 
5. Improve the spacing on success.

## Why are these changes being made?
To improve the design and quality of the Paid Newsletter



## Testing Instructions
Load the UI such as http://calypso.localhost:3000/import/newsletter/substack/example.com/summary?from=exaple.com and notice that they are less variable in the content and the subscriber form. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
