### PR TITLE
Replace all single quote occurrence for a curly apostrophe

### DIFF
--- a/client/performance-profiler/components/charts/history-chart.jsx
+++ b/client/performance-profiler/components/charts/history-chart.jsx
@@ -229,7 +229,7 @@ const HistoryChart = ( { data, range, height } ) => {
 						<p className="heading">{ translate( 'No history available' ) }</p>
 						<p>
 							{ translate(
-								"The Chrome User Experience Report collects speed data from real site visits. Sites with low-traffic don't provide enough data to generate historical trends."
+								'The Chrome User Experience Report collects speed data from real site visits. Sites with low-traffic don‘t provide enough data to generate historical trends.'
 							) }
 						</p>
 					</div>

--- a/client/performance-profiler/components/disclaimer-section/index.tsx
+++ b/client/performance-profiler/components/disclaimer-section/index.tsx
@@ -10,7 +10,7 @@ export const Disclaimer = () => {
 			<div className="performance-profiler-disclaimer">
 				<div className="content">
 					{ translate(
-						"The historical performance data and metrics presented in this site are sourced from the Google Chrome User Experience Report (CrUX) dataset, which reflects real-world user experiences and interactions with your site. Realtime data is provided by PageSpeed Insights. This data helps us provide actionable recommendations to improve your site's performance.{{br}}{{/br}}{{br}}{{/br}}While we strive to provide accurate and helpful insights, please note that performance improvements are dependent on various factors, including your current setup and specific use case. Our recommendations aim to guide you towards potential enhancements, but results may vary.",
+						'The historical performance data and metrics presented in this site are sourced from the Google Chrome User Experience Report (CrUX) dataset, which reflects real-world user experiences and interactions with your site. Realtime data is provided by PageSpeed Insights. This data helps us provide actionable recommendations to improve your site‘s performance.{{br}}{{/br}}{{br}}{{/br}}While we strive to provide accurate and helpful insights, please note that performance improvements are dependent on various factors, including your current setup and specific use case. Our recommendations aim to guide you towards potential enhancements, but results may vary.',
 						{ components: { br: <br /> } }
 					) }
 				</div>

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -19,12 +19,12 @@ export const InsightsSection = forwardRef(
 
 		return (
 			<div className="performance-profiler-insights-section" ref={ ref }>
-				<h2 className="title">{ translate( "Improve your site's performance" ) }</h2>
+				<h2 className="title">{ translate( 'Improve your site‘s performance' ) }</h2>
 				<p className="subtitle">
 					{ Object.keys( audits ).length
 						? translate( 'We found things you can do to speed up your site.' )
 						: translate(
-								"Great job! We didn't find any recommendations for improving the speed of your site."
+								'Great job! We didn‘t find any recommendations for improving the speed of your site.'
 						  ) }
 				</p>
 				{ Object.keys( audits ).map( ( key, index ) => (

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -70,7 +70,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 											>
 												<ThumbsUpIcon />
 
-												{ translate( "Good, it's helpful" ) }
+												{ translate( 'Good, it‘s helpful' ) }
 											</div>
 											<div
 												className="options bad"

--- a/client/performance-profiler/components/newsletter-banner.tsx
+++ b/client/performance-profiler/components/newsletter-banner.tsx
@@ -68,7 +68,7 @@ export const NewsletterBanner = ( { link, onClick }: { link: string; onClick: ()
 				</Heading>
 				<Body>
 					{ translate(
-						"Monitor your site's key performance metrics with a free report delivered to your inbox each week."
+						'Monitor your site‘s key performance metrics with a free report delivered to your inbox each week.'
 					) }
 				</Body>
 				{ ! isLoggedIn && (

--- a/client/performance-profiler/components/performance-score/index.tsx
+++ b/client/performance-profiler/components/performance-score/index.tsx
@@ -72,8 +72,8 @@ export const PerformanceScore = ( props: PerformanceScoreProps ) => {
 				<div className="recommendations-text">
 					{ recommendationsQuantity
 						? translate(
-								"We found %(quantity)d way to improve your site's performance. {{a}}View recommendation{{/a}}",
-								"We found %(quantity)d ways to improve your site's performance. {{a}}View recommendations{{/a}}",
+								'We found %(quantity)d way to improve your site‘s performance. {{a}}View recommendation{{/a}}',
+								'We found %(quantity)d ways to improve your site‘s performance. {{a}}View recommendations{{/a}}',
 								{
 									count: recommendationsQuantity,
 									args: { quantity: recommendationsQuantity },
@@ -91,14 +91,14 @@ export const PerformanceScore = ( props: PerformanceScoreProps ) => {
 								}
 						  )
 						: translate(
-								"We didn't find any recommendations for improving the speed of your site."
+								'We didn‘t find any recommendations for improving the speed of your site.'
 						  ) }
 				</div>
 			</div>
 
 			<div className="disclaimer">
 				{ translate(
-					"The performance score is a combined representation of your site's individual speed metrics. {{link}}See calculator ↗{{/link}}",
+					'The performance score is a combined representation of your site‘s individual speed metrics. {{link}}See calculator ↗{{/link}}',
 					{
 						components: {
 							link: (

--- a/client/performance-profiler/controller.tsx
+++ b/client/performance-profiler/controller.tsx
@@ -78,7 +78,7 @@ export const notFound = ( context: Context, next: () => void ) => {
 			className="content-404"
 			illustration="/calypso/images/illustrations/illustration-404.svg"
 			title={ translate( 'Uh oh. Page not found.' ) }
-			line={ translate( "Sorry, the page you were looking for doesn't exist or has been moved." ) }
+			line={ translate( 'Sorry, the page you were looking for doesn‘t exist or has been moved.' ) }
 			action={ translate( 'Return Home' ) }
 			actionURL="/"
 		/>

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -102,7 +102,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 					displayBadge
 					message={
 						<>
-							{ translate( "We couldn't test the performance of %s", {
+							{ translate( 'We couldn‘t test the performance of %s', {
 								args: [ siteUrl.host ],
 							} ) }
 							<br />

--- a/client/performance-profiler/pages/loading-screen/index.tsx
+++ b/client/performance-profiler/pages/loading-screen/index.tsx
@@ -130,8 +130,8 @@ export const LoadingScreen = ( { isSavedReport }: LoadingScreenProps ) => {
 	const [ step, setStep ] = useState( 0 );
 
 	const heading = isSavedReport
-		? translate( "Your site's results are ready" )
-		: translate( "Testing your site's speed…" );
+		? translate( 'Your site‘s results are ready' )
+		: translate( 'Testing your site‘s speed…' );
 
 	const steps = isSavedReport
 		? [ translate( 'Getting your report…' ) ]
@@ -154,7 +154,7 @@ export const LoadingScreen = ( { isSavedReport }: LoadingScreenProps ) => {
 		{
 			heading: translate( 'Did you know?' ),
 			description: translate(
-				"WordPress.com hosting comes with unlimited bandwidth, visitors, and traffic so you'll never be surprised by extra fees."
+				'WordPress.com hosting comes with unlimited bandwidth, visitors, and traffic so you‘ll never be surprised by extra fees.'
 			),
 		},
 		{

--- a/client/performance-profiler/pages/weekly-report/index.tsx
+++ b/client/performance-profiler/pages/weekly-report/index.tsx
@@ -124,7 +124,7 @@ export const WeeklyReport = ( props: WeeklyReportProps ) => {
 					displayBadge
 					title={ translate( 'You’re all set!' ) }
 					message={ translate(
-						"We'll send you a weekly performance report for {{strong}}%s{{/strong}} so you can keep an eye on your site's speed. The first email is on it's way now.",
+						'We‘ll send you a weekly performance report for {{strong}}%s{{/strong}} so you can keep an eye on your site‘s speed. The first email is on it‘s way now.',
 						{ args: [ siteUrl.host ], components: { strong: <strong /> } }
 					) }
 					ctaText={ translate( '← Back to speed test' ) }

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -23,9 +23,9 @@ export const metricsNames = {
 
 export const metricValuations = {
 	fcp: {
-		good: translate( "Your site's First Contentful Paint is good" ),
-		needsImprovement: translate( "Your site's First Contentful Paint is moderate" ),
-		bad: translate( "Your site's First Contentful Paint needs improvement" ),
+		good: translate( 'Your site‘s First Contentful Paint is good' ),
+		needsImprovement: translate( 'Your site‘s First Contentful Paint is moderate' ),
+		bad: translate( 'Your site‘s First Contentful Paint needs improvement' ),
 		heading: translate( 'What is First Contentful Paint?' ),
 		aka: translate( '(FCP)' ),
 		explanation: translate(
@@ -33,9 +33,9 @@ export const metricValuations = {
 		),
 	},
 	lcp: {
-		good: translate( "Your site's Largest Contentful Paint is good" ),
-		needsImprovement: translate( "Your site's Largest Contentful Paint is moderate" ),
-		bad: translate( "Your site's Largest Contentful Paint needs improvement" ),
+		good: translate( 'Your site‘s Largest Contentful Paint is good' ),
+		needsImprovement: translate( 'Your site‘s Largest Contentful Paint is moderate' ),
+		bad: translate( 'Your site‘s Largest Contentful Paint needs improvement' ),
 		heading: translate( 'What is Largest Contentful Paint?' ),
 		aka: translate( '(LCP)' ),
 		explanation: translate(
@@ -43,9 +43,9 @@ export const metricValuations = {
 		),
 	},
 	cls: {
-		good: translate( "Your site's Cumulative Layout Shift is good" ),
-		needsImprovement: translate( "Your site's Cumulative Layout Shift is moderate" ),
-		bad: translate( "Your site's Cumulative Layout Shift needs improvement" ),
+		good: translate( 'Your site‘s Cumulative Layout Shift is good' ),
+		needsImprovement: translate( 'Your site‘s Cumulative Layout Shift is moderate' ),
+		bad: translate( 'Your site‘s Cumulative Layout Shift needs improvement' ),
 		heading: translate( 'What is Cumulative Layout Shift?' ),
 		aka: translate( '(CLS)' ),
 		explanation: translate(
@@ -53,9 +53,9 @@ export const metricValuations = {
 		),
 	},
 	inp: {
-		good: translate( "Your site's Interaction to Next Paint is good" ),
-		needsImprovement: translate( "Your site's Interaction to Next Paint is moderate" ),
-		bad: translate( "Your site's Interaction to Next Paint needs improvement" ),
+		good: translate( 'Your site‘s Interaction to Next Paint is good' ),
+		needsImprovement: translate( 'Your site‘s Interaction to Next Paint is moderate' ),
+		bad: translate( 'Your site‘s Interaction to Next Paint needs improvement' ),
 		heading: translate( 'What is Interaction to Next Paint?' ),
 		aka: translate( '(INP)' ),
 		explanation: translate(
@@ -63,19 +63,19 @@ export const metricValuations = {
 		),
 	},
 	ttfb: {
-		good: translate( "Your site's Time to First Byte is good" ),
-		needsImprovement: translate( "Your site's Time to First Byte is moderate" ),
-		bad: translate( "Your site's Time to First Byte needs improvement" ),
+		good: translate( 'Your site‘s Time to First Byte is good' ),
+		needsImprovement: translate( 'Your site‘s Time to First Byte is moderate' ),
+		bad: translate( 'Your site‘s Time to First Byte needs improvement' ),
 		heading: translate( 'What is Time to First Byte?' ),
 		aka: translate( '(TTFB)' ),
 		explanation: translate(
-			'Time to First Byte reflects the time taken for a user’s browser to receive the first byte of data from the server after making a request. The best sites load around 800 milliseconds or less.'
+			'Time to First Byte reflects the time taken for a user‘s browser to receive the first byte of data from the server after making a request. The best sites load around 800 milliseconds or less.'
 		),
 	},
 	tbt: {
-		good: translate( "Your site's Total Blocking Time is good" ),
-		needsImprovement: translate( "Your site's Total Blocking Time is moderate" ),
-		bad: translate( "Your site's Total Blocking Time needs improvement" ),
+		good: translate( 'Your site‘s Total Blocking Time is good' ),
+		needsImprovement: translate( 'Your site‘s Total Blocking Time is moderate' ),
+		bad: translate( 'Your site‘s Total Blocking Time needs improvement' ),
 		heading: translate( 'What is Total Blocking Time?' ),
 		aka: translate( '(TBT)' ),
 		explanation: translate(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdt2If-1Jh-p2

## Proposed Changes

* Change all single quote `'` character by a curly apostrophe `‘`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* That is the correct way to display apostrophes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visually check all the code 
* Check some occurrences to check if they display as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?