### PR TITLE
More types for paid newsletter importer

### DIFF
--- a/client/data/paid-newsletter/use-map-stripe-plan-to-product-mutation.ts
+++ b/client/data/paid-newsletter/use-map-stripe-plan-to-product-mutation.ts
@@ -8,7 +8,7 @@ import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
 
 interface MutationVariables {
-	siteId: string;
+	siteId: number;
 	engine: string;
 	currentStep: string;
 	stripePlan: string;
@@ -58,7 +58,7 @@ export const useMapStripePlanToProductMutation = (
 
 	const mapStripePlanToProduct = useCallback(
 		(
-			siteId: string,
+			siteId: number,
 			engine: string,
 			currentStep: string,
 			stripePlan: string,

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -19,7 +19,7 @@ export interface SubscribersStepContent {
 	};
 }
 
-export interface AvailableTier {
+export interface Product {
 	currency: string;
 	id: number;
 	interval: string;
@@ -39,7 +39,7 @@ export interface Plan {
 }
 
 export interface PaidSubscribersStepContent {
-	available_tiers: AvailableTier[];
+	available_tiers: Product[];
 	connect_url?: string;
 	is_connected_stripe: boolean;
 	map_plans: [];

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -1,21 +1,23 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
+export type StepId = 'content' | 'subscribers' | 'paid-subscribers' | 'summary';
+
 interface PaidNewsletterStep {
 	status: string;
 	content?: any;
 }
 
 interface PaidNewsletterData {
-	current_step: string;
-	steps: Record< string, PaidNewsletterStep >;
+	current_step: StepId;
+	steps: Record< StepId, PaidNewsletterStep >;
 }
 
 const REFRESH_INTERVAL = 2000; // every 2 seconds.
 
 export const usePaidNewsletterQuery = (
 	engine: string,
-	currentStep: string,
+	currentStep: StepId,
 	siteId?: number,
 	autoRefresh?: boolean
 ) => {

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -42,7 +42,7 @@ export interface PaidSubscribersStepContent {
 	available_tiers: Product[];
 	connect_url?: string;
 	is_connected_stripe: boolean;
-	map_plans: [];
+	map_plans: Record< string, string >;
 	plans: Plan[];
 }
 

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -4,16 +4,60 @@ import wp from 'calypso/lib/wp';
 export type StepId = 'content' | 'subscribers' | 'paid-subscribers' | 'summary';
 export type StepStatus = 'initial' | 'skipped' | 'importing' | 'done';
 
-interface Step {
+export interface ContentStepContent {}
+
+export interface SubscribersStepContent {
+	meta?: {
+		email_count: string;
+		id: number;
+		paid_subscribers_count: string;
+		platform: string;
+		scheduled_at: string;
+		status: string;
+		subscribed_count: string | null;
+		timestamp: string;
+	};
+}
+
+export interface AvailableTier {
+	currency: string;
+	id: number;
+	interval: string;
+	price: string;
+	title: string;
+}
+
+export interface Plan {
+	active_subscriptions: boolean;
+	is_active: boolean;
+	name: string;
+	plan_amount_decimal: number;
+	plan_currency: string;
+	plan_id: string;
+	plan_interval: string;
+	product_id: string;
+}
+
+export interface PaidSubscribersStepContent {
+	available_tiers: AvailableTier[];
+	connect_url?: string;
+	is_connected_stripe: boolean;
+	map_plans: [];
+	plans: Plan[];
+}
+
+export interface SummaryStepContent {}
+
+interface Step< T > {
 	status: StepStatus;
-	content?: any;
+	content?: T;
 }
 
 interface Steps {
-	content: Step;
-	subscribers: Step;
-	'paid-subscribers': Step;
-	summary: Step;
+	content: Step< ContentStepContent >;
+	subscribers: Step< SubscribersStepContent >;
+	'paid-subscribers': Step< PaidSubscribersStepContent >;
+	summary: Step< SummaryStepContent >;
 }
 
 interface PaidNewsletterData {

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -2,9 +2,10 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 export type StepId = 'content' | 'subscribers' | 'paid-subscribers' | 'summary';
+export type StepStatus = 'initial' | 'skipped' | 'importing' | 'done';
 
 interface PaidNewsletterStep {
-	status: string;
+	status: StepStatus;
 	content?: any;
 }
 

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -4,14 +4,21 @@ import wp from 'calypso/lib/wp';
 export type StepId = 'content' | 'subscribers' | 'paid-subscribers' | 'summary';
 export type StepStatus = 'initial' | 'skipped' | 'importing' | 'done';
 
-interface PaidNewsletterStep {
+interface Step {
 	status: StepStatus;
 	content?: any;
 }
 
+interface Steps {
+	content: Step;
+	subscribers: Step;
+	'paid-subscribers': Step;
+	summary: Step;
+}
+
 interface PaidNewsletterData {
 	current_step: StepId;
-	steps: Record< StepId, PaidNewsletterStep >;
+	steps: Steps;
 }
 
 const REFRESH_INTERVAL = 2000; // every 2 seconds.

--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -97,6 +97,7 @@ export function importerList( context, next ) {
 	next();
 }
 
+// TODO redirect to the first step if context.params.step value is not supported
 export function importSubstackSite( context, next ) {
 	if ( ! config.isEnabled( 'importers/newsletter' ) ) {
 		page.redirect( '/import' );

--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -97,7 +97,6 @@ export function importerList( context, next ) {
 	next();
 }
 
-// TODO redirect to the first step if context.params.step value is not supported
 export function importSubstackSite( context, next ) {
 	if ( ! config.isEnabled( 'importers/newsletter' ) ) {
 		page.redirect( '/import' );
@@ -106,10 +105,22 @@ export function importSubstackSite( context, next ) {
 
 	const state = context.store.getState();
 	const siteSlug = getSelectedSiteSlug( state );
+	const supportedImportSubstackSiteSteps = [
+		'content',
+		'subscribers',
+		'paid-subscribers',
+		'summary',
+	];
+	const step = context.params.step;
+
+	if ( step && ! supportedImportSubstackSiteSteps.includes( step ) ) {
+		page.redirect( '/import/' + siteSlug );
+		return;
+	}
 
 	context.primary = (
 		<BrowserRouter>
-			<NewsletterImporter siteSlug={ siteSlug } engine="substack" step={ context.params.step } />
+			<NewsletterImporter siteSlug={ siteSlug } engine="substack" step={ step } />
 		</BrowserRouter>
 	);
 	next();

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -6,7 +6,10 @@ import { useState, useEffect } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import FormattedHeader from 'calypso/components/formatted-header';
 import StepProgress, { ClickHandler } from 'calypso/components/step-progress';
-import { usePaidNewsletterQuery } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import {
+	StepId,
+	usePaidNewsletterQuery,
+} from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import { useResetMutation } from 'calypso/data/paid-newsletter/use-reset-mutation';
 import { useSkipNextStepMutation } from 'calypso/data/paid-newsletter/use-skip-next-step-mutation';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
@@ -23,7 +26,7 @@ import './importer.scss';
 
 const steps = [ Content, Subscribers, PaidSubscribers, Summary ];
 
-const stepSlugs = [ 'content', 'subscribers', 'paid-subscribers', 'summary' ];
+const stepSlugs: StepId[] = [ 'content', 'subscribers', 'paid-subscribers', 'summary' ];
 
 const logoChainLogos = [
 	{ name: 'substack', color: 'var(--color-substack)' },
@@ -33,7 +36,7 @@ const logoChainLogos = [
 type NewsletterImporterProps = {
 	siteSlug: string;
 	engine: string;
-	step: string;
+	step: StepId;
 };
 
 function getTitle( urlData?: UrlData ) {

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -36,7 +36,7 @@ const logoChainLogos = [
 type NewsletterImporterProps = {
 	siteSlug: string;
 	engine: string;
-	step: StepId;
+	step?: StepId;
 };
 
 function getTitle( urlData?: UrlData ) {
@@ -47,8 +47,12 @@ function getTitle( urlData?: UrlData ) {
 	return 'Import your newsletter';
 }
 
-export default function NewsletterImporter( { siteSlug, engine, step }: NewsletterImporterProps ) {
-	let fromSite = getQueryArg( window.location.href, 'from' ) as string | string[];
+export default function NewsletterImporter( {
+	siteSlug,
+	engine,
+	step = 'content',
+}: NewsletterImporterProps ) {
+	const fromSite = getQueryArg( window.location.href, 'from' ) as string;
 	const selectedSite = useSelector( getSelectedSite ) ?? undefined;
 
 	const [ validFromSite, setValidFromSite ] = useState( false );
@@ -92,11 +96,6 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 	];
 
 	// Steps
-	fromSite = Array.isArray( fromSite ) ? fromSite[ 0 ] : fromSite;
-	if ( fromSite && ! step ) {
-		step = stepSlugs[ 0 ];
-	}
-
 	let stepIndex = 0;
 	let nextStep = stepSlugs[ 0 ];
 

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -197,6 +197,9 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 					skipNextStep={ () => {
 						skipNextStep( selectedSite.ID, engine, nextStep, step );
 					} }
+					// FIXME
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-expect-error
 					cardData={ stepContent }
 					engine={ engine }
 					isFetchingContent={ isFetchingPaidNewsletter }

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -41,7 +41,7 @@ type NewsletterImporterProps = {
 
 function getTitle( urlData?: UrlData ) {
 	if ( urlData?.meta?.title ) {
-		return `Import ${ urlData?.meta?.title }`;
+		return `Import ${ urlData.meta.title }`;
 	}
 
 	return 'Import your newsletter';

--- a/client/my-sites/importer/newsletter/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers.tsx
@@ -1,16 +1,18 @@
+import { SiteDetails } from '@automattic/data-stores';
 import { hasQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
 import { useDispatch } from 'calypso/state';
 import { infoNotice, successNotice } from 'calypso/state/notices/actions';
 import ConnectStripe from './paid-subscribers/connect-stripe';
 import MapPlans from './paid-subscribers/map-plans';
+
 type Props = {
 	nextStepUrl: string;
 	skipNextStep: () => void;
 	fromSite: string;
 	engine: string;
 	cardData: any;
-	selectedSite: any;
+	selectedSite: SiteDetails;
 	isFetchingContent: boolean;
 };
 
@@ -54,7 +56,7 @@ export default function PaidSubscribers( {
 					cardData={ cardData }
 					skipNextStep={ skipNextStep }
 					engine={ engine }
-					siteId={ selectedSite?.ID }
+					siteId={ selectedSite.ID }
 					currentStep="paid-subscribers"
 				/>
 			) }

--- a/client/my-sites/importer/newsletter/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers.tsx
@@ -1,6 +1,7 @@
 import { SiteDetails } from '@automattic/data-stores';
 import { hasQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
+import { PaidSubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import { useDispatch } from 'calypso/state';
 import { infoNotice, successNotice } from 'calypso/state/notices/actions';
 import ConnectStripe from './paid-subscribers/connect-stripe';
@@ -11,7 +12,7 @@ type Props = {
 	skipNextStep: () => void;
 	fromSite: string;
 	engine: string;
-	cardData: any;
+	cardData: PaidSubscribersStepContent;
 	selectedSite: SiteDetails;
 	isFetchingContent: boolean;
 };

--- a/client/my-sites/importer/newsletter/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/connect-stripe.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@automattic/components';
 import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import StripeLogo from 'calypso/assets/images/jetpack/stripe-logo-white.svg';
+import { PaidSubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../../importer-action-buttons/container';
@@ -25,7 +26,7 @@ function updateConnectUrl( connectUrl: string, fromSite: string, engine: string 
 type Props = {
 	nextStepUrl: string;
 	skipNextStep: () => void;
-	cardData: any;
+	cardData: PaidSubscribersStepContent;
 	fromSite: string;
 	engine: string;
 	isFetchingContent: boolean;

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
@@ -24,7 +24,7 @@ export type TierToAdd = {
 
 type MapPlanProps = {
 	plan: Plan;
-	products: Array< Product >;
+	products: Product[];
 	map_plans: any;
 	siteId: number;
 	engine: string;

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
@@ -4,12 +4,9 @@ import { Fragment } from '@wordpress/element';
 import { chevronDown, Icon, arrowRight } from '@wordpress/icons';
 import { useState, KeyboardEvent } from 'react';
 import { useMapStripePlanToProductMutation } from 'calypso/data/paid-newsletter/use-map-stripe-plan-to-product-mutation';
-import { AvailableTier, Plan } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import { Product, Plan } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
 import './map-plan.scss';
-
-// TODO would be nice to get rid of it somehow
-type Product = AvailableTier;
 
 export type TierToAdd = {
 	currency: string;

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
@@ -4,27 +4,12 @@ import { Fragment } from '@wordpress/element';
 import { chevronDown, Icon, arrowRight } from '@wordpress/icons';
 import { useState, KeyboardEvent } from 'react';
 import { useMapStripePlanToProductMutation } from 'calypso/data/paid-newsletter/use-map-stripe-plan-to-product-mutation';
+import { AvailableTier, Plan } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
 import './map-plan.scss';
 
-type Plan = {
-	plan_id: string;
-	name: string;
-	plan_interval: string;
-	active_subscriptions: number;
-	is_active: boolean;
-	plan_currency: string;
-	plan_amount_decimal: number;
-	product_id: string;
-};
-
-type Product = {
-	id: number;
-	price: string;
-	currency: string;
-	title: string;
-	interval: string;
-};
+// TODO would be nice to get rid of it somehow
+type Product = AvailableTier;
 
 export type TierToAdd = {
 	currency: string;
@@ -51,7 +36,7 @@ type MapPlanProps = {
 	tierToAdd: TierToAdd;
 };
 
-function displayProduct( product: Product | undefined ) {
+function displayProduct( product?: Product ) {
 	if ( ! product ) {
 		return 'Select a Newsletter Tier';
 	}
@@ -66,7 +51,7 @@ function displayProduct( product: Product | undefined ) {
 	);
 }
 
-function getProductChoices( products: Array< Product > ) {
+function getProductChoices( products: Product[] ) {
 	return products.map( ( product ) => ( {
 		info: `${ formatCurrency( parseFloat( product.price ), product.currency ) } / ${
 			product.interval

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
@@ -25,7 +25,7 @@ export type TierToAdd = {
 type MapPlanProps = {
 	plan: Plan;
 	products: Product[];
-	map_plans: any;
+	map_plans: Record< string, string >;
 	siteId: number;
 	engine: string;
 	currentStep: string;

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
@@ -44,7 +44,7 @@ type MapPlanProps = {
 	plan: Plan;
 	products: Array< Product >;
 	map_plans: any;
-	siteId: string;
+	siteId: number;
 	engine: string;
 	currentStep: string;
 	onProductAdd: ( arg0: TierToAdd | null ) => void;

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
@@ -2,6 +2,7 @@ import { Card } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState, useRef } from 'react';
+import { PaidSubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import {
 	PLAN_YEARLY_FREQUENCY,
@@ -18,7 +19,7 @@ import { MapPlan, TierToAdd } from './map-plan';
 type Props = {
 	nextStepUrl: string;
 	skipNextStep: () => void;
-	cardData: any;
+	cardData: PaidSubscribersStepContent;
 	siteId: number;
 	engine: string;
 	currentStep: string;
@@ -62,9 +63,13 @@ export default function MapPlans( {
 		} );
 	}, [ sizeOfProducts, sizeOfProductsRef, siteId, engine, currentStep, queryClient ] );
 
-	const monthyPlan = cardData.plans.find( ( plan: any ) => plan.plan_interval === 'month' );
+	const monthyPlan = cardData.plans.find( ( plan ) => plan.plan_interval === 'month' );
+	const annualPlan = cardData.plans.find( ( plan ) => plan.plan_interval === 'year' );
 
-	const annualPlan = cardData.plans.find( ( plan: any ) => plan.plan_interval === 'year' );
+	// TODO what if those plans are undefined?
+	if ( ! monthyPlan || ! annualPlan ) {
+		return;
+	}
 
 	const tierToAdd = {
 		currency: monthyPlan.plan_currency,

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
@@ -19,7 +19,7 @@ type Props = {
 	nextStepUrl: string;
 	skipNextStep: () => void;
 	cardData: any;
-	siteId: string;
+	siteId: number;
 	engine: string;
 	currentStep: string;
 };

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -28,35 +28,29 @@ export default function SelectNewsletterForm( { stepUrl, urlData, isLoading }: P
 
 	if ( isLoading ) {
 		return (
-			<Card>
-				<div className="select-newsletter-form">
-					<p className="is-loading"></p>
-				</div>
+			<Card className="select-newsletter-form">
+				<div className="is-loading" />
 			</Card>
 		);
 	}
 
 	return (
-		<Card>
-			<div className="select-newsletter-form">
-				<FormTextInputWithAction
-					onAction={ handleAction }
-					placeholder="https://example.substack.com"
-					action="Continue"
-					isError={ hasError }
-					defaultValue={ urlData?.url }
-				/>
-				{ hasError && (
-					<p className="select-newsletter-form__help is-error">
-						Please enter a valid Substack URL.
-					</p>
-				) }
-				{ ! hasError && (
-					<p className="select-newsletter-form__help">
-						Enter the URL of the Substack newsletter that you wish to import.
-					</p>
-				) }
-			</div>
+		<Card className="select-newsletter-form">
+			<FormTextInputWithAction
+				onAction={ handleAction }
+				placeholder="https://example.substack.com"
+				action="Continue"
+				isError={ hasError }
+				defaultValue={ urlData?.url }
+			/>
+			{ hasError && (
+				<p className="select-newsletter-form__help is-error">Please enter a valid Substack URL.</p>
+			) }
+			{ ! hasError && (
+				<p className="select-newsletter-form__help">
+					Enter the URL of the Substack newsletter that you wish to import.
+				</p>
+			) }
 		</Card>
 	);
 }

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -5,7 +5,9 @@ import { Modal, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { Icon, people, currencyDollar, external } from '@wordpress/icons';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
+import { toInteger } from 'lodash';
 import { useEffect, useRef } from 'react';
+import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import SubscriberUploadForm from './subscriber-upload-form';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -14,7 +16,7 @@ type Props = {
 	selectedSite: SiteDetails;
 	fromSite: QueryArgParsed;
 	skipNextStep: () => void;
-	cardData: any;
+	cardData: SubscribersStepContent;
 	siteSlug: string;
 	engine: string;
 };
@@ -51,8 +53,8 @@ export default function Subscribers( {
 
 	const open = cardData?.meta?.status === 'pending' || false;
 
-	const all_emails = cardData?.meta?.email_count || 0;
-	const paid_emails = cardData?.meta?.paid_subscribers_count || 0;
+	const all_emails = toInteger( cardData?.meta?.email_count ) || 0;
+	const paid_emails = toInteger( cardData?.meta?.paid_subscribers_count ) || 0;
 	const free_emails = all_emails - paid_emails;
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

It:
- adds some missing types to get rid of `any`
- simplifies `SelectNewsletterForm` component
- handles not supported step slugs
- improves defining `step` and `fromSite`
- adds some TODOs for follow-up work

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

Make sure it didn't introduce any regression.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
