### PR TITLE
Billing History: Add display_brand to individual billing receipts

### DIFF
--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -212,7 +212,9 @@ function ReceiptPaymentMethod( { transaction }: { transaction: BillingTransactio
 	} else if ( 'XXXX' !== transaction.cc_num ) {
 		text = translate( '%(cardType)s ending in %(cardNum)s', {
 			args: {
-				cardType: transaction.cc_type.toUpperCase(),
+				cardType:
+					transaction.cc_display_brand?.replace( '_', ' ' ).toUpperCase() ??
+					transaction.cc_type.toUpperCase(),
 				cardNum: transaction.cc_num,
 			},
 		} );

--- a/client/state/billing-transactions/schema.js
+++ b/client/state/billing-transactions/schema.js
@@ -20,6 +20,7 @@ export const billingTransactionsSchema = {
 					pay_ref: { type: 'string' },
 					pay_part: { type: 'string' },
 					cc_type: { type: 'string' },
+					cc_display_type: { type: [ 'string', 'null' ] },
 					cc_num: { type: 'string' },
 					cc_name: { type: 'string' },
 					cc_email: { type: 'string' },

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -32,6 +32,7 @@ export interface BillingTransaction {
 	cc_name: string;
 	cc_num: string;
 	cc_type: string;
+	cc_display_brand: string | null;
 	credit: string;
 	date: string;
 	desc: string;


### PR DESCRIPTION
> [!warning]
> This PR relies on the data provided by D160555-code, do not merge until **_after_** the diff is deployed.

Follow up to the Stripe Cobadge rollout - this PR will update the card brand displayed on individual receipts under `/purchass/billing` to show the display_brand value if available.

**Note**: still a WIP, I noticed this isn't working for site specific billing history. Will update soon.

Related to https://github.com/Automattic/payments-shilling/issues/3091

## Proposed Changes

* The diff above adds a `cc_display_brand` value to the `billing-history` endpoint, which is then saved in our redux state under `billingTransactions`
* The `transaction` prop is filtered and paginated, then passed to the `<ReceiptBody>` where it is used to create the `MASTERCARD ending in 1001` payment method for the individual billing receipts
* When the `ReceiptPaymentMethod` component is being generated, this change first checks if `cc_display_brand` exists and is not null and uses it before falling back to the `cc_type`
* Also, this change replaces any underscores with a space, then converts the string to uppercase

## Testing Instructions
* Apply this diff to your sandbox D160555-code
* Complete a test purchase with a Cartes Bancaires payment method (see below for instructions)
* Go to /me/purchases/billing and click on `View Receipt` for the recent purchase
* Ensure that the `CARDBRAND ending in 1001` shows as `CARTES BANCAIRES ending in 1001`
* Do the same for the site level billing history at `/purchases/billing-history/[site-name]`

### Test card instructions
- Proxy from the cdg server
- Go to checkout, type in the following test card number 4000002500001001
- Click on network selector next to the card number and select Cartes Bancaires
- Complete checkout to save card

