### PR TITLE
Backups: add "learn about" link to restore

### DIFF
--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -237,6 +237,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
 			<div className="rewind-flow__header">
 				<Gridicon icon="history" size={ 48 } />
+				<div className="rewind-flow__learn-about">
+					<ExternalLink href="https://jetpack.com/support/backup/restoring-with-jetpack-backup/">
+						{ translate( 'Learn about restores' ) }
+					</ExternalLink>
+				</div>
 			</div>
 			<h3 className="rewind-flow__title">{ translate( 'Restore your site' ) }</h3>
 			<p className="rewind-flow__info">

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -232,13 +232,24 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const baseBackupDate = backup.baseRewindId ? moment.unix( backup.baseRewindId ) : null;
 	const showRealTimeMessage = backup.baseRewindId && baseBackupDate && backup.rewindStepCount > 0;
 
+	const onLearnAboutClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_restore_learn_about_click', {
+				has_credentials: hasCredentials,
+			} )
+		);
+	}, [ dispatch, hasCredentials ] );
+
 	const renderConfirm = () => (
 		<>
 			{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
 			<div className="rewind-flow__header">
 				<Gridicon icon="history" size={ 48 } />
 				<div className="rewind-flow__learn-about">
-					<ExternalLink href="https://jetpack.com/support/backup/restoring-with-jetpack-backup/">
+					<ExternalLink
+						href="https://jetpack.com/support/backup/restoring-with-jetpack-backup/"
+						onClick={ onLearnAboutClick }
+					>
 						{ translate( 'Learn about restores' ) }
 					</ExternalLink>
 				</div>

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -11,9 +11,8 @@
 }
 
 .rewind-flow__header {
-	display: block;
-	justify-content: center;
-	line-height: 0;
+	align-items: center;
+	display: flex;
 	margin-bottom: 8px;
 	padding-bottom: 0;
 	padding-top: 0;
@@ -27,6 +26,17 @@
 		height: 48px;
 		width: 48px;
 	}
+}
+
+.rewind-flow__learn-about {
+	flex-grow: 1;
+	font-size: $font-body-small;
+	text-align: right;
+	text-decoration-line: underline;
+}
+
+.rewind-flow__learn-about a {
+	color: var(--studio-gray-80);
 }
 
 .rewind-flow__title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of https://github.com/Automattic/jetpack-backup-team/issues/599.

## Proposed Changes

* Add a `Learn about restores` link to the restore page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, there are no helpful guides or instructions to assist the user. We are adding a link to help them with that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go the `VaultPress Backup` page on Jetpack Cloud.
- In the `Latest backup` section, click on the Actions (`+`) button and select `Restore to this point`.
- The `Learn about restores` link should be visible at the top.

Desktop | Mobile
--- | ---
<img width="708" alt="image" src="https://github.com/user-attachments/assets/669ba95e-8afc-4d93-a447-f1fe1f2d6543"> | <img width="332" alt="image" src="https://github.com/user-attachments/assets/96b4e5e6-d656-4c11-86c4-60ab6c5409f1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
