### PR TITLE
Performance Profiler: Update disclaimer wrapping

### DIFF
--- a/client/performance-profiler/components/disclaimer-section/style.scss
+++ b/client/performance-profiler/components/disclaimer-section/style.scss
@@ -4,6 +4,7 @@
 	justify-content: space-between;
 	align-items: flex-end;
 	gap: 10px;
+	flex-wrap: wrap;
 
 	color: var(--studio-gray-70);
 	font-size: $font-body-extra-small;


### PR DESCRIPTION
Related to [Performance Profiler: Make profiler responsive to various screen sizes](https://github.com/Automattic/dotcom-forge/issues/8898)

## Proposed Changes

Update disclaimer wrapping mode on tablet and mobile screens

## Why are these changes being made?

To match figma and to have a better version on mobile and tablets

## Testing Instructions


* Go to `/speed-test-tool?url=wordpress.com`
* Resize the window and test cellphone and tablet sizes on the browser 
* The link on the right should wrap to bellow other text

| Desktop  | Tablet |
| ------------- | ------------- |
|![CleanShot 2024-09-04 at 13 21 51@2x](https://github.com/user-attachments/assets/6f51284f-5186-4154-a21f-634bddd5ed24)|![CleanShot 2024-09-04 at 13 22 06@2x](https://github.com/user-attachments/assets/ab69f1fa-0a95-4c61-86f7-8a7f61db9de3)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
