### PR TITLE
Stepper: Apply extended props to `calypso_page_view`

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -28,6 +28,7 @@ export const STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW = 'calypso_signup_step_nav_
 export const STEPPER_TRACKS_EVENT_SIGNUP_START = 'calypso_signup_start';
 export const STEPPER_TRACKS_EVENT_SIGNUP_STEP_START = 'calypso_signup_step_start';
 export const STEPPER_TRACKS_EVENT_FLOW_START = 'calypso_stepper_flow_start';
+export const STEPPER_TRACKS_EVENT_PAGE_VIEW = 'calypso_page_view';
 
 export const STEPPER_TRACKS_EVENTS_STEP_NAV = < const >[
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
@@ -42,4 +43,5 @@ export const STEPPER_TRACKS_EVENTS = < const >[
 	STEPPER_TRACKS_EVENT_SIGNUP_START,
 	STEPPER_TRACKS_EVENT_SIGNUP_STEP_START,
 	STEPPER_TRACKS_EVENT_FLOW_START,
+	STEPPER_TRACKS_EVENT_PAGE_VIEW,
 ];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/94108

## Proposed Changes

- Adds `STEPPER_TRACKS_EVENT_PAGE_VIEW`
- Implements props extension for `calypso_signup_page_view` event

**DO NOT MERGE** - depended on ongoing discussions in https://github.com/Automattic/wp-calypso/issues/94175 (similar/same problem)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allow flows to extend the default props tracked by Stepper for all the major/framework events

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- test `/setup/onboarding` and `/setup/newsletter`
- ensure tracking of `calypso_signup_page_view` when walking through steps in Stepper works like before
- should fire once per step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
