### PR TITLE
Point learn more link to #staging-to-production bookmark when creating WooCommerce staging site

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -83,7 +83,10 @@ export const NewStagingSiteCardContent = ( {
 								{
 									components: {
 										a: (
-											<InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />
+											<InlineSupportLink
+												supportContext="staging-to-production-sync"
+												showIcon={ false }
+											/>
 										),
 									},
 								}


### PR DESCRIPTION
## Proposed Changes

![image](https://github.com/user-attachments/assets/9608c2d6-3ed7-46d4-98be-3c4918fbff59)
The learn more link under the staging info box for WooCommerce should point to the `#staging-to-production` bookmark on the `https://developer.wordpress.com/docs/developer-tools/staging-sites` support page.

## Testing Instructions

Have the `staging-site-sync-woo` feature flag enabled on a site that has WooCommerce installed and does not have a staging site set. On the page to create a new staging site, the info box `Learn more `link should point to:
https://developer.wordpress.com/docs/developer-tools/staging-sites/#staging-to-production

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
