### PR TITLE
Fix/checkout 2 year plan breakdown

### DIFF
--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -121,20 +121,15 @@ const useCalculatedDiscounts = () => {
 				isDiscount: true,
 				isIntroductoryOffer: true,
 			} );
-
-			priceBreakdown.push( {
-				label: __( 'Multi-year discount' ),
-				priceInteger: multiYearDiscount,
-				isDiscount: true,
-			} );
-		} else {
-			// If an annual product has a free trial and the biennial does not, show the multi-year discount instead
-			priceBreakdown.push( {
-				label: __( 'Multi-year discount' ),
-				priceInteger: multiYearDiscount,
-				isDiscount: true,
-			} );
 		}
+	}
+
+	if ( multiYearDiscount > 0 ) {
+		priceBreakdown.push( {
+			label: __( 'Multi-year discount' ),
+			priceInteger: multiYearDiscount,
+			isDiscount: true,
+		} );
 	}
 
 	// Coupon discount is added on top of other discounts
@@ -152,6 +147,7 @@ const useCalculatedDiscounts = () => {
 		.reduce( ( sum, discount ) => sum + discount.priceInteger, 0 );
 
 	const subtotalPrice = originalPrice - allAppliedDiscounts;
+
 	const vatPrice = ( originalPrice - allAppliedDiscounts ) * ( product.item_tax_rate ?? 0 );
 
 	priceBreakdown.push( { label: __( 'Tax' ), priceInteger: vatPrice } );

--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -89,6 +89,8 @@ const useCalculatedDiscounts = () => {
 	}
 
 	const originalPrice = current.priceBeforeDiscounts * 2;
+	const introductoryOfferDiscount = biennial.priceBeforeDiscounts - biennial.priceInteger;
+	const multiYearDiscount = originalPrice - biennial.priceBeforeDiscounts;
 
 	const priceBreakdown: PriceBreakdown[] = [];
 
@@ -115,24 +117,24 @@ const useCalculatedDiscounts = () => {
 			// We don't show the discount for free trials (annual) in upsell if biennial plan doesn't have free trial.
 			priceBreakdown.push( {
 				label: __( 'Introductory offer*' ),
-				priceInteger: biennial.priceBeforeDiscounts - biennial.priceInteger,
+				priceInteger: introductoryOfferDiscount,
 				isDiscount: true,
 				isIntroductoryOffer: true,
+			} );
+
+			priceBreakdown.push( {
+				label: __( 'Multi-year discount' ),
+				priceInteger: multiYearDiscount,
+				isDiscount: true,
 			} );
 		} else {
 			// If an annual product has a free trial and the biennial does not, show the multi-year discount instead
 			priceBreakdown.push( {
 				label: __( 'Multi-year discount' ),
-				priceInteger: originalPrice - biennial.priceInteger,
+				priceInteger: multiYearDiscount,
 				isDiscount: true,
 			} );
 		}
-	} else {
-		priceBreakdown.push( {
-			label: __( 'Multi-year discount' ),
-			priceInteger: originalPrice - biennial.priceInteger,
-			isDiscount: true,
-		} );
 	}
 
 	// Coupon discount is added on top of other discounts
@@ -150,8 +152,7 @@ const useCalculatedDiscounts = () => {
 		.reduce( ( sum, discount ) => sum + discount.priceInteger, 0 );
 
 	const subtotalPrice = originalPrice - allAppliedDiscounts;
-	const vatPrice =
-		( biennial.priceBeforeDiscounts - allAppliedDiscounts ) * ( product.item_tax_rate ?? 0 );
+	const vatPrice = ( originalPrice - allAppliedDiscounts ) * ( product.item_tax_rate ?? 0 );
 
 	priceBreakdown.push( { label: __( 'Tax' ), priceInteger: vatPrice } );
 
@@ -194,7 +195,9 @@ const UpsellEntry: FC< Omit< PriceBreakdown, 'priceInteger' > & { priceInteger?:
 			{ undefined !== priceInteger && (
 				<div className={ className }>
 					{ isDiscount ? '-' : '' }
-					{ formatCurrency( priceInteger, product?.currency ?? 'USD', { isSmallestUnit: true } ) }
+					{ formatCurrency( Math.round( priceInteger ), product?.currency ?? 'USD', {
+						isSmallestUnit: true,
+					} ) }
 				</div>
 			) }
 		</>


### PR DESCRIPTION
## Proposed Changes

Fix a couple of bugs related to the 2 year upsell for Akismet and Jetpack products
* Multi-year discount was not showing in most circumstances
* Tax was being incorrectly calculated

## Why are these changes being made?

With these bugs, the 2 year upsell is incorrect and confusing

## Testing Instructions

1. Open up the calypso live link and go to `/checkout/jetpack/jetpack_ai_yearly`
2. Make sure the 2 year upsell look correct with the intro discount and the multi-year discount showing
![image](https://github.com/user-attachments/assets/ce8ac760-430b-484d-b501-5f8018be5b26)
3. Click "Switch to a two-year plan" and make sure the "Total" in the upsell matches the total in checkout after the switch
![image](https://github.com/user-attachments/assets/860a34c7-3950-4f50-af63-6973e82991bd)
4. Go to `/checkout/jetpack/jetpack_stats_yearly` and do the same thing to test a product without an intro discount
![image](https://github.com/user-attachments/assets/621852dd-4d5c-4aaa-9616-f704d3100b05)
![image](https://github.com/user-attachments/assets/41f219a6-8bfe-4c13-a3a5-39641f4e30a7)
5. Go to `/checkout/akismet/ak_pro5h_yearly` and do the same thing to test for an Akismet product
![image](https://github.com/user-attachments/assets/38e8bc72-6a0e-4f92-990f-6e3529f52042)
![image](https://github.com/user-attachments/assets/a9b064dc-5398-4fa4-b684-68121f67b841)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
