### PR TITLE
Performance Profiler: add error screen for invalid URL

### DIFF
--- a/client/performance-profiler/components/message-display/index.tsx
+++ b/client/performance-profiler/components/message-display/index.tsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import styled from '@emotion/styled';
 import { Button, IconType } from '@wordpress/components';
 import clsx from 'clsx';
 import { ReactNode } from 'react';
@@ -16,6 +17,12 @@ type Props = {
 	ctaIcon?: string;
 	isErrorMessage?: boolean;
 };
+
+export const ErrorSecondLine = styled.span`
+	color: var( --studio-red-5 );
+	font-weight: 400;
+	line-height: 20px;
+`;
 
 export const MessageDisplay = ( {
 	displayBadge = false,

--- a/client/performance-profiler/pages/weekly-report/index.tsx
+++ b/client/performance-profiler/pages/weekly-report/index.tsx
@@ -3,7 +3,10 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useLeadMutation } from 'calypso/data/site-profiler/use-lead-query';
-import { MessageDisplay } from 'calypso/performance-profiler/components/message-display';
+import {
+	MessageDisplay,
+	ErrorSecondLine,
+} from 'calypso/performance-profiler/components/message-display';
 
 type WeeklyReportProps = {
 	url: string;
@@ -59,12 +62,6 @@ const LoaderText = styled.span`
 			-webkit-transform: rotate( 360deg );
 		}
 	}
-`;
-
-const ErrorSecondLine = styled.span`
-	color: var( --studio-red-5 );
-	font-weight: 400;
-	line-height: 20px;
 `;
 
 export const WeeklyReport = ( props: WeeklyReportProps ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9045

## Proposed Changes

* Add an error state to the performance profiler dashboard
* Show error state when the `/basic` endpoint returns an error

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/dotcom-forge/issues/9045

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/speed-test` and start a new test with an unregistered URL, eg. `https://thisurldoesntexist.com`
* Check that the error page is shown, and that the CTA navigates back to the landing page
* Check for regressions using other URLs

![CleanShot 2024-09-09 at 13 19 21@2x](https://github.com/user-attachments/assets/5f9c5780-7e38-4ba8-bb1b-4c05762b1823)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
