### PR TITLE
Theme Errors: fetch only the theme_errors field of the site object

### DIFF
--- a/client/my-sites/themes/theme-errors.jsx
+++ b/client/my-sites/themes/theme-errors.jsx
@@ -7,8 +7,10 @@ import wpcom from 'calypso/lib/wp';
  * We make a separate request rather than using getSite here to
  * avoid querying the WP.com cache of a site, which returns theme
  * errors for the multisite (caused by its 'force=wpcom' param).
+ * Also, `theme_errors` is an expensive field that is not normally
+ * fetched by the common `QuerySite` or `QuerySites` helpers.
  */
-function querySiteDataWithoutForceWpcom( siteId ) {
+function fetchSiteThemeErrorsWithoutForceWpcom( siteId ) {
 	return wpcom.req.get( {
 		path: '/sites/' + encodeURIComponent( siteId ),
 		apiVersion: '1.1',
@@ -24,7 +26,7 @@ const ThemeErrors = ( { siteId } ) => {
 	const [ themeErrors, setThemeErrors ] = useState( [] );
 
 	useEffect( () => {
-		querySiteDataWithoutForceWpcom( siteId ).then( ( siteData ) => {
+		fetchSiteThemeErrorsWithoutForceWpcom( siteId ).then( ( siteData ) => {
 			const errors = siteData?.options?.theme_errors;
 			setThemeErrors( errors || [] );
 		} );

--- a/client/my-sites/themes/theme-errors.jsx
+++ b/client/my-sites/themes/theme-errors.jsx
@@ -8,10 +8,14 @@ import wpcom from 'calypso/lib/wp';
  * avoid querying the WP.com cache of a site, which returns theme
  * errors for the multisite (caused by its 'force=wpcom' param).
  */
-async function querySiteDataWithoutForceWpcom( siteId ) {
-	return await wpcom.req.get( {
+function querySiteDataWithoutForceWpcom( siteId ) {
+	return wpcom.req.get( {
 		path: '/sites/' + encodeURIComponent( siteId ),
 		apiVersion: '1.1',
+		query: {
+			fields: 'ID,options',
+			options: 'theme_errors',
+		},
 	} );
 }
 
@@ -20,13 +24,10 @@ const ThemeErrors = ( { siteId } ) => {
 	const [ themeErrors, setThemeErrors ] = useState( [] );
 
 	useEffect( () => {
-		const fetchData = async () => {
-			const siteData = await querySiteDataWithoutForceWpcom( siteId );
+		querySiteDataWithoutForceWpcom( siteId ).then( ( siteData ) => {
 			const errors = siteData?.options?.theme_errors;
 			setThemeErrors( errors || [] );
-		};
-
-		fetchData();
+		} );
 	}, [ siteId ] );
 
 	const dismissNotice = ( themeName, errorIndex ) => {


### PR DESCRIPTION
A little followup to #93554 that optimizes the site REST request to only return the `options.theme_errors` field. We don't need to fetch the entire site object, which is big and expensive.

I'm also making the code a bit more concise by removing `async`/`await` call which are IMO not a good fit here.

FYI @Aurorum 