### PR TITLE
A4A > Site Selector & Importer: Fix the issue of all sites not appearing during Import via WordPress.com

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
@@ -84,7 +84,7 @@ p.import-from-wpcom-modal__instruction {
 
 .wpcom-sites-table.redesigned-a8c-table {
 	overflow-y: auto;
-	margin-block-start: 24px;
+	margin-block: 24px;
 
 	&::-webkit-scrollbar {
 		width: 4px;
@@ -105,7 +105,7 @@ p.import-from-wpcom-modal__instruction {
 		content: "";
 		position: absolute;
 		left: 0;
-		bottom: 85px;
+		bottom: 80px;
 		width: 100%;
 		height: 5%;
 		display: inline-block;
@@ -130,7 +130,7 @@ p.import-from-wpcom-modal__instruction {
 
 	.dataviews-view-table {
 		padding-block-end: 80px;
-		margin: 0;
+		margin: 0 0 32px;
 	}
 
 	.dataviews-view-table thead {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1084

## Proposed Changes

This PR resolves the issue of all sites not appearing during Import via WordPress.com.

## Why are these changes being made?

* To fix the issue with Import via WordPress.com

## Testing Instructions

* Visit A4A live link
* Go to /overview -> Click on the Add sites button on the top right -> Click the Via WordPress.com option -> Verify that all the sites are shown, including the last time. You can [reproduce](https://github.com/Automattic/automattic-for-agencies-dev/issues/1084) this issue when you have more than 10 sites. 


https://github.com/user-attachments/assets/e3336bbc-8dd4-4180-a71a-fbca087aed45



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
