### PR TITLE
A4A Referrals: convert the actions field into proper actions

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -48,7 +48,12 @@ export default function ReferralsOverview( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( initialDataViewsState );
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
+		...initialDataViewsState,
+		layout: {
+			primaryField: 'client',
+		},
+	} );
 	const [ requiredNoticeClose, setRequiredNoticeClosed ] = useState( false );
 
 	const { value: referralEmail, setValue: setReferralEmail } = useUrlQueryParam(

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -161,20 +161,23 @@ export default function ReferralList( {
 		};
 	}, [ dataViewsState ] );
 
-	const actions: Action< any >[] = useMemo( () => {
-		// TODO: fix TypeScript any
-		return [
-			{
-				id: 'view-details',
-				label: translate( 'View Details' ),
-				isPrimary: true,
-				icon: chevronRight, // TODO: is this how you use icons in calypso?
-				callback( items ) {
-					openSitePreviewPane( items[ 0 ] );
+	const actions: Action< Referral >[] = useMemo( () => {
+		if ( dataViewsState.type === 'table' ) {
+			return [
+				{
+					id: 'view-details',
+					label: translate( 'View Details' ),
+					isPrimary: true,
+					icon: chevronRight, // TODO: is this how you use icons in calypso?
+					callback( items ) {
+						openSitePreviewPane( items[ 0 ] );
+					},
 				},
-			},
-		];
-	}, [ openSitePreviewPane, translate ] );
+			];
+		}
+
+		return [];
+	}, [ openSitePreviewPane, translate, dataViewsState.type ] );
 
 	const { data: items, paginationInfo: pagination } = useMemo( () => {
 		return filterSortAndPaginate( referrals, dataViewsState, fields );

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -172,7 +172,7 @@ export default function ReferralList( {
 					id: 'view-details',
 					label: translate( 'View Details' ),
 					isPrimary: true,
-					icon: chevronRight, // TODO: is this how you use icons in calypso?
+					icon: chevronRight,
 					callback( items ) {
 						openSitePreviewPane( items[ 0 ] );
 					},

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/components';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { chevronRight } from '@wordpress/icons';
@@ -49,22 +48,11 @@ export default function ReferralList( {
 		() =>
 			dataViewsState.selectedItem || ! isDesktop
 				? [
-						// Show the client column as a button on mobile
 						{
 							id: 'client',
 							label: translate( 'Client' ).toUpperCase(),
 							getValue: () => '-',
-							render: ( { item }: { item: Referral } ): ReactNode => (
-								<Button
-									className="view-details-button client-email-button"
-									data-client-id={ item.client.id }
-									onClick={ () => openSitePreviewPane( item ) }
-									borderless
-								>
-									{ item.client.email }
-								</Button>
-							),
-							width: '100%',
+							render: ( { item }: { item: Referral } ): ReactNode => item.client.email,
 							enableHiding: false,
 							enableSorting: false,
 						},
@@ -74,16 +62,7 @@ export default function ReferralList( {
 							id: 'client',
 							label: translate( 'Client' ).toUpperCase(),
 							getValue: () => '-',
-							render: ( { item }: { item: Referral } ): ReactNode => (
-								<Button
-									className="view-details-button"
-									data-client-id={ item.client.id }
-									onClick={ () => openSitePreviewPane( item ) }
-									borderless
-								>
-									{ item.client.email }
-								</Button>
-							),
+							render: ( { item }: { item: Referral } ): ReactNode => item.client.email,
 							enableHiding: false,
 							enableSorting: false,
 						},
@@ -134,7 +113,7 @@ export default function ReferralList( {
 							enableSorting: false,
 						},
 				  ],
-		[ dataViewsState.selectedItem, isDesktop, openSitePreviewPane, referralInvoices, translate ]
+		[ dataViewsState.selectedItem, isDesktop, referralInvoices, translate ]
 	);
 
 	useEffect( () => {

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -1,6 +1,7 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { chevronRight } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback, ReactNode, useEffect } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
@@ -11,7 +12,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { Referral, ReferralInvoice } from '../types';
 import CommissionsColumn from './commissions-column';
 import SubscriptionStatus from './subscription-status';
-import type { Field } from '@wordpress/dataviews';
+import type { Field, Action } from '@wordpress/dataviews';
 
 import './style.scss';
 
@@ -67,28 +68,6 @@ export default function ReferralList( {
 							enableHiding: false,
 							enableSorting: false,
 						},
-						// Only show the actions column only on mobile
-						...( ! dataViewsState.selectedItem
-							? [
-									{
-										id: 'actions',
-										label: '',
-										render: ( { item }: { item: Referral } ) => (
-											<div>
-												<Button
-													className="view-details-button"
-													onClick={ () => openSitePreviewPane( item ) }
-													borderless
-												>
-													<Gridicon icon="chevron-right" />
-												</Button>
-											</div>
-										),
-										enableHiding: false,
-										enableSorting: false,
-									},
-							  ]
-							: [] ),
 				  ]
 				: [
 						{
@@ -154,23 +133,6 @@ export default function ReferralList( {
 							enableHiding: false,
 							enableSorting: false,
 						},
-						{
-							id: 'actions',
-							label: translate( 'Actions' ).toUpperCase(),
-							render: ( { item }: { item: Referral } ) => (
-								<div>
-									<Button
-										className="view-details-button action-button"
-										onClick={ () => openSitePreviewPane( item ) }
-										borderless
-									>
-										<Gridicon icon="chevron-right" />
-									</Button>
-								</div>
-							),
-							enableHiding: false,
-							enableSorting: false,
-						},
 				  ],
 		[ dataViewsState.selectedItem, isDesktop, openSitePreviewPane, referralInvoices, translate ]
 	);
@@ -220,7 +182,22 @@ export default function ReferralList( {
 		};
 	}, [ dataViewsState ] );
 
-	const { data: items, paginationInfo } = useMemo( () => {
+	const actions: Action< any >[] = useMemo( () => {
+		// TODO: fix TypeScript any
+		return [
+			{
+				id: 'view-details',
+				label: translate( 'View Details' ),
+				isPrimary: true,
+				icon: chevronRight, // TODO: is this how you use icons in calypso?
+				callback( items ) {
+					openSitePreviewPane( items[ 0 ] );
+				},
+			},
+		];
+	}, [ openSitePreviewPane, translate ] );
+
+	const { data: items, paginationInfo: pagination } = useMemo( () => {
 		return filterSortAndPaginate( referrals, dataViewsState, fields );
 	}, [ referrals, dataViewsState, fields ] );
 
@@ -236,12 +213,12 @@ export default function ReferralList( {
 							openSitePreviewPane( referral );
 						}
 					},
-					pagination: paginationInfo,
+					pagination,
 					enableSearch: false,
-					fields: fields,
-					actions: [],
-					setDataViewsState: setDataViewsState,
-					dataViewsState: dataViewsState,
+					fields,
+					actions,
+					setDataViewsState,
+					dataViewsState,
 					defaultLayouts: { table: {} },
 				} }
 			/>

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -52,7 +52,9 @@ export default function ReferralList( {
 							id: 'client',
 							label: translate( 'Client' ).toUpperCase(),
 							getValue: () => '-',
-							render: ( { item }: { item: Referral } ): ReactNode => item.client.email,
+							render: ( { item }: { item: Referral } ): ReactNode => (
+								<span className="a4a-referrals-client">{ item.client.email }</span>
+							),
 							enableHiding: false,
 							enableSorting: false,
 						},
@@ -62,7 +64,9 @@ export default function ReferralList( {
 							id: 'client',
 							label: translate( 'Client' ).toUpperCase(),
 							getValue: () => '-',
-							render: ( { item }: { item: Referral } ): ReactNode => item.client.email,
+							render: ( { item }: { item: Referral } ): ReactNode => (
+								<span className="a4a-referrals-client">{ item.client.email }</span>
+							),
 							enableHiding: false,
 							enableSorting: false,
 						},

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/style.scss
@@ -1,2 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+
+.a4a-referrals-client {
+	font-size: 0.875rem;
+	color: var(--color-accent-80);
+}

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/style.scss
@@ -1,15 +1,2 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
-.theme-a8c-for-agencies .button.client-email-button {
-	max-width: 215px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	display: block;
-
-	@include break-medium {
-		max-width: unset;
-
-	}
-}

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -21,10 +21,6 @@
 		color: var(--color-jetpack-50);
 	}
 
-	.dataviews-view-table__actions-column {
-		display: none;
-	}
-
 	thead {
 		th.sites-dataviews__site {
 			background: var(--color-light-backdrop);

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -602,14 +602,6 @@ html {
 		}
 	}
 
-	.dataviews-view-list li {
-		cursor: pointer;
-	}
-
-	.dataviews-view-list li .components-h-stack {
-		display: block;
-		width: 100%;
-	}
 }
 
 .full-width-layout-with-table {

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -600,11 +600,6 @@ html {
 				padding-inline-start: 16px;
 			}
 		}
-
-		th[data-field-id="actions"] {
-			text-align: right;
-			padding-inline-end: 16px;
-		}
 	}
 
 	.dataviews-view-list li {

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -108,10 +108,6 @@
 		color: var(--studio-jetpack-green-50);
 	}
 
-	.dataviews-view-table__actions-column {
-		display: none;
-	}
-
 	thead .dataviews-view-table__row th {
 		span,
 		button {

--- a/client/hosting/sites/components/style.scss
+++ b/client/hosting/sites/components/style.scss
@@ -49,10 +49,6 @@
 			padding: 0;
 		}
 	}
-	th[data-field-id="actions"] {
-		padding-inline-end: 16px;
-		text-align: end;
-	}
 	@media (min-width: $break-large) {
 		background: inherit;
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -21,10 +21,6 @@
 		color: var(--studio-jetpack-green-50);
 	}
 
-	.dataviews-view-table__actions-column {
-		display: none;
-	}
-
 	thead {
 		th.sites-dataviews__site {
 			background: var(--studio-white);


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/93503
Related to https://github.com/Automattic/wp-calypso/issues/94198

## Proposed Changes

This PR converts the existing `actions` field into proper DataViews actions.

## Why are these changes being made?

Part of clean-up of DataViews in A4A to use core-first APIs.

## Testing Instructions

```sh
yarn && yarn start-a8c-for-agencies
```

Visit `agencies.localhost:3000` and navigate to the "Referrals" section.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
