### PR TITLE
Themes showcase: Scroll to top of showcase

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -669,7 +669,7 @@ class ThemeShowcase extends Component {
 			siteId && this.props.category === staticFilters.MYTHEMES.key && isJetpackSite;
 
 		return (
-			<div className={ classnames } ref={ this.showcaseRef }>
+			<div className={ classnames }>
 				<PageViewTracker
 					path={ this.props.analyticsPath }
 					title={ this.props.analyticsPageTitle }
@@ -699,15 +699,18 @@ class ThemeShowcase extends Component {
 						<>
 							{ isLoggedIn && (
 								<InView
-									as="div"
-									className={ clsx( 'themes__controls-placeholder', {
-										'is-sticky': this.state.shouldThemeControlsSticky,
-									} ) }
 									rootMargin="-32px 0px 0px 0px"
 									threshold={ 1 }
 									fallbackInView
 									onChange={ this.onShouldThemeControlsStickyChange }
-								/>
+								>
+									<div
+										className={ clsx( 'themes__controls-placeholder', {
+											'is-sticky': this.state.shouldThemeControlsSticky,
+										} ) }
+										ref={ this.showcaseRef }
+									/>
+								</InView>
 							) }
 							<div
 								className={ clsx( 'themes__controls', {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -250,7 +250,7 @@ class ThemeShowcase extends Component {
 		// Scroll to the top of the showcase
 		if ( this.showcaseRef.current ) {
 			this.showcaseRef.current.scrollIntoView( {
-				behavior: 'smooth',
+				behavior: 'instant',
 				block: 'start',
 			} );
 		}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -103,6 +103,7 @@ class ThemeShowcase extends Component {
 		super( props );
 		this.scrollRef = createRef();
 		this.bookmarkRef = createRef();
+		this.showcaseRef = createRef();
 
 		this.subjectFilters = this.getSubjectFilters( props );
 		this.subjectTermTable = getSubjectsFromTermTable( props.filterToTermTable );
@@ -246,6 +247,14 @@ class ThemeShowcase extends Component {
 	};
 
 	scrollToSearchInput = () => {
+		// Scroll to the top of the showcase
+		if ( this.showcaseRef.current ) {
+			this.showcaseRef.current.scrollIntoView( {
+				behavior: 'smooth',
+				block: 'start',
+			} );
+		}
+
 		let y = 0;
 
 		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
@@ -660,7 +669,7 @@ class ThemeShowcase extends Component {
 			siteId && this.props.category === staticFilters.MYTHEMES.key && isJetpackSite;
 
 		return (
-			<div className={ classnames }>
+			<div className={ classnames } ref={ this.showcaseRef }>
 				<PageViewTracker
 					path={ this.props.analyticsPath }
 					title={ this.props.analyticsPageTitle }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92646

## Proposed Changes

* Scroll the header into view when the themes selection changes (by filtering, changing categories, searching).

Before:

https://github.com/user-attachments/assets/bb631905-eb27-4e4b-8dd9-b8ca3363e360

After:

https://github.com/user-attachments/assets/dcc561c3-8aca-467e-9fc7-2c991409e334





Open questions:
- Does this add to the jankiness or improve it?
- Is it weird that we scroll up after any interaction with the search input?
- Are we scrolling up too far? If the ref is in the scrollable area, it doesn't scroll up all the way (only halfway through the top item).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the UX and not end up in weird scrolling positions when changing categories in the sticky header.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /themes while logged in on desktop screen size.
* Scroll down the page, then click to change categories / filters / search.
* The page should scroll back up to the top.
* Repeat on site-specific /themes/{site}
* Test mobile and logged-out to check that changing categories / filtering / searching still works correctly.
* Regression test that clicking on an individual theme and then returning to Themes keeps that theme visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
