### PR TITLE
A4A Dev Sites: Add development site indicator and CTAs to the Site Overview

### DIFF
--- a/client/hosting/overview/components/plan-card.tsx
+++ b/client/hosting/overview/components/plan-card.tsx
@@ -1,10 +1,11 @@
+import config from '@automattic/calypso-config';
 import {
 	getPlan,
 	PlanSlug,
 	PRODUCT_1GB_SPACE,
 	PLAN_MONTHLY_PERIOD,
 } from '@automattic/calypso-products';
-import { Button, PlanPrice, LoadingPlaceholder } from '@automattic/components';
+import { Button, PlanPrice, LoadingPlaceholder, Badge } from '@automattic/components';
 import { AddOns } from '@automattic/data-stores';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
 import { usePlanBillingDescription } from '@automattic/plans-grid-next';
@@ -158,6 +159,7 @@ const PricingSection: FC = () => {
 };
 
 const PlanCard: FC = () => {
+	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 	const translate = useTranslate();
 	const site = useSelector( getSelectedSite );
 	const planDetails = site?.plan;
@@ -166,6 +168,7 @@ const PlanCard: FC = () => {
 		isJetpackSite( state, site?.ID, { treatAtomicAsJetpackSite: false } )
 	);
 	const isStaging = isStagingSite( site ?? undefined );
+	const isDevelopmentSite = site?.is_a4a_dev_site;
 	const isOwner = planDetails?.user_is_owner;
 	const planPurchaseId = useSelector( ( state: AppState ) =>
 		getCurrentPlanPurchaseId( state, site?.ID ?? 0 )
@@ -220,6 +223,9 @@ const PlanCard: FC = () => {
 							<h3 className="hosting-overview__plan-card-title">
 								{ isStaging ? translate( 'Staging site' ) : planName }
 							</h3>
+							{ devSitesEnabled && isDevelopmentSite && (
+								<Badge type="info-purple">{ translate( 'Development' ) }</Badge>
+							) }
 							{ renderManageButton() }
 						</>
 					) }

--- a/client/hosting/overview/components/plan-card.tsx
+++ b/client/hosting/overview/components/plan-card.tsx
@@ -189,7 +189,13 @@ const PlanCard: FC = () => {
 		( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE && ! addOn?.exceedsSiteStorageLimits
 	);
 	const renderManageButton = () => {
-		if ( isJetpack || ! site || isStaging || isAgencyPurchase ) {
+		if (
+			isJetpack ||
+			! site ||
+			isStaging ||
+			isAgencyPurchase ||
+			( devSitesEnabled && isDevelopmentSite )
+		) {
 			return false;
 		}
 		if ( isFreePlan ) {

--- a/client/hosting/overview/components/plan-card.tsx
+++ b/client/hosting/overview/components/plan-card.tsx
@@ -249,6 +249,32 @@ const PlanCard: FC = () => {
 					</div>
 				) }
 
+				{ devSitesEnabled && isDevelopmentSite && (
+					<div className="hosting-overview__development-site-ctas">
+						<div className="hosting-overview__development-site-cta-wrapper">
+							<p>{ translate( 'Generate a preview link to share with your clients.' ) }</p>
+							<Button
+								compact
+								className="hosting-overview__development-site-cta"
+								href={ `/settings/general/${ site?.slug }` }
+							>
+								{ translate( 'Share site for preview' ) }
+							</Button>
+						</div>
+						<div className="hosting-overview__development-site-cta-wrapper">
+							<p>{ translate( 'Ready to go live?' ) }</p>
+							<Button
+								compact
+								primary
+								className="hosting-overview__development-site-cta"
+								href={ `/settings/general/${ site?.slug }` }
+							>
+								{ translate( 'Prepare for launch' ) }
+							</Button>
+						</div>
+					</div>
+				) }
+
 				{ ! isAgencyPurchase && ! isStaging && <PricingSection /> }
 
 				{ ! isLoading && (

--- a/client/hosting/overview/components/plan-card.tsx
+++ b/client/hosting/overview/components/plan-card.tsx
@@ -11,7 +11,7 @@ import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
 import { usePlanBillingDescription } from '@automattic/plans-grid-next';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PlanStorage from 'calypso/blocks/plan-storage';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
@@ -23,6 +23,7 @@ import PlanStorageBar from 'calypso/hosting/overview/components/plan-storage-bar
 import { isPartnerPurchase, purchaseType } from 'calypso/lib/purchases';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
+import SitePreviewModal from 'calypso/sites-dashboard/components/site-preview-modal';
 import { isStagingSite } from 'calypso/sites-dashboard/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isA4AUser } from 'calypso/state/partner-portal/partner/selectors';
@@ -217,6 +218,10 @@ const PlanCard: FC = () => {
 		}
 	};
 
+	const [ isSitePreviewModalVisible, setSitePreviewModalVisible ] = useState( false );
+	const openSitePreviewModal = () => setSitePreviewModalVisible( true );
+	const closeSitePreviewModal = () => setSitePreviewModalVisible( false );
+
 	return (
 		<>
 			<QuerySitePlans siteId={ site?.ID } />
@@ -236,6 +241,13 @@ const PlanCard: FC = () => {
 						</>
 					) }
 				</div>
+
+				<SitePreviewModal
+					siteUrl={ site?.URL ?? '' }
+					siteId={ site?.ID ?? 0 }
+					isVisible={ isSitePreviewModalVisible }
+					closeModal={ closeSitePreviewModal }
+				></SitePreviewModal>
 
 				{ isAgencyPurchase && (
 					<div className="hosting-overview__plan-agency-purchase">
@@ -262,7 +274,7 @@ const PlanCard: FC = () => {
 							<Button
 								compact
 								className="hosting-overview__development-site-cta"
-								href={ `/settings/general/${ site?.slug }` }
+								onClick={ openSitePreviewModal }
 							>
 								{ translate( 'Share site for preview' ) }
 							</Button>

--- a/client/hosting/overview/components/style.scss
+++ b/client/hosting/overview/components/style.scss
@@ -457,3 +457,23 @@ button.hosting-overview__action-button {
 		font-size: 0.875rem;
 	}
 }
+
+.hosting-overview__development-site-ctas {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+
+	.hosting-overview__development-site-cta-wrapper {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+
+		p {
+			margin: 0;
+		}
+
+		.hosting-overview__development-site-cta {
+			min-width: 140px;
+		}
+	}
+}

--- a/client/hosting/overview/components/style.scss
+++ b/client/hosting/overview/components/style.scss
@@ -468,12 +468,12 @@ button.hosting-overview__action-button {
 		align-items: center;
 		justify-content: space-between;
 
-		p {
-			margin: 0;
-		}
-
 		.hosting-overview__development-site-cta {
 			min-width: 140px;
+		}
+
+		p {
+			margin: 0;
 		}
 	}
 }

--- a/client/sites-dashboard/components/site-preview-modal.tsx
+++ b/client/sites-dashboard/components/site-preview-modal.tsx
@@ -1,0 +1,47 @@
+import { css } from '@emotion/css';
+import styled from '@emotion/styled';
+import { Modal } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import SitePreviewLink from 'calypso/components/site-preview-link';
+
+interface SitePreviewModalProps {
+	siteUrl: string;
+	siteId: number;
+	isVisible: boolean;
+	closeModal: () => void;
+}
+
+const ModalContent = styled.div( {
+	width: '80vw',
+	maxWidth: '480px',
+	minHeight: '100px',
+	display: 'flex',
+	flexDirection: 'column',
+} );
+
+const modalOverlayClassName = css( {
+	// global-notices has z-index: 179
+	zIndex: 178,
+} );
+
+const SitePreviewModal = ( { siteUrl, siteId, isVisible, closeModal }: SitePreviewModalProps ) => {
+	const { __ } = useI18n();
+
+	if ( ! isVisible ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ __( 'Share site for preview' ) }
+			onRequestClose={ closeModal }
+			overlayClassName={ modalOverlayClassName }
+		>
+			<ModalContent>
+				<SitePreviewLink siteUrl={ siteUrl } siteId={ siteId } source="smp-modal" />
+			</ModalContent>
+		</Modal>
+	);
+};
+
+export default SitePreviewModal;

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -15,13 +15,12 @@ import {
 } from '@automattic/components';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
-import { DropdownMenu, MenuGroup, MenuItem as CoreMenuItem, Modal } from '@wordpress/components';
+import { DropdownMenu, MenuGroup, MenuItem as CoreMenuItem } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ComponentType, useEffect, useMemo, useState } from 'react';
-import SitePreviewLink from 'calypso/components/site-preview-link';
 import { useSiteCopy } from 'calypso/landing/stepper/hooks/use-site-copy';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
@@ -41,6 +40,7 @@ import {
 	isSimpleSite,
 	isP2Site,
 } from '../utils';
+import SitePreviewModal from './site-preview-modal';
 import type { SiteExcerptData } from '@automattic/sites';
 import type { AppState } from 'calypso/types';
 
@@ -169,19 +169,6 @@ const ManagePluginsItem = ( {
 	);
 };
 
-const ModalContent = styled.div( {
-	width: '80vw',
-	maxWidth: '480px',
-	minHeight: '100px',
-	display: 'flex',
-	flexDirection: 'column',
-} );
-
-const modalOverlayClassName = css( {
-	// global-notices has z-index: 179
-	zIndex: 178,
-} );
-
 function useSafeSiteHasFeature( siteId: number, feature: string ) {
 	const dispatch = useReduxDispatch();
 	useEffect( () => {
@@ -216,17 +203,12 @@ const PreviewSiteModalItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 	return (
 		<>
 			<MenuItemLink onClick={ onSitePreviewClick }>{ __( 'Share site for preview' ) }</MenuItemLink>
-			{ isVisible && (
-				<Modal
-					title={ __( 'Share site for preview' ) }
-					onRequestClose={ closeModal }
-					overlayClassName={ modalOverlayClassName }
-				>
-					<ModalContent>
-						<SitePreviewLink siteUrl={ site.URL } siteId={ site.ID } source="smp-modal" />
-					</ModalContent>
-				</Modal>
-			) }
+			<SitePreviewModal
+				siteUrl={ site.URL }
+				siteId={ site.ID }
+				isVisible={ isVisible }
+				closeModal={ closeModal }
+			/>
 		</>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9039.

## Proposed Changes

* introduce `Development` badge and two CTAs:
  * `Prepare for launch` that leads to the _(General) Hosting settings_ page
  * `Share site for preview` - opening a modal that allows user to share the site

![Markup on 2024-09-10 at 13:29:44](https://github.com/user-attachments/assets/9a84a6ae-d22a-46d5-aca5-cb4f1fe2cbda)

![Markup on 2024-09-11 at 09:53:56](https://github.com/user-attachments/assets/368e98f2-79f0-4e7d-97d8-e4a413f5d99a)

These elements will display for A4A development sites only - and only if the `a4a-dev-sites` feature flag is enabled. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Related P2 post and discussion: pdKhl6-4fe-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build it with `yarn start`.
2. If you don't have any free development site, create it through the Agency portal: https://agencies.automattic.com/sites?flags=a4a-dev-sites.
3. Navigate to the _Site Overview_ page of your free development site: http://calypso.localhost:3000/overview/{site-slug}?flags=a4a-dev-sites (please note the feature flag).
4. The `Development` badge and two CTAs should be rendered correctly (as can be seen in the screenshot above).
5. Try clicking both CTAs. The `Prepare for launch` should get you to the _(General) Hosting_ settings page; the `Share site for preview` - should open a modal that allows you to share the site link. The sharing should work correctly.
6. Open the  _Site Overview_ page again, but now with a non-development site.
7. In this case, there should be no badge, nor any of the CTAs.
8. If you click on the ellipsis menu by a development site, the `Share site for preview` button there should work correctly as well:

![Markup on 2024-09-11 at 09:59:45](https://github.com/user-attachments/assets/18318c2f-2f6a-4dd9-92c6-1bb0d9a5e7a6)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?