### PR TITLE
A4A Dev Sites: Add licenseId and siteUrls to the A4A cart session storage

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
@@ -58,13 +58,17 @@ export default function useShoppingCart() {
 					return {
 						slug: cacheData[ 0 ],
 						quantity: parseInt( cacheData[ 1 ] ),
+						...( cacheData[ 2 ] ? { licenseId: parseInt( cacheData[ 2 ] ) } : {} ),
+						...( cacheData[ 3 ]
+							? { siteUrls: decodeURIComponent( cacheData[ 3 ] ).split( ',' ) }
+							: {} ),
 					};
 				} ) ?? [];
 
 		if ( data && !! selectedItemsCache.length ) {
 			const loadedItems: ShoppingCartItem[] = [];
 
-			selectedItemsCache.forEach( ( { slug, quantity } ) => {
+			selectedItemsCache.forEach( ( { slug, quantity, licenseId, siteUrls } ) => {
 				const match =
 					quantity === 1 || slug.startsWith( 'wpcom-hosting' )
 						? data.find( ( product ) => product.slug === slug )
@@ -75,7 +79,7 @@ export default function useShoppingCart() {
 						  );
 
 				if ( match ) {
-					loadedItems.push( { ...match, quantity } );
+					loadedItems.push( { ...match, quantity, licenseId, siteUrls } );
 				}
 			} );
 
@@ -89,7 +93,15 @@ export default function useShoppingCart() {
 		( items: ShoppingCartItem[] ) => {
 			sessionStorage.setItem(
 				storageKey,
-				items.map( ( item ) => `${ item.slug }:${ item.quantity }` ).join( ',' )
+				items
+					.map( ( item ) =>
+						item.licenseId
+							? `${ item.slug }:${ item.quantity }:${ item.licenseId }:${ encodeURIComponent(
+									item.siteUrls?.join( ',' ) ?? ''
+							  ) }`
+							: `${ item.slug }:${ item.quantity }`
+					)
+					.join( ',' )
 			);
 			setSelectedCartItems( items );
 		},


### PR DESCRIPTION
## Proposed Changes

* Add `licenseId` and `siteUrls` to the A4A cart sessionStorage

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pdDOJh-3Cl-p2

## Testing Instructions

* Apply this PR to your local and make sure you are under proxy and with the Referral payment settings set up
* Run `yarn start-a8c-for-agencies`
* Go to http://agencies.localhost:3000/marketplace/checkout?referral_blog_id={dev_blog_id}
* You should see that the sessionStorage now stores the license ID and site URLs
* Go to the Marketplace home: http://agencies.localhost:3000/marketplace/hosting/wpcom
* You should still see the item in the cart
* Go back to the checkout page and the item should be shown with the site URL
* Try different scenarios like hard reloading the screen and to see if the cart keeps consistent
* Perform regression tests on a regular marketplace flow, for referrals and purchases
* In both scenarios, it should be consistent and restore the items previously added to the cart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?