### PR TITLE
A4A: Update the VIP link with UTM query in the Marketplace section

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/index.tsx
@@ -45,7 +45,7 @@ export default function EnterpriseAgencyHosting() {
 						] }
 					/>
 					<Button
-						href="https://wpvip.com/contact/"
+						href="https://wpvip.com/partner-application/?utm_source=partner&utm_medium=referral&utm_campaign=a4a"
 						onClick={ onRequestDemoClick }
 						target="_blank"
 						variant="primary"

--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -46,7 +46,7 @@ export function getHostingPageUrl( slug: string ) {
 		case 'wpcom-hosting':
 			return A4A_MARKETPLACE_HOSTING_WPCOM_LINK;
 		case 'vip':
-			return 'https://wpvip.com/contact/';
+			return 'https://wpvip.com/partner-application/?utm_source=partner&utm_medium=referral&utm_campaign=a4a';
 	}
 
 	return A4A_MARKETPLACE_HOSTING_LINK;


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/1106

## Proposed Changes

![image](https://github.com/user-attachments/assets/e822c1dd-5111-4457-86af-a6161db12748)

This PR updates the link for `Request a Demo`with this link: `https://wpvip.com/partner-application/?utm_source=partner&utm_medium=referral&utm_campaign=a4a`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code.
- Run Calyso live for this branch.
- Go to the Marketplace section and select the Enterprise tab (WP VIP).
- Click on `Request a Demo` and see that it takes you to the new URL with the UTM query parameters.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
