### PR TITLE
A4A: Remove redundant labeling on the Team member permissions KB link.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
@@ -29,10 +29,6 @@ export function A4ARequestWPAdminAccess() {
 						'Ask the Agency owner to provide you WP-Admin access to this site in order to manage its plugins and features.'
 					) }
 				</div>
-				<div className="a4a-request-wp-admin-access__learn-more">
-					{ translate( 'Learn more about team member permissions' ) }
-				</div>
-
 				<Button
 					variant="link"
 					className="a4a-request-wp-admin-access__learn-more-button"
@@ -41,7 +37,7 @@ export function A4ARequestWPAdminAccess() {
 					target="_blank"
 				>
 					<>
-						{ translate( 'Team members Knowledge Base article' ) }
+						{ translate( 'Learn more about team member permissions' ) }
 						<Icon icon={ external } size={ 18 } />
 					</>
 				</Button>

--- a/client/a8c-for-agencies/components/a4a-request-wp-admin-access/style.scss
+++ b/client/a8c-for-agencies/components/a4a-request-wp-admin-access/style.scss
@@ -31,11 +31,6 @@
 		@include a4a-font-body-lg;
 		padding-block-end: 24px;
 	}
-
-	.a4a-request-wp-admin-access__learn-more {
-		@include a4a-font-body-md($font-weight: 600);
-		padding-block-end: 8px;
-	}
 }
 
 .a4a-request-wp-admin-access__illustration {


### PR DESCRIPTION
This PR simplifies the screen by removing redundant labeling, as we only show one 1 KB link in the WP Admin permission check.

| Before | After |
|--------|--------|
| <img width="958" alt="Screenshot 2024-09-11 at 2 48 17 PM" src="https://github.com/user-attachments/assets/d961070c-4790-4f77-8b99-13f729c2ec4c"> | <img width="956" alt="Screenshot 2024-09-11 at 2 48 32 PM" src="https://github.com/user-attachments/assets/05452890-ab84-4816-bae5-1388a583ae40"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1109

## Proposed Changes

* Remove `a4a-request-wp-admin-access__learn-more`.
* Replace KB link label to Learn more about team member permissions.

## Why are these changes being made?

*

## Testing Instructions

* Login as a member
* Use the A4A live link and go to the `/sites` page.
* Look for a site the user does not have WP admin access and expand.
* Confirm that the page looks like the screenshot above.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
