### PR TITLE
White-labeled migration plugin: Update links on instructions page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/utils.ts
@@ -1,14 +1,32 @@
+import config from '@automattic/calypso-config';
+
 const removeDuplicatedSlashes = ( url: string ) => url.replace( /(https?:\/\/)|(\/)+/g, '$1$2' );
+const isWhiteLabeledPluginEnabled = config.isEnabled(
+	'migration-flow/enable-white-labeled-plugin'
+);
 
 export const getPluginInstallationPage = ( fromUrl: string ) => {
 	if ( fromUrl !== '' ) {
+		if ( isWhiteLabeledPluginEnabled ) {
+			return removeDuplicatedSlashes(
+				`${ fromUrl }/wp-admin/plugin-install.php?s=%2522wpcom%2520migration%2522&tab=search&type=term`
+			);
+		}
+
 		return removeDuplicatedSlashes(
 			`${ fromUrl }/wp-admin/plugin-install.php?s=%2522migrate%2520guru%2522&tab=search&type=term`
 		);
 	}
 
-	return 'https://wordpress.org/plugins/migrate-guru/';
+	return isWhiteLabeledPluginEnabled
+		? 'https://wordpress.org/plugins/wpcom-migration/'
+		: 'https://wordpress.org/plugins/migrate-guru/';
 };
 
-export const getMigrateGuruPageURL = ( siteURL: string ) =>
-	removeDuplicatedSlashes( `${ siteURL }/wp-admin/admin.php?page=migrateguru` );
+export const getMigrateGuruPageURL = ( siteURL: string ) => {
+	if ( isWhiteLabeledPluginEnabled ) {
+		return removeDuplicatedSlashes( `${ siteURL }/wp-admin/admin.php?page=wpcom-migration` );
+	}
+
+	return removeDuplicatedSlashes( `${ siteURL }/wp-admin/admin.php?page=migrateguru` );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* If the `migration-flow/enable-white-labeled-plugin` config flag is enabled, update the links within the steps on the `/setup/migration-signup/site-migration-instructions` screen to point to the upcoming `wpcom-migration` plugin rather than `migrate-guru`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Soon we will switch from Migrate Guru to the Move to WordPress.com plugin, and these changes need to be reflected on the front end during the migration signup flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/setup/migration-setup`
* Go through the flow until you land on the migration instructions step:
<img width="1469" alt="Screenshot 2024-09-11 at 4 27 21 PM" src="https://github.com/user-attachments/assets/c7735391-7c62-4203-824d-e59eae3c33a6">

* Confirm the links within each step reference the `migrate-guru` plugin and go where you'd expect.
* Now add `&flags=migration-flow/enable-white-labeled-plugin` to the URL and refresh the page.
* Links within each step should reference the `wpcom-migration` plugin and go where you'd expect (keeping in mind the plugin won't be installed on the destination site yet, so that link will break).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
