### PR TITLE
A4A > Sites Dashboard: Use the DataViews default spinner while loading data

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -1,8 +1,6 @@
-import { Spinner } from '@automattic/components';
 import { usePrevious } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useRef, useLayoutEffect } from 'react';
-import ReactDOM from 'react-dom';
 import { DataViews } from 'calypso/components/dataviews';
 import { ItemsDataViewsType } from './interfaces';
 import type { Field } from '@wordpress/dataviews';
@@ -59,7 +57,6 @@ const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsP
 	const translate = useTranslate();
 	const scrollContainerRef = useRef< HTMLElement >();
 	const previousDataViewsState = usePrevious( data.dataViewsState );
-	const dataviewsWrapper = document.getElementsByClassName( 'dataviews-wrapper' )[ 0 ];
 
 	useLayoutEffect( () => {
 		if (
@@ -107,17 +104,6 @@ const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsP
 				onChangeSelection={ data.onSelectionChange }
 				header={ data.header }
 			/>
-			{ dataviewsWrapper &&
-				ReactDOM.createPortal(
-					/**
-					 * Until the DataViews package is updated to support the spinner, we need to manually add the (loading) spinner to the table wrapper for now.
-					 * todo: The DataViews v0.9 has the spinner support. Remove this once we upgrade the package.
-					 */
-					<div className="spinner-wrapper">
-						<Spinner />
-					</div>,
-					dataviewsWrapper
-				) }
 		</div>
 	);
 };

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
@@ -1,8 +1,7 @@
-import { Button, Gridicon, Spinner } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useMemo, useState } from 'react';
-import ReactDOM from 'react-dom';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
@@ -425,30 +424,6 @@ const SitesDataViews = ( {
 		],
 		[ translate ]
 	);
-
-	// Until the DataViews package is updated to support the spinner, we need to manually add the (loading) spinner to the table wrapper for now.
-	const SpinnerWrapper = () => {
-		return (
-			<div className="spinner-wrapper">
-				<Spinner />
-			</div>
-		);
-	};
-
-	const dataviewsWrapper = document.getElementsByClassName( 'dataviews-wrapper' )[ 0 ];
-	if ( dataviewsWrapper ) {
-		// Remove any existing spinner if present
-		const existingSpinner = dataviewsWrapper.querySelector( '.spinner-wrapper' );
-		if ( existingSpinner ) {
-			existingSpinner.remove();
-		}
-
-		const spinnerWrapper = dataviewsWrapper.appendChild( document.createElement( 'div' ) );
-		spinnerWrapper.classList.add( 'spinner-wrapper' );
-		// Render the SpinnerWrapper component inside the spinner wrapper
-		ReactDOM.hydrate( <SpinnerWrapper />, spinnerWrapper );
-		//}
-	}
 
 	const urlParams = new URLSearchParams( window.location.search );
 	const isOnboardingTourActive = urlParams.get( 'tour' ) !== null;

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/style.scss
@@ -215,32 +215,3 @@
 		}
 	}
 }
-
-
-.dataviews-wrapper {
-	.dataviews-no-results,
-	.dataviews-loading {
-		padding-top: 1rem;
-		text-align: center;
-	}
-
-	.spinner-wrapper {
-		display: none;
-	}
-
-}
-
-.dataviews-wrapper:has(.dataviews-loading) {
-	.spinner-wrapper {
-		display: block;
-	}
-	.dataviews-loading p {
-		display: none;
-	}
-}
-
-.dataviews-wrapper:has(.dataviews-no-results) {
-	.spinner-wrapper {
-		display: none;
-	}
-}

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -160,34 +160,6 @@
 			}
 		}
 	}
-
-	.dataviews-no-results,
-	.dataviews-loading {
-		padding-top: 1rem;
-		text-align: center;
-	}
-
-	.spinner-wrapper {
-		display: none;
-	}
-}
-
-.dataviews-wrapper:has(.dataviews-loading) {
-	.spinner-wrapper {
-		display: block;
-	}
-	.dataviews-loading p {
-		display: none;
-	}
-	.dataviews-pagination {
-		display: none;
-	}
-}
-
-.dataviews-wrapper:has(.dataviews-no-results) {
-	.spinner-wrapper {
-		display: none;
-	}
 }
 
 // TODO: remove when updating to dataviews@4.3.0.


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/1079

## Proposed Changes

This PR removes the custom spinner added initially when the DataViews package (version < 0.9) didn't have it while the data was loading.

- Components removed
- Styles removed, including any related to `.dataviews-loading` `.spinner-wrapper` and `.dataviews-no-results.

**Note** the current spinner in A4A appears at the bottom of the table.

**Loading view**
![image](https://github.com/user-attachments/assets/ea095484-af1a-43c2-9fd2-8109ff3730d2)

**No result view**
![image](https://github.com/user-attachments/assets/a7ac69e8-47e8-468f-9b5f-03de69588eaf)

**Context affected by this change**

- A4A
- Dotcom

## Why are these changes being made?

DataViews already has the built-in spinner while the data is still loading. 

## Testing Instructions

- Check the code
- Load `/sites`
   - You will see the spinner in the middle of the table for a bit.
   - In A4A, you can try to search, and you will see it again for a bit if the search text is not cached. In Dotcom, you will see it for the first time.
- Search by random characters, and you will get the `No results` text in the middle of the table. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
