### PR TITLE
Design Picker: Continue with default theme

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -939,6 +939,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			skipButtonAlign="top"
 			hideFormattedHeader
 			hideSkip
+			hideNext={ ! siteActiveTheme?.[ 0 ]?.stylesheet }
 			backLabelText={ translate( 'Back' ) }
 			stepContent={ stepContent }
 			recordTracksEvent={ recordStepContainerTracksEvent }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Fixes:
- https://github.com/Automattic/wp-calypso/issues/94145

With the recent changes introduced in marking the active design on the Design Picker, a user who wants to proceed with the default theme (Twenty Twenty-Four) can't do so. This PR adds a 'Continue' button to the Design Picker in the Start flow when there is an active theme, allowing the customer to continue if they wish.



## Proposed Changes

* Added a continue button if there is an Active theme on the Design Picker (Setup).
* The button is the default button created by the StepContainer component.
* (Note) Changing the button's design implies changing it Application wide. I do think there is an opportunity for a redesign since the button seems dated, but at least it's a clear CTA.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that users can proceed with the default theme if they want to.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link and go to `{LiveLink}/start/domains`.
* Continue with the Design Picker flow.
* You should see the default theme marked as active.
* You should see a continue button.
* Press continue.
* On the onboarding, the select design step must be marked as complete.


https://github.com/user-attachments/assets/f4285d76-f637-4a45-9e71-5dbf7558f9d6



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
