### PR TITLE
Performance Profiler: tries SSR.

### DIFF
--- a/client/performance-profiler/index.node.ts
+++ b/client/performance-profiler/index.node.ts
@@ -1,7 +1,7 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
-import { makeLayout, setLocaleMiddleware } from 'calypso/controller';
+import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { serverRouter } from 'calypso/server/isomorphic-routing';
-
+import { PerformanceProfilerDashboardContext } from './controller';
 /**
  * Using the server routing for this section has the sole purpose of defining
  * a named route parameter for the language, that is used to set `context.lang`
@@ -14,5 +14,10 @@ import { serverRouter } from 'calypso/server/isomorphic-routing';
 export default ( router: ReturnType< typeof serverRouter > ) => {
 	const lang = getLanguageRouteParam();
 
-	router( [ `/${ lang }/speed-test-tool(/*)?` ], setLocaleMiddleware(), makeLayout );
+	router(
+		[ `/${ lang }/speed-test-tool(/*)?` ],
+		ssrSetupLocale,
+		PerformanceProfilerDashboardContext,
+		makeLayout
+	);
 };

--- a/client/performance-profiler/index.web.ts
+++ b/client/performance-profiler/index.web.ts
@@ -1,9 +1,20 @@
-import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
+import { getLanguageRouteParam } from '@automattic/i18n-utils';
+import { clientRouter, makeLayout, render as clientRender } from 'calypso/controller/index.web';
 import { PerformanceProfilerDashboardContext, WeeklyReportContext } from './controller';
 
-export default function () {
-	page( '/speed-test-tool/', PerformanceProfilerDashboardContext, makeLayout, clientRender );
-	page( '/speed-test-tool/weekly-report', WeeklyReportContext, makeLayout, clientRender );
-	// page( '/speed-test-tool*', notFound, makeLayout, clientRender );
+export default function ( router: typeof clientRouter ) {
+	const langParam = getLanguageRouteParam();
+	router(
+		`/${ langParam }/speed-test-tool/`,
+		PerformanceProfilerDashboardContext,
+		makeLayout,
+		clientRender
+	);
+	router(
+		`/${ langParam }/speed-test-tool/weekly-report`,
+		WeeklyReportContext,
+		makeLayout,
+		clientRender
+	);
+	//router( `/${ langParam }/speed-test-tool*`, makeLayout, clientRender );
 }

--- a/client/performance-profiler/index.web.ts
+++ b/client/performance-profiler/index.web.ts
@@ -1,9 +1,9 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
-import { PerformanceProfilerDashboardContext, WeeklyReportContext, notFound } from './controller';
+import { PerformanceProfilerDashboardContext, WeeklyReportContext } from './controller';
 
 export default function () {
 	page( '/speed-test-tool/', PerformanceProfilerDashboardContext, makeLayout, clientRender );
 	page( '/speed-test-tool/weekly-report', WeeklyReportContext, makeLayout, clientRender );
-	page( '/speed-test-tool*', notFound, makeLayout, clientRender );
+	// page( '/speed-test-tool*', notFound, makeLayout, clientRender );
 }

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -7,7 +7,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { PerformanceReport } from 'calypso/data/site-profiler/types';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
 import { useUrlPerformanceInsightsQuery } from 'calypso/data/site-profiler/use-url-performance-insights';
-import { PerformanceProfilerDashboardContent } from 'calypso/performance-profiler/components/dashboard-content';
 import { PerformanceProfilerHeader, TabType } from 'calypso/performance-profiler/components/header';
 import { LoadingScreen } from '../loading-screen';
 
@@ -68,7 +67,6 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 	return (
 		<div className="peformance-profiler-dashboard-container">
 			<DocumentHead title={ translate( 'Speed Test' ) } />
-
 			<PerformanceProfilerHeader
 				url={ url }
 				timestamp={ performanceReport?.timestamp }
@@ -77,7 +75,6 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 				showWPcomBadge={ performanceReport?.is_wpcom }
 				showNavigationTabs
 			/>
-
 			<div
 				className={ clsx( 'loading-container', 'mobile-loading', {
 					'is-active': activeTab === TabType.mobile,
@@ -86,7 +83,6 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 			>
 				<LoadingScreen isSavedReport={ isSavedReport.current } key="mobile-loading" />
 			</div>
-
 			<div
 				className={ clsx( 'loading-container', 'desktop-loading', {
 					'is-active': activeTab === TabType.desktop,
@@ -95,15 +91,6 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 			>
 				<LoadingScreen isSavedReport={ isSavedReport.current } key="desktop-loading" />
 			</div>
-
-			{ ( ( activeTab === TabType.mobile && mobileLoaded ) ||
-				( activeTab === TabType.desktop && desktopLoaded ) ) && (
-				<PerformanceProfilerDashboardContent
-					performanceReport={ performanceReport }
-					url={ finalUrl ?? url }
-					hash={ hash }
-				/>
-			) }
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to  http://calypso.localhost:3000/speed-test-tool?url=https%3A%2F%2Fwww.mathema.me%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6Njk3Nn0.Jn_1t7YcV-YzB7L10e4Zr9_2cqt44MyqPq6Lhw22zDU&tab=desktop
* The page should render the Performance Profiler
* Disable javascript and refresh
* The page should again render the Performance Profiler

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
