### PR TITLE
A4A> Referrals: Fix the WPCOM hosting when the refer mode is on

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -111,10 +111,11 @@ function PlanDetails( {
 			</div>
 
 			<div className="wpcom-plan-selector__cta">
-				<div className="wpcom-plan-selector__cta-label">
-					{ translate( 'How many sites would you like to buy?' ) }
-				</div>
-
+				{ ! referralMode && (
+					<div className="wpcom-plan-selector__cta-label">
+						{ translate( 'How many sites would you like to buy?' ) }
+					</div>
+				) }
 				<div className="wpcom-plan-selector__cta-component">
 					<Button
 						className="wpcom-plan-selector__cta-button"
@@ -179,6 +180,8 @@ export default function WPCOMPlanSelector( { onSelect }: WPCOMPlanSelectorProps 
 	// Show the WPCOM slider if the user has less than 10 plans and is not in referral mode.
 	const showWPCOMSlider = ! referralMode && ownedPlans < MAX_PLANS_FOR_SLIDER;
 
+	const displayQuantity = referralMode ? 1 : quantity;
+
 	return (
 		<div
 			className={ clsx( 'wpcom-plan-selector', {
@@ -188,7 +191,7 @@ export default function WPCOMPlanSelector( { onSelect }: WPCOMPlanSelectorProps 
 			<div className="wpcom-plan-selector__slider-container">
 				{ showWPCOMSlider && (
 					<WPCOMPlanSlider
-						quantity={ quantity }
+						quantity={ displayQuantity }
 						onChange={ setQuantity }
 						ownedPlans={ ownedPlans }
 					/>
@@ -202,7 +205,7 @@ export default function WPCOMPlanSelector( { onSelect }: WPCOMPlanSelectorProps 
 						onSelect={ onSelect }
 						ownedPlans={ ownedPlans }
 						referralMode={ referralMode }
-						quantity={ quantity }
+						quantity={ displayQuantity }
 						setQuantity={ setQuantity }
 					/>
 				) : (


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1096

## Proposed Changes

This PR fixes the bug that allows users to add more than one WPCOM hosting while referring when the refer mode is on.

## Why are these changes being made?

* To fix the bug with WPCOM hosting referrals

## Testing Instructions

* Open A4A live link
* You can reproduce the bug mentioned here: https://github.com/Automattic/automattic-for-agencies-dev/issues/1096
* Go to marketplace/hosting/wpcom -> Add more than 1 WPCOM hosting to cart -> Turn the refer mode on -> Verify that the `How many sites would you like to buy?` text is no longer visible.
* Click the `Add to referral` button and verify only 1 WPCOM hosting is added to the card, not the previously added quantity that you added during the non-refer mode.

<img width="1404" alt="Screenshot 2024-09-11 at 1 54 54 PM" src="https://github.com/user-attachments/assets/434445c2-a2e7-4d9f-9912-b737353d3839">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
