### PR TITLE
Stats: add upsell overlay support for date range picker

### DIFF
--- a/client/components/date-range/README.md
+++ b/client/components/date-range/README.md
@@ -36,6 +36,7 @@ Props are displayed as a table with Name, Type, Default, and Description as head
 | `triggerText( startDateText, endDateText )` | `Function`                  | `undefined`         | function to generate the text displayed in the trigger button. Passed the start/end date text in `MM/DD/YYYY` format (or locale-specific alternative)                                                |
 | `displayShortcuts`                          | `Boolean`                   | `false`             | determines whether to display the shortcuts menu alongside the calendar                                                                                                                              |
 | `useArrowNavigation`                        | `Boolean`                   | `false`             | determines whether to display the arrow navigation instead of the month labelled buttons as navigation between calendar months                                                                       |
+| `overlay`                        | `node`                   | `null`             | renders the overlay above the calendar and date inputs if passed |
 
 #### Render Props
 

--- a/client/components/date-range/docs/example.jsx
+++ b/client/components/date-range/docs/example.jsx
@@ -80,11 +80,7 @@ class DateRangeExample extends Component {
 					<DateRange
 						useArrowNavigation
 						displayShortcuts
-						overlay={
-							<div style={ { width: '100%', height: '100%' } }>
-								🔒 Please upgrade to use the date range picker.
-							</div>
-						}
+						overlay={ <div>🔒 Please upgrade to use the date range picker.</div> }
 					/>
 				</Card>
 			</Fragment>

--- a/client/components/date-range/docs/example.jsx
+++ b/client/components/date-range/docs/example.jsx
@@ -74,6 +74,19 @@ class DateRangeExample extends Component {
 				<Card>
 					<DateRange useArrowNavigation />
 				</Card>
+
+				<h3>With Overlay Enabled</h3>
+				<Card>
+					<DateRange
+						useArrowNavigation
+						displayShortcuts
+						overlay={
+							<div style={ { width: '100%', height: '100%' } }>
+								🔒 Please upgrade to use the date range picker.
+							</div>
+						}
+					/>
+				</Card>
 			</Fragment>
 		);
 	}

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -48,6 +48,7 @@ export class DateRange extends Component {
 		displayShortcuts: PropTypes.bool,
 		rootClass: PropTypes.string,
 		useArrowNavigation: PropTypes.bool,
+		overlay: PropTypes.node,
 	};
 
 	static defaultProps = {
@@ -62,6 +63,7 @@ export class DateRange extends Component {
 		displayShortcuts: false,
 		rootClass: '',
 		useArrowNavigation: false,
+		overlay: null,
 	};
 
 	constructor( props ) {
@@ -474,7 +476,14 @@ export class DateRange extends Component {
 				onClose={ this.closePopoverAndCommit }
 			>
 				<div className="date-range__popover-content">
-					<div className="date-range__popover-inner">
+					<div
+						className={ clsx( 'date-range__popover-inner', {
+							'date-range__popover-inner__hasoverlay': !! this.props.overlay,
+						} ) }
+					>
+						{ this.props.overlay && (
+							<div className="date-range__popover-inner-overlay">{ this.props.overlay }</div>
+						) }
 						<div className="date-range__controls">
 							{ this.props.renderHeader( headerProps ) }
 							{ this.renderDateHelp() }
@@ -488,6 +497,7 @@ export class DateRange extends Component {
 							<Shortcuts
 								currentShortcut={ this.state.currentShortcut }
 								onClick={ this.handleDateRangeChange }
+								locked={ !! this.props.overlay }
 							/>
 						</div>
 					) }

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -14,9 +14,11 @@ const DATERANGE_PERIOD = {
 const DateRangePickerShortcuts = ( {
 	currentShortcut,
 	onClick,
+	locked = false,
 }: {
 	currentShortcut?: string;
 	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment, shortcutId: string ) => void;
+	locked?: boolean;
 } ) => {
 	const translate = useTranslate();
 
@@ -82,7 +84,7 @@ const DateRangePickerShortcuts = ( {
 						} ) }
 						key={ shortcut.id || idx }
 					>
-						<Button onClick={ () => handleClick( shortcut ) }>
+						<Button onClick={ () => ! locked && handleClick( shortcut ) }>
 							<span>{ shortcut.label }</span>
 							{ shortcut.id === currentShortcut && <Icon icon={ check } /> }
 						</Button>

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -55,6 +55,26 @@ $date-range-mobile-layout-switch: $break-small;
 	@include breakpoint-deprecated( "<480px" ) {
 		max-width: 300px;
 	}
+
+	&.date-range__popover-inner__hasoverlay {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+
+		.date-range__controls,
+		.date-range__date-inputs,
+		.date-range__picker {
+			filter: blur(10px);
+			z-index: 0;
+		}
+
+		.date-range__popover-inner-overlay {
+			position: absolute;
+			z-index: 1;
+			height: 100%;
+		}
+
+	}
 }
 
 .date-range__controls {

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -57,10 +57,6 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 
 	&.date-range__popover-inner__hasoverlay {
-		display: flex;
-		justify-content: center;
-		align-items: center;
-
 		.date-range__controls,
 		.date-range__date-inputs,
 		.date-range__picker {
@@ -72,6 +68,11 @@ $date-range-mobile-layout-switch: $break-small;
 			position: absolute;
 			z-index: 1;
 			height: 100%;
+			width: 70%;
+
+			display: flex;
+			justify-content: center;
+			align-items: center;
 		}
 
 	}

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -57,24 +57,23 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 
 	&.date-range__popover-inner__hasoverlay {
+		position: relative;
 		.date-range__controls,
 		.date-range__date-inputs,
 		.date-range__picker {
 			filter: blur(10px);
 			z-index: 0;
 		}
-
 		.date-range__popover-inner-overlay {
 			position: absolute;
 			z-index: 1;
-			height: 100%;
-			width: 70%;
+			height: calc(100% - 30px);
+			width: calc(100% - 30px);
 
 			display: flex;
 			justify-content: center;
 			align-items: center;
 		}
-
 	}
 }
 

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -146,6 +146,7 @@ const StatsDateControl = ( {
 						);
 					} }
 					rootClass="stats-date-control-picker"
+					overlay={ overlay }
 					displayShortcuts
 					useArrowNavigation
 				/>


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/163

## Proposed Changes

* Date Range picker allow an overlay component
* Added example

## Why are these changes being made?

* Support upsell overlay for Jetpack Stats

## Testing Instructions

* Open Live Branch `/devdocs/design/date-range`
* Scroll to With Overlay Enabled
* Ensure the overlay shows okay
* Open `/stats/day/:siteSlug?flags=stats/date-picker-calendar` for a site with restricted dashboard
  * Or if test locally you could change [here](https://github.com/Automattic/wp-calypso/blob/cd99aa2f724201d39705d8dc29a1b69045a28d67/client/my-sites/stats/stats-period-navigation/index.jsx#L218) 
* Ensure upsell overlay works okay 

<img width="783" alt="image" src="https://github.com/user-attachments/assets/94a68756-24ef-4c52-a6b3-a209d967bde3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
