### PR TITLE
Host features - fix issue unexpected hosting features page after site switch.

### DIFF
--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -55,6 +55,8 @@ const HostingFeatures = () => {
 			? `/hosting-config/${ siteId }`
 			: `/overview/${ siteId }`
 	);
+	const initialSiteId = useRef( siteId );
+	const siteSelectionChanging = initialSiteId.current !== siteId;
 	const hasEnTranslation = useHasEnTranslation();
 
 	const { data: siteTransferData, refetch: refetchSiteTransferData } = useSiteTransferStatusQuery(
@@ -84,10 +86,10 @@ const HostingFeatures = () => {
 	}, [ siteId, siteTransferData?.status, refetchSiteTransferData, dispatch ] );
 
 	useEffect( () => {
-		if ( isSiteAtomic && ! isPlanExpired ) {
+		if ( isSiteAtomic && ! isPlanExpired && ! siteSelectionChanging ) {
 			page.replace( redirectUrl.current );
 		}
-	}, [ isSiteAtomic, isPlanExpired ] );
+	}, [ isSiteAtomic, isPlanExpired, siteSelectionChanging ] );
 
 	const upgradeLink = `https://wordpress.com/checkout/${ encodeURIComponent( siteSlug ) }/business`;
 	const promoCards = [

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -85,7 +85,6 @@ const HostingFeatures = () => {
 		return () => clearInterval( interval );
 	}, [ siteId, siteTransferData?.status, refetchSiteTransferData, dispatch ] );
 
-	// Redirect for if we are updating the site to atomic on this page.
 	useEffect( () => {
 		if ( isSiteAtomic && ! isPlanExpired ) {
 			page.replace( redirectUrl );

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -50,11 +50,13 @@ const HostingFeatures = () => {
 		isPlanExpired: !! getSelectedSite( state )?.plan?.expired,
 	} ) );
 	// The ref is required to persist the value of redirect_to after renders
-	const redirectUrl = useRef(
-		searchParams.get( 'redirect_to' ) ?? ( hasSftpFeature && isSiteAtomic )
+	const redirectToRef = useRef( searchParams.get( 'redirect_to' ) );
+
+	const redirectUrl =
+		redirectToRef.current ?? ( hasSftpFeature && isSiteAtomic )
 			? `/hosting-config/${ siteId }`
-			: `/overview/${ siteId }`
-	);
+			: `/overview/${ siteId }`;
+
 	const hasEnTranslation = useHasEnTranslation();
 
 	const { data: siteTransferData, refetch: refetchSiteTransferData } = useSiteTransferStatusQuery(
@@ -128,7 +130,7 @@ const HostingFeatures = () => {
 		dispatch( recordTracksEvent( 'calypso_hosting_features_activate_confirm' ) );
 		const params = new URLSearchParams( {
 			siteId: String( siteId ),
-			redirect_to: redirectUrl.current,
+			redirect_to: redirectUrl,
 			feature: FEATURE_SFTP,
 			initiate_transfer_context: 'hosting',
 			initiate_transfer_geo_affinity: options.geo_affinity || '',
@@ -215,7 +217,7 @@ const HostingFeatures = () => {
 					<EligibilityWarnings
 						className="hosting__activating-warnings"
 						onProceed={ handleTransfer }
-						backUrl={ redirectUrl.current }
+						backUrl={ redirectUrl }
 						showDataCenterPicker
 						standaloneProceed
 						currentContext="hosting-features"

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -51,7 +51,7 @@ const HostingFeatures = () => {
 	} ) );
 	// The ref is required to persist the value of redirect_to after renders
 	const redirectUrl = useRef(
-		searchParams.get( 'redirect_to' ) ?? hasSftpFeature
+		searchParams.get( 'redirect_to' ) ?? ( hasSftpFeature && isSiteAtomic )
 			? `/hosting-config/${ siteId }`
 			: `/overview/${ siteId }`
 	);

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -85,6 +85,13 @@ const HostingFeatures = () => {
 		return () => clearInterval( interval );
 	}, [ siteId, siteTransferData?.status, refetchSiteTransferData, dispatch ] );
 
+	// Redirect for if we are updating the site to atomic on this page.
+	useEffect( () => {
+		if ( isSiteAtomic && ! isPlanExpired ) {
+			page.replace( redirectUrl );
+		}
+	}, [ isSiteAtomic, isPlanExpired, redirectUrl ] );
+
 	const upgradeLink = `https://wordpress.com/checkout/${ encodeURIComponent( siteSlug ) }/business`;
 	const promoCards = [
 		{

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -55,8 +55,6 @@ const HostingFeatures = () => {
 			? `/hosting-config/${ siteId }`
 			: `/overview/${ siteId }`
 	);
-	const initialSiteId = useRef( siteId );
-	const siteSelectionChanging = initialSiteId.current !== siteId;
 	const hasEnTranslation = useHasEnTranslation();
 
 	const { data: siteTransferData, refetch: refetchSiteTransferData } = useSiteTransferStatusQuery(
@@ -84,12 +82,6 @@ const HostingFeatures = () => {
 
 		return () => clearInterval( interval );
 	}, [ siteId, siteTransferData?.status, refetchSiteTransferData, dispatch ] );
-
-	useEffect( () => {
-		if ( isSiteAtomic && ! isPlanExpired && ! siteSelectionChanging ) {
-			page.replace( redirectUrl.current );
-		}
-	}, [ isSiteAtomic, isPlanExpired, siteSelectionChanging ] );
 
 	const upgradeLink = `https://wordpress.com/checkout/${ encodeURIComponent( siteSlug ) }/business`;
 	const promoCards = [

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -53,7 +53,7 @@ const HostingFeatures = () => {
 	const redirectToRef = useRef( searchParams.get( 'redirect_to' ) );
 
 	const redirectUrl =
-		redirectToRef.current ?? ( hasSftpFeature && isSiteAtomic )
+		redirectToRef.current ?? hasSftpFeature
 			? `/hosting-config/${ siteId }`
 			: `/overview/${ siteId }`;
 

--- a/client/hosting/hosting-features/index.tsx
+++ b/client/hosting/hosting-features/index.tsx
@@ -1,4 +1,5 @@
 import page, { Context as PageJSContext } from '@automattic/calypso-router';
+import { addQueryArgs } from '@wordpress/url';
 import { makeLayout, render as clientRender, redirectIfP2 } from 'calypso/controller';
 import { DOTCOM_HOSTING_FEATURES } from 'calypso/hosting/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/hosting/sites/controller';
@@ -10,7 +11,7 @@ const redirectForNonSimpleSite = ( context: PageJSContext, next: () => void ) =>
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 	if ( site && site.jetpack && ! site.plan?.expired ) {
-		return page.redirect( `/overview/${ context.params.site }` );
+		return page.redirect( addQueryArgs( `/overview/${ context.params.site }`, context.query ) );
 	}
 	return next();
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/94325

## Proposed Changes

Fixes the issue noted above where changing sites in the dashboard with the hosting-features tab selected can bug out if the site switching from has a business plan but is not atomic, and switching to an atomic site.

* Updates the `redirectUrl` used here to adapt to a changing site Id. We have kept the ref for preserving the `redirect_to` url.
    * This stale redirectUrl was the main cause of the issue. When switching to an atomic site while viewing the hosting-features page, the hook for redirecting atomic sites was being triggered with the URL for the site we were switching from. That site did not have access to hosting-config, and this was causing another redirect back to hosting-features and overriding the site selection that was happening and presenting the hosting-features page again.
    * This also fixes a separate issue where if we load the hosting-features tab for one site, then select another site that hosting-features tab is enabled for, that tab for the new site would have an outdated redirectUrl corresponding to the first site the hosting-features was loaded on. This could present issues with redirects, such as triggering an atomic transfer for that second site.
* Updates the `redirectForNonSimpleSite` middleware function used in the hosting-features controller to continue passing the query params when it redirects to the overview page.
   * When selecting an atomic site while having hosting-features open for another site already, this middleware caused the new site to be redirected to overview without query args. Resetting any search query, filters, etc. the user may have been using for dataViews.  
   * This bug was not apparent before resolving the first bug above, since the `redirectForNonSimpleSite` was not being triggered due to it.

BEFORE
![hosting-before](https://github.com/user-attachments/assets/1288d3ea-eb3e-41bf-9cb3-e74d062228cb)


AFTER
![hosting-after](https://github.com/user-attachments/assets/1c97ade7-3c2c-4771-8061-0e5e574d59a9)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There are a few bugs and some broken UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You can test a few things related to this:

MAIN ISSUE
* Find a site with a business plan but that has not been transfered to atomic. Open overview and select "Hosting Features".
* Using the site list on the left, select another site that is atomic.
* This site should now be properly selected, you should not see the hosting-features content for the first site, the URL should correspond to the newly selected site, and you should be able to switch tabs as expected.

QUERY ARGS TEST
* search a query in the sites dashboard, there should be a search query in the url that influences the sites shown in the list.
* open a site that is not atomic. 
* Select the hosting features tab.
* Using the site list on the left, select another site that is atomic.
* Once the new site is redirected to overview, verify the search query is still present in the url.

> his also fixes a separate issue where if we load the hosting-features tab for one site, then select another site that hosting-features tab is enabled for, that tab for the new site would have an outdated redirectUrl
* Add a console.log beneath to log the redirectUrl we changed to the console.
* Select a non atomic site with in the hosting-features tab. Notice the redirect URL in the console.
* Select another non atomic site using the left site list. It should load at the hosting features tab as well.
* Verify the redirectURL now updates for the new site that has been selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
