### PR TITLE
White-labeled migration plugin: Update front end to fetch key from new endpoint

### DIFF
--- a/client/landing/stepper/hooks/use-site-migration-key.ts
+++ b/client/landing/stepper/hooks/use-site-migration-key.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
@@ -5,10 +6,27 @@ interface ApiResponse {
 	migration_key: string;
 }
 
-const getMigrationKey = async ( siteId: number ): Promise< ApiResponse > =>
-	wpcom.req.get( `/sites/${ siteId }/atomic-migration-status/migrate-guru-key?http_envelope=1`, {
-		apiNamespace: 'wpcom/v2',
-	} );
+const getMigrationKey = async ( siteId: number ): Promise< ApiResponse > => {
+	const isWhiteLabeledPluginEnabled = config.isEnabled(
+		'migration-flow/enable-white-labeled-plugin'
+	);
+
+	if ( isWhiteLabeledPluginEnabled ) {
+		return wpcom.req.get(
+			`/sites/${ siteId }/atomic-migration-status/wpcom-migration-key?http_envelope=1`,
+			{
+				apiNamespace: 'wpcom/v2',
+			}
+		);
+	}
+
+	return wpcom.req.get(
+		`/sites/${ siteId }/atomic-migration-status/migrate-guru-key?http_envelope=1`,
+		{
+			apiNamespace: 'wpcom/v2',
+		}
+	);
+};
 
 type Options = Pick< UseQueryOptions, 'enabled' >;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* When the white-labeled plugin flag is enabled, we want to get the key from the new endpoint introduced in https://github.com/Automattic/jetpack/pull/39377

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Eventually we'll switch to the Migrate to WordPress.com plugin and that requires getting a different key from the new plugin that we'll make available via an endpoint in Jetpack-mu-wpcom.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/setup/migration-signup`
* Go through signup and get to the Migration Instructions screen
* In a new tab, install the latest version of the Migrate to WordPress.com plugin on the new site (link in Slack channel) and activate it
* Add `&flags=migration-flow/enable-white-labeled-plugin` to the URL and reload the page
* Check the Network tab; you should see requests to an endpoint like `wpcom-migration-key`
* The key should be shown in the "Add your migration key" box and should match the key found in your site's `/wp-admin/admin.php?page=wpcom-migration` page.

<img width="381" alt="Screenshot 2024-09-18 at 1 23 50 PM" src="https://github.com/user-attachments/assets/33c1973a-040d-4639-8712-a765dc294cc1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
