### PR TITLE
Account Settings: Fix the username field falsely being marked as changed

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -366,8 +366,15 @@ class Account extends Component {
 	 * @param {Object} event Event from onChange of user_login input
 	 */
 	handleUsernameChange = ( event ) => {
+		const value = event.currentTarget.value;
+
+		if ( value === this.getUserOriginalSetting( 'user_login' ) ) {
+			this.cancelUsernameChange();
+			return;
+		}
+
 		this.validateUsername();
-		this.updateUserSetting( 'user_login', event.currentTarget.value );
+		this.updateUserSetting( 'user_login', value );
 		this.setState( { usernameAction: null } );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/94474

## Proposed Changes

This change resets the user name field state when the user name is the same as the initial one. This fixes a bug where you always get the "unsaved changes" popup when the user name is reverted to the initial value.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Because automatticians are not allowed to change their usernames, apply the following patch:
```diff
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -883,10 +883,6 @@ class Account extends Component {
                                                                autoComplete="off"
                                                                autoCorrect="off"
                                                                className="account__username"
-                                                               disabled={
-                                                                       this.getDisabledState( ACCOUNT_FORM_NAME ) ||
-                                                                       ! this.getUserSetting( 'user_login_can_be_changed' )
-                                                               }
                                                                id="user_login"
                                                                name="user_login"
                                                                onFocus={ this.getFocusHandler( 'Username Field' ) }
```
* Head to /me/account.
* Change your username. You should see a "Confirm Username" field. If you see an "Automatticians are not permitted to access this resource." error, that's normal.
* Change it back to the initial value.
* Click on "My Profile" to navigate away.
* There should be no "unsaved changes" popup.
* To make sure the "unsaved changes" popup is working, change your username and try to navigate away without reverting it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
