### PR TITLE
Fixes disappearing UI when user enters any protected NS value

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -80,25 +80,26 @@ const NameServersCard = ( {
 		} );
 	};
 
-	const hasCloudflareNameservers = () => {
+	const onlyCloudflareNameservers = () => {
 		if ( ! nameservers || nameservers.length === 0 ) {
 			return false;
 		}
 
-		return nameservers.some( ( nameserver ) => {
+		return nameservers.every( ( nameserver ) => {
 			return ! nameserver || CLOUDFLARE_NAMESERVERS_REGEX.test( nameserver );
 		} );
 	};
 
-	const onlyWpcomNameservers = () => {
+	const hasDefaultWpcomNameservers = () => {
 		if ( ! nameservers || nameservers.length === 0 ) {
 			return false;
 		}
 
 		return (
+			nameservers.length === WPCOM_DEFAULT_NAMESERVERS.length &&
 			nameservers.every( ( nameserver ) => {
 				return WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
-			} ) && nameservers.length === WPCOM_DEFAULT_NAMESERVERS.length
+			} )
 		);
 	};
 
@@ -139,12 +140,12 @@ const NameServersCard = ( {
 		);
 
 		let notice;
-		if ( isEditingNameServers && hasWpcomNameservers() ) {
+		if ( hasWpcomNameservers() ) {
 			notice = translate(
 				'Please do not set WordPress.com nameservers manually, toggle that on with the switch above. {{link}}Learn more{{/link}}',
 				{ components: { link } }
 			);
-		} else if ( ! hasCloudflareNameservers() ) {
+		} else if ( ! onlyCloudflareNameservers() ) {
 			notice = translate(
 				'By using custom name servers, you will manage your DNS records with your new provider, not WordPress.com. {{link}}Learn more{{/link}}',
 				{ components: { link } }
@@ -176,7 +177,7 @@ const NameServersCard = ( {
 
 	const handleToggle = () => {
 		setIsEditingNameServers( ! isEditingNameServers );
-		if ( onlyWpcomNameservers() ) {
+		if ( hasDefaultWpcomNameservers() ) {
 			setNameServersBeforeEditing( nameservers );
 			setNameservers( [] );
 			setIsEditingNameServers( true );
@@ -194,7 +195,7 @@ const NameServersCard = ( {
 			<NameServersToggle
 				selectedDomainName={ selectedDomainName }
 				onToggle={ handleToggle }
-				enabled={ onlyWpcomNameservers() && ! isEditingNameServers }
+				enabled={ hasDefaultWpcomNameservers() && ! isEditingNameServers }
 			/>
 		);
 	};
@@ -230,7 +231,7 @@ const NameServersCard = ( {
 		if (
 			! nameservers ||
 			isPendingTransfer() ||
-			( onlyWpcomNameservers() && ! isEditingNameServers )
+			( hasDefaultWpcomNameservers() && ! isEditingNameServers )
 		) {
 			return null;
 		}
@@ -255,7 +256,7 @@ const NameServersCard = ( {
 					onCancel={ handleCancel }
 					onReset={ handleReset }
 					onSubmit={ handleSubmit }
-					submitDisabled={ isLoading() || !! hasWpcomNameservers() }
+					submitDisabled={ isLoading() || hasWpcomNameservers() }
 					notice={ warning() }
 					redesign
 				/>

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -10,6 +10,7 @@ import IcannVerificationCard from 'calypso/my-sites/domains/domain-management/co
 import {
 	WPCOM_DEFAULT_NAMESERVERS,
 	WPCOM_DEFAULT_NAMESERVERS_REGEX,
+	CLOUDFLARE_NAMESERVERS_REGEX,
 } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
 import CustomNameserversForm from 'calypso/my-sites/domains/domain-management/name-servers/custom-nameservers-form';
 import FetchError from 'calypso/my-sites/domains/domain-management/name-servers/fetch-error';
@@ -79,6 +80,16 @@ const NameServersCard = ( {
 		} );
 	};
 
+	const hasCloudflareNameservers = () => {
+		if ( ! nameservers || nameservers.length === 0 ) {
+			return false;
+		}
+
+		return nameservers.some( ( nameserver ) => {
+			return ! nameserver || CLOUDFLARE_NAMESERVERS_REGEX.test( nameserver );
+		} );
+	};
+
 	const onlyWpcomNameservers = () => {
 		if ( ! nameservers || nameservers.length === 0 ) {
 			return false;
@@ -133,7 +144,7 @@ const NameServersCard = ( {
 				'Please do not set WordPress.com nameservers manually, toggle that on with the switch above. {{link}}Learn more{{/link}}',
 				{ components: { link } }
 			);
-		} else {
+		} else if ( ! hasCloudflareNameservers() ) {
 			notice = translate(
 				'By using custom name servers, you will manage your DNS records with your new provider, not WordPress.com. {{link}}Learn more{{/link}}',
 				{ components: { link } }

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -142,7 +142,7 @@ const NameServersCard = ( {
 		let notice;
 		if ( hasWpcomNameservers() ) {
 			notice = translate(
-				'Please do not set WordPress.com nameservers manually, toggle that on with the switch above. {{link}}Learn more{{/link}}',
+				'Please do not set WordPress.com name servers manually, toggle that on with the switch above. {{link}}Learn more{{/link}}',
 				{ components: { link } }
 			);
 		} else if ( ! onlyCloudflareNameservers() ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1061-gh-nomado-issues

## Proposed Changes

* Fixes disappearing UI when user enters any protected NS value
* Introduces new notice text to guide users doing this into using the toggle instead
* Disables submit when a protected NS is used

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes a known bug, better experience for the users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
![Screenshot 2024-09-10 at 10 54 21 AM](https://github.com/user-attachments/assets/8d13c8b2-4cfa-45ba-b871-0c3c36b88dc6)
![Screenshot 2024-09-10 at 11 01 48 AM](https://github.com/user-attachments/assets/7a97902e-cedb-419b-bcb0-6c48ab72a58d)


* As a user, I should NOT be able to manually input ns*.wordpress.com as a custom NS server
* As a user, if I input a cloudflare Name Server (*.ns.cloudflare.com) the warning about custom Name Servers should not appear
* As a user, if the toggle (1) is OFF, clicking it once should set it to ON in every situation
  * This should, in every situation, reset the NS servers to the default WP servers and hide the editable form
* As a user, the Default wpcom nameservers should NOT be displayed if the toggle is ON
  *   However, if the toggle is ON:
    * If custom NS servers are SET and not being edited: Display the custom nameservers (5)
    * Otherwise, if in 'Edit Mode', the editable form should appear
      * 'Edit Mode' is enabled upon toggling OFF or hitting the actual 'Edit Custom Nameservers' Button


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
