### PR TITLE
Calypso DateRange UI Component: Add checkmark icon next to selected shortcut

### DIFF
--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
@@ -74,6 +75,7 @@ const DateRangePickerShortcuts = ( {
 					>
 						<Button onClick={ () => handleClick( shortcut ) }>
 							<span>{ shortcut.label }</span>
+							{ shortcut.id === selectedShortcut && <Icon icon={ check } /> }
 						</Button>
 					</li>
 				) ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/172

## Proposed Changes

* Adds the check mark icon back in next to the currently selected shortcut in the shortcuts area

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open Calypso live branch
* navigate to `/devdocs/design/date-range`
* click on the last demo `With Shortcuts Menu Displayed` to open the calendar popover
* check the styling of the shortcuts menu to confirm a check icon appears only next to the currently active shortcut item
* also thoroughly check on mobile and small displays


![image](https://github.com/user-attachments/assets/14947127-0a0e-45ad-a5b4-0c6ac3af7d18)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
