### PR TITLE
Checkout: Preselect payment method in checkout for first renewal in cart

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -30,6 +30,7 @@ import useCheckoutFlowTrackKey from '../hooks/use-checkout-flow-track-key';
 import useCountryList from '../hooks/use-country-list';
 import useCreatePaymentCompleteCallback from '../hooks/use-create-payment-complete-callback';
 import useCreatePaymentMethods from '../hooks/use-create-payment-methods';
+import { existingCardPrefix } from '../hooks/use-create-payment-methods/use-create-existing-cards';
 import useDetectedCountryCode from '../hooks/use-detected-country-code';
 import useGetThankYouUrl from '../hooks/use-get-thank-you-url';
 import usePrepareProductsForCart from '../hooks/use-prepare-products-for-cart';
@@ -59,8 +60,9 @@ import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
 	CheckoutPageErrorCallback,
 	PaymentEventCallbackArguments,
+	PaymentMethod,
 } from '@automattic/composite-checkout';
-import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import type { MinimalRequestCartProduct, ResponseCart } from '@automattic/shopping-cart';
 import type { CheckoutPaymentMethodSlug, SitelessCheckoutType } from '@automattic/wpcom-checkout';
 
 const { colors } = colorStudio;
@@ -742,6 +744,11 @@ export default function CheckoutMain( {
 		reduxDispatch( infoNotice( translate( 'Redirecting to payment partner…' ) ) );
 	}, [ reduxDispatch, translate ] );
 
+	const initiallySelectedPaymentMethodId = getInitiallySelectedPaymentMethodId(
+		responseCart,
+		paymentMethods
+	);
+
 	return (
 		<Fragment>
 			<PageViewTracker
@@ -765,6 +772,7 @@ export default function CheckoutMain( {
 				isValidating={ isCartPendingUpdate }
 				theme={ theme }
 				selectFirstAvailablePaymentMethod
+				initiallySelectedPaymentMethodId={ initiallySelectedPaymentMethodId }
 			>
 				<CheckoutMainContent
 					loadingHeader={
@@ -851,4 +859,24 @@ function getAnalyticsPath(
 	}
 
 	return { analyticsPath, analyticsProps };
+}
+
+function getInitiallySelectedPaymentMethodId(
+	responseCart: ResponseCart,
+	paymentMethods: PaymentMethod[]
+): string | undefined {
+	const firstRenewalWithPaymentMethod = responseCart.products.find( ( product ) =>
+		Boolean( product.stored_details_id )
+	);
+	if ( ! firstRenewalWithPaymentMethod ) {
+		return undefined;
+	}
+	const matchingCheckoutPaymentMethod = paymentMethods.find(
+		( method ) =>
+			method.id === `${ existingCardPrefix }${ firstRenewalWithPaymentMethod.stored_details_id }`
+	);
+	if ( matchingCheckoutPaymentMethod ) {
+		return matchingCheckoutPaymentMethod.id;
+	}
+	return undefined;
 }

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
@@ -8,6 +8,8 @@ import type {
 	StoredPaymentMethodCard,
 } from 'calypso/lib/checkout/payment-methods';
 
+export const existingCardPrefix = `existingCard-`;
+
 export default function useCreateExistingCards( {
 	isStripeLoading,
 	stripeLoadingError,
@@ -44,7 +46,7 @@ export default function useCreateExistingCards( {
 		return (
 			memoizedStoredCards.map( ( storedDetails ) =>
 				createExistingCardMethod( {
-					id: `existingCard-${ storedDetails.stored_details_id }`,
+					id: `${ existingCardPrefix }${ storedDetails.stored_details_id }`,
 					cardholderName: storedDetails.name,
 					cardExpiry: storedDetails.expiry,
 					brand: storedDetails?.display_brand

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -502,6 +502,13 @@ export interface ResponseCartProduct {
 	 */
 	is_included_for_100yearplan: boolean;
 
+	/**
+	 * If set, this is the ID of the payment method attached to the existing
+	 * subscription for this product. This will only be set for renewals and
+	 * only if the renewal has a payment method attached.
+	 */
+	stored_details_id?: string;
+
 	product_variants: ResponseCartProductVariant[];
 }
 


### PR DESCRIPTION
## Proposed Changes

If a shopping cart product is a renewal of an existing subscription, that subscription may have an attached payment method. It would be nice to be able to pre-select that payment method in checkout when possible. To do that, checkout needs to know the ID of the payment method.

In D161081-code we add a new property to each product returned by the shopping cart endpoint. The property `stored_details_id` will be added whenever a cart item has a subscription that has an attached payment method.

In this diff, we use that property to preselect the payment method in checkout for the first such product in the cart.

Fixes https://github.com/Automattic/wp-calypso/issues/74585

## Testing Instructions

- Make sure D161081-code is applied and that public-api.wordpress.com is pointing to your sandbox.
- Add a product to your cart and complete a purchase with a saved card or find an existing purchase on your account that has a saved card. We'll call this card **payment method A**.
- Visit `/me/purchases/payment-methods` and add a new saved card or find an existing saved card that differs from the one used to make the purchase. We'll call this card **payment method B**.
- WITHOUT this PR, add a renewal for the product to your cart and visit checkout. Since payment method B was most recently added, it should show up first in checkout and be automatically selected. Verify that the pre-selected payment method is **payment method B**.
- WITH this PR, refresh checkout. Verify that the pre-selected payment method is **payment method A**.
- (Optional) Using `/me/purchases`, change the payment method assigned to the purchase. Revisit checkout and verify that the pre-selected payment method matches the one assigned to the product.