### PR TITLE
Help center: use localiseUrl to ensure correct support article

### DIFF
--- a/packages/help-center/src/hooks/use-post-by-url.ts
+++ b/packages/help-center/src/hooks/use-post-by-url.ts
@@ -9,7 +9,6 @@ import type { PostObject } from '../types';
 export function usePostByUrl( url: string ) {
 	const { sectionName } = useHelpCenterContext();
 	const postUrl = encodeURIComponent( localizeUrl( url ) );
-	console.log( postUrl );
 
 	return useQuery< PostObject >( {
 		queryKey: [ 'support-status', url ],

--- a/packages/help-center/src/hooks/use-post-by-url.ts
+++ b/packages/help-center/src/hooks/use-post-by-url.ts
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
@@ -7,18 +8,20 @@ import type { PostObject } from '../types';
 
 export function usePostByUrl( url: string ) {
 	const { sectionName } = useHelpCenterContext();
+	const postUrl = encodeURIComponent( localizeUrl( url ) );
+	console.log( postUrl );
 
 	return useQuery< PostObject >( {
 		queryKey: [ 'support-status', url ],
 		queryFn: () =>
 			canAccessWpcomApis()
 				? wpcomRequest( {
-						path: `help/article?post_url=${ encodeURIComponent( url ) }`,
+						path: `help/article?post_url=${ postUrl }`,
 						apiNamespace: 'wpcom/v2/',
 						apiVersion: '2',
 				  } )
 				: apiFetch( {
-						path: `/help-center/fetch-post?post_url=${ encodeURIComponent( url ) }`,
+						path: `/help-center/fetch-post?post_url=${ postUrl }`,
 				  } ),
 		enabled: !! url,
 		refetchOnWindowFocus: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/39339

When showing a support article in Help center, the link is supposed to be run through `localiseUrl` to make sure the correct locale is used with the support article, i.e;
English - https://wordpress.com/support/seo-tools/
Spanish - https://wordpress.com/es/support/herramientas-seo/

The issue is that if we want to show a support article in Help center on Jetpack, we need access to `localiseUrl`. This brings a lot of Calypso dependencies which we want to avoid on Jetpack.

If we use `localiseUrl` before posting the support link URL to the `help/article` API endpoint, it should ensure the correct localised support article is sent.

## Proposed Changes

* Use `localizeUrl` when making the API call to retrieve a support article post to ensure we are getting the localised version of that post

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There shouldn't be any change in behaviour. You can test opening a non-english support article by following the video below;

https://github.com/user-attachments/assets/97932781-8d8b-4761-b55d-36471e51692d

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
