### PR TITLE
E2E: Fix broken tests due to SSO changes

### DIFF
--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
@@ -48,12 +48,12 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC !== true )(
 
 			jetpackDashboardPage = new JetpackDashboardPage( page );
 
-			// Tests sites might have local users, so the Jetpack SSO login will show
-			// up when visiting the Jetpack dashboard directly. We can bypass it if we
-			// simulate a redirect from Calypso to WP Admin with a hardcoded referer.
+			// Atomic tests sites might have local users, so the Jetpack SSO login will
+			// show up when visiting the Jetpack dashboard directly. We can bypass it if
+			// we simulate a redirect from Calypso to WP Admin with a hardcoded referer.
 			// @see https://github.com/Automattic/jetpack/blob/12b3b9a4771169398d4e1982573aaec820babc17/projects/plugins/wpcomsh/wpcomsh.php#L230-L254
-			const siteSlug = testAccount.getSiteURL( { protocol: false } );
-			await page.goto( `https://${ siteSlug }/wp-admin/`, {
+			const siteUrl = testAccount.getSiteURL( { protocol: true } );
+			await page.goto( `${ siteUrl }wp-admin/`, {
 				timeout: 15 * 1000,
 				referer: 'https://wordpress.com/',
 			} );

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
@@ -47,6 +47,16 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC !== true )(
 			}
 
 			jetpackDashboardPage = new JetpackDashboardPage( page );
+
+			// Tests sites might have local users, so the Jetpack SSO login will show
+			// up when visiting the Jetpack dashboard directly. We can bypass it if we
+			// simulate a redirect from Calypso to WP Admin with a hardcoded referer.
+			// @see https://github.com/Automattic/jetpack/blob/12b3b9a4771169398d4e1982573aaec820babc17/projects/plugins/wpcomsh/wpcomsh.php#L230-L254
+			const siteSlug = testAccount.getSiteURL( { protocol: false } );
+			await page.goto( `https://${ siteSlug }/wp-admin/`, {
+				timeout: 15 * 1000,
+				referer: 'https://wordpress.com/',
+			} );
 		} );
 
 		it( 'Navigate to Jetpack dashboard', async function () {

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -115,6 +115,18 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			} else {
 				await testAccount.authenticate( page );
 			}
+
+			// Atomic tests sites might have local users, so the Jetpack SSO login will
+			// show up when visiting the Jetpack dashboard directly. We can bypass it if
+			// we simulate a redirect from Calypso to WP Admin with a hardcoded referer.
+			// @see https://github.com/Automattic/jetpack/blob/12b3b9a4771169398d4e1982573aaec820babc17/projects/plugins/wpcomsh/wpcomsh.php#L230-L254
+			if ( envVariables.TEST_ON_ATOMIC ) {
+				const siteUrl = testAccount.getSiteURL( { protocol: true } );
+				await page.goto( `${ siteUrl }wp-admin/`, {
+					timeout: 15 * 1000,
+					referer: 'https://wordpress.com/',
+				} );
+			}
 		} );
 
 		it( 'Navigate to the Jetpack Forms Inbox', async function () {


### PR DESCRIPTION
Follow-up of https://github.com/Automattic/jetpack/pull/39139
See p1725471658569589-slack-C034JEXD1RD

## Proposed Changes

Some E2E tests started to fail after we changed the SSO behavior in https://github.com/Automattic/jetpack/pull/39139 for Atomic sites.

Previously, the test site was authenticating the user in WP.com and then accessing a WP Admin screen directly.

Because the test site has a local user, the new SSO logic no longer logs the user in automatically in WP Admin unless they have been redirected from Calypso, and will display the Jetpack SSO login screen which is not expected by the E2E tests.

As a workaround to bypass the Jetpack SSO login, the tests are now performing a redirect from Calypso to WP Admin to ensure the user is automatically logged in into WP Admin.

## Why are these changes being made?

To fix a broken E2E test

## Testing Instructions

- Check out this branch
- Set up the E2E test environment: https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e#quick-start
- Define some environment variables to ensure the affected E2E tests can run:
  - `export TEST_ON_ATOMIC='true'`
  - `export ATOMIC_VARIATION='wp-beta'`
  - `export JETPACK_TARGET='wpcom-deployment'`
- Run the failing E2E tests:
  - `yarn workspace wp-e2e-tests test -- specs/jetpack/jetpack__dashboard-smoke.ts`
  - `yarn workspace wp-e2e-tests test -- specs/published-content/forms__submissions.ts`
- Make sure they pass successfully