### PR TITLE
Automated Migration: Cleanup the translation checks on the Credentials step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -3,7 +3,6 @@ import Card from '@automattic/components/src/card';
 import { NextButton, StepContainer } from '@automattic/onboarding';
 import { Icon, Button } from '@wordpress/components';
 import { seen, unseen, chevronDown, chevronUp } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, type FC } from 'react';
@@ -15,7 +14,6 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextArea from 'calypso/components/forms/form-textarea';
-import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isValidUrl } from 'calypso/lib/importer/url-validation';
@@ -42,13 +40,9 @@ const mapApiError = ( error: any ) => {
 
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip } ) => {
 	const translate = useTranslate();
-	const { hasTranslation } = useI18n();
-	const locale = useFlowLocale();
 
 	const [ passwordHidden, setPasswordHidden ] = useState( true );
-	const [ showNotes, setShowNotes ] = useState(
-		! ( locale === 'en' || hasTranslation( 'Special instructions' ) )
-	);
+	const [ showNotes, setShowNotes ] = useState( false );
 
 	const toggleVisibilityClasses = clsx( {
 		'site-migration-credentials__form-password__toggle': true,
@@ -269,11 +263,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 											id="username"
 											type="text"
 											isError={ !! errors.username }
-											placeholder={
-												locale === 'en' || hasTranslation( 'Enter your Admin username' )
-													? translate( 'Enter your Admin username' )
-													: translate( 'Username' )
-											}
+											placeholder={ translate( 'Enter your Admin username' ) }
 											{ ...field }
 											onChange={ ( e: any ) => {
 												const trimmedValue = e.target.value.trim();
@@ -305,11 +295,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 												id="site-migration-credentials__password"
 												type={ passwordHidden ? 'password' : 'text' }
 												isError={ !! errors.password }
-												placeholder={
-													locale === 'en' || hasTranslation( 'Enter your Admin password' )
-														? translate( 'Enter your Admin password' )
-														: translate( 'Password' )
-												}
+												placeholder={ translate( 'Enter your Admin password' ) }
 												{ ...field }
 											/>
 											<button
@@ -370,16 +356,14 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 				) }
 
 				<div className="site-migration-credentials__special-instructions">
-					{ ( locale === 'en' || hasTranslation( 'Special instructions' ) ) && (
-						<Button onClick={ () => toggleShowNotes() } data-testid="special-instructions">
-							{ translate( 'Special instructions' ) }
-							<Icon
-								icon={ showNotes ? chevronUp : chevronDown }
-								size={ 24 }
-								className="site-migration-credentials__special-instructions-icon"
-							/>
-						</Button>
-					) }
+					<Button onClick={ () => toggleShowNotes() } data-testid="special-instructions">
+						{ translate( 'Special instructions' ) }
+						<Icon
+							icon={ showNotes ? chevronUp : chevronDown }
+							size={ 24 }
+							className="site-migration-credentials__special-instructions-icon"
+						/>
+					</Button>
 					{ showNotes && (
 						<>
 							<div className="site-migration-credentials__form-field site-migration-credentials__form-field--notes">
@@ -406,16 +390,11 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 									{ errors.notes.message }
 								</div>
 							) }
-							{ ( locale === 'en' ||
-								hasTranslation(
+							<div className="site-migration-credentials__form-note">
+								{ translate(
 									"Please don't share any passwords or secure information in this field. We'll reach out to collect that information if you have any additional credentials to access your site."
-								) ) && (
-								<div className="site-migration-credentials__form-note">
-									{ translate(
-										"Please don't share any passwords or secure information in this field. We'll reach out to collect that information if you have any additional credentials to access your site."
-									) }
-								</div>
-							) }
+								) }
+							</div>
 						</>
 					) }
 				</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94204 #94237

## Proposed Changes

* Cleanup the conditional translations as we already have all the translations.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Since we already have all the translations, we can remove the checks we added before.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

  * Go through the migration flow by navigating to `/start`:
  * Go through the domain selection step
  * Select the free plan on the `Plans` page
  * On the `Goals` step, select the "Import existing content or website" option and click continue
  * Input the source site URL in the Identify step
  * Next, select the "Migrate Site" option on the `Import or Migrate` step
  * Select "Do it for me" on the `How to migrate` step
  * Go through the checkout
  * Once you complete the checkout, you should land on the new `Credentials` step
  * Now toggle the Special Instructions page and ensure everything works on that page and the texts are correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
