### PR TITLE
Add ignoreWhitespace option to useIsLargeCurrency

### DIFF
--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -39,7 +39,11 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	);
 
 	const { prices } = usePlanPricingInfoFromGridPlans( { gridPlans: visibleGridPlans } );
-	const isLargeCurrency = useIsLargeCurrency( { prices, currencyCode: currencyCode || 'USD' } );
+	const isLargeCurrency = useIsLargeCurrency( {
+		prices,
+		currencyCode: currencyCode || 'USD',
+		ignoreWhitespace: true,
+	} );
 
 	if ( isWpcomEnterpriseGridPlan( planSlug ) || ! isPricedPlan ) {
 		return null;

--- a/packages/plans-grid-next/src/hooks/use-is-large-currency.ts
+++ b/packages/plans-grid-next/src/hooks/use-is-large-currency.ts
@@ -9,9 +9,10 @@ interface Props {
 	prices?: number[];
 	isAddOn?: boolean;
 	currencyCode: string;
+	ignoreWhitespace?: boolean;
 }
 
-function useDisplayPrices( currencyCode: string, prices?: number[] ) {
+function useDisplayPrices( currencyCode: string, prices?: number[], ignoreWhitespace = false ) {
 	/**
 	 * Prices are represented in smallest units for a currency, and not as prices that
 	 * are actually displayed. Ex. $20 is the integer 2000, and not 20. To determine if
@@ -20,13 +21,15 @@ function useDisplayPrices( currencyCode: string, prices?: number[] ) {
 
 	return useMemo(
 		() =>
-			prices?.map( ( price ) =>
-				formatCurrency( price, currencyCode, {
+			prices?.map( ( price ) => {
+				const displayPrice = formatCurrency( price, currencyCode, {
 					stripZeros: true,
 					isSmallestUnit: true,
-				} )
-			),
-		[ currencyCode, prices ]
+				} );
+
+				return ignoreWhitespace ? displayPrice.replace( /\s/g, '' ) : displayPrice;
+			} ),
+		[ currencyCode, prices, ignoreWhitespace ]
 	);
 }
 
@@ -64,7 +67,12 @@ function hasExceededCombinedPriceThreshold( displayPrices?: string[] ) {
  * 9 characters. For example, $4,000 undiscounted and $30 discounted would be 9 characters.
  * This is primarily used for lowering the font-size of "large" display prices.
  */
-export default function useIsLargeCurrency( { prices, isAddOn = false, currencyCode }: Props ) {
+export default function useIsLargeCurrency( {
+	prices,
+	isAddOn = false,
+	currencyCode,
+	ignoreWhitespace = false,
+}: Props ) {
 	/**
 	 * Because this hook is primarily used for lowering font-sizes of "large" display prices,
 	 * this implementation is non-ideal. It assumes that each character in the display price,
@@ -76,7 +84,7 @@ export default function useIsLargeCurrency( { prices, isAddOn = false, currencyC
 	 *
 	 * https://github.com/Automattic/wp-calypso/pull/81537#discussion_r1323182287
 	 */
-	const displayPrices = useDisplayPrices( currencyCode, prices );
+	const displayPrices = useDisplayPrices( currencyCode, prices, ignoreWhitespace );
 	const exceedsPriceThreshold = hasExceededPriceThreshold( displayPrices, isAddOn );
 	const exceedsCombinedPriceThreshold = hasExceededCombinedPriceThreshold( displayPrices );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/93908

## Proposed Changes

The PR introduces the property `ignoreWhitespace` to `useIsLargeCurrency()`, with the intention of fixing cases where the font size of the display prices were unintendedly reduced in the Plans grid. See https://github.com/Automattic/wp-calypso/issues/93908#issuecomment-2327835263 for an explanation of this issue.

The property `ignoreWhitespace` can be used in the Plans grid since the currency and the price amount are next to each other in the UI, without any spacing.

| Before | After |
| --- | --- | 
| ![image](https://github.com/user-attachments/assets/2aa15ee1-26a6-4f8b-8a19-a8e284bc171e) | ![Screenshot 2024-09-04 at 12 02 58 PM](https://github.com/user-attachments/assets/15b5d379-49e8-48c2-9d49-779b1201ad22)|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Optimize price display on the Plans page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /me/account, and set your language to English.
* Head to /plans/{ SITE }.
* Head to /me/account, and set your language to Spanish.
* Head to /plans/{ SITE } again.
* Ensure that the font size for the display price in both Plan instances are the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
