### PR TITLE
Use Recoleta with extended latin2 glyphs

### DIFF
--- a/packages/typography/styles/fonts.scss
+++ b/packages/typography/styles/fonts.scss
@@ -5,8 +5,8 @@
 	font-family: Recoleta;
 	font-weight: 400;
 	src:
-		url(https://s1.wp.com/i/fonts/recoleta/400.woff2) format("woff2"),
-		url(https://s1.wp.com/i/fonts/recoleta/400.woff) format("woff");
+		url(https://s1.wp.com/i/fonts/recoleta/extended/recoleta-400.woff2) format("woff2"),
+		url(https://s1.wp.com/i/fonts/recoleta/extended/recoleta-400.woff) format("woff");
 }
 
 .wp-brand-font {


### PR DESCRIPTION
The version of the Recoleta font we use in Calypso doesn't contain latin2 glyphs and some european languages like Czech or Polish appear broken. On the following screenshot, note that some of the accented characters (ř and ę) use a fallback from a different font:

<img width="484" alt="Screenshot 2024-09-11 at 9 49 58" src="https://github.com/user-attachments/assets/1220ae35-3c2d-4057-83f1-90cdc3625c18">
<img width="487" alt="Screenshot 2024-09-11 at 9 49 41" src="https://github.com/user-attachments/assets/442b2078-bb82-4716-89a3-cd177cb435a7">

After this patch, the broken characters are fixed:

<img width="472" alt="Screenshot 2024-09-11 at 9 55 30" src="https://github.com/user-attachments/assets/030f91ed-5c4d-4353-aabc-48044b4d67d2">
<img width="488" alt="Screenshot 2024-09-11 at 9 55 44" src="https://github.com/user-attachments/assets/ba5126d7-6ffd-4596-9b94-d1b1b132c880">

There is also a companion dotcom patch (D161116-code) that adds the missing `.woff` file to the server and synchronizes the font files to be identical with these used by the frontend H4 theme. That needs to be merged first. But this PR can be tested independently, because the `.woff2` file is already there.