### PR TITLE
Performance Profiler: Update Score section style

### DIFF
--- a/client/performance-profiler/components/performance-score/index.tsx
+++ b/client/performance-profiler/components/performance-score/index.tsx
@@ -1,3 +1,4 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useResizeObserver } from '@wordpress/compose';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -16,6 +17,7 @@ export const PerformanceScore = ( props: PerformanceScoreProps ) => {
 	const translate = useTranslate();
 	const [ resizeObserverRef, entry ] = useResizeObserver();
 	const [ scoreBarWidth, setScoreBarWidth ] = useState( MAX_SCORE_BAR_WIDTH );
+	const isMobile = useMobileBreakpoint();
 
 	const { value, recommendationsQuantity, recommendationsRef } = props;
 	const getStatus = ( value: number ) => {
@@ -51,7 +53,7 @@ export const PerformanceScore = ( props: PerformanceScoreProps ) => {
 			{ resizeObserverRef }
 			<div className="score-summary">
 				<div className="title">{ translate( 'Performance Score' ) }</div>
-				<div className="score">
+				<div className={ clsx( 'score', { mobile: isMobile } ) }>
 					<span className="current-score">{ Math.floor( value ) }</span>
 					<span className="max-score">/ 100</span>
 				</div>

--- a/client/performance-profiler/components/performance-score/style.scss
+++ b/client/performance-profiler/components/performance-score/style.scss
@@ -37,6 +37,17 @@
 			font-size: 26px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			line-height: 26px;
 		}
+
+		&.mobile {
+			.current-score {
+				font-size: 64px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				line-height: 64px;
+			}
+
+			.max-score {
+				font-size: $font-title-small;
+			}
+		}
 	}
 
 	.disclaimer {

--- a/client/performance-profiler/components/screenshot-thumbnail.tsx
+++ b/client/performance-profiler/components/screenshot-thumbnail.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { translate } from 'i18n-calypso';
 
 const Container = styled.div`
-	height: 255px;
+	height: 280px;
 	display: flex;
 	align-items: center;
 
@@ -30,7 +30,7 @@ export const ScreenshotThumbnail = ( props: { src: string | undefined; alt: stri
 			{ src === undefined ? (
 				<UnavailableScreenshot>{ translate( 'Screenshot unavailable' ) }</UnavailableScreenshot>
 			) : (
-				<img style={ { maxHeight: '240px' } } src={ src } alt={ alt } { ...rest } />
+				<img style={ { maxHeight: '100%' } } src={ src } alt={ alt } { ...rest } />
 			) }
 		</Container>
 	);

--- a/client/performance-profiler/components/screenshot-thumbnail.tsx
+++ b/client/performance-profiler/components/screenshot-thumbnail.tsx
@@ -7,7 +7,7 @@ const Container = styled.div`
 	align-items: center;
 
 	& > * {
-		border: 1px solid var( --studio-gray-0 );
+		border: 1px solid var( --studio-gray-5 );
 		border-radius: 6px;
 	}
 `;


### PR DESCRIPTION
Related to pdt2If-1Jh-p2

## Proposed Changes

* Update the font to a smaller size in mobile screens
* Update the border color to gray 5
* Increase the screenshot height

## Why are these changes being made?

pdt2If-1Jh-p2

## Testing Instructions

* Go to `/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzQ2N30.LOelpUBxFDxMytpSYeB3EBNdBnHeYTvonyZ6zE7aqSM`
* Check if the PErformance Score section looks like the one below

![CleanShot 2024-09-11 at 15 08 32@2x](https://github.com/user-attachments/assets/3a6f4c5a-7533-4e73-8417-45ad20cbf52b)

