### PR TITLE
NPS: bring back the nps survey components

### DIFF
--- a/client/blocks/nps-survey/README.md
+++ b/client/blocks/nps-survey/README.md
@@ -1,0 +1,17 @@
+# NPS Survey
+
+This block is used to display a Net Promoter Score (NPS) survey to the user.
+
+## Usage
+
+```javascript
+<NpsSurvey name="some_screen_v1" onClose={ this.handleSurveyClose } />
+```
+
+## Props
+
+- `name`: The name of the survey, used in reporting to segment by location survey
+  was shown and version of survey. Each distinct location and version combo should
+  have a unique name.
+- `onClose`: A handler that is fired when the survey has been dismissed. A
+  callback function will be passed to the handler that should be called after the survey is hidden.

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -1,8 +1,8 @@
+import { FormLabel } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
-import FormLabel from 'calypso/components/forms/form-label';
 import { successNotice } from 'calypso/state/notices/actions';
 import {
 	submitNpsSurvey,

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -1,0 +1,123 @@
+import { translate } from 'i18n-calypso';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
+import { successNotice } from 'calypso/state/notices/actions';
+import {
+	submitNpsSurvey,
+	submitNpsSurveyWithNoScore,
+	sendNpsSurveyFeedback,
+} from 'calypso/state/nps-survey/actions';
+import {
+	isNpsSurveySubmitted,
+	isNpsSurveySubmitFailure,
+	hasAnsweredNpsSurvey,
+	hasAnsweredNpsSurveyWithNoScore,
+	getNpsSurveyName,
+	getNpsSurveyScore,
+	getNpsSurveyFeedback,
+} from 'calypso/state/nps-survey/selectors';
+import { NpsSurvey } from '../';
+
+const noop = () => {};
+
+class NpsSurveyExample extends PureComponent {
+	state = {
+		isClosed: false,
+		hasAvailableConciergeSession: false,
+		isBusinessUser: false,
+	};
+
+	handleClose = ( afterClose ) => {
+		this.setState( {
+			isClosed: true,
+		} );
+		afterClose();
+	};
+
+	toggleBusinessUser = ( event ) => {
+		this.setState( { isBusinessUser: event.target.checked } );
+	};
+
+	toggleConciergeSessionAvailability = ( event ) => {
+		this.setState( { hasAvailableConciergeSession: event.target.checked } );
+	};
+
+	renderOptions() {
+		return (
+			<div style={ { marginTop: '10px' } }>
+				<FormLabel>
+					<FormInputCheckbox onClick={ this.toggleBusinessUser } />
+					<span>The user subscribes the Business plan.</span>
+				</FormLabel>
+				<FormLabel>
+					<FormInputCheckbox onClick={ this.toggleConciergeSessionAvailability } />
+					<span>The user is available for concierge sessions.</span>
+				</FormLabel>
+			</div>
+		);
+	}
+
+	render() {
+		return (
+			<div>
+				{ ! this.state.isClosed && (
+					<NpsSurvey
+						name="api-valid-test-survey"
+						onClose={ this.handleClose }
+						translate={ translate }
+						hasAnswered={ this.props.hasAnswered }
+						submitNpsSurvey={ this.props.submitNpsSurvey }
+						submitNpsSurveyWithNoScore={ this.props.submitNpsSurveyWithNoScore }
+						sendNpsSurveyFeedback={ this.props.sendNpsSurveyFeedback }
+						successNotice={ this.props.successNotice }
+						isBusinessUser={ this.state.isBusinessUser }
+						hasAvailableConciergeSession={ this.state.hasAvailableConciergeSession }
+						recordTracksEvent={ noop }
+					/>
+				) }
+				{ ! this.state.isClosed && this.renderOptions() }
+				{ this.state.isClosed && this.props.hasAnswered && (
+					<div>
+						User closed survey after submitting:
+						<ul>
+							<li>Survey name: { this.props.surveyName }</li>
+							<li>Score: { this.props.surveyScore }</li>
+							<li>Contextual feedback: { this.props.surveyFeedback }</li>
+						</ul>
+					</div>
+				) }
+				{ this.state.isClosed && this.props.hasAnsweredWithNoScore && (
+					<div>User dismissed survey without submitting.</div>
+				) }
+				{ this.state.isClosed && this.props.isSubmitFailure && <div>Error submitting survey.</div> }
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = ( state ) => {
+	return {
+		isSubmitted: isNpsSurveySubmitted( state ),
+		isSubmitFailure: isNpsSurveySubmitFailure( state ),
+		hasAnswered: hasAnsweredNpsSurvey( state ),
+		hasAnsweredWithNoScore: hasAnsweredNpsSurveyWithNoScore( state ),
+		surveyName: getNpsSurveyName( state ),
+		surveyScore: getNpsSurveyScore( state ),
+		surveyFeedback: getNpsSurveyFeedback( state ),
+	};
+};
+
+const mapDispatchToProp = {
+	submitNpsSurvey,
+	submitNpsSurveyWithNoScore,
+	sendNpsSurveyFeedback,
+	successNotice,
+};
+
+const ConnectedNpsSurveyExample = connect( mapStateToProps, mapDispatchToProp )( NpsSurveyExample );
+
+ConnectedNpsSurveyExample.displayName = 'NpsSurvey';
+
+export default ConnectedNpsSurveyExample;

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -1,15 +1,14 @@
-import { Button, Card, ScreenReaderText } from '@automattic/components';
-import classNames from 'classnames';
+import { Button, Card, Gridicon, ScreenReaderText } from '@automattic/components';
+import { CALYPSO_CONTACT } from '@automattic/urls';
+import clsx from 'clsx';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import { trim } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent, Fragment } from 'react';
 import { connect } from 'react-redux';
 import FormTextArea from 'calypso/components/forms/form-textarea';
-import Gridicon from 'calypso/components/gridicon';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 import {
@@ -284,7 +283,7 @@ export class NpsSurvey extends PureComponent {
 
 	render() {
 		const { translate } = this.props;
-		const className = classNames( 'nps-survey', {
+		const className = clsx( 'nps-survey', {
 			'is-recommendation-selected': Number.isInteger( this.state.score ),
 			'is-submitted': this.props.hasAnswered,
 		} );

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -1,0 +1,329 @@
+import { Button, Card, ScreenReaderText } from '@automattic/components';
+import classNames from 'classnames';
+import { localize, getLocaleSlug } from 'i18n-calypso';
+import { trim } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { PureComponent, Fragment } from 'react';
+import { connect } from 'react-redux';
+import FormTextArea from 'calypso/components/forms/form-textarea';
+import Gridicon from 'calypso/components/gridicon';
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
+import {
+	submitNpsSurvey,
+	submitNpsSurveyWithNoScore,
+	sendNpsSurveyFeedback,
+} from 'calypso/state/nps-survey/actions';
+import {
+	hasAnsweredNpsSurvey,
+	isAvailableForConciergeSession,
+} from 'calypso/state/nps-survey/selectors';
+import RecommendationSelect from './recommendation-select';
+
+import './style.scss';
+
+const noop = () => {};
+
+export class NpsSurvey extends PureComponent {
+	static propTypes = {
+		onChangeForm: PropTypes.func,
+		onClose: PropTypes.func,
+		name: PropTypes.string,
+		hasAnswered: PropTypes.bool,
+		isBusinessUser: PropTypes.bool,
+		hasAvailableConciergeSession: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		hasAnswered: false,
+		isBusinessUser: false,
+		hasAvailableConciergeSession: false,
+	};
+
+	state = {
+		score: null,
+		feedback: '',
+		currentForm: 'score', // score, feedback or promotion
+	};
+
+	componentDidUpdate( _, prevState ) {
+		const { hasAvailableConciergeSession, onChangeForm } = this.props;
+
+		if ( prevState.currentForm !== this.state.currentForm ) {
+			onChangeForm && onChangeForm( this.state.currentForm );
+			this.props.recordTracksEventAction( 'calypso_nps_survey_page_displayed', {
+				name: this.state.currentForm,
+				has_available_concierge_sessions: hasAvailableConciergeSession,
+			} );
+		}
+	}
+
+	handleRecommendationSelectChange = ( score ) => {
+		this.setState( { score } );
+	};
+
+	handleSubmitScore = () => {
+		this.props.submitNpsSurvey( this.props.name, this.state.score );
+		this.setState( { currentForm: 'feedback' } );
+	};
+
+	handleDismissClick = () => {
+		if ( ! this.props.hasAnswered ) {
+			this.props.submitNpsSurveyWithNoScore( this.props.name );
+		}
+		this.onClose( noop );
+	};
+
+	handleTextBoxChange = ( event ) => {
+		this.setState( { feedback: trim( event.target.value ) } );
+	};
+
+	handleSendFeedbackClick = () => {
+		this.props.sendNpsSurveyFeedback( this.props.name, this.state.feedback );
+		if ( this.shouldShowPromotion() ) {
+			this.setState( { currentForm: 'promotion' } );
+		} else {
+			this.onClose( this.showThanksNotice );
+		}
+	};
+
+	handleFeedbackFormClose = () => {
+		if ( this.shouldShowPromotion() ) {
+			this.setState( { currentForm: 'promotion' } );
+		} else {
+			this.onClose( this.showThanksNotice );
+		}
+	};
+
+	handlePromotionClose = () => {
+		this.onClose( noop );
+	};
+
+	handleLinkClick = ( event ) => {
+		this.props.recordTracksEventAction( 'calypso_nps_survey_link_clicked', {
+			url: event.target.href,
+			type: event.target.dataset.type,
+		} );
+		this.onClose( noop );
+	};
+
+	showThanksNotice = () => {
+		this.props.successNotice( this.props.translate( 'Thanks for your feedback!' ), {
+			duration: 5000,
+		} );
+	};
+
+	onClose = ( afterClose ) => {
+		// ensure that state is updated before onClose handler is called
+		setTimeout( () => {
+			this.props.onClose( afterClose );
+		}, 0 );
+	};
+
+	UNSAFE_componentWillMount() {
+		bumpStat( 'calypso_nps_survey', 'survey_displayed' );
+		recordTracksEvent( 'calypso_nps_survey_displayed' );
+	}
+
+	shouldShowPromotion() {
+		return (
+			[ 'en', 'en-gb' ].indexOf( getLocaleSlug() ) >= 0 &&
+			this.props.isBusinessUser &&
+			typeof this.state.score === 'number' &&
+			this.state.score < 7
+		);
+	}
+
+	renderScoreForm() {
+		const { translate } = this.props;
+
+		return (
+			<Fragment>
+				<div className="nps-survey__question">
+					{ translate(
+						'How likely are you to recommend WordPress.com to your friends, family, or colleagues?'
+					) }
+				</div>
+				<div className="nps-survey__recommendation-select-wrapper">
+					<RecommendationSelect
+						value={ this.state.score }
+						disabled={ this.props.hasAnswered }
+						onChange={ this.handleRecommendationSelectChange }
+					/>
+				</div>
+				<div className="nps-survey__buttons">
+					<Button
+						primary
+						className="nps-survey__finish-button"
+						disabled={ this.props.hasAnswered }
+						onClick={ this.handleSubmitScore }
+					>
+						{ translate( 'Submit' ) }
+					</Button>
+					<Button
+						borderless
+						className="nps-survey__not-answer-button"
+						disabled={ this.props.hasAnswered }
+						onClick={ this.handleDismissClick }
+					>
+						{ translate( 'Close' ) }
+					</Button>
+				</div>
+			</Fragment>
+		);
+	}
+
+	renderFeedbackForm() {
+		const { translate } = this.props;
+
+		return (
+			<Fragment>
+				<div className="nps-survey__question">
+					{ translate( 'What is the most important reason for your score?' ) }
+				</div>
+				<div className="nps-survey__recommendation-select-wrapper">
+					<FormTextArea
+						onChange={ this.handleTextBoxChange }
+						placeholder={ translate( 'Please input your thoughts here' ) }
+					/>
+				</div>
+				<div className="nps-survey__buttons">
+					<Button
+						primary
+						className="nps-survey__finish-button"
+						disabled={ ! this.state.feedback }
+						onClick={ this.handleSendFeedbackClick }
+					>
+						{ translate( 'Submit' ) }
+					</Button>
+					{ ! this.shouldShowPromotion() && (
+						<Button
+							borderless
+							className="nps-survey__not-answer-button"
+							onClick={ this.handleFeedbackFormClose }
+						>
+							{ translate( 'Close' ) }
+						</Button>
+					) }
+				</div>
+			</Fragment>
+		);
+	}
+
+	renderPromotion() {
+		const { hasAvailableConciergeSession, translate } = this.props;
+
+		return (
+			<div className="nps-survey__promotion">
+				<p>{ translate( 'Thank you for your feedback!' ) }</p>
+				{ hasAvailableConciergeSession && (
+					<Fragment>
+						<p>
+							{ translate(
+								'You have a free, 30-minute one-on-one call with a website expert as part of your WordPress.com Business plan benefits.'
+							) }
+						</p>
+						<p>
+							{ translate(
+								'{{booking}}Reserve a 1:1 Quick Start Session{{/booking}} now or connect with a Happiness Engineer {{contact}}over live chat or email{{/contact}}.',
+								{
+									components: {
+										booking: (
+											<a
+												href="/me/concierge"
+												onClick={ this.handleLinkClick }
+												data-type="booking"
+											/>
+										),
+										contact: (
+											<a
+												href={ CALYPSO_CONTACT }
+												onClick={ this.handleLinkClick }
+												data-type="contact"
+											/>
+										),
+									},
+								}
+							) }
+						</p>
+					</Fragment>
+				) }
+				{ ! hasAvailableConciergeSession && (
+					<p>
+						{ translate(
+							'If you would like help with your site, our WordPress.com Happiness Engineers are ready {{contact}}over live chat or email{{/contact}} now.',
+							{
+								components: {
+									contact: (
+										<a
+											href={ CALYPSO_CONTACT }
+											onClick={ this.handleLinkClick }
+											data-type="contact"
+										/>
+									),
+								},
+							}
+						) }
+					</p>
+				) }
+				<div className="nps-survey__buttons">
+					<Button
+						primary
+						className="nps-survey__finish-button"
+						onClick={ this.handlePromotionClose }
+					>
+						{ translate( 'Close' ) }
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	render() {
+		const { translate } = this.props;
+		const className = classNames( 'nps-survey', {
+			'is-recommendation-selected': Number.isInteger( this.state.score ),
+			'is-submitted': this.props.hasAnswered,
+		} );
+
+		return (
+			<Card className={ className }>
+				<Button
+					borderless
+					className="nps-survey__close-button"
+					onClick={
+						this.state.currentForm === 'feedback'
+							? this.handleFeedbackFormClose
+							: this.handleDismissClick
+					}
+				>
+					<Gridicon icon="cross" />
+					<ScreenReaderText>{ translate( 'Close' ) }</ScreenReaderText>
+				</Button>
+				<div className="nps-survey__question-screen">
+					{ this.state.currentForm === 'score' && this.renderScoreForm() }
+					{ this.state.currentForm === 'feedback' && this.renderFeedbackForm() }
+					{ this.state.currentForm === 'promotion' && this.renderPromotion() }
+				</div>
+			</Card>
+		);
+	}
+}
+
+const mapStateToProps = ( state ) => {
+	return {
+		hasAnswered: hasAnsweredNpsSurvey( state ),
+		hasAvailableConciergeSession: isAvailableForConciergeSession( state ),
+	};
+};
+
+export default connect( mapStateToProps, {
+	submitNpsSurvey,
+	submitNpsSurveyWithNoScore,
+	sendNpsSurveyFeedback,
+	successNotice,
+	recordTracksEventAction,
+} )( localize( NpsSurvey ) );

--- a/client/blocks/nps-survey/recommendation-option.jsx
+++ b/client/blocks/nps-survey/recommendation-option.jsx
@@ -1,7 +1,7 @@
-import classNames from 'classnames';
+import { FormLabel } from '@automattic/components';
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 
 class RecommendationOption extends Component {
@@ -21,7 +21,7 @@ class RecommendationOption extends Component {
 	}
 
 	render() {
-		const className = classNames( 'nps-survey__recommendation-option', {
+		const className = clsx( 'nps-survey__recommendation-option', {
 			'is-selected': this.props.selected,
 		} );
 

--- a/client/blocks/nps-survey/recommendation-option.jsx
+++ b/client/blocks/nps-survey/recommendation-option.jsx
@@ -1,0 +1,43 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
+
+class RecommendationOption extends Component {
+	constructor( props ) {
+		super( props );
+		this.handleChange = this.handleChange.bind( this );
+	}
+
+	static propTypes = {
+		disabled: PropTypes.bool,
+		selected: PropTypes.bool,
+		value: PropTypes.number,
+	};
+
+	handleChange( event ) {
+		this.props.onChange( parseInt( event.target.value, 10 ) );
+	}
+
+	render() {
+		const className = classNames( 'nps-survey__recommendation-option', {
+			'is-selected': this.props.selected,
+		} );
+
+		return (
+			<FormLabel className={ className }>
+				<FormRadio
+					name="nps-survey-recommendation-option"
+					value={ this.props.value }
+					checked={ this.props.selected }
+					disabled={ this.props.disabled }
+					onChange={ this.handleChange }
+					label={ this.props.value }
+				/>
+			</FormLabel>
+		);
+	}
+}
+
+export default RecommendationOption;

--- a/client/blocks/nps-survey/recommendation-select.jsx
+++ b/client/blocks/nps-survey/recommendation-select.jsx
@@ -1,0 +1,53 @@
+import { localize } from 'i18n-calypso';
+import { range } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import RecommendationOption from './recommendation-option';
+
+class RecommendationSelect extends PureComponent {
+	static propTypes = {
+		disabled: PropTypes.bool,
+	};
+
+	renderOption( value ) {
+		return (
+			<RecommendationOption
+				key={ value }
+				value={ value }
+				selected={ this.props.value === value }
+				disabled={ this.props.disabled }
+				onChange={ this.props.onChange }
+			/>
+		);
+	}
+
+	render() {
+		const { translate } = this.props;
+		const values = range( 0, 11 );
+		const options = values.map( ( value ) => this.renderOption( value ) );
+
+		return (
+			<div className="nps-survey__recommendation-select">
+				<div className="nps-survey__scale-labels">
+					<span>
+						{ translate( 'Unlikely', {
+							context: 'NPS',
+							comment:
+								'Answer to the question: How likely are you to recommend WordPress.com to your friends, family, or colleagues?',
+						} ) }
+					</span>
+					<span className="nps-survey__very-likely-label">
+						{ translate( 'Very likely', {
+							context: 'NPS',
+							comment:
+								'Answer to the question: How likely are you to recommend WordPress.com to your friends, family, or colleagues?',
+						} ) }
+					</span>
+				</div>
+				<div className="nps-survey__options">{ options }</div>
+			</div>
+		);
+	}
+}
+
+export default localize( RecommendationSelect );

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -1,5 +1,3 @@
-
-
 .card.nps-survey {
 	margin: 0;
 	padding: 0;
@@ -13,7 +11,7 @@
 	padding: 16px;
 	padding-right: 36px;
 
-	@include breakpoint-deprecated( '>480px' ) {
+	@include breakpoint-deprecated( ">480px" ) {
 		padding: 24px;
 		padding-right: 48px;
 	}
@@ -21,7 +19,7 @@
 
 .nps-survey__buttons {
 	padding: 16px 16px 7px;
-	transform: translateY( -25px );
+	transform: translateY(-25px);
 	transition: transform 0.1s ease-in;
 }
 
@@ -45,25 +43,23 @@
 
 .nps-survey.is-recommendation-selected {
 	.nps-survey__buttons {
-		//height: 75px;
-		transform: translateY( 0 );
+		transform: translateY(0);
 	}
 
 	.button.nps-survey__finish-button {
 		opacity: 1;
-		//transform: translateY(0);
 		visibility: visible;
 	}
 }
 
 .nps-survey__recommendation-select-wrapper {
-	background-color: var( --color-neutral-0 );
-	border-top: 1px solid var( --color-neutral-10 );
-	border-bottom: 1px solid var( --color-neutral-10 );
+	background-color: var(--color-neutral-0);
+	border-top: 1px solid var(--color-neutral-10);
+	border-bottom: 1px solid var(--color-neutral-10);
 	padding: 16px 0;
 	text-align: center;
 
-	@include breakpoint-deprecated( '>480px' ) {
+	@include breakpoint-deprecated( ">480px" ) {
 		padding: 16px;
 	}
 }
@@ -78,13 +74,13 @@
 	padding: 0 3px;
 	margin-bottom: 8px;
 
-	@include breakpoint-deprecated( '>480px' ) {
+	@include breakpoint-deprecated( ">480px" ) {
 		padding: 0 6px;
 	}
 }
 
 .nps-survey__scale-labels {
-	color: var( --color-text-subtle );
+	color: var(--color-text-subtle);
 	text-align: left;
 }
 
@@ -97,15 +93,15 @@
 }
 
 .nps-survey__recommendation-option.is-selected {
-	color: var( --color-primary-40 );
+	color: var(--color-primary-40);
 	font-weight: 600;
 }
 
-.nps-survey__recommendation-option input[type='radio'] {
+.nps-survey__recommendation-option input[type="radio"] {
 	margin: 0 2px;
 }
 
-.nps-survey__recommendation-option input[type='radio'] + span {
+.nps-survey__recommendation-option input[type="radio"] + span {
 	clear: both;
 	margin-left: 0;
 	text-align: center;
@@ -117,7 +113,7 @@
 	top: 0;
 }
 .nps-survey__close-button.button.is-borderless {
-	color: var( --color-text-subtle );
+	color: var(--color-text-subtle);
 }
 
 .nps-survey__promotion {

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -1,0 +1,133 @@
+
+
+.card.nps-survey {
+	margin: 0;
+	padding: 0;
+}
+
+.dialog__content .card.nps-survey {
+	box-shadow: unset;
+}
+
+.nps-survey__question {
+	padding: 16px;
+	padding-right: 36px;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		padding: 24px;
+		padding-right: 48px;
+	}
+}
+
+.nps-survey__buttons {
+	padding: 16px 16px 7px;
+	transform: translateY( -25px );
+	transition: transform 0.1s ease-in;
+}
+
+.button.nps-survey__finish-button,
+.button.nps-survey__not-answer-button,
+.button.nps-survey__dismiss-button {
+	display: block;
+	margin: 0 auto;
+	min-width: 170px;
+}
+
+.button.nps-survey__finish-button {
+	opacity: 0;
+	visibility: hidden;
+	transition: opacity 0.2s ease-in;
+}
+
+.button.nps-survey__finish-button:last-child {
+	margin-bottom: 9px;
+}
+
+.nps-survey.is-recommendation-selected {
+	.nps-survey__buttons {
+		//height: 75px;
+		transform: translateY( 0 );
+	}
+
+	.button.nps-survey__finish-button {
+		opacity: 1;
+		//transform: translateY(0);
+		visibility: visible;
+	}
+}
+
+.nps-survey__recommendation-select-wrapper {
+	background-color: var( --color-neutral-0 );
+	border-top: 1px solid var( --color-neutral-10 );
+	border-bottom: 1px solid var( --color-neutral-10 );
+	padding: 16px 0;
+	text-align: center;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		padding: 16px;
+	}
+}
+
+.nps-survey__recommendation-select {
+	box-sizing: border-box;
+	display: inline-block;
+}
+
+.nps-survey__scale-labels,
+.nps-survey__recommendation-option {
+	padding: 0 3px;
+	margin-bottom: 8px;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		padding: 0 6px;
+	}
+}
+
+.nps-survey__scale-labels {
+	color: var( --color-text-subtle );
+	text-align: left;
+}
+
+.nps-survey__very-likely-label {
+	float: right;
+}
+
+.nps-survey__recommendation-option.form-label {
+	display: inline-block;
+}
+
+.nps-survey__recommendation-option.is-selected {
+	color: var( --color-primary-40 );
+	font-weight: 600;
+}
+
+.nps-survey__recommendation-option input[type='radio'] {
+	margin: 0 2px;
+}
+
+.nps-survey__recommendation-option input[type='radio'] + span {
+	clear: both;
+	margin-left: 0;
+	text-align: center;
+}
+
+.nps-survey__close-button {
+	position: absolute;
+	right: 5px;
+	top: 0;
+}
+.nps-survey__close-button.button.is-borderless {
+	color: var( --color-text-subtle );
+}
+
+.nps-survey__promotion {
+	padding: 24px 48px 8px 24px;
+
+	p {
+		margin: 10px 0 0;
+	}
+
+	p:first-child {
+		margin-top: 0;
+	}
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -27,6 +27,7 @@ import ImageEditor from 'calypso/blocks/image-editor/docs/example';
 import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt/docs/example';
 import LikeButtons from 'calypso/blocks/like-button/docs/example';
 import Login from 'calypso/blocks/login/docs/example';
+import NpsSurvey from 'calypso/blocks/nps-survey/docs/example';
 import PlanStorage from 'calypso/blocks/plan-storage/docs/example';
 import PlanThankYouCard from 'calypso/blocks/plan-thank-you-card/docs/example';
 import PostEditButton from 'calypso/blocks/post-edit-button/docs/example';
@@ -161,6 +162,7 @@ export default class AppComponents extends Component {
 					<DailyPostButton readmeFilePath="daily-post-button" />
 					<PostLikes readmeFilePath="post-likes" />
 					<ReaderFeaturedVideo readmeFilePath="reader-featured-video" />
+					{ isEnabled( 'nps-survey/devdocs' ) && <NpsSurvey readmeFilePath="nps-survey" /> }
 					<ReaderExportButton readmeFilePath="reader-export-button" />
 					<ReaderImportButton readmeFilePath="reader-import-button" />
 					<SharingPreviewPane />

--- a/client/layout/nps-survey-notice/style.scss
+++ b/client/layout/nps-survey-notice/style.scss
@@ -1,0 +1,7 @@
+.dialog.card.nps-survey-notice {
+	max-width: 480px;
+}
+
+.dialog.card.nps-survey-notice .dialog__content {
+	padding: 0;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR is based on https://github.com/Automattic/wp-calypso/pull/94469, and is part of resolving the request of bringing the deprecated NPS survey back: p1725885879720739-slack-CFFF01Q4V . To see it in action as a whole, please refer to the integration PR: https://github.com/Automattic/wp-calypso/pull/94361. Even though it's overall quite intuitive, I think it's safer to be deployed incrementally as isolated as possible.

In this PR, the components are reverted.
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As part of the continuous effort of understanding our user's needs better, we want to bring the NPS survey back and further polish it to the higher standard. Instead of starting from scratch, we wanted to build upon our prior work, hence bringing the code back.

As a reference, the NPS survey code was previously removed by:

* https://github.com/Automattic/wp-calypso/pull/55232
* https://github.com/Automattic/wp-calypso/pull/58393

## Testing Instructions

No functional-wise change has been introduced here. Thus, as long as the build passes, it is all good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?