### PR TITLE
Admin bar: Remove extra padding from the Reader icon on mobile sizes

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -305,16 +305,7 @@ body.is-mobile-app-view {
 		}
 
 		&.masterbar__reader {
-			padding: 0 8px;
-
-			.masterbar_svg-reader {
-				padding: 0 0 0 2px;
-			}
-
-			&.is-active {
-				padding: 0 2px 0 0;
-				margin: 0 6px 0 4px;
-			}
+			padding: 0;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93534

## Proposed Changes

* Remove the extra padding on the admin bar Reader icon at mobile sizes, so that it has the same width as other icons. 

Less than 781px wide, all icons are now 52px wide:

<img width="776" alt="Screen Shot 2024-09-10 at 4 14 17 PM" src="https://github.com/user-attachments/assets/e6565aee-89b6-4611-a57f-54cfb95259a8">
<img width="776" alt="Screen Shot 2024-09-10 at 4 14 06 PM" src="https://github.com/user-attachments/assets/2ad433ad-9e27-41ae-bf6b-d0c3b317633a">

Less than 480px wide, all icons are now 46px wide:

<img width="381" alt="Screen Shot 2024-09-10 at 4 13 07 PM" src="https://github.com/user-attachments/assets/5bd303b2-856f-4f81-b26a-808a6e1d0c32">
<img width="382" alt="Screen Shot 2024-09-10 at 4 12 53 PM" src="https://github.com/user-attachments/assets/17a22fc8-3b9a-4490-bc9e-a8778a3539a0">

Note this will need a Jetpack follow-up to make the same changes in wp-admin.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To align the Reader icon with the other admin bar icons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View the admin bar at both the /sites and /home levels and check that the Reader icon is 52px wide, including spacing.
* Click on the Reader icon and check that the active spacing is still even on either side.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?