### PR TITLE
A4A > Marketplace: restrict license purchases from users who can't issue new licenses

### DIFF
--- a/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
+++ b/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
@@ -20,7 +20,7 @@ export default function PendingPaymentNotification() {
 		getPreference( state, PENDING_PAYMENT_NOTIFICATION_DISMISS_PREFERENCE )
 	);
 
-	const canIssueLicenses = agency?.can_issue_licenses;
+	const canIssueLicenses = agency?.can_issue_licenses ?? true;
 
 	const translate = useTranslate();
 

--- a/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
+++ b/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
@@ -1,0 +1,60 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { setPreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { CONTACT_URL_HASH_FRAGMENT } from '../a4a-contact-support-widget';
+import { A4A_INVOICES_LINK } from '../sidebar-menu/lib/constants';
+
+import './style.scss';
+
+const PENDING_PAYMENT_NOTIFICATION_DISMISS_PREFERENCE = 'pending-payment-notification-dismissed';
+
+export default function PendingPaymentNotification() {
+	const dispatch = useDispatch();
+	const agency = useSelector( getActiveAgency );
+
+	const isDismissed = useSelector( ( state ) =>
+		getPreference( state, PENDING_PAYMENT_NOTIFICATION_DISMISS_PREFERENCE )
+	);
+
+	const canIssueLicenses = agency?.can_issue_licenses;
+
+	const translate = useTranslate();
+
+	// If the agency can issue licenses or the notification has been dismissed, do not show the notification.
+	if ( canIssueLicenses || isDismissed ) {
+		return null;
+	}
+
+	return (
+		<LayoutBanner
+			className="pending-payment-notification"
+			level="warning"
+			title={ translate( 'Payment reminder' ) }
+			onClose={ () =>
+				// Dismiss the notification temporarily so that it shows again on the next page load.
+				dispatch( setPreference( PENDING_PAYMENT_NOTIFICATION_DISMISS_PREFERENCE, true ) )
+			}
+		>
+			<div>
+				{ translate(
+					'Your payment for the latest invoice is now overdue. To continue purchasing products and maintain uninterrupted services,{{br/}}please make your payment as soon as possible.',
+					{
+						components: {
+							br: <br />,
+						},
+					}
+				) }
+			</div>
+			<Button className="is-dark" href={ A4A_INVOICES_LINK }>
+				{ translate( 'Pay invoice' ) }
+			</Button>
+			<Button variant="secondary" href={ CONTACT_URL_HASH_FRAGMENT }>
+				{ translate( 'Contact support' ) }
+			</Button>
+		</LayoutBanner>
+	);
+}

--- a/client/a8c-for-agencies/components/pending-payment-notification/style.scss
+++ b/client/a8c-for-agencies/components/pending-payment-notification/style.scss
@@ -1,0 +1,14 @@
+
+.pending-payment-notification {
+	.notice-banner {
+		margin-block-end: 24px;
+	}
+
+	.components-button {
+		margin-block-start: 1rem;
+
+		&.is-secondary {
+			margin-inline-start: 8px;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -3,19 +3,21 @@ import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useContext, useEffect } from 'react';
+import { useCallback, useMemo, useContext, useEffect, useRef, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import PendingPaymentNotification from 'calypso/a8c-for-agencies/components/pending-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import {
 	A4A_MARKETPLACE_LINK,
 	A4A_SITES_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSites from 'calypso/state/selectors/get-sites';
 import useFetchClientReferral from '../../client/hooks/use-fetch-client-referral';
@@ -28,6 +30,7 @@ import useShoppingCart from '../hooks/use-shopping-cart';
 import { getClientReferralQueryArgs } from '../lib/get-client-referral-query-args';
 import useSubmitForm from '../products-overview/product-listing/hooks/use-submit-form';
 import NoticeSummary from './notice-summary';
+import PendingPaymentPopover from './pending-payment-popover';
 import PricingSummary from './pricing-summary';
 import ProductInfo from './product-info';
 import RequestClientPayment from './request-client-payment';
@@ -44,6 +47,11 @@ interface Props {
 function Checkout( { isClient, referralBlogId }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const agency = useSelector( getActiveAgency );
+
+	const canIssueLicenses = agency?.can_issue_licenses;
+	const [ showPopover, setShowPopover ] = useState( false );
+	const wrapperRef = useRef< HTMLButtonElement | null >( null );
 
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const isAutomatedReferrals = marketplaceType === MARKETPLACE_TYPE_REFERRAL;
@@ -147,14 +155,20 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 			<NoticeSummary type="agency-purchase" />
 
 			<div className="checkout__aside-actions">
-				<Button
-					primary
-					onClick={ onCheckout }
-					disabled={ ! checkoutItems.length || ! isReady }
-					busy={ ! isReady }
+				<span
+					className="checkout__aside-actions-wrapper"
+					onMouseEnter={ () => setShowPopover( true ) }
 				>
-					{ translate( 'Purchase' ) }
-				</Button>
+					<Button
+						primary
+						onClick={ onCheckout }
+						disabled={ ! checkoutItems.length || ! isReady || ! canIssueLicenses }
+						busy={ ! isReady }
+						ref={ wrapperRef }
+					>
+						{ translate( 'Purchase' ) }
+					</Button>
+				</span>
 
 				{ siteId ? (
 					<Button onClick={ cancelPurchase }>{ translate( 'Cancel' ) }</Button>
@@ -166,6 +180,12 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 							{ translate( 'Empty cart' ) }
 						</Button>
 					</>
+				) }
+				{ showPopover && (
+					<PendingPaymentPopover
+						wrapperRef={ wrapperRef }
+						hidePopover={ () => setShowPopover( false ) }
+					/>
 				) }
 			</div>
 		</>
@@ -190,6 +210,10 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 		>
 			{ isClient ? null : (
 				<LayoutTop>
+					{
+						// Show the pending payment notification only when the user is trying to make a purchase
+						! isAutomatedReferrals && <PendingPaymentNotification />
+					}
 					<LayoutHeader>
 						<Breadcrumb
 							items={ [

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -49,7 +49,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 	const dispatch = useDispatch();
 	const agency = useSelector( getActiveAgency );
 
-	const canIssueLicenses = agency?.can_issue_licenses;
+	const canIssueLicenses = agency?.can_issue_licenses ?? true;
 	const [ showPopover, setShowPopover ] = useState( false );
 	const wrapperRef = useRef< HTMLButtonElement | null >( null );
 
@@ -150,14 +150,28 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 
 	const title = isAutomatedReferrals ? translate( 'Referral checkout' ) : translate( 'Checkout' );
 
+	const handleShowPopover = () => {
+		if ( ! canIssueLicenses ) {
+			setShowPopover( true );
+		}
+	};
+
 	let actionContent = (
 		<>
 			<NoticeSummary type="agency-purchase" />
 
 			<div className="checkout__aside-actions">
 				<span
+					role="button"
+					tabIndex={ 0 }
 					className="checkout__aside-actions-wrapper"
-					onMouseEnter={ () => setShowPopover( true ) }
+					onMouseEnter={ handleShowPopover }
+					onClick={ handleShowPopover }
+					onKeyUp={ ( event ) => {
+						if ( event.key === 'Enter' || event.key === ' ' ) {
+							handleShowPopover;
+						}
+					} }
 				>
 					<Button
 						primary

--- a/client/a8c-for-agencies/sections/marketplace/checkout/pending-payment-popover.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pending-payment-popover.tsx
@@ -22,10 +22,11 @@ export default function PendingPaymentPopover( { wrapperRef, hidePopover }: Prop
 		>
 			<div className="checkout__button-popover-description">
 				{ translate(
-					'Your payment for the latest invoice is now overdue. To continue purchasing products and maintain uninterrupted services,{{br/}}please make your payment as soon as possible.',
+					'Your payment for the latest invoice is now overdue. To continue purchasing products and maintain uninterrupted services,{{br/}}please make your payment as soon as{{nbsp/}}possible.',
 					{
 						components: {
 							br: <br />,
+							nbsp: <>&nbsp;</>,
 						},
 					}
 				) }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/pending-payment-popover.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pending-payment-popover.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
+import { A4A_INVOICES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+
+type Props = {
+	wrapperRef: React.RefObject< HTMLButtonElement >;
+	hidePopover: () => void;
+};
+
+export default function PendingPaymentPopover( { wrapperRef, hidePopover }: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<A4APopover
+			className="checkout__button-popover"
+			title={ translate( 'Payment reminder' ) }
+			offset={ 12 }
+			position="top"
+			wrapperRef={ wrapperRef }
+			onFocusOutside={ hidePopover }
+		>
+			<div className="checkout__button-popover-description">
+				{ translate(
+					'Your payment for the latest invoice is now overdue. To continue purchasing products and maintain uninterrupted services,{{br/}}please make your payment as soon as possible.',
+					{
+						components: {
+							br: <br />,
+						},
+					}
+				) }
+			</div>
+			<Button className="is-dark" href={ A4A_INVOICES_LINK }>
+				{ translate( 'Pay invoice' ) }
+			</Button>
+		</A4APopover>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -337,3 +337,19 @@
 	}
 }
 
+.checkout__aside-actions-wrapper {
+	display: grid;
+}
+
+.checkout__button-popover {
+	.a4a-popover__content {
+		.a4a-popover__title {
+			@include a4a-font-heading-md;
+			color: var(--studio-gray-80);
+		}
+
+		.checkout__button-popover-description {
+			@include a4a-font-body-md;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -342,7 +342,17 @@
 }
 
 .checkout__button-popover {
+	.components-popover__content {
+		width: 300px;
+
+		@include break-large {
+			width: 350px;
+		}
+	}
+
 	.a4a-popover__content {
+		width: 100%;
+
 		.a4a-popover__title {
 			@include a4a-font-heading-md;
 			color: var(--studio-gray-80);

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -11,6 +11,7 @@ import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import PendingPaymentNotification from 'calypso/a8c-for-agencies/components/pending-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
@@ -80,6 +81,7 @@ function Hosting( { section }: Props ) {
 			compact
 		>
 			<LayoutTop>
+				<PendingPaymentNotification />
 				<LayoutHeader>
 					<Breadcrumb
 						items={ [

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -10,6 +10,7 @@ import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import PendingPaymentNotification from 'calypso/a8c-for-agencies/components/pending-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
@@ -86,6 +87,7 @@ function ProductsOverview( { siteId, suggestedProduct, productBrand, searchQuery
 			compact
 		>
 			<LayoutTop withNavigation>
+				<PendingPaymentNotification />
 				<LayoutHeader showStickyContent={ showStickyContent }>
 					<Breadcrumb
 						items={ [

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -66,6 +66,7 @@ export interface Agency {
 		role: 'a4a_administrator' | 'a4a_manager';
 		capabilities: string[];
 	};
+	can_issue_licenses: boolean;
 }
 
 export interface AgencyStore {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/971

## Proposed Changes

This PR restricts license purchases from users who can't issue new licenses.

## Why are these changes being made?

 Let the users know their payment is overdue and they cannot make a new purchase.

Note: This doesn't restrict users from referring products to a client. But we will still show the banner in refer mode on the marketplace except on the Checkout page.

## Testing Instructions

* Apply the patch: D160834-code
* Open the A4A live link.
* Follow the instructions on the patch to set the `can_issue_licenses` to false > Verify that we show the banner on Marketplace pages: Hosting, Products & Checkout. Verify both the CTAs work as expected. This banner should be hidden if the user dismisses it and should reappear if they refresh the page.
* Add a product > Go to Checkout > Verify the `Purchase` button is disabled and you can a popover when hovering over it.
* Toggle the refer mode on and verify the banner is not shown on the checkout page and you can refer a product.

Screenshots:

Hosting:

<img width="1728" alt="Screenshot 2024-09-10 at 10 16 55 AM" src="https://github.com/user-attachments/assets/12c317a6-b937-4651-9747-22d4432ca294">


Products:

<img width="1728" alt="Screenshot 2024-09-10 at 10 17 01 AM" src="https://github.com/user-attachments/assets/7d73646a-19a9-4aaf-b20e-95a0fce318c8">


Checkout:

<img width="1728" alt="Screenshot 2024-09-10 at 11 10 20 AM" src="https://github.com/user-attachments/assets/7d2387cf-f23d-4e14-b8dc-bebff36cc6aa">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?