### PR TITLE
Correctly remove previous color scheme after updating to a new one

### DIFF
--- a/client/layout/color-scheme/index.jsx
+++ b/client/layout/color-scheme/index.jsx
@@ -1,0 +1,45 @@
+import { getAdminColor } from 'calypso/state/admin-color/selectors';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export function getColorScheme( { state, isGlobalSidebarVisible, sectionName } ) {
+	if ( isGlobalSidebarVisible ) {
+		return 'global';
+	}
+	if ( sectionName === 'checkout' ) {
+		return null;
+	}
+	const calypsoColorScheme = getPreference( state, 'colorScheme' );
+	const siteId = getSelectedSiteId( state );
+	const siteColorScheme = getAdminColor( state, siteId );
+
+	return siteColorScheme ?? calypsoColorScheme;
+}
+
+export function refreshColorScheme( prevColorScheme, nextColorScheme ) {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+	if ( prevColorScheme === nextColorScheme ) {
+		return;
+	}
+
+	const classList = document.querySelector( 'body' ).classList;
+
+	if ( prevColorScheme ) {
+		classList.remove( `is-${ prevColorScheme }` );
+	}
+
+	if ( nextColorScheme ) {
+		classList.add( `is-${ nextColorScheme }` );
+
+		const themeColor = getComputedStyle( document.body )
+			.getPropertyValue( '--color-masterbar-background' )
+			.trim();
+		const themeColorMeta = document.querySelector( 'meta[name="theme-color"]' );
+		// We only adjust the `theme-color` meta content value in case we set it in `componentDidMount`
+		if ( themeColorMeta && themeColorMeta.getAttribute( 'data-colorscheme' ) === 'true' ) {
+			themeColorMeta.content = themeColor;
+		}
+	}
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -35,7 +35,6 @@ import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { useSelector } from 'calypso/state';
-import { getAdminColor } from 'calypso/state/admin-color/selectors';
 import { isOffline } from 'calypso/state/application/selectors';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
 import {
@@ -45,7 +44,6 @@ import {
 } from 'calypso/state/global-sidebar/selectors';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
-import { getPreference } from 'calypso/state/preferences/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
@@ -63,6 +61,7 @@ import {
 	masterbarIsVisible,
 } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
+import { getColorScheme, refreshColorScheme } from './color-scheme';
 import GlobalNotifications from './global-notifications';
 import LayoutLoader from './loader';
 import { shouldLoadInlineHelp, handleScroll } from './utils';
@@ -245,70 +244,11 @@ class Layout extends Component {
 			this.setState( { isDesktop } );
 		} );
 
-		this.refreshColorScheme( undefined, this.props.colorScheme );
+		refreshColorScheme( undefined, this.props.colorScheme );
 	}
 
-	/**
-	 * Refresh the color scheme if
-	 * - the color scheme has changed
-	 * - the global sidebar is visible and the color scheme is not `global`
-	 * - the global sidebar was visible and is now hidden and the color scheme is not `global`
-	 * - the section changed to `checkout` or changes from 'checkout' to something else
-	 * @param prevProps object
-	 */
 	componentDidUpdate( prevProps ) {
-		const willTransitionFromOrToCheckout =
-			( prevProps.sectionName === 'checkout' && this.props.sectionName !== 'checkout' ) ||
-			( prevProps.sectionName !== 'checkout' && this.props.sectionName === 'checkout' );
-
-		if (
-			prevProps.colorScheme !== this.props.colorScheme ||
-			( this.props.isGlobalSidebarVisible && this.props.colorScheme !== 'global' ) ||
-			( prevProps.isGlobalSidebarVisible &&
-				! this.props.isGlobalSidebarVisible &&
-				this.props.colorScheme !== 'global' ) ||
-			willTransitionFromOrToCheckout
-		) {
-			this.refreshColorScheme( prevProps.colorScheme, this.props.colorScheme );
-		}
-	}
-
-	refreshColorScheme( prevColorScheme, nextColorScheme ) {
-		if ( ! config.isEnabled( 'me/account/color-scheme-picker' ) ) {
-			return;
-		}
-
-		if ( typeof document !== 'undefined' ) {
-			const classList = document.querySelector( 'body' ).classList;
-			const globalColorScheme = 'global';
-
-			if ( this.props.sectionName === 'checkout' ) {
-				classList.remove( `is-${ prevColorScheme }` );
-				return;
-			}
-
-			if ( this.props.isGlobalSidebarVisible ) {
-				// Force the global color scheme when the global sidebar is visible.
-				nextColorScheme = globalColorScheme;
-			} else {
-				// Revert back to user's color scheme when the global sidebar is gone.
-				prevColorScheme = globalColorScheme;
-			}
-
-			classList.remove( `is-${ prevColorScheme }` );
-			classList.add( `is-${ nextColorScheme }` );
-
-			const themeColor = getComputedStyle( document.body )
-				.getPropertyValue( '--color-masterbar-background' )
-				.trim();
-			const themeColorMeta = document.querySelector( 'meta[name="theme-color"]' );
-			// We only adjust the `theme-color` meta content value in case we set it in `componentDidMount`
-			if ( themeColorMeta && themeColorMeta.getAttribute( 'data-colorscheme' ) === 'true' ) {
-				themeColorMeta.content = themeColor;
-			}
-		}
-
-		// intentionally don't remove these in unmount
+		refreshColorScheme( prevProps.colorScheme, this.props.colorScheme );
 	}
 
 	renderMasterbar( loadHelpCenterIcon ) {
@@ -564,15 +504,16 @@ export default withCurrentRoute(
 			'comments',
 		].includes( sectionName );
 		const sidebarIsHidden = ! secondary || isWcMobileApp() || isDomainAndPlanPackageFlow;
+		const isGlobalSidebarVisible = shouldShowGlobalSidebar && ! sidebarIsHidden;
+
 		const userAllowedToHelpCenter =
 			config.isEnabled( 'calypso/help-center' ) && ! getIsOnboardingAffiliateFlow( state );
 
-		const calypsoColorScheme = getPreference( state, 'colorScheme' );
-		const siteColorScheme = getAdminColor( state, siteId ) ?? calypsoColorScheme;
-		const colorScheme =
-			shouldShowUnifiedSiteSidebar || config.isEnabled( 'layout/site-level-user-profile' )
-				? siteColorScheme
-				: calypsoColorScheme;
+		const colorScheme = getColorScheme( {
+			state,
+			sectionName,
+			isGlobalSidebarVisible,
+		} );
 
 		return {
 			masterbarIsHidden,
@@ -606,7 +547,7 @@ export default withCurrentRoute(
 			sidebarIsCollapsed: sectionName !== 'reader' && getSidebarIsCollapsed( state ),
 			userAllowedToHelpCenter,
 			currentRoute,
-			isGlobalSidebarVisible: shouldShowGlobalSidebar && ! sidebarIsHidden,
+			isGlobalSidebarVisible,
 			isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar && ! sidebarIsHidden,
 			isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar && ! sidebarIsHidden,
 			isNewUser: isUserNewerThan( WEEK_IN_MILLISECONDS )( state ),


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/dotcom-forge/issues/8796

## Proposed Changes

This PR fixes a "regression" caused by:

- https://github.com/Automattic/wp-calypso/pull/91035

In that PR, we assumed that `prevColorScheme` is always the current color scheme or `'global'`. However, after pbxlJb-63Y-p2, it is now possible to change the current color scheme within the same site context. The PR caused the old color scheme to NOT be removed from `<body>`, e.g.:

<img width="944" alt="image" src="https://github.com/user-attachments/assets/d2c67de3-f4d0-4872-82d3-a5b402171a68">

So, the new color scheme will not be respected UNTIL the page is refreshed.

---

I think this was partly caused by the convoluted logic of the existing code. The code tries to "override" the color scheme during `componentDidUpdate()`, which needs to account for both prev and next color schemes. In this PR, I clean that up by assigning the correct color scheme to the current prop itself.

## Why are these changes being made?

Fixes a regression.

## Testing Instructions

1. Prepare a site.
2. Go to Users -> Profile and change the color scheme to Modern.
3. Go to `<Calypso Live>/home/:site`, then refresh the page.
    - This will set up the redux store.
4. Go to Users -> Profile and change the color scheme to Ectoplasm.
5. Go to `<Calypso Live>/home/:site`.
6. Verify that the color scheme does change to Ectoplasm.
7. Open the dev console, inspect the `<body>` element, and verify that there is only `is-ectoplasm` and no `is-modern`.

### Regression tests

- Regression test for https://github.com/Automattic/wp-calypso/pull/91035
   1. Go to `<Calypso Live>/home/:site`
   2. Click the `W` logo to enter the global view, verify that the color scheme is now global.
   3. Click your any of the site row's `My Home`, verify that the color scheme is now that site's.

- Regression test for https://github.com/Automattic/wp-calypso/pull/93776
   - Follow the instructions there 🙈 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?