### PR TITLE
Calypso UI Component: DateRangePicker: add Custom Range shortcut back in 

### DIFF
--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -109,6 +109,7 @@ export class DateRange extends Component {
 			initialStartDate: startDate, // cache values in case we need to reset to them
 			initialEndDate: endDate, // cache values in case we need to reset to them
 			focusedMonth: this.props.focusedMonth,
+			currentShortcut: '',
 		};
 
 		// Ref to the Trigger <button> used to position the Popover component
@@ -390,15 +391,21 @@ export class DateRange extends Component {
 		return window.matchMedia( '(min-width: 480px)' ).matches ? 2 : 1;
 	}
 
-	handleDateRangeChange( startDate, endDate ) {
+	handleDateRangeChange = ( startDate, endDate, shortcutId = '' ) => {
 		this.setState( {
 			startDate,
 			endDate,
 			textInputStartDate: this.toDateString( startDate ),
 			textInputEndDate: this.toDateString( endDate ),
+			currentShortcut: shortcutId,
 		} );
 		this.props.onDateSelect && this.props.onDateSelect( startDate, endDate );
-	}
+	};
+
+	handleCalendarChange = ( startDate, endDate ) => {
+		// When the calendar or inputs change directly, set to custom range
+		this.handleDateRangeChange( startDate, endDate, 'custom_date_range' );
+	};
 
 	renderDateHelp() {
 		const { startDate, endDate } = this.state;
@@ -477,9 +484,8 @@ export class DateRange extends Component {
 					{ this.props.displayShortcuts && (
 						<div className="date-range-picker-shortcuts">
 							<Shortcuts
-								onClick={ ( startDate, endDate ) =>
-									this.handleDateRangeChange( startDate, endDate )
-								}
+								currentShortcut={ this.state.currentShortcut }
+								onClick={ this.handleDateRangeChange }
 							/>
 						</div>
 					) }
@@ -499,9 +505,7 @@ export class DateRange extends Component {
 				lastSelectableDate={ this.props.lastSelectableDate }
 				selectedStartDate={ this.state.startDate }
 				selectedEndDate={ this.state.endDate }
-				onDateRangeChange={ ( startDate, endDate ) =>
-					this.handleDateRangeChange( startDate, endDate )
-				}
+				onDateRangeChange={ this.handleCalendarChange }
 				focusedMonth={ this.state.focusedMonth }
 				numberOfMonths={ this.getNumberOfMonths() }
 			/>

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
@@ -74,6 +75,7 @@ const DateRangePickerShortcuts = ( {
 					>
 						<Button onClick={ () => handleClick( shortcut ) }>
 							<span>{ shortcut.label }</span>
+							{ shortcut.id === selectedShortcut && <Icon icon={ check } /> }
 						</Button>
 					</li>
 				) ) }

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { useState } from 'react';
 
 const DATERANGE_PERIOD = {
 	DAY: 'day',
@@ -17,10 +16,9 @@ const DateRangePickerShortcuts = ( {
 	onClick,
 }: {
 	currentShortcut?: string;
-	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment ) => void;
+	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment, shortcutId: string ) => void;
 } ) => {
 	const translate = useTranslate();
-	const [ selectedShortcut, setSelectedShortcut ] = useState( currentShortcut );
 
 	const getShortcutList = () => [
 		{
@@ -29,6 +27,7 @@ const DateRangePickerShortcuts = ( {
 			offset: 0,
 			range: 6,
 			period: DATERANGE_PERIOD.DAY,
+			shortcutId: 'last_7_days',
 		},
 		{
 			id: 'last_30_days',
@@ -36,6 +35,7 @@ const DateRangePickerShortcuts = ( {
 			offset: 0,
 			range: 29,
 			period: DATERANGE_PERIOD.DAY,
+			shortcutId: 'last_30_days',
 		},
 		{
 			id: 'last_3_months',
@@ -43,6 +43,7 @@ const DateRangePickerShortcuts = ( {
 			offset: 0,
 			range: 89,
 			period: DATERANGE_PERIOD.WEEK,
+			shortcutId: 'last_3_months',
 		},
 		{
 			id: 'last_year',
@@ -50,6 +51,7 @@ const DateRangePickerShortcuts = ( {
 			offset: 0,
 			range: 364, // ranges are zero based!
 			period: DATERANGE_PERIOD.MONTH,
+			shortcutId: 'last_year',
 		},
 		{
 			id: 'custom_date_range',
@@ -57,17 +59,17 @@ const DateRangePickerShortcuts = ( {
 			offset: 0,
 			range: 0,
 			period: DATERANGE_PERIOD.DAY,
+			shortcutId: 'custom_date_range',
 		},
 	];
 
 	const shortcutList = getShortcutList();
 
 	const handleClick = ( { id, offset, range }: { id?: string; offset: number; range: number } ) => {
-		setSelectedShortcut( id );
 		const newToDate = moment().subtract( offset, 'days' );
 		const newFromDate = moment().subtract( offset + range, 'days' );
 
-		onClick( newFromDate, newToDate );
+		onClick( newFromDate, newToDate, id || '' );
 	};
 
 	return (
@@ -76,13 +78,13 @@ const DateRangePickerShortcuts = ( {
 				{ shortcutList.map( ( shortcut, idx ) => (
 					<li
 						className={ clsx( 'date-range-picker-shortcuts__shortcut', {
-							'is-selected': shortcut.id === selectedShortcut,
+							'is-selected': shortcut.id === currentShortcut,
 						} ) }
 						key={ shortcut.id || idx }
 					>
 						<Button onClick={ () => handleClick( shortcut ) }>
 							<span>{ shortcut.label }</span>
-							{ shortcut.id === selectedShortcut && <Icon icon={ check } /> }
+							{ shortcut.id === currentShortcut && <Icon icon={ check } /> }
 						</Button>
 					</li>
 				) ) }

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -51,6 +51,13 @@ const DateRangePickerShortcuts = ( {
 			range: 364, // ranges are zero based!
 			period: DATERANGE_PERIOD.MONTH,
 		},
+		{
+			id: 'custom_date_range',
+			label: translate( 'Custom Range' ),
+			offset: 0,
+			range: 0,
+			period: DATERANGE_PERIOD.DAY,
+		},
 	];
 
 	const shortcutList = getShortcutList();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/140

## Proposed Changes

* Adds the previous "custom range" shortcut item back in, as it previously was in earlier iterations. 
* The 'custom range' shortcut removes the focus off the other shortcuts, and defaults to todays date to allow the user to create a new custom range. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* open Calypso live branch
* navigate to `/devdocs/design/date-range`
* click on the last demo `With Shortcuts Menu Displayed` to open the calendar popover
* check the shortcuts menu has an additional 'custom range' option at the bottom
* click on custom range to check it de-selects the current date range and refocuses on today
* select another shortcut, eg `Last 30 Days` then click on any date inside the calendar picker to ensure the `Custom Range` is reselected. 
* also thoroughly check on mobile and small displays


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
