### PR TITLE
Calypso UI Component: DateRangePicker: add shortcuts styling

### DIFF
--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -486,7 +486,7 @@ export class DateRange extends Component {
 	 */
 	renderShortcuts() {
 		return (
-			<div className="date-control-picker-shortcuts">
+			<div className="date-range-picker-shortcuts">
 				<Shortcuts
 					onClick={ ( startDate, endDate ) => this.handleDateRangeChange( startDate, endDate ) }
 				/>

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -473,6 +473,7 @@ export class DateRange extends Component {
 						{ this.props.renderInputs( inputsProps ) }
 						{ this.renderDatePicker() }
 					</div>
+					{ /* Render shortcuts to the right of the calendar */ }
 					{ this.props.displayShortcuts && this.renderShortcuts() }
 				</div>
 			</Popover>

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -474,23 +474,17 @@ export class DateRange extends Component {
 						{ this.renderDatePicker() }
 					</div>
 					{ /* Render shortcuts to the right of the calendar */ }
-					{ this.props.displayShortcuts && this.renderShortcuts() }
+					{ this.props.displayShortcuts && (
+						<div className="date-range-picker-shortcuts">
+							<Shortcuts
+								onClick={ ( startDate, endDate ) =>
+									this.handleDateRangeChange( startDate, endDate )
+								}
+							/>
+						</div>
+					) }
 				</div>
 			</Popover>
-		);
-	}
-
-	/**
-	 * Renders the Shortcuts component
-	 * @returns {import('react').Element} the Shortcuts component
-	 */
-	renderShortcuts() {
-		return (
-			<div className="date-range-picker-shortcuts">
-				<Shortcuts
-					onClick={ ( startDate, endDate ) => this.handleDateRangeChange( startDate, endDate ) }
-				/>
-			</div>
 		);
 	}
 

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -63,11 +63,11 @@ const DateRangePickerShortcuts = ( {
 	};
 
 	return (
-		<div className="date-control-picker-shortcuts__inner">
-			<ul className="date-control-picker-shortcuts__list">
+		<div className="date-range-picker-shortcuts__inner">
+			<ul className="date-range-picker-shortcuts__list">
 				{ shortcutList.map( ( shortcut, idx ) => (
 					<li
-						className={ clsx( 'date-control-picker-shortcuts__shortcut', {
+						className={ clsx( 'date-range-picker-shortcuts__shortcut', {
 							'is-selected': shortcut.id === selectedShortcut,
 						} ) }
 						key={ shortcut.id || idx }

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -278,11 +278,6 @@
 	padding: 16px;
 	border-left: 1px solid var(--gray-gray-5, #dcdcde);
 	box-sizing: border-box;
-
-	@media (max-width: $date-control-mobile-layout-switch) {
-		border-left: 0 none;
-		border-bottom: 1px solid var(--gray-gray-5, #dcdcde);
-	}
 }
 
 .date-control-picker-shortcuts__list {

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -1,3 +1,8 @@
+@import "@wordpress/base-styles/breakpoints";
+
+$date-range-shortcut-min-width: 140px;
+$date-range-mobile-layout-switch: $break-small;
+
 .date-range {
 	position: relative;
 	display: flex;
@@ -272,12 +277,32 @@
 .date-range__popover-content { // Styling to fit optional shortcuts sidebar
 	display: flex;
 	align-items: stretch; // Ensure children stretch to full height
+
+	@media (min-width: $date-range-mobile-layout-switch) {
+		flex-direction: row; // Align items in a row on larger screens
+	}
+
+	@media (max-width: $date-range-mobile-layout-switch) {
+		flex-direction: column; // Stack items vertically on small screens
+	}
 }
 
 .date-control-picker-shortcuts {
 	padding: 16px;
 	border-left: 1px solid var(--gray-gray-5, #dcdcde);
 	box-sizing: border-box;
+
+	@media (max-width: $date-range-mobile-layout-switch) {
+		border-left: 0 none;
+		border-bottom: 1px solid var(--gray-gray-5, #dcdcde);
+		display: block; // Ensure it takes full width on mobile
+		margin-bottom: 16px; // Space between shortcuts and calendar
+	}
+
+	@media (min-width: $date-range-mobile-layout-switch) {
+		// Adjust layout for larger screens
+		flex: 0 0 auto; // Allow it to take only necessary space
+	}
 }
 
 .date-control-picker-shortcuts__list {
@@ -287,6 +312,8 @@
 
 .date-control-picker-shortcuts__shortcut {
 	border-radius: 4px;
+	min-width: $date-range-shortcut-min-width;
+
 
 	&:hover {
 		background-color: var(--color-primary-0);

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -273,3 +273,42 @@
 	display: flex;
 	align-items: stretch; // Ensure children stretch to full height
 }
+
+.date-control-picker-shortcuts {
+	padding: 16px;
+	border-left: 1px solid var(--gray-gray-5, #dcdcde);
+	box-sizing: border-box;
+
+	@media (max-width: $date-control-mobile-layout-switch) {
+		border-left: 0 none;
+		border-bottom: 1px solid var(--gray-gray-5, #dcdcde);
+	}
+}
+
+.date-control-picker-shortcuts__list {
+	list-style: none;
+	margin: 0;
+}
+
+.date-control-picker-shortcuts__shortcut {
+	border-radius: 4px;
+	min-width: $date-control-shortcut-min-width;
+
+	&:hover {
+		background-color: var(--color-primary-0);
+	}
+
+	& + & {
+		margin-top: 2px; // space for an outline for the current item and hover for the next
+	}
+
+	&.is-selected {
+		background-color: var(--color-accent-5);
+	}
+
+	.components-button {
+		display: flex;
+		justify-content: space-between;
+		width: 100%;
+	}
+}

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -287,14 +287,14 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 }
 
-.date-control-picker-shortcuts {
+.date-range-picker-shortcuts {
 	padding: 16px;
 	border-left: 1px solid var(--gray-gray-5, #dcdcde);
 	box-sizing: border-box;
 
 	@media (max-width: $date-range-mobile-layout-switch) {
 		border-left: 0 none;
-		border-bottom: 1px solid var(--gray-gray-5, #dcdcde);
+		border-top: 1px solid var(--gray-gray-5, #dcdcde);
 		display: block; // Ensure it takes full width on mobile
 		margin-bottom: 16px; // Space between shortcuts and calendar
 	}
@@ -305,12 +305,12 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 }
 
-.date-control-picker-shortcuts__list {
+.date-range-picker-shortcuts__list {
 	list-style: none;
 	margin: 0;
 }
 
-.date-control-picker-shortcuts__shortcut {
+.date-range-picker-shortcuts__shortcut {
 	border-radius: 4px;
 	min-width: $date-range-shortcut-min-width;
 

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -292,7 +292,6 @@
 
 .date-control-picker-shortcuts__shortcut {
 	border-radius: 4px;
-	min-width: $date-control-shortcut-min-width;
 
 	&:hover {
 		background-color: var(--color-primary-0);


### PR DESCRIPTION
## Proposed Changes

* Updates the styling on the Date Range picker shortcuts

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For styling consistency

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open Calypso live branch
* navigate to `/devdocs/design/date-range`
* click on the last demo `With Shortcuts Menu Displayed` to open the calendar popover
* check the styling of the shortcuts menu
* also thoroughly check on mobile and small displays

![image](https://github.com/user-attachments/assets/39a59639-8547-43f4-a23a-39f383ec7489)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
