### PR TITLE
Performance Profiler: update insights section styling

### DIFF
--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -11,6 +11,8 @@ $blueberry-color: #3858e9;
 		justify-content: space-between;
 		align-items: center;
 		margin-bottom: 32px;
+		flex-wrap: wrap;
+		row-gap: 32px;
 	}
 
 	.title {

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -108,6 +108,15 @@ $blueberry-color: #3858e9;
 				}
 			}
 
+			.md-code {
+				border: 1px solid var(--studio-gray-5);
+				background: var(--studio-gray-0);
+				padding: 2px 4px;
+				border-radius: 4px;
+				font-family: monospace;
+				font-size: $font-body-small;
+			}
+
 			.header-code {
 				color: #3858e9;
 			}

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -227,7 +227,7 @@ $blueberry-color: #3858e9;
 				overflow-x: auto;
 
 				table {
-					table-layout: fixed;
+					table-layout: auto;
 					width: 100%;
 					margin-bottom: 0;
 					min-width: $break-small;
@@ -238,6 +238,7 @@ $blueberry-color: #3858e9;
 						word-break: break-word;
 						font-size: $font-body-small;
 						border-bottom: 1px solid var(--studio-gray-5);
+						min-width: 100px;
 					}
 
 					tr.sub {

--- a/client/performance-profiler/components/metrics-insight/insight-header.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-header.tsx
@@ -35,7 +35,7 @@ export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
 							return <p className="title-description">{ props.children }</p>;
 						},
 						code( props ) {
-							return <span className="value">{ props.children }</span>;
+							return <span className="md-code">{ props.children }</span>;
 						},
 					} }
 				>

--- a/client/performance-profiler/components/metrics-insight/insight-table.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-table.tsx
@@ -43,13 +43,13 @@ function SubRows( { items, headings }: { items: any[]; headings: any[] } ) {
 	return items.map( ( subItem, subIndex ) => (
 		<tr key={ `sub-${ subIndex }` } className="sub">
 			{ headings.map( ( heading, index ) => {
-				const { subItemsHeading } = heading;
+				const { subItemsHeading, valueType } = heading;
 
 				return (
 					<td key={ `subrow-${ index }` }>
 						<Cell
 							data={ subItem[ subItemsHeading?.key ] }
-							headingValueType={ subItemsHeading?.valueType }
+							headingValueType={ subItemsHeading?.valueType ?? valueType }
 						/>
 					</td>
 				);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9121
Closes https://github.com/Automattic/dotcom-forge/issues/9120
Closes https://github.com/Automattic/dotcom-forge/issues/9119

## Proposed Changes

* Change color and use a monospaced font on markdown highlights
* Wrap the feedback options should below the prompt on smaller screens
* Update the text wrapping within tables

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pdt2If-1Kx-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/speed-test` and start a new test, or go to a results page eg. `/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzA1N30.7KXaBL1qcm0y0GqvM8ymJ0pbST9ls6P09_hri8EaKSI`
* Check the styling of the insights section

| Section | Before | After |
|--------|--------|--------|
| Markdown code | ![CleanShot 2024-09-13 at 11 56 25@2x](https://github.com/user-attachments/assets/6318094c-52ed-4c53-99c3-5f6ce3d902b5) | ![CleanShot 2024-09-13 at 11 56 40@2x](https://github.com/user-attachments/assets/e8ce4248-429f-4d0d-bb1b-38ad5e956357) | 
| Dropdown wrapping | ![CleanShot 2024-09-13 at 11 55 32@2x](https://github.com/user-attachments/assets/4da05939-7066-41db-a18a-77cf28798a80) | ![CleanShot 2024-09-13 at 11 55 52@2x](https://github.com/user-attachments/assets/7b4f37c5-ee34-45ca-b964-a81009b5b4bf) |
| Table columns | ![CleanShot 2024-09-13 at 11 54 17@2x](https://github.com/user-attachments/assets/30e76a62-aae3-4918-a246-1cf1d0251b11) | <img width="1026" alt="image" src="https://github.com/user-attachments/assets/a886c3ae-64ab-4179-b561-d865dce8ebe0"> |