### PR TITLE
Sites Dashboard: stop saving preferences too often

### DIFF
--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -1,4 +1,5 @@
 import { SitesSortOptions, SitesSortKey, SitesSortOrder, isValidSorting } from '@automattic/sites';
+import { useCallback } from 'react';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
@@ -41,18 +42,23 @@ export const stringifySitesSorting = ( sorting: Required< SitesSortOptions > ): 
 export const useSitesSorting = () => {
 	const siteCount = useSelector( getCurrentUserSiteCount );
 
-	const [ sitesSorting, onSitesSortingChange ] = useAsyncPreference< SitesSorting >( {
+	const [ sitesSorting, setSitesSorting ] = useAsyncPreference< SitesSorting >( {
 		defaultValue: stringifySitesSorting(
 			siteCount && siteCount > 6 ? MAGIC_SORTING : ALPHABETICAL_SORTING
 		),
 		preferenceName: 'sites-sorting',
 	} );
 
+	const onSitesSortingChange = useCallback(
+		( newSorting: Required< SitesSortOptions > ) => {
+			setSitesSorting( stringifySitesSorting( newSorting ) );
+		},
+		[ setSitesSorting ]
+	);
+
 	return {
 		hasSitesSortingPreferenceLoaded: sitesSorting !== 'none',
 		sitesSorting: parseSitesSorting( sitesSorting ),
-		onSitesSortingChange: ( newSorting: Required< SitesSortOptions > ) => {
-			onSitesSortingChange( stringifySitesSorting( newSorting ) );
-		},
+		onSitesSortingChange,
 	};
 };


### PR DESCRIPTION
Fixes a bug where the `POST /me/preferences` request is issued many times when loading the Sites Dashboard:

<img width="993" alt="Screenshot 2024-09-06 at 12 35 06" src="https://github.com/user-attachments/assets/9cd8d29f-fdd3-4a7f-8955-81747eb47e34">

All the POST requests save the `sites-sorting` state:

<img width="976" alt="Screenshot 2024-09-06 at 12 35 40" src="https://github.com/user-attachments/assets/1b50da1a-1a34-42fd-96f7-047477f1e3da">

It happens because the `useSitesSorting` hook returns a different instance of `onSitesSortingChange` on every call, and then `onSitesSortingChange` is used as a dependency of the effect that does the saving. So the saving is done of every render of `SitesDashboard` basically.

The fix is to wrap the function with `useCallback` so that it's stable. The result is that the preference is saved just once:

<img width="992" alt="Screenshot 2024-09-06 at 12 41 57" src="https://github.com/user-attachments/assets/777242cb-fcab-44c1-bc77-f20b03184d67">
