### PR TITLE
Checkout: choose one primary button

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
@@ -34,17 +34,18 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 		return ! isDomainProduct( purchase ) || predicate( purchase );
 	} );
 
-	const products = filteredPurchases.map( ( purchase, index ) => {
-		// Check if this is the first product to set isPrimary
-		const isPrimary = index === 0;
+	// If the user has multiple purchases, we want the domain product to have a primary button.
+	// All other purchases should have secondary buttons.
+	// If the user has no domain purchases, we want the first purchase to have a primary button.
+	const hasDomainPurchase = filteredPurchases.some( isDomainProduct );
 
+	const products = filteredPurchases.map( ( purchase ) => {
 		if ( isDomainProduct( purchase ) ) {
 			return (
 				<ThankYouDomainProduct
 					key={ `domain-${ purchase.meta }` }
 					purchase={ purchase }
 					siteSlug={ siteSlug }
-					isPrimary={ isPrimary }
 				/>
 			);
 		} else if ( isPlan( purchase ) ) {
@@ -54,7 +55,7 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 					purchase={ purchase }
 					siteSlug={ siteSlug }
 					siteId={ siteId }
-					isPrimary={ isPrimary }
+					isSecondary={ hasDomainPurchase }
 				/>
 			);
 		} else if ( isTitanMail( purchase ) ) {
@@ -65,7 +66,7 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 					siteSlug={ siteSlug }
 					emailAddress={ emailAddress }
 					numberOfMailboxesPurchased={ purchase?.newQuantity }
-					isPrimary={ isPrimary }
+					isSecondary={ hasDomainPurchase }
 				/>
 			);
 		}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
@@ -34,13 +34,17 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 		return ! isDomainProduct( purchase ) || predicate( purchase );
 	} );
 
-	const products = filteredPurchases.map( ( purchase ) => {
+	const products = filteredPurchases.map( ( purchase, index ) => {
+		// Check if this is the first product to set isPrimary
+		const isPrimary = index === 0;
+
 		if ( isDomainProduct( purchase ) ) {
 			return (
 				<ThankYouDomainProduct
 					key={ `domain-${ purchase.meta }` }
 					purchase={ purchase }
 					siteSlug={ siteSlug }
+					isPrimary={ isPrimary }
 				/>
 			);
 		} else if ( isPlan( purchase ) ) {
@@ -50,6 +54,7 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 					purchase={ purchase }
 					siteSlug={ siteSlug }
 					siteId={ siteId }
+					isPrimary={ isPrimary }
 				/>
 			);
 		} else if ( isTitanMail( purchase ) ) {
@@ -60,6 +65,7 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 					siteSlug={ siteSlug }
 					emailAddress={ emailAddress }
 					numberOfMailboxesPurchased={ purchase?.newQuantity }
+					isPrimary={ isPrimary }
 				/>
 			);
 		}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -51,7 +51,6 @@ export default function ThankYouDomainProduct( {
 	siteSlug,
 	currency,
 	isGravatarDomain,
-	isPrimary,
 }: ThankYouDomainProductProps ) {
 	const translate = useTranslate();
 
@@ -61,8 +60,6 @@ export default function ThankYouDomainProduct( {
 	if ( ! domainName ) {
 		return null;
 	}
-
-	const defaultButtonClass = isPrimary ? 'is-primary' : 'secondary';
 
 	let actions;
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -41,6 +41,7 @@ type ThankYouDomainProductProps = {
 	siteSlug?: string | null;
 	currency?: string;
 	isGravatarDomain?: boolean;
+	isPrimary?: boolean;
 };
 
 export default function ThankYouDomainProduct( {
@@ -50,6 +51,7 @@ export default function ThankYouDomainProduct( {
 	siteSlug,
 	currency,
 	isGravatarDomain,
+	isPrimary,
 }: ThankYouDomainProductProps ) {
 	const translate = useTranslate();
 
@@ -59,6 +61,8 @@ export default function ThankYouDomainProduct( {
 	if ( ! domainName ) {
 		return null;
 	}
+
+	const defaultButtonClass = isPrimary ? 'is-primary' : 'secondary';
 
 	let actions;
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
@@ -20,12 +20,14 @@ export type ThankYouPlanProductProps = {
 	purchase: ReceiptPurchase;
 	siteSlug: string | null;
 	siteId: number | null;
+	isSecondary?: boolean;
 };
 
 export default function ThankYouPlanProduct( {
 	purchase,
 	siteSlug,
 	siteId,
+	isSecondary,
 }: ThankYouPlanProductProps ) {
 	const isLoadingPurchases = useSelector(
 		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
@@ -113,7 +115,7 @@ export default function ThankYouPlanProduct( {
 					{ ! isWpComEcommercePlan( purchase.productSlug ) && (
 						<Button
 							isBusy={ letsWorkButtonBusy }
-							variant="primary"
+							variant={ isSecondary ? 'secondary' : 'primary' }
 							href={ letsWorkHref }
 							onClick={ letsWorkButtonOnClick }
 						>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/titan-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/titan-product.tsx
@@ -16,6 +16,7 @@ export type ThankYouEmailProductProps = {
 	siteSlug: string | null;
 	emailAddress?: string;
 	numberOfMailboxesPurchased?: number;
+	isSecondary?: boolean;
 };
 
 export function ThankYouTitanProduct( {
@@ -23,6 +24,7 @@ export function ThankYouTitanProduct( {
 	siteSlug,
 	emailAddress,
 	numberOfMailboxesPurchased,
+	isSecondary,
 }: ThankYouEmailProductProps ) {
 	const translate = useTranslate();
 	const titanAppsUrlPrefix = useTitanAppsUrlPrefix();
@@ -44,7 +46,7 @@ export function ThankYouTitanProduct( {
 		actions.push(
 			<Button
 				key="inbox"
-				variant="primary"
+				variant={ isSecondary ? 'secondary' : 'primary' }
 				href={ inboxPath }
 				onClick={ () => {
 					recordEmailAppLaunchEvent( {
@@ -68,7 +70,7 @@ export function ThankYouTitanProduct( {
 			<Button
 				key="set-up-mailbox"
 				href={ getTitanSetUpMailboxPath( siteSlug, domainName ) }
-				variant="primary"
+				variant={ isSecondary ? 'secondary' : 'primary' }
 			>
 				{ translate( 'Set up mailbox' ) }
 			</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8786

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
