### PR TITLE
Theme Marketplace: Add external link to theme download card

### DIFF
--- a/client/my-sites/theme/theme-download-card/index.jsx
+++ b/client/my-sites/theme/theme-download-card/index.jsx
@@ -1,4 +1,5 @@
 import { Button, Card, Gridicon } from '@automattic/components';
+import { Icon, external } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
@@ -14,10 +15,13 @@ class ThemeDownloadCard extends PureComponent {
 		const { href, translate } = this.props;
 
 		const downloadText = translate(
-			'This theme is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.',
+			'This theme is available for download to be used on your {{a}}WordPress self-hosted{{icon/}}{{/a}} installation.',
 			{
 				components: {
-					a: <a href="https://wordpress.org" />,
+					a: <a href="https://wordpress.org" target="_blank" rel="noreferrer" />,
+					icon: (
+						<Icon icon={ external } size={ 16 } className="theme-download-card__external-icon" />
+					),
 				},
 			}
 		);

--- a/client/my-sites/theme/theme-download-card/style.scss
+++ b/client/my-sites/theme/theme-download-card/style.scss
@@ -18,6 +18,10 @@
 			text-decoration: underline;
 		}
 	}
+
+	&__external-icon {
+		vertical-align: text-bottom;
+	}
 }
 
 @include breakpoint-deprecated( ">1040px" ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8076

## Proposed Changes

* The theme download card contains a link to wordpress.org. This PR opens that link in a new tab and adds the external link icon.

Before | After
--|--
<img width="1726" alt="Screenshot 2024-09-06 at 11 32 00 AM" src="https://github.com/user-attachments/assets/574e8963-1e3d-4074-a415-c9b73b93ced3">  | <img width="1727" alt="Screenshot 2024-09-06 at 11 32 22 AM" src="https://github.com/user-attachments/assets/1b8cbda5-2776-4af1-96c2-133882635737">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Better inform the user.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live and go to a theme page like /theme/hola
* At the bottom of the page is the theme download card.
* Ensure the wordpress.org link has the external link icon and opens in a new tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
