### PR TITLE
A4A: update wording for magic link flows

### DIFF
--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -15,6 +15,7 @@ import {
 	isGravPoweredOAuth2Client,
 	isWPJobManagerOAuth2Client,
 	isWooOAuth2Client,
+	isA4AOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -178,6 +179,7 @@ class HandleEmailedLinkForm extends Component {
 			activate,
 			wccomFrom,
 			isWoo,
+			isA4A,
 		} = this.props;
 		const isWooDna = wooDnaConfig( initialQuery ).isWooDnaFlow();
 		const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
@@ -206,6 +208,8 @@ class HandleEmailedLinkForm extends Component {
 			buttonLabel = translate( 'Continue to Woo Express' );
 		} else if ( isWoo ) {
 			buttonLabel = translate( 'Continue to Woo.com' );
+		} else if ( isA4A ) {
+			buttonLabel = translate( 'Continue to Automattic for Agencies' );
 		} else {
 			buttonLabel = translate( 'Continue to WordPress.com' );
 		}
@@ -225,6 +229,8 @@ class HandleEmailedLinkForm extends Component {
 			title = translate( 'Update your payment details and renew your subscription' );
 		} else if ( isWooDna ) {
 			title = wooDnaConfig( initialQuery ).getServiceName();
+		} else if ( isA4A ) {
+			title = translate( 'Finish sign up using your WordPress.com account' );
 		} else {
 			title =
 				this.props.clientId === config( 'wpcom_signup_id' )
@@ -319,6 +325,7 @@ const mapState = ( state ) => {
 		twoFactorNotificationSent: getTwoFactorNotificationSent( state ),
 		initialQuery: getInitialQueryArguments( state ),
 		isWoo: isWooOAuth2Client( oauth2Client ),
+		isA4A: isA4AOAuth2Client( oauth2Client ),
 		wccomFrom: getWccomFrom( state ),
 		oauth2Client,
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1726168402114319/1725918582.678639-slack-C047ACYM8UQ

## Proposed Changes

This PR should update magic link screen with proper wording as here:

<img width="451" alt="Screenshot 2024-09-12 at 3 15 19 PM" src="https://github.com/user-attachments/assets/0d975251-0ea7-4e1d-9014-b7de4a5f29f6">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I'm not sure on how we could test this flow with local branch, as there's a couple redirects involved.
To generate magic link for a4a and given email you can use this page: https://automattic.com/for-agencies/wordcamp/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?