### PR TITLE
Sites dashboard - remove default filter and dummy column hack

### DIFF
--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -52,7 +52,7 @@ import { DOTCOM_OVERVIEW, FEATURE_TO_ROUTE_MAP } from './site-preview-pane/const
 import DotcomPreviewPane from './site-preview-pane/dotcom-preview-pane';
 import SitesDashboardHeader from './sites-dashboard-header';
 import DotcomSitesDataViews, { useSiteStatusGroups } from './sites-dataviews';
-import { getSitesPagination, addDummyDataViewPrefix } from './sites-dataviews/utils';
+import { getSitesPagination } from './sites-dataviews/utils';
 import type { SiteDetails } from '@automattic/data-stores';
 
 // todo: we are using A4A styles until we extract them as common styles in the ItemsDashboard component
@@ -77,7 +77,6 @@ const siteSortingKeys = [
 ];
 
 const DEFAULT_PER_PAGE = 50;
-const DEFAULT_STATUS_GROUP = 'all';
 const DEFAULT_SITE_TYPE = 'non-p2';
 
 const SitesDashboard = ( {
@@ -88,7 +87,7 @@ const SitesDashboard = ( {
 		perPage = DEFAULT_PER_PAGE,
 		search,
 		newSiteID,
-		status = DEFAULT_STATUS_GROUP,
+		status,
 		siteType = DEFAULT_SITE_TYPE,
 	},
 	selectedSite,
@@ -160,13 +159,17 @@ const SitesDashboard = ( {
 		perPage,
 		search: search ?? '',
 		fields: getFieldsByBreakpoint( isDesktop ),
-		filters: [
-			{
-				field: addDummyDataViewPrefix( 'status' ),
-				operator: 'is',
-				value: siteStatusGroups.find( ( item ) => item.slug === status )?.value || 1,
-			},
-		],
+		...( status
+			? {
+					filters: [
+						{
+							field: 'status',
+							operator: 'is',
+							value: siteStatusGroups.find( ( item ) => item.slug === status )?.value || 1,
+						},
+					],
+			  }
+			: {} ),
 		selectedItem: selectedSite,
 		type: selectedSite ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
 		layout: {
@@ -260,9 +263,7 @@ const SitesDashboard = ( {
 
 	// Get the status group slug.
 	const statusSlug = useMemo( () => {
-		const statusFilter = dataViewsState.filters?.find(
-			( filter ) => filter.field === addDummyDataViewPrefix( 'status' )
-		);
+		const statusFilter = dataViewsState.filters?.find( ( filter ) => filter.field === 'status' );
 		const statusNumber = statusFilter?.value || 1;
 		return ( siteStatusGroups.find( ( status ) => status.value === statusNumber )?.slug ||
 			'all' ) as GroupableSiteLaunchStatuses;
@@ -303,7 +304,7 @@ const SitesDashboard = ( {
 	useEffect( () => {
 		const queryParams = {
 			search: dataViewsState.search?.trim(),
-			status: statusSlug === DEFAULT_STATUS_GROUP ? undefined : statusSlug,
+			status: statusSlug === 'all' ? undefined : statusSlug,
 			page: dataViewsState.page && dataViewsState.page > 1 ? dataViewsState.page : undefined,
 			'per-page': dataViewsState.perPage === DEFAULT_PER_PAGE ? undefined : dataViewsState.perPage,
 		};

--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -264,14 +264,14 @@ const SitesDashboard = ( {
 	// Get the status group slug.
 	const statusSlug = useMemo( () => {
 		const statusFilter = dataViewsState.filters?.find( ( filter ) => filter.field === 'status' );
-		const statusNumber = statusFilter?.value || 1;
-		return ( siteStatusGroups.find( ( status ) => status.value === statusNumber )?.slug ||
-			'all' ) as GroupableSiteLaunchStatuses;
+		const statusNumber = statusFilter?.value;
+		return siteStatusGroups.find( ( status ) => status.value === statusNumber )
+			?.slug as GroupableSiteLaunchStatuses;
 	}, [ dataViewsState.filters, siteStatusGroups ] );
 
 	// Filter sites list by status group.
 	const { currentStatusGroup } = useSitesListGrouping( allSites, {
-		status: statusSlug,
+		status: statusSlug || 'all',
 		showHidden: true,
 	} );
 
@@ -304,7 +304,7 @@ const SitesDashboard = ( {
 	useEffect( () => {
 		const queryParams = {
 			search: dataViewsState.search?.trim(),
-			status: statusSlug === 'all' ? undefined : statusSlug,
+			status: statusSlug,
 			page: dataViewsState.page && dataViewsState.page > 1 ? dataViewsState.page : undefined,
 			'per-page': dataViewsState.perPage === DEFAULT_PER_PAGE ? undefined : dataViewsState.perPage,
 		};

--- a/client/hosting/sites/components/sites-dataviews/index.tsx
+++ b/client/hosting/sites/components/sites-dataviews/index.tsx
@@ -132,7 +132,6 @@ const DotcomSitesDataViews = ( {
 				elements: siteStatusGroups,
 				filterBy: {
 					operators: [ 'is' ],
-					isPrimary: true,
 				},
 			},
 			{

--- a/client/hosting/sites/components/sites-dataviews/index.tsx
+++ b/client/hosting/sites/components/sites-dataviews/index.tsx
@@ -10,7 +10,6 @@ import ActionsField from './dataviews-fields/actions-field';
 import SiteField from './dataviews-fields/site-field';
 import { SiteStats } from './sites-site-stats';
 import { SiteStatus } from './sites-site-status';
-import { addDummyDataViewPrefix } from './utils';
 import type { SiteExcerptData } from '@automattic/sites';
 import type { Field } from '@wordpress/dataviews';
 import type {
@@ -126,11 +125,15 @@ const DotcomSitesDataViews = ( {
 			},
 			{
 				id: 'status',
-				// @ts-expect-error -- Need to fix the label type upstream in @wordpress/dataviews to support React elements.
-				label: <span>{ __( 'Status' ) }</span>,
+				label: __( 'Status' ),
 				render: ( { item }: { item: SiteExcerptData } ) => <SiteStatus site={ item } />,
 				enableHiding: false,
 				enableSorting: false,
+				elements: siteStatusGroups,
+				filterBy: {
+					operators: [ 'is' ],
+					isPrimary: true,
+				},
 			},
 			{
 				id: 'last-publish',
@@ -168,19 +171,6 @@ const DotcomSitesDataViews = ( {
 				render: () => null,
 				enableHiding: false,
 				enableSorting: true,
-				getValue: () => null,
-			},
-			{
-				id: addDummyDataViewPrefix( 'status' ),
-				label: __( 'Status' ),
-				render: () => null,
-				elements: siteStatusGroups,
-				filterBy: {
-					operators: [ 'is' ],
-					isPrimary: true,
-				},
-				enableHiding: false,
-				enableSorting: false,
 				getValue: () => null,
 			},
 		],

--- a/client/hosting/sites/components/sites-dataviews/utils.ts
+++ b/client/hosting/sites/components/sites-dataviews/utils.ts
@@ -21,10 +21,6 @@ export function getSitesPagination(
 	return { totalItems, totalPages };
 }
 
-export function addDummyDataViewPrefix( dataView: string ) {
-	return `${ DUMMY_DATA_VIEW_PREFIX }${ dataView }`;
-}
-
 export function removeDummyDataViewPrefix( dataView: string ) {
 	return dataView.replace( DUMMY_DATA_VIEW_PREFIX, '' );
 }

--- a/client/hosting/sites/controller.tsx
+++ b/client/hosting/sites/controller.tsx
@@ -1,7 +1,4 @@
-import {
-	DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE,
-	siteLaunchStatusGroupValues,
-} from '@automattic/sites';
+import { siteLaunchStatusGroupValues } from '@automattic/sites';
 import { Global, css } from '@emotion/react';
 import { removeQueryArgs } from '@wordpress/url';
 import AsyncLoad from 'calypso/components/async-load';
@@ -35,7 +32,6 @@ export function sanitizeQueryParameters( context: PageJSContext, next: () => voi
 	 * in the route.
 	 */
 	if ( context.query.status === undefined ) {
-		context.query.status = DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE;
 		return next();
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/93815

## Proposed Changes

* Removes the default filter of "all sites" when loading the dashboard. Instead it loads with no filters selected unless the query params are present.
* Removes the dummy column we used for filtering by status. This was originally added due to design input to hide the filtering dropdown in the status column header, which has since changed significantly with the upgraded version of dataViews.

(more 🟥  than 🟩 , 🥳 )


BEFORE: When the page is loaded the 'all sites' filter is active, even after reloaded after resetting the filters.
![filters-before](https://github.com/user-attachments/assets/b7bd1215-0381-4056-925d-50a2c21c0455)


AFTER: The page loads with no filters applied if there are no filter is set (such as through url query params).

![non-primary-filter](https://github.com/user-attachments/assets/df8a32cc-f821-474c-a492-84b2dad5a2e9)

The above shows a **_standard filter_** - when the page is loaded, the filter bar is empty. The user must select to add the filter from the status column header or from the filter icon next to the search input. Once cleared, the filter bar disappears.

We also have the option to use a **_primary filter_**, but this seems less fitting (below). In this case, when the page is loaded the filter bar is present with the 'status' item regardless of there being no filter set. Clearing filters does not remove this and it is always present:

![primary-filter](https://github.com/user-attachments/assets/286adf05-3c0f-4bc4-bb2f-5161b3988263)
(currently not used for this PR)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Its confusing and redundant that the filter is shown active when nothing is being filtered out.
* There is no longer a need for the dummy column hack.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR.
* Go to the sites dashboard with no query params.
* There should be no filter set.
* Test applying filters for the 'status' column, verify they work as expected in the list and add a query param to the URL.
* Reload with a filter set (query param in url), verify the state does not change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
