### PR TITLE
Checkout: Only consider introductory offer as "discount" if it's less per month

### DIFF
--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -8,7 +8,6 @@ import {
 	LineItemType,
 	getSubtotalWithoutDiscounts,
 	getTotalDiscountsWithoutCredits,
-	filterAndGroupCostOverridesForDisplay,
 	isBillingInfoEmpty,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
@@ -97,8 +96,7 @@ export default function BeforeSubmitCheckoutHeader() {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const translate = useTranslate();
 
-	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart, translate );
-	const totalDiscount = getTotalDiscountsWithoutCredits( responseCart, translate );
+	const totalDiscount = getTotalDiscountsWithoutCredits( responseCart );
 	const discountLineItem: LineItemType = {
 		id: 'total-discount',
 		type: 'subtotal',
@@ -113,10 +111,7 @@ export default function BeforeSubmitCheckoutHeader() {
 	const subTotalLineItemWithoutCoupon: LineItemType = {
 		id: 'subtotal-without-coupon',
 		type: 'subtotal',
-		label:
-			costOverridesList.length > 0
-				? translate( 'Subtotal before discounts' )
-				: translate( 'Subtotal' ),
+		label: totalDiscount > 0 ? translate( 'Subtotal before discounts' ) : translate( 'Subtotal' ),
 		formattedAmount: formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
@@ -131,9 +126,7 @@ export default function BeforeSubmitCheckoutHeader() {
 			<WPOrderReviewSection>
 				<NonTotalPrices>
 					<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
-					{ costOverridesList.length > 0 && (
-						<NonProductLineItem subtotal lineItem={ discountLineItem } />
-					) }
+					{ totalDiscount > 0 && <NonProductLineItem subtotal lineItem={ discountLineItem } /> }
 					{ taxLineItems.map( ( taxLineItem ) => (
 						<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
 					) ) }

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -1,6 +1,7 @@
 import { isDomainRegistration } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import i18n from 'i18n-calypso';
+import { doesIntroductoryOfferHavePriceIncrease } from './transformations';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 export function getIntroductoryOfferIntervalDisplay( {
@@ -231,7 +232,7 @@ export function getItemIntroductoryOfferDisplay(
 		intervalUnit: product.introductory_offer_terms.interval_unit,
 		intervalCount: product.introductory_offer_terms.interval_count,
 		isFreeTrial,
-		isPriceIncrease: false,
+		isPriceIncrease: doesIntroductoryOfferHavePriceIncrease( product ),
 		context: 'checkout',
 		remainingRenewalsUsingOffer: product.introductory_offer_terms.transition_after_renewal_count,
 	} );

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -589,8 +589,8 @@ export function getSubtotalWithoutDiscountsForProduct( product: ResponseCartProd
 	// "Subtotal before discounts" as lower than the "Subtotal". The details of
 	// the price increase will be displayed elsewhere.
 	if ( doesIntroductoryOfferHavePriceIncrease( product ) ) {
-		const introOffer = product.cost_overrides?.find(
-			( offer ) => offer.override_code === 'introductory-offer'
+		const introOffer = product.cost_overrides?.find( ( offer ) =>
+			isOverrideCodeIntroductoryOffer( offer.override_code )
 		);
 		if ( introOffer ) {
 			return introOffer.new_subtotal_integer + multiYearDiscount;

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -1,9 +1,3 @@
-import {
-	isBiennially,
-	isJetpackPlan,
-	isJetpackProduct,
-	isJetpackSocialAdvancedSlug,
-} from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import { translate, useTranslate } from 'i18n-calypso';
 import { getContactDetailsType } from './get-contact-details-type';
@@ -406,88 +400,6 @@ export function filterCostOverridesForLineItem(
 }
 
 /**
- * Returns cost overrides (typically discounts) for display in checkout.
- *
- * Cost overrides are applied to shopping-cart line items, but they are
- * displayed as if they applied to the entire cart. For example, we may have
- * two items which have a "Coupon code" discount, but we will only display one
- * "Coupon code" discount line which shows the savings from both of those items
- * combined.
- *
- * This function therefore merges the discounts for each line item in the cart
- * by the item's human-readable reason.
- *
- * In most cases, the human-readable reasons are provided directly by the
- * shopping-cart, but each cost override also includes a unique code which
- * identifies it and we can use those codes to perform special behaviors for
- * certain discounts. For example we rename Sale Coupon discounts to mention
- * the item on sale.
- *
- * This function also removes original cost overrides since they are never
- * displayed to users (they represent a change to the product's base price
- * rather than a discount).
- *
- * Finally, this adds a fake "multi-year" pseudo-discount in some cases (see
- * `canDisplayMultiYearDiscountForProduct()`). In that case, the cart item's
- * total will also need to be increased by this amount for the discount to be
- * subtracted without messing up the math. See
- * `getMultiYearDiscountForProduct()`,
- * `getSubtotalWithoutDiscountsForProduct()`, and
- * `getSubtotalWithoutDiscounts().`
- */
-export function filterAndGroupCostOverridesForDisplay(
-	responseCart: ResponseCart,
-	translate: ReturnType< typeof useTranslate >
-): CostOverrideForDisplay[] {
-	// Collect cost overrides from each line item and group them by type so we
-	// can show them all together after the line item list.
-	const costOverridesGrouped = responseCart.products.reduce<
-		Record< string, CostOverrideForDisplay >
-	>( ( grouped: Record< string, CostOverrideForDisplay >, product ) => {
-		const costOverrides = product?.cost_overrides ?? [];
-
-		costOverrides
-			.filter( ( costOverride ) => isUserVisibleCostOverride( costOverride ) )
-			// Remove intro offers which increase the cost because they are not
-			// discounts and will have their terms displayed elsewhere.
-			.filter(
-				( costOverride ) =>
-					! doesIntroductoryOfferCostOverrideHavePriceIncrease( product, costOverride )
-			)
-			.map( ( costOverride ) => makeSaleCostOverrideUnique( costOverride, product, translate ) )
-			.map( ( costOverride ) =>
-				makeIntroductoryOfferCostOverrideUnique( costOverride, product, translate, false )
-			)
-			.forEach( ( costOverride ) => {
-				// Group discounts by human_readable_reason.
-				const discountAmount = grouped[ costOverride.human_readable_reason ]?.discountAmount ?? 0;
-				grouped[ costOverride.human_readable_reason ] = {
-					humanReadableReason: costOverride.human_readable_reason,
-					overrideCode: costOverride.override_code,
-					discountAmount: discountAmount + getDiscountForCostOverrideForDisplay( costOverride ),
-				};
-			} );
-
-		// Add a fake "multi-year" discount if applicable. These are not real
-		// discounts in terms of our billing system; they are just the
-		// difference in cost between a multi-year version of a product and
-		// that product's yearly version multiplied by the number of years.
-		const multiYearDiscount = getMultiYearDiscountForProduct( product );
-		if ( multiYearDiscount > 0 ) {
-			const discountAmount = grouped[ 'multi-year-discount' ]?.discountAmount ?? 0;
-			grouped[ 'multi-year-discount' ] = {
-				humanReadableReason: translate( 'Multi-year discount' ),
-				overrideCode: 'multi-year-discount',
-				discountAmount: discountAmount + multiYearDiscount,
-			};
-		}
-		return grouped;
-	}, {} );
-
-	return Object.values( costOverridesGrouped );
-}
-
-/**
  * Even though a user might have a number of credits available, that number may
  * be greater than the cart's total. This function returns the number of
  * credits actually being used by a cart.
@@ -500,87 +412,19 @@ function getCreditsUsedByCart( responseCart: ResponseCart ): number {
 	return isFullCredits ? responseCart.sub_total_with_taxes_integer : responseCart.credits_integer;
 }
 
-function getYearlyVariantFromProduct( product: ResponseCartProduct ) {
-	return product.product_variants.find( ( variant ) => 12 === variant.bill_period_in_months );
-}
-
-/**
- * The idea of a multi-year discount is conceptual; it is not a true discount
- * in terms of our billing system. Purchases of different product renewal
- * intervals have different prices set and the amount they save depends on what
- * you compare them to.
- *
- * This function allows us to control which store product IDs will be
- * considered for a multi-year discount by `getMultiYearDiscountForProduct()`.
- */
-function canDisplayMultiYearDiscountForProduct( product: ResponseCartProduct ): boolean {
-	const isJetpack = isJetpackProduct( product ) || isJetpackPlan( product );
-	if (
-		isJetpack &&
-		isBiennially( product ) &&
-		! isJetpackSocialAdvancedSlug( product.product_slug )
-	) {
-		return true;
-	}
-	return false;
-}
-
-/**
- * We want to be able to display a discount for a multi-year purchase, although
- * this is not a true discount; purchases of different product renewal
- * intervals have different prices set and the amount they save depends on what
- * you compare them to.
- *
- * In this case we will ignore monthly intervals and only concern ourselves
- * with the discount of the currently selected product compared to the yearly
- * version of that product multiplied by the number of years, if such a product
- * exists. In order to display the difference in the multi-year price versus
- * the yearly price as a discount, we need to INCREASE the subtotal of the
- * product by the same amount.
- *
- * This function returns the amount by which we'd need to increase that price,
- * which is also the amount of the pseudo-discount.
- *
- * Note that this function returns the cost in the currency's smallest unit.
- */
-function getMultiYearDiscountForProduct( product: ResponseCartProduct ): number {
-	if ( ! product.months_per_bill_period || ! canDisplayMultiYearDiscountForProduct( product ) ) {
-		return 0;
-	}
-
-	const oneYearVariant = getYearlyVariantFromProduct( product );
-	if ( oneYearVariant ) {
-		const numberOfYears = product.months_per_bill_period / 12;
-		const expectedMultiYearPrice = oneYearVariant.price_before_discounts_integer * numberOfYears;
-		const actualMultiYearPrice = product.item_original_cost_integer;
-		const multiYearDiscount = expectedMultiYearPrice - actualMultiYearPrice;
-		if ( multiYearDiscount > 0 ) {
-			return multiYearDiscount;
-		}
-	}
-
-	return 0;
-}
-
 /**
  * Return a shopping-cart line item's cost before any discounts are applied.
  *
  * Note that this function returns the cost in the currency's smallest unit.
  */
 export function getSubtotalWithoutDiscountsForProduct( product: ResponseCartProduct ): number {
-	// If there is a fake multi-year pseudo-discount being displayed for this
-	// line item, we need to increase the total of the line item by that amount
-	// so that the math for the discount makes sense. See
-	// `getMultiYearDiscountForProduct()`.
-	const multiYearDiscount = getMultiYearDiscountForProduct( product );
-
 	// Return the last original cost override's new price.
 	const originalCostOverrides =
 		product.cost_overrides?.filter( ( override ) => override.does_override_original_cost ) ?? [];
 	if ( originalCostOverrides.length > 0 ) {
 		const lastOriginalCostOverride = originalCostOverrides.pop();
 		if ( lastOriginalCostOverride ) {
-			return lastOriginalCostOverride.new_subtotal_integer + multiYearDiscount;
+			return lastOriginalCostOverride.new_subtotal_integer;
 		}
 	}
 
@@ -593,7 +437,7 @@ export function getSubtotalWithoutDiscountsForProduct( product: ResponseCartProd
 			isOverrideCodeIntroductoryOffer( offer.override_code )
 		);
 		if ( introOffer ) {
-			return introOffer.new_subtotal_integer + multiYearDiscount;
+			return introOffer.new_subtotal_integer;
 		}
 	}
 
@@ -602,13 +446,13 @@ export function getSubtotalWithoutDiscountsForProduct( product: ResponseCartProd
 	if ( product.cost_overrides && product.cost_overrides.length > 0 ) {
 		const firstOverride = product.cost_overrides[ 0 ];
 		if ( firstOverride ) {
-			return firstOverride.old_subtotal_integer + multiYearDiscount;
+			return firstOverride.old_subtotal_integer;
 		}
 	}
 
 	// If there are no cost overrides, return the item's cost, since it has no
 	// discounts.
-	return product.item_subtotal_integer + multiYearDiscount;
+	return product.item_subtotal_integer;
 }
 
 /**
@@ -629,21 +473,29 @@ export function getSubtotalWithoutDiscounts( responseCart: ResponseCart ): numbe
 /**
  * Return the total savings from shopping-cart item discounts.
  *
- * This includes fake "multi-year" pseudo-discounts. See
- * `getMultiYearDiscountForProduct()`.
- *
  * This does not include credits which are not a discount; they reduce the
  * final price after taxes.
  *
  * Note that this function returns the cost in the currency's smallest unit.
  */
-export function getTotalDiscountsWithoutCredits(
-	responseCart: ResponseCart,
-	translate: ReturnType< typeof useTranslate >
-): number {
-	const filteredOverrides = filterAndGroupCostOverridesForDisplay( responseCart, translate );
+export function getTotalDiscountsWithoutCredits( responseCart: ResponseCart ): number {
+	const filteredOverrides = responseCart.products.reduce< ResponseCartCostOverride[] >(
+		( overrides, product ) => {
+			product.cost_overrides.forEach( ( override ) => {
+				if ( override.does_override_original_cost ) {
+					return;
+				}
+				if ( doesIntroductoryOfferCostOverrideHavePriceIncrease( product, override ) ) {
+					return;
+				}
+				overrides.push( override );
+			} );
+			return overrides;
+		},
+		[]
+	);
 	return -filteredOverrides.reduce( ( total, override ) => {
-		total = total + override.discountAmount;
+		total = total + ( override.old_subtotal_integer - override.new_subtotal_integer );
 		return total;
 	}, 0 );
 }


### PR DESCRIPTION
## Background

Introductory offers can be very complex, mainly because they can have a different billing term length than the billing term length of the product after the offer completes. 

Checkout uses the concept of "discounts" in a few places, notably in the sidebar cost override list and the footer subtotal list. Most price adjustments reduce the shopping cart total and therefore are discounts, but sometimes an introductory offer will actually _increase_ the price of the product. If that happens, for our messaging to make sense, we need to be sure not to display those price adjustments as "discounts". This is handled by the helper function `doesIntroductoryOfferHavePriceIncrease()`.

However, our helper function only takes into account the raw prices themselves in isolation, ignoring the billing term. 

If we have a product which costs $500 with a two year billing term and an introductory offer for $400 with a one year billing term, the function would consider that a "discount": the user is paying less in checkout with the offer than they would without the offer applied. But looked at another way, they are paying _more_. $500 for two years is $250 per year, and the initial cost of $400 per year is much more than that.

## Proposed Changes

In this PR, we alter `doesIntroductoryOfferHavePriceIncrease()` to take the relative billing terms before and after the introductory offer into account. It does this by determining the monthly cost of the product before and after the introductory offer and then comparing those instead of the raw cost.

For consistency, this also removes the fake "multi-year" discount which we weren't displaying anyway but was still included in the "Discounts" section in the checkout footer as it didn't make any sense with (or honestly without) these changes.

Fixes https://github.com/Automattic/payments-shilling/issues/3101

## Screenshots

Before             |  After
:-------------------------:|:-------------------------:
<img width="315" alt="discount-text-before" src="https://github.com/user-attachments/assets/afb1e86a-8fa6-4edb-b051-2703d4b049d9"> | <img width="319" alt="discount-text-after" src="https://github.com/user-attachments/assets/26c2274d-658d-4f6b-b7f0-b7b93c77d28f">
<img width="567" alt="subtotal-before" src="https://github.com/user-attachments/assets/4248cfde-4a12-418d-851a-d316131529b8"> | <img width="570" alt="Screenshot 2024-09-11 at 7 33 08 PM" src="https://github.com/user-attachments/assets/f034a381-6ad2-4e3f-8309-81e92eb5ca2b">
<img width="503" alt="Screenshot 2024-09-11 at 7 49 13 PM" src="https://github.com/user-attachments/assets/4488a374-0a35-4900-8ebb-0a2a0e85063b"> | <img width="507" alt="Screenshot 2024-09-11 at 7 48 47 PM" src="https://github.com/user-attachments/assets/23a84a9c-be00-45b8-8533-a9fc75b29b12">

## Testing Instructions

- Make sure you have a Jetpack site.
- Use an account with USD as the currency (or use the appropriate billing plans in the next step to match your currency).
- Point public-api.wordpress.com to your sandbox and override product ID `2035` to fetch the `2024-09-06-intro-offer` version of the plan instead of the default. Contact me on Slack if you don't know how to do this.
- Visit https://cloud.jetpack.com/pricing and add "Jetpack Complete" to your cart.
- When you reach checkout, change the billing term length of the product to "Two years".
- Verify that the price list in the sidebar does not read "Discount".
- Verify that the "Subtotal before discounts" and "Discounts" in the checkout footer do not include the price change from the introductory offer.