### PR TITLE
A4A > Team: Minor UI enhancements

### DIFF
--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -27,7 +27,7 @@ export default function GetStarted() {
 	};
 
 	return (
-		<Layout className="team-list-get-started" title={ title } wide>
+		<Layout className="team-list-get-started" title={ title } wide compact>
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title }</Title>

--- a/client/a8c-for-agencies/sections/team/primary/get-started/style.scss
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/style.scss
@@ -4,8 +4,7 @@
 
 .team-list-get-started__heading {
 	@include a4a-font-heading-xl;
-
-	margin-block-start: 48px;
+	margin-block-start: 16px;
 	margin-block-end: 8px;
 }
 

--- a/client/a8c-for-agencies/sections/team/primary/get-started/style.scss
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/style.scss
@@ -17,3 +17,7 @@
 a.team-list-get-started__learn-more-button.is-link {
 	color: var(--color-primary-50);
 }
+
+.team-list-get-started__excluded-operation-list {
+	margin-block-end: 0;
+}

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/index.tsx
@@ -104,7 +104,12 @@ export default function TeamAcceptInvite( { agencyId, inviteId, secret }: Props 
 	}
 
 	return (
-		<Layout className="team-accept-invite" title={ translate( 'Accepting team invite' ) } wide>
+		<Layout
+			className="team-accept-invite"
+			title={ translate( 'Accepting team invite' ) }
+			wide
+			compact
+		>
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title }</Title>

--- a/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
@@ -63,7 +63,7 @@ export default function TeamInvite() {
 	}, [] );
 
 	return (
-		<Layout className="team-invite" title={ title } wide>
+		<Layout className="team-invite" title={ title } wide compact>
 			<LayoutTop>
 				<LayoutHeader>
 					<Breadcrumb

--- a/client/a8c-for-agencies/sections/team/primary/team-invite/style.scss
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite/style.scss
@@ -5,6 +5,10 @@
 	max-width: 700px;
 }
 
+.team-invite-form {
+	padding-block-start: 16px;
+}
+
 .team-invite-form__required-information {
 	@include a4a-font-body-md;
 	color: var(--color-neutral-50);

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -115,7 +115,7 @@ export default function TeamList() {
 	}
 
 	return (
-		<Layout className="team-list full-width-layout-with-table" title={ title } wide>
+		<Layout className="team-list full-width-layout-with-table" title={ title } wide compact>
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title }</Title>


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1056

## Proposed Changes

This PR does some minor UI enhancements. 

## Why are these changes being made?

* To make some UI enhancements.

## Testing Instructions

* Open the A4A live link
* Verify the below:

- Removed the extra bottom margin

| Before | After |
|--------|--------|
| <img width="751" alt="Screenshot 2024-09-04 at 11 02 04 AM" src="https://github.com/user-attachments/assets/cefbcca3-d4cc-427a-988a-4e9cafe89fbc"> | <img width="751" alt="Screenshot 2024-09-04 at 11 02 36 AM" src="https://github.com/user-attachments/assets/a3375c9e-8bd7-45f9-9728-10c084a07239"> |

- Reduced the padding on the header

| Before | After |
|--------|--------|
| <img width="1461" alt="Screenshot 2024-09-04 at 11 03 12 AM" src="https://github.com/user-attachments/assets/d563c2fa-f6f9-4073-935c-012ee72cd1ff">  |  <img width="1461" alt="Screenshot 2024-09-04 at 11 03 07 AM" src="https://github.com/user-attachments/assets/e5c8c6b7-3381-43af-a17a-3e1e92f0cc99">
<img width="1461" alt="Screenshot 2024-09-04 at 11 03 00 AM" src="https://github.com/user-attachments/assets/ec7372cb-86f6-4496-a8de-94f8433d9241"> | <img width="1461" alt="Screenshot 2024-09-04 at 11 02 53 AM" src="https://github.com/user-attachments/assets/b3390070-6900-44e6-a48b-e6afafe85a52"> |

- Increased the padding on the Invite page

| Before | After |
|--------|--------|
| <img width="1461" alt="Screenshot 2024-09-04 at 11 03 25 AM" src="https://github.com/user-attachments/assets/8c4be931-7424-4f54-a8ab-6c3ed40fa513"> | <img width="1461" alt="Screenshot 2024-09-04 at 11 03 28 AM" src="https://github.com/user-attachments/assets/07fb841f-4282-4626-a010-87e36dde4247"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
