### PR TITLE
Update copy in siteless checkout thank you page last step

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import licensingActivationPluginBanner from 'calypso/assets/images/jetpack/licensing-activation-plugin-banner.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicensingActivation from 'calypso/components/jetpack/licensing-activation';
@@ -9,6 +9,7 @@ import {
 	isProductsListFetching as getIsProductListFetching,
 	getProductName,
 } from 'calypso/state/products-list/selectors';
+import JetpackInstructionList from './jetpack-instruction-list';
 import JetpackLicenseKeyClipboard, {
 	JetpackLicenseKeyProps,
 } from './jetpack-license-key-clipboard';
@@ -26,6 +27,31 @@ const LicensingActivationInstructions: FC< JetpackLicenseKeyProps > = ( {
 	);
 
 	const isProductListFetching = useSelector( getIsProductListFetching );
+
+	const items = useMemo(
+		() => [
+			{
+				id: 1,
+				content: translate( 'From WP Admin, go to {{strong}}Jetpack > My Jetpack{{/strong}}.', {
+					components: { strong: <strong /> },
+				} ),
+			},
+			{
+				id: 2,
+				content: translate(
+					'Click the {{strong}}Activate a license{{/strong}} link at the bottom of the page.',
+					{
+						components: { strong: <strong /> },
+					}
+				),
+			},
+			{
+				id: 3,
+				content: translate( 'Use your license key below to activate your product.' ),
+			},
+		],
+		[ translate ]
+	);
 
 	return (
 		<>
@@ -47,16 +73,9 @@ const LicensingActivationInstructions: FC< JetpackLicenseKeyProps > = ( {
 				progressIndicatorValue={ 3 }
 				progressIndicatorTotal={ 3 }
 			>
-				<p>
-					{ translate(
-						'After installing the plugin, in WP-Admin, go to {{strong}}Jetpack > My Jetpack{{/strong}} and click the "Activate a license" link at the bottom of the page. Then use this license key to activate your product.',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
-					) }
-				</p>
+				<p>{ translate( 'After installing the plugin:' ) }</p>
+
+				<JetpackInstructionList items={ items } />
 
 				<JetpackLicenseKeyClipboard productSlug={ productSlug } receiptId={ receiptId } />
 			</LicensingActivation>

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
@@ -49,7 +49,7 @@ const LicensingActivationInstructions: FC< JetpackLicenseKeyProps > = ( {
 			>
 				<p>
 					{ translate(
-						'Go to your {{strong}}WP Admin Jetpack Dashboard > My Plan{{/strong}} page after Jetpack is installed, and use this license key to activate your product.',
+						'After installing the plugin, in WP-Admin, go to {{strong}}Jetpack > My Jetpack{{/strong}} and click the "Activate a license" link at the bottom of the page. Then use this license key to activate your product.',
 						{
 							components: {
 								strong: <strong />,


### PR DESCRIPTION
This PR updates the copy in the siteless checkout thank you page last step to point the user to the "activate a license" link at "Jetpack > My Jetpack" as the place to go to activate the license, instead of "Jetpack > Dashboard > My Plans".

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/jetpack-marketing/issues/744

## Proposed Changes

* Minor copy update on the Jetpack siteless checkout thank you manual license activation page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This change was motivated by [this comment](https://github.com/Automattic/jetpack-marketing/issues/744#issuecomment-2293797946) on [this issue](https://github.com/Automattic/jetpack-marketing/issues/744).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this PR branch and `yarn && yarn start`
- Go to http://calypso.localhost:3000/checkout/jetpack/jetpack_security_t1_yearly and complete checkout (using credits).
- In the dropdown, select "I don't see my site, let me configure it manually", and click Continue.
- Click Continue again, to advance to the final step.
- Take a look at the copy changes.. Verify it points the user to My Jetpack to activate their license (instead of Dashboard) and the instructions are correct, and they make sense, and it looks good. (See Screenshots)

### Screenshots:

**Before:**

![Screen Shot 2024-09-11 at 15 29 43](https://github.com/user-attachments/assets/bc0d4d7b-2f56-4314-a99b-e6853f3c5fac)

**AFTER:**

![Screen Shot 2024-09-11 at 15 25 25](https://github.com/user-attachments/assets/11d5da0e-d848-448f-8094-eb47037fc19d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
