### PR TITLE
Fix layout issue with social login buttons on the core profiler connect page

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1051,8 +1051,43 @@ $breakpoint-mobile: 660px;
 			padding-top: 24px;
 		}
 
-		button.social-buttons__button.button {
+		.auth-form__social-buttons {
 			width: 100%;
+			.auth-form__social-buttons-container {
+				width: 100%;
+			}
+		}
+
+		.wp-login__container .is-jetpack .auth-form__social,
+		.signup-form .auth-form__social {
+			padding-left: 0;
+			padding-right: 0;
+
+			button.social-buttons__button.button {
+				width: 100%;
+				border: 1px solid var(--studio-gray-50, #646970);
+				border-radius: 2px;
+				border-color: #ccc;
+				padding: 4px 16px;
+				display: flex;
+				justify-content: stretch;
+				align-items: center;
+				align-self: center;
+				margin: 0;
+				svg {
+					margin-right: auto;
+					border: 0;
+				}
+				span {
+					text-align: center;
+					margin-left: -44px;
+					margin-right: auto;
+					font-weight: 400;
+				}
+				&:last-child {
+					margin-bottom: 16px;
+				}
+			}
 		}
 
 		// Log in link on signup page
@@ -1347,7 +1382,7 @@ $breakpoint-mobile: 660px;
 			}
 
 			.auth-form__social-buttons-tos {
-				margin: 0;
+				margin: 24px 0 0 0;
 
 				@media (max-width: $break-medium) {
 					max-width: $max-width;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1055,8 +1055,43 @@ $breakpoint-mobile: 660px;
 			padding-top: 24px;
 		}
 
-		button.social-buttons__button.button {
+		.auth-form__social-buttons {
 			width: 100%;
+			.auth-form__social-buttons-container {
+				width: 100%;
+			}
+		}
+
+		.wp-login__container .is-jetpack .auth-form__social,
+		.signup-form .auth-form__social {
+			padding-left: 0;
+			padding-right: 0;
+
+			button.social-buttons__button.button {
+				width: 100%;
+				border: 1px solid var(--studio-gray-50, #646970);
+				border-radius: 2px;
+				border-color: #ccc;
+				padding: 4px 16px;
+				display: flex;
+				justify-content: stretch;
+				align-items: center;
+				align-self: center;
+				margin: 0;
+				svg {
+					margin-right: auto;
+					border: 0;
+				}
+				span {
+					text-align: center;
+					margin-left: -44px;
+					margin-right: auto;
+					font-weight: 400;
+				}
+				&:last-child {
+					margin-bottom: 16px;
+				}
+			}
 		}
 
 		// Log in link on signup page
@@ -1351,7 +1386,7 @@ $breakpoint-mobile: 660px;
 			}
 
 			.auth-form__social-buttons-tos {
-				margin: 0;
+				margin: 24px 0 0 0;
 
 				@media (max-width: $break-medium) {
 					max-width: $max-width;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -363,7 +363,7 @@ $breakpoint-mobile: 660px;
 
 		button.social-buttons__button.button {
 			border: 0;
-			text-align: left;
+			text-align: center;
 			padding-bottom: 0;
 			padding-left: 0;
 			padding-right: 0;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -590,6 +590,10 @@ $breakpoint-mobile: 660px;
 		display: none;
 	}
 
+	.login__form-password {
+		margin-top: 8px;
+	}
+
 	.auth-form__separator::before,
 	.auth-form__separator::after {
 		border-block-start: $woo-form-divider-border;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1066,6 +1066,7 @@ $breakpoint-mobile: 660px;
 		.signup-form .auth-form__social {
 			padding-left: 0;
 			padding-right: 0;
+			padding-top: 40px;
 
 			button.social-buttons__button.button {
 				width: 100%;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1051,43 +1051,8 @@ $breakpoint-mobile: 660px;
 			padding-top: 24px;
 		}
 
-		.auth-form__social-buttons {
+		button.social-buttons__button.button {
 			width: 100%;
-			.auth-form__social-buttons-container {
-				width: 100%;
-			}
-		}
-
-		.wp-login__container .is-jetpack .auth-form__social,
-		.signup-form .auth-form__social {
-			padding-left: 0;
-			padding-right: 0;
-
-			button.social-buttons__button.button {
-				width: 100%;
-				border: 1px solid var(--studio-gray-50, #646970);
-				border-radius: 2px;
-				border-color: #ccc;
-				padding: 4px 16px;
-				display: flex;
-				justify-content: stretch;
-				align-items: center;
-				align-self: center;
-				margin: 0;
-				svg {
-					margin-right: auto;
-					border: 0;
-				}
-				span {
-					text-align: center;
-					margin-left: -44px;
-					margin-right: auto;
-					font-weight: 400;
-				}
-				&:last-child {
-					margin-bottom: 16px;
-				}
-			}
 		}
 
 		// Log in link on signup page
@@ -1382,7 +1347,7 @@ $breakpoint-mobile: 660px;
 			}
 
 			.auth-form__social-buttons-tos {
-				margin: 24px 0 0 0;
+				margin: 0;
 
 				@media (max-width: $break-medium) {
 					max-width: $max-width;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

I've noticed that the social button layout is not styled correctly on the core profiler jetpack auth page.

The design should look similar to: Y5pUYSJPsGEud1vknUZhi8-fi-3182_13788

This is an interim implementation, that aligns the button designs with the new one but it is not the full implementation yet.

**Current on prod:**
![Screenshot 2024-09-05 at 2 23 29 PM](https://github.com/user-attachments/assets/eb085b73-f2f1-49d3-a617-9844a8e86c0d)
![Screenshot 2024-09-05 at 2 23 24 PM](https://github.com/user-attachments/assets/df8604ed-e01f-4164-a40f-0dc89d9e0fc4)



This is probably due to changes from other PRs. 

## Proposed Changes

* Fixed layout issue with the social buttons

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Layout issue

## Testing Instructions

1. Checkout this branch locally and build the changes with `yarn start`.
2. Visit [this link](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=236381464&redirect_uri=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D32ab4c9508%26redirect%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A2ca8ea2582da1c066074563a12cc8b22&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=13.7&secret=QFoaAXaOIPZTr9p6Z5Hqf6RWkCboPylJ&blogname=Noisily+Fortunate+Toucan&site_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&home_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&site_icon&site_lang=en_US&site_created=2024-08-26+19%3A40%3A51&allow_site_connection=1&calypso_env=production&source&_as=search-term&_ak=jetpack&from=woocommerce-core-profiler&installed_ext_success=1&_ui=254662545&_ut=wpcom%3Auser_id&purchase_nonce=lbtPaOlO&_wp_nonce=69744335dc&redirect_after_auth=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja) in an incognito mode and confirm the social buttons are rendered correctly.
3. Click on `Log in` and confirm the social buttons are rendered correctly. 

It should look like:

![image](https://github.com/user-attachments/assets/81d09157-2244-419f-86fa-7fa2d2efc16c)
![image](https://github.com/user-attachments/assets/949a6153-5b6b-4a91-b48c-ed9affae3e32)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?