### PR TITLE
Jetpack Backup: improve real-time message including today/yesterday references

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-realtime-message.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-realtime-message.tsx
@@ -35,14 +35,45 @@ export const BackupRealtimeMessage: FunctionComponent< Props > = ( {
 		return;
 	}
 
+	const isBackupFromToday = baseBackupDate.isSame( moment(), 'day' );
+	const isBackupFromYesterday = baseBackupDate.isSame( moment().subtract( 1, 'days' ), 'day' );
 	const daysDiff = selectedBackupDate.diff( baseBackupDate, 'days' );
 	let message: string | React.ReactNode;
 
-	if ( daysDiff === 0 ) {
+	if ( daysDiff === 0 && isBackupFromToday ) {
+		// Base backup date is the same as today's date
+		message = translate(
+			'We are using a full backup from today (%(baseBackupDate)s) with %(eventsCount)d change you have made since then until now.',
+			'We are using a full backup from today (%(baseBackupDate)s) with %(eventsCount)d changes you have made since then until now.',
+			{
+				count: eventsCount,
+				args: {
+					baseBackupDate: baseBackupDate.format( 'YYYY-MM-DD hh:mm A' ),
+					eventsCount: eventsCount,
+				},
+				comment: '%(eventsCount)d is the number of changes made since the backup.',
+			}
+		);
+	} else if ( daysDiff === 0 ) {
 		// Base backup date is the same as the selected backup date
 		message = translate(
 			'We are using a full backup from this day (%(baseBackupDate)s) with %(eventsCount)d change you have made since then until now.',
 			'We are using a full backup from this day (%(baseBackupDate)s) with %(eventsCount)d changes you have made since then until now.',
+			{
+				count: eventsCount,
+				args: {
+					baseBackupDate: baseBackupDate.format( 'YYYY-MM-DD hh:mm A' ),
+					eventsCount: eventsCount,
+				},
+				comment:
+					'%(baseBackupDate)s is the date and time of the backup, and %(eventsCount)d is the number of changes made since the backup.',
+			}
+		);
+	} else if ( daysDiff === 1 && isBackupFromYesterday ) {
+		// Base backup date is the same as yesterday
+		message = translate(
+			'We are using a full backup from yesterday (%(baseBackupDate)s) with %(eventsCount)d change you have made since then until now.',
+			'We are using a full backup from yesterday (%(baseBackupDate)s) with %(eventsCount)d changes you have made since then until now.',
 			{
 				count: eventsCount,
 				args: {

--- a/client/components/jetpack/daily-backup-status/test/backup-realtime-message.jsx
+++ b/client/components/jetpack/daily-backup-status/test/backup-realtime-message.jsx
@@ -106,8 +106,6 @@ describe( 'BackupRealtimeMessage', () => {
 	} );
 
 	test( 'renders the correct message and the "Learn more" link when learnMoreUrl is provided', () => {
-		useTranslate.mockImplementation( () => translateMock );
-
 		const selectedDate = moment( '2024-08-26T12:00:00Z' );
 		const baseBackupDate = moment( '2024-08-26T12:00:00Z' );
 		const learnMoreUrl = '/learn-more';

--- a/client/components/jetpack/daily-backup-status/test/backup-realtime-message.jsx
+++ b/client/components/jetpack/daily-backup-status/test/backup-realtime-message.jsx
@@ -40,6 +40,26 @@ describe( 'BackupRealtimeMessage', () => {
 		useDispatch.mockImplementation( () => jest.fn() );
 	} );
 
+	test( 'renders the correct message when backup date and selected date are today', () => {
+		const today = moment();
+		const formattedDate = today.format( 'YYYY-MM-DD hh:mm A' );
+		const { container } = renderMessage( today, 3, today );
+		expect( container.textContent ).toBe(
+			`We are using a full backup from today (${ formattedDate }) with 3 changes you have made since then until now.`
+		);
+	} );
+
+	test( 'renders the correct message when backup date is yesterday and selected date is today', () => {
+		const today = moment(); // today
+		const yesterday = moment().subtract( 1, 'days' ); // yesterday
+		const formattedDate = yesterday.format( 'YYYY-MM-DD hh:mm A' ); // formatted backup date
+
+		const { container } = renderMessage( yesterday, 5, today );
+		expect( container.textContent ).toBe(
+			`We are using a full backup from yesterday (${ formattedDate }) with 5 changes you have made since then until now.`
+		);
+	} );
+
 	test( 'renders the correct message when the base backup date is the same as the selected backup date', () => {
 		const selectedDate = moment( '2024-08-26T12:00:00Z' );
 		const baseBackupDate = selectedDate; // same day


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/616

We recently implemented the `BackupRealtimeMessage` in https://github.com/Automattic/wp-calypso/pull/93935 including messages like:
* _We are using a full backup from this day(...)_
* _We are using a full backup from the previous day(...)_
* _We are using a 3-day old full backup(...)_

After discussing with @mavegaf we noted that could be useful to use a more natural language when the user is navigating through real-time events where the backup prior the real-time events was made `today` or `yesterday`. Note: "this day" and "previous day" are relative to the current date the user is viewing (they can navigate through different dates using a calendar).

So the idea is to introduce these new messages:
* _We are using a full backup from today(...)_
* _We are using a full backup from yesterday(...)_

## Proposed Changes

* Update `BackupRealtimeMessage` component to consider two new scenarios:
  * Base backup date and selected date are today: _"We are using a full backup from today(...)"_
  * Base backup date is yesterday and selected date is today: _"We are using a full backup from yesterday(...)"_
* Update unit tests
* Remove unnecessary useTranslate() mock, because we were already mocking it on the beforeEach block

![CleanShot 2024-09-09 at 22 15 05@2x](https://github.com/user-attachments/assets/00f3a332-cf51-4ae2-9386-2855eb402da4)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

For making clear daily vs real-time backups to end users.
Project thread: peaFOp-2Iy-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> The acceptance test is optional, you could proofread the changes and ensure the unit tests makes sense and validate them by running `yarn run test-client client/components/jetpack/daily-backup-status/test/backup-realtime-message.jsx`

* Perform an action in one of your test sites with a VaultPress Backup a plan that triggers a real-time event, like a new post or uploading an image to the media library.
* Spin up a Jetpack Cloud live branch
* Enable the feature flag appending `flags=jetpack/backup-realtime-message` to the URL
* Pick your test site
* Navigate to the Backup page
* If the real-time was processed, you should see a message similar to:
![CleanShot 2024-09-09 at 22 17 55@2x](https://github.com/user-attachments/assets/9c130c56-09b6-4b4c-880f-4b33daffc681)
* Ensure the timeframe makes sense (like saying `today` or `yesterday`).
  * Testing the `yesterday` scenario is a bit tricky, as you might need a site that the last full backup was made yesterday, and then you can trigger a new real-time event for today. I'd recommend proofreading and trust the unit tests.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?