### PR TITLE
Last Used Login: fix github issues

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -124,7 +124,7 @@ export class LoginForm extends Component {
 		emailSuggestion: '',
 		emailSuggestionError: false,
 		password: '',
-		lastUsedAuthenticationMethod: '',
+		lastUsedAuthenticationMethod: this.getLastUsedAuthenticationMethod(),
 	};
 
 	componentDidMount() {
@@ -134,9 +134,6 @@ export class LoginForm extends Component {
 		this.setState( { isFormDisabledWhileLoading: false }, () => {
 			! disableAutoFocus && this.usernameOrEmail && this.usernameOrEmail.focus();
 		} );
-
-		// eslint-disable-next-line react/no-did-mount-set-state
-		this.setState( { lastUsedAuthenticationMethod: this.getLastUsedAuthenticationMethod() } );
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
@@ -796,14 +793,14 @@ export class LoginForm extends Component {
 			...params,
 		} );
 
-	getLastUsedAuthenticationMethod = () => {
+	getLastUsedAuthenticationMethod() {
 		if ( typeof document !== 'undefined' ) {
 			const cookies = cookie.parse( document.cookie );
 			return cookies.last_used_authentication_method ?? '';
 		}
 
 		return '';
-	};
+	}
 
 	resetLastUsedAuthenticationMethod = () => {
 		this.setState( { lastUsedAuthenticationMethod: 'password' } );


### PR DESCRIPTION
## Proposed Changes

Set the `lastUsedAuthenticationMethod` default state to prevent additional renders. This requires making `getLastUsedAuthenticationMethod` a true function rather than an arrow function.

## Why are these changes being made?

GitHub has a single-use auth code that is passed to WordPress.com that we then validate from our end. This was running twice with the same code which was breaking the login process. The cause of this was the `lastUsedAuthenticationMethod` updating on reload. This caused the github component the render again and run the same login request with the same code. By setting the initial state we prevent the change between reloads and only run the login once.

## Testing Instructions

1. Mock WordPress.com from local calypso.
2. Set yourself to the `treatment` group of this experiment - 21986-explat-experiment
3. Log in to WordPress.com using GitHub
4. Immediately log out and reassign yourself to the experiment group.
5. Go to the login page. You should see GitHub as your last used option.
6. Log in using GitHub. There should be no errors or warnings.