### PR TITLE
Remove feature flag and ship Woo database sync from staging sites

### DIFF
--- a/client/hosting/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/hosting/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
@@ -44,7 +43,6 @@ export const NewStagingSiteCardContent = ( {
 	{
 		const translate = useTranslate();
 		const hasEnTranslation = useHasEnTranslation();
-		const stagingSiteSyncWoo = config.isEnabled( 'staging-site-sync-woo' );
 		const isSiteWooStore = !! useSelector( ( state ) => isSiteStore( state, siteId ) );
 
 		return (
@@ -74,7 +72,7 @@ export const NewStagingSiteCardContent = ( {
 								}
 						  ) }
 				</HostingCardDescription>
-				{ stagingSiteSyncWoo && isSiteWooStore && (
+				{ isSiteWooStore && (
 					<WarningContainer>
 						<WarningTitle>{ translate( 'WooCommerce Site' ) }</WarningTitle>
 						<WarningDescription>

--- a/client/hosting/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/hosting/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { FormLabel } from '@automattic/components';
 import styled from '@emotion/styled';
 import { translate, useTranslate } from 'i18n-calypso';
@@ -238,8 +237,6 @@ const StagingToProductionSync = ( {
 		[ translate ]
 	);
 
-	const stagingSiteSyncWoo = config.isEnabled( 'staging-site-sync-woo' );
-
 	return (
 		<>
 			{ showSyncPanel && (
@@ -276,7 +273,7 @@ const StagingToProductionSync = ( {
 									return <li key={ item.name }>{ item.label }</li>;
 								} ) }
 							</ConfirmationModalList>
-							{ stagingSiteSyncWoo && isSiteWooStore && isSqlSyncOptionChecked && (
+							{ isSiteWooStore && isSqlSyncOptionChecked && (
 								<SyncWarningContainer>
 									<SyncWarningTitle>{ translate( 'Warning:' ) }</SyncWarningTitle>
 									<SyncWarningContent>
@@ -533,10 +530,7 @@ export const SiteSyncCard = ( {
 	}, [ isSqlSyncOptionChecked, databaseSyncConfirmed, setdatabaseSyncConfirmed ] );
 
 	const disallowWooCommerceSync =
-		config.isEnabled( 'staging-site-sync-woo' ) &&
-		isSiteWooStore &&
-		isSqlSyncOptionChecked &&
-		! databaseSyncConfirmed;
+		isSiteWooStore && isSqlSyncOptionChecked && ! databaseSyncConfirmed;
 
 	const isSyncButtonDisabled =
 		disabled ||
@@ -562,8 +556,6 @@ export const SiteSyncCard = ( {
 			setSelectedItems( [] );
 		}
 	}, [ dispatch, selectedOption, status, syncError ] );
-
-	const stagingSiteSyncWoo = config.isEnabled( 'staging-site-sync-woo' );
 
 	return (
 		<SyncCardContainer
@@ -624,7 +616,7 @@ export const SiteSyncCard = ( {
 					selectedItems={ selectedItems }
 					isSyncButtonDisabled={ isSyncButtonDisabled }
 					onConfirm={ selectedOption === 'push' ? onPushInternal : onPullInternal }
-					isSqlsOptionDisabled={ stagingSiteSyncWoo ? false : isSiteWooStore }
+					isSqlsOptionDisabled={ false }
 					isSiteWooStore={ isSiteWooStore }
 					databaseSyncConfirmed={ databaseSyncConfirmed }
 					setdatabaseSyncConfirmed={ setdatabaseSyncConfirmed }

--- a/client/hosting/staging-site/components/staging-site-card/sync-options-panel.tsx
+++ b/client/hosting/staging-site/components/staging-site-card/sync-options-panel.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import styled from '@emotion/styled';
 import { ToggleControl, CheckboxControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
@@ -152,8 +151,6 @@ export default function SyncOptionsPanel( {
 		onChange( selectedItems );
 	}, [ optionItemsMap, onChange ] );
 
-	const stagingSiteSyncWoo = config.isEnabled( 'staging-site-sync-woo' );
-
 	return (
 		<>
 			{ nonDangerousItems.map( ( item ) => {
@@ -201,7 +198,7 @@ export default function SyncOptionsPanel( {
 						</div>
 					);
 				} ) }
-				{ stagingSiteSyncWoo && isSiteWooStore && (
+				{ isSiteWooStore && (
 					<div>
 						<WooCommerceOverwriteWarning>
 							{ translate(

--- a/client/hosting/staging-site/hooks/use-staging-sync.ts
+++ b/client/hosting/staging-site/hooks/use-staging-sync.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useMutation, UseMutationOptions, useIsMutating } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
@@ -53,8 +52,6 @@ export const usePullFromStagingMutation = (
 		MutationVariables
 	>
 ) => {
-	const isStagingSiteSyncWooEnabled = config.isEnabled( 'staging-site-sync-woo' );
-
 	const mutation = useMutation( {
 		mutationFn: async ( options ) =>
 			wp.req.post(
@@ -62,7 +59,7 @@ export const usePullFromStagingMutation = (
 					path: `/sites/${ productionSiteId }/staging-site/pull-from-staging/${ stagingSiteId }`,
 					apiNamespace: 'wpcom/v2',
 				},
-				{ options, allow_woo_sync: isStagingSiteSyncWooEnabled ? 1 : 0 }
+				{ options, allow_woo_sync: 1 }
 			),
 		...options,
 		mutationKey: [ PULL_FROM_STAGING, stagingSiteId ],


### PR DESCRIPTION
## Proposed Changes

Review it but **do not merge this**

We are removing the `staging-site-sync-woo` feature flag and releasing the Woo SQL Sync to all users.

## Testing Instructions

The new messaging should be displayed when WooCommerce plugin is active on the site.


### Before creating a staging site
The new `Preview and troubleshoot changes before updating your production site` message should be visible only when WooCommerce is active.
| WooCommerce active   |      WooCommerce deactivated      |  
|----------|:-------------:|
| ![image](https://github.com/user-attachments/assets/63e19fc4-8159-480c-974b-a07f038c6d30) |  ![image](https://github.com/user-attachments/assets/931d0e29-61fb-44b9-ad56-c3192e5b033d) | 


### Toggling Site database (SQL)
If WooCommerce is not active on the site, you should be able to Sync SQL without any warning.
If WooCommerce is active, you should see the new messaging. If user toggle to sync SQL, the `Synchronize` button should be disabled until the confirmation checkbox is checked.

| WooCommerce active   |   WooCommerce deactivated      | 
|----------|:-------------:|
|![image](https://github.com/user-attachments/assets/64cefd0f-2e17-4130-8c01-d48a42aa09a9) | ![image](https://github.com/user-attachments/assets/a061be22-af17-4eaa-ae04-d874eb807ea0) |

### Confirmation modal
After clicking on `Synchronize` button user should see the final confirmation modal.

If WooCommerce is active, you should see the new warning box.
If WooCommerce is not active, the warning box should not be present.

Also test that if the SQL option is **not toggled**, the new warning box should not be present even if WooCommerce is active.

| WooCommerce active   |      WooCommerce deactivated      |      WooCommerce active *BUT* SQL is not toggled  | 
|----------|:-------------:|:-------------:|
| ![image](https://github.com/user-attachments/assets/a36aa2f8-9650-466f-a25b-eed5b660f50e) | ![image](https://github.com/user-attachments/assets/c1d1d5f7-4aeb-4b39-95aa-9098185fe70e) | ![image](https://github.com/user-attachments/assets/64779373-5eb6-47f0-ae82-dd68c863fa2e) |


### Test syncing

Complete the sync with WooCommerce toggling the SQL option.
It may take some time, but syncing data from staging to production should work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
