### PR TITLE
Upgrade upload-artifact GH action to v4 to fix ICFY stats calculation

### DIFF
--- a/.github/workflows/icfy-stats.yml
+++ b/.github/workflows/icfy-stats.yml
@@ -25,7 +25,7 @@ jobs:
           WORKERS: 2
         run: yarn run analyze-icfy
       - run: mkdir icfy-stats && mv client/{chart,stats}.json icfy-stats
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: icfy
           path: icfy-stats


### PR DESCRIPTION
Update the `upload-artifact` action for the "Calculate ICFY stats" task. Current PRs are getting this error:

<img width="741" alt="Screenshot 2024-09-11 at 10 16 06" src="https://github.com/user-attachments/assets/92f97eea-874b-4787-99f5-355a3657c408">

It seems that something has changed on GitHub servers this morning.