### PR TITLE
Masterbar: update 'My Account' link to /me

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -525,7 +525,7 @@ class MasterbarLoggedIn extends Component {
 			},
 			{
 				label: translate( 'My Account' ),
-				url: '/me/account',
+				url: '/me',
 				className: 'account-link',
 			},
 			{


### PR DESCRIPTION
Related to pbxlJb-6it-p2

## Proposed Changes

This PR updates the following masterbar profile menu item "My Account" to point to `/me`.

<img width="703" alt="image" src="https://github.com/user-attachments/assets/0b16e9cf-3518-429f-be02-1b2ae0bc654d">


## Why are these changes being made?

1. After pbxlJb-63Y-p2, the "Edit Profile" menu item points to `profile.php` in most cases, making the original `/me` link hidden.
2. `/me` page is the entrypoint of all `/me/*` subpages, so it makes sense to point the link there.

## Testing Instructions

1. Go to any Calypso page.
2. Verify that the `Howdy` -> `My Account` menu item point to `/me`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?