### PR TITLE
Backup: Enable feature backup-realtime-message

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { default as ActivityCard, useToggleContent } from 'calypso/components/activity-card';
@@ -99,7 +98,7 @@ const BackupSuccessful = ( {
 			</div>
 			<div className="status-card__hide-mobile">
 				<div className="status-card__title">{ displayDateNoLatest }</div>
-				{ config.isEnabled( 'jetpack/backup-realtime-message' ) && showRealTimeMessage && (
+				{ showRealTimeMessage && (
 					<BackupRealtimeMessage
 						baseBackupDate={ baseBackupDate }
 						eventsCount={ backup.rewindStepCount }
@@ -151,9 +150,7 @@ const BackupSuccessful = ( {
 			) }
 			{ hasWarnings && <BackupWarningRetry siteId={ siteId } /> }
 
-			{ config.isEnabled( 'jetpack/backup-realtime-message' ) && isToday && lastBackupFailed && (
-				<BackupLastFailed siteId={ siteId } />
-			) }
+			{ isToday && lastBackupFailed && <BackupLastFailed siteId={ siteId } /> }
 		</>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -265,7 +265,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					},
 				} ) }
 			</p>
-			{ config.isEnabled( 'jetpack/backup-realtime-message' ) && showRealTimeMessage && (
+			{ showRealTimeMessage && (
 				<BackupRealtimeMessage
 					baseBackupDate={ baseBackupDate }
 					eventsCount={ backup.rewindStepCount }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to peaFOp-2Iy-p2 

## Proposed Changes

* Enable `jetpack/backup-realtime-message` (by removing the config)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Clarifying Daily vs Real-Time Backups in “Latest Backups” release

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify a real-time change to check the change is enabled

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?