### PR TITLE
Send magic login email when a passwordless account submits forgot password form

### DIFF
--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -63,31 +63,32 @@ const LostPasswordForm = ( {
 	const onSubmit = async ( event ) => {
 		event.preventDefault();
 
-		const accountType = await getAuthAccountTypeRequest( email );
 		if (
 			config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) &&
-			accountType?.passwordless === true &&
 			isWooCoreProfilerFlow
 		) {
-			await dispatch(
-				sendEmailLogin( email, {
-					redirectTo: redirectToAfterLoginUrl,
-					loginFormFlow: true,
-					showGlobalNotices: true,
-					flow: 'jetpack',
-				} )
-			);
-			page(
-				login( {
-					isJetpack: true,
-					// If no notification is sent, the user is using the authenticator for 2FA by default
-					twoFactorAuthType: 'link',
-					locale: locale,
-					from: from,
-					emailAddress: email,
-				} )
-			);
-			return;
+			const accountType = await getAuthAccountTypeRequest( email );
+			if ( accountType?.passwordless === true ) {
+				await dispatch(
+					sendEmailLogin( email, {
+						redirectTo: redirectToAfterLoginUrl,
+						loginFormFlow: true,
+						showGlobalNotices: true,
+						flow: 'jetpack',
+					} )
+				);
+				page(
+					login( {
+						isJetpack: true,
+						// If no notification is sent, the user is using the authenticator for 2FA by default
+						twoFactorAuthType: 'link',
+						locale: locale,
+						from: from,
+						emailAddress: email,
+					} )
+				);
+				return;
+			}
 		}
 
 		try {

--- a/client/blocks/login/test/lost-password-form.jsx
+++ b/client/blocks/login/test/lost-password-form.jsx
@@ -5,6 +5,11 @@ import { screen, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LostPasswordForm from 'calypso/blocks/login/lost-password-form';
 
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useDispatch: jest.fn().mockImplementation( () => {} ),
+} ) );
+
 describe( 'LostPasswordForm', () => {
 	test( 'displays a lost password form without errors', () => {
 		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94352

## Proposed Changes

* Send a magic link when a passwordless account requests password reset

This change only applies when `woocommerce/core-profiler-passwordless-auth` feature flag is enabled and the user is on the core profiler flow.


## Testing Instructions

1. Checkout this branch locally.
2. Open `config/development.json` and add `"woocommerce/core-profiler-passwordless-auth": true`
3. Build the changes `yarn start`
4. Logout from WPCOM and navigate to http://calypso.localhost:3000/log-in/jetpack/lostpassword?from=woocommerce-core-profiler
5. Enter a passwordless account email and submit the form.
6. You should see `Check your email` page
![Screenshot 2024-09-10 at 12 46 13 PM](https://github.com/user-attachments/assets/5c79a14b-c429-4c01-a24d-473257238fb6)
7. Go back and enter a regular account.
8. Confirm a request to `/wp-login.php` and an error message (this is expected)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
