### PR TITLE
Automated Migraiton: Hide the notes field and expand the credentials fields

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -416,9 +416,6 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 					) }
 				</div>
 
-				{ errors?.notes && (
-					<div className="site-migration-credentials__form-error">{ errors.notes.message }</div>
-				) }
 				{ errors?.root && (
 					<div className="site-migration-credentials__form-error">{ errors.root.message }</div>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -378,8 +378,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 					) }
 					{ showNotes && (
 						<>
-							<div className="site-migration-credentials__form-field">
-								<FormLabel htmlFor="notes">{ translate( 'Notes (optional)' ) }</FormLabel>
+							<div className="site-migration-credentials__form-field site-migration-credentials__form-field--notes">
 								<Controller
 									control={ control }
 									name="notes"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -364,7 +364,10 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 				<div className="site-migration-credentials__special-instructions">
 					{ ( locale === 'en' || hasTranslation( 'Special instructions' ) ) && (
-						<Button onClick={ () => setShowNotes( ! showNotes ) }>
+						<Button
+							onClick={ () => setShowNotes( ! showNotes ) }
+							data-testid="special-instructions"
+						>
 							{ translate( 'Special instructions' ) }
 							<Icon
 								icon={ showNotes ? chevronUp : chevronDown }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -1,8 +1,9 @@
 import { FormLabel } from '@automattic/components';
 import Card from '@automattic/components/src/card';
 import { NextButton, StepContainer } from '@automattic/onboarding';
-import { Icon } from '@wordpress/components';
-import { seen, unseen } from '@wordpress/icons';
+import { Icon, Button } from '@wordpress/components';
+import { seen, unseen, chevronDown, chevronUp } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, type FC } from 'react';
@@ -40,8 +41,10 @@ const mapApiError = ( error: any ) => {
 
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip } ) => {
 	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
 
 	const [ passwordHidden, setPasswordHidden ] = useState( true );
+	const [ showNotes, setShowNotes ] = useState( ! hasTranslation( 'Special instructions' ) );
 
 	const toggleVisibilityClasses = clsx( {
 		'site-migration-credentials__form-password__toggle': true,
@@ -240,67 +243,74 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 								) }
 							</div>
 
-							<div className="site-migration-credentials__form-fields-row">
-								<div className="site-migration-credentials__form-field">
-									<FormLabel htmlFor="username">
-										{ translate( 'WordPress admin username' ) }
-									</FormLabel>
-									<Controller
-										control={ control }
-										name="username"
-										rules={ {
-											required: translate( 'Please enter your WordPress admin username.' ),
-										} }
-										render={ ( { field } ) => (
+							<div className="site-migration-credentials__form-field">
+								<FormLabel htmlFor="username">
+									{ translate( 'WordPress admin username' ) }
+								</FormLabel>
+								<Controller
+									control={ control }
+									name="username"
+									rules={ {
+										required: translate( 'Please enter your WordPress admin username.' ),
+									} }
+									render={ ( { field } ) => (
+										<FormTextInput
+											id="username"
+											type="text"
+											isError={ !! errors.username }
+											placeholder={
+												hasTranslation( 'Enter your Admin username' )
+													? translate( 'Enter your Admin username' )
+													: translate( 'Username' )
+											}
+											{ ...field }
+											onChange={ ( e: any ) => {
+												const trimmedValue = e.target.value.trim();
+												field.onChange( trimmedValue );
+											} }
+											onBlur={ ( e: any ) => {
+												field.onBlur();
+												e.target.value = e.target.value.trim();
+											} }
+										/>
+									) }
+								/>
+							</div>
+
+							<div className="site-migration-credentials__form-field">
+								<FormLabel htmlFor="site-migration-credentials__password">
+									{ translate( 'Password' ) }
+								</FormLabel>
+								<Controller
+									control={ control }
+									name="password"
+									rules={ {
+										required: translate( 'Please enter your WordPress admin password.' ),
+									} }
+									render={ ( { field } ) => (
+										<div className="site-migration-credentials__form-password">
 											<FormTextInput
-												id="username"
-												type="text"
-												isError={ !! errors.username }
-												placeholder={ translate( 'Username' ) }
+												autoComplete="off"
+												id="site-migration-credentials__password"
+												type={ passwordHidden ? 'password' : 'text' }
+												isError={ !! errors.password }
+												placeholder={
+													hasTranslation( 'Enter your Admin password' )
+														? translate( 'Enter your Admin password' )
+														: translate( 'Password' )
+												}
 												{ ...field }
-												onChange={ ( e: any ) => {
-													const trimmedValue = e.target.value.trim();
-													field.onChange( trimmedValue );
-												} }
-												onBlur={ ( e: any ) => {
-													field.onBlur();
-													e.target.value = e.target.value.trim();
-												} }
 											/>
-										) }
-									/>
-								</div>
-								<div className="site-migration-credentials__form-field">
-									<FormLabel htmlFor="site-migration-credentials__password">
-										{ translate( 'Password' ) }
-									</FormLabel>
-									<Controller
-										control={ control }
-										name="password"
-										rules={ {
-											required: translate( 'Please enter your WordPress admin password.' ),
-										} }
-										render={ ( { field } ) => (
-											<div className="site-migration-credentials__form-password">
-												<FormTextInput
-													autoComplete="off"
-													id="site-migration-credentials__password"
-													type={ passwordHidden ? 'password' : 'text' }
-													isError={ !! errors.password }
-													placeholder={ translate( 'Password' ) }
-													{ ...field }
-												/>
-												<button
-													className={ toggleVisibilityClasses }
-													onClick={ () => setPasswordHidden( ! passwordHidden ) }
-													type="button"
-												>
-													{ passwordHidden ? <Icon icon={ unseen } /> : <Icon icon={ seen } /> }
-												</button>
-											</div>
-										) }
-									/>
-								</div>
+											<button
+												className={ toggleVisibilityClasses }
+												onClick={ () => setPasswordHidden( ! passwordHidden ) }
+												type="button"
+											>
+												{ passwordHidden ? <Icon icon={ unseen } /> : <Icon icon={ seen } /> }
+											</button>
+										</div>
+									) }
+								/>
 							</div>
 
 							{ ( errors.username || errors.password ) && (
@@ -348,25 +358,47 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 					</div>
 				) }
 
-				<div className="site-migration-credentials__form-field">
-					<FormLabel htmlFor="notes">{ translate( 'Notes (optional)' ) }</FormLabel>
-					<Controller
-						control={ control }
-						name="notes"
-						render={ ( { field } ) => (
-							<FormTextArea
-								id="notes"
-								type="text"
-								maxLength={ 1000 }
-								placeholder={ translate(
-									'Share any other details that will help us access your site for the migration.'
-								) }
-								{ ...field }
-								ref={ null }
+				<div className="site-migration-credentials__special-instructions">
+					{ hasTranslation( 'Special instructions' ) && (
+						<Button onClick={ () => setShowNotes( ! showNotes ) }>
+							{ translate( 'Special instructions' ) }
+							<Icon
+								icon={ showNotes ? chevronUp : chevronDown }
+								size={ 24 }
+								className="site-migration-credentials__special-instructions-icon"
 							/>
-						) }
-					/>
+						</Button>
+					) }
+					{ showNotes && (
+						<>
+							<div className="site-migration-credentials__form-field">
+								<FormLabel htmlFor="notes">{ translate( 'Notes (optional)' ) }</FormLabel>
+								<Controller
+									control={ control }
+									name="notes"
+									render={ ( { field } ) => (
+										<FormTextArea
+											id="notes"
+											type="text"
+											maxLength={ 1000 }
+											placeholder={ translate(
+												'Share any other details that will help us access your site for the migration.'
+											) }
+											{ ...field }
+											ref={ null }
+										/>
+									) }
+								/>
+							</div>
+							{ errors?.notes && (
+								<div className="site-migration-credentials__form-error">
+									{ errors.notes.message }
+								</div>
+							) }
+						</>
+					) }
 				</div>
+
 				{ errors?.notes && (
 					<div className="site-migration-credentials__form-error">{ errors.notes.message }</div>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -349,7 +349,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 									{ errors.backupFileLocation?.message }
 								</div>
 							) }
-							<div className="site-migration-credentials__form-note">
+							<div className="site-migration-credentials__form-note site-migration-credentials__backup-note">
 								{ translate(
 									"Upload your file to a service like Dropbox or Google Drive to get a link. Don't forget to make sure that anyone with the link can access it."
 								) }
@@ -393,6 +393,15 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 							{ errors?.notes && (
 								<div className="site-migration-credentials__form-error">
 									{ errors.notes.message }
+								</div>
+							) }
+							{ hasTranslation(
+								"Please don't share any passwords or secure information in this field. We'll reach out to collect that information if you have any additional credentials to access your site."
+							) && (
+								<div className="site-migration-credentials__form-note">
+									{ translate(
+										"Please don't share any passwords or secure information in this field. We'll reach out to collect that information if you have any additional credentials to access your site."
+									) }
 								</div>
 							) }
 						</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -15,6 +15,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextArea from 'calypso/components/forms/form-textarea';
+import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isValidUrl } from 'calypso/lib/importer/url-validation';
@@ -42,9 +43,12 @@ const mapApiError = ( error: any ) => {
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip } ) => {
 	const translate = useTranslate();
 	const { hasTranslation } = useI18n();
+	const locale = useFlowLocale();
 
 	const [ passwordHidden, setPasswordHidden ] = useState( true );
-	const [ showNotes, setShowNotes ] = useState( ! hasTranslation( 'Special instructions' ) );
+	const [ showNotes, setShowNotes ] = useState(
+		! ( locale === 'en' || hasTranslation( 'Special instructions' ) )
+	);
 
 	const toggleVisibilityClasses = clsx( {
 		'site-migration-credentials__form-password__toggle': true,
@@ -259,7 +263,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 											type="text"
 											isError={ !! errors.username }
 											placeholder={
-												hasTranslation( 'Enter your Admin username' )
+												locale === 'en' || hasTranslation( 'Enter your Admin username' )
 													? translate( 'Enter your Admin username' )
 													: translate( 'Username' )
 											}
@@ -295,7 +299,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 												type={ passwordHidden ? 'password' : 'text' }
 												isError={ !! errors.password }
 												placeholder={
-													hasTranslation( 'Enter your Admin password' )
+													locale === 'en' || hasTranslation( 'Enter your Admin password' )
 														? translate( 'Enter your Admin password' )
 														: translate( 'Password' )
 												}
@@ -359,7 +363,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 				) }
 
 				<div className="site-migration-credentials__special-instructions">
-					{ hasTranslation( 'Special instructions' ) && (
+					{ ( locale === 'en' || hasTranslation( 'Special instructions' ) ) && (
 						<Button onClick={ () => setShowNotes( ! showNotes ) }>
 							{ translate( 'Special instructions' ) }
 							<Icon
@@ -395,9 +399,10 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 									{ errors.notes.message }
 								</div>
 							) }
-							{ hasTranslation(
-								"Please don't share any passwords or secure information in this field. We'll reach out to collect that information if you have any additional credentials to access your site."
-							) && (
+							{ ( locale === 'en' ||
+								hasTranslation(
+									"Please don't share any passwords or secure information in this field. We'll reach out to collect that information if you have any additional credentials to access your site."
+								) ) && (
 								<div className="site-migration-credentials__form-note">
 									{ translate(
 										"Please don't share any passwords or secure information in this field. We'll reach out to collect that information if you have any additional credentials to access your site."

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -386,6 +386,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 										<FormTextArea
 											id="notes"
 											type="text"
+											data-testid="special-instructions-textarea"
 											maxLength={ 1000 }
 											placeholder={ translate(
 												'Share any other details that will help us access your site for the migration.'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -61,8 +61,9 @@
 			}
 		}
 		.site-migration-credentials__form-note {
-			margin-top: 1em;
 			color: var(--color-text-subtle);
+			font-size: 0.875rem;
+			font-style: italic;
 		}
 		.site-migration-credentials__form-error {
 			color: var(--color-error);
@@ -110,5 +111,8 @@
 		.site-migration-credentials__special-instructions-icon {
 			fill: var(--color-text) !important;
 		}
+	}
+	.site-migration-credentials__backup-note {
+		margin-top: 0.25rem;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -97,4 +97,18 @@
 		margin-top: 1em;
 		text-align: center;
 	}
+	.site-migration-credentials__special-instructions {
+		.components-button {
+			padding: 0;
+			height: auto;
+			font-size: 0.875rem;
+			font-weight: 600;
+			color: var(--color-text);
+			margin-top: 1rem;
+		}
+
+		.site-migration-credentials__special-instructions-icon {
+			fill: var(--color-text) !important;
+		}
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -35,6 +35,9 @@
 			margin-top: 1em;
 			flex: 1;
 		}
+		.site-migration-credentials__form-field--notes {
+			margin-top: 5px;
+		}
 		.site-migration-credentials__radio-group {
 			display: flex;
 			flex-direction: column;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -110,6 +110,9 @@ describe( 'SiteMigrationCredentials', () => {
 			const submit = jest.fn();
 			render( { navigation: { submit } } );
 
+			const expandNotesButton = screen.getByTestId( 'special-instructions' );
+			await userEvent.click( expandNotesButton );
+
 			const addressInput = screen.getByLabelText( /Site address/ );
 			const usernameInput = screen.getByLabelText( /WordPress admin username/ );
 			const passwordInput = screen.getByLabelText( /Password/ );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -41,7 +41,7 @@ describe( 'SiteMigrationCredentials', () => {
 		expect( screen.queryByText( 'Site address' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'WordPress admin username' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Password' ) ).toBeInTheDocument();
-		expect( screen.queryByText( 'Notes (optional)' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Special instructions' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not show any error message by default', async () => {
@@ -175,6 +175,10 @@ describe( 'SiteMigrationCredentials', () => {
 			const addressInput = screen.getByLabelText(
 				isBackupRequest ? /Backup file location/ : /Site address/
 			);
+
+			const expandNotesButton = screen.getByTestId( 'special-instructions' );
+			await userEvent.click( expandNotesButton );
+
 			const notesInput = screen.getByLabelText( /Notes \(optional\)/ );
 
 			await userEvent.type( addressInput, siteAddress );
@@ -280,6 +284,9 @@ describe( 'SiteMigrationCredentials', () => {
 
 			const submit = jest.fn();
 			render( { navigation: { submit } } );
+
+			const expandNotesButton = screen.getByTestId( 'special-instructions' );
+			await userEvent.click( expandNotesButton );
 
 			await userEvent.type( screen.getByLabelText( /Site address/ ), 'test.com' );
 			await userEvent.type( screen.getByLabelText( /WordPress admin username/ ), 'username' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -116,7 +116,7 @@ describe( 'SiteMigrationCredentials', () => {
 			const addressInput = screen.getByLabelText( /Site address/ );
 			const usernameInput = screen.getByLabelText( /WordPress admin username/ );
 			const passwordInput = screen.getByLabelText( /Password/ );
-			const notesInput = screen.getByLabelText( /Notes \(optional\)/ );
+			const notesInput = screen.getByTestId( 'special-instructions-textarea' );
 
 			siteAddress && ( await userEvent.type( addressInput, siteAddress ) );
 			username && ( await userEvent.type( usernameInput, username ) );
@@ -182,7 +182,7 @@ describe( 'SiteMigrationCredentials', () => {
 			const expandNotesButton = screen.getByTestId( 'special-instructions' );
 			await userEvent.click( expandNotesButton );
 
-			const notesInput = screen.getByLabelText( /Notes \(optional\)/ );
+			const notesInput = screen.getByTestId( 'special-instructions-textarea' );
 
 			await userEvent.type( addressInput, siteAddress );
 			username &&
@@ -294,7 +294,7 @@ describe( 'SiteMigrationCredentials', () => {
 			await userEvent.type( screen.getByLabelText( /Site address/ ), 'test.com' );
 			await userEvent.type( screen.getByLabelText( /WordPress admin username/ ), 'username' );
 			await userEvent.type( screen.getByLabelText( /Password/ ), 'password' );
-			await userEvent.type( screen.getByLabelText( /Notes \(optional\)/ ), 'notes' );
+			await userEvent.type( screen.getByTestId( 'special-instructions-textarea' ), 'notes' );
 
 			( wpcomRequest as jest.Mock ).mockRejectedValue( errorResponse );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #94003

## Proposed Changes

* Put the notes field behind a toggle button. The toggle button is only displayed if the translation is ready.
* Added a note to let the users know that they should not put sensitive information in it.
* Fixed the styling for the notes, made it smaller and added the italic style.
* Display the texts changed only when the translations are ready.


https://github.com/user-attachments/assets/1e0a0239-539a-45f9-9319-9476472a436a



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* More context: p9Jlb4-dPf-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
  * Go through the migration flow by navigating to `/start`:
  * Go through the domain selection step
  * Select the free plan on the `Plans` page
  * On the `Goals` step, select the "Import existing content or website" option and click continue
  * Input the source site URL in the Identify step
  * Next, select the "Migrate Site" option on the `Import or Migrate` step
  * Select "Do it for me" on the `How to migrate` step
  * Go through the checkout
  * Once you complete the checkout, you should land on the new `Credentials` step
  * Now validate that the toggle works as expected; as of now, it will only be displayed for English users.
  * You can also change your locale to verify that all the new texts are not displayed anymore(while the translations are not ready).


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?