### PR TITLE
Themes Marketplace: Add external icon to external theme demo buttons

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -21,6 +21,7 @@ import {
 } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { Icon, external } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import photon from 'photon';
@@ -759,6 +760,7 @@ class ThemeSheet extends Component {
 			! isWPForTeamsSite &&
 			! this.shouldRenderForStaging() &&
 			( ! this.hasWpOrgThemeUpsellBanner() || ! isLoggedIn );
+		const isExternalLink = ! this.props.isWpcomTheme || this.props.isExternallyManagedTheme;
 
 		return (
 			<div className="theme__sheet-header">
@@ -785,6 +787,7 @@ class ThemeSheet extends Component {
 						/>
 						{ this.shouldRenderPreviewButton() && ! isLivePreviewSupported && (
 							<Button
+								className="theme__sheet-demo-button"
 								onClick={ ( e ) => {
 									this.previewAction( e, 'link', 'actions' );
 								} }
@@ -792,6 +795,7 @@ class ThemeSheet extends Component {
 								{ translate( 'Demo site', {
 									context: 'The button to open the demo site of individual theme',
 								} ) }
+								{ isExternalLink && <Icon icon={ external } size={ 16 } /> }
 							</Button>
 						) }
 					</div>

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -239,6 +239,7 @@ $button-border: 4px;
 			svg {
 				vertical-align: text-bottom;
 				margin-left: 4px;
+				fill: currentColor;
 			}
 		}
 	}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -234,6 +234,13 @@ $button-border: 4px;
 			top: auto;
 			margin-right: 0 !important;
 		}
+
+		.theme__sheet-demo-button {
+			svg {
+				vertical-align: text-bottom;
+				margin-left: 4px;
+			}
+		}
 	}
 
 	.theme__sheet-main-info-title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8076

## Proposed Changes

* The "Demo site" button on non-wpcom themes opens to an external site in a new tab. This PR adds an external link icon to these buttons to inform the user. It does not add the icon to wpcom embedded live demos.

Before | After
--|--
<img width="1170" alt="Screenshot 2024-09-06 at 10 33 53 AM" src="https://github.com/user-attachments/assets/cf6535c0-22bf-4a5d-81bf-0ccb136d7307"> | <img width="1171" alt="Screenshot 2024-09-06 at 10 33 34 AM" src="https://github.com/user-attachments/assets/a3c49627-102f-4a8d-aad2-b15b62c1486b">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Inform the user of external links.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /themes
* Select a non-wpcom theme, such as a "Subscribe and Upgrade" labeled theme.
* These themes should have an external link icon on the "Demo site" button, and clicking the button should open an external link in a new tab.
* Go back to /themes and select a wpcom theme (this will be most themes)
* The "Demo site" button should NOT have an external link icon. Clicking on the button should open a modal demo of the theme.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
