### PR TITLE
Add feature flag for core profiler passwordless auth

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -615,12 +615,13 @@ class Login extends Component {
 		} else if ( isWooCoreProfilerFlow ) {
 			const isLostPasswordFlow = currentQuery.lostpassword_flow === 'true';
 			const isTwoFactorAuthFlow = this.props.twoFactorEnabled;
-
 			let subtitle = null;
 
 			switch ( true ) {
 				case isLostPasswordFlow:
-					headerText = <h3>{ translate( "You've got mail" ) }</h3>;
+					headerText = config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ? (
+						<h3>{ translate( "You've got mail" ) }</h3>
+					) : null;
 					subtitle = translate(
 						"Your password reset confirmation is on its way to your email address – please check your junk folder if it's not in your inbox! Once you've reset your password, head back to this page to log in to your account."
 					);
@@ -629,16 +630,33 @@ class Login extends Component {
 					headerText = <h3>{ translate( 'Authenticate your login' ) }</h3>;
 					break;
 				default:
-					headerText = <h3>{ translate( 'Log in to your account' ) }</h3>;
-					subtitle = translate(
-						"In order to take advantage of the benefits offered by Jetpack and WooPayments, please log in to your WordPress.com account below. {{br}}{{/br}}Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
-						{
-							components: {
-								signupLink,
-								br: <br />,
-							},
-						}
+					headerText = (
+						<h3>
+							{ config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
+								? translate( 'Log in to your account' )
+								: translate( 'One last step' ) }
+						</h3>
 					);
+					if ( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
+						subtitle = translate(
+							"In order to take advantage of the benefits offered by Jetpack and WooPayments, please log in to your WordPress.com account below. {{br}}{{/br}}Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
+							{
+								components: {
+									signupLink,
+									br: <br />,
+								},
+							}
+						);
+					} else {
+						subtitle = translate(
+							"In order to take advantage of the benefits offered by Jetpack, please log in to your WordPress.com account below. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
+							{
+								components: {
+									signupLink,
+								},
+							}
+						);
+					}
 			}
 			preHeader = null;
 			postHeader = <p className="login__header-subtitle">{ subtitle }</p>;
@@ -1043,7 +1061,10 @@ class Login extends Component {
 							isJetpack={ isJetpack }
 							isFromAutomatticForAgenciesPlugin={ isFromAutomatticForAgenciesPlugin }
 							loginButtonText={
-								this.props.initialQuery?.lostpassword_flow === 'true' ? translate( 'Log in' ) : null
+								config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) &&
+								this.props.initialQuery?.lostpassword_flow === 'true'
+									? translate( 'Log in' )
+									: null
 							}
 						/>
 					);

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -1062,6 +1062,7 @@ class Login extends Component {
 							isFromAutomatticForAgenciesPlugin={ isFromAutomatticForAgenciesPlugin }
 							loginButtonText={
 								config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) &&
+								isWooCoreProfilerFlow &&
 								this.props.initialQuery?.lostpassword_flow === 'true'
 									? translate( 'Log in' )
 									: null

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { safeImageUrl } from '@automattic/calypso-url';
 import { CompactCard } from '@automattic/components';
 import { Icon, globe } from '@wordpress/icons';
@@ -164,10 +165,16 @@ export class AuthFormHeader extends Component {
 		}
 
 		if ( isWooCoreProfiler ) {
-			const pluginNames = {
-				'jetpack-ai': translate( 'Jetpack and WooPayments' ),
-				default: translate( 'Jetpack and WooPayments' ),
-			};
+			const pluginNames = config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
+				? {
+						'jetpack-ai': translate( 'Jetpack and WooPayments' ),
+						default: translate( 'Jetpack and WooPayments' ),
+				  }
+				: {
+						'jetpack-ai': 'Jetpack AI',
+						'jetpack-boost': 'Jetpack Boost',
+						default: 'Jetpack',
+				  };
 
 			const pluginName = pluginNames[ this.props.authQuery.plugin_name ] || pluginNames.default;
 			const translateParams = {
@@ -190,10 +197,15 @@ export class AuthFormHeader extends Component {
 
 			switch ( currentState ) {
 				case 'logged-out':
-					return translate(
-						"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to create a WordPress account. {{br/}} Already have one? {{a}}Log in{{/a}}",
-						translateParams
-					);
+					return config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
+						? translate(
+								"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to create a WordPress account. {{br/}} Already have one? {{a}}Log in{{/a}}",
+								translateParams
+						  )
+						: translate(
+								"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
+								translateParams
+						  );
 				default:
 					return translate(
 						"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account.",

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -5,7 +5,7 @@ import {
 	getJetpackProductOrPlanDisplayName,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
-import { Button, Card, FormLabel, Gridicon, Spinner } from '@automattic/components';
+import { Button, Card, FormLabel, Gridicon, Spinner, JetpackLogo } from '@automattic/components';
 import { Spinner as WPSpinner, Modal } from '@wordpress/components';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -75,6 +75,7 @@ import {
 	REMOTE_PATH_AUTH,
 } from './constants';
 import Disclaimer from './disclaimer';
+import { JetpackFeatures } from './features';
 import { OFFER_RESET_FLOW_TYPES } from './flow-types';
 import HelpButton from './help-button';
 import JetpackConnectNotices from './jetpack-connect-notices';
@@ -857,10 +858,17 @@ export class JetpackAuthorize extends Component {
 		}
 
 		if ( this.isWooCoreProfiler() ) {
-			return (
+			return config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ? (
 				<>
 					<strong>{ this.props.user.display_name }</strong>
 					<small>{ this.props.user.email }</small>
+				</>
+			) : (
+				<>
+					{ translate( 'Connecting as %(user)s', {
+						args: { user: this.props.user.display_name },
+					} ) }
+					<br />
 				</>
 			);
 		}
@@ -1006,6 +1014,33 @@ export class JetpackAuthorize extends Component {
 	renderContent() {
 		const { translate, user, authQuery } = this.props;
 		if ( this.isWooCoreProfiler() ) {
+			let col1Features = [];
+			let col2Features = [];
+			if ( authQuery.plugin_name === 'jetpack-boost' ) {
+				col1Features = [
+					translate( 'Speed up your store' ),
+					translate( 'Optimize CSS loading' ),
+					translate( 'Defer non-essential Javascript' ),
+				];
+				col2Features = [
+					translate( 'Lazy image loading' ),
+					translate( 'Site performance scores' ),
+					translate( 'Improve SEO' ),
+				];
+			} else {
+				col1Features = [
+					translate( 'Speed up content creation' ),
+					translate( 'Prompt based AI assistant' ),
+					translate( 'Adaptive tone adjustment' ),
+					translate( 'Generate text, tables, and lists' ),
+				];
+				col2Features = [
+					translate( 'Quota of 20 requests' ),
+					translate( 'Title and summary generation' ),
+					translate( 'Translate content to multiple languages' ),
+					translate( 'Spelling and grammar correction' ),
+				];
+			}
 			return (
 				<Fragment>
 					<div className="jetpack-connect__logged-in-content">
@@ -1027,11 +1062,20 @@ export class JetpackAuthorize extends Component {
 						</Card>
 						<div className="jetpack-connect__logged-in-bottom">
 							{ this.renderStateAction() }
+							{ ! config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) && (
+								<JetpackFeatures col1Features={ col1Features } col2Features={ col2Features } />
+							) }
 							<Disclaimer
 								siteName={ decodeEntities( authQuery.blogname ) }
 								companyName={ this.getCompanyName() }
 								from={ authQuery.from }
 							/>
+							{ ! config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) && (
+								<div className="jetpack-connect__jetpack-logo-wrapper">
+									<JetpackLogo monochrome size={ 18 } />{ ' ' }
+									<span>{ translate( 'Jetpack powered' ) }</span>
+								</div>
+							) }
 						</div>
 					</div>
 					{ authQuery.installedExtSuccess && <WooInstallExtSuccessNotice /> }

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -870,6 +870,7 @@ export class JetpackAuthorize extends Component {
 						args: { user: this.props.user.display_name },
 					} ) }
 					<br />
+					<small>{ this.props.user.email }</small>
 				</>
 			);
 		}
@@ -1045,13 +1046,7 @@ export class JetpackAuthorize extends Component {
 			return (
 				<Fragment>
 					<div className="jetpack-connect__logged-in-content">
-						<Card
-							className={ clsx( 'jetpack-connect__logged-in-card', {
-								'feature-flag-passwordless-auth': config.isEnabled(
-									'woocommerce/core-profiler-passwordless-auth'
-								),
-							} ) }
-						>
+						<Card className="jetpack-connect__logged-in-card">
 							<div className="jetpack-connect__logged-in-form-user">
 								<Gravatar user={ user } size={ 40 } />
 								<p className="jetpack-connect__logged-in-form-user-text">{ this.getUserText() }</p>
@@ -1282,7 +1277,13 @@ export class JetpackAuthorize extends Component {
 					wooDna.isWooDnaFlow() ? wooDna.getServiceName() + ' — ' + translate( 'Connect' ) : ''
 				}
 			>
-				<div className="jetpack-connect__authorize-form">
+				<div
+					className={ clsx( 'jetpack-connect__authorize-form', {
+						'feature-flag-woocommerce-core-profiler-passwordless-auth': config.isEnabled(
+							'woocommerce/core-profiler-passwordless-auth'
+						),
+					} ) }
+				>
 					<div className="jetpack-connect__logged-in-form">
 						<QuerySiteFeatures siteIds={ [ authSiteId ] } />
 						<QuerySitePurchases siteId={ authSiteId } />

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -7,6 +7,7 @@ import {
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button, Card, FormLabel, Gridicon, Spinner, JetpackLogo } from '@automattic/components';
 import { Spinner as WPSpinner, Modal } from '@wordpress/components';
+import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
 import { flowRight, get, includes, startsWith } from 'lodash';
@@ -1044,7 +1045,13 @@ export class JetpackAuthorize extends Component {
 			return (
 				<Fragment>
 					<div className="jetpack-connect__logged-in-content">
-						<Card className="jetpack-connect__logged-in-card">
+						<Card
+							className={ clsx( 'jetpack-connect__logged-in-card', {
+								'feature-flag-passwordless-auth': config.isEnabled(
+									'woocommerce/core-profiler-passwordless-auth'
+								),
+							} ) }
+						>
 							<div className="jetpack-connect__logged-in-form-user">
 								<Gravatar user={ user } size={ 40 } />
 								<p className="jetpack-connect__logged-in-form-user-text">{ this.getUserText() }</p>

--- a/client/jetpack-connect/features.tsx
+++ b/client/jetpack-connect/features.tsx
@@ -1,0 +1,33 @@
+import { Icon, check } from '@wordpress/icons';
+import clsx from 'clsx';
+
+export const JetpackFeatures = ( {
+	className,
+	col1Features,
+	col2Features,
+}: {
+	className?: string;
+	col1Features: string[];
+	col2Features: string[];
+} ) => {
+	return (
+		<div className={ clsx( 'jetpack-connect__features_wrapper', className ) }>
+			<ul className="jetpack-connect__features">
+				{ col1Features.map( ( feature, index ) => (
+					<li key={ index }>
+						<Icon size={ 20 } icon={ check } />
+						<span>{ feature }</span>
+					</li>
+				) ) }
+			</ul>
+			<ul className="jetpack-connect__features">
+				{ col2Features.map( ( feature, index ) => (
+					<li key={ index }>
+						<Icon size={ 20 } icon={ check } />
+						<span>{ feature }</span>
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+};

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -7,7 +7,7 @@
  */
 
 import { isEnabled } from '@automattic/calypso-config';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, JetpackLogo } from '@automattic/components';
 import { Button, Card, Modal } from '@wordpress/components';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -514,9 +514,17 @@ export class JetpackSignup extends Component {
 					/>
 					<SignupForm
 						disabled={ isCreatingAccount }
-						isPasswordless={ isWooCoreProfiler }
-						disableTosText={ isWooCoreProfiler }
-						labelText={ isWooCoreProfiler ? this.props.translate( 'Your Email' ) : null }
+						isPasswordless={
+							isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) && isWooCoreProfiler
+						}
+						disableTosText={
+							isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) && isWooCoreProfiler
+						}
+						labelText={
+							isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) && isWooCoreProfiler
+								? this.props.translate( 'Your Email' )
+								: null
+						}
 						email={ this.props.authQuery.userEmail }
 						footerLink={ this.renderFooterLink() }
 						handleSocialResponse={ this.handleSocialResponse }
@@ -540,6 +548,12 @@ export class JetpackSignup extends Component {
 				</div>
 				{ isWooCoreProfiler && this.props.authQuery.installedExtSuccess && (
 					<WooInstallExtSuccessNotice />
+				) }
+				{ ! isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) && isWooCoreProfiler && (
+					<div className="jetpack-connect__jetpack-logo-wrapper">
+						<JetpackLogo monochrome size={ 18 } />{ ' ' }
+						<span>{ this.props.translate( 'Jetpack powered' ) }</span>
+					</div>
 				) }
 			</MainWrapper>
 		);

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -510,7 +510,9 @@ export class JetpackSignup extends Component {
 						isWooOnboarding={ this.isWooOnboarding() }
 						isWooCoreProfiler={ this.isWooCoreProfiler() }
 						isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
-						disableSiteCard={ isWooCoreProfiler }
+						disableSiteCard={
+							isWooCoreProfiler && isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
+						}
 					/>
 					<SignupForm
 						disabled={ isCreatingAccount }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1119,7 +1119,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		max-width: 615px;
 	}
 
-	.is-woo-passwordless {
+	.is-woo-passwordless,
+	.feature-flag-woocommerce-core-profiler-passwordless-auth {
 		.signup-form {
 			max-width: 327px;
 			padding-top: 48px;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1281,6 +1281,27 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			align-items: center;
 		}
 
+		&.feature-flag-passwordless-auth {
+			.jetpack-connect__logged-in-form-user {
+				flex-direction: column;
+			}
+
+			.jetpack-connect__logged-in-form-user-text {
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				margin-bottom: 13.5px;
+
+				strong {
+					font-size: 1rem;
+					font-weight: 500;
+					line-height: 24px;
+					letter-spacing: -0.008px;
+					display: block;
+				}
+			}
+		}
+
 		.gravatar {
 			margin: 0;
 		}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1119,50 +1119,97 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		max-width: 615px;
 	}
 
-	.signup-form {
-		max-width: 327px;
-		padding-top: 48px;
-		.signup-form__passwordless-form-wrapper {
-			button.is-primary {
-				background-color: var(--wp-admin-theme-color);
-				border-radius: 0;
+	.is-woo-passwordless {
+		.signup-form {
+			max-width: 327px;
+			padding-top: 48px;
+			.signup-form__passwordless-form-wrapper {
+				button.is-primary {
+					background-color: var(--wp-admin-theme-color);
+					border-radius: 0;
+				}
+				.logged-out-form__footer {
+					padding: 0;
+				}
+				.form-fieldset {
+					margin-bottom: 24px;
+				}
 			}
-			.logged-out-form__footer {
-				padding: 0;
-			}
-			.form-fieldset {
-				margin-bottom: 24px;
-			}
-		}
 
-		input.signup-form__passwordless-email {
-			margin-bottom: 0;
-		}
+			input.signup-form__passwordless-email {
+				margin-bottom: 0;
+			}
 
-		.auth-form__social {
-			padding-top: 0;
-			.auth-form__social-buttons {
-				width: 100%;
-				.social-buttons__button {
+			.auth-form__social {
+				padding-top: 0;
+				.auth-form__social-buttons {
 					width: 100%;
-					border: 1px solid #a7aaad;
-					border-radius: 2px;
-					display: flex;
-					align-items: center;
-					justify-content: center;
-					svg {
-						border-radius: 0;
-						border: none;
-						flex-shrink: 0;
-					}
-					span {
-						flex-grow: 1;
-						text-align: center;
-						// icon width * 2
-						margin-left: -40px;
+					.social-buttons__button {
+						width: 100%;
+						border: 1px solid #a7aaad;
+						border-radius: 2px;
+						display: flex;
+						align-items: center;
+						justify-content: center;
+						svg {
+							border-radius: 0;
+							border: none;
+							flex-shrink: 0;
+						}
+						span {
+							flex-grow: 1;
+							text-align: center;
+							// icon width * 2
+							margin-left: -40px;
+						}
 					}
 				}
 			}
+		}
+
+		.site-icon {
+			border-radius: 4px;
+		}
+
+		.jetpack-connect__logged-in-card {
+			padding: 32px 24px;
+			align-items: center;
+			border: 1px solid $gray-300;
+		}
+
+		a.logged-out-form__link-item {
+			margin: 0;
+			font-size: 0.875rem;
+			font-weight: 400;
+			line-height: 24px;
+		}
+
+		img.gravatar {
+			width: 80px;
+			height: 80px;
+		}
+
+		.jetpack-connect__logged-in-form-user {
+			flex-direction: column;
+		}
+
+		.jetpack-connect__logged-in-form-user-text {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			margin-bottom: 13.5px;
+
+			strong {
+				font-size: 1rem;
+				font-weight: 500;
+				line-height: 24px;
+				letter-spacing: -0.008px;
+				display: block;
+			}
+		}
+
+		.jetpack-connect__tos-link {
+			margin: 24px auto 70px;
 		}
 	}
 
@@ -1228,23 +1275,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			max-width: 100%;
 		}
 
-		a.logged-out-form__link-item {
-			margin: 0;
-			font-size: 0.875rem;
-			font-weight: 400;
-			line-height: 24px;
-		}
-
-		img.gravatar {
-			width: 80px;
-			height: 80px;
-		}
-
 		.jetpack-connect__logged-in-form-user {
 			display: flex;
 			gap: 16px;
 			align-items: center;
-			flex-direction: column;
 		}
 
 		.gravatar {
@@ -1252,10 +1286,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 
 		.jetpack-connect__logged-in-form-user-text {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			margin-bottom: 13.5px;
 			color: var(--studio-gray-100);
 			font-size: 1rem;
 			font-weight: 500;
@@ -1266,14 +1296,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				line-height: 24px;
 				font-weight: 400;
 				color: $gray-700;
-			}
-
-			strong {
-				font-size: 1rem;
-				font-weight: 500;
-				line-height: 24px;
-				letter-spacing: -0.008px;
-				display: block;
 			}
 		}
 
@@ -1307,7 +1329,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	.jetpack-connect__tos-link {
-		margin: 24px auto 70px;
+		margin: 40px auto 70px;
 		letter-spacing: -0.08px;
 		line-height: 18px;
 		color: $gray-700;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1236,7 +1236,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 
 		.site-icon {
-			border-radius: 4px;
+			border-radius: 50%;
 			margin-right: 16px;
 			height: 40px !important;
 			width: 40px !important;
@@ -1263,9 +1263,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.jetpack-connect__logged-in-card {
 		display: flex;
 		flex-direction: column;
-		padding: 32px 24px;
+		padding: 16px 24px;
 		background: #fff;
-		align-items: center;
 		border: 1px solid $gray-300;
 		border-radius: 2px;
 		max-width: 405px;
@@ -1279,27 +1278,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			display: flex;
 			gap: 16px;
 			align-items: center;
-		}
-
-		&.feature-flag-passwordless-auth {
-			.jetpack-connect__logged-in-form-user {
-				flex-direction: column;
-			}
-
-			.jetpack-connect__logged-in-form-user-text {
-				display: flex;
-				flex-direction: column;
-				align-items: center;
-				margin-bottom: 13.5px;
-
-				strong {
-					font-size: 1rem;
-					font-weight: 500;
-					line-height: 24px;
-					letter-spacing: -0.008px;
-					display: block;
-				}
-			}
 		}
 
 		.gravatar {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -304,6 +304,9 @@ class Layout extends Component {
 			'is-global-sidebar-collapsed': this.props.isGlobalSidebarCollapsed,
 			'is-unified-site-sidebar-visible': this.props.isUnifiedSiteSidebarVisible,
 			'is-blaze-pro': this.props.isBlazePro,
+			'feature-flag-woocommerce-core-profiler-passwordless-auth': config.isEnabled(
+				'woocommerce/core-profiler-passwordless-auth'
+			),
 		} );
 
 		const optionalBodyProps = () => {

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -146,6 +146,9 @@ const LayoutLoggedOut = ( {
 		'is-woo-passwordless': isWooPasswordless,
 		'is-blaze-pro': isBlazePro,
 		'two-factor-auth-enabled': twoFactorEnabled,
+		'feature-flag-woocommerce-core-profiler-passwordless-auth': config.isEnabled(
+			'woocommerce/core-profiler-passwordless-auth'
+		),
 	};
 
 	let masterbar = null;

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { ProgressBar } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { getQueryArg } from '@wordpress/url';
@@ -34,7 +35,8 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 
 	if (
 		currentRoute === '/log-in/jetpack/lostpassword' ||
-		currentRoute === '/log-in/jetpack/link' ||
+		( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) &&
+			currentRoute === '/log-in/jetpack/link' ) ||
 		currentQueryArguments?.lostpassword_flow
 	) {
 		shouldShowProgressBar = false;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -888,7 +888,7 @@ $breakpoint-mobile: 660px;
 		.login form,
 		.signup-form {
 			max-width: 405px;
-			margin: 0 auto;
+			margin: 48px auto;
 
 			input.form-text-input {
 				border-color: #bbb;
@@ -1160,6 +1160,18 @@ $breakpoint-mobile: 660px;
 						text-decoration: underline;
 						text-underline-offset: 2px;
 					}
+				}
+			}
+		}
+
+		&.two-factor-auth-enabled {
+			.two-factor-authentication__verification-code-form-wrapper {
+				fieldset,
+				button,
+				.auth-form__separator,
+				.two-factor-authentication__actions,
+				.login__two-factor-footer {
+					max-width: 327px;
 				}
 			}
 		}
@@ -1883,320 +1895,12 @@ $breakpoint-mobile: 660px;
 
 	}
 
-	&.is-woocommerce-core-profiler-flow {
-		background: #fff;
-
-		* {
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-		}
-
-		input[type="text"].form-text-input,
-		input[type="email"].form-text-input,
-		input[type="password"].form-text-input,
-		input[type="tel"].form-text-input,
-		textarea.form-text-input {
-			&:focus,
-			&:hover,
-			&:focus:hover {
-				border-color: var(--wp-admin-theme-color);
-				outline: none;
-				box-shadow: none;
-			}
-		}
-
-		.masterbar {
-			display: flex;
-		}
-
-		.masterbar__woo-nav-item:first-child {
-			margin-right: auto;
-		}
-
-		.masterbar__no-thanks-button {
-			color: var(--wp-admin-theme-color);
-			font-size: $woo-font-body-extra-small;
-			text-decoration: none;
-		}
-
-		.masterbar__woo-link {
-			display: flex;
-		}
-
-		.wp-login__container,
-		.magic-login,
-		.step-wrapper {
-			@media (max-width: $break-mobile) {
-				padding-top: 40px;
-			}
-		}
-
-		.login form,
-		.signup-form {
-			max-width: 405px;
-			margin: 0 auto;
-
-			input.form-text-input {
-				border-color: #bbb;
-
-				&.is-valid {
-					border-color: #bbb;
-				}
-			}
-		}
-
-		.login__form-userdata label.form-label {
-			line-height: 16px;
-		}
-
-		.login__form .login__form-userdata input.form-text-input,
-		.login__form .login__form-userdata input {
-			margin-bottom: 16px;
-		}
-
-		.login__form-header h3,
-		.formatted-header .formatted-header__title {
-			margin-bottom: 12px;
-			font-size: $woo-font-title-large;
-			line-height: 32px;
-			font-weight: 500;
-
-			@media (max-width: $break-mobile) {
-				font-size: rem(28px);
-			}
-		}
-
-		.login__form-header-wrapper h3 {
-			font-weight: 500;
-		}
-
-		form.two-factor-authentication__verification-code-form-wrapper {
-			@media (max-width: $break-mobile) {
-				margin: 0;
-				max-width: 660px;
-			}
-		}
-
-		.login__header-subtitle,
-		.formatted-header__subtitle {
-			color: $gray-700;
-
-			@media (max-width: $break-mobile) {
-				width: auto;
-			}
-		}
-
-		.login__form-userdata label.form-label,
-		.logged-out-form label.form-label {
-			font-weight: 500;
-			text-transform: uppercase;
-			font-size: rem(11px);
-			color: $gray-900;
-		}
-
-		.jetpack-connect__action-disclaimer .button.is-primary,
-		.form-button.is-primary {
-			border-radius: 2px;
-			height: 48px;
-			padding: 10px 16px;
-			font-weight: 500;
-			background-color: var(--wp-admin-theme-color);
-		}
-
-		.two-factor-authentication__actions.card button.button {
-			border-radius: 2px;
-			height: 48px;
-			padding: 10px 16px;
-			font-weight: 500;
-			background-color: transparent;
-			color: var(--wp-admin-theme-color);
-			border: 1px solid var(--wp-admin-theme-color);
-			width: 100%;
-		}
-
-		.two-factor-authentication__verification-code-form.card {
-			padding-top: 0;
-			margin-bottom: 36px;
-
-			.verification-code-form__help-text {
-				color: $gray-700;
-			}
-
-			.security-key-form__help-text {
-				color: $gray-700;
-				margin-bottom: 24px;
-
-				p strong {
-					color: $gray-700;
-					font-weight: 400;
-				}
-
-				p:nth-child(2) {
-					@media screen and (min-width: 660px) {
-						// css to allow for this element to exceed parent's width
-						width: 152%; // 152% * 405px gets us to 615px which is the design spec
-						position: relative;
-						left: -26%; // shift position back by half of that so that it remains centered
-					}
-				}
-			}
-
-			fieldset.form-fieldset label.form-label {
-				font-weight: 500;
-				text-transform: uppercase;
-				font-size: rem(11px);
-				color: $gray-900;
-			}
-		}
-
-		div.login__two-factor-footer {
-			margin-top: 16px;
-			p {
-				margin-bottom: 0;
-				color: $woo-label-color;
-				font-size: rem(14px);
-				line-height: 24px;
-				letter-spacing: -0.1px;
-
-				a {
-					color: var(--wp-admin-theme-color);
-					font-size: rem(14px);
-					line-height: 24px;
-					letter-spacing: -0.1px;
-				}
-			}
-		}
-
-		span.social-buttons__service-name {
-			font-weight: 600;
-		}
-
-		.auth-form__social-buttons-tos {
-			text-align: center;
-			line-height: 16px;
-
-			@media (max-width: $break-mobile) {
-				text-align: start;
-			}
-
-			a {
-				line-height: 16px;
-			}
-		}
-
-		.jetpack-connect__logged-in-content {
-			@media (max-width: $break-mobile) {
-				padding-left: $woo-form-whitespace-660;
-				padding-right: $woo-form-whitespace-660;
-			}
-		}
-
-		.jetpack-connect__features_wrapper {
-			@media (max-width: $break-mobile) {
-				display: none !important;
-			}
-		}
-
-		.signup-form {
-			padding-top: 24px;
-		}
-
-		button.social-buttons__button.button {
-			width: 100%;
-		}
-
-		// Log in link on signup page
-		.login__header-subtitle a,
-		.formatted-header__subtitle a {
-			color: var(--wp-admin-theme-color);
-			line-height: inherit;
-		}
-
-		.form-input-validation {
-			padding: 8px 0 11px;
-
-			p,
-			a {
-				line-height: 16px;
-			}
-
-			// Hide form validation icon
-			svg {
-				display: none;
-			}
-		}
-
-		// Lost password
-		.login__lostpassword-form {
-			display: flex;
-			flex-direction: column;
-			padding: 48px 24px 32px;
-
-			@media (max-width: $break-mobile) {
-				padding: 32px 16px 28px;
-			}
-
-			.login__form-action {
-				margin-top: 24px;
-			}
-
-			input[type="email"].form-text-input {
-				margin-bottom: 0;
-			}
-			.form-input-validation {
-				padding-bottom: 0;
-			}
-		}
-
-		.login__lostpassword-subtitle a {
-			line-height: inherit;
-		}
-    
-    .auth-form__social-buttons-container {
-			width: 100%;
-		}
-    
-    .jetpack-connect__authorize-form .jetpack-connect__logged-in-content {
-			.jetpack-connect__logged-in-bottom {
-				@media (max-width: $break-mobile) {
-					position: initial;
-					max-width: 100%;
-					padding-right: 0;
-				}
-
-				.jetpack-connect__tos-link {
-					a.jetpack-connect__sso-actions-modal-link {
-						color: var(--wp-admin-theme-color);
-						text-decoration: underline;
-						text-underline-offset: 2px;
-					}
-				}
-			}
-		}
-
-
-		&.two-factor-auth-enabled {
-			.two-factor-authentication__verification-code-form-wrapper {
-				fieldset,
-				button,
-				.auth-form__separator,
-				.two-factor-authentication__actions,
-				.login__two-factor-footer {
-					max-width: 327px;
-				}
-			}
-		}
-	}
-
 	&.is-woocommerce-core-profiler-flow.is-woo-passwordless {
 		h3 {
 			font-family: inherit;
 		}
 		.login__lost-password-link {
 			color: var(--wp-admin-theme-color);
-		}
-
-		.signup-form {
-			max-width: 327px;
 		}
 
 		.login__form-forgot-password {
@@ -2219,7 +1923,8 @@ $breakpoint-mobile: 660px;
 		}
 
 		.signup-form {
-			margin-top: 0;
+			max-width: 327px;
+			margin-top: 48px;
 			label.form-label {
 				font-size: rem(11px);
 			}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -2080,7 +2080,6 @@ $breakpoint-mobile: 660px;
 
 			a {
 				line-height: 16px;
-				color: var(--wp-admin-theme-color);
 			}
 		}
 
@@ -2196,6 +2195,10 @@ $breakpoint-mobile: 660px;
 			color: var(--wp-admin-theme-color);
 		}
 
+		.signup-form {
+			max-width: 327px;
+		}
+
 		.login__form-forgot-password {
 			font-size: rem(12px);
 			text-underline-offset: 2px;
@@ -2209,6 +2212,7 @@ $breakpoint-mobile: 660px;
 		button.button.is-primary {
 			background-color: var(--wp-admin-theme-color);
 			font-family: inherit;
+			border-radius: 2px;
 			&:hover:not(:disabled) {
 				background-color: var(--wp-admin-theme-color);
 			}
@@ -2320,13 +2324,17 @@ $breakpoint-mobile: 660px;
 			}
 		}
 
-		.auth-form__social-buttons .social-buttons__button.button {
-			border-radius: 2px;
-			border: 1px solid var(--Gray-Gray-20, #a7aaad) !important;
-			background: var(--black-white-white, #fff);
-			span {
-				font-size: 0.875rem;
-				letter-spacing: 0.32px;
+		.main {
+			.auth-form__social {
+				.auth-form__social-buttons .social-buttons__button.button {
+					border-radius: 2px;
+					border: 1px solid var(--Gray-Gray-20, #a7aaad) !important;
+					background: var(--black-white-white, #fff);
+					span {
+						font-size: 0.875rem;
+						letter-spacing: 0.32px;
+					}
+				}
 			}
 		}
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -888,7 +888,7 @@ $breakpoint-mobile: 660px;
 		.login form,
 		.signup-form {
 			max-width: 405px;
-			margin: 48px auto;
+			margin: 0 auto;
 
 			input.form-text-input {
 				border-color: #bbb;
@@ -896,6 +896,14 @@ $breakpoint-mobile: 660px;
 				&.is-valid {
 					border-color: #bbb;
 				}
+			}
+		}
+
+		&.feature-flag-woocommerce-core-profiler-passwordless-auth {
+			.login form,
+			.signup-form {
+				max-width: 327px;
+				margin: 48px auto;
 			}
 		}
 

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1214,7 +1214,10 @@ class MagicLogin extends Component {
 		} = this.props;
 		const { showSecondaryEmailOptions, showEmailCodeVerification, usernameOrEmail } = this.state;
 
-		if ( query?.from === 'woocommerce-core-profiler' ) {
+		if (
+			query?.from === 'woocommerce-core-profiler' &&
+			config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
+		) {
 			return (
 				<Main className="magic-login magic-login__request-link is-white-login">
 					{ this.renderLocaleSuggestions() }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -470,6 +470,7 @@ export class Login extends Component {
 
 		if (
 			currentQuery.lostpassword_flow === 'true' &&
+			isWooCoreProfilerFlow &&
 			config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
 		) {
 			return null;

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -321,7 +321,10 @@ export class Login extends Component {
 
 		if (
 			isReactLostPasswordScreenEnabled() &&
-			( this.props.isWoo || this.props.isBlazePro || this.props.isWooCoreProfilerFlow )
+			( this.props.isWoo ||
+				this.props.isBlazePro ||
+				( this.props.isWooCoreProfilerFlow &&
+					config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) )
 		) {
 			return (
 				<a
@@ -465,7 +468,10 @@ export class Login extends Component {
 			return this.renderGravPoweredLoginBlockFooter();
 		}
 
-		if ( currentQuery.lostpassword_flow === 'true' ) {
+		if (
+			currentQuery.lostpassword_flow === 'true' &&
+			config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
+		) {
 			return null;
 		}
 

--- a/client/state/selectors/get-is-woo-passwordless.ts
+++ b/client/state/selectors/get-is-woo-passwordless.ts
@@ -15,12 +15,11 @@ export default function getIsWooPasswordless( state: AppState ): boolean {
 		return false;
 	}
 
-	if ( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
-		return true;
-	}
-
 	// Enable Woo Passwordless if user is from WooCommerce Core Profiler.
-	if ( isWooCommerceCoreProfilerFlow( state ) ) {
+	if (
+		isWooCommerceCoreProfilerFlow( state ) &&
+		config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
+	) {
 		return true;
 	}
 

--- a/client/state/selectors/get-is-woo-passwordless.ts
+++ b/client/state/selectors/get-is-woo-passwordless.ts
@@ -15,6 +15,10 @@ export default function getIsWooPasswordless( state: AppState ): boolean {
 		return false;
 	}
 
+	if ( ! config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
+		return false;
+	}
+
 	// Enable Woo Passwordless if user is from WooCommerce Core Profiler.
 	if ( isWooCommerceCoreProfilerFlow( state ) ) {
 		return true;

--- a/client/state/selectors/get-is-woo-passwordless.ts
+++ b/client/state/selectors/get-is-woo-passwordless.ts
@@ -15,8 +15,8 @@ export default function getIsWooPasswordless( state: AppState ): boolean {
 		return false;
 	}
 
-	if ( ! config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
-		return false;
+	if ( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
+		return true;
 	}
 
 	// Enable Woo Passwordless if user is from WooCommerce Core Profiler.

--- a/client/state/selectors/is-woocommerce-core-profiler-flow.ts
+++ b/client/state/selectors/is-woocommerce-core-profiler-flow.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { get } from 'lodash';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
@@ -13,8 +14,9 @@ export const isWooCommerceCoreProfilerFlow = ( state: AppState ): boolean => {
 	return (
 		'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ) ||
 		'woocommerce-core-profiler' === get( getInitialQueryArguments( state ), 'from' ) ||
-		new URLSearchParams( state.login?.redirectTo?.original ).get( 'from' ) ===
-			'woocommerce-core-profiler'
+		( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) &&
+			new URLSearchParams( state.login?.redirectTo?.original ).get( 'from' ) ===
+				'woocommerce-core-profiler' )
 	);
 };
 

--- a/config/development.json
+++ b/config/development.json
@@ -242,6 +242,7 @@
 		"woo/passwordless": true,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"yolo/command-palette": true
+		"yolo/command-palette": true,
+		"woocommerce/core-profiler-passwordless-auth": true
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -243,6 +243,6 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
 		"yolo/command-palette": true,
-		"woocommerce/core-profiler-passwordless-auth": true
+		"woocommerce/core-profiler-passwordless-auth": false
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -166,7 +166,8 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/command-palette": true
+		"yolo/command-palette": true,
+		"woocommerce/core-profiler-passwordless-auth": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR adds `"woocommerce/core-profiler-passwordless-auth` feature flag for the changes in https://github.com/Automattic/wp-calypso/pull/93163

**NOTE**: You might notice a layout issue with the social login buttons. `trunk` also has the issue as well and it is handled separately in [Fix layout issue with social login buttons on the core profiler connect page](https://github.com/Automattic/wp-calypso/pull/94266#top)

## Proposed Changes

* Added feature flag

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To deploy and test the new features without disturbing the current feature set.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Setup [woocommerce-start-dev-env](https://github.com/woocommerce/woocommerce-start-dev-env)
2. Checkout this branch locally.
4. Build the changes by running `yarn start`
5. Create a new JN site, go through the Jetpack connection flow, and confirm that you're not seeing the passwordless authentication. You can compare your local environment with the production environment.
6. Open `config/development.json` and enable `woocommerce/core-profiler-passwordless-auth`
7. Go through the process again and confirm you're seeing the passwordless auth.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
