### PR TITLE
Plugin upload -> upgrade plan: Show success notice upon return.

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -119,7 +119,9 @@ export const EligibilityWarnings = ( {
 			const planSlug = PLAN_BUSINESS;
 			let redirectUrl = `/checkout/${ siteSlug }/${ planSlug }`;
 			if ( context === 'plugins-upload' ) {
-				redirectUrl = `${ redirectUrl }?redirect_to=/plugins/upload/${ siteSlug }`;
+				redirectUrl = `${ redirectUrl }?redirect_to=${ encodeURIComponent(
+					`/plugins/upload/${ siteSlug }?showUpgradeSuccessNotice=true`
+				) }`;
 			}
 			if ( showFreeTrial ) {
 				onProceed( options );

--- a/client/my-sites/plugins/controller-logged-in.js
+++ b/client/my-sites/plugins/controller-logged-in.js
@@ -1,8 +1,27 @@
+import { removeQueryArgs } from '@wordpress/url';
+import { translate } from 'i18n-calypso';
+import { successNotice } from 'calypso/state/notices/actions';
 import Plans from './plans';
 import PluginUpload from './plugin-upload';
 
 export function upload( context, next ) {
 	context.primary = <PluginUpload />;
+	next();
+}
+
+export function maybeShowUpgradeSuccessNotice( context, next ) {
+	if ( context.query.showUpgradeSuccessNotice ) {
+		// Bump the notice to the back of the callstack so it is called after client render.
+		setTimeout( () => {
+			context.store.dispatch(
+				successNotice( translate( 'Thank you for your purchase!' ), {
+					id: 'plugin-upload-upgrade-plan-success',
+					duration: 5000,
+				} )
+			);
+		}, 0 );
+		context.page.replace( removeQueryArgs( context.canonicalPath, 'showUpgradeSuccessNotice' ) );
+	}
 	next();
 }
 

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -27,7 +27,7 @@ import {
 	redirectStagingSites,
 	renderPluginsSidebar,
 } from './controller';
-import { plans, upload } from './controller-logged-in';
+import { maybeShowUpgradeSuccessNotice, plans, upload } from './controller-logged-in';
 
 export default function ( router ) {
 	const langParam = getLanguageRouteParam();
@@ -89,6 +89,7 @@ export default function ( router ) {
 		redirectTrialSites,
 		upload,
 		makeLayout,
+		maybeShowUpgradeSuccessNotice,
 		clientRender
 	);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/93607

## Proposed Changes

Adds an upgrade success notice to the plugin/upload page when returning from the plan upgrade flow from here.
* Adds a query arg for `showUpgradeSuccessNotice` on the `redirect_to` URL passed to and used by checkout.
* Adds a middleware on the route for `*/plugins/upload/:site` to remove the query param and trigger a success notice when present.

Current copy: "Thank you for your purchase!"

<img width="400" alt="Screenshot 2024-09-04 at 1 15 36 PM" src="https://github.com/user-attachments/assets/f6f5cb92-faa0-44eb-b0f1-aed67c608c4d">

<img width="700" alt="Screenshot 2024-09-04 at 1 15 36 PM" src="https://github.com/user-attachments/assets/f85f6368-cffc-4b1e-9e8b-cea50366c0bb">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There is no indication the upgrade succeeded and no thank you page in this upgrade flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test the query param itself.
* go to `*/plugins/upload/:siteSlug` for a site.
* verify there is no notice shown.
* add they query param `?showUpgradeSuccessNotice=true` and reload.
* verify a success notice appears, and that the query param is gone from the url.

Test the upgrade flow
* go to `*/plugins/upload/:siteSlug` for a free site.
* click the CTA to upgrade your plan in order to upload a plugin.
* complete checkout.
* when landing back on the plugin upload page, verify a success message is present.
Test other variations, like bailing from the checkout flow. Verify there is no success notice.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
