### PR TITLE
A4A: Show a confirmation dialog when deleting a member or canceling a member invite.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-confirmation-dialog/index.tsx
@@ -1,0 +1,61 @@
+import { Button, Dialog } from '@automattic/components';
+import { clsx } from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { ReactNode } from 'react';
+
+import './style.scss';
+
+type Props = {
+	className?: string;
+	title: string;
+	children: ReactNode;
+	onClose: () => void;
+	onConfirm?: () => void;
+	ctaLabel?: string;
+	closeLabel?: string;
+	busy?: boolean;
+	scary?: boolean;
+};
+
+export function A4AConfirmationDialog( {
+	className,
+	title,
+	children,
+	onConfirm,
+	ctaLabel,
+	closeLabel,
+	onClose,
+	busy,
+	scary,
+}: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<Dialog
+			label={ title }
+			isVisible
+			additionalClassNames={ clsx( 'a4a-confirmation-dialog', className ) }
+			onClose={ onClose }
+			buttons={ [
+				<Button key="cancel-button" onClick={ onClose } disabled={ busy }>
+					{ closeLabel ?? translate( 'Cancel' ) }
+				</Button>,
+
+				<Button
+					key="confirmation-button"
+					primary
+					scary={ scary }
+					disabled={ busy }
+					busy={ busy }
+					onClick={ onConfirm }
+				>
+					{ ctaLabel ?? translate( 'Confirm' ) }
+				</Button>,
+			] }
+		>
+			<h1 className="a4a-confirmation-dialog__heading">{ title }</h1>
+
+			{ children }
+		</Dialog>
+	);
+}

--- a/client/a8c-for-agencies/components/a4a-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-confirmation-dialog/index.tsx
@@ -38,7 +38,7 @@ export function A4AConfirmationDialog( {
 			additionalClassNames={ clsx( 'a4a-confirmation-dialog', className ) }
 			onClose={ onClose }
 			buttons={ [
-				<Button key="cancel-button" onClick={ onClose } disabled={ isLoading }>
+				<Button key="cancel-button" onClick={ onClose } disabled={ isLoading } variant="secondary">
 					{ closeLabel ?? translate( 'Cancel' ) }
 				</Button>,
 

--- a/client/a8c-for-agencies/components/a4a-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-confirmation-dialog/index.tsx
@@ -1,4 +1,5 @@
-import { Button, Dialog } from '@automattic/components';
+import { Dialog } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { clsx } from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
@@ -13,8 +14,8 @@ export type Props = {
 	onConfirm?: () => void;
 	ctaLabel?: string;
 	closeLabel?: string;
-	busy?: boolean;
-	scary?: boolean;
+	isLoading?: boolean;
+	isDestructive?: boolean;
 };
 
 export function A4AConfirmationDialog( {
@@ -25,8 +26,8 @@ export function A4AConfirmationDialog( {
 	ctaLabel,
 	closeLabel,
 	onClose,
-	busy,
-	scary,
+	isLoading,
+	isDestructive,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -37,16 +38,16 @@ export function A4AConfirmationDialog( {
 			additionalClassNames={ clsx( 'a4a-confirmation-dialog', className ) }
 			onClose={ onClose }
 			buttons={ [
-				<Button key="cancel-button" onClick={ onClose } disabled={ busy }>
+				<Button key="cancel-button" onClick={ onClose } disabled={ isLoading }>
 					{ closeLabel ?? translate( 'Cancel' ) }
 				</Button>,
 
 				<Button
 					key="confirmation-button"
-					primary
-					scary={ scary }
-					disabled={ busy }
-					busy={ busy }
+					variant="primary"
+					isDestructive={ isDestructive }
+					isBusy={ isLoading }
+					disabled={ isLoading }
 					onClick={ onConfirm }
 				>
 					{ ctaLabel ?? translate( 'Confirm' ) }

--- a/client/a8c-for-agencies/components/a4a-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-confirmation-dialog/index.tsx
@@ -5,7 +5,7 @@ import { ReactNode } from 'react';
 
 import './style.scss';
 
-type Props = {
+export type Props = {
 	className?: string;
 	title: string;
 	children: ReactNode;

--- a/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
+++ b/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
@@ -2,3 +2,10 @@
 	padding-block-end: 16px;
 	@include a4a-font-heading-lg;
 }
+
+.a4a-confirmation-dialog .dialog__action-buttons {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+	justify-content: flex-end;
+}

--- a/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
+++ b/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
@@ -1,0 +1,4 @@
+.a4a-confirmation-dialog__heading {
+	padding-block-end: 16px;
+	@include a4a-font-heading-lg;
+}

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -1,6 +1,7 @@
-import { Button, Dialog } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useCancelClientSubscription from 'calypso/a8c-for-agencies/data/client/use-cancel-client-subscription';
 import useFetchClientProducts from 'calypso/a8c-for-agencies/data/client/use-fetch-client-products';
@@ -59,47 +60,35 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 				{ translate( 'Cancel the subscription' ) }
 			</Button>
 
-			<Dialog
-				className="cancel-subscription-confirmation-dialog"
-				isVisible={ isVisible }
-				buttons={ [
-					<Button onClick={ handleClose } disabled={ isPending }>
-						{ translate( 'Keep the subscription' ) }
-					</Button>,
-					<Button
-						onClick={ () => onConfirm() }
-						scary
-						primary
-						busy={ isPending }
-						disabled={ isPending }
-					>
-						{ translate( 'Cancel subscription' ) }
-					</Button>,
-				] }
-				shouldCloseOnEsc
-				onClose={ handleClose }
-			>
-				<h1 className="cancel-subscription-confirmation-dialog__title">
-					{ translate( 'Are you sure you want to cancel this subscription?' ) }
-				</h1>
-				{ isFetchingProductInfo ? (
-					<TextPlaceholder />
-				) : (
-					translate(
-						'{{b}}%(productName)s{{/b}} will stop recommending products to your customers. This action cannot be undone.',
-						{
-							args: {
-								productName,
-							},
-							components: {
-								b: <b />,
-							},
-							comment:
-								'%(productName)s is the name of the product that the user is about to cancel.',
-						}
-					)
-				) }
-			</Dialog>
+			{ isVisible && (
+				<A4AConfirmationDialog
+					title={ translate( 'Are you sure you want to cancel this subscription?' ) }
+					onClose={ handleClose }
+					onConfirm={ onConfirm }
+					ctaLabel={ translate( 'Cancel subscription' ) }
+					closeLabel={ translate( 'Keep the subscription' ) }
+					busy={ isPending }
+					scary
+				>
+					{ isFetchingProductInfo ? (
+						<TextPlaceholder />
+					) : (
+						translate(
+							'{{b}}%(productName)s{{/b}} will stop recommending products to your customers. This action cannot be undone.',
+							{
+								args: {
+									productName,
+								},
+								components: {
+									b: <b />,
+								},
+								comment:
+									'%(productName)s is the name of the product that the user is about to cancel.',
+							}
+						)
+					) }
+				</A4AConfirmationDialog>
+			) }
 		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -67,8 +67,8 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 					onConfirm={ onConfirm }
 					ctaLabel={ translate( 'Cancel subscription' ) }
 					closeLabel={ translate( 'Keep the subscription' ) }
-					busy={ isPending }
-					scary
+					isLoading={ isPending }
+					isDestructive
 				>
 					{ isFetchingProductInfo ? (
 						<TextPlaceholder />

--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/secondary-confirmation-dialog.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/secondary-confirmation-dialog.tsx
@@ -1,5 +1,5 @@
-import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
 
 type Props = {
 	title: string;
@@ -19,29 +19,15 @@ export function SecondaryConfirmationDialog( {
 	const translate = useTranslate();
 
 	return (
-		<Dialog
-			isVisible
-			additionalClassNames="revoke-license-dialog"
-			onClose={ close }
-			buttons={ [
-				<Button disabled={ false } onClick={ onCancel } key="cancel-secondary-confirmation">
-					{ translate( 'Cancel' ) }
-				</Button>,
-
-				<Button
-					primary
-					scary
-					busy={ isPending }
-					onClick={ onConfirm }
-					key="confirm-secondary-confirmation"
-				>
-					{ translate( 'Continue revoke' ) }
-				</Button>,
-			] }
+		<A4AConfirmationDialog
+			title={ title }
+			ctaLabel={ translate( 'Revoke Pressable plan license' ) }
+			onClose={ onCancel }
+			onConfirm={ onConfirm }
+			busy={ isPending }
+			scary
 		>
-			<h2 className="revoke-license-dialog__heading">{ title }</h2>
-
 			{ description }
-		</Dialog>
+		</A4AConfirmationDialog>
 	);
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/secondary-confirmation-dialog.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/secondary-confirmation-dialog.tsx
@@ -24,8 +24,8 @@ export function SecondaryConfirmationDialog( {
 			ctaLabel={ translate( 'Revoke Pressable plan license' ) }
 			onClose={ onCancel }
 			onConfirm={ onConfirm }
-			busy={ isPending }
-			scary
+			isLoading={ isPending }
+			isDestructive
 		>
 			{ description }
 		</A4AConfirmationDialog>

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
@@ -46,8 +46,8 @@ const StoredCreditCardDeleteDialog: FunctionComponent< Props > = ( {
 			onConfirm={ onConfirm }
 			ctaLabel={ translate( 'Delete payment method' ) }
 			closeLabel={ translate( 'Go back' ) }
-			busy={ isDeleteInProgress }
-			scary
+			isLoading={ isDeleteInProgress }
+			isDestructive
 		>
 			<p>
 				{ translate(

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/index.tsx
@@ -1,6 +1,6 @@
-import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, type FunctionComponent } from 'react';
+import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
 import { PaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
 import { PaymentMethodOverviewContext } from '../../context';
 import useStoredCards from '../../hooks/use-stored-cards';
@@ -34,31 +34,21 @@ const StoredCreditCardDeleteDialog: FunctionComponent< Props > = ( {
 		isFetching,
 	} = useStoredCards( paging, true );
 
+	if ( ! isVisible ) {
+		return null;
+	}
+
 	return (
-		<Dialog
-			isVisible={ isVisible }
-			additionalClassNames="stored-credit-card-delete-dialog"
+		<A4AConfirmationDialog
+			className="stored-credit-card-delete-dialog"
+			title={ translate( 'Delete payment method' ) }
 			onClose={ onClose }
-			buttons={ [
-				<Button disabled={ false } onClick={ onClose }>
-					{ translate( 'Go back' ) }
-				</Button>,
-
-				<Button
-					busy={ isDeleteInProgress }
-					disabled={ isDeleteInProgress }
-					onClick={ onConfirm }
-					primary
-					scary
-				>
-					{ translate( 'Delete payment method' ) }
-				</Button>,
-			] }
+			onConfirm={ onConfirm }
+			ctaLabel={ translate( 'Delete payment method' ) }
+			closeLabel={ translate( 'Go back' ) }
+			busy={ isDeleteInProgress }
+			scary
 		>
-			<h2 className="stored-credit-card-delete-dialog__heading">
-				{ translate( 'Delete payment method' ) }
-			</h2>
-
 			<p>
 				{ translate(
 					'The payment method {{paymentMethodSummary/}} will be removed from your account',
@@ -87,7 +77,7 @@ const StoredCreditCardDeleteDialog: FunctionComponent< Props > = ( {
 					isFetching={ isFetching }
 				/>
 			) }
-		</Dialog>
+		</A4AConfirmationDialog>
 	);
 };
 

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/style.scss
@@ -10,41 +10,4 @@
 			font-size: 1rem;
 		}
 	}
-
-	.dialog__action-buttons {
-		display: flex;
-		justify-content: flex-end;
-		align-items: center;
-		background: var(--color-neutral-0);
-		border: 0;
-
-		a {
-			margin-right: auto;
-			font-weight: 600;
-			text-decoration: underline;
-		}
-
-		button {
-			width: 100%;
-
-			@include break-mobile {
-				width: auto;
-			}
-		}
-	}
-}
-
-.stored-credit-card-delete-dialog__heading {
-	margin: -16px -16px 16px;
-	padding: 9px 16px;
-	font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
-	font-weight: 600;
-	line-height: 20px;
-	border-bottom: 1px solid var(--color-neutral-5);
-
-	@include break-mobile() {
-		margin: -24px -24px 24px;
-		padding: 9px 24px;
-		line-height: 36px;
-	}
 }

--- a/client/a8c-for-agencies/sections/sites/site-remove-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-remove-confirmation-dialog/index.tsx
@@ -1,7 +1,5 @@
-import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-
-import './style.scss';
+import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
 
 type Props = {
 	siteName: string;
@@ -16,30 +14,14 @@ export function SiteRemoveConfirmationDialog( { siteName, onConfirm, onClose, bu
 	const title = translate( 'Remove site' );
 
 	return (
-		<Dialog
-			label={ title }
-			isVisible
-			additionalClassNames="site-remove-confirmation-dialog"
+		<A4AConfirmationDialog
+			title={ title }
 			onClose={ onClose }
-			buttons={ [
-				<Button key="cancel-button" onClick={ onClose } disabled={ busy }>
-					{ translate( 'Cancel' ) }
-				</Button>,
-
-				<Button
-					key="remove-site-button"
-					primary
-					scary
-					disabled={ busy }
-					busy={ busy }
-					onClick={ onConfirm }
-				>
-					{ translate( 'Remove site' ) }
-				</Button>,
-			] }
+			onConfirm={ onConfirm }
+			ctaLabel={ translate( 'Remove site' ) }
+			busy={ busy }
+			scary
 		>
-			<h2 className="site-remove-confirmation-dialog__heading">{ title }</h2>
-
 			{ translate(
 				'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}} from the dashboard?',
 				{
@@ -50,6 +32,6 @@ export function SiteRemoveConfirmationDialog( { siteName, onConfirm, onClose, bu
 					comment: '%(siteName)s is the site name',
 				}
 			) }
-		</Dialog>
+		</A4AConfirmationDialog>
 	);
 }

--- a/client/a8c-for-agencies/sections/sites/site-remove-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-remove-confirmation-dialog/index.tsx
@@ -19,8 +19,8 @@ export function SiteRemoveConfirmationDialog( { siteName, onConfirm, onClose, bu
 			onClose={ onClose }
 			onConfirm={ onConfirm }
 			ctaLabel={ translate( 'Remove site' ) }
-			busy={ busy }
-			scary
+			isLoading={ busy }
+			isDestructive
 		>
 			{ translate(
 				'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}} from the dashboard?',

--- a/client/a8c-for-agencies/sections/sites/site-remove-confirmation-dialog/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-remove-confirmation-dialog/style.scss
@@ -1,9 +1,0 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
-
-.site-remove-confirmation-dialog {
-	.site-remove-confirmation-dialog__heading {
-		padding-block-end: 16px;
-		@include a4a-font-heading-lg;
-	}
-}

--- a/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
@@ -19,7 +19,7 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 	const { mutate: removeMember } = useRemoveMemberMutation();
 
 	return useCallback(
-		( action: string, item: TeamMember ) => {
+		( action: string, item: TeamMember, callback?: () => void ) => {
 			if ( action === 'cancel-user-invite' ) {
 				cancelMemberInvite(
 					{ id: item.id },
@@ -32,6 +32,7 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 								} )
 							);
 							onRefetchList?.();
+							callback?.();
 						},
 
 						onError: ( error ) => {
@@ -41,6 +42,7 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 									duration: 5000,
 								} )
 							);
+							callback?.();
 						},
 					}
 				);
@@ -58,6 +60,7 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 								} )
 							);
 							onRefetchList?.();
+							callback?.();
 						},
 
 						onError: ( error ) => {
@@ -67,6 +70,7 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 									duration: 5000,
 								} )
 							);
+							callback?.();
 						},
 					}
 				);

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -124,7 +124,7 @@ export const ActionColumn = ( {
 				setConfirmationDialog( {
 					...confirmation,
 					onConfirm: () => {
-						setConfirmationDialog( ( prev ) => ( prev ? { ...prev, busy: true } : null ) );
+						setConfirmationDialog( ( prev ) => ( prev ? { ...prev, isLoading: true } : null ) );
 						onMenuSelected?.( name, () => setConfirmationDialog( null ) );
 					},
 					onClose: () => {
@@ -159,7 +159,7 @@ export const ActionColumn = ( {
 								}
 							),
 							ctaLabel: translate( 'Cancel invitation' ),
-							scary: true,
+							isDestructive: true,
 						},
 					},
 			  ]
@@ -184,12 +184,13 @@ export const ActionColumn = ( {
 								comment: '%(memberName)s is the member name',
 							} ),
 							ctaLabel: translate( 'Delete user' ),
-							scary: true,
+							isDestructive: true,
 						},
 					},
 			  ];
 	}, [ member, canRemove, translate ] );
 
+	// We don't show the action menu when the member is the owner of the team.
 	if ( member.role === OWNER_ROLE ) {
 		return null;
 	}

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -107,7 +107,7 @@ export default function TeamList() {
 					return (
 						<ActionColumn
 							member={ item }
-							onMenuSelected={ ( action ) => handleAction( action, item ) }
+							onMenuSelected={ ( action, callback ) => handleAction( action, item, callback ) }
 							canRemove={ canRemove || item.email === currentUser?.email }
 						/>
 					);

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -181,6 +181,7 @@
 		}
 	}
 
+	.components-button.is-destructive,
 	.button.is-scary {
 		color: var(--color-scary-50);
 		border-color: var(--color-scary-50);
@@ -193,6 +194,7 @@
 		}
 	}
 
+	.components-button.is-primary.is-destructive,
 	.button.is-primary.is-scary {
 		background-color: var(--color-scary-50);
 		color: var(--color-text-inverted);


### PR DESCRIPTION
This pull request includes a feature that adds a confirmation dialog when deleting a member or canceling an invite. This prevents accidental deletions or cancellations.

<img width="744" alt="Screenshot 2024-09-04 at 7 08 53 PM" src="https://github.com/user-attachments/assets/d80c8712-3a30-43a8-8af2-0fec7d6fa4e0">
<img width="612" alt="Screenshot 2024-09-04 at 7 10 11 PM" src="https://github.com/user-attachments/assets/26ae1fa2-4e27-4899-bbac-698910242190">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1023

## Proposed Changes

* **Secondary changes:** I've noticed that we use confirmation dialogs in a few different areas, and we have some repeated implementations. This pull request unifies these implementations by adding a reusable component to prevent duplicating similar patterns. An additional advantage of this approach is that we ensure consistent styling across all confirmation dialogs.
* **Mange changes:** Using the reusable confirmation dialog, we now show a message when cancelling a member invitation or removing a member.

## Why are these changes being made?

 This is to prevent accidental deletions or cancellations.

## Testing Instructions

* Use the A4A live link and go to the `/team` page
* Add a member to the agency and as well create the invitation.
* Confirm that when removing a member, a confirmation dialog is displayed.
* Confirm that when canceling a member invite, a confirmation dialog is displayed.
* Please also test that there are no regressions to existing confirmation dialogs:
  * Remove site
  * Revoke license
  * Remove Payment methods
  * Cancel client subscription

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
