### PR TITLE
Fix: Paid Newsletters fetch more data and mark things as stale

### DIFF
--- a/client/my-sites/importer/newsletter/content-upload/file-importer.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/file-importer.jsx
@@ -62,6 +62,7 @@ class FileImporter extends PureComponent {
 		fromSite: PropTypes.string,
 		nextStepUrl: PropTypes.string,
 		skipNextStep: PropTypes.func,
+		invalidateCardData: PropTypes.func,
 	};
 
 	handleClick = ( shouldStartImport ) => {
@@ -83,7 +84,8 @@ class FileImporter extends PureComponent {
 	render() {
 		const { title, overrideDestination, uploadDescription, optionalUrl, acceptedFileTypes } =
 			this.props.importerData;
-		const { importerStatus, site, fromSite, nextStepUrl, skipNextStep } = this.props;
+		const { importerStatus, site, fromSite, nextStepUrl, skipNextStep, invalidateCardData } =
+			this.props;
 		const { errorData, importerState, summaryModalOpen } = importerStatus;
 		const isEnabled = appStates.DISABLED !== importerState;
 		const showStart = includes( compactStates, importerState );
@@ -145,6 +147,7 @@ class FileImporter extends PureComponent {
 						sourceType={ title }
 						site={ site }
 						nextStepUrl={ nextStepUrl }
+						invalidateCardData={ invalidateCardData }
 					/>
 				) }
 				{ showUploadingPane && (

--- a/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
@@ -103,6 +103,7 @@ export class ImportingPane extends PureComponent {
 		} ).isRequired,
 		sourceType: PropTypes.string.isRequired,
 		nextStepUrl: PropTypes.string.isRequired,
+		invalidateCardData: PropTypes.func,
 	};
 
 	getErrorMessage = ( { description } ) => {
@@ -215,6 +216,7 @@ export class ImportingPane extends PureComponent {
 			site: { ID: siteId, name: siteName },
 			sourceType,
 			site,
+			invalidateCardData,
 		} = this.props;
 		const { customData } = importerStatus;
 		const progressClasses = clsx( 'importer__import-progress', {
@@ -252,6 +254,7 @@ export class ImportingPane extends PureComponent {
 						onMap={ this.handleOnMap }
 						onStartImport={ () => {
 							this.props.startImporting( this.props.importerStatus );
+							invalidateCardData();
 							navigate( this.props.nextStepUrl );
 						} }
 						siteId={ siteId }

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -14,6 +14,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 type ContentProps = {
 	nextStepUrl: string;
+	engine: string;
 	selectedSite: SiteDetails;
 	siteSlug: string;
 	fromSite: string;
@@ -23,9 +24,9 @@ type ContentProps = {
 
 export default function Content( {
 	nextStepUrl,
+	engine,
 	selectedSite,
 	siteSlug,
-	engine,
 	fromSite,
 	skipNextStep,
 }: ContentProps ) {

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -1,7 +1,8 @@
 import { Card } from '@automattic/components';
+import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { external } from '@wordpress/icons';
-import { useEffect } from 'react';
+import { useEffect, Dispatch, SetStateAction } from 'react';
 import importerConfig from 'calypso/lib/importer/importer-config';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -17,17 +18,27 @@ type ContentProps = {
 	siteSlug: string;
 	fromSite: string;
 	skipNextStep: () => void;
+	setAutoFetchData: Dispatch< SetStateAction< boolean > >;
 };
 
 export default function Content( {
 	nextStepUrl,
 	selectedSite,
 	siteSlug,
+	engine,
 	fromSite,
 	skipNextStep,
 }: ContentProps ) {
 	const siteTitle = selectedSite.title;
 	const siteId = selectedSite.ID;
+
+	const queryClient = useQueryClient();
+
+	const invalidateCardData = () => {
+		queryClient.invalidateQueries( {
+			queryKey: [ 'paid-newsletter-importer', selectedSite.ID, engine ],
+		} );
+	};
 
 	const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
 
@@ -91,6 +102,7 @@ export default function Content( {
 					fromSite={ fromSite }
 					nextStepUrl={ nextStepUrl }
 					skipNextStep={ skipNextStep }
+					invalidateCardData={ invalidateCardData }
 				/>
 			) }
 		</Card>

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -115,10 +115,20 @@ export default function NewsletterImporter( {
 		} else {
 			setAutoFetchData( false );
 		}
+
+		if (
+			! paidNewsletterData?.steps?.[ 'paid-subscribers' ]?.content &&
+			step === 'paid-subscribers'
+		) {
+			// If we have empty content
+			setAutoFetchData( true );
+		}
 	}, [
 		paidNewsletterData?.steps?.content?.status,
-		paidNewsletterData?.steps.subscribers?.status,
+		paidNewsletterData?.steps?.subscribers?.status,
+		step,
 		setAutoFetchData,
+		paidNewsletterData?.steps,
 	] );
 
 	stepSlugs.forEach( ( stepName, index ) => {
@@ -202,6 +212,7 @@ export default function NewsletterImporter( {
 					cardData={ stepContent }
 					engine={ engine }
 					isFetchingContent={ isFetchingPaidNewsletter }
+					setAutoFetchData={ setAutoFetchData }
 				/>
 			) }
 		</div>

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -1,12 +1,11 @@
 import { Card } from '@automattic/components';
 import { Subscriber } from '@automattic/data-stores';
-import { useQueryClient } from '@tanstack/react-query';
 import { Modal, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { Icon, people, currencyDollar, external } from '@wordpress/icons';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
 import { toInteger } from 'lodash';
-import { useEffect, useRef } from 'react';
+import { Dispatch, SetStateAction, useEffect, useRef } from 'react';
 import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import SubscriberUploadForm from './subscriber-upload-form';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -19,6 +18,7 @@ type Props = {
 	cardData: SubscribersStepContent;
 	siteSlug: string;
 	engine: string;
+	setAutoFetchData: Dispatch< SetStateAction< boolean > >;
 };
 
 export default function Subscribers( {
@@ -29,8 +29,8 @@ export default function Subscribers( {
 	skipNextStep,
 	cardData,
 	engine,
+	setAutoFetchData,
 }: Props ) {
-	const queryClient = useQueryClient();
 	const { importSelector } = useSelect( ( select ) => {
 		const subscriber = select( Subscriber.store );
 		return {
@@ -41,11 +41,7 @@ export default function Subscribers( {
 	const prevInProgress = useRef( importSelector?.inProgress );
 	useEffect( () => {
 		if ( ! prevInProgress.current && importSelector?.inProgress ) {
-			setTimeout( () => {
-				queryClient.invalidateQueries( {
-					queryKey: [ 'paid-newsletter-importer', selectedSite.ID, engine ],
-				} );
-			}, 1500 ); // 1500ms = 1.5s delay so that we have enought time to propagate the changes.
+			setAutoFetchData( true );
 		}
 
 		prevInProgress.current = importSelector?.inProgress;


### PR DESCRIPTION
This PR make it so that we have the most relevent state form the server  when we use the importer depending the  on what actions are taken. 

## Proposed Changes
* Fix the loading indicator of the content importer when moving to the next step. 
* Fix the fetching of the paid-subscriber data when on that page. 

## Why are these changes being made?
So that things work more like expected when the user goes though the flow and we only make the requests that are needed. 

## Testing Instructions

Load this PR. 
Go to the paid-newsletter flow
1. Start the Content Import 
2. Notice that when you land on subscriber flow that you you can see the progress indicator on the paid subscriber
3. Start the Subscriber flow
4. Notice that once you load the paid subscriber that you there is a request for the paid subscriber flow. 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
