### PR TITLE
A4A > Backup: Fix backup not working for selected dates

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/backup/routes.ts
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/backup/routes.ts
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { Context, type Callback } from '@automattic/calypso-router';
 import { sitesContext } from 'calypso/a8c-for-agencies/sections/sites/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { addQueryArgs } from 'calypso/lib/url';
 import { JETPACK_BACKUP_ID } from '../../features';
 import {
 	backupClone,
@@ -156,7 +157,8 @@ function handleJetpackCloudRedirections() {
 	page( `/backup/:site`, ( context, next ) => {
 		const { site } = context.params;
 		//todo: get the current selected feature family instead of the hardcoded 'overview'
-		page.replace( `/sites/overview/${ site }/${ JETPACK_BACKUP_ID }`, context.state, true, true );
+		const path = addQueryArgs( context.query, `/sites/overview/${ site }/${ JETPACK_BACKUP_ID }` );
+		page.replace( path, context.state, true, true );
 		next();
 	} );
 }

--- a/client/my-sites/backup/paths.ts
+++ b/client/my-sites/backup/paths.ts
@@ -1,7 +1,13 @@
+import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { addQueryArgs } from 'calypso/lib/url';
 
-export const backupMainPath = ( siteName?: string | null, query = {} ) =>
-	siteName ? addQueryArgs( query, `/backup/${ siteName }` ) : '/backup';
+export const backupMainPath = ( siteName?: string | null, query = {} ) => {
+	if ( isA8CForAgencies() ) {
+		return addQueryArgs( query, `${ A4A_SITES_LINK }/overview/${ siteName }/jetpack-backup` );
+	}
+	return siteName ? addQueryArgs( query, `/backup/${ siteName }` ) : '/backup';
+};
 
 const backupSubSectionPath = (
 	siteName: string,

--- a/client/my-sites/backup/paths.ts
+++ b/client/my-sites/backup/paths.ts
@@ -1,13 +1,7 @@
-import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { addQueryArgs } from 'calypso/lib/url';
 
-export const backupMainPath = ( siteName?: string | null, query = {} ) => {
-	if ( isA8CForAgencies() ) {
-		return addQueryArgs( query, `${ A4A_SITES_LINK }/overview/${ siteName }/jetpack-backup` );
-	}
-	return siteName ? addQueryArgs( query, `/backup/${ siteName }` ) : '/backup';
-};
+export const backupMainPath = ( siteName?: string | null, query = {} ) =>
+	siteName ? addQueryArgs( query, `/backup/${ siteName }` ) : '/backup';
 
 const backupSubSectionPath = (
 	siteName: string,


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1097

## Proposed Changes

This PR fixes the issue with the backup not working for selected dates.

## Why are these changes being made?

* To fix the issue with backup not working on A4A for selected dates.

## Testing Instructions

* Open A4A live link
* Go to Sites dashboard > Open the detailed view of any site > Click the backup tab > Now click on the `< Yesterday` button and verify that the URL gets appended with the date and the backup for the previous day is loaded as expected. 
* Now, select a date from the date picker and verify it works as described above.
* Click on `Backup now` and verify that you are redirected to the current date with the backup in progress.
* Verify the steps mentioned above work fine on WordPress.com and Jetpack Cloud using the live links.


https://github.com/user-attachments/assets/1191e95c-37cc-481b-ab0e-28fe0e60f58c



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
