### PR TITLE
Fix loading bar colour

### DIFF
--- a/client/components/loading-bar/style.scss
+++ b/client/components/loading-bar/style.scss
@@ -10,7 +10,7 @@ $progress-duration: 800ms;
 	--progress: 0;
 
 	&::before {
-		background: var(--studio-blue-50);
+		background: var(--color-accent);
 		transform: translateX(calc(-100% * min(1 - var(--progress, 0), 1)));
 		position: absolute;
 		content: "";


### PR DESCRIPTION
## Proposed Changes

This PR fixes a colour swatch for our loading bar component. We currently have two different blue colour swatches on the same screen which look off:

**Before**
<img width="1802" alt="image" src="https://github.com/user-attachments/assets/5ef3f14e-3884-425d-a059-1b5dcc32267c">

**After**
<img width="1802" alt="image" src="https://github.com/user-attachments/assets/03733494-0c4e-4413-90ed-0a42e06e5860">


## Why are these changes being made?
We're standardizing the colours for a more cohesive look.

## Testing Instructions

* Go to the All sites view
* Pick a site on the business plan
* Click on the staging tab
* Create a new staging site or update a staging site to see the progress bar.

