### PR TITLE
Logged-in Performance Profiler: Add feature flag to gate development work

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -168,6 +168,7 @@
 		"pattern-assembler/v2": true,
 		"performance-profiler": true,
 		"performance-profiler/llm": true,
+		"performance-profiler/logged-in": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/production.json
+++ b/config/production.json
@@ -138,6 +138,7 @@
 		"pattern-assembler/v2": true,
 		"performance-profiler": false,
 		"performance-profiler/llm": true,
+		"performance-profiler/logged-in": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -134,6 +134,7 @@
 		"pattern-assembler/v2": true,
 		"performance-profiler": false,
 		"performance-profiler/llm": true,
+		"performance-profiler/logged-in": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -133,6 +133,7 @@
 		"pattern-assembler/v2": true,
 		"performance-profiler": true,
 		"performance-profiler/llm": true,
+		"performance-profiler/logged-in": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9055
## Proposed Changes

* Add feature flag `performance-profiler/logged-in` to gate development work.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To Gate the development work of the feature

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* None needed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
