### PR TITLE
Plugins Scheduled Updates: Left-align the empty list layout

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -4,12 +4,6 @@
 
 $brand-display: "SF Pro Display", sans-serif;
 
-.plugins-update-manager:not(.plugins-update-manager-multisite) {
-	.empty-state {
-		max-width: 80%;
-	}
-}
-
 .plugins-update-manager,
 .plugins-update-manager-multisite {
 	// Table cells style based on the screen size
@@ -81,7 +75,6 @@ $brand-display: "SF Pro Display", sans-serif;
 	}
 
 	.empty-state {
-		max-width: 50%;
 		text-align: left;
 		padding: 0;
 

--- a/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
@@ -15,7 +15,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 	const { siteHasEligiblePlugins } = useSiteHasEligiblePlugins();
 
 	return (
-		<div className="empty-state empty-state__center">
+		<div className="empty-state">
 			<Text as="p">
 				{ ( () => {
 					if ( ! siteHasEligiblePlugins && canCreateSchedules ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/93611

## Proposed Changes

This PR updates the empty list layout from being centered to left-aligned.

| Before | After | 
| --- | --- |
| ![SCR-20240905-lsem](https://github.com/user-attachments/assets/733f508a-4896-49f7-9c04-a69b42a7cc20) | ![SCR-20240905-lsac](https://github.com/user-attachments/assets/625b7ead-b850-482e-bf16-e9d0f6f09098)|

| Before | After | 
| --- | --- |
| ![SCR-20240905-lsmc](https://github.com/user-attachments/assets/d2c03ad2-840a-42a3-91c2-582fdd8601c3) | ![SCR-20240905-lstd](https://github.com/user-attachments/assets/14fb163b-2a18-4710-bff5-85d088915763)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WordPress.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a site with plugins installed, head to /plugins/scheduled-updates/{ SITE }, and ensure the layout is update as shown above.
* On a site without plugins installed, repeat the step above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
