### PR TITLE
Sites dashboard - fix broken layout of site actions in overview

### DIFF
--- a/client/hosting/sites/components/sites-dataviews/style.scss
+++ b/client/hosting/sites/components/sites-dataviews/style.scss
@@ -17,6 +17,10 @@
 	padding-top: 8px;
 	overflow: hidden;
 
+	.list-tile {
+		margin-right: 0;
+	}
+
 	.button {
 		margin: 0;
 		padding: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/94278 / p1725601374661019-slack-C03NLNTPZ2T

## Proposed Changes

Fixes the broken layout of the site actions ellipsis that can happen in overview with the list panel
* Adds a `margin-right: 0;` rule to .list-tile elements within `..sites-dataviews__site`.
    * The list-tile components default style adds 20px of right margin. The styled components used in the sites dashboard override this with their own rule. However, they have the exact same specificity so loading order matters and sometimes causes breakage. With this change, regardless of loading order there will be no right margin applied to the list items here. 

BEFORE
![Screenshot 2024-09-06 at 9 13 21 AM](https://github.com/user-attachments/assets/e45328c5-fcce-45ed-889d-e8824dd296ee)

AFTER
![Screenshot 2024-09-06 at 9 13 52 AM](https://github.com/user-attachments/assets/3e6ee049-9bab-446a-bfa9-cfaf526b9be9)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* broken things look bad

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR.
* Get on a wide screen width (if dev tools are open, ensure you dont have responsive device selected because this seems to make it hard to repro).
* Visit my home for a site.
* go to the sites dashboard.
* open overview for a site.
* the ellipsis should be good.
* inspect the dom. inspect the "my home" or "wp-admin" link in the site list. A few elements above this in the dom you should see a parent for list-tile:
![Screenshot 2024-09-06 at 9 09 53 AM](https://github.com/user-attachments/assets/4540ae98-a07f-471e-8fd5-30668e89aa14)
* Inspect the styles for this element. Verify there is a `margin-right: 0` rule with higher specificity than the basic list-tile rule for `margin-right: 20px`
![Screenshot 2024-09-06 at 9 10 58 AM](https://github.com/user-attachments/assets/76f2e569-b207-44e9-ab30-75e1a5c5f307)

* test other viewport widths and flows into here, verify the layout looks good and has not regressed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?