### PR TITLE
Command Palette: make text-decoration into camelCase

### DIFF
--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -83,12 +83,12 @@ const StyledCommandsFooter = styled.div( {
 	color: 'var(--studio-gray-50)',
 	a: {
 		color: 'var(--studio-gray-50)',
-		'text-decoration': 'none',
+		textDecoration: 'none',
 	},
 	'a.command-palette__footer-current-site, a:hover': {
 		color: 'var(--studio-gray-100)',
 	},
-	'a:hover': { 'text-decoration': 'underline' },
+	'a:hover': { textDecoration: 'underline' },
 } );
 
 export function CommandMenuGroup() {


### PR DESCRIPTION
## Proposed Changes

Convert `text-decoration` to `textDecoration`.

## Why are these changes being made?

I am not sure where this is being used at but Calypso gives this warning every time I `yarn start`.

| before | after |
| - | - |
| <img width="805" alt="Screen Shot 2024-09-06 at 12 51 09" src="https://github.com/user-attachments/assets/2cc1b57d-1077-4abb-930f-ecef300a3e33"> | <img width="827" alt="Screen Shot 2024-09-06 at 12 55 11" src="https://github.com/user-attachments/assets/be5632e3-9c9d-4d33-a51d-10aaad355e18"> |

## Testing Instructions

Make sure it looks ok 😄 