### PR TITLE
Enabling Staging Site Syncing for WooCommerce 

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -1,12 +1,33 @@
 import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
+import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { HostingCardDescription } from 'calypso/components/hosting-card';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { useSelector } from 'calypso/state';
+import isSiteStore from 'calypso/state/selectors/is-site-store';
 import { ExceedQuotaErrorContent } from './exceed-quota-error-content';
 
+const WarningContainer = styled.div( {
+	marginTop: '16px',
+	padding: '16px',
+	marginBottom: '24px',
+	border: '1px solid #f0c930',
+	borderRadius: '4px',
+} );
+
+const WarningTitle = styled.p( {
+	fontWeight: 500,
+	marginBottom: '8px',
+} );
+
+const WarningDescription = styled.p( {
+	marginBottom: '8px',
+} );
+
 type CardContentProps = {
+	siteId: number;
 	onAddClick: () => void;
 	isButtonDisabled: boolean;
 	showQuotaError: boolean;
@@ -14,6 +35,7 @@ type CardContentProps = {
 };
 
 export const NewStagingSiteCardContent = ( {
+	siteId,
 	onAddClick,
 	isButtonDisabled,
 	showQuotaError,
@@ -23,6 +45,7 @@ export const NewStagingSiteCardContent = ( {
 		const translate = useTranslate();
 		const hasEnTranslation = useHasEnTranslation();
 		const stagingSiteSyncWoo = config.isEnabled( 'staging-site-sync-woo' );
+		const isSiteWooStore = !! useSelector( ( state ) => isSiteStore( state, siteId ) );
 
 		return (
 			<>
@@ -51,10 +74,10 @@ export const NewStagingSiteCardContent = ( {
 								}
 						  ) }
 				</HostingCardDescription>
-				{ stagingSiteSyncWoo && (
-					<div>
-						<p>{ translate( 'WooCommerce Site' ) }</p>
-						<p>
+				{ stagingSiteSyncWoo && isSiteWooStore && (
+					<WarningContainer>
+						<WarningTitle>{ translate( 'WooCommerce Site' ) }</WarningTitle>
+						<WarningDescription>
 							{ translate(
 								'Syncing staging database to production overwrites posts, pages, products and orders. {{a}}Learn more{{/a}}.',
 								{
@@ -65,8 +88,8 @@ export const NewStagingSiteCardContent = ( {
 									},
 								}
 							) }
-						</p>
-					</div>
+						</WarningDescription>
+					</WarningContainer>
 				) }
 				{ isDevelopmentSite && (
 					// Not wrapped in translation to avoid request unconfirmed copy

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -543,7 +543,6 @@ export const SiteSyncCard = ( {
 			siteToSync={ siteToSync }
 			progress={ progress }
 			isSyncInProgress={ isSyncInProgress }
-			isSiteWooStore={ isSiteWooStore }
 			error={ syncError }
 			siteUrls={ siteUrls }
 			onRetry={ () => {

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -468,6 +468,9 @@ export const SiteSyncCard = ( {
 		[] as CheckboxOptionItem[]
 	);
 	const [ selectedOption, setSelectedOption ] = useState< string | null >( null );
+	// TODO: remove the eslint ignore once setdatabaseSyncConfirmed is passed to the checkbox
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [ databaseSyncConfirmed, setdatabaseSyncConfirmed ] = useState< boolean >( false );
 	const siteSlug = useSelector(
 		type === 'staging' ? ( state ) => getSiteSlug( state, productionSiteId ) : getSelectedSiteSlug
 	);
@@ -513,10 +516,18 @@ export const SiteSyncCard = ( {
 		}
 	}, [ resetSyncStatus, dispatch, type, onPull, transformSelectedItems, selectedItems ] );
 
+	const isSqlSyncOptionChecked = selectedItems.some( ( item ) => item.name === 'sqls' );
+	const disallowWooCommerceSync =
+		config.isEnabled( 'staging-site-sync-woo' ) &&
+		isSiteWooStore &&
+		isSqlSyncOptionChecked &&
+		! databaseSyncConfirmed;
+
 	const isSyncButtonDisabled =
 		disabled ||
 		( selectedItems.length === 0 && selectedOption === actionForType ) ||
-		selectedOption === null;
+		selectedOption === null ||
+		disallowWooCommerceSync;
 
 	let siteToSync: 'production' | 'staging' | null = null;
 	if ( targetSite ) {
@@ -596,7 +607,7 @@ export const SiteSyncCard = ( {
 					selectedItems={ selectedItems }
 					isSyncButtonDisabled={ isSyncButtonDisabled }
 					onConfirm={ selectedOption === 'push' ? onPushInternal : onPullInternal }
-					isSqlsOptionDisabled={ isSiteWooStore }
+					isSqlsOptionDisabled={ false }
 					isSiteWooStore={ isSiteWooStore }
 				/>
 			) }

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -447,6 +447,7 @@ export const SiteSyncCard = ( {
 	const siteSlug = useSelector(
 		type === 'staging' ? ( state ) => getSiteSlug( state, productionSiteId ) : getSelectedSiteSlug
 	);
+
 	const isSiteWooStore = !! useSelector( ( state ) => isSiteStore( state, productionSiteId ) );
 	const {
 		progress,

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -116,6 +116,28 @@ const OptionsTreeTitle = styled.p( {
 	marginBottom: '16px',
 } );
 
+const SyncWarningContainer = styled.div( {
+	display: 'flex',
+	flexDirection: 'column',
+	border: '1px solid #D63638',
+	borderRadius: '4px',
+	maxWidth: '807px',
+	padding: '16px',
+	marginBottom: '16px',
+} );
+
+const SyncWarningTitle = styled.p( {
+	fontWeight: 600,
+	marginTop: '0px',
+	marginBottom: '8px',
+	color: '#D63638',
+} );
+
+const SyncWarningContent = styled.p( {
+	marginTop: '0px',
+	marginBottom: '0px',
+} );
+
 interface SyncCardProps {
 	type: 'production' | 'staging';
 	onPull: ( ( items?: string[] ) => void ) | ( () => void );
@@ -139,6 +161,7 @@ const StagingToProductionSync = ( {
 	onConfirm,
 	showSyncPanel,
 	isSqlsOptionDisabled,
+	isSiteWooStore,
 }: {
 	disabled: boolean;
 	siteSlug: string;
@@ -149,6 +172,7 @@ const StagingToProductionSync = ( {
 	onConfirm: () => void;
 	showSyncPanel: boolean;
 	isSqlsOptionDisabled: boolean;
+	isSiteWooStore?: boolean;
 } ) => {
 	const [ typedSiteName, setTypedSiteName ] = useState( '' );
 	const translate = useTranslate();
@@ -242,15 +266,15 @@ const StagingToProductionSync = ( {
 									return <li key={ item.name }>{ item.label }</li>;
 								} ) }
 							</ConfirmationModalList>
-							{ stagingSiteSyncWoo && (
-								<div>
-									<p>{ translate( 'Warning' ) }</p>
-									<p>
+							{ stagingSiteSyncWoo && isSiteWooStore && (
+								<SyncWarningContainer>
+									<SyncWarningTitle>{ translate( 'Warning:' ) }</SyncWarningTitle>
+									<SyncWarningContent>
 										{ translate(
 											'We do not recommend syncing or pushing data from a staging site to live production news sites or sites that use eCommerce plugins, such as WooCommerce, without proper planning and testing. Keep in mind that data on the destination site could have newer transactions, such as customers and orders, and would be lost when overwritten by the staging site’s data.'
 										) }
-									</p>
-								</div>
+									</SyncWarningContent>
+								</SyncWarningContainer>
 							) }
 							<ConfirmationModalInputTitle>
 								{ translate( "Enter your site's name {{span}}%(siteSlug)s{{/span}} to confirm.", {
@@ -519,6 +543,7 @@ export const SiteSyncCard = ( {
 			siteToSync={ siteToSync }
 			progress={ progress }
 			isSyncInProgress={ isSyncInProgress }
+			isSiteWooStore={ isSiteWooStore }
 			error={ syncError }
 			siteUrls={ siteUrls }
 			onRetry={ () => {
@@ -573,6 +598,7 @@ export const SiteSyncCard = ( {
 					isSyncButtonDisabled={ isSyncButtonDisabled }
 					onConfirm={ selectedOption === 'push' ? onPushInternal : onPullInternal }
 					isSqlsOptionDisabled={ isSiteWooStore }
+					isSiteWooStore={ isSiteWooStore }
 				/>
 			) }
 			{ selectedOption !== actionForType && (

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -503,6 +503,7 @@ export const StagingSiteCard = ( {
 	} else if ( showAddStagingSiteCard ) {
 		stagingSiteCardContent = (
 			<NewStagingSiteCardContent
+				siteId={ siteId }
 				onAddClick={ onAddClick }
 				isDevelopmentSite={ isDevelopmentSite }
 				isButtonDisabled={

--- a/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
+++ b/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
@@ -23,6 +23,11 @@ const DangerousItemsTitle = styled.p( {
 	color: '#D63638',
 } );
 
+const WooCommerceOverwriteWarning = styled.p( {
+	color: '#D63638',
+	marginTop: '1.5em',
+} );
+
 const ToggleControlWithHelpMargin = styled( ToggleControl )( {
 	'.components-base-control__help': {
 		marginLeft: '44px',
@@ -191,7 +196,7 @@ export default function SyncOptionsPanel( {
 				} ) }
 				{ stagingSiteSyncWoo && (
 					<div>
-						<p>
+						<WooCommerceOverwriteWarning>
 							{ translate(
 								'This site has WooCommerce installed. All orders in the production database will be overwritten. {{a}}Learn more{{/a}}.',
 								{
@@ -202,8 +207,7 @@ export default function SyncOptionsPanel( {
 									},
 								}
 							) }
-						</p>
-						<p>{ translate( 'Confirm I want to proceed with database synchronization ' ) }</p>
+						</WooCommerceOverwriteWarning>
 					</div>
 				) }
 			</DangerousItemsContainer>

--- a/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
+++ b/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import { ToggleControl, CheckboxControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { useState, useEffect, useMemo } from 'react';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 
 const DangerousItemsContainer = styled.div( {
 	marginTop: '16px',
@@ -71,12 +70,20 @@ export default function SyncOptionsPanel( {
 	disabled,
 	onChange,
 	isSqlsOptionDisabled,
+	isSiteWooStore,
+	databaseSyncConfirmed,
+	setdatabaseSyncConfirmed,
+	isSqlSyncOptionChecked,
 }: {
 	items: CheckboxOptionItem[];
 	reset: boolean;
 	disabled: boolean;
 	onChange: ( items: CheckboxOptionItem[] ) => void;
 	isSqlsOptionDisabled: boolean;
+	isSiteWooStore: boolean;
+	databaseSyncConfirmed: boolean;
+	isSqlSyncOptionChecked: boolean;
+	setdatabaseSyncConfirmed: ( value: boolean ) => void;
 } ) {
 	const initialItemsMap = useMemo(
 		() =>
@@ -194,26 +201,19 @@ export default function SyncOptionsPanel( {
 						</div>
 					);
 				} ) }
-				{ stagingSiteSyncWoo && (
+				{ stagingSiteSyncWoo && isSiteWooStore && (
 					<div>
 						<WooCommerceOverwriteWarning>
 							{ translate(
-								'This site has WooCommerce installed. All orders in the production database will be overwritten. {{a}}Learn more{{/a}}.',
-								{
-									components: {
-										a: (
-											<InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />
-										),
-									},
-								}
+								'This site has WooCommerce installed. All orders in the production database will be overwritten.'
 							) }
 						</WooCommerceOverwriteWarning>
 						<CheckboxControl
 							key="checkbox"
 							label={ translate( 'Confirm I want to proceed with database synchronization ' ) }
-							checked={ false }
-							disabled={ false }
-							onChange={ () => {} }
+							checked={ databaseSyncConfirmed }
+							disabled={ ! isSqlSyncOptionChecked }
+							onChange={ setdatabaseSyncConfirmed }
 						/>
 					</div>
 				) }

--- a/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
+++ b/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import styled from '@emotion/styled';
-import { ToggleControl } from '@wordpress/components';
+import { ToggleControl, CheckboxControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { useState, useEffect, useMemo } from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -208,6 +208,13 @@ export default function SyncOptionsPanel( {
 								}
 							) }
 						</WooCommerceOverwriteWarning>
+						<CheckboxControl
+							key="checkbox"
+							label={ translate( 'Confirm I want to proceed with database synchronization ' ) }
+							checked={ false }
+							disabled={ false }
+							onChange={ () => {} }
+						/>
 					</div>
 				) }
 			</DangerousItemsContainer>

--- a/client/my-sites/hosting/staging-site-card/use-staging-sync.ts
+++ b/client/my-sites/hosting/staging-site-card/use-staging-sync.ts
@@ -53,13 +53,13 @@ export const usePullFromStagingMutation = (
 	>
 ) => {
 	const mutation = useMutation( {
-		mutationFn: async ( options ) =>
+		mutationFn: async ( options, allowWooSync: boolean = false ) =>
 			wp.req.post(
 				{
 					path: `/sites/${ productionSiteId }/staging-site/pull-from-staging/${ stagingSiteId }`,
 					apiNamespace: 'wpcom/v2',
 				},
-				{ options }
+				{ options, allow_woo_sync: allowWooSync }
 			),
 		...options,
 		mutationKey: [ PULL_FROM_STAGING, stagingSiteId ],

--- a/client/my-sites/hosting/staging-site-card/use-staging-sync.ts
+++ b/client/my-sites/hosting/staging-site-card/use-staging-sync.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useMutation, UseMutationOptions, useIsMutating } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
@@ -52,14 +53,16 @@ export const usePullFromStagingMutation = (
 		MutationVariables
 	>
 ) => {
+	const isStagingSiteSyncWooEnabled = config.isEnabled( 'staging-site-sync-woo' );
+
 	const mutation = useMutation( {
-		mutationFn: async ( options, allowWooSync: boolean = false ) =>
+		mutationFn: async ( options ) =>
 			wp.req.post(
 				{
 					path: `/sites/${ productionSiteId }/staging-site/pull-from-staging/${ stagingSiteId }`,
 					apiNamespace: 'wpcom/v2',
 				},
-				{ options, allow_woo_sync: allowWooSync }
+				{ options, allow_woo_sync: isStagingSiteSyncWooEnabled }
 			),
 		...options,
 		mutationKey: [ PULL_FROM_STAGING, stagingSiteId ],

--- a/client/my-sites/hosting/staging-site-card/use-staging-sync.ts
+++ b/client/my-sites/hosting/staging-site-card/use-staging-sync.ts
@@ -62,7 +62,7 @@ export const usePullFromStagingMutation = (
 					path: `/sites/${ productionSiteId }/staging-site/pull-from-staging/${ stagingSiteId }`,
 					apiNamespace: 'wpcom/v2',
 				},
-				{ options, allow_woo_sync: isStagingSiteSyncWooEnabled }
+				{ options, allow_woo_sync: isStagingSiteSyncWooEnabled ? 1 : 0 }
 			),
 		...options,
 		mutationKey: [ PULL_FROM_STAGING, stagingSiteId ],


### PR DESCRIPTION
## Proposed Changes

We are introducing the option for users to sync the database for WooCommerce sites with clear messaging to manage expectations of production data override. 
This should be applied when syncing site on Staging to production direction.


## Testing Instructions

The new messaging should be displayed when WooCommerce plugin is active on the site **AND** the `staging-site-sync-woo` feature flag is present.
Note that we need to text the negative scenario **twice**:
- `staging-site-sync-woo` is not active.
- WooCommerce plugin is not active.

(Click on the images to enlarge it)

### Before creating a staging site
The new `Preview and troubleshoot changes before updating your production site` message should be visible only when WooCommerce and `staging-site-sync-woo` are active.
| WooCommerce **AND** `staging-site-sync-woo` active   |      WooCommerce **OR** `staging-site-sync-woo` deactivated      |  
|----------|:-------------:|
| ![image](https://github.com/user-attachments/assets/63e19fc4-8159-480c-974b-a07f038c6d30) |  ![image](https://github.com/user-attachments/assets/931d0e29-61fb-44b9-ad56-c3192e5b033d) | 


### Toggling Site database (SQL)
If WooCommerce is not active on the site, you should be able to Sync SQL without any warning.
If WooCommerce is active, and the feature flag is disabled, the SQL toggle should be disabled.

If both WooCommerce and feature flag are enabled you should see the new messaging. If user toggle to sync SQL, the `Synchronize` button should be disabled until the confirmation checkbox is checked.

| WooCommerce **AND** `staging-site-sync-woo` active   |     `staging-site-sync-woo` deactivated      |   WooCommerce deactivated      | 
|----------|:-------------:|:-------------:|
|![image](https://github.com/user-attachments/assets/64cefd0f-2e17-4130-8c01-d48a42aa09a9) |  ![image]![image](https://github.com/user-attachments/assets/11739eb3-4e0b-4d88-a3a6-68fe65d31b68) | ![image](https://github.com/user-attachments/assets/a061be22-af17-4eaa-ae04-d874eb807ea0) |

### Confirmation modal
After clicking on `Synchronize` button user should see the final confirmation modal.

If WooCommerce and the feature flag are active, you should see the new warning box.
If WooCommerce is not active, the warning box should not be present.
If WooCommerce is active, but the feature is not, the SQL toggle should not be enabled and the user can't reach a state for confirmation modal with the SQL option to sync.

Also test that if the SQL option is **not toggled**, the new warning box should not be present even if WooCommerce and feature flag are active.

| WooCommerce **AND** `staging-site-sync-woo` active   |      WooCommerce deactivated      |      WooCommerce **AND** `staging-site-sync-woo` active *BUT* SQL is not toggled  | 
|----------|:-------------:|:-------------:|
| ![image](https://github.com/user-attachments/assets/a36aa2f8-9650-466f-a25b-eed5b660f50e) | ![image](https://github.com/user-attachments/assets/c1d1d5f7-4aeb-4b39-95aa-9098185fe70e) | ![image](https://github.com/user-attachments/assets/64779373-5eb6-47f0-ae82-dd68c863fa2e) |


### Test syncing
Apply this patch on your sandbox D159947-code
Sandbox `public-api.wordpress.com`.
Complete the sync with WooCommerce toggling the SQL option.
IT may take some time, but syncing data from staging to production should work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?