### PR TITLE
Backup: Show warning when the last daily backup failed

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-last-failed.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-last-failed.tsx
@@ -1,7 +1,9 @@
-import { Gridicon } from '@automattic/components';
 import { ExternalLink } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import type { Moment } from 'moment';
 
@@ -14,31 +16,31 @@ type Props = {
 
 export const BackupLastFailed: FunctionComponent< Props > = () => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const learnMoreLink = 'https://jetpack.com/support/backup/troubleshooting-jetpack-backup/';
+
+	const onLearnMoreClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_last_failed_learn_more_click' ) );
+	}, [ dispatch ] );
+
+	const translatedText = translate(
+		"We encountered some issues with the latest backup, but don't worry! " +
+			"We're using the most recent backup available. " +
+			'{{ExternalLink}}Learn more.{{/ExternalLink}}',
+		{
+			components: {
+				ExternalLink: (
+					<ExternalLink href={ learnMoreLink } children={ null } onClick={ onLearnMoreClick } />
+				),
+			},
+		}
+	);
 
 	return (
 		<div className="backup-last-failed__wrapper">
 			<span className="backup-last-failed__info">
-				<Gridicon icon="notice-outline" />
-				{ translate(
-					"We encountered some issues with the latest backup, but don't worry! " +
-						"We're using the most recent backup available. " +
-						'{{ExternalLink}}Learn more.{{/ExternalLink}}',
-					{
-						components: {
-							ExternalLink: (
-								<ExternalLink
-									href={ learnMoreLink }
-									children={ null }
-									rel="noopener noreferrer"
-									onClick={ () =>
-										recordTracksEvent( 'calypso_jetpack_backup_last_faileds_learn_more_click' )
-									}
-								/>
-							),
-						},
-					}
-				) }
+				<Icon icon={ info } size={ 26 } className="icon" />
+				{ translatedText }
 			</span>
 		</div>
 	);

--- a/client/components/jetpack/daily-backup-status/status-card/backup-last-failed.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-last-failed.tsx
@@ -21,7 +21,7 @@ export const BackupLastFailed: FunctionComponent< Props > = () => {
 			<span className="backup-last-failed__info">
 				<Gridicon icon="notice-outline" />
 				{ translate(
-					"We encountered some issues with today's backup, but don't worry! " +
+					"We encountered some issues with the latest backup, but don't worry! " +
 						"We're using the most recent backup available. " +
 						'{{ExternalLink}}Learn more.{{/ExternalLink}}',
 					{

--- a/client/components/jetpack/daily-backup-status/status-card/backup-last-failed.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-last-failed.tsx
@@ -5,16 +5,8 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import type { Moment } from 'moment';
 
-type Props = {
-	baseBackupDate: Moment;
-	eventsCount: number;
-	selectedBackupDate: Moment;
-	learnMoreUrl?: string;
-};
-
-export const BackupLastFailed: FunctionComponent< Props > = () => {
+export const BackupLastFailed: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const learnMoreLink = 'https://jetpack.com/support/backup/troubleshooting-jetpack-backup/';

--- a/client/components/jetpack/daily-backup-status/status-card/backup-last-failed.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-last-failed.tsx
@@ -1,0 +1,45 @@
+import { Gridicon } from '@automattic/components';
+import { ExternalLink } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import type { Moment } from 'moment';
+
+type Props = {
+	baseBackupDate: Moment;
+	eventsCount: number;
+	selectedBackupDate: Moment;
+	learnMoreUrl?: string;
+};
+
+export const BackupLastFailed: FunctionComponent< Props > = () => {
+	const translate = useTranslate();
+	const learnMoreLink = 'https://jetpack.com/support/backup/troubleshooting-jetpack-backup/';
+
+	return (
+		<div className="backup-last-failed__wrapper">
+			<span className="backup-last-failed__info">
+				<Gridicon icon="notice-outline" />
+				{ translate(
+					"We encountered some issues with today's backup, but don't worry! " +
+						"We're using the most recent backup available. " +
+						'{{ExternalLink}}Learn more.{{/ExternalLink}}',
+					{
+						components: {
+							ExternalLink: (
+								<ExternalLink
+									href={ learnMoreLink }
+									children={ null }
+									rel="noopener noreferrer"
+									onClick={ () =>
+										recordTracksEvent( 'calypso_jetpack_backup_last_faileds_learn_more_click' )
+									}
+								/>
+							),
+						},
+					}
+				) }
+			</span>
+		</div>
+	);
+};

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -45,8 +45,6 @@ const BackupSuccessful = ( {
 	const getDisplayDate = useGetDisplayDate();
 	const displayDate = getDisplayDate( backup.activityTs );
 	const displayDateNoLatest = getDisplayDate( backup.activityTs, false );
-	// TODO To be use in the future
-	//const displayDateBaseRewind = backup.baseRewindId ? getDisplayDate( backup.baseRewindId * 1000, false ) : null;
 
 	const today = applySiteOffset( moment(), {
 		timezone: timezone,

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -16,6 +16,7 @@ import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-sit
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ActionButtons from '../action-buttons';
 import useGetDisplayDate from '../use-get-display-date';
+import { BackupLastFailed } from './backup-last-failed';
 import { BackupRealtimeMessage } from './backup-realtime-message';
 import cloudSuccessIcon from './icons/cloud-success.svg';
 import cloudWarningIcon from './icons/cloud-warning.svg';
@@ -149,6 +150,8 @@ const BackupSuccessful = ( {
 				</div>
 			) }
 			{ hasWarnings && <BackupWarningRetry siteId={ siteId } /> }
+
+			{ isToday && <BackupLastFailed siteId={ siteId } /> }
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -10,6 +10,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { useActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id';
 import { getBackupWarnings } from 'calypso/lib/jetpack/backup-utils';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
+import getBackupLastBackupFailed from 'calypso/state/rewind/selectors/get-backup-last-backup-failed';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
@@ -39,6 +40,7 @@ const BackupSuccessful = ( {
 	const moment = useLocalizedMoment();
 	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
 	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
+	const lastBackupFailed = useSelector( ( state ) => getBackupLastBackupFailed( state, siteId ) );
 
 	const getDisplayDate = useGetDisplayDate();
 	const displayDate = getDisplayDate( backup.activityTs );
@@ -151,7 +153,9 @@ const BackupSuccessful = ( {
 			) }
 			{ hasWarnings && <BackupWarningRetry siteId={ siteId } /> }
 
-			{ isToday && <BackupLastFailed siteId={ siteId } /> }
+			{ config.isEnabled( 'jetpack/backup-realtime-message' ) && isToday && lastBackupFailed && (
+				<BackupLastFailed siteId={ siteId } />
+			) }
 		</>
 	);
 };

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -261,3 +261,22 @@
 	margin-bottom: 0;
 }
 
+.backup-last-failed__wrapper {
+	border-top: 1px solid var(--color-neutral-5);
+	padding-top: 22px;
+	padding-bottom: 22px;
+	margin-top: 1.5rem;
+}
+
+.backup-last-failed__info {
+	height: 24px;
+	a {
+		color: #101517;
+		text-decoration: underline;
+	}
+	.gridicons-notice-outline {
+		vertical-align: middle;
+		margin-right: 8px;
+		color: #7d5600;
+	}
+}

--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -274,9 +274,9 @@
 		color: #101517;
 		text-decoration: underline;
 	}
-	.gridicons-notice-outline {
+	.icon {
 		vertical-align: middle;
 		margin-right: 8px;
-		color: #7d5600;
+		fill: #7d5600;
 	}
 }

--- a/client/components/jetpack/daily-backup-status/test/backup-last-failed.jsx
+++ b/client/components/jetpack/daily-backup-status/test/backup-last-failed.jsx
@@ -32,7 +32,7 @@ describe( 'BackupLastFailed', () => {
 	test( 'renders message last backup failed', () => {
 		const { container } = renderMessage();
 		expect( container.textContent ).toBe(
-			`We encountered some issues with today's backup, but don't worry! We're using the most recent backup available. {{ExternalLink}}Learn more.{{/ExternalLink}}`
+			`We encountered some issues with the latest backup, but don't worry! We're using the most recent backup available. {{ExternalLink}}Learn more.{{/ExternalLink}}`
 		);
 	} );
 } );

--- a/client/components/jetpack/daily-backup-status/test/backup-last-failed.jsx
+++ b/client/components/jetpack/daily-backup-status/test/backup-last-failed.jsx
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'calypso/state';
+import { BackupLastFailed } from '../status-card/backup-last-failed';
+
+jest.mock( 'i18n-calypso' ); // Mock the useTranslate hook
+jest.mock( 'calypso/state' ); // Mock the useDispatch hook
+
+describe( 'BackupLastFailed', () => {
+	const renderMessage = () => {
+		return render( <BackupLastFailed /> );
+	};
+
+	const translateMock = jest.fn( ( singular, plural, options ) => {
+		if ( options === undefined ) {
+			return singular;
+		}
+
+		const translatedText = options.count === 1 ? singular : plural;
+		return translatedText;
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useTranslate.mockImplementation( () => translateMock );
+		useDispatch.mockImplementation( () => jest.fn() );
+	} );
+
+	test( 'renders message last backup failed', () => {
+		const { container } = renderMessage();
+		expect( container.textContent ).toBe(
+			`We encountered some issues with today's backup, but don't worry! We're using the most recent backup available. {{ExternalLink}}Learn more.{{/ExternalLink}}`
+		);
+	} );
+} );

--- a/client/my-sites/backup/clone-flow/test/index.jsx
+++ b/client/my-sites/backup/clone-flow/test/index.jsx
@@ -68,6 +68,7 @@ jest.mock( 'calypso/state/rewind/selectors/get-backup-staging-sites', () =>
 );
 
 // Mock several data-fetching related selectors which may not be available.
+jest.mock( 'calypso/state/rewind/selectors/get-backup-last-backup-failed' );
 jest.mock( 'calypso/state/rewind/selectors/has-fetched-staging-sites-list' );
 jest.mock( 'calypso/state/rewind/selectors/is-fetching-staging-sites-list' );
 jest.mock( 'calypso/data/activity-log/use-rewindable-activity-log-query' );

--- a/client/state/data-layer/wpcom/sites/rewind/size/from-api.ts
+++ b/client/state/data-layer/wpcom/sites/rewind/size/from-api.ts
@@ -10,6 +10,7 @@ type ApiResponse = {
 	retention_days: number;
 	last_backup_size: number;
 	backups_stopped: boolean;
+	last_backup_failed: boolean;
 };
 
 const fromApi = ( {
@@ -20,6 +21,7 @@ const fromApi = ( {
 	retention_days,
 	last_backup_size,
 	backups_stopped,
+	last_backup_failed,
 }: ApiResponse ): RewindSizeInfo => ( {
 	bytesUsed: size,
 	minDaysOfBackupsAllowed: min_days_of_backups_allowed,
@@ -28,6 +30,7 @@ const fromApi = ( {
 	retentionDays: retention_days,
 	lastBackupSize: last_backup_size,
 	backupsStopped: backups_stopped,
+	lastBackupFailed: !! last_backup_failed,
 } );
 
 export default fromApi;

--- a/client/state/rewind/selectors/get-backup-last-backup-failed.ts
+++ b/client/state/rewind/selectors/get-backup-last-backup-failed.ts
@@ -1,0 +1,12 @@
+import type { AppState } from 'calypso/types';
+
+/**
+ * Indicates if the last backup failed.
+ * @param state The application state.
+ * @param siteId The site ID for which to backup status.
+ * @returns true if backups failed. false otherwise.
+ */
+const getBackupLastBackupFailed = ( state: AppState, siteId: number ): boolean =>
+	state.rewind[ siteId ]?.size?.lastBackupFailed ?? false;
+
+export default getBackupLastBackupFailed;

--- a/client/state/rewind/size/reducer.ts
+++ b/client/state/rewind/size/reducer.ts
@@ -99,6 +99,17 @@ const backupsStopped = (
 	return size.backupsStopped ?? false;
 };
 
+const lastBackupFailed = (
+	state: AppState = null,
+	{ type, size }: AnyAction
+): AppState | boolean | null => {
+	if ( type !== REWIND_SIZE_SET ) {
+		return state;
+	}
+
+	return size.lastBackupFailed ?? false;
+};
+
 export default combineReducers( {
 	requestStatus,
 	bytesUsed,
@@ -108,4 +119,5 @@ export default combineReducers( {
 	retentionDays,
 	lastBackupSize,
 	backupsStopped,
+	lastBackupFailed,
 } );

--- a/client/state/rewind/size/types.ts
+++ b/client/state/rewind/size/types.ts
@@ -6,4 +6,5 @@ export type RewindSizeInfo = {
 	lastBackupSize: number;
 	retentionDays: number;
 	backupsStopped: boolean;
+	lastBackupFailed: boolean;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/617

## Proposed Changes

* Add a message warning when the last daily backup failed
<img width="791" alt="Screenshot 2024-09-10 at 22 37 30" src="https://github.com/user-attachments/assets/a19ad40a-1299-4f6d-a88c-efd87b31de66">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It helps to make clear when the daily backup has failed since the real-time backup can still be working

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check [the instructions in the related ticket](https://github.com/Automattic/jetpack-backup-team/issues/617#issuecomment-2341627824) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
