### PR TITLE
Automated Migrations: Return default behavior to the Migrate Message step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -37,7 +37,7 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 	const siteSlugParam = useSiteSlugParam();
 	const fromUrl = useQuery().get( 'from' ) || '';
 	const siteSlug = siteSlugParam ?? '';
-	const isCredentialsSkipped = useQuery().get( 'credentials' ) === 'skipped';
+	const shouldPreventTicketCreation = useQuery().get( 'preventTicketCreation' ) === 'true';
 	const { isPending, sendTicket } = useSubmitMigrationTicket( {
 		onSuccess: () => {
 			recordTracksEvent( 'calypso_importer_migration_ticket_submit_success', {
@@ -61,9 +61,9 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
 			path: window.location.pathname,
 			automated_migration: config.isEnabled( 'automated-migration/collect-credentials' ),
-			skipped_credentials: isCredentialsSkipped,
+			prevent_ticket_creation: shouldPreventTicketCreation,
 		} );
-		if ( ! config.isEnabled( 'automated-migration/collect-credentials' ) || isCredentialsSkipped ) {
+		if ( ! shouldPreventTicketCreation ) {
 			sendTicket( {
 				locale,
 				from_url: fromUrl,
@@ -71,11 +71,14 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 			} );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ isCredentialsSkipped, config, fromUrl, siteSlug ] );
+	}, [ shouldPreventTicketCreation, config, fromUrl, siteSlug ] );
 	let whatToExpect: WhatToExpectProps[] = [];
 	let actions: ActionsProps[] = [];
 
-	if ( ! isCredentialsSkipped && config.isEnabled( 'automated-migration/collect-credentials' ) ) {
+	if (
+		shouldPreventTicketCreation &&
+		config.isEnabled( 'automated-migration/collect-credentials' )
+	) {
 		whatToExpect = [
 			{
 				icon: group,

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -267,12 +267,12 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 			submit: ( props?: ProvidedDependencies ) => {
 				const action = getFromPropsOrUrl( 'action', props ) as 'skip' | 'submit';
 				const extraPrams = {
-					...( action === 'skip' ? { credentials: 'skipped' } : {} ),
+					...( action !== 'skip' ? { preventTicketCreation: true } : {} ),
 				};
 
 				return navigateWithQueryParams(
 					SITE_MIGRATION_ASSISTED_MIGRATION,
-					[ 'credentials' ],
+					[ 'preventTicketCreation' ],
 					{ ...props, ...extraPrams },
 					{ replaceHistory: true }
 				);

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -401,6 +401,7 @@ describe( `${ flow.name }`, () => {
 						siteId: 123,
 						siteSlug: 'example.wordpress.com',
 						from: 'http://oldsite.example.com',
+						preventTicketCreation: 'true',
 					},
 				} );
 			} );
@@ -414,7 +415,7 @@ describe( `${ flow.name }`, () => {
 
 				expect( destination ).toMatchDestination( {
 					step: STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
-					query: { siteId: 123, siteSlug: 'example.wordpress.com', credentials: 'skipped' },
+					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
 				} );
 			} );
 		} );

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -428,16 +428,18 @@ const siteMigration: Flow = {
 					if ( action === 'skip' ) {
 						return navigate(
 							addQueryArgs(
-								{ siteId, from: fromQueryParam, siteSlug, credentials: 'skipped' },
+								{ siteId, from: fromQueryParam, siteSlug },
 								STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
 							)
 						);
 					}
 
-					return navigate( STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug, {
-						siteId,
-						siteSlug,
-					} );
+					return navigate(
+						addQueryArgs(
+							{ siteId, from: fromQueryParam, siteSlug, preventTicketCreation: true },
+							STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
+						)
+					);
 				}
 
 				case STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug: {

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -356,7 +356,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug }?siteSlug=example.wordpress.com&credentials=skipped`,
+				path: `/${ STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug }?siteSlug=example.wordpress.com`,
 				state: null,
 			} );
 		} );
@@ -370,10 +370,8 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug }`,
-				state: {
-					siteSlug: 'example.wordpress.com',
-				},
+				path: `/${ STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug }?siteSlug=example.wordpress.com&preventTicketCreation=true`,
+				state: null,
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #94206

## Proposed Changes

* Create the Zendesk ticket on the default behavior on the Migrate Message step.
* Add a flag to prevent the ticket creation.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When we first introduced the credentials step we decided to use a flag to create the ticket, thus overriding the default behavior of the Migrate Message step. The Migrate Message step, by default should create the ticket and we should have a flag to prevent the ticket creation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 * Go through the migration flow by navigating to `/start`:
  * Go through the domain selection step
  * Select the free plan on the `Plans` page
  * On the `Goals` step, select the "Import existing content or website" option and click continue
  * Input the source site URL in the Identify step
  * Next, select the "Migrate Site" option on the `Import or Migrate` step
  * Select "Do it for me" on the `How to migrate` step
  * Go through the checkout
  * Once you complete the checkout, you should land on the new `Credentials` step
  * Now skip the step and ensure you the ticket is created on the "Migrate Message" step.
  * Repeat the steps with a new site and go through the `Credentials` step, but this time, complete it.
  * You should land on the Migrate Message step with the `preventTicketCreation=true` on your URL, and the ticket should not be created in that step. This means we should not see the `help/migration-ticket/new` request fired.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
