### PR TITLE
Align checkout review elements

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -905,10 +905,14 @@ const CheckoutTermsAndCheckboxesWrapper = styled.div`
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
-	padding: 32px 20px 0 24px;
+	padding: 24px;
 	width: 100%;
-	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		padding: 12px 20px 0 40px;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding-top: 50px;
+		padding-bottom: 0;
+		padding-inline-start: 40px;
+		padding-inline-end: 0;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -52,11 +52,12 @@ const CouponLinkWrapper = styled.div`
 `;
 
 const CouponAreaWrapper = styled.div`
-	padding-bottom: 12px;
-	padding-top: 28px;
+	padding: 24px;
 	align-self: stretch;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding-top: 50px;
+		padding-bottom: 0;
 		padding-inline-start: 40px;
 		padding-inline-end: 0;
 	}

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -534,9 +534,7 @@ export const CheckoutStepAreaWrapper = styled.div`
 
 export const SubmitButtonWrapper = styled.div`
 	background: ${ ( props ) => props.theme.colors.surface };
-	padding: 24px 16px;
-	bottom: 0;
-	left: 0;
+	padding: 24px;
 	box-sizing: border-box;
 	width: 100%;
 	z-index: 10;


### PR DESCRIPTION
As noted in [this issue](https://github.com/Automattic/wp-calypso/issues/94187), the coupon link in Checkout appears to break outside of the layout when the browser size shrinks below 700px wide.

**Before**
![image](https://github.com/user-attachments/assets/1e61b76a-5d70-4e1d-bb1b-82bc61ce8620)

I also noticed some weirdness with the ToS section since it uses the `desktopUp` breakpoint instead of the `tabletUp`, so I fixed these too.

**Before**
![image](https://github.com/user-attachments/assets/f2a781eb-5973-4c93-8992-72f6aeb7741c)

**After**
![image](https://github.com/user-attachments/assets/6c5c8e19-d4e4-4a98-8fc8-f1c03e89fbb6)

![image](https://github.com/user-attachments/assets/2f9180bf-6607-40bc-a13a-b32bef4537b9)

![image](https://github.com/user-attachments/assets/8bef6146-15bf-4236-9b66-53d421840a10)
![image](https://github.com/user-attachments/assets/7544efe3-b64a-4fb0-9811-7e844ec3dcdc)

Related to #94187

## Testing Instructions

* Go to Checkout and adjust your browser width to wider than 700px.
* Check with devtools that the coupon and ToS sections have a padding of:
```
padding-top: 50px;
padding-bottom: 0;
padding-inline-start: 40px;
padding-inline-end: 0;
```
* Reduce the browser size to below 700px
* Check that the coupon, ToS, AND submit button sections have a padding of `padding: 24px;`
