### PR TITLE
A4A Dev Sites: Update launch confirmation modal copy.

### DIFF
--- a/client/my-sites/site-settings/site-visibility/launch-confirmation-modal.tsx
+++ b/client/my-sites/site-settings/site-visibility/launch-confirmation-modal.tsx
@@ -20,19 +20,13 @@ export function LaunchConfirmationModal( {
 	billingAgencyMessage,
 	onConfirmation,
 }: LaunchConfirmationModalProps ) {
-	// Not wrapped in translation to avoid request unconfirmed copy
-	const modalTitle = 'You’re about to update your production site';
+	const modalTitle = translate( "You're about to launch this website" );
 
 	return (
 		<>
 			<Modal title={ modalTitle } onRequestClose={ closeModal }>
-				{ billingAgencyMessage && (
-					<p>
-						{ billingAgencyMessage }
-						<br />
-						Are you sure you want to proceed?
-					</p>
-				) }
+				{ billingAgencyMessage && <p>{ billingAgencyMessage }</p> }
+				<p>{ translate( 'Ready to launch?' ) }</p>
 				<ActionButtons>
 					<Button
 						onClick={ () => {
@@ -42,7 +36,7 @@ export function LaunchConfirmationModal( {
 						{ translate( 'Cancel' ) }
 					</Button>
 					<Button primary onClick={ onConfirmation }>
-						{ translate( 'Yes, launch site' ) }
+						{ translate( 'Launch site' ) }
 					</Button>
 				</ActionButtons>
 			</Modal>

--- a/client/my-sites/site-settings/site-visibility/launch-confirmation-modal.tsx
+++ b/client/my-sites/site-settings/site-visibility/launch-confirmation-modal.tsx
@@ -12,34 +12,36 @@ const ActionButtons = styled.div( {
 type LaunchConfirmationModalProps = {
 	onConfirmation: () => void;
 	closeModal: () => void;
-	billingAgencyMessage: string;
+	message: string;
 };
 
 export function LaunchConfirmationModal( {
 	closeModal,
-	billingAgencyMessage,
+	message,
 	onConfirmation,
 }: LaunchConfirmationModalProps ) {
 	const modalTitle = translate( "You're about to launch this website" );
 
 	return (
-		<>
-			<Modal title={ modalTitle } onRequestClose={ closeModal }>
-				{ billingAgencyMessage && <p>{ billingAgencyMessage }</p> }
-				<p>{ translate( 'Ready to launch?' ) }</p>
-				<ActionButtons>
-					<Button
-						onClick={ () => {
-							closeModal();
-						} }
-					>
-						{ translate( 'Cancel' ) }
-					</Button>
-					<Button primary onClick={ onConfirmation }>
-						{ translate( 'Launch site' ) }
-					</Button>
-				</ActionButtons>
-			</Modal>
-		</>
+		<Modal
+			className="site-settings__launch-confirmation-modal"
+			title={ modalTitle }
+			onRequestClose={ closeModal }
+		>
+			{ message && <p>{ message }</p> }
+			<p>{ translate( 'Ready to launch?' ) }</p>
+			<ActionButtons>
+				<Button
+					onClick={ () => {
+						closeModal();
+					} }
+				>
+					{ translate( 'Cancel' ) }
+				</Button>
+				<Button primary onClick={ onConfirmation }>
+					{ translate( 'Launch site' ) }
+				</Button>
+			</ActionButtons>
+		</Modal>
 	);
 }

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -120,16 +120,21 @@ const LaunchSite = () => {
 		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ siteId }`;
 	};
 
-	// Not wrapped in translation to avoid request unconfirmed copy
 	const billingAgencyMessage =
-		agencyLoading || agencyError ? (
-			'Once launched, your agency {agench-name} will be billed for this website in the next billing cycle.'
-		) : (
-			<>
-				Once launched, <strong>{ agencyName }</strong> will be billed for this website in the next
-				billing cycle.
-			</>
-		);
+		agencyLoading || agencyError
+			? translate( 'Once launched, your agency will be billed for it in the next billing cycle.' )
+			: translate(
+					'This means your agency, {{strong}}%(agencyName)s{{/strong}}, will be billed for it in the next billing cycle.',
+					{
+						args: {
+							agencyName: agencyName,
+						},
+						components: {
+							strong: <strong />,
+						},
+						comment: 'name of the agency that will be billed for the site',
+					}
+			  );
 
 	return (
 		<>

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -120,19 +120,32 @@ const LaunchSite = () => {
 		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ siteId }`;
 	};
 
-	const billingAgencyMessage =
+	const agencyBillingMessage =
 		agencyLoading || agencyError
-			? translate( 'Once launched, your agency will be billed for it in the next billing cycle.' )
+			? translate( "After launch, we'll bill your agency in the next billing cycle." )
 			: translate(
-					'This means your agency, {{strong}}%(agencyName)s{{/strong}}, will be billed for it in the next billing cycle.',
+					"After launch, we'll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting license, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}",
+					"After launch, we'll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting licenses, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}",
 					{
+						count: existingWPCOMLicenseCount + 1,
 						args: {
 							agencyName: agencyName,
+							licenseCount: existingWPCOMLicenseCount + 1,
+							price,
 						},
 						components: {
 							strong: <strong />,
+							a: (
+								<a
+									className="site-settings__general-settings-launch-site-agency-learn-more"
+									href="https://agencieshelp.automattic.com/knowledge-base/the-marketplace/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
 						},
-						comment: 'name of the agency that will be billed for the site',
+						comment:
+							'agencyName: name of the agency that will be billed for the site; licenseCount: number of licenses the agency will be billed for; price: price per license',
 					}
 			  );
 
@@ -140,7 +153,7 @@ const LaunchSite = () => {
 		<>
 			{ isLaunchConfirmationModalOpen && (
 				<LaunchConfirmationModal
-					billingAgencyMessage={ billingAgencyMessage }
+					message={ agencyBillingMessage }
 					closeModal={ closeLaunchConfirmationModal }
 					onConfirmation={ () => {
 						dispatchSiteLaunch();
@@ -162,37 +175,7 @@ const LaunchSite = () => {
 										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
 								  ) }
 						</p>
-						{ isDevelopmentSite && (
-							<i>
-								{ agencyLoading || agencyError
-									? translate( 'After launch, we’ll bill your agency in the next billing cycle.' )
-									: translate(
-											'After launch, we’ll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting license, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}',
-											'After launch, we’ll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting licenses, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}',
-											{
-												count: existingWPCOMLicenseCount + 1,
-												args: {
-													agencyName: agencyName,
-													licenseCount: existingWPCOMLicenseCount + 1,
-													price,
-												},
-												components: {
-													strong: <strong />,
-													a: (
-														<a
-															className="site-settings__general-settings-launch-site-agency-learn-more"
-															href="https://agencieshelp.automattic.com/knowledge-base/the-marketplace/"
-															target="_blank"
-															rel="noopener noreferrer"
-														/>
-													),
-												},
-												comment:
-													'agencyName: name of the agency that will be billed for the site; licenseCount: number of licenses the agency will be billed for; price: price per license',
-											}
-									  ) }
-							</i>
-						) }
+						{ isDevelopmentSite && <i>{ agencyBillingMessage }</i> }
 					</div>
 					<div className={ launchSiteClasses }>{ btnComponent }</div>
 					{ isDevelopmentSite && (

--- a/client/my-sites/site-settings/site-visibility/styles.scss
+++ b/client/my-sites/site-settings/site-visibility/styles.scss
@@ -13,3 +13,7 @@
 	margin-left: 20px;
 	white-space: nowrap;
 }
+
+.site-settings__launch-confirmation-modal {
+	max-width: 60%;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9042
Closes https://github.com/Automattic/dotcom-forge/issues/9040

## Proposed Changes

Update launch confirmation modal copy to:

```
You’re about to launch this website

After launch, we'll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting licenses, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}

Ready to launch?

[[Cancel]] [[Launch site]]
```

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* CfT Context: pdtkmj-2Te-p2#comment-5583

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to the hosting settings page of an A4A dev blog, e.g. `https://wordpress.com/settings/general/<blog-id>`.
2. Click **Launch Site** button.
3. Inspect the copy on the launch site confirmation dialog.l

**Before**
<img width="877" alt="image" src="https://github.com/user-attachments/assets/346ac6d0-cff8-424b-a714-110ef210e9c6">

**After**
![image](https://github.com/user-attachments/assets/419d6685-1385-41d3-b993-d02118276182)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?