### PR TITLE
Backup: use activity rewindId as selectedDate for BackupRealtimeMessage

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -69,7 +69,7 @@ const BackupSuccessful = ( {
 	const isCloneFlow =
 		availableActions && availableActions.length === 1 && availableActions[ 0 ] === 'clone';
 
-	const currentSelectedDate = moment( backup.rewindId, 'X' );
+	const selectedBackupDate = moment( backup.rewindId, 'X' );
 	const baseBackupDate = backup.baseRewindId ? moment.unix( backup.baseRewindId ) : null;
 	const showRealTimeMessage = backup.baseRewindId && baseBackupDate && backup.rewindStepCount > 0;
 	return (
@@ -102,7 +102,7 @@ const BackupSuccessful = ( {
 					<BackupRealtimeMessage
 						baseBackupDate={ baseBackupDate }
 						eventsCount={ backup.rewindStepCount }
-						selectedBackupDate={ currentSelectedDate }
+						selectedBackupDate={ selectedBackupDate }
 					/>
 				) }
 			</div>

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -69,6 +69,7 @@ const BackupSuccessful = ( {
 	const isCloneFlow =
 		availableActions && availableActions.length === 1 && availableActions[ 0 ] === 'clone';
 
+	const currentSelectedDate = moment( backup.rewindId, 'X' );
 	const baseBackupDate = backup.baseRewindId ? moment.unix( backup.baseRewindId ) : null;
 	const showRealTimeMessage = backup.baseRewindId && baseBackupDate && backup.rewindStepCount > 0;
 	return (
@@ -101,7 +102,7 @@ const BackupSuccessful = ( {
 					<BackupRealtimeMessage
 						baseBackupDate={ baseBackupDate }
 						eventsCount={ backup.rewindStepCount }
-						selectedBackupDate={ selectedDate }
+						selectedBackupDate={ currentSelectedDate }
 					/>
 				) }
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/616

We found an inconsistency between the real-time message in the backup page and in the restore confirmation page.
This is because for the restore page we are using the `rewindId` of the activity, and on the backup page we are using the selected date in the date picker, which could cause inconsistency in some rare cases.

This PR will use the activity rewindId as the source of truth of the selected date on the backup page, as we do on the restore confirmation page:
https://github.com/Automattic/wp-calypso/blob/c393d88e2c8186c92cd34ddd1b14b8c3e84c1555/client/my-sites/backup/rewind-flow/restore.tsx#L231

## Proposed Changes
* Use the activity `rewindId` as the source of truth of the selected date on the backup page 

| Backup page | Restore confirmation page |
|---|---|
| ![image](https://github.com/user-attachments/assets/d8f37c1d-1fcb-4a71-a563-60f385ef7de9) | ![image](https://github.com/user-attachments/assets/7bf3a38c-79fe-467d-80d1-63520a637f12) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

For making clear daily vs real-time backups to end users.
Project thread: peaFOp-2Iy-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Same as https://github.com/Automattic/wp-calypso/pull/94218, and ensure you see the same real-time message in backup page and restore confirmation page as presented in the screenshots above.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?