### PR TITLE
Launchpad: "Write your first post" task links to first post if you have one

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
@@ -4,7 +4,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { TaskAction } from '../../types';
 
 export const getFirstPostPublished: TaskAction = ( task, flow, context ): Task => {
-	const { siteSlug, isEmailVerified } = context;
+	const { isEmailVerified } = context;
 	const mustVerifyEmailBeforePosting = isNewsletterFlow( flow || null ) && ! isEmailVerified;
 
 	return {
@@ -15,7 +15,7 @@ export const getFirstPostPublished: TaskAction = ( task, flow, context ): Task =
 			false,
 		calypso_path: ! isBlogOnboardingFlow( flow || null )
 			? task.calypso_path
-			: addQueryArgs( `https://${ siteSlug }/wp-admin/post-new.php`, {
+			: addQueryArgs( task.calypso_path, {
 					origin: window.location.origin,
 			  } ),
 		useCalypsoPath: true,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
@@ -14,7 +14,7 @@ export const getFirstPostPublished: TaskAction = ( task, flow, context ): Task =
 			( task.completed && isBlogOnboardingFlow( flow || null ) ) ||
 			false,
 		calypso_path: ! isBlogOnboardingFlow( flow || null )
-			? `/post/${ siteSlug }`
+			? task.calypso_path
 			: addQueryArgs( `https://${ siteSlug }/wp-admin/post-new.php`, {
 					origin: window.location.origin,
 			  } ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/test/index.ts
@@ -16,12 +16,12 @@ const buildContext = ( options?: Partial< TaskContext > ) => {
 describe( 'getFirstPostPublished', () => {
 	const task = buildTask( { id: 'task', calypso_path: 'some-path' } );
 
-	it( 'returns the plans page', () => {
+	it( 'returns the calypso_path provided by the server', () => {
 		const context = buildContext( { siteSlug: 'site.wordpress.com' } );
 
 		expect( getFirstPostPublished( task, 'flowId', context ) ).toMatchObject( {
 			useCalypsoPath: true,
-			calypso_path: '/post/site.wordpress.com',
+			calypso_path: 'some-path',
 		} );
 	} );
 
@@ -36,17 +36,13 @@ describe( 'getFirstPostPublished', () => {
 		} );
 	} );
 
-	it( 'returns the wp-admin post new page when is a blog onboarding flow', () => {
-		const siteSlug = 'site.wordpress.com';
+	it( 'appends an `origin` param to calypso_path when it is a blog onboarding flow', () => {
 		const context = buildContext( {
-			siteSlug,
 			isEmailVerified: false,
 		} );
 
 		expect( getFirstPostPublished( task, START_WRITING_FLOW, context ) ).toMatchObject( {
-			calypso_path: `https://${ siteSlug }/wp-admin/post-new.php?origin=${ encodeURIComponent(
-				window.location.origin
-			) }`,
+			calypso_path: `some-path?origin=${ encodeURIComponent( window.location.origin ) }`,
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/94086
Fixes https://github.com/Automattic/wp-calypso/issues/94086

## Proposed Changes

The "publish your first post" task in launchpad always uses the URL returned by the server.
In combination with https://github.com/Automattic/jetpack/pull/39259, this means sometimes clicking the task takes the user to a draft already in progress.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As reported in #94086, the user can find themselves in an onboarding flow loop: they draft a first post, head back to the launchpad, click "write your first post", draft a new post, head back to the launchpad, etc. etc.
The user should be more successful completing the task if they don't end up in a loop.

This PR removes some logic that meant the `start-writing` and `design-first` flows were forced to use the `wp-admin` version of the editor. That behaviour still exists but it's now on the backend.

This PR has also retained the behaviour of only appending the `origin` query param for the `start-writing` and `design-first` flows. It's not clear what this query param is used for, but it seems best not to change it if I don't understand it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add the Jetpack changes to your sandbox
  * Sandbox `public-api`
  * Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin feat/launchpad_draft_post`
  * See PCYsg-Osp-p2 for more details
* Build Calypso changes locally
* Test `write` flow with a draft post
  * Create new site using `/start`
  * When asked about goals choose **Write & Publish**
  * Continue on flow and choose **Draft your first post: Start writing** button
  * Confirm the suggested writing ideas modal appears when the editor loads
    * This is controlled by the `new_prompt=true` query param
  * Save your post as draft but *do not publish*
  * Preview the draft in a new tab
  * In the new tab click **Next steps**
  * You are taken to launchpad, at this point you'll need to change the page domain back to `calypso.localhost:3000`
  * Confirm the **Continue to write your first post** button links back to the editor
    * It should re-open your existing post
    * It should use the Calypso editor
    * There is no `new_prompt` modal when the editor loads
  * Now test in `wp-admin` mode
    * Jump straight to `/settings/general/{{ site slug }}` and change the admin interface to **classic**
    * Click **My Home** in the sidebar to get redirected to the launchpad (confirm your still looking at `calypso.localhost:3000`)
    * Confirm the **Continue to write your first post** button links back to the editor
      * It should re-open your existing post
      * It should use the`wp-admin` editor
      * There is no `new_prompt` modal when the editor loads
* Test `write` flow with no draft post in Calypso site
  * Create new site using `/start`
  * When asked about goals choose **Write & Publish**
  * Continue on flow and choose **Draft your first post: Start writing** button
  * Confirm the suggested writing ideas modal appears when the editor loads
    * This is controlled by the `new_prompt=true` query param
  * *do not save a draft*, leave the editor with the (W) button
  * You are taken to launchpad, at this point you'll need to change the page domain back to `calypso.localhost:3000`
  * Confirm the **Write your first post** button links back to the editor
    * It opens a blank editor
    * It should use the Calypso editor
    * This is a `new_prompt` modal when the editor loads (they might have accidentally dropped out of the flow earlier so I think it's reasonable to show it to them here)
  * Now test in `wp-admin` mode
    * Jump straight to `/settings/general/{{ site slug }}` and change the admin interface to **classic**
    * Click **My Home** in the sidebar to get redirected to the launchpad (confirm your still looking at `calypso.localhost:3000`)
    * Confirm the **Continue to write your first post** button links back to the editor
      * It should open a blank editor
      * It should use the`wp-admin` editor
      * There is a `new_prompt` modal when the editor loads
* Test `start-writing` or `design-first` flow
  * Create a new site using `/setup/start-writing`
  * You are eventually taken to the launchpad
  * Confirm the **Write your first post** button links to the editor
    * It should open a blank editor
    * It should use the `wp-admin` editor (remember these flows are special cased to use `wp-admin`)
    * There is no `new_prompt` modal
    * An `origin` query param has been added
  * Save and preview a draft post
  * In the new tab click **Next steps**
  * Back in the launchpad (confirm you're on `calypso.localhost:3000`) check the **Continue to write your first post** button
    * It should open the existing draft
    * It should use the `wp-admin` editor (remember these flows are special cased to use `wp-admin`)
    * There is no `new_prompt` modal
    * An `origin` query param has been added


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] !Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)!
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~