### PR TITLE
Hide is_fully_managed_agency_site from A4A dev sites configuration

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -224,43 +224,50 @@ export default function SiteConfigurationsModal( {
 				</FormField>
 				<FormField label="">
 					<div className="configure-your-site-modal-form__allow-clients-to-use-help-center">
-						<CheckboxControl
-							id="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox"
-							onChange={ toggleAllowClientsToUseSiteHelpCenter }
-							checked={ allowClientsToUseSiteHelpCenter }
-							name="is_fully_managed_agency_site"
-							disabled={ isDevSite || isSubmitting }
-						/>
-						<label
-							className={ isDevSite ? 'disabled-label' : '' }
-							htmlFor="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox"
-						>
-							{ translate(
-								'Allow clients to use the {{HcLink}}WordPress.com Help Center{{/HcLink}} and {{HfLink}}hosting features.{{/HfLink}}',
-								{
-									components: {
-										HcLink: (
-											<a
-												target="_blank"
-												href={ localizeUrl(
-													'https://wordpress.com/support/help-support-options/#how-to-contact-us'
-												) }
-												rel="noreferrer"
-											/>
-										),
-										HfLink: (
-											<a
-												target="_blank"
-												href={ localizeUrl(
-													'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
-												) }
-												rel="noreferrer"
-											/>
-										),
-									},
-								}
-							) }
-						</label>
+						{ isDevSite ? (
+							<label className="dev-sites-label">
+								{ translate(
+									'Clients cannot use the WordPress.com Help Center and hosting features of development sites. You can grant access to those features via Site Settings after the site is launched.'
+								) }
+							</label>
+						) : (
+							<>
+								<CheckboxControl
+									id="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox"
+									onChange={ toggleAllowClientsToUseSiteHelpCenter }
+									checked={ allowClientsToUseSiteHelpCenter }
+									name="is_fully_managed_agency_site"
+									disabled={ isDevSite || isSubmitting }
+								/>
+								<label htmlFor="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox">
+									{ translate(
+										'Allow clients to use the {{HcLink}}WordPress.com Help Center{{/HcLink}} and {{HfLink}}hosting features.{{/HfLink}}',
+										{
+											components: {
+												HcLink: (
+													<a
+														target="_blank"
+														href={ localizeUrl(
+															'https://wordpress.com/support/help-support-options/#how-to-contact-us'
+														) }
+														rel="noreferrer"
+													/>
+												),
+												HfLink: (
+													<a
+														target="_blank"
+														href={ localizeUrl(
+															'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
+														) }
+														rel="noreferrer"
+													/>
+												),
+											},
+										}
+									) }
+								</label>
+							</>
+						) }
 					</div>
 				</FormField>
 				<div className="configure-your-site-modal-form__footer">

--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -259,7 +259,7 @@ export default function SiteConfigurationsModal( {
 									onChange={ toggleAllowClientsToUseSiteHelpCenter }
 									checked={ allowClientsToUseSiteHelpCenter }
 									name="is_fully_managed_agency_site"
-									disabled={ isDevSite || isSubmitting }
+									disabled={ isSubmitting }
 								/>
 								<label htmlFor="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox">
 									{ translate(

--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -227,7 +227,29 @@ export default function SiteConfigurationsModal( {
 						{ isDevSite ? (
 							<label className="dev-sites-label">
 								{ translate(
-									'Clients cannot use the WordPress.com Help Center and hosting features of development sites. You can grant access to those features via Site Settings after the site is launched.'
+									'Clients can’t access the {{HcLink}}WordPress.com Help Center{{/HcLink}} or {{HfLink}}hosting features{{/HfLink}} on development sites. Once the site is launched, enable access in Site Settings.',
+									{
+										components: {
+											HcLink: (
+												<a
+													target="_blank"
+													href={ localizeUrl(
+														'https://wordpress.com/support/help-support-options/#how-to-contact-us'
+													) }
+													rel="noreferrer"
+												/>
+											),
+											HfLink: (
+												<a
+													target="_blank"
+													href={ localizeUrl(
+														'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
+													) }
+													rel="noreferrer"
+												/>
+											),
+										},
+									}
 								) }
 							</label>
 						) : (

--- a/client/a8c-for-agencies/components/site-configurations-modal/style.scss
+++ b/client/a8c-for-agencies/components/site-configurations-modal/style.scss
@@ -18,12 +18,8 @@
 		font-size: rem(14px);
 		line-height: 1.5;
 
-		.disabled-label {
-			color: var(--studio-gray-20);
-
-			a {
-				color: var(--studio-gray-20);
-			}
+		.dev-sites-label {
+			margin-top: 15px;
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9009

## Proposed Changes

<img width="729" alt="image" src="https://github.com/user-attachments/assets/0893178e-4d40-49b9-8ce3-88dbf366d07a">



Replaces `Allow clients to use the WordPress.com Help Center and hosting features.` checkbox with `Clients cannot use the WordPress.com Help Center and hosting features of development sites. You can grant access to those features via Site Settings after the site is launched.` label on A4A site configuration modal, when it is a development site.


## Testing Instructions

Apply the changes on your environment or use the live preview links on this PR.
Open the new development site configuration modal. It should look like the image above.
Open the new **non-development** site configuration modal. It should still have the checkbox.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
