### PR TITLE
Hosting dashboard: Fix sites thumbnail margin

### DIFF
--- a/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -15,12 +15,7 @@ import { SiteName } from 'calypso/sites-dashboard/components/sites-site-name';
 import { Truncated } from 'calypso/sites-dashboard/components/sites-site-url';
 import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
 import { ThumbnailLink } from 'calypso/sites-dashboard/components/thumbnail-link';
-import {
-	displaySiteUrl,
-	isNotAtomicJetpack,
-	isStagingSite,
-	MEDIA_QUERIES,
-} from 'calypso/sites-dashboard/utils';
+import { displaySiteUrl, isNotAtomicJetpack, isStagingSite } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
@@ -41,16 +36,6 @@ const SiteListTile = styled( ListTile )`
 		gap: 12px;
 		max-width: 500px;
 		width: 100%;
-	}
-
-	${ MEDIA_QUERIES.hideTableRows } {
-		margin-inline-end: 12px;
-	}
-`;
-
-const ListTileLeading = styled( ThumbnailLink )`
-	${ MEDIA_QUERIES.hideTableRows } {
-		margin-inline-end: 12px;
 	}
 `;
 
@@ -106,14 +91,14 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 						borderless
 						disabled={ site.is_deleted }
 					>
-						<ListTileLeading title={ title }>
+						<ThumbnailLink title={ title }>
 							<SiteFavicon
 								className="sites-site-favicon"
 								blogId={ site.ID }
 								fallback="first-grapheme"
 								size={ 56 }
 							/>
-						</ListTileLeading>
+						</ThumbnailLink>
 					</Button>
 				}
 				title={


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/94202

## Proposed Changes

* Removes extra margin on /sites thumbnails.

Before | After
--|--
<img width="886" alt="Screenshot 2024-09-12 at 4 00 19 PM" src="https://github.com/user-attachments/assets/8fcf21a7-d6ca-4bc5-a5ba-576bc73ef93a">  |  <img width="885" alt="Screenshot 2024-09-12 at 4 00 29 PM" src="https://github.com/user-attachments/assets/5ce483da-314c-4098-b6ca-e652c1ca4c96">




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve aesthetics and readability.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /sites and ensure the site list and thumbnails look good in various widths.
* Try searching and filtering with different criteria to try and break the layout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
