### PR TITLE
Theme Details: Add compact breadcrumb on mobile

### DIFF
--- a/client/components/breadcrumb/README.md
+++ b/client/components/breadcrumb/README.md
@@ -31,4 +31,4 @@ const BreadcrumbExamples = () => {
 
 - `items` (`{ label: string; href?: string; helpBubble?: React.ReactElement; onClick?: () => void }[]`) - The Navigations items to be shown
 - `compact` (`boolean`) - Displays only the previous item URL (optional)
-- `mobileItem` (`string`) - In compact version, displays this value. If not passed defaults to "Back" (optional)
+- `mobileItem` (`{ label: string; href?: string; helpBubble?: React.ReactElement; onClick?: () => void }`) - In compact version, displays this value. If not passed defaults to "Back" and the href of the second-to-last item (optional)

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -121,9 +121,10 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 
 	if ( compact ) {
 		const urlBack = mobileItem?.href ?? items[ items.length - 2 ].href;
+		const onClick = mobileItem?.onClick ?? items[ items.length - 2 ].onClick;
 		const label = mobileItem?.label ?? translate( 'Back' );
 		return (
-			<StyledBackLink className="breadcrumbs-back" href={ urlBack }>
+			<StyledBackLink className="breadcrumbs-back" href={ urlBack } onClick={ onClick }>
 				<Gridicon icon="chevron-left" size={ 18 } />
 				{ label }
 			</StyledBackLink>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -20,6 +20,7 @@ import {
 	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { isWithinBreakpoint } from '@automattic/viewport';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Icon, external } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -1377,6 +1378,7 @@ class ThemeSheet extends Component {
 			{ label: translate( 'Themes' ), href: this.getBackLink(), onClick: this.handleBackLinkClick },
 			{ label: title },
 		];
+		const isWide = isWithinBreakpoint( '>960px' );
 
 		return (
 			<Main className="theme__sheet">
@@ -1427,7 +1429,7 @@ class ThemeSheet extends Component {
 				/>
 				<ThanksModal source="details" themeId={ this.props.themeId } />
 				<ActivationModal source="details" />
-				<NavigationHeader navigationItems={ navigationItems } />
+				<NavigationHeader navigationItems={ navigationItems } compactBreadcrumb={ ! isWide } />
 				<div className={ columnsClassName }>
 					<div className="theme__sheet-column-header">
 						{ this.renderStagingPaidThemeNotice() }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -324,7 +324,7 @@ class ThemeSheet extends Component {
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { disabledButton: this.isLoading() } );
 
-		// Subscribe to breakpoint changes
+		// Subscribe to breakpoint changes to switch to a compact breadcrumb on mobile.
 		this.unsubscribeBreakpoint = subscribeIsWithinBreakpoint( '>960px', ( isWide ) => {
 			this.setState( { isWide } );
 		} );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -20,7 +20,7 @@ import {
 	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { isWithinBreakpoint } from '@automattic/viewport';
+import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Icon, external } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -306,6 +306,7 @@ class ThemeSheet extends Component {
 		isAtomicTransferCompleted: false,
 		isReviewsModalVisible: false,
 		isSiteSelectorModalVisible: false,
+		isWide: isWithinBreakpoint( '>960px' ),
 	};
 
 	scrollToTop = () => {
@@ -322,6 +323,11 @@ class ThemeSheet extends Component {
 
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { disabledButton: this.isLoading() } );
+
+		// Subscribe to breakpoint changes
+		this.unsubscribeBreakpoint = subscribeIsWithinBreakpoint( '>960px', ( isWide ) => {
+			this.setState( { isWide } );
+		} );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -333,6 +339,10 @@ class ThemeSheet extends Component {
 			// eslint-disable-next-line react/no-did-update-set-state
 			this.setState( { disabledButton: this.isLoading() } );
 		}
+	}
+
+	componentWillUnmount() {
+		this.unsubscribeBreakpoint();
 	}
 
 	isLoaded = () => {
@@ -1378,7 +1388,6 @@ class ThemeSheet extends Component {
 			{ label: translate( 'Themes' ), href: this.getBackLink(), onClick: this.handleBackLinkClick },
 			{ label: title },
 		];
-		const isWide = isWithinBreakpoint( '>960px' );
 
 		return (
 			<Main className="theme__sheet">
@@ -1429,7 +1438,10 @@ class ThemeSheet extends Component {
 				/>
 				<ThanksModal source="details" themeId={ this.props.themeId } />
 				<ActivationModal source="details" />
-				<NavigationHeader navigationItems={ navigationItems } compactBreadcrumb={ ! isWide } />
+				<NavigationHeader
+					navigationItems={ navigationItems }
+					compactBreadcrumb={ ! this.state.isWide }
+				/>
 				<div className={ columnsClassName }>
 					<div className="theme__sheet-column-header">
 						{ this.renderStagingPaidThemeNotice() }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to https://github.com/Automattic/wp-calypso/pull/94038

## Proposed Changes

* Show a compact < Back breadcrumb on mobile, to match Plugins.
* Update the Breadcrumb component README.

<img width="486" alt="Screen Shot 2024-09-11 at 2 51 59 PM" src="https://github.com/user-attachments/assets/98388452-f8d9-461a-ac46-5a5a2ec775d3">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To keep the page header consistent with other pages, especially the theme showcase and individual plugin pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /themes and click on a theme.
* Switch to a mobile screen size (under 960px wide).
* Check that the header has a < Back link instead of two breadcrumbs.
* Click to go back and check that the `calypso_theme_sheet_back_click` event is fired.
* Repeat on /themes/{site} and logged-out.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
