### PR TITLE
Stepper: Remove `steps` param from `useStepNavigation`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -19,20 +19,14 @@ interface Params< FlowSteps extends StepperStep[] > {
 	flow: Flow;
 	currentStepRoute: string;
 	navigate: Navigate< FlowSteps >;
-	steps: StepperStep[];
 }
 
 export const useStepNavigationWithTracking = ( {
 	flow,
 	currentStepRoute,
 	navigate,
-	steps,
 }: Params< ReturnType< Flow[ 'useSteps' ] > > ) => {
-	const stepNavigation = flow.useStepNavigation(
-		currentStepRoute,
-		navigate,
-		steps.map( ( step ) => step.slug )
-	);
+	const stepNavigation = flow.useStepNavigation( currentStepRoute, navigate );
 	const intent =
 		useSelect( ( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(), [] ) ?? '';
 	const tracksEventPropsFromFlow = flow.useTracksEventProps?.();

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/test/index.tsx
@@ -22,27 +22,26 @@ jest.mock( '../../../analytics/record-step-navigation', () => ( {
 	recordStepNavigation: jest.fn(),
 } ) );
 
+const stepNavControls = {
+	submit: jest.fn(),
+	exitFlow: jest.fn(),
+	goBack: jest.fn(),
+	goNext: jest.fn(),
+	goToStep: jest.fn(),
+};
+
+const mockParams = {
+	flow: {
+		name: 'mock-flow',
+		isSignupFlow: false,
+		useSteps: () => [],
+		useStepNavigation: () => stepNavControls,
+	},
+	currentStepRoute: 'mock-step',
+	navigate: () => {},
+};
+
 describe( 'useStepNavigationWithTracking', () => {
-	const stepNavControls = {
-		submit: jest.fn(),
-		exitFlow: jest.fn(),
-		goBack: jest.fn(),
-		goNext: jest.fn(),
-		goToStep: jest.fn(),
-	};
-
-	const mockParams = {
-		flow: {
-			name: 'mock-flow',
-			isSignupFlow: false,
-			useSteps: () => [],
-			useStepNavigation: () => stepNavControls,
-		},
-		currentStepRoute: 'mock-step',
-		navigate: () => {},
-		steps: [],
-	};
-
 	beforeEach( () => {
 		jest.clearAllMocks();
 	} );
@@ -55,6 +54,20 @@ describe( 'useStepNavigationWithTracking', () => {
 		expect( result.current ).toHaveProperty( 'goBack' );
 		expect( result.current ).toHaveProperty( 'goNext' );
 		expect( result.current ).toHaveProperty( 'goToStep' );
+	} );
+
+	it( 'ensures reference equality given same input', () => {
+		const { result, rerender } = renderHook(
+			( params ) => useStepNavigationWithTracking( params ),
+			{
+				initialProps: mockParams,
+			}
+		);
+
+		const previous = result.current;
+
+		rerender( mockParams );
+		expect( result.current ).toBe( previous );
 	} );
 
 	it( 'calls the wrapped submit control with correct parameters and records the respective event', () => {

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -112,7 +112,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		flow,
 		currentStepRoute,
 		navigate,
-		steps: flowSteps,
 	} );
 
 	// Retrieve any extra step data from the stepper-internal store. This will be passed as a prop to the current step.

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -101,8 +101,7 @@ export type UseStepsHook = () => StepperStep[];
 
 export type UseStepNavigationHook< FlowSteps extends StepperStep[] > = (
 	currentStepSlug: FlowSteps[ number ][ 'slug' ],
-	navigate: Navigate< FlowSteps >,
-	steps?: FlowSteps[ number ][ 'slug' ][]
+	navigate: Navigate< FlowSteps >
 ) => NavigationControls;
 
 export type UseAssertConditionsHook< FlowSteps extends StepperStep[] > = (

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -27,9 +27,10 @@ import {
 } from './plugin-bundle-data';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
 
-const getNextStep = ( currentStep: string, steps: string[] ): string | undefined => {
-	const currentStepIndex = steps.indexOf( currentStep );
-	const nextStep = steps[ currentStepIndex + 1 ];
+const getNextStep = ( currentStep: string, steps: StepperStep[] ): string | undefined => {
+	const stepsIndex = steps.map( ( step ) => step.slug );
+	const currentStepIndex = stepsIndex.indexOf( currentStep );
+	const nextStep = stepsIndex[ currentStepIndex + 1 ];
 
 	return nextStep;
 };
@@ -54,7 +55,8 @@ const pluginBundleFlow: Flow = {
 		}
 		return [ ...initialBundleSteps, ...bundlePluginSteps ];
 	},
-	useStepNavigation( currentStep, navigate, steps = [] ) {
+	useStepNavigation( currentStep, navigate ) {
+		const steps = this.useSteps();
 		const intent = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 			[]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/93808

## Proposed Changes

- Removes `steps` parameter from `flow.useStepNavigation`. This invalidates the internal cache in `useStepNavigationWithTracking` for no good reason. No use that's not possible through calling `flow.useSteps`
- Updates `plugin-bundle-flow`
- Updates tests to ensure `useStepNavigationWithTracking` returns properly memoized results on same parameter references

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Addresses https://github.com/Automattic/wp-calypso/issues/93808

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ensure step navigation events get logged as expected when navigating through flow (these are defined in [constants.ts](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/constants.ts) as `STEPPER_TRACKS_EVENTS_STEP_NAV`)
  * test `/setup/onboarding`
  * test `/setup/plugin-bundle` (confirm step submit event works correctly). See testing instructions in [comment below](https://github.com/Automattic/wp-calypso/pull/94328#issuecomment-2346081110)
* tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
