### PR TITLE
Add: paid newsletter step navigation

### DIFF
--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { Spinner } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
@@ -24,8 +25,6 @@ const steps = [ Content, Subscribers, PaidSubscribers, Summary ];
 
 const stepSlugs = [ 'content', 'subscribers', 'paid-subscribers', 'summary' ];
 
-const noop = () => {};
-
 const logoChainLogos = [
 	{ name: 'substack', color: 'var(--color-substack)' },
 	{ name: 'wordpress', color: '#3858E9' },
@@ -46,19 +45,48 @@ function getTitle( urlData?: UrlData ) {
 }
 
 export default function NewsletterImporter( { siteSlug, engine, step }: NewsletterImporterProps ) {
+	let fromSite = getQueryArg( window.location.href, 'from' ) as string | string[];
 	const selectedSite = useSelector( getSelectedSite ) ?? undefined;
 
 	const [ validFromSite, setValidFromSite ] = useState( false );
 	const [ autoFetchData, setAutoFetchData ] = useState( false );
 
 	const stepsProgress: ClickHandler[] = [
-		{ message: 'Content', onClick: noop },
-		{ message: 'Subscribers', onClick: noop },
-		{ message: 'Paid Subscribers', onClick: noop },
-		{ message: 'Summary', onClick: noop },
+		{
+			message: 'Content',
+			onClick: () => {
+				page(
+					addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/content`, {
+						from: fromSite,
+					} )
+				);
+			},
+			show: 'onComplete',
+		},
+		{
+			message: 'Subscribers',
+			onClick: () => {
+				page(
+					addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/subscribers`, {
+						from: fromSite,
+					} )
+				);
+			},
+			show: 'onComplete',
+		},
+		{
+			message: 'Paid Subscribers',
+			onClick: () => {
+				page(
+					addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/paid-subscribers`, {
+						from: fromSite,
+					} )
+				);
+			},
+			show: 'onComplete',
+		},
+		{ message: 'Summary', onClick: () => {} },
 	];
-
-	let fromSite = getQueryArg( window.location.href, 'from' ) as string | string[];
 
 	// Steps
 	fromSite = Array.isArray( fromSite ) ? fromSite[ 0 ] : fromSite;


### PR DESCRIPTION
Related to #

## Proposed Changes

* This PR adds stepper navigation to the Paid Newsletter flow. 


## Why are these changes being made?
So that the user can more easily naviage to previous steps. The same way they can currently do when they use the back button. 


## Testing Instructions

* Go though the flow. Are you able to navigate as expected?  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
