### PR TITLE
A4A Sites & Referrals: fix styles for sticky actions column

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -81,17 +81,6 @@ $data-view-border-color: #f1f1f1;
 		.dataviews-view-table tr td:first-child {
 			padding-inline-start: 64px;
 		}
-		.dataviews-view-table tr {
-			th:last-child,
-			td:last-child {
-				padding-inline-end: 64px;
-				width: 20px;
-				white-space: nowrap;
-				position: sticky;
-				right: 0;
-				z-index: 1;
-			}
-		}
 	}
 
 	.referrals-overview__section-container {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -67,19 +67,6 @@
 		&.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-subtitle {
 			display: none;
 		}
-
-		.dataviews-view-table tr {
-			th:last-child,
-			td:last-child {
-				width: 20px;
-				white-space: nowrap;
-				background: linear-gradient(90deg, #0000 0, #fff 25%);
-				padding-left: 48px;
-				position: sticky;
-				right: 0;
-				z-index: 1;
-			}
-		}
 	}
 
 	@media (max-width: 660px) {

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -56,8 +56,6 @@
 		}
 
 		&:hover {
-			background: var(--color-neutral-0);
-
 			.site-set-favorite__favorite-icon,
 			.components-checkbox-control__input {
 				opacity: 1;

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -239,3 +239,20 @@
 .dataviews-filters__summary-chip {
 	font-size: 0.875rem;
 }
+
+// TODO: remove when this is implemented upstream.
+//
+// https://github.com/WordPress/gutenberg/pull/65086
+.is-section-a8c-for-agencies-referrals .dataviews-view-table tr,
+.is-section-a8c-for-agencies-sites .dataviews-view-table tr {
+	th:last-child,
+	td:last-child {
+		width: 20px;
+		white-space: nowrap;
+		position: sticky;
+		right: 0;
+		z-index: 1;
+		background: linear-gradient(90deg, #0000 0, #fff 25%);
+		padding-left: 48px;
+	}
+}

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -27,8 +27,6 @@
 		}
 
 		&:hover {
-			background: var(--color-neutral-0);
-
 			.site-set-favorite__favorite-icon,
 			.components-checkbox-control__input {
 				opacity: 1;
@@ -252,7 +250,7 @@
 		position: sticky;
 		right: 0;
 		z-index: 1;
-		background: linear-gradient(90deg, #0000 0, #fff 25%);
+		background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0, rgb(255, 255, 255) 25%);
 		padding-left: 48px;
 	}
 }


### PR DESCRIPTION
## What

This PR fixes the sticky actions column for A4A Sites and A4A Referrals.

## How

A4A Sites, when the actions' table header was hovered, there was a color artifact:

| Before | After |
| --- | --- |
| <img width="567" alt="Captura de ecrã 2024-09-09, às 12 32 16" src="https://github.com/user-attachments/assets/c1f4306d-3f22-44b0-92ff-8c2d6891ed75"> | <img width="567" alt="Captura de ecrã 2024-09-09, às 12 32 01" src="https://github.com/user-attachments/assets/0a4f430b-2506-4851-b64e-5e6f11edcf99"> |

A4A Referrals: the actions' column was sticky but transparent.

| Before | After |
| --- | --- |
| <img width="567" alt="Captura de ecrã 2024-09-09, às 12 36 17" src="https://github.com/user-attachments/assets/6ca612c5-f686-49ee-8134-9d096d5d13e8"> | <img width="567" alt="Captura de ecrã 2024-09-09, às 12 36 04" src="https://github.com/user-attachments/assets/43b6f536-75a9-4269-b80a-51c5db37c17e"> |

