### PR TITLE
/wordpress-hosting experiment: Treatment version signups should be identified as a dev account

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -74,7 +74,8 @@ class PasswordlessSignupForm extends Component {
 			password: '',
 		};
 		const { flowName, queryArgs = {} } = this.props;
-		const isDevAccount = queryArgs.ref === 'hosting-lp' || queryArgs.ref === 'developer-lp';
+		const devAccountLandingPageRefs = [ 'hosting-lp', 'developer-lp', 'wordpress-hosting-dev-lp' ];
+		const isDevAccount = devAccountLandingPageRefs.includes( queryArgs.ref );
 
 		// If not in a flow, submit the form as a standard signup form.
 		// Since it is a passwordless form, we don't need to submit a password.

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -146,7 +146,8 @@ class SocialSignupForm extends Component {
 export default connect(
 	( state ) => {
 		const query = getCurrentQueryArguments( state );
-		const isDevAccount = query?.ref === 'hosting-lp' || query?.ref === 'developer-lp';
+		const devAccountLandingPageRefs = [ 'hosting-lp', 'developer-lp', 'wordpress-hosting-dev-lp' ];
+		const isDevAccount = devAccountLandingPageRefs.includes( query?.ref );
 
 		return {
 			recordTracksEvent: recordTracks,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* This PR adds a new `ref` that is eligible for a dev account on signup.
* The change is made as part of the request pcNC1U-1oo-p2. We are launching an experiment in which the treatment version will divert traffic to the hosted signup flow. We want the sites created from this flow to be dev accounts that are atomic by default.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the calypso.live link, visit `/setup/new-hosted-site?ref=wordpress-hosting-dev-lp&section=hero` and purchase a Business plan.
* Verify in `/me/developer` page that the "I am a developer"  toggle is turned on.
* Verify in Blog RC that the site is atomic.
* Verify in Store Admin that a "Developer" tag is added to the site 
* Verify that the "classic" view is set up by default for wp-admin.
![7PYlK82Q7T.png](https://github.com/user-attachments/assets/9f314608-4d9c-4452-8be7-b297fba6b86d)