### PR TITLE
Purchases: Update cancellation page's support link to use Odie

### DIFF
--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -79,7 +79,7 @@ const CancelPurchaseRefundInformation = ( {
 				},
 			} );
 		} else {
-			setNavigateToRoute( '/contact-form?mode=CHAT' );
+			setNavigateToRoute( '/contact-options' );
 			setShowHelpCenter( true );
 		}
 	}, [

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -53,6 +53,10 @@
 	font-size: $font-body-small;
 }
 
+.cancel-purchase__support-information .support-link {
+	color: var(--color-primary);
+}
+
 .cancel-purchase__site-title {
 	font-size: $font-body-extra-small;
 	text-transform: uppercase;

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -55,6 +55,8 @@
 
 .cancel-purchase__support-information .support-link {
 	color: var(--color-primary);
+	font-weight: 600;
+	padding-inline-start: 0;
 }
 
 .cancel-purchase__site-title {


### PR DESCRIPTION
> [!NOTE]
> Reposted from https://github.com/Automattic/wp-calypso/pull/93567 - branch was incorrect, updated here

When a customer proceeds through the cancelation flow they have the option to 'Ask a Happiness Engineer' if they have a question:

![image](https://github.com/user-attachments/assets/4cc5366e-69a9-4661-9356-ec6c2b2c189d)

This link leads them to our general `/help` page which would then require a customer to click on 'Get help' to open an omnichannel chat:

<img width="691" alt="image" src="https://github.com/user-attachments/assets/921469d2-a5fd-416a-a0e3-c8dbd908592a">

A more optimal path may be to open the omnichannel chat directly from the cancellation page, similar to a pre-sale chat during Checkout. This would allow us quick access to a churning customer for one last attempt to address any concerns.

Happy path:
![image](https://github.com/user-attachments/assets/66259280-2a24-4252-904f-2333a78f016c)

@Automattic/martech Is this an oversight or is this the expected behavior of the 'Ask a Happiness Engineer' link?

Related to #93568 

## Proposed Changes

* Change out the `CALYPSO_CONTACT` url with the Odie functionality found in Help Center.

## Testing Instructions

* Go to an existing purchase under /purchases, make sure it isn't expired and can be canceled
* Click on the 'Cancel [product]' button at the bottom of the page
* Look for the `Have a question? Ask a Happiness Engineer!` line in the first paragraph box
* Click on the Ask a Happiness Engineer link, it should correctly open the Odie/omnichannel chat box
* Now, you'll need this branch on your local environment for the next part.
* Go to `client/me/purchases/cancel-purchase/refund-information.jsx` and make the following change:
```diff
	const { data: isMessagingAvailable } = useZendeskMessagingAvailability(
		'wpcom_messaging',
-               true
+		false
	);
```
* This should simulate chat not being available and let you test the fallback to our support options in Help Center