### PR TITLE
Performance Profiler: General updates to CWV details area

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-accordion/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-accordion/index.tsx
@@ -51,7 +51,7 @@ export const CoreWebVitalsAccordion = ( props: Props ) => {
 
 	return (
 		<div className="core-web-vitals-accordion">
-			{ Object.entries( metricsNames ).map( ( [ key, { displayName } ] ) => {
+			{ Object.entries( metricsNames ).map( ( [ key, { name: displayName } ] ) => {
 				if ( props[ key as Metrics ] === undefined || props[ key as Metrics ] === null ) {
 					return null;
 				}

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -97,7 +97,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 					<div className="range">
 						<StatusIndicator speed="good" />
 						<div className="range-description">
-							<div className="range-heading">{ translate( 'Fast' ) }</div>
+							<div className="range-heading">{ translate( 'Excellent' ) }</div>
 							<div className="range-subheading">
 								{ translate( '0–%(to)s%(unit)s', {
 									args: { to: formatUnit( good ), unit: displayUnit() },
@@ -109,7 +109,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 					<div className="range">
 						<StatusIndicator speed="needsImprovement" />
 						<div className="range-description">
-							<div className="range-heading">{ translate( 'Moderate' ) }</div>
+							<div className="range-heading">{ translate( 'Need Improvement' ) }</div>
 							<div className="range-subheading">
 								{ translate( '%(from)s–%(to)s%(unit)s', {
 									args: {
@@ -125,7 +125,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 					<div className="range">
 						<StatusIndicator speed="bad" />
 						<div className="range-description">
-							<div className="range-heading">{ translate( 'Slow' ) }</div>
+							<div className="range-heading">{ translate( 'Poor' ) }</div>
 							<div className="range-subheading">
 								{ translate( '>%(from)s%(unit)s', {
 									args: {

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -26,7 +26,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 		return null;
 	}
 
-	const { displayName } = metricsNames[ activeTab ];
+	const { name: displayName } = metricsNames[ activeTab ];
 	const value = metrics[ activeTab ];
 	const valuation = mapThresholdsToStatus( activeTab, value );
 

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -109,7 +109,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 					<div className="range">
 						<StatusIndicator speed="needsImprovement" />
 						<div className="range-description">
-							<div className="range-heading">{ translate( 'Need Improvement' ) }</div>
+							<div className="range-heading">{ translate( 'Needs Improvement' ) }</div>
 							<div className="range-subheading">
 								{ translate( '%(from)s–%(to)s%(unit)s', {
 									args: {

--- a/client/performance-profiler/components/header/style.scss
+++ b/client/performance-profiler/components/header/style.scss
@@ -26,7 +26,6 @@
 		text-decoration: none;
 		color: var(--studio-white);
 		padding: 0;
-		font-family: $brand-serif;
 
 		&:hover {
 			color: var(--studio-white);

--- a/client/performance-profiler/components/metric-tab-bar/index.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/index.tsx
@@ -18,7 +18,7 @@ export const MetricTabBar = ( props: Props ) => {
 
 	return (
 		<div className="metric-tab-bar">
-			{ Object.entries( metricsNames ).map( ( [ key, { displayName } ] ) => {
+			{ Object.entries( metricsNames ).map( ( [ key, { name: displayName } ] ) => {
 				if ( props[ key as Metrics ] === undefined || props[ key as Metrics ] === null ) {
 					return null;
 				}

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -35,7 +35,7 @@ export const metricValuations = {
 	lcp: {
 		good: translate( "Your site's Largest Contentful Paint is good" ),
 		needsImprovement: translate( "Your site's Largest Contentful Paint is moderate" ),
-		bad: translate( "Your site's Largest Contentful Paint load needs improvement" ),
+		bad: translate( "Your site's Largest Contentful Paint needs improvement" ),
 		heading: translate( 'What is Largest Contentful Paint load?' ),
 		aka: translate( '(LCP)' ),
 		explanation: translate(

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -39,7 +39,7 @@ export const metricValuations = {
 		heading: translate( 'What is Largest Contentful Paint?' ),
 		aka: translate( '(LCP)' ),
 		explanation: translate(
-			'Largest Contentful Paint load measures the time it takes for the largest visible element (like an image or text block) on a page to load. The best sites load in under 2.5 seconds.'
+			'Largest Contentful Paint measures the time it takes for the largest visible element (like an image or text block) on a page to load. The best sites load in under 2.5 seconds.'
 		),
 	},
 	cls: {

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -34,7 +34,7 @@ export const metricValuations = {
 	},
 	lcp: {
 		good: translate( "Your site's Largest Contentful Paint is good" ),
-		needsImprovement: translate( "Your site's Largest Contentful Paint load is moderate" ),
+		needsImprovement: translate( "Your site's Largest Contentful Paint is moderate" ),
 		bad: translate( "Your site's Largest Contentful Paint load needs improvement" ),
 		heading: translate( 'What is Largest Contentful Paint load?' ),
 		aka: translate( '(LCP)' ),

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -3,88 +3,83 @@ import { Metrics } from 'calypso/data/site-profiler/types';
 import { Valuation } from '../types/performance-metrics';
 
 export const metricsNames = {
-	fcp: { displayName: translate( 'Loading speed' ), name: translate( 'First Contentful Paint' ) },
+	fcp: { name: translate( 'First Contentful Paint' ) },
 	lcp: {
-		displayName: translate( 'Largest content load' ),
 		name: translate( 'Largest Contentful Paint' ),
 	},
 	cls: {
-		displayName: translate( 'Visual stability' ),
 		name: translate( 'Cumulative Layout Shift' ),
 	},
 	inp: {
-		displayName: translate( 'Interactivity' ),
 		name: translate( 'Interaction to Next Paint' ),
 	},
 	ttfb: {
-		displayName: translate( 'Server responsiveness' ),
 		name: translate( 'Time to First Byte' ),
 	},
 	tbt: {
-		displayName: translate( 'Wait time' ),
 		name: translate( 'Total Blocking Time' ),
 	},
 };
 
 export const metricValuations = {
 	fcp: {
-		good: translate( "Your site's loading speed is good" ),
-		needsImprovement: translate( "Your site's loading speed is moderate" ),
-		bad: translate( "Your site's loading speed needs improvement" ),
-		heading: translate( 'What is loading speed?' ),
-		aka: translate( '(aka First Contentful Paint)' ),
+		good: translate( "Your site's First Contentful Paint is good" ),
+		needsImprovement: translate( "Your site's First Contentful Paint is moderate" ),
+		bad: translate( "Your site's First Contentful Paint needs improvement" ),
+		heading: translate( 'What is First Contentful Paint?' ),
+		aka: translate( '(FCP)' ),
 		explanation: translate(
-			'Loading speed reflects the time it takes to display the first text or image to visitors. The best sites load in under 1.8 seconds.'
+			'First Contentful Paint reflects the time it takes to display the first text or image to visitors. The best sites load in under 1.8 seconds.'
 		),
 	},
 	lcp: {
-		good: translate( "Your site's largest content load is good" ),
-		needsImprovement: translate( "Your site's largest content load is moderate" ),
-		bad: translate( "Your site's largest content load needs improvement" ),
-		heading: translate( 'What is largest content load?' ),
-		aka: translate( '(aka Largest Contentful Paint)' ),
+		good: translate( "Your site's Largest Contentful Paint load is good" ),
+		needsImprovement: translate( "Your site's Largest Contentful Paint load is moderate" ),
+		bad: translate( "Your site's Largest Contentful Paint load needs improvement" ),
+		heading: translate( 'What is Largest Contentful Paint load?' ),
+		aka: translate( '(LCP)' ),
 		explanation: translate(
-			'Largest content load measures the time it takes for the largest visible element (like an image or text block) on a page to load. The best sites load in under 2.5 seconds.'
+			'Largest Contentful Paint load measures the time it takes for the largest visible element (like an image or text block) on a page to load. The best sites load in under 2.5 seconds.'
 		),
 	},
 	cls: {
-		good: translate( "Your site's visual stability is good" ),
-		needsImprovement: translate( "Your site's visual stability is moderate" ),
-		bad: translate( "Your site's visual stability needs improvement" ),
-		heading: translate( 'What is visual stability?' ),
-		aka: translate( '(aka Cumulative Layout Shift)' ),
+		good: translate( "Your site's Cumulative Layout Shift is good" ),
+		needsImprovement: translate( "Your site's Cumulative Layout Shift is moderate" ),
+		bad: translate( "Your site's Cumulative Layout Shift needs improvement" ),
+		heading: translate( 'What is Cumulative Layout Shift?' ),
+		aka: translate( '(CLS)' ),
 		explanation: translate(
-			'Visual stability is assessed by measuring how often content moves unexpectedly during loading. The best sites have a score of 0.1 or lower.'
+			'Cumulative Layout Shift is assessed by measuring how often content moves unexpectedly during loading. The best sites have a score of 0.1 or lower.'
 		),
 	},
 	inp: {
-		good: translate( "Your site's interactivity is good" ),
-		needsImprovement: translate( "Your site's interactivity is moderate" ),
-		bad: translate( "Your site's interactivity needs improvement" ),
-		heading: translate( 'What is interactivity?' ),
-		aka: translate( '(aka Interaction to Next Paint)' ),
+		good: translate( "Your site's Interaction to Next Paint is good" ),
+		needsImprovement: translate( "Your site's Interaction to Next Paint is moderate" ),
+		bad: translate( "Your site's Interaction to Next Paint needs improvement" ),
+		heading: translate( 'What is Interaction to Next Paint?' ),
+		aka: translate( '(INP)' ),
 		explanation: translate(
-			'Interactivity measures the overall responsiveness of a webpage by evaluating how quickly it reacts to user interactions. A good score is 200 milliseconds or less, indicating that the page responds swiftly to user inputs.'
+			'Interaction to Next Paint measures the overall responsiveness of a webpage by evaluating how quickly it reacts to user interactions. A good score is 200 milliseconds or less, indicating that the page responds swiftly to user inputs.'
 		),
 	},
 	ttfb: {
-		good: translate( "Your site's server responsiveness is good" ),
-		needsImprovement: translate( "Your site's server responsiveness is moderate" ),
-		bad: translate( "Your site's server responsiveness needs improvement" ),
-		heading: translate( 'What is server responsiveness?' ),
-		aka: translate( '(aka Time To First Byte)' ),
+		good: translate( "Your site's Time to First Byte is good" ),
+		needsImprovement: translate( "Your site's Time to First Byte is moderate" ),
+		bad: translate( "Your site's Time to First Byte needs improvement" ),
+		heading: translate( 'What is Time to First Byte?' ),
+		aka: translate( '(TTFB)' ),
 		explanation: translate(
-			'Server responsiveness reflects the time taken for a user’s browser to receive the first byte of data from the server after making a request. The best sites load around 800 milliseconds or less.'
+			'Time to First Byte reflects the time taken for a user’s browser to receive the first byte of data from the server after making a request. The best sites load around 800 milliseconds or less.'
 		),
 	},
 	tbt: {
-		good: translate( "Your site's wait time is good" ),
-		needsImprovement: translate( "Your site's wait time is moderate" ),
-		bad: translate( "Your site's wait time needs improvement" ),
-		heading: translate( 'What is wait time?' ),
-		aka: translate( '(aka Total Blocking Time)' ),
+		good: translate( "Your site's Total Blocking Time is good" ),
+		needsImprovement: translate( "Your site's Total Blocking Time is moderate" ),
+		bad: translate( "Your site's Total Blocking Time needs improvement" ),
+		heading: translate( 'What is Total Blocking Time?' ),
+		aka: translate( '(TBT)' ),
 		explanation: translate(
-			'Wait time measures the total amount of time that a page is blocked from responding to user input, such as mouse clicks, screen taps, or keyboard presses. The best sites have a wait time of less than 200 milliseconds.'
+			'Total Blocking Time measures the total amount of time that a page is blocked from responding to user input, such as mouse clicks, screen taps, or keyboard presses. The best sites have a wait time of less than 200 milliseconds.'
 		),
 	},
 };

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -36,7 +36,7 @@ export const metricValuations = {
 		good: translate( "Your site's Largest Contentful Paint is good" ),
 		needsImprovement: translate( "Your site's Largest Contentful Paint is moderate" ),
 		bad: translate( "Your site's Largest Contentful Paint needs improvement" ),
-		heading: translate( 'What is Largest Contentful Paint load?' ),
+		heading: translate( 'What is Largest Contentful Paint?' ),
 		aka: translate( '(LCP)' ),
 		explanation: translate(
 			'Largest Contentful Paint load measures the time it takes for the largest visible element (like an image or text block) on a page to load. The best sites load in under 2.5 seconds.'

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -33,7 +33,7 @@ export const metricValuations = {
 		),
 	},
 	lcp: {
-		good: translate( "Your site's Largest Contentful Paint load is good" ),
+		good: translate( "Your site's Largest Contentful Paint is good" ),
 		needsImprovement: translate( "Your site's Largest Contentful Paint load is moderate" ),
 		bad: translate( "Your site's Largest Contentful Paint load needs improvement" ),
 		heading: translate( 'What is Largest Contentful Paint load?' ),


### PR DESCRIPTION
## Proposed Changes

* Change user-friendly CWV names to standard CWV terms
* Update string for standard range bar
* Update font family for the badge

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match the new proposed design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit following URL on calypso live link. 
```
/speed-test-tool?url=https%3A%2F%2Fwww.atliq.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NjkzNH0.uoPBbETEfzOEqTdJ_kro-zUpmvSF6vQz7JabJYumwME
````
- Verify that suggested changes are applied. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
