### PR TITLE
Performance Profiler: Adds a timing delay description in loading screen.

### DIFF
--- a/client/performance-profiler/pages/loading-screen/index.tsx
+++ b/client/performance-profiler/pages/loading-screen/index.tsx
@@ -16,6 +16,16 @@ const StyledLoadingScreen = styled.div`
 		font-size: 20px;
 		font-weight: 500;
 		line-height: 26px;
+		margin-bottom: 5px;
+
+		&.saved-report {
+			margin-bottom: 30px;
+		}
+	}
+
+	p {
+		font-size: 14px;
+		color: var( --studio-gray-70 );
 		margin-bottom: 30px;
 	}
 
@@ -207,7 +217,8 @@ export const LoadingScreen = ( { isSavedReport }: LoadingScreenProps ) => {
 	return (
 		<LayoutBlock className="landing-page-header-block">
 			<StyledLoadingScreen>
-				<h2>{ heading }</h2>
+				<h2 className={ isSavedReport ? 'saved-report' : '' }>{ heading }</h2>
+				{ ! isSavedReport && <p>{ translate( 'This may take around 30 seconds.' ) }</p> }
 				{ steps.map( ( heading, index ) => (
 					<span key={ index } className={ stepStatus( index, step ) }>
 						<Gridicon icon="checkmark" size={ 18 } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1725888086555339-slack-C07AV9N4Y1H

## Proposed Changes

- Adds messaging related to the estimated time to run the tests.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Go to `/speed-test-tool?url=https%3A%2F%2Fblecyclingclub.gr%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzQ5N30.mkgZ42KqRm1VSSAZP2rcp_w8lZ2CB2ZKRDNkL2XLNA0`
* The messaging `This may take around 30 seconds.` should not appear 
* Run a new test
* The messaging `This may take around 30 seconds.` should appear 

![CleanShot 2024-09-11 at 13 58 43](https://github.com/user-attachments/assets/0d027fe9-9994-4e37-8459-c8b9d002585d)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?