### PR TITLE
Gravatar: Disable the email input for Gravatar-powered clients

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -155,13 +155,26 @@ class Login extends Component {
 			this.props.requestError?.field === 'usernameOrEmail' &&
 			this.props.requestError?.code === 'email_login_not_allowed'
 		) {
-			const magicLoginUrl = login( {
+			let urlConfig = {
 				locale: this.props.locale,
 				twoFactorAuthType: 'link',
 				oauth2ClientId: this.props.currentQuery?.client_id,
 				redirectTo: this.props.redirectTo,
 				usernameOnly: true,
-			} );
+			};
+
+			if ( this.props.isGravPoweredClient ) {
+				urlConfig = {
+					...urlConfig,
+					gravatarFrom:
+						isGravatarOAuth2Client( this.props.oauth2Client ) &&
+						this.props.currentQuery?.gravatar_from,
+					gravatarFlow: isGravatarFlowOAuth2Client( this.props.oauth2Client ),
+					emailAddress: this.props.currentQuery?.email_address,
+				};
+			}
+
+			const magicLoginUrl = login( urlConfig );
 
 			page( magicLoginUrl );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 108781-gh-Automattic/gravatar

## Proposed Changes

* Pass the necessary URL parameters to the login URL to disable the email input for Gravatar-powered clients

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Please refer to 108781-gh-Automattic/gravatar

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* [Setup Calypso](https://github.com/Automattic/wp-calypso?tab=readme-ov-file#getting-started)
* Check out this PR, and run `yarn start`
* For the OAuth flow:
  * Use [this URL](http://calypso.localhost:3000/log-in/link?client_id=101356&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D101356%26redirect_uri%3Dwp-oauth-test%253A%252F%252Fauthorization-callback%26response_type%3Dcode%26user_email%3Detoledom2%2540icloud.com%26from-calypso%3D1&email_address=etoledom2%40icloud.com&gravatar_flow=1)
  * Click the "Sign in another way"
  * On the password login page, click the "Continue" button. You will see the email input is disabled

* For the OAuth flow:
  * Use [this URL](http://calypso.localhost:3000/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D3ba319421bb62da965a6cee6551c86d3e094d377c747dd52352e582a99133dbc%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&email_address=etoledom2%40icloud.com&client_id=1854&gravatar_from=3rd-party)
  * Click the "Sign in another way"
  * On the password login page, click the "Continue" button. You will see the email input is disabled

* WP.com login:
  * Use [this URL](http://calypso.localhost:3000/log-in?email_address=etoledom2%40icloud.com), and it should still work the same

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
