### PR TITLE
Stats: Apply notice endpoint to limit feedback form submission

### DIFF
--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -120,7 +120,9 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 				<div className="stats-feedback-modal__button">
 					{ ! isCheckingAbilityToSubmitFeedback && ! isAbleToSubmitFeedback && (
 						<strong>
-							<em>{ translate( 'You may submit additional feedback 24 hours later.' ) }</em>
+							<em>
+								{ translate( 'Feedback submission is currently limited to one per 24 hours.' ) }
+							</em>
 						</strong>
 					) }
 					<StatsButton

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -115,6 +115,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 					name="content"
 					value={ content }
 					onChange={ setContent }
+					disabled={ ! isCheckingAbilityToSubmitFeedback && ! isAbleToSubmitFeedback }
 				/>
 				<div className="stats-feedback-modal__button">
 					{ ! isCheckingAbilityToSubmitFeedback && ! isAbleToSubmitFeedback && (

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -29,7 +29,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 	} = useNoticeVisibilityQuery( siteId, 'able_to_submit_user_feedback' );
 
 	// Disable feedback submission for 24 hours.
-	const { mutateAsync: disableFeedbackSubmissionInOneDay } = useNoticeVisibilityMutation(
+	const { mutateAsync: disableFeedbackSubmissionForOneDay } = useNoticeVisibilityMutation(
 		siteId,
 		'able_to_submit_user_feedback',
 		'postponed',
@@ -74,7 +74,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 				} )
 			);
 
-			disableFeedbackSubmissionInOneDay().then( () => {
+			disableFeedbackSubmissionForOneDay().then( () => {
 				refetchNotices();
 			} );
 
@@ -85,7 +85,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 		isSubmissionSuccessful,
 		handleClose,
 		translate,
-		disableFeedbackSubmissionInOneDay,
+		disableFeedbackSubmissionForOneDay,
 		refetchNotices,
 	] );
 

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -17,7 +17,7 @@ interface ModalProps {
 	onClose: () => void;
 }
 
-const NOTICE_KEY_TO_DISABLE_FEEDBACK_SUBMISSION = 'able_to_submit_user_feedback';
+const NOTICE_KEY_FOR_FEEDBACK_SUBMISSION = 'able_to_submit_user_feedback';
 
 const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 	const translate = useTranslate();
@@ -28,12 +28,12 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 		data: isAbleToSubmitFeedback,
 		isFetching: isCheckingAbilityToSubmitFeedback,
 		refetch: refetchNotices,
-	} = useNoticeVisibilityQuery( siteId, NOTICE_KEY_TO_DISABLE_FEEDBACK_SUBMISSION );
+	} = useNoticeVisibilityQuery( siteId, NOTICE_KEY_FOR_FEEDBACK_SUBMISSION );
 
 	// Disable feedback submission for 24 hours.
 	const { mutateAsync: disableFeedbackSubmissionForOneDay } = useNoticeVisibilityMutation(
 		siteId,
-		NOTICE_KEY_TO_DISABLE_FEEDBACK_SUBMISSION,
+		NOTICE_KEY_FOR_FEEDBACK_SUBMISSION,
 		'postponed',
 		24 * 3600
 	);

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -3,6 +3,8 @@ import { close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useCallback, useEffect } from 'react';
 import StatsButton from 'calypso/my-sites/stats/components/stats-button';
+import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -19,6 +21,20 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const [ content, setContent ] = useState( '' );
+
+	const {
+		data: isAbleToSubmitFeedback,
+		isFetching: isCheckingAbilityToSubmitFeedback,
+		refetch: refetchNotices,
+	} = useNoticeVisibilityQuery( siteId, 'able_to_submit_user_feedback' );
+
+	// Disable feedback submission for 24 hours.
+	const { mutateAsync: disableFeedbackSubmissionInOneDay } = useNoticeVisibilityMutation(
+		siteId,
+		'able_to_submit_user_feedback',
+		'postponed',
+		24 * 3600
+	);
 
 	const { isSubmittingFeedback, submitFeedback, isSubmissionSuccessful } =
 		useSubmitProductFeedback( siteId );
@@ -58,9 +74,20 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 				} )
 			);
 
+			disableFeedbackSubmissionInOneDay().then( () => {
+				refetchNotices();
+			} );
+
 			handleClose();
 		}
-	}, [ dispatch, isSubmissionSuccessful, handleClose, translate ] );
+	}, [
+		dispatch,
+		isSubmissionSuccessful,
+		handleClose,
+		translate,
+		disableFeedbackSubmissionInOneDay,
+		refetchNotices,
+	] );
 
 	return (
 		<Modal className="stats-feedback-modal" onRequestClose={ handleClose } __experimentalHideHeader>
@@ -90,11 +117,20 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 					onChange={ setContent }
 				/>
 				<div className="stats-feedback-modal__button">
+					{ ! isCheckingAbilityToSubmitFeedback && ! isAbleToSubmitFeedback && (
+						<small>{ translate( 'You may submit additional feedback 24 hours later.' ) }</small>
+					) }
 					<StatsButton
 						primary
 						onClick={ onFormSubmit }
 						busy={ isSubmittingFeedback }
-						disabled={ isSubmittingFeedback || isSubmissionSuccessful || ! content }
+						disabled={
+							isCheckingAbilityToSubmitFeedback ||
+							! isAbleToSubmitFeedback ||
+							isSubmittingFeedback ||
+							isSubmissionSuccessful ||
+							! content
+						}
 					>
 						{ translate( 'Submit' ) }
 					</StatsButton>

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -17,6 +17,8 @@ interface ModalProps {
 	onClose: () => void;
 }
 
+const NOTICE_KEY_TO_DISABLE_FEEDBACK_SUBMISSION = 'able_to_submit_user_feedback';
+
 const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -26,12 +28,12 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 		data: isAbleToSubmitFeedback,
 		isFetching: isCheckingAbilityToSubmitFeedback,
 		refetch: refetchNotices,
-	} = useNoticeVisibilityQuery( siteId, 'able_to_submit_user_feedback' );
+	} = useNoticeVisibilityQuery( siteId, NOTICE_KEY_TO_DISABLE_FEEDBACK_SUBMISSION );
 
 	// Disable feedback submission for 24 hours.
 	const { mutateAsync: disableFeedbackSubmissionForOneDay } = useNoticeVisibilityMutation(
 		siteId,
-		'able_to_submit_user_feedback',
+		NOTICE_KEY_TO_DISABLE_FEEDBACK_SUBMISSION,
 		'postponed',
 		24 * 3600
 	);

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -118,7 +118,9 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 				/>
 				<div className="stats-feedback-modal__button">
 					{ ! isCheckingAbilityToSubmitFeedback && ! isAbleToSubmitFeedback && (
-						<small>{ translate( 'You may submit additional feedback 24 hours later.' ) }</small>
+						<strong>
+							<em>{ translate( 'You may submit additional feedback 24 hours later.' ) }</em>
+						</strong>
 					) }
 					<StatsButton
 						primary

--- a/client/my-sites/stats/feedback/modal/style.scss
+++ b/client/my-sites/stats/feedback/modal/style.scss
@@ -44,12 +44,18 @@
 }
 
 .stats-feedback-modal__button {
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
 	margin-top: 24px;
 	font-family: $font-sf-pro-text;
 	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 20px;
-	text-align: right;
+
+	small {
+		margin-right: 8px;
+	}
 
 	button {
 		padding: 10px 16px;

--- a/client/my-sites/stats/feedback/modal/style.scss
+++ b/client/my-sites/stats/feedback/modal/style.scss
@@ -53,7 +53,7 @@
 	font-weight: 400;
 	line-height: 20px;
 
-	small {
+	strong {
 		margin-right: 8px;
 	}
 

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -12,6 +12,7 @@ const DEFAULT_SERVER_NOTICES_VISIBILITY = {
 	// TODO: Check if the site needs to be upgraded to a higher tier on the back end.
 	tier_upgrade: true,
 	gdpr_cookie_consent: false,
+	able_to_submit_user_feedback: false,
 };
 const DEFAULT_CLIENT_NOTICES_VISIBILITY = {
 	client_paid_plan_purchase_success: true,

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -12,7 +12,7 @@ const DEFAULT_SERVER_NOTICES_VISIBILITY = {
 	// TODO: Check if the site needs to be upgraded to a higher tier on the back end.
 	tier_upgrade: true,
 	gdpr_cookie_consent: false,
-	able_to_submit_user_feedback: false,
+	able_to_submit_user_feedback: true,
 };
 const DEFAULT_CLIENT_NOTICES_VISIBILITY = {
 	client_paid_plan_purchase_success: true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/157

## Proposed Changes

* Add the Stats notice ID `able_to_submit_user_feedback` to check the ability to send the feedback form.
* Postpone the Stats notice ID `able_to_submit_user_feedback` for 24 hours after submitting the feedback form.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Use the Stats notice mechanism to prevent submitting feedback forms frequently.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the Diff D160350-code and sandbox `public-api.wordpress.com`.
* Spin this change up with the Calypso Live branch.
* Launch the Stats feedback modal.
* Ensure the `Submit` button is enabled when typing content.

<img width="750" alt="截圖 2024-09-05 上午12 45 41" src="https://github.com/user-attachments/assets/7d97c0fa-e42d-4bad-a570-958fc7b118c4">

* Submit the modal form and reopen the feedback modal.
* Ensure the `Submit` button is disabled with a notice sentence.

<img width="731" alt="截圖 2024-09-05 上午12 45 59" src="https://github.com/user-attachments/assets/ffdc6f7c-3b1b-4582-b27f-afaf6cd42829">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
