### PR TITLE
Plugins Marketplace: Fix CSS for "Get started with plugins" cards 

### DIFF
--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -29,13 +29,21 @@ const EducationFooterContainer = styled.div`
 
 	> div:first-child {
 		padding: 0;
+		margin-bottom: 18px;
+
+		@media ( max-width: 660px ) {
+			padding: 0 16px;
+		}
 
 		.wp-brand-font {
 			font-size: var( --scss-font-title-medium );
 		}
+	}
 
-		> div:first-child {
-			margin-bottom: 24px;
+	.plugin-how-to-guides {
+		@media ( min-width: 1280px ) {
+			justify-content: flex-start;
+			gap: 18px;
 		}
 	}
 
@@ -43,10 +51,22 @@ const EducationFooterContainer = styled.div`
 		display: flex;
 		width: calc( 33% - 10px );
 
-		@media ( max-width: 660px ) {
-			display: block;
+		@media ( max-width: 960px ) {
 			width: 100%;
 			margin-top: 10px;
+
+			> div:first-child {
+				padding: 16px;
+			}
+		}
+
+		> div:first-child:hover {
+			border-color: var( --studio-gray-30 );
+		}
+
+		div {
+			width: 100%;
+			text-wrap: pretty;
 		}
 	}
 `;
@@ -151,7 +171,7 @@ const EducationFooter = () => {
 				title={ __( 'Get started with plugins' ) }
 				subtitle={ __( 'Our favorite how-to guides to get you started with plugins' ) }
 			/>
-			<ThreeColumnContainer>
+			<ThreeColumnContainer className="plugin-how-to-guides">
 				<LinkCard
 					external
 					target="_blank"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/94294

## Proposed Changes

* This PR fixes style issues with the "Get started with plugins" cards so that these cards more closely match the style and behavior of the plugin cards around them.
  * The cards now fill the entire screen at large widths
  * Margin issues were fixed for small and mobile widths
  * On hover the card borders darken, just like the surrounding plugin cards
  * The `text-wrap: pretty` style is applied for browsers that support it to prevent word widows

Before | After
--|--
<video src="https://github.com/user-attachments/assets/6b337bd2-6002-4ec3-8504-01ede259c06d" /> | <video src="https://github.com/user-attachments/assets/2e5dd34e-72ab-44b7-a219-0570e9b150f5" /> 



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To create consistency in design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /plugins and ensure the "Get started with plugins" cards look good at any width on desktop and mobile
* Also test on /plugins logged out
* Also test on /plugins/[siteSlug]

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
