### PR TITLE
Site Level User Profile: clean up feature flags (take 2)

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -361,10 +361,7 @@ class Layout extends Component {
 				) }
 				<QueryPreferences />
 				<QuerySiteFeatures siteIds={ [ this.props.siteId ] } />
-				{ ( this.props.isUnifiedSiteSidebarVisible ||
-					config.isEnabled( 'layout/site-level-user-profile' ) ) && (
-					<QuerySiteAdminColor siteId={ this.props.siteId } />
-				) }
+				<QuerySiteAdminColor siteId={ this.props.siteId } />
 				{ config.isEnabled( 'layout/query-selected-editor' ) && (
 					<QuerySiteSelectedEditor siteId={ this.props.siteId } />
 				) }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -500,12 +500,8 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderProfileMenu() {
-		const { translate, user, siteUrl, isClassicView } = this.props;
-		const editProfileLink =
-			siteUrl && ( config.isEnabled( 'layout/site-level-user-profile' ) || isClassicView )
-				? siteUrl + '/wp-admin/profile.php'
-				: '/me';
-
+		const { translate, user, siteAdminUrl } = this.props;
+		const editProfileLink = siteAdminUrl ? `${ siteAdminUrl }profile.php` : '/me';
 		const profileActions = [
 			{
 				label: (

--- a/client/layout/masterbar/test/logged-in.js
+++ b/client/layout/masterbar/test/logged-in.js
@@ -5,7 +5,7 @@ import { screen } from '@testing-library/react';
 import React from 'react';
 import commandPaletteReducer from 'calypso/state/command-palette/reducers';
 import preferencesReducer from 'calypso/state/preferences/reducer';
-import { getSiteUrl } from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import uiReducer from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import MasterbarLoggedIn from '../logged-in';
@@ -42,7 +42,7 @@ test( 'edit profile menu link goes to /me when the user has no site', () => {
 } );
 
 test( 'edit profile menu link goes to site.com/wp-admin/profile.php when the user has a site', () => {
-	getSiteUrl.mockReturnValue( 'example.com' );
+	getSiteAdminUrl.mockReturnValue( 'example.com/wp-admin/' );
 
 	renderWithState( <MasterbarLoggedIn /> );
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -9,7 +9,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
-import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
@@ -30,7 +29,6 @@ import SectionHeader from 'calypso/components/section-header';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { withGeoLocation } from 'calypso/data/geo/with-geolocation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { supportsCssCustomProperties } from 'calypso/lib/feature-detection';
 import { ENABLE_TRANSLATOR_KEY } from 'calypso/lib/i18n-utils/constants';
 import { onboardingUrl } from 'calypso/lib/paths';
 import { protectForm } from 'calypso/lib/protect-form';
@@ -677,24 +675,6 @@ class Account extends Component {
 					{ this.renderPrimarySite() }
 				</FormFieldset>
 
-				{ ! config.isEnabled( 'layout/site-level-user-profile' ) && (
-					<FormFieldset>
-						<FormLabel htmlFor="user_URL">{ translate( 'Web address' ) }</FormLabel>
-						<FormTextInput
-							disabled={ this.getDisabledState( ACCOUNT_FORM_NAME ) }
-							id="user_URL"
-							name="user_URL"
-							type="url"
-							onFocus={ this.getFocusHandler( 'Web Address Field' ) }
-							value={ this.getUserSetting( 'user_URL' ) || '' }
-							onChange={ this.updateUserSettingInput }
-						/>
-						<FormSettingExplanation>
-							{ translate( 'Shown publicly when you comment on blogs.' ) }
-						</FormSettingExplanation>
-					</FormFieldset>
-				) }
-
 				<FormButton
 					isSubmitting={ this.isSubmittingForm( ACCOUNT_FORM_NAME ) }
 					disabled={ this.shouldDisableAccountSubmitButton() }
@@ -962,27 +942,16 @@ class Account extends Component {
 							<ToggleSitesAsLandingPage />
 						</FormFieldset>
 
-						{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
-							supportsCssCustomProperties() && (
-								<FormFieldset>
-									<FormLabel id="account__color_scheme" htmlFor="color_scheme">
-										{ translate( 'Dashboard color scheme' ) }
-									</FormLabel>
-									{ config.isEnabled( 'layout/site-level-user-profile' ) ? (
-										<FormSettingExplanation>
-											{ translate(
-												'You can now set the color scheme on your individual site by visiting Users → Profile from your site dashboard.'
-											) }
-										</FormSettingExplanation>
-									) : (
-										<ColorSchemePicker
-											disabled={ this.getDisabledState( INTERFACE_FORM_NAME ) }
-											defaultSelection="classic-dark"
-											onSelection={ this.updateColorScheme }
-										/>
-									) }
-								</FormFieldset>
-							) }
+						<FormFieldset>
+							<FormLabel id="account__color_scheme" htmlFor="color_scheme">
+								{ translate( 'Dashboard color scheme' ) }
+							</FormLabel>
+							<FormSettingExplanation>
+								{ translate(
+									'You can now set the color scheme on your individual site by visiting Users → Profile from your site dashboard.'
+								) }
+							</FormSettingExplanation>
+						</FormFieldset>
 					</form>
 				</Card>
 

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Card, FormLabel } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
@@ -101,33 +100,29 @@ class Profile extends Component {
 								onFocus={ this.getFocusHandler( 'Display Name Field' ) }
 								value={ this.props.getSetting( 'display_name' ) }
 							/>
-							{ isEnabled( 'layout/site-level-user-profile' ) && (
-								<FormSettingExplanation>
-									{ this.props.translate( 'Shown publicly when you comment on blogs.' ) }
-								</FormSettingExplanation>
-							) }
+							<FormSettingExplanation>
+								{ this.props.translate( 'Shown publicly when you comment on blogs.' ) }
+							</FormSettingExplanation>
 						</FormFieldset>
 
-						{ isEnabled( 'layout/site-level-user-profile' ) && (
-							<FormFieldset>
-								<FormLabel htmlFor="user_URL">
-									{ this.props.translate( 'Public web address' ) }
-								</FormLabel>
-								<FormTextInput
-									disabled={ this.props.getDisabledState() }
-									id="user_URL"
-									name="user_URL"
-									type="url"
-									onChange={ this.props.updateSetting }
-									onFocus={ this.getFocusHandler( 'Web Address Field' ) }
-									placeholder="https://example.com"
-									value={ this.props.getSetting( 'user_URL' ) }
-								/>
-								<FormSettingExplanation>
-									{ this.props.translate( 'Shown publicly when you comment on blogs.' ) }
-								</FormSettingExplanation>
-							</FormFieldset>
-						) }
+						<FormFieldset>
+							<FormLabel htmlFor="user_URL">
+								{ this.props.translate( 'Public web address' ) }
+							</FormLabel>
+							<FormTextInput
+								disabled={ this.props.getDisabledState() }
+								id="user_URL"
+								name="user_URL"
+								type="url"
+								onChange={ this.props.updateSetting }
+								onFocus={ this.getFocusHandler( 'Web Address Field' ) }
+								placeholder="https://example.com"
+								value={ this.props.getSetting( 'user_URL' ) }
+							/>
+							<FormSettingExplanation>
+								{ this.props.translate( 'Shown publicly when you comment on blogs.' ) }
+							</FormSettingExplanation>
+						</FormFieldset>
 
 						<FormFieldset>
 							<FormLabel htmlFor="description">{ this.props.translate( 'About me' ) }</FormLabel>

--- a/config/development.json
+++ b/config/development.json
@@ -126,7 +126,6 @@
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
-		"layout/site-level-user-profile": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": true,
 		"livechat_solution": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -78,7 +78,6 @@
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
-		"layout/site-level-user-profile": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,

--- a/config/production.json
+++ b/config/production.json
@@ -102,7 +102,6 @@
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
-		"layout/site-level-user-profile": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -98,7 +98,6 @@
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
-		"layout/site-level-user-profile": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -95,7 +95,6 @@
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
-		"layout/site-level-user-profile": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,


### PR DESCRIPTION
This is a re-do of https://github.com/Automattic/wp-calypso/pull/94315, which had to be reverted (see discussion: p1725864944279569-slack-C047ACYM8UQ)

The only difference is that we reverted this change:

https://github.com/Automattic/wp-calypso/pull/94315/files#diff-f6f644435925f8d32f55672ed90ae4d6260160c18937b3f3a9124e087cc3f5ccL151-L153

## Proposed Changes

This is the last step to finish pbxlJb-63Y-p2 once and for all.

This PR cleans up the `layout/site-level-user-profile` and the old `me/account/color-scheme-picker` flags.

## Why are these changes being made?

Cleaning up launched feature flags.

## Testing Instructions

Smoke test the feature:

1. Verify that the `Howdy` -> `Edit Profile` menu point to `profile.php`.
1. Verify that the `Howdy` -> `My Account` menu point to `/me`.
2. Verify that `/me` contain the `Public web address` field.
2. Verify that `/me/account` does not contain the `Web address` field.
2. Verify that `/me/account` does not contain the color scheme picker.
2. Verify that you can change the color scheme from `profile.php` and it gets reflected to Calypso pages.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?