### PR TITLE
A4A: Update the contact support view to handle the Pressable product

### DIFF
--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -225,37 +225,22 @@ export default function UserContactSupportModalForm( {
 
 				<FormFieldset>
 					<FormLabel htmlFor="message">{ translate( 'How can we help?' ) }</FormLabel>
-					{ ! isPressableSelected ? (
-						<FormTextarea
-							name="message"
-							id="message"
-							placeholder={ translate( 'Add your message here' ) }
-							value={ message }
-							onChange={ onMessageChange }
-							onClick={ () =>
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_user_contact_support_form_message_click' )
-								)
-							}
-						/>
-					) : (
-						<p>
-							{ translate(
-								'For help with Pressable, please {{a}}login to your Pressable account{{/a}} and request help using the chat widget on the bottom right of the page.',
-								{
-									components: {
-										a: (
-											<a
-												href="https://my.pressable.com/login"
-												target="_blank"
-												rel="noreferrer noopener"
-											/>
-										),
-									},
-								}
-							) }
-						</p>
-					) }
+					<FormTextarea
+						name="message"
+						id="message"
+						placeholder={
+							isPressableSelected
+								? translate(
+										'Please provide the team with a detailed explanation of the issue you’re facing, including steps to reproduce the issue on our end and/or URLs (if not specified above). Providing these details will greatly help us with your support request.'
+								  )
+								: translate( 'Add your message here' )
+						}
+						value={ message }
+						onChange={ onMessageChange }
+						onClick={ () =>
+							dispatch( recordTracksEvent( 'calypso_a4a_user_contact_support_form_message_click' ) )
+						}
+					/>
 				</FormFieldset>
 			</div>
 

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -117,8 +117,18 @@ export default function UserContactSupportModalForm( {
 			} )
 		);
 
-		submit( { message, name, email, product, site } );
-	}, [ hasCompletedForm, dispatch, message, submit, name, email, product, site ] );
+		submit( { message, name, email, product, site, pressableContactType } );
+	}, [
+		hasCompletedForm,
+		dispatch,
+		message,
+		submit,
+		name,
+		email,
+		product,
+		site,
+		pressableContactType,
+	] );
 
 	useEffect( () => {
 		if ( show ) {

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -239,7 +239,7 @@ export default function UserContactSupportModalForm( {
 						placeholder={
 							isPressableSelected
 								? translate(
-										'Please provide the team with a detailed explanation of the issue you’re facing, including steps to reproduce the issue on our end and/or URLs (if not specified above). Providing these details will greatly help us with your support request.'
+										'Please provide the team with a detailed explanation of the issue you’re facing, including steps to reproduce the issue on our end and/or URLs. Providing these details will greatly help us with your support request.'
 								  )
 								: translate( 'Add your message here' )
 						}

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -117,7 +117,7 @@ export default function UserContactSupportModalForm( {
 			} )
 		);
 
-		submit( { message, name, email, product, site, pressableContactType } );
+		submit( { message, name, email, product, site, contact_type: pressableContactType } );
 	}, [
 		hasCompletedForm,
 		dispatch,

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -38,6 +38,7 @@ export default function UserContactSupportModalForm( {
 	const [ name, setName ] = useState( user?.display_name );
 	const [ email, setEmail ] = useState( user?.email );
 	const [ product, setProduct ] = useState( DEFAULT_PRODUCT_VALUE );
+	const [ pressableContactType, setPressableContactType ] = useState( 'sales' );
 	const [ site, setSite ] = useState( '' );
 	const [ message, setMessage ] = useState( defaultMessage );
 
@@ -90,6 +91,13 @@ export default function UserContactSupportModalForm( {
 	const onProductChange: FormEventHandler = useCallback(
 		( event: ChangeEvent< HTMLSelectElement > ) => {
 			setProduct( event.currentTarget.value );
+		},
+		[]
+	);
+
+	const onPressableContactTypeChange: FormEventHandler = useCallback(
+		( event: ChangeEvent< HTMLSelectElement > ) => {
+			setPressableContactType( event.currentTarget.value );
 		},
 		[]
 	);
@@ -208,8 +216,8 @@ export default function UserContactSupportModalForm( {
 							<FormSelect
 								name="pressable_contact"
 								id="product"
-								value={ product }
-								onChange={ onProductChange }
+								value={ pressableContactType }
+								onChange={ onPressableContactTypeChange }
 							>
 								<option value="sales">{ translate( 'Sales' ) }</option>
 								<option value="support">{ translate( 'Support' ) }</option>

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -199,6 +199,30 @@ export default function UserContactSupportModalForm( {
 					</FormSelect>
 				</FormFieldset>
 
+				{ isPressableSelected ? (
+					<>
+						<FormFieldset>
+							<FormLabel htmlFor="product">
+								{ translate( 'Would you like help with Pressable sales or support?' ) }
+							</FormLabel>
+							<FormSelect
+								name="pressable_contact"
+								id="product"
+								value={ product }
+								onChange={ onProductChange }
+							>
+								<option value="sales">{ translate( 'Sales' ) }</option>
+								<option value="support">{ translate( 'Support' ) }</option>
+							</FormSelect>
+						</FormFieldset>
+						<div className="form-field-description">
+							{ translate(
+								'Your request will be routed directly to a Pressable support specialist to chat about your needs.'
+							) }
+						</div>
+					</>
+				) : null }
+
 				<FormFieldset>
 					<FormLabel htmlFor="message">{ translate( 'How can we help?' ) }</FormLabel>
 					{ ! isPressableSelected ? (

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -43,7 +43,7 @@ export default function UserContactSupportModalForm( {
 	const [ message, setMessage ] = useState( defaultMessage );
 
 	const isPressableSelected = product === 'pressable';
-	const hasCompletedForm = !! message && !! name && !! email && !! product && ! isPressableSelected;
+	const hasCompletedForm = !! message && !! name && !! email && !! product;
 
 	const { isSubmitting, submit, isSubmissionSuccessful } = useSubmitContactSupport();
 

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -217,7 +217,7 @@ export default function UserContactSupportModalForm( {
 					</FormSelect>
 				</FormFieldset>
 
-				{ isPressableSelected ? (
+				{ isPressableSelected && (
 					<>
 						<FormFieldset>
 							<FormLabel htmlFor="product">
@@ -239,7 +239,7 @@ export default function UserContactSupportModalForm( {
 							) }
 						</div>
 					</>
-				) : null }
+				) }
 
 				<FormFieldset>
 					<FormLabel htmlFor="message">{ translate( 'How can we help?' ) }</FormLabel>

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -9,6 +9,7 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -34,6 +35,7 @@ export default function UserContactSupportModalForm( {
 	const dispatch = useDispatch();
 
 	const user = useSelector( getCurrentUser );
+	const agency = useSelector( getActiveAgency );
 
 	const [ name, setName ] = useState( user?.display_name );
 	const [ email, setEmail ] = useState( user?.email );
@@ -43,7 +45,7 @@ export default function UserContactSupportModalForm( {
 	const [ message, setMessage ] = useState( defaultMessage );
 
 	const isPressableSelected = product === 'pressable';
-	const hasCompletedForm = !! message && !! name && !! email && !! product;
+	const hasCompletedForm = !! message && !! name && !! email && !! product && !! agency;
 
 	const { isSubmitting, submit, isSubmissionSuccessful } = useSubmitContactSupport();
 
@@ -117,7 +119,19 @@ export default function UserContactSupportModalForm( {
 			} )
 		);
 
-		submit( { message, name, email, product, site, contact_type: pressableContactType } );
+		const pressable_id = agency?.third_party?.pressable?.pressable_id;
+
+		const formData = {
+			message,
+			name,
+			email,
+			product,
+			...( site && { site } ),
+			...( pressableContactType && { contact_type: pressableContactType } ),
+			...( pressable_id && { pressable_id } ),
+		};
+
+		submit( formData );
 	}, [
 		hasCompletedForm,
 		dispatch,
@@ -128,6 +142,7 @@ export default function UserContactSupportModalForm( {
 		product,
 		site,
 		pressableContactType,
+		agency,
 	] );
 
 	useEffect( () => {

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/style.scss
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/style.scss
@@ -33,6 +33,13 @@
 		border-radius: 4px;
 	}
 
+	.form-field-description {
+		margin-top: -20px;
+		font-size: rem(14px);
+		font-weight: 400;
+		color: var(--color-neutral-50);
+	}
+
 	@include break-medium {
 		margin: auto;
 	}

--- a/client/a8c-for-agencies/data/support/types.ts
+++ b/client/a8c-for-agencies/data/support/types.ts
@@ -12,5 +12,5 @@ export interface SubmitContactSupportParams {
 	product: string;
 	site?: string;
 	no_of_sites?: number;
-	pressableContactType?: string;
+	contact_type?: string;
 }

--- a/client/a8c-for-agencies/data/support/types.ts
+++ b/client/a8c-for-agencies/data/support/types.ts
@@ -12,4 +12,5 @@ export interface SubmitContactSupportParams {
 	product: string;
 	site?: string;
 	no_of_sites?: number;
+	pressableContactType?: string;
 }

--- a/client/a8c-for-agencies/data/support/types.ts
+++ b/client/a8c-for-agencies/data/support/types.ts
@@ -13,4 +13,5 @@ export interface SubmitContactSupportParams {
 	site?: string;
 	no_of_sites?: number;
 	contact_type?: string;
+	pressable_id?: number;
 }

--- a/client/a8c-for-agencies/data/support/use-submit-support-form-mutation.ts
+++ b/client/a8c-for-agencies/data/support/use-submit-support-form-mutation.ts
@@ -7,6 +7,13 @@ interface APIResponse {
 }
 
 function mutationSubmitSupportForm( params: SubmitContactSupportParams ): Promise< APIResponse > {
+	// Send an email to Pressable support
+	if ( params.product === 'pressable' ) {
+		// todo: Send the data to the endpoint
+		return Promise.resolve( { success: true } );
+	}
+
+	// Create the ticket in Zendesk
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
 		path: '/agency/help/zendesk/create-ticket',

--- a/client/a8c-for-agencies/data/support/use-submit-support-form-mutation.ts
+++ b/client/a8c-for-agencies/data/support/use-submit-support-form-mutation.ts
@@ -7,16 +7,16 @@ interface APIResponse {
 }
 
 function mutationSubmitSupportForm( params: SubmitContactSupportParams ): Promise< APIResponse > {
-	// Send an email to Pressable support
+	let path = '/agency/help/zendesk/create-ticket';
+
 	if ( params.product === 'pressable' ) {
-		// todo: Send the data to the endpoint
-		return Promise.resolve( { success: true } );
+		path = '/agency/help/pressable/support';
 	}
 
 	// Create the ticket in Zendesk
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
-		path: '/agency/help/zendesk/create-ticket',
+		path,
 		body: params,
 	} );
 }


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/896

## Proposed Changes

<img width="793" alt="image" src="https://github.com/user-attachments/assets/243acec5-fff4-443b-bf95-16b2adc3e10c">

**Tested by Pressable:** The Pressable support team confirmed they received the email, one for Sales and another for Support.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- You have to apply this diff: D161044 
- Follow the instructions on that diff.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
