### PR TITLE
A4A: Add 'Manage team members' KB links and track events.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
@@ -2,13 +2,21 @@ import { Button } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import illustration from 'calypso/assets/images/a8c-for-agencies/request-wp-admin-access-illustration.svg';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
 
 export function A4ARequestWPAdminAccess() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
-	const kbArticleUrl = '#'; // FIXME: Add the correct URL
+	const onLearnMoreClick = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_click' ) );
+	};
+
+	const kbArticleUrl =
+		'https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members/#allowing-team-members-to-access-wp-admin';
 
 	return (
 		<div className="a4a-request-wp-admin-access">
@@ -29,6 +37,7 @@ export function A4ARequestWPAdminAccess() {
 					variant="link"
 					className="a4a-request-wp-admin-access__learn-more-button"
 					href={ kbArticleUrl }
+					onClick={ onLearnMoreClick }
 					target="_blank"
 				>
 					<>

--- a/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
@@ -12,7 +12,7 @@ export function A4ARequestWPAdminAccess() {
 	const dispatch = useDispatch();
 
 	const onLearnMoreClick = () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_click' ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_wp_admin_access_click' ) );
 	};
 
 	const kbArticleUrl =

--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -27,7 +27,7 @@ export default function GetStarted() {
 	};
 
 	const onLearnMoreClick = () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_click' ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_managing_members_click' ) );
 	};
 
 	return (

--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -26,6 +26,10 @@ export default function GetStarted() {
 		dispatch( recordTracksEvent( 'calypso_a4a_team_invite_team_member_click' ) );
 	};
 
+	const onLearnMoreClick = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_click' ) );
+	};
+
 	return (
 		<Layout className="team-list-get-started" title={ title } wide compact>
 			<LayoutTop>
@@ -83,7 +87,8 @@ export default function GetStarted() {
 						className="team-list-get-started__learn-more-button"
 						variant="link"
 						target="_blank"
-						href="#" // FIXME: Add link to the KB article
+						href="https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members"
+						onClick={ onLearnMoreClick }
 					>
 						{ translate( 'Team members Knowledge Base article' ) }
 						<Icon icon={ external } size={ 18 } />

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
@@ -7,7 +7,9 @@ import {
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StepSection from 'calypso/a8c-for-agencies/sections/referrals/common/step-section';
 import StepSectionItem from 'calypso/a8c-for-agencies/sections/referrals/common/step-section-item';
+import { useDispatch } from 'calypso/state';
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 type Props = {
 	currentAgency: Agency;
@@ -16,6 +18,11 @@ type Props = {
 
 export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: Props ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onLearnMoreClick = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_click' ) );
+	};
 
 	return (
 		<>
@@ -89,7 +96,8 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 					className="team-accept-invite__learn-more-button"
 					variant="link"
 					target="_blank"
-					href="#" // FIXME: Add link to the KB article
+					href="https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members/#accepting-an-invitation-a-team-member-s-guide"
+					onClick={ onLearnMoreClick }
 				>
 					{ translate( 'Team members Knowledge Base article' ) }
 					<Icon icon={ external } size={ 18 } />

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
@@ -21,7 +21,7 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 	const dispatch = useDispatch();
 
 	const onLearnMoreClick = () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_click' ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_joining_agency_click' ) );
 	};
 
 	return (


### PR DESCRIPTION
This pull request includes the missing KB URLs for the 'Manage team members' KB links.

Closes  https://github.com/Automattic/automattic-for-agencies-dev/issues/980

| Description | Screen |
|--------|--------|
| Get started view | <img width="890" alt="Screenshot 2024-09-09 at 5 59 14 PM" src="https://github.com/user-attachments/assets/2323017f-573c-4b06-ab7e-d056220c5b40"> |
| No multi-agency message | <img width="1019" alt="Screenshot 2024-09-09 at 6 03 05 PM" src="https://github.com/user-attachments/assets/825fa20f-9c20-466b-9372-4e2ceb169e48"> |
| No WP-Admin permission check | <img width="1402" alt="Screenshot 2024-09-09 at 6 01 48 PM" src="https://github.com/user-attachments/assets/78d35a88-a21a-42d6-99cd-7bc3aace94b6"> | 

## Proposed Changes

* Update KB links with the correct URL.
* Add some track events.

## Why are these changes being made?

* We need to make sure we have accessible links to KB articles to reduce support assistance.

## Testing Instructions

**Get start view**
* Use the A4A live link and go to the `/team` page.
* Remove all members or pending invites.
* Confirm the KB link is working.

**No multi-agency message**
* Spin up this branch locally.
* Attempt to invite a user who is already on an existing agency.
* Access the Magic link sent to the email.
* Replace the https://agencies.automattic.com with http://agencies.localhost:3000/
* Confirm that the KB link is working.

**No WP-Admin permission check**
* Login as a member
* Use the A4A live link and go to the `/sites` page.
* Expand a site that the member does not have WP-Admin access.
* Confirm that the KB link in the message is working.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
