### PR TITLE
A4A: Implement 'Resend invite' functionality on the Team members page.

### DIFF
--- a/client/a8c-for-agencies/data/team/use-resend-member-invite.ts
+++ b/client/a8c-for-agencies/data/team/use-resend-member-invite.ts
@@ -1,0 +1,44 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+interface APIError {
+	status: number;
+	code: string | null;
+	message: string;
+}
+
+export interface resendMemberInviteParams {
+	id: number;
+}
+
+interface APIResponse {
+	success: boolean;
+}
+
+function resendMemberInviteMutation(
+	params: resendMemberInviteParams,
+	agencyId?: number
+): Promise< APIResponse > {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to assign a license' );
+	}
+
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/user-invites/${ params.id }/resend`,
+		method: 'POST',
+	} );
+}
+
+export default function useResendMemberInviteMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, resendMemberInviteParams, TContext >
+): UseMutationResult< APIResponse, APIError, resendMemberInviteParams, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< APIResponse, APIError, resendMemberInviteParams, TContext >( {
+		...options,
+		mutationFn: ( args ) => resendMemberInviteMutation( args, agencyId ),
+	} );
+}

--- a/client/a8c-for-agencies/data/team/use-resend-member-invite.ts
+++ b/client/a8c-for-agencies/data/team/use-resend-member-invite.ts
@@ -22,7 +22,7 @@ function resendMemberInviteMutation(
 	agencyId?: number
 ): Promise< APIResponse > {
 	if ( ! agencyId ) {
-		throw new Error( 'Agency ID is required to assign a license' );
+		throw new Error( 'Agency ID is required to resend invite' );
 	}
 
 	return wpcom.req.post( {

--- a/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
@@ -29,7 +29,7 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 					{
 						onSuccess: () => {
 							dispatch(
-								successNotice( translate( 'The invitation has been resend.' ), {
+								successNotice( translate( 'The invitation has been resent.' ), {
 									id: 'resend-user-invite-success',
 									duration: 5000,
 								} )

--- a/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import useCancelMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-cancel-member-invite';
 import useRemoveMemberMutation from 'calypso/a8c-for-agencies/data/team/use-remove-member';
+import useResendMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-resend-member-invite';
 import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { TeamMember } from '../types';
@@ -14,12 +15,42 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const { mutate: resendMemberInvite } = useResendMemberInviteMutation();
+
 	const { mutate: cancelMemberInvite } = useCancelMemberInviteMutation();
 
 	const { mutate: removeMember } = useRemoveMemberMutation();
 
 	return useCallback(
 		( action: string, item: TeamMember, callback?: () => void ) => {
+			if ( action === 'resend-user-invite' ) {
+				resendMemberInvite(
+					{ id: item.id },
+					{
+						onSuccess: () => {
+							dispatch(
+								successNotice( translate( 'The invitation has been resend.' ), {
+									id: 'resend-user-invite-success',
+									duration: 5000,
+								} )
+							);
+							onRefetchList?.();
+							callback?.();
+						},
+
+						onError: ( error ) => {
+							dispatch(
+								errorNotice( error.message, {
+									id: 'resend-user-invite-error',
+									duration: 5000,
+								} )
+							);
+							callback?.();
+						},
+					}
+				);
+			}
+
 			if ( action === 'cancel-user-invite' ) {
 				cancelMemberInvite(
 					{ id: item.id },

--- a/client/a8c-for-agencies/sections/team/hooks/use-member-list.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-member-list.ts
@@ -29,7 +29,7 @@ export function useMemberList() {
 				displayName: invite.displayName,
 				email: invite.email,
 				avatar: invite.avatar,
-				status: 'pending' as const,
+				status: invite.status as 'active' | 'pending' | 'expired',
 			} ) ) ?? [] ),
 		];
 

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -139,12 +139,11 @@ export const ActionColumn = ( {
 	);
 
 	const actions = useMemo( () => {
-		return member.status === 'pending'
+		return member.status === 'pending' || member.status === 'expired'
 			? [
 					{
 						name: 'resend-user-invite',
 						label: translate( 'Resend invite' ),
-						className: 'is-danger',
 						isEnabled: true,
 					},
 					{

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -142,6 +142,12 @@ export const ActionColumn = ( {
 		return member.status === 'pending'
 			? [
 					{
+						name: 'resend-user-invite',
+						label: translate( 'Resend invite' ),
+						className: 'is-danger',
+						isEnabled: true,
+					},
+					{
 						name: 'cancel-user-invite',
 						label: translate( 'Cancel invite' ),
 						className: 'is-danger',


### PR DESCRIPTION
This pull request adds the 'Resend invite' capability to the Team members page.

<img width="303" alt="Screenshot 2024-09-09 at 6 59 16 PM" src="https://github.com/user-attachments/assets/3b99583b-8394-4384-af00-557863cabd54">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/967

## Proposed Changes

* Add a **'Resend invite'** button to the Actions column, including the event handler and mutation hook.
* Additional: Fix hardcoded Pending state for user invites and missing handler for expired state.

## Why are these changes being made?

* This allows users to resend an invite in case of problems with the original invitation.

## Testing Instructions

* Use the A4A live link and go to the `/team` page.
* Create a member invite.
* Confirm you received the email. (Make sure you do not access it)
* In the Team member table, resend the invite.
* Confirm you received another email.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
