### PR TITLE
A4A > Referrals: fix the env data showing up for referral details

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -47,6 +47,7 @@ export default function ReferralDetails( {
 			</div>
 		),
 		withIcon: false,
+		hideEnvDataInHeader: true,
 	};
 
 	const isDesktop = useDesktopBreakpoint();


### PR DESCRIPTION
## Proposed Changes

This PR fixes the issue with ENV data showing up on the referral details.

This issue was caused due to this PR: https://github.com/Automattic/wp-calypso/pull/93223

NOTE: 

- I think we should also refactor this component as this should ideally not have a site-specific content as this is a reusable component.
- I also see `hosting-overview-refinements` is enabled on A4A. I don’t think we are using this anywhere on A4A :thinking_face: 

## Why are these changes being made?

* To fix the issue with ENV data showing up on the referral details page.

## Testing Instructions

* Open the A4A live link
* Go to Referrals > Open any referral details and verify you can no longer see the env details

| Before | After |
|--------|--------|
| <img width="1728" alt="Screenshot 2024-09-06 at 10 36 56 AM" src="https://github.com/user-attachments/assets/d98db285-18e6-4435-a62a-c43593af3125"> | <img width="1728" alt="Screenshot 2024-09-06 at 10 33 59 AM" src="https://github.com/user-attachments/assets/67de4e96-d258-4e95-8088-cc6487922072"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
