### PR TITLE
A4A: Implement 'Remove self from agency' flow.

### DIFF
--- a/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
@@ -1,5 +1,4 @@
 import { getCurrentUser } from '@automattic/calypso-analytics';
-import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import useCancelMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-cancel-member-invite';
@@ -89,7 +88,7 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 					{
 						onSuccess: () => {
 							if ( item.email === currentUser?.email ) {
-								page( 'https://automattic.com/for/agencies' );
+								window.location.href = 'https://automattic.com/for/agencies';
 								return;
 							}
 
@@ -116,6 +115,14 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 				);
 			}
 		},
-		[ cancelMemberInvite, dispatch, onRefetchList, removeMember, resendMemberInvite, translate ]
+		[
+			cancelMemberInvite,
+			currentUser?.email,
+			dispatch,
+			onRefetchList,
+			removeMember,
+			resendMemberInvite,
+			translate,
+		]
 	);
 }

--- a/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
@@ -1,9 +1,11 @@
+import { getCurrentUser } from '@automattic/calypso-analytics';
+import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import useCancelMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-cancel-member-invite';
 import useRemoveMemberMutation from 'calypso/a8c-for-agencies/data/team/use-remove-member';
 import useResendMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-resend-member-invite';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { TeamMember } from '../types';
 
@@ -20,6 +22,8 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 	const { mutate: cancelMemberInvite } = useCancelMemberInviteMutation();
 
 	const { mutate: removeMember } = useRemoveMemberMutation();
+
+	const currentUser = useSelector( getCurrentUser );
 
 	return useCallback(
 		( action: string, item: TeamMember, callback?: () => void ) => {
@@ -84,6 +88,11 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 					{ id: item.id },
 					{
 						onSuccess: () => {
+							if ( item.email === currentUser?.email ) {
+								page( 'https://automattic.com/for/agencies' );
+								return;
+							}
+
 							dispatch(
 								successNotice( translate( 'The member has been successfully removed.' ), {
 									id: 'remove-user-success',

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -228,8 +228,10 @@ export const ActionColumn = ( {
 		agency?.name,
 	] );
 
+	const activeActions = actions.filter( ( { isEnabled } ) => isEnabled );
+
 	// We don't show the action menu when the member is the owner of the team.
-	if ( member.role === OWNER_ROLE || actions.length === 0 ) {
+	if ( member.role === OWNER_ROLE || activeActions.length === 0 ) {
 		return null;
 	}
 
@@ -245,19 +247,17 @@ export const ActionColumn = ( {
 				onClose={ onCloseMenu }
 				position="bottom left"
 			>
-				{ actions
-					.filter( ( { isEnabled } ) => isEnabled )
-					.map( ( action ) => (
-						<PopoverMenuItem
-							key={ action.name }
-							onClick={ () =>
-								onSelect( { name: action.name, confirmation: action.confirmationDialog } )
-							}
-							className={ clsx( 'team-list__action-menu-item', action.className ) }
-						>
-							{ action.label }
-						</PopoverMenuItem>
-					) ) }
+				{ activeActions.map( ( action ) => (
+					<PopoverMenuItem
+						key={ action.name }
+						onClick={ () =>
+							onSelect( { name: action.name, confirmation: action.confirmationDialog } )
+						}
+						className={ clsx( 'team-list__action-menu-item', action.className ) }
+					>
+						{ action.label }
+					</PopoverMenuItem>
+				) ) }
 			</PopoverMenu>
 
 			{ confirmationDialog && <A4AConfirmationDialog { ...confirmationDialog } /> }

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -185,7 +185,7 @@ export const ActionColumn = ( {
 					},
 					{
 						name: 'delete-user',
-						label: translate( 'Delete user' ),
+						label: isSelfAction ? translate( 'Leave agency' ) : translate( 'Remove team member' ),
 						className: 'is-danger',
 						isEnabled: canRemove,
 						confirmationDialog: {
@@ -194,7 +194,7 @@ export const ActionColumn = ( {
 										args: { agencyName: agency?.name ?? '' },
 										comment: '%(agencyName)s is the agency name',
 								  } ) as string )
-								: translate( 'Delete user' ),
+								: translate( 'Remove team member' ),
 							children: isSelfAction
 								? translate(
 										"By proceeding, you'll lose management access of all sites that belong to this agency and you will be removed from this dashboard. {{br/}}The agency owner will need to re-invite you if you wish to gain access again.",
@@ -204,14 +204,16 @@ export const ActionColumn = ( {
 											},
 										}
 								  )
-								: translate( 'Are you sure you want to delete {{b}}%(memberName)s{{/b}}?', {
+								: translate( 'Are you sure you want to remove {{b}}%(memberName)s{{/b}}?', {
 										args: { memberName: member.displayName ?? member.email },
 										components: {
 											b: <b />,
 										},
 										comment: '%(memberName)s is the member name',
 								  } ),
-							ctaLabel: isSelfAction ? translate( 'Leave agency' ) : translate( 'Delete user' ),
+							ctaLabel: isSelfAction
+								? translate( 'Leave agency' )
+								: translate( 'Remove team member' ),
 							isDestructive: true,
 						},
 					},
@@ -227,7 +229,7 @@ export const ActionColumn = ( {
 	] );
 
 	// We don't show the action menu when the member is the owner of the team.
-	if ( member.role === OWNER_ROLE ) {
+	if ( member.role === OWNER_ROLE || actions.length === 0 ) {
 		return null;
 	}
 


### PR DESCRIPTION
This PR implements a flow where we gracefully exit a member who is leaving the agency.

<img width="1046" alt="Screenshot 2024-09-12 at 7 15 39 PM" src="https://github.com/user-attachments/assets/8a9a6ce5-9911-4347-83e7-836d2eddb575">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1112

## Proposed Changes

* Show a specific confirmation dialog for users who try removing themselves from the agency. Once confirmed, the user is redirected to https://automattic.com/for/agencies/.

## Why are these changes being made?

* Currently, we don't gracefully exit users when leaving the agency. The UI stays on the team page, while requests in the background fail due to non-existing access.

## Testing Instructions

* Apply D161143-code to your sandbox
* Point public-api.wordpress.com to your sandbox
* Login as a **Team member**.
* Use the A4A live link below and go to the `/team` page.
* Remove yourself.
* Confirm that you see the correct message.
* Confirm the dialog and verify that you are redirected to https://automattic.com/for/agencies/
* Finally, test that the 'Delete user' functionality for the Agency owner is working as expected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?