### PR TITLE
Fix: Plugins sidebar link on single site accounts goes to global plugins page

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -519,6 +519,8 @@ export function noSite( context, next ) {
 	return next();
 }
 
+const PATHS_EXCLUDED_FROM_SINGLE_SITE_CONTEXT_FOR_SINGLE_SITE_USERS = [ '/plugins' ];
+
 /*
  * Set up site selection based on last URL param and/or handle no-sites error cases
  */
@@ -532,7 +534,8 @@ export function siteSelection( context, next ) {
 	const siteFragment = context.params.site || getSiteFragment( context.path );
 	const currentUser = getCurrentUser( getState() );
 	const hasOneSite = currentUser && currentUser.visible_site_count === 1;
-	const isNextPathPlugins = context.path === '/plugins';
+	const isPathExcludedFromSingleSiteContext =
+		PATHS_EXCLUDED_FROM_SINGLE_SITE_CONTEXT_FOR_SINGLE_SITE_USERS.includes( context.path );
 
 	// Making sure non-connected users get redirected to user connection flow.
 	// Details: p9dueE-6Hf-p2
@@ -568,7 +571,7 @@ export function siteSelection( context, next ) {
 	 * current user object and therefore always available, we need to fetch the site info in order
 	 * to convert the site ID to the site slug that will be part of the redirect URL)
 	 */
-	if ( hasOneSite && ! siteFragment && ! isNextPathPlugins ) {
+	if ( hasOneSite && ! siteFragment && ! isPathExcludedFromSingleSiteContext ) {
 		const primarySiteId = getPrimarySiteId( getState() );
 		const primarySiteSlug = getSiteSlug( getState(), primarySiteId );
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -532,6 +532,7 @@ export function siteSelection( context, next ) {
 	const siteFragment = context.params.site || getSiteFragment( context.path );
 	const currentUser = getCurrentUser( getState() );
 	const hasOneSite = currentUser && currentUser.visible_site_count === 1;
+	const isNextPathPlugins = context.path === '/plugins';
 
 	// Making sure non-connected users get redirected to user connection flow.
 	// Details: p9dueE-6Hf-p2
@@ -560,14 +561,14 @@ export function siteSelection( context, next ) {
 
 	/*
 	 * If the user has only one site, redirect to the single site context instead of
-	 * rendering the all-site views.
+	 * rendering the all-site views. Exclude plugins page from this behavior.
 	 *
 	 * If the primary site is not yet available in Redux state, initiate a fetch and postpone the
 	 * redirect until the fetch is complete. (while the primary site ID is a property of the
 	 * current user object and therefore always available, we need to fetch the site info in order
 	 * to convert the site ID to the site slug that will be part of the redirect URL)
 	 */
-	if ( hasOneSite && ! siteFragment ) {
+	if ( hasOneSite && ! siteFragment && ! isNextPathPlugins ) {
 		const primarySiteId = getPrimarySiteId( getState() );
 		const primarySiteSlug = getSiteSlug( getState(), primarySiteId );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8054

## Proposed Changes

* The `siteSelection` handler on the `/plugins` route redirects users to the single site context when the account has only one site. I'm adding a check so that doesn't happen and the users go to the global plugins page instead.

## Testing Instructions

* Open the live preview with a single site account
* On the global sidebar, click on the `Plugins` link
* Check that you go to the global plugins page

|Before|After|
|---|---|
|![before](https://github.com/user-attachments/assets/a6dbd689-134e-4c46-b196-1834c40309a4)|![after](https://github.com/user-attachments/assets/87e2f369-4f63-4c9f-9ae5-ff96cf91a2e9)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
