### PR TITLE
Plugins: Open Education links in Help Center

### DIFF
--- a/client/components/link-card/index.tsx
+++ b/client/components/link-card/index.tsx
@@ -18,7 +18,7 @@ interface LinkCardProps {
 	url: string;
 	target?: string;
 	external?: boolean;
-	onClick?: () => void;
+	onClick?: ( ( event: React.MouseEvent< HTMLAnchorElement > ) => void ) | ( () => void );
 }
 
 const LinkCardContainer = styled.div< LinkCardContainerProps >`

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -1,4 +1,5 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
+import { useOpenArticleInHelpCenter } from '@automattic/help-center/src/hooks';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
@@ -155,15 +156,27 @@ const EducationFooter = () => {
 	const { __ } = useI18n();
 	const localizeUrl = useLocalizeUrl();
 	const dispatch = useDispatch();
+	const { openArticleInHelpCenter } = useOpenArticleInHelpCenter();
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const onClickLinkCard = useCallback(
-		( content_type: string ) => {
+		( content_type: string, url: string ) => ( e: React.MouseEvent< HTMLAnchorElement > ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_plugins_educational_content_click', { content_type } )
 			);
+			if ( isLoggedIn ) {
+				e.preventDefault();
+				openArticleInHelpCenter( url );
+			}
 		},
-		[ dispatch ]
+		[ dispatch, openArticleInHelpCenter ]
 	);
+
+	const websiteBuildingLink = localizeUrl( 'https://wordpress.com/support/plugins/' );
+	const customizationLink = localizeUrl(
+		'https://wordpress.com/support/plugins/install-a-plugin/'
+	);
+	const seoLink = localizeUrl( 'https://wordpress.com/support/plugins/find-and-choose-plugins/' );
 
 	return (
 		<EducationFooterContainer>
@@ -173,8 +186,6 @@ const EducationFooter = () => {
 			/>
 			<ThreeColumnContainer className="plugin-how-to-guides">
 				<LinkCard
-					external
-					target="_blank"
 					title={
 						<CardText color="var(--studio-gray-100)">
 							{ __( 'What Are WordPress Plugins? Everything You Need to Know as a Beginner' ) }
@@ -182,13 +193,11 @@ const EducationFooter = () => {
 					}
 					titleMarginBottom="16px"
 					cta={ <ReadMoreLink /> }
-					url={ localizeUrl( 'https://wordpress.com/support/plugins/' ) }
+					url={ websiteBuildingLink }
 					border="var(--studio-gray-5)"
-					onClick={ () => onClickLinkCard( 'website_building' ) }
+					onClick={ onClickLinkCard( 'website_building', websiteBuildingLink ) }
 				/>
 				<LinkCard
-					external
-					target="_blank"
 					title={
 						<CardText color="var(--studio-gray-100)">
 							{ __(
@@ -198,13 +207,11 @@ const EducationFooter = () => {
 					}
 					titleMarginBottom="16px"
 					cta={ <ReadMoreLink /> }
-					url={ localizeUrl( 'https://wordpress.com/support/plugins/install-a-plugin/' ) }
+					url={ customizationLink }
 					border="var(--studio-gray-5)"
-					onClick={ () => onClickLinkCard( 'customization' ) }
+					onClick={ onClickLinkCard( 'customization', customizationLink ) }
 				/>
 				<LinkCard
-					external
-					target="_blank"
 					title={
 						<CardText color="var(--studio-gray-100)">
 							{ __( 'How to Find and Choose the Best WordPress Plugins (Useful for All Sites)' ) }
@@ -212,9 +219,9 @@ const EducationFooter = () => {
 					}
 					titleMarginBottom="16px"
 					cta={ <ReadMoreLink /> }
-					url={ localizeUrl( 'https://wordpress.com/support/plugins/find-and-choose-plugins/' ) }
+					url={ seoLink }
 					border="var(--studio-gray-5)"
-					onClick={ () => onClickLinkCard( 'seo' ) }
+					onClick={ onClickLinkCard( 'seo', seoLink ) }
 				/>
 			</ThreeColumnContainer>
 		</EducationFooterContainer>
@@ -224,12 +231,7 @@ const EducationFooter = () => {
 function ReadMoreLink() {
 	const { __ } = useI18n();
 
-	return (
-		<CardText color="var(--studio-blue-50)">
-			{ __( 'Read More' ) }
-			<Gridicon icon="external" size={ 12 } />
-		</CardText>
-	);
+	return <CardText color="var(--studio-blue-50)">{ __( 'Learn more' ) }</CardText>;
 }
 
 export default EducationFooter;

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -172,11 +172,11 @@ const EducationFooter = () => {
 		[ dispatch, openArticleInHelpCenter ]
 	);
 
-	const websiteBuildingLink = localizeUrl( 'https://wordpress.com/support/plugins/' );
-	const customizationLink = localizeUrl(
-		'https://wordpress.com/support/plugins/install-a-plugin/'
-	);
-	const seoLink = localizeUrl( 'https://wordpress.com/support/plugins/find-and-choose-plugins/' );
+	const links = {
+		websiteBuilding: localizeUrl( 'https://wordpress.com/support/plugins/' ),
+		customization: localizeUrl( 'https://wordpress.com/support/plugins/install-a-plugin/' ),
+		seo: localizeUrl( 'https://wordpress.com/support/plugins/find-and-choose-plugins/' ),
+	};
 
 	return (
 		<EducationFooterContainer>
@@ -193,9 +193,9 @@ const EducationFooter = () => {
 					}
 					titleMarginBottom="16px"
 					cta={ <ReadMoreLink /> }
-					url={ websiteBuildingLink }
+					url={ links.websiteBuilding }
 					border="var(--studio-gray-5)"
-					onClick={ onClickLinkCard( 'website_building', websiteBuildingLink ) }
+					onClick={ onClickLinkCard( 'website_building', links.websiteBuilding ) }
 				/>
 				<LinkCard
 					title={
@@ -207,9 +207,9 @@ const EducationFooter = () => {
 					}
 					titleMarginBottom="16px"
 					cta={ <ReadMoreLink /> }
-					url={ customizationLink }
+					url={ links.customization }
 					border="var(--studio-gray-5)"
-					onClick={ onClickLinkCard( 'customization', customizationLink ) }
+					onClick={ onClickLinkCard( 'customization', links.customization ) }
 				/>
 				<LinkCard
 					title={
@@ -219,9 +219,9 @@ const EducationFooter = () => {
 					}
 					titleMarginBottom="16px"
 					cta={ <ReadMoreLink /> }
-					url={ seoLink }
+					url={ links.seo }
 					border="var(--studio-gray-5)"
-					onClick={ onClickLinkCard( 'seo', seoLink ) }
+					onClick={ onClickLinkCard( 'seo', links.seo ) }
 				/>
 			</ThreeColumnContainer>
 		</EducationFooterContainer>

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -169,7 +169,7 @@ const EducationFooter = () => {
 				openArticleInHelpCenter( url );
 			}
 		},
-		[ dispatch, openArticleInHelpCenter ]
+		[ dispatch, openArticleInHelpCenter, isLoggedIn ]
 	);
 
 	const links = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9089 and https://github.com/Automattic/wp-calypso/pull/94349


## Proposed Changes

* This PR opens the /plugins "Education" links in the Help Center if the user is logged in.
* If the user is logged out, the /plugins "Education" cards link to the support article in the current tab (because the Help Center is unavailable).
* Note that the Help Center will try to open near the card, but if there is not enough room, it will open in the upper right hand corner of the screen.

<img width="1854" alt="Screenshot 2024-09-12 at 11 23 13 AM" src="https://github.com/user-attachments/assets/24ea56be-3f5d-49b4-a053-156369ee5c3f">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistency in user experience (not opening "internal" content in a new tab)
* Leveraging the Help Center to keep the user on the /plugins screen to maintain context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /plugins while logged in
* Click on the "education cards" and see that the Help Center opens to the correct article in the correct language.
* Go to /plugins/[site] and repeat the test
* Go to /plugins while logged out
* Click on the "education cards" and see the links open in the current tab to the correct article in the correct language.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
