### PR TITLE
Ensure domain submit happens with the correct data

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -188,12 +188,19 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		! isNewHostedSiteCreationFlow( flow ) &&
 		! isSiteAssemblerFlow( flow ) &&
 		! isMigrationSignupFlow( flow );
+	const shouldGoToCheckout = Boolean( planCartItem || mergedDomainCartItems.length );
 
 	async function createSite() {
 		if ( isManageSiteFlow ) {
+			const slug = getSignupCompleteSlug();
+
+			if ( planCartItem && slug ) {
+				await addPlanToCart( slug, flow, true, theme, planCartItem );
+			}
+
 			return {
 				siteSlug: getSignupCompleteSlug(),
-				goToCheckout: true,
+				goToCheckout: shouldGoToCheckout,
 				siteCreated: true,
 			};
 		}
@@ -253,7 +260,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		return {
 			siteId: site?.siteId,
 			siteSlug: site?.siteSlug,
-			goToCheckout: Boolean( planCartItem || mergedDomainCartItems.length ),
+			goToCheckout: shouldGoToCheckout,
 			hasSetPreselectedTheme: Boolean( preselectedThemeSlug ),
 			siteCreated: true,
 		};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -30,7 +30,6 @@ import { fetchUsernameSuggestion } from 'calypso/state/signup/optional-dependenc
 import { removeStep } from 'calypso/state/signup/progress/actions';
 import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { ProvidedDependencies, StepProps } from '../../types';
 import { useIsManagedSiteFlowProps } from './use-is-managed-site-flow';
 
@@ -38,7 +37,6 @@ const RenderDomainsStepConnect = connect(
 	( state, { flow }: StepProps ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
-		const selectedSite = getSelectedSite( state );
 		const multiDomainDefaultPlan = planItem( PLAN_PERSONAL );
 		const userLoggedIn = isUserLoggedIn( state as object );
 		const currentUserSiteCount = getCurrentUserSiteCount( state as object );
@@ -51,7 +49,6 @@ const RenderDomainsStepConnect = connect(
 			currentUser: getCurrentUser( state as object ),
 			productsList,
 			productsLoaded,
-			selectedSite,
 			isDomainOnly: false,
 			sites: getSitesItems( state ),
 			userSiteCount: currentUserSiteCount,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -106,7 +106,6 @@ export default function DomainsStep( props: StepProps ) {
 				goToNextStep={ ( state: ProvidedDependencies ) => {
 					props.navigation.submit?.( { ...mostRecentStateRef.current, ...state } );
 				} }
-				goToNextStep={ () => {} }
 				step={ stepState }
 				flowName={ props.flow }
 				useStepperWrapper

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -103,6 +103,7 @@ export default function DomainsStep( props: StepProps ) {
 				goToNextStep={ ( state: ProvidedDependencies ) => {
 					props.navigation.submit?.( { ...mostRecentStateRef.current, ...state } );
 				} }
+				goToNextStep={ () => {} }
 				step={ stepState }
 				flowName={ props.flow }
 				useStepperWrapper

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -32,6 +32,7 @@ import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { ProvidedDependencies, StepProps } from '../../types';
+import { useIsManagedSiteFlowProps } from './use-is-managed-site-flow';
 
 const RenderDomainsStepConnect = connect(
 	( state, { flow }: StepProps ) => {
@@ -83,6 +84,7 @@ const RenderDomainsStepConnect = connect(
 export default function DomainsStep( props: StepProps ) {
 	const [ stepState, setStepState ] =
 		useStepPersistedState< ProvidedDependencies >( 'domains-step' );
+	const managedSiteFlowProps = useIsManagedSiteFlowProps();
 
 	const mostRecentStateRef = useRef< ProvidedDependencies | undefined >( undefined );
 
@@ -97,6 +99,7 @@ export default function DomainsStep( props: StepProps ) {
 		<CalypsoShoppingCartProvider>
 			<RenderDomainsStepConnect
 				{ ...props }
+				{ ...managedSiteFlowProps }
 				page={ ( url: string ) => window.location.assign( url ) }
 				saveSignupStep={ updateSignupStepState }
 				submitSignupStep={ updateSignupStepState }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/use-is-managed-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/use-is-managed-site-flow.ts
@@ -4,13 +4,12 @@ import {
 	retrieveSignupDestination,
 	wasSignupCheckoutPageUnloaded,
 	clearSignupDestinationCookie,
+	getSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
-import { useSelector } from 'calypso/state';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 export const useIsManagedSiteFlowProps = () => {
 	const [ props, setProps ] = useState( {} );
-	const selectedSiteData = useSelector( getSelectedSite );
+	const signupSlug = getSignupCompleteSlug();
 
 	useEffect( () => {
 		const signupDestinationCookieExists = retrieveSignupDestination();
@@ -23,14 +22,15 @@ export const useIsManagedSiteFlowProps = () => {
 			return;
 		}
 
-		if ( selectedSiteData ) {
-			setProps( {
+		if ( signupSlug ) {
+			return setProps( {
+				selectedSite: { slug: signupSlug },
 				showExampleSuggestions: false,
 				showSkipButton: true,
 				includeWordPressDotCom: false,
 			} );
 		}
-	}, [ selectedSiteData ] );
+	}, [ signupSlug ] );
 
 	return props;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/use-is-managed-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/use-is-managed-site-flow.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import {
+	getSignupCompleteFlowName,
+	retrieveSignupDestination,
+	wasSignupCheckoutPageUnloaded,
+	clearSignupDestinationCookie,
+} from 'calypso/signup/storageUtils';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+export const useIsManagedSiteFlowProps = () => {
+	const [ props, setProps ] = useState( {} );
+	const selectedSiteData = useSelector( getSelectedSite );
+
+	useEffect( () => {
+		const signupDestinationCookieExists = retrieveSignupDestination();
+		const isReEnteringFlow = getSignupCompleteFlowName() === 'onboarding';
+		const isManageSiteFlow =
+			wasSignupCheckoutPageUnloaded() && signupDestinationCookieExists && isReEnteringFlow;
+		clearSignupDestinationCookie();
+
+		if ( isManageSiteFlow && selectedSiteData ) {
+			setProps( {
+				showExampleSuggestions: false,
+				showSkipButton: true,
+				includeWordPressDotCom: false,
+			} );
+		}
+	}, [ selectedSiteData ] );
+
+	return props;
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/use-is-managed-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/use-is-managed-site-flow.ts
@@ -17,9 +17,13 @@ export const useIsManagedSiteFlowProps = () => {
 		const isReEnteringFlow = getSignupCompleteFlowName() === 'onboarding';
 		const isManageSiteFlow =
 			wasSignupCheckoutPageUnloaded() && signupDestinationCookieExists && isReEnteringFlow;
-		clearSignupDestinationCookie();
 
-		if ( isManageSiteFlow && selectedSiteData ) {
+		if ( ! isManageSiteFlow ) {
+			clearSignupDestinationCookie();
+			return;
+		}
+
+		if ( selectedSiteData ) {
 			setProps( {
 				showExampleSuggestions: false,
 				showSkipButton: true,

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -43,7 +43,7 @@ const onboarding: Flow = {
 
 	useStepNavigation( currentStepSlug, navigate ) {
 		const flowName = this.name;
-		const { setDomain, setDomainCartItem, setDomainCartItems, setPlanCartItem } =
+		const { setDomain, setDomainCartItem, setDomainCartItems, setPlanCartItem, setSiteUrl } =
 			useDispatch( ONBOARD_STORE );
 
 		const { planCartItem } = useSelect(
@@ -71,9 +71,11 @@ const onboarding: Flow = {
 		const submit = async ( providedDependencies: ProvidedDependencies = {} ) => {
 			switch ( currentStepSlug ) {
 				case 'domains':
+					setSiteUrl( providedDependencies.siteUrl );
 					setDomain( providedDependencies.suggestion );
 					setDomainCartItem( providedDependencies.domainItem );
 					setDomainCartItems( providedDependencies.domainCart );
+
 					if ( providedDependencies.navigateToUseMyDomain ) {
 						setRedirectedToUseMyDomain( true );
 						let useMyDomainURL = 'use-my-domain?step=domain-input';
@@ -85,6 +87,7 @@ const onboarding: Flow = {
 						}
 						return navigate( useMyDomainURL );
 					}
+
 					setRedirectedToUseMyDomain( false );
 					return navigate( 'plans' );
 				case 'use-my-domain':

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import {
 	clearSignupDestinationCookie,
 	persistSignupDestination,
+	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
 import { ONBOARD_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
@@ -40,13 +41,8 @@ const onboarding: Flow = {
 		] );
 	},
 
-	useSideEffect() {
-		useEffect( () => {
-			clearSignupDestinationCookie();
-		}, [] );
-	},
-
 	useStepNavigation( currentStepSlug, navigate ) {
+		const flowName = this.name;
 		const { setDomain, setDomainCartItem, setDomainCartItems, setPlanCartItem } =
 			useDispatch( ONBOARD_STORE );
 
@@ -111,6 +107,8 @@ const onboarding: Flow = {
 						siteSlug: providedDependencies.siteSlug,
 					} );
 					persistSignupDestination( destination );
+					setSignupCompleteFlowName( flowName );
+
 					if ( providedDependencies.goToCheckout ) {
 						const siteSlug = providedDependencies.siteSlug as string;
 

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -2,11 +2,11 @@ import { OnboardSelect } from '@automattic/data-stores';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import {
-	clearSignupDestinationCookie,
 	persistSignupDestination,
 	setSignupCompleteFlowName,
+	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
 import { ONBOARD_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
@@ -98,6 +98,7 @@ const onboarding: Flow = {
 				case 'plans': {
 					const cartItems = providedDependencies.cartItems as Array< typeof planCartItem >;
 					setPlanCartItem( cartItems?.[ 0 ] ?? null );
+					setSignupCompleteFlowName( flowName );
 					return navigate( 'create-site', undefined, true );
 				}
 				case 'create-site':
@@ -108,6 +109,7 @@ const onboarding: Flow = {
 					} );
 					persistSignupDestination( destination );
 					setSignupCompleteFlowName( flowName );
+					setSignupCompleteSlug( providedDependencies.siteSlug );
 
 					if ( providedDependencies.goToCheckout ) {
 						const siteSlug = providedDependencies.siteSlug as string;

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -33,7 +33,6 @@ import { createQueryClient } from 'calypso/state/query-client';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
 import { setCurrentFlowName } from 'calypso/state/signup/flow/actions';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { FlowRenderer } from './declarative-flow/internals';
 import { AsyncHelpCenter } from './declarative-flow/internals/components';
 import 'calypso/components/environment-badge/style.scss';
@@ -45,7 +44,6 @@ import { enhanceFlowWithAuth } from './utils/enhanceFlowWithAuth';
 import { startStepperPerformanceTracking } from './utils/performance-tracking';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
 import type { Flow } from './declarative-flow/internals/types';
-import type { AnyAction } from 'redux';
 
 declare const window: AppWindow;
 
@@ -142,10 +140,8 @@ window.AppBoot = async () => {
 
 	// When re-using steps from /start, we need to set the current flow name in the redux store, since some depend on it.
 	reduxStore.dispatch( setCurrentFlowName( flow.name ) );
-	// Reset the selected site ID when the stepper is loaded.
-	reduxStore.dispatch( setSelectedSiteId( null ) as unknown as AnyAction );
 
-	geolocateCurrencySymbol();
+	await geolocateCurrencySymbol();
 
 	const root = createRoot( document.getElementById( 'wpcom' ) as HTMLElement );
 

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -33,6 +33,7 @@ import { createQueryClient } from 'calypso/state/query-client';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
 import { setCurrentFlowName } from 'calypso/state/signup/flow/actions';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { FlowRenderer } from './declarative-flow/internals';
 import { AsyncHelpCenter } from './declarative-flow/internals/components';
 import 'calypso/components/environment-badge/style.scss';
@@ -44,6 +45,7 @@ import { enhanceFlowWithAuth } from './utils/enhanceFlowWithAuth';
 import { startStepperPerformanceTracking } from './utils/performance-tracking';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
 import type { Flow } from './declarative-flow/internals/types';
+import type { AnyAction } from 'redux';
 
 declare const window: AppWindow;
 
@@ -140,6 +142,8 @@ window.AppBoot = async () => {
 
 	// When re-using steps from /start, we need to set the current flow name in the redux store, since some depend on it.
 	reduxStore.dispatch( setCurrentFlowName( flow.name ) );
+	// Reset the selected site ID when the stepper is loaded.
+	reduxStore.dispatch( setSelectedSiteId( null ) as unknown as AnyAction );
 
 	await geolocateCurrencySymbol();
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -697,8 +697,7 @@ export class RenderDomainsStep extends Component {
 								} ) );
 							}
 						} )
-						.catch( ( error ) => {
-							console.log( error );
+						.catch( () => {
 							this.handleReplaceProductsInCartError(
 								this.props.translate(
 									'Sorry, there was a problem adding that domain. Please try again later.'

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -697,7 +697,8 @@ export class RenderDomainsStep extends Component {
 								} ) );
 							}
 						} )
-						.catch( () => {
+						.catch( ( error ) => {
+							console.log( error );
 							this.handleReplaceProductsInCartError(
 								this.props.translate(
 									'Sorry, there was a problem adding that domain. Please try again later.'

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -373,7 +373,7 @@ export class RenderDomainsStep extends Component {
 		const { suggestion } = this.props.step;
 
 		if ( previousState ) {
-			this.removeDomain( suggestion );
+			await this.removeDomain( suggestion );
 		} else {
 			await this.addDomain( suggestion );
 			this.props.setDesignType( this.getDesignType() );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94427

The domains step in stepper was submitting with the incorrect data.
This PR ensures that the unified domains step submits with the correct data.

## Proposed Changes

* Unwire goToNext and submit with the provided step data

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The domains step was submitting with the incorrect data

## Testing Instructions
- Use PR link or build the PR
- Visit: `/setup/onboarding`
- Test the various combinations when adding domains: free domain, paid domain, multiple paid domains etc.
- Ensure that the plans page reflects the correct plans according to the domains selected.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
