### PR TITLE
A4A > Team: Show date on Added column for added users

### DIFF
--- a/client/a8c-for-agencies/data/team/use-fetch-active-members.ts
+++ b/client/a8c-for-agencies/data/team/use-fetch-active-members.ts
@@ -10,6 +10,7 @@ type MemberAPIResponse = {
 	email: string;
 	avatar_url: string;
 	role: string;
+	joined_timestamp: string;
 };
 
 export default function useFetchActiveMembers(): UseQueryResult< TeamMember[], unknown > {
@@ -30,6 +31,7 @@ export default function useFetchActiveMembers(): UseQueryResult< TeamMember[], u
 				avatar: member.avatar_url,
 				role: member.role,
 				status: 'active',
+				dateAdded: member.joined_timestamp,
 			} ) );
 		},
 		enabled: !! agencyId,

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -3,6 +3,7 @@ import { Icon, moreVertical } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useCallback, useRef, useState } from 'react';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { OWNER_ROLE } from '../../constants';
@@ -71,7 +72,13 @@ export const MemberColumn = ( {
 };
 
 export const DateColumn = ( { date }: { date?: string } ): ReactNode => {
-	return date ? new Date( date ).toLocaleDateString() : <Gridicon icon="minus" />;
+	const moment = useLocalizedMoment();
+	const formattedDate = Number( date );
+	return formattedDate ? (
+		moment.unix( formattedDate ).format( 'MMMM D, YYYY' )
+	) : (
+		<Gridicon icon="minus" />
+	);
 };
 
 export const ActionColumn = ( {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1064 

## Proposed Changes

This PR shows the date for the added users on the `Added` column on Team

## Why are these changes being made?

* To show the date when the team member was added.

## Testing Instructions

* Open the A4A live link
* Verify that the date is shown only for the added(invite accepted) user as shown below

<img width="1728" alt="Screenshot 2024-09-05 at 4 02 16 PM" src="https://github.com/user-attachments/assets/c5f3dd93-f72c-459f-9a06-53c88daa90d5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
