### PR TITLE
Use QueryProducts to queue 'currencyCode' state change on account level 'Add Payment Method' page

### DIFF
--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -5,6 +5,7 @@ import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryProducts from 'calypso/components/data/query-products-list';
 import HeaderCake from 'calypso/components/header-cake';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
@@ -28,7 +29,6 @@ function AddNewPaymentMethod() {
 	const goToPaymentMethods = () => page( paymentMethods );
 	const addPaymentMethodTitle = String( titles.addPaymentMethod );
 	const currency = useSelector( getCurrentUserCurrencyCode );
-
 	const translate = useTranslate();
 	const { isStripeLoading, stripeLoadingError } = useStripe();
 	const stripeMethod = useCreateCreditCard( {
@@ -87,9 +87,19 @@ function AddNewPaymentMethod() {
 
 export default function AccountLevelAddNewPaymentMethodWrapper() {
 	const locale = useSelector( getCurrentUserLocale );
+
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
 			<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+				{
+					// QueryProducts added to ensure currency-code state gets populated for usage of getCurrentUserCurrencyCode
+					// Returning a couple of standard products to speed up the render time and ensure redundancy
+					// We only need one to get the currency code into state
+				 }
+				<QueryProducts
+					productSlugList={ [ 'value_bundle', 'personal-bundle', 'business-bundle' ] }
+				/>
+				;
 				<AddNewPaymentMethod />
 			</RazorpayHookProvider>
 		</StripeHookProvider>

--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -99,7 +99,6 @@ export default function AccountLevelAddNewPaymentMethodWrapper() {
 				<QueryProducts
 					productSlugList={ [ 'value_bundle', 'personal-bundle', 'business-bundle' ] }
 				/>
-				;
 				<AddNewPaymentMethod />
 			</RazorpayHookProvider>
 		</StripeHookProvider>


### PR DESCRIPTION
As noted in the project thread, the original implementation of the `<CBLogo />` within the `PaymentMethodSelector` component relied on a currency code value in order to conditionally show the CBLogo only to customers who have their account currency set to `EUR`. 

Originally, this value was taken from the state value `currencyCode` which initially worked for both site level and account level versions of the Add Payment Method pages...sort of.

Since `currencyCode` is populated by only three actions, it relies on specific network requests to `plans` and `products` to update it:

https://github.com/Automattic/wp-calypso/blob/28740d3224a8fc659adc6d056ad6b424826bbe7d/client/state/currency-code/reducer.js#L13-L19

This is fine for the site level 'Add Payment Method' page, and even for the account level if you navigate to it from a section that already triggered these actions and set the `currencyCode` state. 

But, if you were to reload the account level version, the `currencyCode` state is never populated since `me/purchases/add-payment-method` never makes these network requests and therefore doesn't call the actions.

This isn't the case for the site level version, since the plans endpoint is called when Calypso loads the sidebar (I think).

Related to https://github.com/Automattic/payments-shilling/issues/3092

## Proposed Changes

In `AccountLevelAddNewPaymentMethodWrapper` we can run `QueryProducts` to populate the `currencyCode` state in redux. 

I also pass an array of a couple dotcom product slugs in order to speed up the request, instead of calling for every single product available. This creates a noticable impact on how quickly the CBLogo is rendered.

## Testing Instructions
* Set account currency to `EUR`
* Go directly to http://calypso.localhost:3000/me/purchases/add-payment-method (don't navigate via /me/purchases > Add Payment Method)
* Ensure that the CBLogo loads alongside Visa, Mastercard, and AMEX. 
* Refresh the page, and make sure it still loads

<img width="1146" alt="image" src="https://github.com/user-attachments/assets/bada1914-6891-423c-a141-0e5a82122f7d">

