### PR TITLE
Automated Migration: Add tracks event toggling the special instructions on the Credentials step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -172,6 +172,13 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 		requestAutomatedMigration( data );
 	};
 
+	const toggleShowNotes = () => {
+		setShowNotes( ! showNotes );
+		recordTracksEvent( 'calypso_site_migration_special_instructions_toggle', {
+			show_notes: ! showNotes,
+		} );
+	};
+
 	return (
 		<form onSubmit={ handleSubmit( submitHandler ) }>
 			<Card>
@@ -364,10 +371,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 				<div className="site-migration-credentials__special-instructions">
 					{ ( locale === 'en' || hasTranslation( 'Special instructions' ) ) && (
-						<Button
-							onClick={ () => setShowNotes( ! showNotes ) }
-							data-testid="special-instructions"
-						>
+						<Button onClick={ () => toggleShowNotes() } data-testid="special-instructions">
 							{ translate( 'Special instructions' ) }
 							<Icon
 								icon={ showNotes ? chevronUp : chevronDown }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94003

## Proposed Changes

* Add tracks event to the Special Instructions section toggle.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This will help us to understand how many people will use the Special Instruction, or at least have interested in doing so.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In this case, the automated tests are enough to ensure we didn't break the behavior, and the visual inspection should be sufficient. However, if you want to test it manually please follow the steps below:

* Go through the migration flow by navigating to `/start`:
  * Go through the domain selection step
  * Select the free plan on the `Plans` page
  * On the `Goals` step, select the "Import existing content or website" option and click continue
  * Input the source site URL in the Identify step
  * Next, select the "Migrate Site" option on the `Import or Migrate` step
  * Select "Do it for me" on the `How to migrate` step
  * Go through the checkout
  * Once you complete the checkout, you should land on the new `Credentials` step
  * Toggle the special instructions sections a few times
  * Use Tracks Vigilant to confirm that the event is being fired

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
