### PR TITLE
Sites DataViews: Remove the padding around the table columns to fix alignment

### DIFF
--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -147,15 +147,6 @@
 	table.dataviews-view-table thead .dataviews-view-table__row th {
 		border-bottom-color: var(--color-border-secondary);
 
-		@include break-large {
-			padding-left: 26px;
-		}
-		@include break-huge {
-			&:first-child {
-				padding-left: 64px;
-			}
-		}
-
 		&:nth-child(4) {
 			.site-sort {
 				display: inline-block;
@@ -184,14 +175,6 @@
 
 	table.dataviews-view-table .dataviews-view-table__row td {
 		border-bottom-color: var(--color-border-secondary);
-		@include break-large {
-			padding-left: 26px;
-		}
-		@include break-huge {
-			&:first-child {
-				padding-left: 64px;
-			}
-		}
 		&:nth-child(2) {
 			white-space: wrap;
 			overflow-wrap: anywhere;

--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -180,19 +180,19 @@ const SitesDashboard = ( {
 					width: getSiteNameColWidth( isDesktop, isWide ),
 				},
 				plan: {
-					width: '100px',
+					width: '126px',
 				},
 				status: {
-					width: '116px',
+					width: '142px',
 				},
 				'last-publish': {
-					width: '120px',
+					width: '146px',
 				},
 				stats: {
-					width: '80px',
+					width: '106px',
 				},
 				actions: {
-					width: '48px',
+					width: '74px',
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #94199

## Proposed Changes

In this previous PR https://github.com/Automattic/wp-calypso/pull/90420 custom paddings have been added to the different table columns in the sites dataviews. The reason for these paddings is a bit unclear to me and would love some help understanding it.

Anyway, I feel like we shouldn't be overriding the default column table paddings, so this PR reverts a part of this PR. Removing the padding fixes the alignment of the columns between the headers and the body of the table.

The removal of the paddings make the columns that have a fixed width smaller potentially causing the columns to overlap (depending on the language and the length of the label). Personally I would argue that we should remove these columns fixed widths entirely. But I don't really know the reasons for the existence of these widths so to trade carefully there, I only increased their size to compensate for the removed padding.

## Testing Instructions

* Open the `/sites` dashboard
* Check that the different column widths and alignments are correct in different screen sizes.

<img width="1084" alt="Screenshot 2024-09-09 at 12 47 38 PM" src="https://github.com/user-attachments/assets/5ae2ad82-31e4-498d-b664-e555617d1a16">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
