### PR TITLE
Logged-in Performance Profiler: Add `Performance` tab to the Global site view

### DIFF
--- a/client/hosting/sites/components/site-preview-pane/constants.ts
+++ b/client/hosting/sites/components/site-preview-pane/constants.ts
@@ -6,6 +6,7 @@ export const DOTCOM_GITHUB_DEPLOYMENTS = 'dotcom-github-deployments';
 export const DOTCOM_HOSTING_CONFIG = 'dotcom-hosting-config';
 export const DOTCOM_HOSTING_FEATURES = 'dotcom-hosting-features';
 export const DOTCOM_STAGING_SITE = 'dotcom-staging-site';
+export const DOTCOM_SITE_PERFORMANCE = 'dotcom-site-performance';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOTCOM_OVERVIEW ]: 'overview/:site',
@@ -16,4 +17,5 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOTCOM_HOSTING_CONFIG ]: 'hosting-config/:site',
 	[ DOTCOM_HOSTING_FEATURES ]: 'hosting-features/:site',
 	[ DOTCOM_STAGING_SITE ]: 'staging-site/:site',
+	[ DOTCOM_SITE_PERFORMANCE ]: 'site-performance/:site',
 };

--- a/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -12,6 +12,7 @@ import {
 	DOTCOM_HOSTING_CONFIG,
 	DOTCOM_OVERVIEW,
 	DOTCOM_MONITORING,
+	DOTCOM_SITE_PERFORMANCE,
 	DOTCOM_LOGS_PHP,
 	DOTCOM_LOGS_WEB,
 	DOTCOM_GITHUB_DEPLOYMENTS,
@@ -91,6 +92,11 @@ const DotcomPreviewPane = ( {
 				label: __( 'Monitoring' ),
 				enabled: isActiveAtomicSite,
 				featureIds: [ DOTCOM_MONITORING ],
+			},
+			{
+				label: __( 'Performance' ),
+				enabled: isActiveAtomicSite,
+				featureIds: [ DOTCOM_SITE_PERFORMANCE ],
 			},
 			{
 				label: __( 'Logs' ),

--- a/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { SiteExcerptData } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
@@ -95,7 +96,7 @@ const DotcomPreviewPane = ( {
 			},
 			{
 				label: __( 'Performance' ),
-				enabled: isActiveAtomicSite,
+				enabled: isActiveAtomicSite && config.isEnabled( 'performance-profiler/logged-in' ),
 				featureIds: [ DOTCOM_SITE_PERFORMANCE ],
 			},
 			{

--- a/client/sections.js
+++ b/client/sections.js
@@ -726,6 +726,12 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'site-performance',
+		paths: [ '/site-performance' ],
+		module: 'calypso/site-performance',
+		group: 'sites',
+	},
+	{
 		name: 'site-logs',
 		paths: [ '/site-logs' ],
 		module: 'calypso/site-logs',

--- a/client/site-performance/controller.tsx
+++ b/client/site-performance/controller.tsx
@@ -1,0 +1,20 @@
+import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import type { Context as PageJSContext } from '@automattic/calypso-router';
+
+export function sitePerformance( context: PageJSContext, next: () => void ) {
+	if ( ! config.isEnabled( 'performance-profiler/logged-in' ) ) {
+		page.redirect( '/' );
+		return;
+	}
+
+	context.primary = (
+		<>
+			<PageViewTracker path="/site-performance/:site" title="Site Performance" />
+			<div>Site Performance</div>
+		</>
+	);
+
+	next();
+}

--- a/client/site-performance/index.tsx
+++ b/client/site-performance/index.tsx
@@ -1,0 +1,25 @@
+import page from '@automattic/calypso-router';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectToHostingPromoIfNotAtomic,
+} from 'calypso/controller';
+import { DOTCOM_SITE_PERFORMANCE } from 'calypso/hosting/sites/components/site-preview-pane/constants';
+import { siteDashboard } from 'calypso/hosting/sites/controller';
+import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
+import { sitePerformance } from './controller';
+
+export default function () {
+	page( '/site-performance', siteSelection, sites, makeLayout, clientRender );
+
+	page(
+		'/site-performance/:site',
+		siteSelection,
+		redirectToHostingPromoIfNotAtomic,
+		navigation,
+		sitePerformance,
+		siteDashboard( DOTCOM_SITE_PERFORMANCE ),
+		makeLayout,
+		clientRender
+	);
+}


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9056

## Proposed Changes

* Add site performance tab to Global Site View
* Gate behind feature flag

![image](https://github.com/user-attachments/assets/2f2e999d-4227-4440-a871-697fe516d49f)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To give user easy access to the sites performance report

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* Select an Atomic site
* Verify the `Performance` tab is shown.
* Clicking will show page not found as the `/site-performance` path is not yer registered to point to calypso

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
