### PR TITLE
A4A: Split the team member table into two tabs.

### DIFF
--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -35,7 +35,6 @@ import {
 	A4A_PAYMENT_METHODS_LINK,
 	A4A_PAYMENT_METHODS_ADD_LINK,
 	A4A_MIGRATIONS_LINK,
-	A4A_TEAM_LINK,
 	A4A_TEAM_INVITE_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import type { Agency } from 'calypso/state/a8c-for-agencies/types';
@@ -77,12 +76,12 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_PAYMENT_METHODS_LINK ]: [ 'a4a_jetpack_licensing' ],
 	[ A4A_PAYMENT_METHODS_ADD_LINK ]: [ 'a4a_jetpack_licensing' ],
 	[ A4A_MIGRATIONS_LINK ]: [ 'a4a_read_migrations' ],
-	[ A4A_TEAM_LINK ]: [ 'a4a_read_users' ],
 	[ A4A_TEAM_INVITE_LINK ]: [ 'a4a_edit_user_invites' ],
 };
 
 const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {
 	'sites-overview': [ 'a4a_read_managed_sites' ],
+	team: [ 'a4a_read_team' ],
 	marketplace: [ 'a4a_read_marketplace' ],
 	licenses: [ 'a4a_jetpack_licensing' ],
 };
@@ -91,6 +90,7 @@ const DYNAMIC_PATH_PATTERNS: Record< string, RegExp > = {
 	'sites-overview': /^\/sites\/overview\/[^/]+(\/.*)?$/,
 	marketplace: /^\/marketplace\/[^/]+\/[^/]+(\/.*)?$/,
 	licenses: /^\/purchases\/licenses(\/.*)?$/,
+	team: /^\/team(\/.*)?$/,
 };
 
 export const isPathAllowed = ( pathname: string, agency: Agency | null ) => {

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -81,7 +81,7 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 
 const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {
 	'sites-overview': [ 'a4a_read_managed_sites' ],
-	team: [ 'a4a_read_team' ],
+	team: [ 'a4a_read_users' ],
 	marketplace: [ 'a4a_read_marketplace' ],
 	licenses: [ 'a4a_jetpack_licensing' ],
 };

--- a/client/a8c-for-agencies/sections/team/constants.ts
+++ b/client/a8c-for-agencies/sections/team/constants.ts
@@ -1,1 +1,4 @@
 export const OWNER_ROLE = 'a4a_administrator';
+
+export const TAB_ACTIVE_MEMBERS = 'active-members';
+export const TAB_INVITED_MEMBERS = 'invited-members';

--- a/client/a8c-for-agencies/sections/team/controller.tsx
+++ b/client/a8c-for-agencies/sections/team/controller.tsx
@@ -1,16 +1,18 @@
 import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import MainSidebar from '../../components/sidebar-menu/main';
+import { TAB_ACTIVE_MEMBERS } from './constants';
 import TeamAcceptInvite from './primary/team-accept-invite';
 import TeamInvite from './primary/team-invite';
 import TeamList from './primary/team-list';
 
 export const teamContext: Callback = ( context, next ) => {
+	const { tab } = context.params;
 	context.secondary = <MainSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Manage team" path={ context.path } />
-			<TeamList />
+			<TeamList currentTab={ tab ?? TAB_ACTIVE_MEMBERS } />
 		</>
 	);
 

--- a/client/a8c-for-agencies/sections/team/controller.tsx
+++ b/client/a8c-for-agencies/sections/team/controller.tsx
@@ -12,7 +12,7 @@ export const teamContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Manage team" path={ context.path } />
-			<TeamList currentTab={ tab ?? TAB_ACTIVE_MEMBERS } />
+			<TeamList currentTab={ tab } />
 		</>
 	);
 

--- a/client/a8c-for-agencies/sections/team/controller.tsx
+++ b/client/a8c-for-agencies/sections/team/controller.tsx
@@ -7,7 +7,7 @@ import TeamInvite from './primary/team-invite';
 import TeamList from './primary/team-list';
 
 export const teamContext: Callback = ( context, next ) => {
-	const { tab } = context.params;
+	const { tab = TAB_ACTIVE_MEMBERS } = context.params;
 	context.secondary = <MainSidebar path={ context.path } />;
 	context.primary = (
 		<>

--- a/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
@@ -107,6 +107,6 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 				);
 			}
 		},
-		[ cancelMemberInvite, dispatch, onRefetchList, removeMember, translate ]
+		[ cancelMemberInvite, dispatch, onRefetchList, removeMember, resendMemberInvite, translate ]
 	);
 }

--- a/client/a8c-for-agencies/sections/team/hooks/use-member-list.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-member-list.ts
@@ -1,7 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import useFetchActiveMembers from 'calypso/a8c-for-agencies/data/team/use-fetch-active-members';
 import useFetchMemberInvites from 'calypso/a8c-for-agencies/data/team/use-fetch-member-invites';
-import { TeamMember } from '../types';
 
 export function useMemberList() {
 	const {
@@ -21,25 +20,9 @@ export function useMemberList() {
 		refetchMemberInvites();
 	}, [ refetchActiveMembers, refetchMemberInvites ] );
 
-	const members: TeamMember[] = useMemo( () => {
-		const data = [
-			...( activeMembers ?? [] ),
-			...( memberInvites?.map( ( invite ) => ( {
-				id: invite.id,
-				displayName: invite.displayName,
-				email: invite.email,
-				avatar: invite.avatar,
-				status: invite.status as 'active' | 'pending' | 'expired',
-			} ) ) ?? [] ),
-		];
-
-		return data;
-	}, [ activeMembers, memberInvites ] );
-
 	return {
 		refetch,
 		isPending: isActiveMembersPending || isMemberInvitesPending,
-		members,
 		activeMembers: activeMembers ?? [],
 		invitedMembers:
 			memberInvites?.map( ( invite ) => ( {
@@ -47,8 +30,8 @@ export function useMemberList() {
 				displayName: invite.displayName,
 				email: invite.email,
 				avatar: invite.avatar,
-				status: 'pending' as const,
+				status: invite.status as 'active' | 'pending' | 'expired',
 			} ) ) ?? [],
-		hasMembers: members.length > 1, // We exclude the owner from the count
+		hasMembers: ( activeMembers && activeMembers.length > 1 ) || memberInvites?.length, // We exclude the owner from the count
 	};
 }

--- a/client/a8c-for-agencies/sections/team/hooks/use-member-list.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-member-list.ts
@@ -40,6 +40,15 @@ export function useMemberList() {
 		refetch,
 		isPending: isActiveMembersPending || isMemberInvitesPending,
 		members,
+		activeMembers: activeMembers ?? [],
+		invitedMembers:
+			memberInvites?.map( ( invite ) => ( {
+				id: invite.id,
+				displayName: invite.displayName,
+				email: invite.email,
+				avatar: invite.avatar,
+				status: 'pending' as const,
+			} ) ) ?? [],
 		hasMembers: members.length > 1, // We exclude the owner from the count
 	};
 }

--- a/client/a8c-for-agencies/sections/team/index.tsx
+++ b/client/a8c-for-agencies/sections/team/index.tsx
@@ -9,9 +9,9 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import { teamAcceptInviteContext, teamContext, teamInviteContext } from './controller';
 
 export default function () {
-	page( `${ A4A_TEAM_LINK }/:tab?`, requireAccessContext, teamContext, makeLayout, clientRender );
-
 	page( A4A_TEAM_INVITE_LINK, requireAccessContext, teamInviteContext, makeLayout, clientRender );
 
 	page( A4A_TEAM_ACCEPT_INVITE_LINK, teamAcceptInviteContext, makeLayout, clientRender );
+
+	page( `${ A4A_TEAM_LINK }/:tab?`, requireAccessContext, teamContext, makeLayout, clientRender );
 }

--- a/client/a8c-for-agencies/sections/team/index.tsx
+++ b/client/a8c-for-agencies/sections/team/index.tsx
@@ -9,7 +9,7 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import { teamAcceptInviteContext, teamContext, teamInviteContext } from './controller';
 
 export default function () {
-	page( A4A_TEAM_LINK, requireAccessContext, teamContext, makeLayout, clientRender );
+	page( `${ A4A_TEAM_LINK }/:tab?`, requireAccessContext, teamContext, makeLayout, clientRender );
 
 	page( A4A_TEAM_INVITE_LINK, requireAccessContext, teamInviteContext, makeLayout, clientRender );
 

--- a/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
@@ -15,6 +15,7 @@ import { A4A_TEAM_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/
 import useSendTeamMemberInvite from 'calypso/a8c-for-agencies/data/team/use-send-team-member-invite';
 import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { TAB_INVITED_MEMBERS } from '../../constants';
 
 import './style.scss';
 
@@ -47,7 +48,7 @@ export default function TeamInvite() {
 							duration: 5000,
 						} )
 					);
-					page( A4A_TEAM_LINK );
+					page( `${ A4A_TEAM_LINK }/${ TAB_INVITED_MEMBERS }` );
 				},
 
 				onError: ( error ) => {

--- a/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
@@ -79,7 +79,7 @@ export default function TeamInvite() {
 					className="team-invite-form"
 					title={ translate( 'Invite a team member.' ) }
 					autocomplete="off"
-					description={ translate( 'Invite team members to manage client sites and purchases' ) }
+					description={ translate( 'Invite team members to manage client sites and purchases.' ) }
 				>
 					<FormSection title={ translate( 'Team member information' ) }>
 						<FormField

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -1,52 +1,50 @@
 import page from '@automattic/calypso-router';
-import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
-import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode, useMemo, useState } from 'react';
-import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
-import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
-import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { useMemo } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 	LayoutHeaderTitle as Title,
 } from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutNavigation, {
+	LayoutNavigationTabs,
+} from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import PagePlaceholder from 'calypso/a8c-for-agencies/components/page-placeholder';
-import { A4A_TEAM_INVITE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { useDispatch, useSelector } from 'calypso/state';
-import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
+import {
+	A4A_TEAM_INVITE_LINK,
+	A4A_TEAM_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import useHandleMemberAction from '../../hooks/use-handle-member-action';
+import { TAB_ACTIVE_MEMBERS, TAB_INVITED_MEMBERS } from '../../constants';
 import { useMemberList } from '../../hooks/use-member-list';
 import { TeamMember } from '../../types';
 import GetStarted from '../get-started';
-import { ActionColumn, DateColumn, MemberColumn, RoleStatusColumn } from './columns';
+import { TeamTable } from './table';
 
 import './style.scss';
 
-export default function TeamList() {
+type Props = {
+	currentTab: string;
+};
+
+type Tab = {
+	key: string;
+	label: string;
+	count?: number;
+	selected: boolean;
+	path: string;
+	data: TeamMember[];
+};
+
+export default function TeamList( { currentTab }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const isDesktop = useDesktopBreakpoint();
-
-	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
-		...initialDataViewsState,
-		layout: {
-			styles: {
-				actions: {
-					width: isDesktop ? '10%' : undefined,
-				},
-			},
-		},
-	} );
-
-	const { members, hasMembers, isPending, refetch } = useMemberList();
+	const { activeMembers, invitedMembers, hasMembers, isPending, refetch } = useMemberList();
 
 	const title = translate( 'Manage team members' );
 
@@ -55,73 +53,33 @@ export default function TeamList() {
 		page( A4A_TEAM_INVITE_LINK );
 	};
 
-	const handleAction = useHandleMemberAction( { onRefetchList: refetch } );
-
-	const canRemove = useSelector( ( state: A4AStore ) =>
-		hasAgencyCapability( state, 'a4a_remove_users' )
-	);
-
-	const currentUser = useSelector( getCurrentUser );
-
-	const fields = useMemo(
-		() => [
+	const tabs = useMemo( () => {
+		const items: Tab[] = [
 			{
-				id: 'user',
-				label: translate( 'User' ).toUpperCase(),
-				getValue: ( { item }: { item: TeamMember } ) => item.displayName ?? '',
-				render: ( { item }: { item: TeamMember } ): ReactNode => {
-					return <MemberColumn member={ item } withRoleStatus={ ! isDesktop } />;
-				},
-				enableHiding: false,
-				enableSorting: false,
+				key: TAB_ACTIVE_MEMBERS,
+				label: translate( 'Active Members' ),
+				count: activeMembers?.length,
+				selected: currentTab === TAB_ACTIVE_MEMBERS,
+				path: `${ A4A_TEAM_LINK }/${ TAB_ACTIVE_MEMBERS }`,
+				data: activeMembers,
 			},
-			...( isDesktop
-				? [
-						{
-							id: 'role',
-							label: translate( 'Role' ).toUpperCase(),
-							getValue: ( { item }: { item: TeamMember } ) => item.role || '',
-							render: ( { item }: { item: TeamMember } ): ReactNode => {
-								return <RoleStatusColumn member={ item } />;
-							},
-							enableHiding: false,
-							enableSorting: false,
-						},
-						{
-							id: 'added-date',
-							getValue: ( { item }: { item: TeamMember } ): string => item.dateAdded || '',
-							label: translate( 'Added' ).toUpperCase(),
-							render: ( { item }: { item: TeamMember } ): ReactNode => {
-								return <DateColumn date={ item.dateAdded } />;
-							},
-							enableHiding: false,
-							enableSorting: false,
-						},
-				  ]
-				: [] ),
 			{
-				id: 'actions',
-				getValue: () => '',
-				label: '',
-				render: ( { item }: { item: TeamMember } ): ReactNode => {
-					return (
-						<ActionColumn
-							member={ item }
-							onMenuSelected={ ( action, callback ) => handleAction( action, item, callback ) }
-							canRemove={ canRemove || item.email === currentUser?.email }
-						/>
-					);
-				},
-				enableHiding: false,
-				enableSorting: false,
+				key: TAB_INVITED_MEMBERS,
+				label: translate( 'Invited' ),
+				count: invitedMembers?.length,
+				selected: currentTab === TAB_INVITED_MEMBERS,
+				path: `${ A4A_TEAM_LINK }/${ TAB_INVITED_MEMBERS }`,
+				data: invitedMembers,
 			},
-		],
-		[ canRemove, currentUser?.email, handleAction, isDesktop, translate ]
-	);
+		];
 
-	const { data: items, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( members, dataViewsState, fields );
-	}, [ members, dataViewsState, fields ] );
+		const selected: Tab = items.find( ( tab: Tab ) => tab.selected ) ?? items[ 0 ];
+
+		return {
+			items,
+			selected,
+		};
+	}, [ activeMembers, currentTab, invitedMembers, translate ] );
 
 	if ( isPending ) {
 		return <PagePlaceholder />;
@@ -142,21 +100,20 @@ export default function TeamList() {
 						</Button>
 					</Actions>
 				</LayoutHeader>
+
+				<LayoutNavigation
+					selectedText={ tabs.selected.label }
+					selectedCount={ tabs.selected.count }
+				>
+					<LayoutNavigationTabs
+						selectedText={ tabs.selected.label }
+						selectedCount={ tabs.selected.count }
+						items={ tabs.items }
+					/>
+				</LayoutNavigation>
 			</LayoutTop>
 			<LayoutBody>
-				<ItemsDataViews
-					data={ {
-						items,
-						getItemId: ( user ) => `${ user.id }`,
-						pagination: paginationInfo,
-						enableSearch: false,
-						fields,
-						actions: [],
-						setDataViewsState: setDataViewsState,
-						dataViewsState: dataViewsState,
-						defaultLayouts: { table: {} },
-					} }
-				/>
+				<TeamTable data={ tabs.selected.data } onRefresh={ refetch } />
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -13,6 +13,7 @@ import LayoutNavigation, {
 } from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import PagePlaceholder from 'calypso/a8c-for-agencies/components/page-placeholder';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import {
 	A4A_TEAM_INVITE_LINK,
 	A4A_TEAM_LINK,
@@ -91,10 +92,11 @@ export default function TeamList( { currentTab }: Props ) {
 
 	return (
 		<Layout className="team-list full-width-layout-with-table" title={ title } wide compact>
-			<LayoutTop>
+			<LayoutTop withNavigation>
 				<LayoutHeader>
 					<Title>{ title }</Title>
 					<Actions>
+						<MobileSidebarNavigation />
 						<Button variant="primary" onClick={ onInviteClick }>
 							{ translate( 'Invite a team member' ) }
 						</Button>

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useMemo } from 'react';
@@ -47,7 +48,9 @@ export default function TeamList( { currentTab }: Props ) {
 
 	const { activeMembers, invitedMembers, hasMembers, isPending, refetch } = useMemberList();
 
-	const title = translate( 'Manage team members' );
+	const isDesktop = useDesktopBreakpoint();
+
+	const title = isDesktop ? translate( 'Manage team members' ) : translate( 'Team' );
 
 	const onInviteClick = () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_team_invite_team_member_click' ) );

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -21,9 +21,9 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { TAB_ACTIVE_MEMBERS, TAB_INVITED_MEMBERS } from '../../constants';
 import { useMemberList } from '../../hooks/use-member-list';
-import { TeamMember } from '../../types';
 import GetStarted from '../get-started';
-import { TeamTable } from './table';
+import { TeamInviteTable } from './invite-table';
+import { TeamMemberTable } from './member-table';
 
 import './style.scss';
 
@@ -37,7 +37,7 @@ type Tab = {
 	count?: number;
 	selected: boolean;
 	path: string;
-	data: TeamMember[];
+	content: ReactNode;
 };
 
 export default function TeamList( { currentTab }: Props ) {
@@ -61,7 +61,7 @@ export default function TeamList( { currentTab }: Props ) {
 				count: activeMembers?.length,
 				selected: currentTab === TAB_ACTIVE_MEMBERS,
 				path: `${ A4A_TEAM_LINK }/${ TAB_ACTIVE_MEMBERS }`,
-				data: activeMembers,
+				content: <TeamMemberTable members={ activeMembers } onRefresh={ refetch } />,
 			},
 			{
 				key: TAB_INVITED_MEMBERS,
@@ -69,7 +69,7 @@ export default function TeamList( { currentTab }: Props ) {
 				count: invitedMembers?.length,
 				selected: currentTab === TAB_INVITED_MEMBERS,
 				path: `${ A4A_TEAM_LINK }/${ TAB_INVITED_MEMBERS }`,
-				data: invitedMembers,
+				content: <TeamInviteTable members={ invitedMembers } onRefresh={ refetch } />,
 			},
 		];
 
@@ -79,7 +79,7 @@ export default function TeamList( { currentTab }: Props ) {
 			items,
 			selected,
 		};
-	}, [ activeMembers, currentTab, invitedMembers, translate ] );
+	}, [ activeMembers, currentTab, invitedMembers, refetch, translate ] );
 
 	if ( isPending ) {
 		return <PagePlaceholder />;
@@ -112,9 +112,7 @@ export default function TeamList( { currentTab }: Props ) {
 					/>
 				</LayoutNavigation>
 			</LayoutTop>
-			<LayoutBody>
-				<TeamTable data={ tabs.selected.data } onRefresh={ refetch } />
-			</LayoutBody>
+			<LayoutBody>{ tabs.selected.content }</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/team/primary/team-list/invite-table.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/invite-table.tsx
@@ -1,0 +1,99 @@
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { useTranslate } from 'i18n-calypso';
+import { ReactNode, useMemo, useState } from 'react';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import useHandleMemberAction from '../../hooks/use-handle-member-action';
+import { TeamMember } from '../../types';
+import { ActionColumn, MemberColumn, RoleStatusColumn } from './columns';
+
+type Props = {
+	members: TeamMember[];
+	onRefresh?: () => void;
+};
+
+export function TeamInviteTable( { members, onRefresh }: Props ) {
+	const translate = useTranslate();
+
+	const isDesktop = useDesktopBreakpoint();
+
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
+		...initialDataViewsState,
+		layout: {
+			styles: {
+				actions: {
+					width: isDesktop ? '10%' : undefined,
+				},
+			},
+		},
+	} );
+
+	const handleAction = useHandleMemberAction( { onRefetchList: onRefresh } );
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'user',
+				label: translate( 'User' ).toUpperCase(),
+				getValue: ( { item }: { item: TeamMember } ) => item.displayName ?? '',
+				render: ( { item }: { item: TeamMember } ): ReactNode => {
+					return <MemberColumn member={ item } withRoleStatus={ ! isDesktop } />;
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			...( isDesktop
+				? [
+						{
+							id: 'status',
+							label: translate( 'Status' ).toUpperCase(),
+							getValue: ( { item }: { item: TeamMember } ) => item.role || '',
+							render: ( { item }: { item: TeamMember } ): ReactNode => {
+								return <RoleStatusColumn member={ item } />;
+							},
+							enableHiding: false,
+							enableSorting: false,
+						},
+				  ]
+				: [] ),
+			{
+				id: 'actions',
+				getValue: () => '',
+				label: '',
+				render: ( { item }: { item: TeamMember } ): ReactNode => {
+					return (
+						<ActionColumn
+							member={ item }
+							onMenuSelected={ ( action, callback ) => handleAction( action, item, callback ) }
+						/>
+					);
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+		],
+		[ handleAction, isDesktop, translate ]
+	);
+
+	const { data: items, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( members, dataViewsState, fields );
+	}, [ members, dataViewsState, fields ] );
+
+	return (
+		<ItemsDataViews
+			data={ {
+				items,
+				getItemId: ( user ) => `${ user.id }`,
+				pagination: paginationInfo,
+				enableSearch: false,
+				fields,
+				actions: [],
+				setDataViewsState: setDataViewsState,
+				dataViewsState: dataViewsState,
+				defaultLayouts: { table: {} },
+			} }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/team/primary/team-list/member-table.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/member-table.tsx
@@ -14,11 +14,11 @@ import { TeamMember } from '../../types';
 import { ActionColumn, DateColumn, MemberColumn, RoleStatusColumn } from './columns';
 
 type Props = {
-	data: TeamMember[];
+	members: TeamMember[];
 	onRefresh?: () => void;
 };
 
-export function TeamTable( { data, onRefresh }: Props ) {
+export function TeamMemberTable( { members, onRefresh }: Props ) {
 	const translate = useTranslate();
 
 	const isDesktop = useDesktopBreakpoint();
@@ -99,8 +99,8 @@ export function TeamTable( { data, onRefresh }: Props ) {
 	);
 
 	const { data: items, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( data, dataViewsState, fields );
-	}, [ data, dataViewsState, fields ] );
+		return filterSortAndPaginate( members, dataViewsState, fields );
+	}, [ members, dataViewsState, fields ] );
 
 	return (
 		<ItemsDataViews

--- a/client/a8c-for-agencies/sections/team/primary/team-list/style.scss
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/style.scss
@@ -3,8 +3,12 @@
 		padding-block-start: 32px;
 	}
 
-	.dataviews-filters__view-actions {
+	.dataviews__view-actions {
 		display: none;
+	}
+
+	.a4a-layout__navigation-wrapper {
+		max-width: 100%;
 	}
 
 	.dataviews-view-table__row td:last-child {
@@ -69,3 +73,6 @@
 	color: var(--color-error);
 }
 
+.team-list__action-button {
+	padding: 0;
+}

--- a/client/a8c-for-agencies/sections/team/primary/team-list/style.scss
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/style.scss
@@ -1,6 +1,13 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .team-list {
 	.a4a-layout__body {
-		padding-block-start: 32px;
+		margin-block-end: 16px;
+
+		@include break-medium {
+			padding-block-start: 32px;
+		}
 	}
 
 	.dataviews__view-actions {
@@ -8,7 +15,12 @@
 	}
 
 	.a4a-layout__navigation-wrapper {
+		margin-block-end: 16px;
 		max-width: 100%;
+
+		@include break-medium {
+			margin-block-end: 0;
+		}
 	}
 
 	.dataviews-view-table__row td:last-child {
@@ -16,7 +28,6 @@
 		padding: 16px 48px;
 
 	}
-
 }
 
 

--- a/client/a8c-for-agencies/sections/team/primary/team-list/table.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/table.tsx
@@ -1,0 +1,120 @@
+import { getCurrentUser } from '@automattic/calypso-analytics';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { useTranslate } from 'i18n-calypso';
+import { ReactNode, useMemo, useState } from 'react';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { useSelector } from 'calypso/state';
+import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
+import useHandleMemberAction from '../../hooks/use-handle-member-action';
+import { TeamMember } from '../../types';
+import { ActionColumn, DateColumn, MemberColumn, RoleStatusColumn } from './columns';
+
+type Props = {
+	data: TeamMember[];
+	onRefresh?: () => void;
+};
+
+export function TeamTable( { data, onRefresh }: Props ) {
+	const translate = useTranslate();
+
+	const isDesktop = useDesktopBreakpoint();
+
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
+		...initialDataViewsState,
+		layout: {
+			styles: {
+				actions: {
+					width: isDesktop ? '10%' : undefined,
+				},
+			},
+		},
+	} );
+
+	const handleAction = useHandleMemberAction( { onRefetchList: onRefresh } );
+
+	const canRemove = useSelector( ( state: A4AStore ) =>
+		hasAgencyCapability( state, 'a4a_remove_users' )
+	);
+
+	const currentUser = useSelector( getCurrentUser );
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'user',
+				label: translate( 'User' ).toUpperCase(),
+				getValue: ( { item }: { item: TeamMember } ) => item.displayName ?? '',
+				render: ( { item }: { item: TeamMember } ): ReactNode => {
+					return <MemberColumn member={ item } withRoleStatus={ ! isDesktop } />;
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			...( isDesktop
+				? [
+						{
+							id: 'role',
+							label: translate( 'Role' ).toUpperCase(),
+							getValue: ( { item }: { item: TeamMember } ) => item.role || '',
+							render: ( { item }: { item: TeamMember } ): ReactNode => {
+								return <RoleStatusColumn member={ item } />;
+							},
+							enableHiding: false,
+							enableSorting: false,
+						},
+						{
+							id: 'added-date',
+							getValue: ( { item }: { item: TeamMember } ): string => item.dateAdded || '',
+							label: translate( 'Added' ).toUpperCase(),
+							render: ( { item }: { item: TeamMember } ): ReactNode => {
+								return <DateColumn date={ item.dateAdded } />;
+							},
+							enableHiding: false,
+							enableSorting: false,
+						},
+				  ]
+				: [] ),
+			{
+				id: 'actions',
+				getValue: () => '',
+				label: '',
+				render: ( { item }: { item: TeamMember } ): ReactNode => {
+					return (
+						<ActionColumn
+							member={ item }
+							onMenuSelected={ ( action, callback ) => handleAction( action, item, callback ) }
+							canRemove={ canRemove || item.email === currentUser?.email }
+						/>
+					);
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+		],
+		[ canRemove, currentUser?.email, handleAction, isDesktop, translate ]
+	);
+
+	const { data: items, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data, dataViewsState, fields );
+	}, [ data, dataViewsState, fields ] );
+
+	return (
+		<ItemsDataViews
+			data={ {
+				items,
+				getItemId: ( user ) => `${ user.id }`,
+				pagination: paginationInfo,
+				enableSearch: false,
+				fields,
+				actions: [],
+				setDataViewsState: setDataViewsState,
+				dataViewsState: dataViewsState,
+				defaultLayouts: { table: {} },
+			} }
+		/>
+	);
+}


### PR DESCRIPTION
To enhance navigation on the Team page, this PR splits the active members and invited members into two tables.

| Before | After |
|--------|--------|
| <img width="1469" alt="Screenshot 2024-09-09 at 5 40 00 PM" src="https://github.com/user-attachments/assets/baebc86f-aac4-40bc-a655-ed14431d314b"> | <img width="1472" alt="Screenshot 2024-09-09 at 5 39 39 PM" src="https://github.com/user-attachments/assets/0437e435-430c-43e3-a6e6-bbcd9e998d1e"><img width="1469" alt="Screenshot 2024-09-09 at 5 39 45 PM" src="https://github.com/user-attachments/assets/243657d2-1969-4c8f-9be9-19bade49ae2e"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1025

## Proposed Changes

* Add a navigation tab in the Team's page layout with 'Active members' and 'Invited' tabs.
* Render two separate tables for the active members and the invited members.
* Improves some few codes related to this PR which includes the member list hook.

## Why are these changes being made?

*. Improves UX in the Team section page.

## Testing Instructions

* Use the A4A live link and go to the `/team` page.
* Add users and create invites.
* Confirm that the page now renders two tabs for active members and invited members.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
