### PR TITLE
Performance Profiler: Updates copy and color of Share button

### DIFF
--- a/client/performance-profiler/components/header/index.tsx
+++ b/client/performance-profiler/components/header/index.tsx
@@ -125,7 +125,7 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 										onClick={ () => setPopoverMenu( true ) }
 									>
 										<Icon className="share-icon" icon={ share } />
-										<span>{ translate( 'Share results' ) }</span>
+										<span>{ translate( 'Share' ) }</span>
 									</div>
 									<Popover
 										id="profiler-share-buttons-popover"

--- a/client/performance-profiler/components/header/style.scss
+++ b/client/performance-profiler/components/header/style.scss
@@ -223,10 +223,9 @@
 				justify-content: center;
 				align-items: center;
 				gap: 4px;
-				color: var(--studio-gray-20);
 
 				.share-icon {
-					fill: var(--studio-gray-20);
+					fill: #fff;
 					margin-bottom: -1px;
 				}
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Changes `Share results` to `Share` to better fit  in mobile breakpoints
* Changes `Share` color to white to match figma

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/speed-test-tool?url=https%3A%2F%2Fwww.mathema.me%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6Njk3Nn0.Jn_1t7YcV-YzB7L10e4Zr9_2cqt44MyqPq6Lhw22zDU&tab=mobile`

![CleanShot 2024-09-12 at 12 32 37](https://github.com/user-attachments/assets/970bc3bb-117f-4881-975f-3a4d4b837b6d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
