### PR TITLE
Fix URL in case it does not have the http protocol

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/test/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/test/utils.ts
@@ -1,0 +1,49 @@
+import { getPluginInstallationPage, getMigrateGuruPageURL } from '../utils';
+
+describe( 'utils', () => {
+	describe( 'getPluginInstallationPage', () => {
+		it( 'should return WordPress.org plugin page if fromUrl is empty', () => {
+			expect( getPluginInstallationPage( '' ) ).toBe(
+				'https://wordpress.org/plugins/migrate-guru/'
+			);
+		} );
+
+		it( 'should return correct plugin installation page for given URL', () => {
+			expect( getPluginInstallationPage( 'example.com' ) ).toBe(
+				'https://example.com/wp-admin/plugin-install.php?s=%2522migrate%2520guru%2522&tab=search&type=term'
+			);
+		} );
+
+		it( 'should handle URLs with existing protocol', () => {
+			expect( getPluginInstallationPage( 'http://example.com' ) ).toBe(
+				'http://example.com/wp-admin/plugin-install.php?s=%2522migrate%2520guru%2522&tab=search&type=term'
+			);
+		} );
+
+		it( 'should remove duplicate slashes from the URL', () => {
+			expect( getPluginInstallationPage( 'https://example.com///' ) ).toBe(
+				'https://example.com/wp-admin/plugin-install.php?s=%2522migrate%2520guru%2522&tab=search&type=term'
+			);
+		} );
+	} );
+
+	describe( 'getMigrateGuruPageURL', () => {
+		it( 'should return correct Migrate Guru page URL', () => {
+			expect( getMigrateGuruPageURL( 'example.com' ) ).toBe(
+				'https://example.com/wp-admin/admin.php?page=migrateguru'
+			);
+		} );
+
+		it( 'should handle URLs with existing protocol', () => {
+			expect( getMigrateGuruPageURL( 'http://example.com' ) ).toBe(
+				'http://example.com/wp-admin/admin.php?page=migrateguru'
+			);
+		} );
+
+		it( 'should remove duplicate slashes from the URL', () => {
+			expect( getMigrateGuruPageURL( 'https://example.com///' ) ).toBe(
+				'https://example.com/wp-admin/admin.php?page=migrateguru'
+			);
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/utils.ts
@@ -5,16 +5,25 @@ const isWhiteLabeledPluginEnabled = config.isEnabled(
 	'migration-flow/enable-white-labeled-plugin'
 );
 
+const ensureProtocol = ( url: string ) => {
+	if ( ! url.startsWith( 'http://' ) && ! url.startsWith( 'https://' ) ) {
+		return `https://${ url }`;
+	}
+	return url;
+};
+
 export const getPluginInstallationPage = ( fromUrl: string ) => {
 	if ( fromUrl !== '' ) {
+		const baseUrl = ensureProtocol( fromUrl );
+
 		if ( isWhiteLabeledPluginEnabled ) {
 			return removeDuplicatedSlashes(
-				`${ fromUrl }/wp-admin/plugin-install.php?s=%2522wpcom%2520migration%2522&tab=search&type=term`
+				`${ baseUrl }/wp-admin/plugin-install.php?s=%2522wpcom%2520migration%2522&tab=search&type=term`
 			);
 		}
 
 		return removeDuplicatedSlashes(
-			`${ fromUrl }/wp-admin/plugin-install.php?s=%2522migrate%2520guru%2522&tab=search&type=term`
+			`${ baseUrl }/wp-admin/plugin-install.php?s=%2522migrate%2520guru%2522&tab=search&type=term`
 		);
 	}
 
@@ -24,9 +33,11 @@ export const getPluginInstallationPage = ( fromUrl: string ) => {
 };
 
 export const getMigrateGuruPageURL = ( siteURL: string ) => {
+	const baseUrl = ensureProtocol( siteURL );
+
 	if ( isWhiteLabeledPluginEnabled ) {
-		return removeDuplicatedSlashes( `${ siteURL }/wp-admin/admin.php?page=wpcom-migration` );
+		return removeDuplicatedSlashes( `${ baseUrl }/wp-admin/admin.php?page=wpcom-migration` );
 	}
 
-	return removeDuplicatedSlashes( `${ siteURL }/wp-admin/admin.php?page=migrateguru` );
+	return removeDuplicatedSlashes( `${ baseUrl }/wp-admin/admin.php?page=migrateguru` );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94122

## Proposed Changes

* Fix URLs in the migration instructions flow in case it does not have the http protocol.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If we access the flow without the `http://` protocol, the migration instructions was linking the site to a wrong URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/setup/migration?from=www.v11e4pan.com`.
* Navigate until the migration instructions (Choose to migrate yourself).
* Click on the links, and check that it works properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
