### PR TITLE
Try: remove style variation badges from theme card

### DIFF
--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -2,7 +2,6 @@ import { Card, Popover } from '@automattic/components';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { forwardRef, useMemo, useRef, useState } from 'react';
-import StyleVariationBadges from '../style-variation-badges';
 import type { StyleVariation } from '../../types';
 import type { Ref } from 'react';
 import './style.scss';
@@ -63,7 +62,6 @@ const ThemeCard = forwardRef(
 			banner,
 			badge,
 			styleVariations = [],
-			selectedStyleVariation,
 			optionsMenu,
 			isActive,
 			isLoading,
@@ -71,8 +69,6 @@ const ThemeCard = forwardRef(
 			isSoftLaunched,
 			onClick,
 			onImageClick,
-			onStyleVariationClick,
-			onStyleVariationMoreClick,
 		}: ThemeCardProps,
 		forwardedRef: Ref< any > // eslint-disable-line @typescript-eslint/no-explicit-any
 	) => {
@@ -88,6 +84,7 @@ const ThemeCard = forwardRef(
 		const themeInfoClasses = clsx( 'theme-card__info', {
 			'theme-card__info--has-style-variations': styleVariations.length > 0,
 		} );
+		const shouldDisplayBadge = ! isActive && ! optionsMenu;
 
 		return (
 			<Card
@@ -145,17 +142,7 @@ const ThemeCard = forwardRef(
 						<h2 className="theme-card__info-title">
 							<span>{ name }</span>
 						</h2>
-						{ ! optionsMenu && styleVariations.length > 0 && (
-							<div className="theme-card__info-style-variations">
-								<StyleVariationBadges
-									variations={ styleVariations }
-									selectedVariation={ selectedStyleVariation }
-									onMoreClick={ onStyleVariationMoreClick }
-									onClick={ onStyleVariationClick }
-								/>
-							</div>
-						) }
-						{ ! isActive && <>{ badge }</> }
+						{ shouldDisplayBadge && <div className="theme-card__info-tier-badge">{ badge }</div> }
 						{ optionsMenu && <div className="theme-card__info-options">{ optionsMenu }</div> }
 						{ isActive && <ActiveBadge /> }
 					</div>

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -276,19 +276,11 @@ $theme-card-info-margin-top: 16px;
 	width: 0;
 }
 
-.theme-card__info-style-variations {
+.theme-card__info-tier-badge {
 	align-items: center;
 	display: flex;
 	font-size: 0;
-	gap: 4px;
 	height: 24px;
-
-	.style-variation__badge-wrapper,
-	.style-variation__badge-more-wrapper {
-		&:focus-visible span {
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2), 0 0 0 2px var(--color-primary-light);
-		}
-	}
 }
 
 .theme-card__info-options,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #93931

## Proposed Changes

* Remove Style Variation badges from Theme Cards.
* Place the Theme Tier badge where the Style Variation badges were.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To simplify the visual layout of theme cards by removing the redundant style variation badges.
* To address user feedback from [#93799](https://github.com/Automattic/wp-calypso/issues/93799), which highlighted that multiple badges on theme cards were causing confusion and visual clutter.
* By removing the style variation badges and keeping only the Theme Tier badge, the theme selection process becomes focused on key information (Theme Tier).

| Before                        | After                         |
|-------------------------------|-------------------------------|
| ![image](https://github.com/user-attachments/assets/94a6d827-3dc2-4627-92af-cf9f319532be)| ![image](https://github.com/user-attachments/assets/25ef8dce-4e9c-4024-9e25-009de21872ef) |
| Multiple badges displayed, including style variations, which caused visual clutter.     | Only the Theme Tier badge is displayed, simplifying the UI. |   

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that style variation badges have been removed from all theme cards.
* Check that the Theme Tier badge now appears in place of the removed style variation badges.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
