### PR TITLE
Performance Profiler: Display a specific message when there are no additional recommendations

### DIFF
--- a/client/performance-profiler/components/badge/style.scss
+++ b/client/performance-profiler/components/badge/style.scss
@@ -1,4 +1,5 @@
 .badge-container {
+	font-family: Inter, $sans;
 	width: fit-content;
 	display: flex;
 	padding: 6px 14px;

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -20,7 +20,11 @@ export const InsightsSection = forwardRef(
 			<div className="performance-profiler-insights-section" ref={ ref }>
 				<h2 className="title">{ translate( "Improve your site's performance" ) }</h2>
 				<p className="subtitle">
-					{ translate( 'We found things you can do to speed up your site.' ) }
+					{ Object.keys( audits ).length
+						? translate( 'We found things you can do to speed up your site.' )
+						: translate(
+								"Great job! We didn't find any recommendations for improving the speed of your site."
+						  ) }
 				</p>
 				{ Object.keys( audits ).map( ( key, index ) => (
 					<MetricsInsight


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8977
## Proposed Changes

* Display a specific message when there are no additional recommendations
* Update badge font-family to Inter


## Why are these changes being made?

*  https://github.com/Automattic/dotcom-forge/issues/8977
* https://github.com/Automattic/dotcom-forge/issues/8946

## Testing Instructions

* Go to `/speed-test-tool?url=example.com`
* Check the badge front-family if is displayed as `Inter`
* Scroll to the recommendations section and see the text displayed is `Great job! We didn't find any recommendations for improving the speed of your site.`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
