### PR TITLE
Stepper: Rename query param  flag `signup` to `start`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -16,13 +16,15 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 	const steps = flow.useSteps();
 	const [ queryParams, setQuery ] = useSearchParams();
 	const ref = queryParams.get( 'ref' ) || '';
-	const isSignupStep = queryParams.has( 'signup' );
 
-	// TODO: Using the new signup flag we can remove reference to SENSEI_FLOW
+	// TODO: Using the new start flag we can remove reference to SENSEI_FLOW
 	const firstStepSlug = ( flow.name === SENSEI_FLOW ? steps[ 1 ] : steps[ 0 ] ).slug;
 	const isFirstStep = firstStepSlug === currentStepRoute;
 	const flowVariant = flow.variantSlug;
 	const signupStartEventProps = flow.useSignupStartEventProps?.();
+	const isStartingFlow = isFirstStep || queryParams.has( 'start' );
+	const flowName = flow.name;
+	const shouldTrack = flow.isSignupFlow && isStartingFlow;
 
 	const extraProps = useMemo(
 		() => ( {
@@ -31,11 +33,10 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 		} ),
 		[ signupStartEventProps, flowVariant ]
 	);
-	const flowName = flow.name;
-	const shouldTrack = flow.isSignupFlow && ( isFirstStep || isSignupStep );
+
 	const removeSignupParam = useCallback( () => {
-		if ( queryParams.has( 'signup' ) ) {
-			queryParams.delete( 'signup' );
+		if ( queryParams.has( 'start' ) ) {
+			queryParams.delete( 'start' );
 			setQuery( queryParams );
 		}
 	}, [ queryParams, setQuery ] );

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -66,7 +66,7 @@ describe( 'useSignUpTracking', () => {
 	} );
 
 	it( 'does not track event when the flow is not a isSignupFlow and the signup flag is set', () => {
-		render( { flow: regularFlow, currentStepRoute: 'step-1', queryParams: { signup: 1 } } );
+		render( { flow: regularFlow, currentStepRoute: 'step-1', queryParams: { start: 1 } } );
 
 		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
@@ -85,11 +85,11 @@ describe( 'useSignUpTracking', () => {
 			} );
 		} );
 
-		it( 'tracks the event when the step is not the first but the signup flag is set', () => {
+		it( 'tracks the event when the step is not the first but the start flag is set', () => {
 			render( {
 				flow: signUpFlow,
 				currentStepRoute: 'step-2',
-				queryParams: { signup: 1 },
+				queryParams: { start: 1 },
 			} );
 
 			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {


### PR DESCRIPTION
Closes #93950
Related to [#91280](https://github.com/Automattic/wp-calypso/issues/91280)

## Proposed Changes

*  Rename the `signup` query param to `start`

> [!NOTE]  
> As soon we merge it, the `/move` and `/hosting` links should be updated to replace the `signup` param. 


## Why are these changes being made?

* We are having unexpected calls to the `calypso_signup_start` when the flow opens the checkout page. This is happening because internally, the checkout page is also updating the current URL with the `signup` parameter, and it is conflicting with the logic to trigger the `calypso_signup_start` event on the only step,  introduced recently on the PR https://github.com/Automattic/wp-calypso/pull/93485

The code that is updating the current step URL with the signup query param for the checkout process is [here](https://github.com/Automattic/wp-calypso/blob/40b701a2f4c99c9c6185ad3468f4fffda493d08b/client/landing/stepper/utils/checkout.ts#L36-L37). 



## Testing Instructions
Scenario 1: Regular tracking
* Go to any signup flow (e.g., `/setup/migration`)
* Use Vigilant watch and check if only one calypso_signup_start was triggered.
* Follow the steps until it arrives on the checkout page
* Check no  `calypso_signup_start` was triggered. 

Scenario 2: `start` query param
* Go to any signup flow non-initial step using the signup query param  (E.g, `/setup/migration/create-site?start=true`) 
* Use Vigilant watch and check if only one calypso_signup_start was triggered.
* Follow the steps until it arrives on the checkout page
* Check no  calypso_signup_start was triggered. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
