### PR TITLE
Backups: add "learn about" link to file browser

### DIFF
--- a/client/my-sites/backup/backup-contents-page/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/index.tsx
@@ -1,5 +1,5 @@
 import { Card } from '@automattic/components';
-import { Button } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
 import { arrowLeft, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useEffect } from 'react';
@@ -58,7 +58,14 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 					<div className="backup-contents-page__header daily-backup-status status-card">
 						<div className="status-card__message-head">
 							<img src={ cloudIcon } alt="" role="presentation" />
-							<div className="status-card__title">{ translate( 'Backup contents from:' ) }</div>
+							<div className="status-card__header-content">
+								<div className="status-card__title">{ translate( 'Backup contents from:' ) }</div>
+								<div className="status-card__learn-about">
+									<ExternalLink href="https://jetpack.com/blog/introducing-backup-file-browser/">
+										{ translate( 'Learn about the file browser' ) }
+									</ExternalLink>
+								</div>
+							</div>
 						</div>
 						<div className="status-card__title">{ displayDate }</div>
 						{ browserCheckList.totalItems === 0 && (

--- a/client/my-sites/backup/backup-contents-page/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/index.tsx
@@ -2,7 +2,7 @@ import { Card } from '@automattic/components';
 import { Button, ExternalLink } from '@wordpress/components';
 import { arrowLeft, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, useEffect } from 'react';
+import { FunctionComponent, useCallback, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
 import ActionButtons from 'calypso/components/jetpack/daily-backup-status/action-buttons';
@@ -41,6 +41,10 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 		dispatch( recordTracksEvent( 'calypso_jetpack_backup_browser_view' ) );
 	}, [ dispatch ] );
 
+	const onLearnAboutClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_browser_learn_about_click' ) );
+	}, [ dispatch ] );
+
 	return (
 		<>
 			<QuerySiteCredentials siteId={ siteId } />
@@ -61,7 +65,10 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 							<div className="status-card__header-content">
 								<div className="status-card__title">{ translate( 'Backup contents from:' ) }</div>
 								<div className="status-card__learn-about">
-									<ExternalLink href="https://jetpack.com/blog/introducing-backup-file-browser/">
+									<ExternalLink
+										href="https://jetpack.com/blog/introducing-backup-file-browser/"
+										onClick={ onLearnAboutClick }
+									>
 										{ translate( 'Learn about the file browser' ) }
 									</ExternalLink>
 								</div>

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -21,12 +21,39 @@
 		}
 	}
 
+	.status-card__header-content {
+		align-items: center;
+		display: flex;
+		// Given the layout is mobile-first, reverse the div arrangement by default
+		flex-direction: column-reverse;
+	}
+
+	.status-card__learn-about {
+		font-size: $font-body-small;
+		font-weight: 400;
+		text-decoration-line: underline;
+	}
+
+	.status-card__learn-about a {
+		color: var(--studio-gray-80);
+	}
+
 	// We are using the deprecated mixin to match the when the mobile navigation appears
 	// which is at 660px instead of the 600px break-small breakpoint.
 	@include breakpoint-deprecated( ">660px" ) {
 		&__back-button.components-button.is-link {
 			padding: 0 0 12px 0;
 			margin: 0;
+		}
+
+		.status-card__header-content {
+			// Return to the default div arrangement on the desktop
+			flex-direction: row;
+			flex-grow: 1;
+		}
+
+		.status-card__learn-about {
+			margin-left: auto;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of Automattic/jetpack-backup-team#599.

## Proposed Changes

* Add a `Learn about file browser` link to the file browsing page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, there are no helpful guides or instructions to assist the user. We are adding a link to help them with that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go the `VaultPress Backup` page on Jetpack Cloud.
* In the `Latest backup` section, click on the Actions (`+`) button and select `View files`.
* The `Learn about file browser` link should be visible at the top.

> [!NOTE]
>
> The design proposal doesn't include mobile details. In order increase the legibility and not leave the link between the `Backup contents from:` statement and the actual backup date, their arrangement is swapped between desktop and mobile:

Desktop | Mobile
--- | ---
<img width="705" alt="image" src="https://github.com/user-attachments/assets/306c8077-8537-4a7d-aff1-07d5bd934269"> | <img width="330" alt="image" src="https://github.com/user-attachments/assets/9f9a17f6-ed97-469c-a107-335a30e028b6">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
