### PR TITLE
Cancellation form: Fix button border and checkbox color

### DIFF
--- a/client/components/blank-canvas/style.scss
+++ b/client/components/blank-canvas/style.scss
@@ -75,10 +75,6 @@
 		color: var(--color-text-inverted);
 		opacity: 0.5;
 	}
-
-	.components-button.is-secondary:focus {
-		box-shadow: inset 0 0 0 1px var(--color-neutral-10);
-	}
 }
 
 .blank-canvas__header {

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -71,15 +71,6 @@
 			text-wrap: pretty;
 		}
 
-		.components-checkbox-control__input[type="checkbox"]:checked {
-			background: var(--studio-black);
-			border-color: var(--studio-black);
-		}
-
-		.components-checkbox-control__input[type="checkbox"]:focus {
-			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-black);
-		}
-
 		.components-checkbox-control__input-container,
 		.components-checkbox-control__input[type="checkbox"],
 		svg.components-checkbox-control__checked {
@@ -131,10 +122,12 @@
 .cancel-purchase-form__buttons {
 	display: flex;
 	position: relative;
+	padding: 3px;
 
 	@include break-small {
 		display: inline-block;
 	}
+
 
 	.components-button {
 		flex: 1;


### PR DESCRIPTION
This PR adds some minor CSS improvements to the cancellation form. 
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to https://github.com/Automattic/wp-calypso/issues/93601

## Proposed Changes

* Change the color of the checkbox to blue
* Fix the border on the submit button on focus mode

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* UI consistency

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link
* Go to Purchases and try to cancel a plan for an AT site
* Notice that the "Submit" button has a top and bottom border in focus state
* Choose other/other so that you land in the AT warning page
* Notice that the checkboxes are now blue (including the border in focus state)
![Screenshot 2024-09-09 at 19 13 48](https://github.com/user-attachments/assets/c2a93149-6f05-4dff-8e7f-f4811e65870a)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
