### PR TITLE
Block Editor: Fix underline keyboard shortcut

### DIFF
--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -1,5 +1,10 @@
 /* global wpcomGutenberg */
-import { RichTextToolbarButton } from '@wordpress/block-editor';
+import {
+	RichTextShortcut,
+	RichTextToolbarButton,
+	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
+	__unstableRichTextInputEvent,
+} from '@wordpress/block-editor';
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect, withDispatch, select, subscribe } from '@wordpress/data';
 import { toggleFormat, registerFormatType, unregisterFormatType } from '@wordpress/rich-text';
@@ -27,12 +32,16 @@ const unsubscribe = subscribe( () => {
 				);
 
 			return (
-				<RichTextToolbarButton
-					icon="editor-underline"
-					title={ settings.title }
-					onClick={ onToggle }
-					isActive={ isActive }
-				/>
+				<>
+					<RichTextShortcut type="primary" character="u" onUse={ onToggle } />
+					<RichTextToolbarButton
+						icon="editor-underline"
+						title={ settings.title }
+						onClick={ onToggle }
+						isActive={ isActive }
+					/>
+					<__unstableRichTextInputEvent inputType="formatUnderline" onInput={ onToggle } />
+				</>
 			);
 		},
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/71631

## Proposed Changes

This PR adds the shortcut handling as it is in core. I couldn't think of a way to handle this in core with a setting or something, but I think even if we find a core first way later, this PR is still valuable for now.


## Testing Instructions
1. Open the post editor and select some text
2. Use the shortcut `Command+U` (Mac) or `Ctrl+U` (Windows)
3. The text should be underlined and the format active

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
