### PR TITLE
A4A Dev Sites: Add license count and pricing on A4A launch text.

### DIFF
--- a/client/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog.ts
+++ b/client/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog.ts
@@ -18,6 +18,8 @@ export default function useFetchAgencyFromBlog(
 			return {
 				id: data?.id,
 				name: data?.name,
+				existing_wpcom_license_count: data?.existing_wpcom_license_count,
+				prices: data?.prices,
 			};
 		},
 		enabled: !! blogId && enabled,

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -1,5 +1,6 @@
 import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products';
 import { Card, CompactCard, Button } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -112,6 +113,10 @@ const LaunchSite = () => {
 		isLoading: agencyLoading,
 	} = useFetchAgencyFromBlog( site?.ID, { enabled: !! site?.ID && isDevelopmentSite } );
 	const agencyName = agency?.name;
+	const existingWPCOMLicenseCount = agency?.existing_wpcom_license_count || 0;
+	const price = formatCurrency( agency?.prices?.actual_price, agency?.prices?.currency );
+
+	console.log( agency?.prices );
 
 	const handleReferToClient = () => {
 		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ siteId }`;
@@ -159,13 +164,23 @@ const LaunchSite = () => {
 								{ agencyLoading || agencyError
 									? translate( 'After launch, we’ll bill your agency in the next billing cycle.' )
 									: translate(
-											'After launch, we’ll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle.',
+											'After launch, we’ll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting licenses, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}',
 											{
 												args: {
 													agencyName: agencyName,
+													licenseCount: existingWPCOMLicenseCount + 1,
+													price,
 												},
 												components: {
 													strong: <strong />,
+													a: (
+														<a
+															className="site-settings__general-settings-launch-site-agency-learn-more"
+															href="https://agencieshelp.automattic.com/knowledge-base/the-marketplace/"
+															target="_blank"
+															rel="noopener noreferrer"
+														/>
+													),
 												},
 												comment: 'name of the agency that will be billed for the site',
 											}

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -162,8 +162,10 @@ const LaunchSite = () => {
 								{ agencyLoading || agencyError
 									? translate( 'After launch, we’ll bill your agency in the next billing cycle.' )
 									: translate(
+											'After launch, we’ll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting license, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}',
 											'After launch, we’ll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting licenses, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}',
 											{
+												count: existingWPCOMLicenseCount + 1,
 												args: {
 													agencyName: agencyName,
 													licenseCount: existingWPCOMLicenseCount + 1,
@@ -180,7 +182,8 @@ const LaunchSite = () => {
 														/>
 													),
 												},
-												comment: 'name of the agency that will be billed for the site',
+												comment:
+													'agencyName: name of the agency that will be billed for the site; licenseCount: number of licenses the agency will be billed for; price: price per license',
 											}
 									  ) }
 							</i>

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -116,8 +116,6 @@ const LaunchSite = () => {
 	const existingWPCOMLicenseCount = agency?.existing_wpcom_license_count || 0;
 	const price = formatCurrency( agency?.prices?.actual_price, agency?.prices?.currency );
 
-	console.log( agency?.prices );
-
 	const handleReferToClient = () => {
 		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ siteId }`;
 	};


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9040.

## Proposed Changes

* Add license count and pricing on A4A launch text on hosting settings page.
* Also includes Learn More link.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/Automattic/dotcom-forge/issues/9040
* See context: pdtkmj-2Te-p2#comment-5580

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
1. Apply the API patch D160970-code on your sandbox.
2. Go to the hosting settings page of an A4A dev blog, e.g. `https://wordpress.com/settings/general/<blog-id>`.
3. You should see the updated launch text (refer to screenshot).
4. Check if the license count + pricing is correct.
   - Verify with what you see on https://agencies.automattic.com/marketplace/hosting/wpcom.
   - Remember, if you have 6 existing licenses, it is calculating the price of 7 licenses (6 existing + 1 after you launch).
5. The Learn More link should work.

<img width="1283" alt="image" src="https://github.com/user-attachments/assets/a34f8caf-cfe8-43fb-af55-a6a15f691fc6">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?