### PR TITLE
Automated Migrations: Add checks to url

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -74,6 +74,12 @@
 			margin-top: 0.25rem;
 		}
 
+		.site-migration-credentials__form-warning {
+			color: var(--color-warning);
+			font-size: 0.875rem;
+			margin-top: 0.25rem;
+		}
+
 		.site-migration-credentials__form-password {
 			position: relative;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

**THIS IS A WIP**

## Proposed Changes

This PR adds functionality to check site URLs. It will show warnings in the following conditions:
* If the site is not on WordPress
* If the site is hosted on WordPress.com

This is still a bit raw, but the idea is to get feedback on the following:
* Does the check happen in the right place?
* I had to re-enable edition on the site url input. If we show a warning we should enable the user to fix it.
* Are messages ok?. Some messaging was proposed by @fditrapani here pdtkmj-2RI-p2#comment-5560, but there are a couple more messages to check

<img width="655" alt="image" src="https://github.com/user-attachments/assets/65f34642-f8d8-453f-af45-17e1e7b2a729">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We need more validation on the source url before submitting the Zendesk ticket. At least to be able to add more context to it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the calypso.live link and go through the /start flow until you reach the credential gathering screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?