### PR TITLE
A4A: Revert changes to CreditCardElementField

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/credit-card-element-field.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/credit-card-element-field.tsx
@@ -1,5 +1,5 @@
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
-import { CardNumberElement } from '@stripe/react-stripe-js';
+import { CardElement } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -26,17 +26,16 @@ export default function CreditCardElementField( {
 	return (
 		<div className="credit-card-fields__input-field">
 			<label className="credit-card-fields__label">
-				<span className="credit-card-fields__label-text">{ translate( 'Card details!' ) }</span>
+				<span className="credit-card-fields__label-text">{ translate( 'Card details' ) }</span>
 				<span
 					className={ clsx( 'credit-card-fields__stripe-element', 'number', {
 						'credit-card-fields__stripe-element--has-error': cardError,
 					} ) }
 				>
-					<CardNumberElement
+					<CardElement
 						options={ {
 							disabled: isDisabled,
 							style: stripeElementStyle,
-							showIcon: true,
 						} }
 						onReady={ () => {
 							setIsStripeFullyLoaded( true );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Reverts https://github.com/Automattic/wp-calypso/pull/94018, which introduced a regression that prevents users from entering a new payment method.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The flow to add new credit cards is broken.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Live Branch and proceed to the payment methods page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
