### PR TITLE
Revert "Stepper: Rename query param  flag `signup` to `start`"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -16,15 +16,13 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 	const steps = flow.useSteps();
 	const [ queryParams, setQuery ] = useSearchParams();
 	const ref = queryParams.get( 'ref' ) || '';
+	const isSignupStep = queryParams.has( 'signup' );
 
-	// TODO: Using the new start flag we can remove reference to SENSEI_FLOW
+	// TODO: Using the new signup flag we can remove reference to SENSEI_FLOW
 	const firstStepSlug = ( flow.name === SENSEI_FLOW ? steps[ 1 ] : steps[ 0 ] ).slug;
 	const isFirstStep = firstStepSlug === currentStepRoute;
 	const flowVariant = flow.variantSlug;
 	const signupStartEventProps = flow.useSignupStartEventProps?.();
-	const isStartingFlow = isFirstStep || queryParams.has( 'start' );
-	const flowName = flow.name;
-	const shouldTrack = flow.isSignupFlow && isStartingFlow;
 
 	const extraProps = useMemo(
 		() => ( {
@@ -33,10 +31,11 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 		} ),
 		[ signupStartEventProps, flowVariant ]
 	);
-
+	const flowName = flow.name;
+	const shouldTrack = flow.isSignupFlow && ( isFirstStep || isSignupStep );
 	const removeSignupParam = useCallback( () => {
-		if ( queryParams.has( 'start' ) ) {
-			queryParams.delete( 'start' );
+		if ( queryParams.has( 'signup' ) ) {
+			queryParams.delete( 'signup' );
 			setQuery( queryParams );
 		}
 	}, [ queryParams, setQuery ] );

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -66,7 +66,7 @@ describe( 'useSignUpTracking', () => {
 	} );
 
 	it( 'does not track event when the flow is not a isSignupFlow and the signup flag is set', () => {
-		render( { flow: regularFlow, currentStepRoute: 'step-1', queryParams: { start: 1 } } );
+		render( { flow: regularFlow, currentStepRoute: 'step-1', queryParams: { signup: 1 } } );
 
 		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
@@ -85,11 +85,11 @@ describe( 'useSignUpTracking', () => {
 			} );
 		} );
 
-		it( 'tracks the event when the step is not the first but the start flag is set', () => {
+		it( 'tracks the event when the step is not the first but the signup flag is set', () => {
 			render( {
 				flow: signUpFlow,
 				currentStepRoute: 'step-2',
-				queryParams: { start: 1 },
+				queryParams: { signup: 1 },
 			} );
 
 			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#94364