### PR TITLE
Stats: Update hibernation value on feedback submission

### DIFF
--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -19,10 +19,7 @@ const FEEDBACK_PANEL_PRESENTATION_DELAY = 3000;
 const FEEDBACK_LEAVE_REVIEW_URL = 'https://wordpress.org/support/plugin/jetpack/reviews/';
 
 const FEEDBACK_SHOULD_SHOW_PANEL_API_KEY = NOTICES_KEY_SHOW_FLOATING_USER_FEEDBACK_PANEL;
-const FEEDBACK_SHOULD_SHOW_PANEL_API_HIBERNATION_DELAY = 30; // 30 seconds for now
-// Examples values:
-// 30 minutes = 60 * 30;
-// 30 days = 3600 * 24 * 30;
+const FEEDBACK_SHOULD_SHOW_PANEL_API_HIBERNATION_DELAY = 3600 * 24 * 30 * 6; // 6 months
 
 function useNoticeVisibilityHooks( siteId: number ) {
 	const { data: shouldShowFeedbackPanel, refetch } = useNoticeVisibilityQuery(

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -47,7 +47,6 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 		refetch: refetchNotices,
 	} = useNoticeVisibilityQuery( siteId, NOTICES_KEY_ABLE_TO_SUBMIT_FEEDBACK );
 
-	// Disable feedback submission for 24 hours.
 	const { mutateAsync: disableFeedbackSubmission } = useNoticeVisibilityMutation(
 		siteId,
 		NOTICES_KEY_ABLE_TO_SUBMIT_FEEDBACK,

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -23,6 +23,7 @@ interface ModalProps {
 
 const FEEDBACK_SHOULD_SHOW_PANEL_API_KEY = NOTICES_KEY_SHOW_FLOATING_USER_FEEDBACK_PANEL;
 const FEEDBACK_SHOULD_SHOW_PANEL_API_HIBERNATION_DELAY = 3600 * 24 * 30 * 12; // 12 months
+const FEEDBACK_THROTTLE_SUBMISSION_DELAY = 60 * 5; // 5 minutes
 
 function useFeedbackHibernationMutation( siteId: number ) {
 	const { mutateAsync: updateFeedbackHibernationPeriod } = useNoticeVisibilityMutation(
@@ -51,7 +52,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 		siteId,
 		NOTICES_KEY_ABLE_TO_SUBMIT_FEEDBACK,
 		'postponed',
-		5 * 60
+		FEEDBACK_THROTTLE_SUBMISSION_DELAY
 	);
 
 	const { updateFeedbackHibernationPeriod } = useFeedbackHibernationMutation( siteId );

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -25,17 +25,6 @@ const FEEDBACK_SHOULD_SHOW_PANEL_API_KEY = NOTICES_KEY_SHOW_FLOATING_USER_FEEDBA
 const FEEDBACK_SHOULD_SHOW_PANEL_API_HIBERNATION_DELAY = 3600 * 24 * 30 * 12; // 12 months
 const FEEDBACK_THROTTLE_SUBMISSION_DELAY = 60 * 5; // 5 minutes
 
-function useFeedbackHibernationMutation( siteId: number ) {
-	const { mutateAsync: updateFeedbackHibernationPeriod } = useNoticeVisibilityMutation(
-		siteId,
-		FEEDBACK_SHOULD_SHOW_PANEL_API_KEY,
-		'postponed',
-		FEEDBACK_SHOULD_SHOW_PANEL_API_HIBERNATION_DELAY
-	);
-
-	return { updateFeedbackHibernationPeriod };
-}
-
 const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -54,7 +43,12 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 		FEEDBACK_THROTTLE_SUBMISSION_DELAY
 	);
 
-	const { updateFeedbackHibernationPeriod } = useFeedbackHibernationMutation( siteId );
+	const { mutateAsync: updateFeedbackHibernationPeriod } = useNoticeVisibilityMutation(
+		siteId,
+		FEEDBACK_SHOULD_SHOW_PANEL_API_KEY,
+		'postponed',
+		FEEDBACK_SHOULD_SHOW_PANEL_API_HIBERNATION_DELAY
+	);
 
 	const { isSubmittingFeedback, submitFeedback, isSubmissionSuccessful } =
 		useSubmitProductFeedback( siteId );

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -6,6 +6,7 @@ import StatsButton from 'calypso/my-sites/stats/components/stats-button';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import {
 	NOTICES_KEY_ABLE_TO_SUBMIT_FEEDBACK,
+	NOTICES_KEY_SHOW_FLOATING_USER_FEEDBACK_PANEL,
 	useNoticeVisibilityQuery,
 } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { useDispatch } from 'calypso/state';
@@ -18,6 +19,20 @@ import './style.scss';
 interface ModalProps {
 	siteId: number;
 	onClose: () => void;
+}
+
+const FEEDBACK_SHOULD_SHOW_PANEL_API_KEY = NOTICES_KEY_SHOW_FLOATING_USER_FEEDBACK_PANEL;
+const FEEDBACK_SHOULD_SHOW_PANEL_API_HIBERNATION_DELAY = 3600 * 24 * 30 * 12; // 12 months
+
+function useFeedbackHibernationMutation( siteId: number ) {
+	const { mutateAsync: updateFeedbackHibernationPeriod } = useNoticeVisibilityMutation(
+		siteId,
+		FEEDBACK_SHOULD_SHOW_PANEL_API_KEY,
+		'postponed',
+		FEEDBACK_SHOULD_SHOW_PANEL_API_HIBERNATION_DELAY
+	);
+
+	return { updateFeedbackHibernationPeriod };
 }
 
 const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
@@ -38,6 +53,8 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 		'postponed',
 		5 * 60
 	);
+
+	const { updateFeedbackHibernationPeriod } = useFeedbackHibernationMutation( siteId );
 
 	const { isSubmittingFeedback, submitFeedback, isSubmissionSuccessful } =
 		useSubmitProductFeedback( siteId );
@@ -77,6 +94,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 				} )
 			);
 
+			updateFeedbackHibernationPeriod();
 			disableFeedbackSubmission().then( () => {
 				refetchNotices();
 			} );
@@ -89,6 +107,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 		handleClose,
 		translate,
 		disableFeedbackSubmission,
+		updateFeedbackHibernationPeriod,
 		refetchNotices,
 	] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/red-team/issues/164

## Proposed Changes

Updates the hibernation value via the API so that the floating feedback panel is hidden for an appropriate amount of time. ie: If the user successfully submits feedback, we don't want to show the floating panel again in the near term.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently the floating panel will reappear immediately after feedback is submitted (on the next page load). This change makes sure to hide the floating panel in response to a successful feedback submission.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Calypso Live site.
* Visit the Traffic page.
* Enable the feature flag: `?flags=stats/user-feedback`
* Confirm the floating panel is visible at the bottom of the window (not the page).
* Click the feedback button.
* Confirm the panel is hidden and the modal is displayed.
* Close the modal without submitting feedback and reload the page.
* Confirm the panel is visible again.
* Click the feedback button and submit feedback.
* Confirm both the modal and the panel disappear and the success message is presented.
* Reload the page.
* Confirm the panel is not shown again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
