### PR TITLE
A4A Dev Sites: Reset to page 1 when changing between submenus on Sites page.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -3,7 +3,7 @@ import { isWithinBreakpoint } from '@automattic/viewport';
 import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { useContext, useEffect, useCallback, useState } from 'react';
+import { useContext, useEffect, useCallback, useState, useRef } from 'react';
 import GuidedTour from 'calypso/a8c-for-agencies/components/guided-tour';
 import {
 	DATAVIEWS_LIST,
@@ -105,6 +105,30 @@ export default function SitesDashboard() {
 		showOnlyFavorites,
 		showOnlyDevelopmentSites,
 	] );
+
+	// Reset back to page one when entering Needs Attention, Favourites, or Development page.
+	const selectedFilters = getSelectedFilters( dataViewsState.filters );
+	const isOnNeedsAttentionPage = selectedFilters.includes( 'all_issues' );
+	const prevIsOnFavouritesPageRef = useRef( showOnlyFavorites );
+	const prevIsOnDevelopmentPageRef = useRef( showOnlyDevelopmentSites );
+	const prevIsOnNeedsAttentionPageRef = useRef( isOnNeedsAttentionPage );
+
+	useEffect( () => {
+		const selectedFilters = getSelectedFilters( dataViewsState.filters );
+		const isOnNeedsAttentionPage = selectedFilters.includes( 'all_issues' );
+
+		if (
+			prevIsOnFavouritesPageRef.current !== showOnlyFavorites ||
+			prevIsOnDevelopmentPageRef.current !== showOnlyDevelopmentSites ||
+			prevIsOnNeedsAttentionPageRef.current !== isOnNeedsAttentionPage
+		) {
+			setDataViewsState( { ...dataViewsState, page: 1 } );
+		}
+
+		prevIsOnFavouritesPageRef.current = showOnlyFavorites;
+		prevIsOnDevelopmentPageRef.current = showOnlyDevelopmentSites;
+		prevIsOnNeedsAttentionPageRef.current = isOnNeedsAttentionPage;
+	}, [ dataViewsState, setDataViewsState, showOnlyFavorites, showOnlyDevelopmentSites ] );
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites( {
 		isPartnerOAuthTokenLoaded: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes [#9012](https://github.com/Automattic/dotcom-forge/issues/9012)

## Proposed Changes

* Reset to page 1 when changing between submenus on Sites page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bugfix pdtkmj-2Te-p2#comment-5537

## Testing Instructions

**Setup**
* Change the value `perPage` from `50` to something smaller like `5`in the file `calypso/client/a8c-for-agencies/components/items-dashboard/constants.ts`.
* Spin up`PORT=3002 yarn start-a8c-for-agencies`.

**Test**
* Go to http://agencies.localhost:3002/sites.
* Open up network panel in your dev console.
* Filter it down to `sites` and `Fetch/XHR`.
* While under **"All"**, change to page 2 or 3 (up to you).
* Switch between **"Needs Attention"** / **"Favourites"** / **"Development"** sidebar menu items.
* Check and ensure the request made to the Sites API endpoint should have the `page=1` parameter.

**(Optional) Test No Regression In Changing Page**
1. Favourite more than 5 sites so that you have the pagination bar on the Favourites page.
2. While under **"All"**, change to page 2 or 3 (up to you).
3. Go to "Favourites" page.
   - It should change to page 1.
4. Change to page 2 on "Favourites" page.
   - It should let you change to page 2 without causing a reset.

**Before**
![image](https://github.com/user-attachments/assets/cb3f814d-d15c-493b-82cd-51cf72ab3cad)

**After**
![image](https://github.com/user-attachments/assets/ebaa88c6-e54f-4862-85ac-38b9acdf445d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?