### PR TITLE
A4A: add support for new Pressable plans

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -82,7 +82,7 @@ export function getHostingLogo( slug: string, showText = true ) {
  */
 export function isPressableHostingProduct( keyOrSlug: string ) {
 	return (
-		keyOrSlug.startsWith( 'pressable-wp' ) ||
+		keyOrSlug.startsWith( 'pressable-' ) ||
 		keyOrSlug.startsWith( 'pressable-hosting' ) ||
 		keyOrSlug.startsWith( 'jetpack-pressable' )
 	);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-existing-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-existing-pressable-plan.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import getPressablePlan from '../lib/get-pressable-plan';
 
 type Props = {
 	plans: APIProductFamilyProduct[];
@@ -11,7 +12,7 @@ export default function useExistingPressablePlan( { plans }: Props ) {
 
 	return useMemo( () => {
 		const pressablePlans = Object.keys( data?.products ?? {} ).filter( ( slug ) =>
-			slug.startsWith( 'pressable-wp' )
+			slug.startsWith( 'pressable-' )
 		);
 
 		const existingPlan = pressablePlans.find( ( slug ) => {
@@ -20,6 +21,7 @@ export default function useExistingPressablePlan( { plans }: Props ) {
 
 		return {
 			existingPlan: plans.find( ( plan ) => plan.slug === existingPlan ) ?? null,
+			pressablePlan: existingPlan ? getPressablePlan( existingPlan ) : null,
 			isReady,
 		};
 	}, [ data?.products, isReady, plans ] );

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -48,6 +48,68 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		visits: 2000000,
 		storage: 500,
 	},
+
+	// New pressable plans
+	'pressable-build': {
+		slug: 'pressable-build',
+		install: 1,
+		visits: 30000,
+		storage: 20,
+	},
+	'pressable-growth': {
+		slug: 'pressable-growth',
+		install: 3,
+		visits: 50000,
+		storage: 30,
+	},
+	'pressable-advanced': {
+		slug: 'pressable-advanced',
+		install: 5,
+		visits: 75000,
+		storage: 35,
+	},
+	'pressable-pro': {
+		slug: 'pressable-pro',
+		install: 10,
+		visits: 150000,
+		storage: 50,
+	},
+	'pressable-premium': {
+		slug: 'pressable-premium',
+		install: 20,
+		visits: 400000,
+		storage: 80,
+	},
+	'pressable-business': {
+		slug: 'pressable-business',
+		install: 50,
+		visits: 1000000,
+		storage: 80,
+	},
+	'pressable-business-80': {
+		slug: 'pressable-business-80',
+		install: 80,
+		visits: 1600000,
+		storage: 275,
+	},
+	'pressable-business-100': {
+		slug: 'pressable-business-100',
+		install: 100,
+		visits: 2000000,
+		storage: 325,
+	},
+	'pressable-business-120': {
+		slug: 'pressable-business-120',
+		install: 120,
+		visits: 2400000,
+		storage: 375,
+	},
+	'pressable-business-150': {
+		slug: 'pressable-business-150',
+		install: 150,
+		visits: 3000000,
+		storage: 450,
+	},
 };
 
 export default function getPressablePlan( slug: string ) {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -84,7 +84,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		slug: 'pressable-business',
 		install: 50,
 		visits: 1000000,
-		storage: 80,
+		storage: 200,
 	},
 	'pressable-business-80': {
 		slug: 'pressable-business-80',

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -8,7 +8,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { FILTER_TYPE_INSTALL, FILTER_TYPE_VISITS } from '../constants';
-import getPressablePlan from '../lib/get-pressable-plan';
+import getPressablePlan, { PressablePlan } from '../lib/get-pressable-plan';
 import getSliderOptions from '../lib/get-slider-options';
 import { FilterType } from '../types';
 
@@ -16,6 +16,7 @@ type Props = {
 	selectedPlan: APIProductFamilyProduct | null;
 	plans: APIProductFamilyProduct[];
 	existingPlan?: APIProductFamilyProduct | null;
+	pressablePlan?: PressablePlan | null;
 	onSelectPlan: ( plan: APIProductFamilyProduct | null ) => void;
 	isLoading?: boolean;
 };
@@ -25,6 +26,7 @@ export default function PlanSelectionFilter( {
 	plans,
 	onSelectPlan,
 	existingPlan,
+	pressablePlan,
 	isLoading,
 }: Props ) {
 	const translate = useTranslate();
@@ -83,9 +85,22 @@ export default function PlanSelectionFilter( {
 			: 'a4a-pressable-filter-wrapper-visits';
 	const wrapperClass = clsx( additionalWrapperClass, 'pressable-overview-plan-selection__filter' );
 
-	const minimum = existingPlan
-		? options.findIndex( ( { value } ) => value === existingPlan.slug ) + 1
-		: 0;
+	const minimum = useMemo( () => {
+		if ( ! pressablePlan ) {
+			return 0;
+		}
+
+		const allAvailablePlans = plans
+			.map( ( plan ) => getPressablePlan( plan.slug ) )
+			.sort( ( a, b ) => a.install - b.install );
+
+		for ( let i = 0; i < allAvailablePlans.length; i++ ) {
+			if ( pressablePlan.install < allAvailablePlans[ i ].install ) {
+				return i;
+			}
+		}
+		return allAvailablePlans.length;
+	}, [ plans, pressablePlan ] );
 
 	if ( isLoading ) {
 		return (

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
@@ -40,7 +40,11 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 		productSearchQuery: '',
 	} );
 
-	const { existingPlan, isReady: isExistingPlanFetched } = useExistingPressablePlan( {
+	const {
+		existingPlan,
+		pressablePlan,
+		isReady: isExistingPlanFetched,
+	} = useExistingPressablePlan( {
 		plans: pressablePlans,
 	} );
 
@@ -82,6 +86,7 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 					plans={ pressablePlans }
 					onSelectPlan={ onSelectPlan }
 					existingPlan={ existingPlan }
+					pressablePlan={ pressablePlan }
 					isLoading={ ! isExistingPlanFetched }
 				/>
 			) }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
@@ -38,7 +38,7 @@ const useGetLicenseIssuedMessage = () => {
 				const productName =
 					products?.data?.find?.( ( p ) => p.slug === licenses[ 0 ].slug )?.name ?? '';
 
-				if ( licenses[ 0 ].slug.startsWith( 'pressable-wp' ) ) {
+				if ( licenses[ 0 ].slug.startsWith( 'pressable-' ) ) {
 					return translate(
 						'Thanks for your purchase! Below you can view and manage your new {{strong}}%(productName)s{{/strong}}',
 						{

--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
@@ -59,7 +59,7 @@ export default function RevokeLicenseDialog( {
 
 	const revoke = useCallback(
 		( force?: boolean ) => {
-			if ( ! force && licenseKey.startsWith( 'pressable-wp' ) ) {
+			if ( ! force && licenseKey.startsWith( 'pressable-' ) ) {
 				setShowPressableConfirmationDialog( true );
 				return;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1063

## Proposed Changes

After adding new Pressable plans, we need to make sure that users with existing ones have smooth experience. 
This PR adds new plans description, and updates the logic behind slider, selecting next minimum option based on possbile site `installs`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

Please follow testing instructions here: D160530-code

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?