### PR TITLE
Calypso UI Component: DateRange + DatePicker: Add useArrowNavigation 

### DIFF
--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -53,6 +53,7 @@ class DatePicker extends PureComponent {
 		onDayTouchEnd: PropTypes.func,
 		onDayTouchMove: PropTypes.func,
 		rootClassNames: PropTypes.object,
+		useArrowNavigation: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -71,6 +72,7 @@ class DatePicker extends PureComponent {
 		onDayTouchEnd: noop,
 		onDayTouchMove: noop,
 		rootClassNames: {},
+		useArrowNavigation: false,
 	};
 
 	isSameDay( d0, d1 ) {
@@ -247,7 +249,7 @@ class DatePicker extends PureComponent {
 				localeUtils={ this.getLocaleUtils() }
 				onMonthChange={ this.props.onMonthChange }
 				showOutsideDays={ this.props.showOutsideDays }
-				navbarElement={ <DatePickerNavBar /> }
+				navbarElement={ <DatePickerNavBar useArrowNavigation={ this.props.useArrowNavigation } /> }
 				selectedDays={ this.props.selectedDays }
 				numberOfMonths={ this.props.numberOfMonths }
 			/>

--- a/client/components/date-picker/nav-bar.jsx
+++ b/client/components/date-picker/nav-bar.jsx
@@ -20,7 +20,7 @@ export const DatePickerNavBar = ( {
 	localeUtils,
 	showPreviousButton = true,
 	showNextButton = true,
-	useArrowNavigation = true,
+	useArrowNavigation = false,
 } ) => {
 	const classes = clsx( 'date-picker__nav-bar', {
 		[ className ]: !! className,

--- a/client/components/date-picker/nav-bar.jsx
+++ b/client/components/date-picker/nav-bar.jsx
@@ -1,3 +1,4 @@
+import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 
@@ -19,15 +20,21 @@ export const DatePickerNavBar = ( {
 	localeUtils,
 	showPreviousButton = true,
 	showNextButton = true,
+	useChevronButtons = true, // Todo: false once finished testing
 } ) => {
 	const classes = clsx( 'date-picker__nav-bar', {
 		[ className ]: !! className,
 	} );
+
+	const buttonClass = useChevronButtons
+		? 'date-picker__chevron-button'
+		: 'date-picker__month-button';
+
 	return (
 		<div className={ classes }>
 			{ showPreviousButton && (
 				<button
-					className="date-picker__previous-month button"
+					className={ `date-picker__previous-month ${ buttonClass }` }
 					type="button"
 					aria-label={ translate( 'Previous month (%s)', {
 						comment: 'Aria label for date picker controls',
@@ -35,13 +42,17 @@ export const DatePickerNavBar = ( {
 					} ) }
 					onClick={ handleMonthClick( onPreviousClick ) }
 				>
-					{ localeUtils.formatMonthShort( previousMonth ) }
+					{ useChevronButtons ? (
+						<Icon icon={ chevronLeft } />
+					) : (
+						localeUtils.formatMonthShort( previousMonth )
+					) }
 				</button>
 			) }
 
 			{ showNextButton && (
 				<button
-					className="date-picker__next-month button"
+					className={ `date-picker__next-month ${ buttonClass }` }
 					type="button"
 					aria-label={ translate( 'Next month (%s)', {
 						comment: 'Aria label for date picker controls',
@@ -49,7 +60,11 @@ export const DatePickerNavBar = ( {
 					} ) }
 					onClick={ handleMonthClick( onNextClick ) }
 				>
-					{ localeUtils.formatMonthShort( nextMonth ) }
+					{ useChevronButtons ? (
+						<Icon icon={ chevronRight } />
+					) : (
+						localeUtils.formatMonthShort( nextMonth )
+					) }
 				</button>
 			) }
 		</div>

--- a/client/components/date-picker/nav-bar.jsx
+++ b/client/components/date-picker/nav-bar.jsx
@@ -20,14 +20,14 @@ export const DatePickerNavBar = ( {
 	localeUtils,
 	showPreviousButton = true,
 	showNextButton = true,
-	useChevronButtons = true, // Todo: false once finished testing
+	useArrowNavigation = true,
 } ) => {
 	const classes = clsx( 'date-picker__nav-bar', {
 		[ className ]: !! className,
 	} );
 
-	const buttonClass = useChevronButtons
-		? 'date-picker__chevron-button'
+	const buttonClass = useArrowNavigation
+		? 'date-picker__arrow-button'
 		: 'date-picker__month-button';
 
 	return (
@@ -42,7 +42,7 @@ export const DatePickerNavBar = ( {
 					} ) }
 					onClick={ handleMonthClick( onPreviousClick ) }
 				>
-					{ useChevronButtons ? (
+					{ useArrowNavigation ? (
 						<Icon icon={ chevronLeft } />
 					) : (
 						localeUtils.formatMonthShort( previousMonth )
@@ -60,7 +60,7 @@ export const DatePickerNavBar = ( {
 					} ) }
 					onClick={ handleMonthClick( onNextClick ) }
 				>
-					{ useChevronButtons ? (
+					{ useArrowNavigation ? (
 						<Icon icon={ chevronRight } />
 					) : (
 						localeUtils.formatMonthShort( nextMonth )

--- a/client/components/date-picker/nav-bar.jsx
+++ b/client/components/date-picker/nav-bar.jsx
@@ -28,7 +28,7 @@ export const DatePickerNavBar = ( {
 
 	const buttonClass = useArrowNavigation
 		? 'date-picker__arrow-button'
-		: 'date-picker__month-button';
+		: 'date-picker__month-button button';
 
 	return (
 		<div className={ classes }>

--- a/client/components/date-range/README.md
+++ b/client/components/date-range/README.md
@@ -34,7 +34,8 @@ Props are displayed as a table with Name, Type, Default, and Description as head
 | `onDateCommit(startDate, endDate)`          | `Function`                  | `undefined`         | callback function called when a date is _committed_ (ie: "Applied").                                                                                                                               |
 | `onDateSelect(startDate, endDate)`          | `Function`                  | `undefined`         | callback function called when a date is _selected_ (but not committed ie: "Applied")                                                                                                               |
 | `triggerText( startDateText, endDateText )` | `Function`                  | `undefined`         | function to generate the text displayed in the trigger button. Passed the start/end date text in `MM/DD/YYYY` format (or locale specific alternative)                                              |
-| `displayShortcuts`                          | `Boolean`                   | `false`             | determines whether to display the shortcuts menu alongside the calendar                                                                                                                            |
+| `displayShortcuts`                          | `Boolean`                   | `false`             | determines whether to display the shortcuts menu alongside the calendar                                                                                                        
+| `useArrowNavigation`                          | `Boolean`                   | `false`             | determines whether to display the arrow navigation instead of the month labelled buttons as navigation between calendar months                      |
 
 #### Render Props
 

--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -15,6 +15,7 @@ interface DateRangePickerProps {
 	onDateRangeChange?: ( startDate: MomentOrNull, endDate: MomentOrNull ) => void;
 	focusedMonth?: Date;
 	numberOfMonths?: number;
+	useArrowNavigation?: boolean;
 }
 
 /**
@@ -32,6 +33,7 @@ const DateRangePicker = ( {
 	focusedMonth,
 	onDateRangeChange = noop,
 	numberOfMonths = 2,
+	useArrowNavigation = false,
 }: DateRangePickerProps ) => {
 	/**
 	 * Converts a moment date to a native JS Date object
@@ -211,6 +213,7 @@ const DateRangePicker = ( {
 			selectedDays={ selected }
 			numberOfMonths={ numberOfMonths }
 			disabledDays={ getDisabledDaysConfig() }
+			useArrowNavigation={ useArrowNavigation }
 		/>
 	);
 };

--- a/client/components/date-range/docs/example.jsx
+++ b/client/components/date-range/docs/example.jsx
@@ -69,6 +69,11 @@ class DateRangeExample extends Component {
 				<Card>
 					<DateRange displayShortcuts />
 				</Card>
+
+				<h3>With Arrow Navigation Enabled</h3>
+				<Card>
+					<DateRange useArrowNavigation />
+				</Card>
 			</Fragment>
 		);
 	}

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -47,6 +47,7 @@ export class DateRange extends Component {
 		renderInputs: PropTypes.func,
 		displayShortcuts: PropTypes.bool,
 		rootClass: PropTypes.string,
+		useArrowNavigation: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -60,6 +61,7 @@ export class DateRange extends Component {
 		renderInputs: ( props ) => <DateRangeInputs { ...props } />,
 		displayShortcuts: false,
 		rootClass: '',
+		useArrowNavigation: false,
 	};
 
 	constructor( props ) {
@@ -508,6 +510,7 @@ export class DateRange extends Component {
 				onDateRangeChange={ this.handleCalendarChange }
 				focusedMonth={ this.state.focusedMonth }
 				numberOfMonths={ this.getNumberOfMonths() }
+				useArrowNavigation={ this.props.useArrowNavigation }
 			/>
 		);
 	}

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -147,6 +147,7 @@ const StatsDateControl = ( {
 					} }
 					rootClass="stats-date-control-picker"
 					displayShortcuts
+					useArrowNavigation
 				/>
 			) : (
 				<DateControlPicker


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#162](https://github.com/Automattic/red-team/issues/162)

## Proposed Changes

* This PR extends the DateRange + DatePicker components to optionally display arrow navigations for the calendar months instead of month labelled buttons

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To extend the Calypso DateRange picker component for use with the Stats Date Control update.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open Calypso live branch
* navigate to `/devdocs/design/date-range`
* click on the last demo `With Shortcuts Menu Displayed` to open the calendar popover
* check the monthly navigation buttons are now displaying as arrows
* also thoroughly check on mobile and small displays


![image](https://github.com/user-attachments/assets/0c681d86-a5ae-476d-b37d-b28a57a902bf)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
