### PR TITLE
Rich Text: Remove overridden underline format

### DIFF
--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -1,42 +1,9 @@
 /* global wpcomGutenberg */
 import { RichTextToolbarButton } from '@wordpress/block-editor';
 import { compose, ifCondition } from '@wordpress/compose';
-import { withSelect, withDispatch, select, subscribe } from '@wordpress/data';
-import { toggleFormat, registerFormatType, unregisterFormatType } from '@wordpress/rich-text';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { registerFormatType } from '@wordpress/rich-text';
 import { get } from 'lodash';
-
-const unsubscribe = subscribe( () => {
-	const underlineFormat = select( 'core/rich-text' ).getFormatType( 'core/underline' );
-	if ( ! underlineFormat ) {
-		return;
-	}
-	unsubscribe();
-	const settings = unregisterFormatType( 'core/underline' );
-	registerFormatType( 'wpcom/underline', {
-		...settings,
-		name: 'wpcom/underline',
-		edit( { isActive, value, onChange } ) {
-			const onToggle = () =>
-				onChange(
-					toggleFormat( value, {
-						type: 'wpcom/underline',
-						attributes: {
-							style: 'text-decoration: underline;',
-						},
-					} )
-				);
-
-			return (
-				<RichTextToolbarButton
-					icon="editor-underline"
-					title={ settings.title }
-					onClick={ onToggle }
-					isActive={ isActive }
-				/>
-			);
-		},
-	} );
-} );
 
 const RichTextJustifyButton = ( { blockId, isBlockJustified, updateBlockAttributes } ) => {
 	const onToggle = () =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves: https://github.com/Automattic/wp-calypso/issues/94243
Resolves: https://github.com/Automattic/wp-calypso/issues/71631

From the issue:

Currently the `underline` format is overridden from core in order to add an option in block's toolbar formats dropdown. 


In core this button (alongside with the justify one) were removed [years ago](https://core.trac.wordpress.org/ticket/27159). TLDR; 
>Underline - It introduces a potentially bad user experience issue: readers confusing the underline text with a link. Underlined text is broadly interpreted as web links.

 Additionally, right now is buggy, because it doesn't handle the [shortcuts](https://github.com/Automattic/wp-calypso/issues/71631) for it (Command + U).

This PR removes the overridden format and aligns with core.

#### Steps to reproduce

1. Open the post editor and insert some text in a paragraph
2. Open the formats dropdown in the block's toolbar
3. Observe the `Underline` format is not rendered
4. Use the shortcut Command+U (Mac) or Ctrl+U (Windows)
5. The text should be underlined and the format active

Before            |  After
:-------------------------:|:-------------------------:
<img width="541" alt="Screenshot 2024-09-05 at 3 51 52 PM" src="https://github.com/user-attachments/assets/b8ff1b26-6eb8-47af-9e2a-5e366fb7e566"> | <img width="541" alt="Screenshot 2024-09-05 at 4 47 19 PM" src="https://github.com/user-attachments/assets/ecdc04cb-2c57-42b6-9ab6-2f3da41b41a2">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
