### PR TITLE
A4A Dev Sites: Update copy message on staging sites panel for A4A dev sites.

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -92,8 +92,9 @@ export const NewStagingSiteCardContent = ( {
 					</WarningContainer>
 				) }
 				{ isDevelopmentSite && (
-					// Not wrapped in translation to avoid request unconfirmed copy
-					<p>The staging feature will be available once the site is launched.</p>
+					<p>
+						{ translate( 'Staging sites are only available to sites launched in production.' ) }
+					</p>
 				) }
 				<Button primary disabled={ isButtonDisabled } onClick={ onAddClick }>
 					<span>{ translate( 'Add staging site' ) }</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8964

## Proposed Changes

* Update copy message on staging sites panel for A4A dev sites.
* The final copy is `Staging sites are only available to sites launched in production. [[Prepare to launch my site]]`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Copy update.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `wordpress.com/staging-site/youra4adevsite.wpcomstaging.com`.
* You should see the string `Staging sites are only available to sites launched in production.`.

![image](https://github.com/user-attachments/assets/70a284bb-bc2d-453d-a956-6beb737b531c)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
