### PR TITLE
Email subscription: Remove random username generation

### DIFF
--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -181,7 +181,6 @@ function SubscribeEmailStep( props ) {
 					extra: {
 						first_name,
 						...( includeLastName && { last_name: queryArguments.last_name } ),
-						generate_random_username: true,
 					},
 				},
 				flowName,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* The flow currently generates a random username. This may not be appropriate in some contexts, so let's use email based username.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You'd first need to create a new user account using the email subscription signup flow. In the following URL: `http://calypso.localhost:3000/start/email-subscription/subscribe?user_email=email%40gmail.com&first_name=dfwef&last_name=fwfw&mailing_list=news_developer&redirect_to=https%3A%2F%2Fwordpress.com%2Fwordcamp%2Fnewsletter%2F&from=%2Fwordcamp%2Fnewsletter%2F`

Replace "email" in the user_name param with your email ID. Also replace gmail to your email domain.  Ensure that this email ID does not have an existing WP.com account.

* Visit the link and check your inbox. Verify that the username created is based off of the email ID.

