### PR TITLE
A4A: Fix the incorrect condition for showing the 'Get started' view on the Team page.

### DIFF
--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -46,7 +46,7 @@ export default function TeamList() {
 		},
 	} );
 
-	const { members, isPending, refetch } = useMemberList();
+	const { members, hasMembers, isPending, refetch } = useMemberList();
 
 	const title = translate( 'Manage team members' );
 
@@ -127,7 +127,7 @@ export default function TeamList() {
 		return <PagePlaceholder />;
 	}
 
-	if ( items.length === 0 ) {
+	if ( ! hasMembers ) {
 		return <GetStarted />;
 	}
 


### PR DESCRIPTION
This PR fixes minor regression introduced in this line. https://github.com/Automattic/wp-calypso/pull/93503/files#diff-0c55d56ee234f91dbd760c19c368bcd133d036bee77b10dfce42407126f11ba7R146. The issue was that, the 'Get started' view no longer shows up since the condition was incorrect.

Context: p1725520564142669/1725507880.143809-slack-C047ACYM8UQ

## Proposed Changes

* Fix incorrect condition in the Team list component.

## Why are these changes being made?

*

## Testing Instructions

* Use the A4A live link and go to the `/team` page.
* Remove any invites or members.
* Confirm that you see the Get started view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?