### PR TITLE
A4A: add wpcom account manage link

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -49,3 +49,4 @@ export const A4A_CLIENT_PAYMENT_METHODS_ADD_LINK = `${ A4A_CLIENT_PAYMENT_METHOD
 export const A4A_CLIENT_CHECKOUT = '/client/checkout';
 export const EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE =
 	'https://agencieshelp.automattic.com/knowledge-base/client-billing/';
+export const EXTERNAL_WPCOM_ACCOUNT_URL = 'https://wordpress.com/me/';

--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -13,6 +13,7 @@ import { CONTACT_URL_HASH_FRAGMENT } from '../../a4a-contact-support-widget';
 import {
 	EXTERNAL_A4A_KNOWLEDGE_BASE,
 	EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE,
+	EXTERNAL_WPCOM_ACCOUNT_URL,
 } from '../../sidebar-menu/lib/constants';
 
 import './style.scss';
@@ -56,6 +57,16 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 					rel="noopener noreferrer"
 				>
 					{ translate( 'View Knowledge Base' ) } <Gridicon icon="external" size={ 18 } />
+				</Button>
+			</li>
+			<li className="a4a-sidebar__profile-dropdown-menu-item">
+				<Button
+					borderless
+					href={ EXTERNAL_WPCOM_ACCOUNT_URL }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ translate( 'Manage your profile' ) } <Gridicon icon="external" size={ 18 } />
 				</Button>
 			</li>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -81,7 +81,7 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 }
 
 .a4a-sidebar__profile-dropdown.is-align-menu-up .a4a-sidebar__profile-dropdown-menu {
-	inset-block-start: calc(-100% + -48px);
+	inset-block-start: calc(-100% + -92px);
 }
 
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1726074640867909/1725918582.678639-slack-C047ACYM8UQ

## Proposed Changes

This improves navigation for users seeking to update their personal details in WPCOM profile. 
This can especially help for users created through magic link

<img width="251" alt="Screenshot 2024-09-11 at 5 27 41 PM" src="https://github.com/user-attachments/assets/e6274044-f095-4548-85a5-750c98b28726">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below, check new buttons in the left bottom corner when clicking on your account.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?