### PR TITLE
Launch modal: set min-width

### DIFF
--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -1,3 +1,5 @@
+$breakpoint-mobile: 782px; //Mobile size.
+
 .launched__modal {
 	max-width: 640px;
 
@@ -16,7 +18,10 @@
 		display: flex;
 		flex-direction: column;
 		gap: 32px;
-		min-width: 640px;
+
+		@media (min-width: $breakpoint-mobile) {
+			min-width: 640px;
+		}
 	}
 
 	&-heading {
@@ -34,7 +39,10 @@
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		max-width: 75%;
+		max-width: 100%;
+		@media (min-width: $breakpoint-mobile) {
+			max-width: 75%;
+		}
 	}
 
 	&-body,
@@ -65,9 +73,12 @@
 		padding: 8px;
 		background: var(--studio-gray-0);
 		display: flex;
-		flex-direction: row;
+		flex-direction: column;
 		justify-content: space-between;
 		align-items: center;
+		@media (min-width: $breakpoint-mobile) {
+			flex-direction: row;
+		}
 	}
 
 	.launchpad__clipboard-button {
@@ -105,7 +116,10 @@
 		align-items: center;
 		padding: 32px 48px;
 		gap: 32px;
-
+		flex-direction: column;
+		@media (min-width: $breakpoint-mobile) {
+			flex-direction: row;
+		}
 		.components-button {
 			height: 42px;
 		}

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -16,6 +16,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 32px;
+		min-width: 640px;
 	}
 
 	&-heading {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/93897

## Proposed Changes

* Sets min-width on launched modal content to ensure close icon doesn't overlap
* Fixes layout on mobile resolutions

## Before
<img width="577" alt="Screenshot 2024-09-04 at 10 15 30" src="https://github.com/user-attachments/assets/6c64aa89-dec9-4f52-90e5-cc6f0b69ca60">
<img width="389" alt="Screenshot 2024-09-04 at 1 37 53 PM" src="https://github.com/user-attachments/assets/75a5fab2-f929-4c45-8c27-3479dcb78137">

## After
https://github.com/user-attachments/assets/e88aa1e8-a804-473b-80aa-358f727cfe13

<img width="210" alt="Screenshot 2024-09-05 at 10 58 51" src="https://github.com/user-attachments/assets/e4b17c6d-e3cf-42b3-af04-632e5755b423">
<img width="204" alt="Screenshot 2024-09-05 at 11 00 17" src="https://github.com/user-attachments/assets/98880935-957b-46ec-bc06-8a65c8a6e3b0">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tidy up UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new test site
* Choose a paid domain, like .blog
* Choose a paid plan, like personal
* Skip through to dashboard
* Launch the site
* You should see the launched modal without the domain upsell and the close button should not overlap the header

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
