### PR TITLE
Sites dashboard - update search label placeholder

### DIFF
--- a/client/hosting/sites/components/sites-dataviews/index.tsx
+++ b/client/hosting/sites/components/sites-dataviews/index.tsx
@@ -1,3 +1,4 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
@@ -52,6 +53,7 @@ const DotcomSitesDataViews = ( {
 	setDataViewsState,
 }: Props ) => {
 	const { __ } = useI18n();
+	const hasEnTranslation = useHasEnTranslation();
 	const userId = useSelector( getCurrentUserId );
 
 	const openSitePreviewPane = useCallback(
@@ -176,11 +178,15 @@ const DotcomSitesDataViews = ( {
 		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState, siteStatusGroups ]
 	);
 
+	const siteSearchLabel = hasEnTranslation( 'Search sites…' )
+		? __( 'Search sites…' )
+		: __( 'Search sites' );
+
 	// Create the itemData packet state
 	const [ itemsData, setItemsData ] = useState< ItemsDataViewsType< SiteExcerptData > >( {
 		items: sites,
 		itemFieldId: 'ID',
-		searchLabel: __( 'Search by name or domain…' ),
+		searchLabel: siteSearchLabel,
 		fields,
 		actions: [],
 		setDataViewsState: setDataViewsState,
@@ -198,10 +204,11 @@ const DotcomSitesDataViews = ( {
 			// actions: actions,
 			setDataViewsState,
 			dataViewsState,
+			searchLabel: siteSearchLabel,
 			selectedItem: dataViewsState.selectedItem,
 			pagination: paginationInfo,
 		} ) );
-	}, [ fields, dataViewsState, paginationInfo, setDataViewsState, sites ] ); // add actions when implemented
+	}, [ fields, dataViewsState, paginationInfo, setDataViewsState, sites, siteSearchLabel ] ); // add actions when implemented
 
 	return (
 		<ItemsDataViews


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/94298 

## Proposed Changes

* Updates the search label, reducing it to "Search sites..."
* Checks for this translation, falls back to the translation for existing "Search sites" if not available for the locale.
* Updates the hook that manages updating the itemData packet to update the search label when it changes. I was finding the first call of hasEnTranslation was giving a false positive for "Search sites..." and since this was not updated in the item data packet it was showing this to locales without the translation. The hook should now update this since we use the label as a dependency for the hook.

BEFORE
<img width="313" alt="Screenshot 2024-09-09 at 2 44 09 PM" src="https://github.com/user-attachments/assets/1073a910-7351-41fa-98cb-6852e412da5f">


AFTER
<img width="293" alt="Screenshot 2024-09-09 at 2 44 01 PM" src="https://github.com/user-attachments/assets/268e9720-721f-433a-a214-761cd0e16ef0">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The search label placeholder is too long for the input.
* The search label placeholder is too busy.
* We need a label that will work well on all viewport widths.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch
* Visit the sites dashboard and verify the label has changed.
* Switch your locale, go back to the sites dashboard and see the translation with the "Search sites" phrase with no ellipsis ... (since the ellipsis version is not yet translated).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
