### PR TITLE
Stats: Date control update: adjust selected date colors

### DIFF
--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -221,7 +221,7 @@ $date-picker_nav_button_size: 20px;
 // `today` day
 .DayPicker-Day--today .date-picker__day {
 	color: var(--color-text-inverted);
-	background-color: var(--color-neutral-70);
+	background-color: var(--color-neutral-light);
 
 	&:hover {
 		background-color: var(--color-neutral-50);

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -143,8 +143,6 @@ $date-range-mobile-layout-switch: $break-small;
 .date-range__popover {
 	.DayPicker {
 		order: 3;
-		margin-top: 12px;
-		border-top: 1px solid var(--color-neutral-5);
 	}
 
 	.DayPicker-wrapper,

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -247,31 +247,38 @@ $date-range-mobile-layout-switch: $break-small;
 		}
 	}
 
-	.DayPicker-Day--range,
+	.DayPicker-Day--range .date-picker__day {
+		color: var(--color-text);
+		background-color: var(--color-neutral-20);
+	}
+
 	.DayPicker-Day--start,
 	.DayPicker-Day--end {
-		.date-picker__day {
+		&.DayPicker-Day--range .date-picker__day {
 			color: var(--color-text-inverted);
 			background-color: var(--color-primary);
 		}
+		&:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+			border-radius: 200px; /* stylelint-disable-line scales/radii */
+			&.DayPicker-Day--range {
+				background-color: var(--color-primary);
+				.date-picker__day {
+					&:hover,
+					&:focus {
+						background-color: var(--color-neutral-20);
+					}
+				}
+			}
+		}
 	}
 
-	.DayPicker-Day--range:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),
-	.DayPicker-Day--start:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),
-	.DayPicker-Day--end:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-		background-color: var(--color-primary);
+	.DayPicker-Day--range:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+		background-color: var(--color-neutral-20);
 		.date-picker__day {
 			&:hover,
 			&:focus {
 				background-color: var(--color-primary-light);
 			}
-		}
-	}
-
-	.DayPicker-Day--start,
-	.DayPicker-Day--end {
-		&:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-			border-radius: 200px; /* stylelint-disable-line scales/radii */
 		}
 	}
 

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -3,6 +3,10 @@
 $date-range-shortcut-min-width: 140px;
 $date-range-mobile-layout-switch: $break-small;
 
+:root {
+	--date-range-picker-highlight-color: rgba(var(--color-primary-light-rgb), 0.7);
+}
+
 .date-range {
 	position: relative;
 	display: flex;
@@ -240,14 +244,14 @@ $date-range-mobile-layout-switch: $break-small;
 			&:hover,
 			&:focus {
 				color: var(--color-text-inverted);
-				background-color: var(--color-primary);
+				background-color: var(--date-range-picker-highlight-color);
 			}
 		}
 	}
 
 	.DayPicker-Day--range .date-picker__day {
 		color: var(--color-text);
-		background-color: rgba(var(--color-primary-light-rgb), 0.7);
+		background-color: var(--date-range-picker-highlight-color);
 	}
 
 	.DayPicker-Day--start.DayPicker-Day--range-start,
@@ -263,7 +267,7 @@ $date-range-mobile-layout-switch: $break-small;
 				.date-picker__day {
 					&:hover,
 					&:focus {
-						background-color: rgba(var(--color-primary-light-rgb), 0.7);
+						background-color: var(--date-range-picker-highlight-color);
 					}
 				}
 			}
@@ -271,13 +275,9 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 
 	.DayPicker-Day--range:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-		background-color: rgba(var(--color-primary-light-rgb), 0.7);
+		background-color: var(--date-range-picker-highlight-color);
 		.date-picker__day {
 			background-color: transparent;
-			&:hover,
-			&:focus {
-				background-color: var(--color-primary-light);
-			}
 		}
 	}
 

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -3,10 +3,6 @@
 $date-range-shortcut-min-width: 140px;
 $date-range-mobile-layout-switch: $break-small;
 
-:root {
-	--date-range-picker-highlight-color: rgba(var(--color-primary-light-rgb), 0.7);
-}
-
 .date-range {
 	position: relative;
 	display: flex;
@@ -229,6 +225,7 @@ $date-range-mobile-layout-switch: $break-small;
 
 
 .date-range__picker {
+	--date-range-picker-highlight-color: rgba(var(--color-primary-light-rgb), 0.4);
 
 	.DayPicker-Day,
 	.DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -249,7 +249,7 @@ $date-range-mobile-layout-switch: $break-small;
 
 	.DayPicker-Day--range .date-picker__day {
 		color: var(--color-text);
-		background-color: var(--color-neutral-20);
+		background-color: var(--theme-highlight-color-0);
 	}
 
 	.DayPicker-Day--start,
@@ -265,7 +265,7 @@ $date-range-mobile-layout-switch: $break-small;
 				.date-picker__day {
 					&:hover,
 					&:focus {
-						background-color: var(--color-neutral-20);
+						background-color: var(--theme-highlight-color-0);
 					}
 				}
 			}
@@ -273,7 +273,7 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 
 	.DayPicker-Day--range:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-		background-color: var(--color-neutral-20);
+		background-color: var(--theme-highlight-color-0);
 		.date-picker__day {
 			&:hover,
 			&:focus {

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -249,12 +249,12 @@ $date-range-mobile-layout-switch: $break-small;
 
 	.DayPicker-Day--range .date-picker__day {
 		color: var(--color-text);
-		background-color: var(--theme-highlight-color-0);
+		background-color: rgba(var(--color-primary-light-rgb), 0.7);
 	}
 
-	.DayPicker-Day--start,
-	.DayPicker-Day--end {
-		&.DayPicker-Day--range .date-picker__day {
+	.DayPicker-Day--start.DayPicker-Day--range-start,
+	.DayPicker-Day--end.DayPicker-Day--range-end {
+		& .date-picker__day {
 			color: var(--color-text-inverted);
 			background-color: var(--color-primary);
 		}
@@ -265,7 +265,7 @@ $date-range-mobile-layout-switch: $break-small;
 				.date-picker__day {
 					&:hover,
 					&:focus {
-						background-color: var(--theme-highlight-color-0);
+						background-color: rgba(var(--color-primary-light-rgb), 0.7);
 					}
 				}
 			}
@@ -273,8 +273,9 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 
 	.DayPicker-Day--range:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-		background-color: var(--theme-highlight-color-0);
+		background-color: rgba(var(--color-primary-light-rgb), 0.7);
 		.date-picker__day {
+			background-color: transparent;
 			&:hover,
 			&:focus {
 				background-color: var(--color-primary-light);


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/176

## Proposed Changes

* Use accent color for start and end dates
* Use highlight color for the date range in between

## Why are these changes being made?

* Match the design better

## Testing Instructions

* Open Calypso Live Branch `/stats/day/:siteSlug?flags=stats%2Fdate-picker-calendar`
* Open date range popover
* Ensure start/end/range dates are colored like the following
* Switch themes
* Ensure the colors look okay

<img width="495" alt="image" src="https://github.com/user-attachments/assets/3e240fab-0a89-44f1-8302-b4a43fbcdd1f">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
