### PR TITLE
Performance Profiler: fix historical graph rendering issue on safari

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -51,7 +51,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 		return '';
 	};
 
-	// Add leading zero to date values
+	// Add leading zero to date values. Safari expects the date string to follow the ISO 8601 format (i.e., YYYY-MM-DD)
 	const addLeadingZero = ( value: number ) => {
 		if ( value < 10 ) {
 			return `0${ value }`;

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -51,6 +51,14 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 		return '';
 	};
 
+	// Add leading zero to date values
+	const addLeadingZero = ( value: number ) => {
+		if ( value < 10 ) {
+			return `0${ value }`;
+		}
+		return value;
+	};
+
 	let metricsData: number[] = history?.metrics[ activeTab ] ?? [];
 	let dates = history?.collection_period ?? [];
 
@@ -69,7 +77,6 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 			formattedDate = date;
 		} else {
 			const { year, month, day } = date;
-			const addLeadingZero = ( value: number ) => ( value < 10 ? `0${ value }` : value );
 			formattedDate = `${ year }-${ addLeadingZero( month ) }-${ addLeadingZero( day ) }`;
 		}
 

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -69,7 +69,8 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 			formattedDate = date;
 		} else {
 			const { year, month, day } = date;
-			formattedDate = `${ year }-${ month }-${ day }`;
+			const addLeadingZero = ( value: number ) => ( value < 10 ? `0${ value }` : value );
+			formattedDate = `${ year }-${ addLeadingZero( month ) }-${ addLeadingZero( day ) }`;
 		}
 
 		return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/dotcom-forge/issues/8841

## Proposed Changes

* Fixes graph rendering problem on Safari browser. 
 
Safari's JavaScript engine (based on WebKit) is stricter about the format of date strings than other browsers, such as Chrome or Firefox. Safari expects the date string to follow the ISO 8601 format (i.e., YYYY-MM-DD). 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the following URL on the safari browser
`/speed-test-tool?url=https%3A%2F%2Fautomattic.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzEyNn0.L1FayuY8nj3H45Tml-Xkf8AkUcJ7fqjX5wn9L2nURkM`

* Make sure the history graph is rendered. On the wpcalypso link, it will not render the graph.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
