### PR TITLE
A4A Dev Sites: Update copy related to the "create free development site" CTA and `isFullyManagedAgencySite` setting section

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -207,14 +207,10 @@ export default function AddNewSiteButton( {
 			{ devSitesEnabled && (
 				<div className="site-selector-and-importer__popover-column">
 					{ menuItem( {
-						icon: <img src={ devSiteBanner } alt="WordPress.com Development Site" />,
-						heading: translate( 'WordPress.com Development Site' ),
+						icon: <img src={ devSiteBanner } alt="Start Building for Free" />,
+						heading: translate( 'Start Building for Free' ),
 						description: translate(
-							'Try our hosting for free indefinitely.{{br/}}Only pay when you launch.',
-							{
-								components: { br: <br /> },
-								comment: 'br is a line break',
-							}
+							'Develop a WordPress.com site for as long as your client requires with a free development license. Only pay when you launch!'
 						),
 						disabled: ! hasAvailableDevSites,
 						isBanner: true,
@@ -238,14 +234,14 @@ export default function AddNewSiteButton( {
 							<div>
 								<div className="site-selector-and-importer__popover-site-count">
 									{ translate(
-										'%(pendingSites)d site available',
-										'%(pendingSites)d sites available',
+										'%(pendingSites)d free license available',
+										'%(pendingSites)d free licenses available',
 										{
 											args: {
 												pendingSites: availableDevSites,
 											},
 											count: availableDevSites,
-											comment: '%(pendingSites)s is the number of sites available.',
+											comment: '%(pendingSites)s is the number of free licenses available.',
 										}
 									) }
 								</div>

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -210,7 +210,11 @@ export default function AddNewSiteButton( {
 						icon: <img src={ devSiteBanner } alt="Start Building for Free" />,
 						heading: translate( 'Start Building for Free' ),
 						description: translate(
-							'Develop a WordPress.com site for as long as your client requires with a free development license. Only pay when you launch!'
+							'Develop a WordPress.com site for as long as your client requires with a free development license.{{br/}}Only pay when you launch!',
+							{
+								components: { br: <br /> },
+								comment: 'br is a line break',
+							}
 						),
 						disabled: ! hasAvailableDevSites,
 						isBanner: true,

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -210,10 +210,10 @@ export default function AddNewSiteButton( {
 						icon: <img src={ devSiteBanner } alt="Start Building for Free" />,
 						heading: translate( 'Start Building for Free' ),
 						description: translate(
-							'Develop a WordPress.com site for as long as your client requires with a free development license.{{br/}}Only pay when you launch!',
+							'Develop up to 5 WordPress.com sites at{{nbsp/}}once with free development licenses.{{br/}}Only pay when you launch!',
 							{
-								components: { br: <br /> },
-								comment: 'br is a line break',
+								components: { br: <br />, nbsp: <>&nbsp;</> },
+								comment: 'br is a line break, nbsp is a non-breaking space character',
 							}
 						),
 						disabled: ! hasAvailableDevSites,
@@ -237,17 +237,12 @@ export default function AddNewSiteButton( {
 						extraContent: (
 							<div>
 								<div className="site-selector-and-importer__popover-site-count">
-									{ translate(
-										'%(pendingSites)d free license available',
-										'%(pendingSites)d free licenses available',
-										{
-											args: {
-												pendingSites: availableDevSites,
-											},
-											count: availableDevSites,
-											comment: '%(pendingSites)s is the number of free licenses available.',
-										}
-									) }
+									{ translate( '%(pendingSites)d of 5 free licenses available', {
+										args: {
+											pendingSites: availableDevSites,
+										},
+										comment: '%(pendingSites)s is the number of free licenses available.',
+									} ) }
 								</div>
 								<div
 									className={ clsx( 'site-selector-and-importer__popover-development-site-cta', {

--- a/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
+++ b/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
@@ -60,7 +60,7 @@ export function A4AFullyManagedSiteSetting( {
 	return (
 		<div className="site-settings__a4a-fully-managed-container">
 			<SettingsSectionHeader
-				title={ translate( 'Help Center and hosting features visibility' ) }
+				title={ translate( 'Agency settings' ) }
 				id="site-settings__a4a-fully-managed-header"
 				disabled={ disabled }
 				isSaving={ isSaving }
@@ -71,7 +71,7 @@ export function A4AFullyManagedSiteSetting( {
 				{ isDevSite ? (
 					<p className="form-setting-explanation">
 						{ translate(
-							"Clients can't access the {{HcLink}}WordPress.com Help Center{{/HcLink}} or {{HfLink}}hosting features{{/HfLink}} on development sites. Once the site is launched, enable access in Site Settings.",
+							"Clients can't access the {{HcLink}}WordPress.com Help Center{{/HcLink}} or {{HfLink}}hosting features{{/HfLink}} on development sites. You may configure access after the site is launched.",
 							{
 								components: translationComponents,
 							}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9039 and https://github.com/Automattic/dotcom-forge/issues/8922 (comment: https://github.com/Automattic/dotcom-forge/issues/8922#issuecomment-2340699232).
Resolves https://github.com/Automattic/dotcom-forge/issues/9037.

## Proposed Changes

* update copy related to:
  * the "create free development site" CTA
  * `isFullyManagedAgencySite` setting section

| Before | After |
|--------|--------|
| ![Markup on 2024-09-11 at 13:29:08](https://github.com/user-attachments/assets/634eebb7-172a-4bd6-a4ab-3634478acbfd) | ![Markup on 2024-09-11 at 16:06:29](https://github.com/user-attachments/assets/37edbd62-04d9-44d8-9581-a9d5411e9821) |
| ![Markup on 2024-09-11 at 13:28:36](https://github.com/user-attachments/assets/dc88e349-91e8-4b24-a39d-90822c732986) | ![Markup on 2024-09-11 at 13:28:05](https://github.com/user-attachments/assets/1d5a6ad2-fbe1-43f7-9907-2d85e5019034) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR locally.
2. Build the changes using `yarn start-a8c-for-agencies` and navigate to http://agencies.localhost:3000/overview?flags=a4a-dev-sites where you can click on the `Add sites` button and review the updated copy.
3. Build the changes using `yarn start` and head over to http://calypso.localhost:3000/settings/general/{site-slug}?flags=a4a-dev-sites for an **A4A development site**. Review the updated copy of the `isFullyManagedAgencySite` setting section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?