### PR TITLE
Masterbar: Fix profile link not working in accounts without a site

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -502,9 +502,10 @@ class MasterbarLoggedIn extends Component {
 	renderProfileMenu() {
 		const { translate, user, siteUrl, isClassicView } = this.props;
 		const editProfileLink =
-			config.isEnabled( 'layout/site-level-user-profile' ) || isClassicView
+			siteUrl && ( config.isEnabled( 'layout/site-level-user-profile' ) || isClassicView )
 				? siteUrl + '/wp-admin/profile.php'
 				: '/me';
+
 		const profileActions = [
 			{
 				label: (

--- a/client/layout/masterbar/test/logged-in.js
+++ b/client/layout/masterbar/test/logged-in.js
@@ -41,7 +41,7 @@ test( 'edit profile menu link goes to /me when the user has no site', () => {
 	);
 } );
 
-test( 'edit profile menu link goes to /site/wp-admin/profile.php when the user has a site', () => {
+test( 'edit profile menu link goes to site.com/wp-admin/profile.php when the user has a site', () => {
 	getSiteUrl.mockReturnValue( 'example.com' );
 
 	renderWithState( <MasterbarLoggedIn /> );

--- a/client/layout/masterbar/test/logged-in.js
+++ b/client/layout/masterbar/test/logged-in.js
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import React from 'react';
+import commandPaletteReducer from 'calypso/state/command-palette/reducers';
+import preferencesReducer from 'calypso/state/preferences/reducer';
+import { getSiteUrl } from 'calypso/state/sites/selectors';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import MasterbarLoggedIn from '../logged-in';
+
+jest.mock( 'calypso/state/sites/selectors' );
+jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
+	getSitePlanSlug: jest.fn().mockImplementation( () => 'business-bundle' ),
+} ) );
+
+function renderWithState( ui ) {
+	return renderWithProvider( ui, {
+		reducers: {
+			ui: uiReducer,
+			preferences: preferencesReducer,
+			commandPalette: commandPaletteReducer,
+		},
+		initialState: {
+			currentUser: {
+				user: {
+					display_name: 'John Doe',
+				},
+			},
+		},
+	} );
+}
+
+test( 'edit profile menu link goes to /me when the user has no site', () => {
+	renderWithState( <MasterbarLoggedIn /> );
+
+	expect( screen.getByRole( 'link', { name: 'John Doe Edit Profile' } ) ).toHaveAttribute(
+		'href',
+		'/me'
+	);
+} );
+
+test( 'edit profile menu link goes to /site/wp-admin/profile.php when the user has a site', () => {
+	getSiteUrl.mockReturnValue( 'example.com' );
+
+	renderWithState( <MasterbarLoggedIn /> );
+
+	expect( screen.getByRole( 'link', { name: 'John Doe Edit Profile' } ) ).toHaveAttribute(
+		'href',
+		'example.com/wp-admin/profile.php'
+	);
+} );

--- a/config/test.json
+++ b/config/test.json
@@ -76,6 +76,7 @@
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
+		"layout/site-level-user-profile": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": true,
 		"login/last-used-method": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94249

## Proposed Changes

In accounts without a site, the masterbar profile links go to https://wordpress.com/null/wp-admin/profile.php.

This PR fixes that by linking to https://wordpress.com/me.

To avoid testing gymnastics, it also adds the default state of the `layout/site-level-user-profile` feature to the test config.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/` and log in.
* Because you probably have sites, open `client/state/sites/selectors/get-site-url.js` and edit the `getSiteUrl` function to always return `null`.
* Make sure the "Edit Profile" link points to `/me`.

![image](https://github.com/user-attachments/assets/161b1c7f-d501-4f27-aa48-612dd5d0e80a)

* Revert the code change and make sure the "Edit Profile" link goes to `yoursite.com/wp-admin/profile.php`

![image](https://github.com/user-attachments/assets/21423545-da9b-4dcf-a0aa-408647f80c06)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
