### PR TITLE
Gardening: add OpenAI key to GitHub action

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -46,4 +46,5 @@ jobs:
          slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}
          triage_projects_token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
          project_board_url: ${{ secrets.PROJECT_BOARD_URL }}
+         openai_api_key: ${{ secrets.OPENAI_API_KEY }}
          tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss,triageIssues,gatherSupportReferences,replyToCustomersReminder,updateBoard'


### PR DESCRIPTION
## Proposed Changes

This will allow us to start using the auto-labeling functionality added to the action in this PR:
https://github.com/Automattic/jetpack/pull/39152/

## Why are these changes being made?

This should allow for faster issue triage, by having OpenAI do part of the work. Down the road, this may mean that issues should get under the eyes of the right team faster.

## Testing Instructions

This cannot really be tested until this PR is merged. Once it has been merged, one should be able to have OpenAI auto-label any issue by adding the "[Experiment] Automated labeling" label.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
