### PR TITLE
Fix/paid newsletter subscriber skip

### DIFF
--- a/client/data/paid-newsletter/use-map-stripe-plan-to-product-mutation.ts
+++ b/client/data/paid-newsletter/use-map-stripe-plan-to-product-mutation.ts
@@ -48,10 +48,8 @@ export const useMapStripePlanToProductMutation = (
 		},
 		...options,
 		onSuccess( ...args ) {
-			const [ , { siteId, engine, currentStep } ] = args;
-			queryClient.invalidateQueries( {
-				queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
-			} );
+			const [ data, { siteId, engine } ] = args;
+			queryClient.setQueryData( [ 'paid-newsletter-importer', siteId, engine ], data );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -21,7 +21,8 @@ export const usePaidNewsletterQuery = (
 ) => {
 	return useQuery( {
 		enabled: !! siteId,
-		queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
+		queryKey: [ 'paid-newsletter-importer', siteId, engine ],
 		queryFn: (): Promise< PaidNewsletterData > => {
 			return wp.req.get(
 				{

--- a/client/data/paid-newsletter/use-reset-mutation.ts
+++ b/client/data/paid-newsletter/use-reset-mutation.ts
@@ -38,10 +38,9 @@ export const useResetMutation = (
 		},
 		...options,
 		onSuccess( ...args ) {
-			const [ , { siteId, engine, currentStep } ] = args;
-			queryClient.invalidateQueries( {
-				queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
-			} );
+			const [ data, { siteId, engine } ] = args;
+
+			queryClient.setQueryData( [ 'paid-newsletter-importer', siteId, engine ], data );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/data/paid-newsletter/use-subscriber-import-mutation.ts
+++ b/client/data/paid-newsletter/use-subscriber-import-mutation.ts
@@ -38,10 +38,8 @@ export const useSubscriberImportMutation = (
 		},
 		...options,
 		onSuccess( ...args ) {
-			const [ , { siteId, engine, currentStep } ] = args;
-			queryClient.invalidateQueries( {
-				queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
-			} );
+			const [ data, { siteId, engine } ] = args;
+			queryClient.setQueryData( [ 'paid-newsletter-importer', siteId, engine ], data );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
@@ -58,7 +58,7 @@ export default function MapPlans( {
 		}
 		sizeOfProductsRef.current = sizeOfProducts;
 		queryClient.invalidateQueries( {
-			queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
+			queryKey: [ 'paid-newsletter-importer', siteId, engine ],
 		} );
 	}, [ sizeOfProducts, sizeOfProductsRef, siteId, engine, currentStep, queryClient ] );
 

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -15,6 +15,7 @@ type Props = {
 	fromSite: QueryArgParsed;
 	skipNextStep: () => void;
 	cardData: any;
+	siteSlug: string;
 	engine: string;
 };
 
@@ -22,6 +23,7 @@ export default function Subscribers( {
 	nextStepUrl,
 	selectedSite,
 	fromSite,
+	siteSlug,
 	skipNextStep,
 	cardData,
 	engine,
@@ -39,7 +41,7 @@ export default function Subscribers( {
 		if ( ! prevInProgress.current && importSelector?.inProgress ) {
 			setTimeout( () => {
 				queryClient.invalidateQueries( {
-					queryKey: [ 'paid-newsletter-importer', selectedSite.ID, engine, 'subscribers' ],
+					queryKey: [ 'paid-newsletter-importer', selectedSite.ID, engine ],
 				} );
 			}, 1500 ); // 1500ms = 1.5s delay so that we have enought time to propagate the changes.
 		}
@@ -75,7 +77,7 @@ export default function Subscribers( {
 				{ selectedSite.ID && (
 					<SubscriberUploadForm
 						siteId={ selectedSite.ID }
-						nextStepUrl={ nextStepUrl }
+						nextStepUrl={ `/import/newsletter/${ engine }/${ siteSlug }/summary?from=${ fromSite }` }
 						skipNextStep={ skipNextStep }
 						cardData={ cardData }
 					/>


### PR DESCRIPTION
## Proposed Changes

* Improved the way skip works for paid newsletter importer. 
* With this PR we are more optimisic about the update. So that we can show the new skip value earlier. 
* We skip the paid subscriber step completely if we skip the importing of subscriber. 
For all the mutations since they return the data that we need we 

## Why are these changes being made?
* So that we reduce the number of request and remove race conditions that return data that needs updating. 


## Testing Instructions

* Load the paid newsletter UI. 
* Skip Content and Subscriber steps. Does that work as expected? 
* Import content and import subscribers. Does that work as expected? 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
