### PR TITLE
A4A Dev Sites: Persistent gray background for create dev site CTA button.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -102,6 +102,7 @@
 		flex-direction: column;
 		padding-top: 0;
 		gap: 4px;
+		background-color: var(--color-neutral-0);
 
 		@include break-large {
 			padding: 16px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9043

## Proposed Changes

* The create dev site CTA button should be persistently gray.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Context: pdtkmj-2Te-p2#comment-5578

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `yarn start-a8c-for-agencies`.
2. Go to `http://agencies.localhost:3000/sites?flags=a4a-dev-sites`.
3. Click on **Add Sites**.
4. The create dev site CTA button should have a gray background.


<img width="1181" alt="image" src="https://github.com/user-attachments/assets/53ab2dbc-aa91-4e60-97a7-ff3d0bca1658">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?