### PR TITLE
Stepper: Update tests to reflect `calypso_signup_start` event triggered N times, not 1

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -147,7 +147,7 @@ describe( 'useSignUpTracking', () => {
 			} );
 		} );
 
-		it( 'does not trigger the event on rerender', () => {
+		it( 'triggers the event on rerender', () => {
 			const { rerender } = render( {
 				flow: { ...signUpFlow, useSignupStartEventProps: () => ( { extra: 'props' } ) },
 				currentStepRoute: 'step-1',
@@ -156,7 +156,33 @@ describe( 'useSignUpTracking', () => {
 
 			rerender();
 
+			expect( recordTracksEvent ).toHaveBeenCalledTimes( 2 );
+
 			expect( recordTracksEvent ).toHaveBeenNthCalledWith( 1, 'calypso_signup_start', {
+				flow: 'sign-up-flow',
+				ref: 'another-flow-or-cta',
+				extra: 'props',
+			} );
+
+			expect( recordTracksEvent ).toHaveBeenNthCalledWith( 2, 'calypso_signup_start', {
+				flow: 'sign-up-flow',
+				ref: 'another-flow-or-cta',
+				extra: 'props',
+			} );
+		} );
+
+		it( 'is we add the signup param, then we trigger it even more', () => {
+			const { rerender } = render( {
+				flow: { ...signUpFlow, useSignupStartEventProps: () => ( { extra: 'props' } ) },
+				currentStepRoute: 'step-1',
+				queryParams: { ref: 'another-flow-or-cta', signup: 1 },
+			} );
+
+			rerender();
+
+			expect( recordTracksEvent ).toHaveBeenCalledTimes( 3 );
+
+			expect( recordTracksEvent ).toHaveBeenNthCalledWith( 3, 'calypso_signup_start', {
 				flow: 'sign-up-flow',
 				ref: 'another-flow-or-cta',
 				extra: 'props',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/94175

## Proposed Changes

Updates the test suite for `useSignUpStartTracking` to presumably "correct" the tests. 

This is not meant for shipping, but rather to highlight a false positive in the test suite (one of the most important tests I guess). Only meant to accompany/verify https://github.com/Automattic/wp-calypso/issues/94175

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To demonstrate a false positive test. See https://github.com/Automattic/wp-calypso/issues/94175

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- tests should pass, even though they shouldn't
- `yarn test-client client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
