### PR TITLE
A4A > Team: Allow Licenses page access using regex

### DIFF
--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -30,8 +30,6 @@ import {
 	A4A_REFERRALS_FAQ,
 	A4A_PARTNER_DIRECTORY_LINK,
 	A4A_PURCHASES_LINK,
-	A4A_LICENSES_LINK,
-	A4A_UNASSIGNED_LICENSES_LINK,
 	A4A_BILLING_LINK,
 	A4A_INVOICES_LINK,
 	A4A_PAYMENT_METHODS_LINK,
@@ -74,8 +72,6 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_PARTNER_DIRECTORY_AGENCY_DETAILS_LINK ]: [ 'a4a_read_partner_directory' ],
 	[ A4A_PARTNER_DIRECTORY_AGENCY_EXPERTISE_LINK ]: [ 'a4a_read_partner_directory' ],
 	[ A4A_PURCHASES_LINK ]: [ 'a4a_jetpack_licensing' ],
-	[ A4A_LICENSES_LINK ]: [ 'a4a_jetpack_licensing' ],
-	[ A4A_UNASSIGNED_LICENSES_LINK ]: [ 'a4a_jetpack_licensing' ],
 	[ A4A_BILLING_LINK ]: [ 'a4a_jetpack_licensing' ],
 	[ A4A_INVOICES_LINK ]: [ 'a4a_jetpack_licensing' ],
 	[ A4A_PAYMENT_METHODS_LINK ]: [ 'a4a_jetpack_licensing' ],
@@ -88,11 +84,13 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {
 	'sites-overview': [ 'a4a_read_managed_sites' ],
 	marketplace: [ 'a4a_read_marketplace' ],
+	licenses: [ 'a4a_jetpack_licensing' ],
 };
 
 const DYNAMIC_PATH_PATTERNS: Record< string, RegExp > = {
 	'sites-overview': /^\/sites\/overview\/[^/]+(\/.*)?$/,
 	marketplace: /^\/marketplace\/[^/]+\/[^/]+(\/.*)?$/,
+	licenses: /^\/purchases\/licenses(\/.*)?$/,
 };
 
 export const isPathAllowed = ( pathname: string, agency: Agency | null ) => {


### PR DESCRIPTION
## Proposed Changes

This PR updates the permissions for team members to access all the tabs on the Licenses page.

## Why are these changes being made?

This change allows team members to access all the tabs on the Licenses page.

## Testing Instructions

* Open the A4A live link by logging in as a team member
* Verify that you can access all the tabs on the Licenses(/purchases/licenses) page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
