### PR TITLE
Stats: Hide submission controls during cooldown

### DIFF
--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -91,6 +91,8 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 		refetchNotices,
 	] );
 
+	const showSubmissionControls = ! isCheckingAbilityToSubmitFeedback && isAbleToSubmitFeedback;
+
 	return (
 		<Modal className="stats-feedback-modal" onRequestClose={ handleClose } __experimentalHideHeader>
 			<Button
@@ -104,44 +106,43 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 					{ translate( 'Help us make Jetpack Stats better' ) }
 				</h1>
 
-				<div className="stats-feedback-modal__text">
+				<p className="stats-feedback-modal__text">
 					{ translate(
 						'We value your opinion and would love to hear more about your experience. Please share any specific thoughts or suggestions you have to improve Jetpack Stats.'
 					) }
-				</div>
-				<TextareaControl
-					rows={ 5 }
-					cols={ 40 }
-					className="stats-feedback-modal__form"
-					placeholder={ translate( 'Add your feedback here' ) }
-					name="content"
-					value={ content }
-					onChange={ setContent }
-					disabled={ ! isCheckingAbilityToSubmitFeedback && ! isAbleToSubmitFeedback }
-				/>
-				<div className="stats-feedback-modal__button">
-					{ ! isCheckingAbilityToSubmitFeedback && ! isAbleToSubmitFeedback && (
+				</p>
+				{ ! showSubmissionControls && (
+					<p>
 						<strong>
 							<em>
 								{ translate( 'Feedback submission is currently limited to one per 24 hours.' ) }
 							</em>
 						</strong>
-					) }
-					<StatsButton
-						primary
-						onClick={ onFormSubmit }
-						busy={ isSubmittingFeedback }
-						disabled={
-							isCheckingAbilityToSubmitFeedback ||
-							! isAbleToSubmitFeedback ||
-							isSubmittingFeedback ||
-							isSubmissionSuccessful ||
-							! content
-						}
-					>
-						{ translate( 'Submit' ) }
-					</StatsButton>
-				</div>
+					</p>
+				) }
+				{ showSubmissionControls && (
+					<>
+						<TextareaControl
+							rows={ 5 }
+							cols={ 40 }
+							className="stats-feedback-modal__form"
+							placeholder={ translate( 'Add your feedback here' ) }
+							name="content"
+							value={ content }
+							onChange={ setContent }
+						/>
+						<div className="stats-feedback-modal__button">
+							<StatsButton
+								primary
+								onClick={ onFormSubmit }
+								busy={ isSubmittingFeedback }
+								disabled={ isSubmittingFeedback || isSubmissionSuccessful || ! content }
+							>
+								{ translate( 'Submit' ) }
+							</StatsButton>
+						</div>
+					</>
+				) }
 			</div>
 		</Modal>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Hide submission controls when submitting is blocked. I'm thinking of this as a form of [Progress Disclosure](https://www.interaction-design.org/literature/book/the-glossary-of-human-computer-interaction/progressive-disclosure#:~:text=Progressive%20disclosure%20is%20a%20design,customer's%20progress%20through%20the%20application%E2%80%9D.) wherein we prefer to hide controls over showing disabled controls. Disabled controls are often confusing in that they add clutter and can be visually difficult to identify.

### Proposed UI if submitting is blocked

<img width="718" alt="SCR-20240911-lqdd" src="https://github.com/user-attachments/assets/36132eda-f454-4898-ab6b-b3e0877e3452">

### Proposed UI if submitting is enabled

<img width="718" alt="SCR-20240911-lpzr" src="https://github.com/user-attachments/assets/c085826a-e1ca-42fd-9db7-95f2ce9e7f0f">

Matches the current UI when submitting is enabled.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
