### PR TITLE
Themes: Stop showing upgrade badge to jp sites

### DIFF
--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -12,6 +12,7 @@ import {
 	MARKETPLACE_THEME,
 } from '@automattic/design-picker';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getThemeType, getThemeSoftwareSet } from 'calypso/state/themes/selectors';
 
 import 'calypso/state/themes/init';
@@ -39,7 +40,11 @@ export function canUseTheme( state, siteId, themeId ) {
 	}
 
 	if ( type === DOT_ORG_THEME ) {
-		return siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES );
+		return (
+			siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES ) ||
+			// Atomic sites are tested above through the features system
+			isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+		);
 	}
 
 	if ( type === BUNDLED_THEME ) {


### PR DESCRIPTION



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9052

## Proposed Changes

Change `canuseTheme` to have an explicit check for Jetpack sites when checking whether a site can use a dot org theme.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

A standalone Jetpack site can install themes from WordPress.org but without this change they show an "upgrade" badge on the theme showcase grid

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
1. Create a jurassic.ninja site
2. Connect the site and user to WordPress.com (you can choose the free jp plan)
3. Use the live link below and then go to /themes/your-quirky-sitename.jurassic.ninja
4. Search for "kubrick" or whatever to get some dot org results
5. Check that you don't see an upgrade badge
6. Click through to the theme details page
7. Note that (after giving it a second to update) the cta says "Activate this design" and clicking on it works

Before | After
-------|------
 <img width="1217" alt="Screenshot 2024-09-12 at 20 19 12" src="https://github.com/user-attachments/assets/0ef8e64d-2201-47db-be26-40f1d3d0a2e0"> | <img width="1217" alt="Screenshot 2024-09-12 at 20 17 29" src="https://github.com/user-attachments/assets/f2fa1f30-0763-483c-87ac-ba51e8517de6">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
