### PR TITLE
Active Theme Card improvements

### DIFF
--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -183,15 +183,12 @@ $theme-info-height: 54px;
 		.gridicon {
 			color: var(--color-primary);
 		}
-
-		&.is-active .gridicon {
-			color: var(--color-text-inverted);
-		}
 	}
 
 	&.is-open {
 		.gridicon {
 			transform: rotate(90deg);
+			color: var(--color-primary);
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -643,11 +643,6 @@ $design-button-primary-color: rgb(17, 122, 201);
 // Free flow
 .update-design.design-setup,
 .free.design-setup {
-	.step-container:not(.design-setup__preview) {
-		.navigation-link {
-			display: none;
-		}
-	}
 	.step-container__navigation {
 		.step-container__skip-wrapper {
 			button.step-container__navigation-link {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -929,6 +929,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			oldHighResImageLoading={ oldHighResImageLoading }
 			isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
 			siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
+			showActiveThemeBadge={ intent !== 'build' }
 		/>
 	);
 
@@ -939,12 +940,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			skipButtonAlign="top"
 			hideFormattedHeader
 			hideSkip
-			hideNext={ ! siteActiveTheme?.[ 0 ]?.stylesheet }
 			backLabelText={ translate( 'Back' ) }
 			stepContent={ stepContent }
 			recordTracksEvent={ recordStepContainerTracksEvent }
 			goNext={ handleSubmit }
-			goBack={ handleBackClick }
+			goBack={ intent === 'update-design' ? submit : handleBackClick }
 		/>
 	);
 };

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -318,14 +318,6 @@
 				}
 			}
 		}
-
-		&.theme-card--is-active {
-			order: 0;
-		}
-
-		&:not(.theme-card--is-active) {
-			order: 1;
-		}
 	}
 
 	.design-button-container .design-picker__design-option .design-picker__image-frame:hover::after,

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -145,7 +145,7 @@ const ThemeCard = forwardRef(
 						<h2 className="theme-card__info-title">
 							<span>{ name }</span>
 						</h2>
-						{ ! isActive && styleVariations.length > 0 && (
+						{ ! optionsMenu && styleVariations.length > 0 && (
 							<div className="theme-card__info-style-variations">
 								<StyleVariationBadges
 									variations={ styleVariations }
@@ -156,8 +156,8 @@ const ThemeCard = forwardRef(
 							</div>
 						) }
 						{ ! isActive && <>{ badge }</> }
-						{ isActive && <ActiveBadge /> }
 						{ optionsMenu && <div className="theme-card__info-options">{ optionsMenu }</div> }
+						{ isActive && <ActiveBadge /> }
 					</div>
 				</div>
 			</Card>

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -14,7 +14,7 @@ $theme-card-info-margin-top: 16px;
 
 	&--is-active {
 		.theme-card__image-container {
-			border: 2px solid var(--color-primary);
+			box-shadow: 0 0 0 2px var(--color-primary);
 			border-radius: 4px;
 		}
 	}
@@ -294,7 +294,6 @@ $theme-card-info-margin-top: 16px;
 .theme-card__info-options,
 .theme-card__info-options .theme__more-button {
 	border: 0;
-	bottom: 0;
 	display: flex;
 	flex: 0 0 auto;
 	height: 20px;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -205,7 +205,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 		shouldLimitGlobalStyles,
 	} );
 
-	const conditionalProps = ! isActive
+	const conditionalProps = isLocked
 		? { onImageClick: () => onPreview( design, selectedStyleVariation ) }
 		: {};
 

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -232,7 +232,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 				setSelectedStyleVariation( variation );
 			} }
 			onStyleVariationMoreClick={ () => onPreview( design ) }
-			isActive={ isActive }
+			isActive={ isActive && ! isLocked }
 			{ ...conditionalProps }
 		/>
 	);
@@ -252,6 +252,7 @@ interface DesignPickerProps {
 	oldHighResImageLoading?: boolean; // Temporary for A/B test
 	isSiteAssemblerEnabled?: boolean; // Temporary for A/B test
 	siteActiveTheme?: string | null;
+	showActiveThemeBadge?: boolean;
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -268,6 +269,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	oldHighResImageLoading,
 	isSiteAssemblerEnabled,
 	siteActiveTheme = null,
+	showActiveThemeBadge = false,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const filteredDesigns = useMemo( () => {
@@ -323,7 +325,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 							onPreview={ onPreview }
 							getBadge={ getBadge }
 							oldHighResImageLoading={ oldHighResImageLoading }
-							isActive={ design.recipe?.stylesheet === siteActiveTheme }
+							isActive={ showActiveThemeBadge && design.recipe?.stylesheet === siteActiveTheme }
 						/>
 					);
 				} ) }
@@ -351,6 +353,7 @@ export interface UnifiedDesignPickerProps {
 	oldHighResImageLoading?: boolean; // Temporary for A/B test
 	isSiteAssemblerEnabled?: boolean; // Temporary for A/B test
 	siteActiveTheme?: string | null;
+	showActiveThemeBadge?: boolean;
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -369,6 +372,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	oldHighResImageLoading,
 	isSiteAssemblerEnabled,
 	siteActiveTheme = null,
+	showActiveThemeBadge = false,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 
@@ -404,6 +408,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					oldHighResImageLoading={ oldHighResImageLoading }
 					isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
 					siteActiveTheme={ siteActiveTheme }
+					showActiveThemeBadge={ showActiveThemeBadge }
 				/>
 				{ bottomAnchorContent }
 			</div>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -205,9 +205,10 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 		shouldLimitGlobalStyles,
 	} );
 
-	const conditionalProps = isLocked
-		? { onImageClick: () => onPreview( design, selectedStyleVariation ) }
-		: {};
+	const conditionalProps =
+		! isLocked && isActive
+			? {}
+			: { onImageClick: () => onPreview( design, selectedStyleVariation ) };
 
 	return (
 		<ThemeCard


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes
This PR consists of two main blocks of changes, on one side I've fine-tuned some visual details and problems on the LiTS. The three-dot menu wasn't aligned with the theme name, and the active and hover states were not working as expected.
| Before | After |
|-----|-----|
|![lits-before](https://github.com/user-attachments/assets/a3b6558d-c363-4b11-84e6-57de08fadb1d)|![lits-after](https://github.com/user-attachments/assets/b089f94b-ad2d-47c9-a60d-e2031879d190)|

The Design Picker consists of two main flows, the first flow is once the customer starts a new site, the intent for this part of the flow is `build`. On the build flow the user hasn't selected any design/theme yet, with the proposed changes we do not show the active theme at this point of the user journey. Once the user ends up on the onboarding flow and enters the select design step we do show the active theme. If the user selects a style variation on the active theme we remove the active badge, since in theory, the selected design doesn't correspond with the active design.
I've also removed the continue button and added an escape hatch (Back Button) to the onboarding step. Going back keeps the currently selected theme selected.

### Build intent
https://github.com/user-attachments/assets/6303b1bd-f00a-4e61-b753-36a6aaa66612

### Onboarding step

https://github.com/user-attachments/assets/a405c485-d4be-4e54-a954-9a8449729fbc




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Active badge was in an inconsistent state across screens and affected the quality of the flows we have.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link and create a new site.
* Choose "Pick a theme", the screen should work as described.
* Move forward to the onboarding flow and click on the pick design step, the theme you've picked should be marked with the Active badge.
* Finish the flow an go to the LiTS, you should see your active theme with the correct design and working as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
