### PR TITLE
Logged-in Performance Profiler: Add version 2 of core web vitals details section

### DIFF
--- a/client/performance-profiler/components/charts/history-chart.jsx
+++ b/client/performance-profiler/components/charts/history-chart.jsx
@@ -97,7 +97,7 @@ const drawLine = ( svg, data, xScale, yScale ) => {
 };
 
 // Draw axes
-const drawAxes = ( svg, xScale, yScale, data, margin, width, height ) => {
+const drawAxes = ( svg, xScale, yScale, data, margin, width, height, d3Format ) => {
 	const dates = data.map( ( item ) => new Date( item.date ) );
 
 	svg
@@ -106,7 +106,7 @@ const drawAxes = ( svg, xScale, yScale, data, margin, width, height ) => {
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( dates )
-				.tickFormat( d3TimeFormat( '%-m/%d' ) )
+				.tickFormat( d3TimeFormat( d3Format ) )
 				.tickPadding( 10 )
 		)
 		.call( ( g ) => g.select( '.domain' ).remove() );
@@ -181,7 +181,7 @@ const generateSampleData = ( range ) => {
 	return data;
 };
 
-const HistoryChart = ( { data, range, height } ) => {
+const HistoryChart = ( { data, range, height, d3Format = '%-m/%d' } ) => {
 	const translate = useTranslate();
 	const svgRef = createRef();
 	const tooltipRef = createRef();
@@ -212,11 +212,11 @@ const HistoryChart = ( { data, range, height } ) => {
 		drawGrid( svg, yScale, width, margin );
 
 		dataAvailable && drawLine( svg, data, xScale, yScale );
-		drawAxes( svg, xScale, yScale, data, margin, width, height );
+		drawAxes( svg, xScale, yScale, data, margin, width, height, d3Format );
 
 		const tooltip = d3Select( tooltipRef.current ).attr( 'class', 'tooltip' );
 		dataAvailable && drawDots( svg, data, xScale, yScale, colorScale, range, tooltip );
-	}, [ dataAvailable, data, range, svgRef, tooltipRef, height, entry ] );
+	}, [ dataAvailable, data, range, svgRef, tooltipRef, height, entry, d3Format ] );
 
 	return (
 		<div className="chart-container">

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
@@ -1,0 +1,177 @@
+import { useTranslate } from 'i18n-calypso';
+import { Metrics, PerformanceMetricsHistory } from 'calypso/data/site-profiler/types';
+import {
+	metricsNames,
+	metricsTresholds,
+	mapThresholdsToStatus,
+	metricValuations,
+	displayValue,
+} from 'calypso/performance-profiler/utils/metrics';
+import HistoryChart from '../charts/history-chart';
+import { StatusIndicator } from '../status-indicator';
+import { StatusSection } from '../status-section';
+
+type CoreWebVitalsDetailsProps = Record< Metrics, number > & {
+	history: PerformanceMetricsHistory;
+	activeTab: Metrics | null;
+};
+
+export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
+	activeTab,
+	history,
+	...metrics
+} ) => {
+	const translate = useTranslate();
+
+	if ( ! activeTab ) {
+		return null;
+	}
+
+	const { name: displayName } = metricsNames[ activeTab ];
+	const value = metrics[ activeTab ];
+
+	const { good, needsImprovement } = metricsTresholds[ activeTab ];
+
+	const formatUnit = ( value: number ) => {
+		if ( [ 'lcp', 'fcp', 'ttfb' ].includes( activeTab ) ) {
+			return +( value / 1000 ).toFixed( 2 );
+		}
+		return value;
+	};
+
+	const displayUnit = () => {
+		if ( [ 'lcp', 'fcp', 'ttfb' ].includes( activeTab ) ) {
+			return translate( 's', { comment: 'Used for displaying a time range in seconds, eg. 1-2s' } );
+		}
+		if ( [ 'inp', 'tbt' ].includes( activeTab ) ) {
+			return translate( 'ms', {
+				comment: 'Used for displaying a range in milliseconds, eg. 100-200ms',
+			} );
+		}
+		return '';
+	};
+
+	// Add leading zero to date values. Safari expects the date string to follow the ISO 8601 format (i.e., YYYY-MM-DD)
+	const addLeadingZero = ( value: number ) => {
+		if ( value < 10 ) {
+			return `0${ value }`;
+		}
+		return value;
+	};
+
+	let metricsData: number[] = history?.metrics[ activeTab ] ?? [];
+	let dates = history?.collection_period ?? [];
+
+	// last 8 weeks only
+	metricsData = metricsData.slice( -8 );
+	dates = dates.slice( -8 );
+
+	const dataAvailable = metricsData.length > 0 && metricsData.some( ( item ) => item !== null );
+	const historicalData = metricsData.map( ( item, index ) => {
+		let formattedDate: unknown;
+		const date = dates[ index ];
+		if ( 'string' === typeof date ) {
+			formattedDate = date;
+		} else {
+			const { year, month, day } = date;
+			formattedDate = `${ year }-${ addLeadingZero( month ) }-${ addLeadingZero( day ) }`;
+		}
+
+		return {
+			date: formattedDate,
+			value: formatUnit( item ),
+		};
+	} );
+
+	const status = mapThresholdsToStatus( activeTab as Metrics, value );
+	const statusClass = status === 'needsImprovement' ? 'needs-improvement' : status;
+
+	return (
+		<div
+			className="core-web-vitals-display__details"
+			style={ {
+				flexDirection: 'column',
+			} }
+		>
+			<div className="core-web-vitals-display__description">
+				<div
+					css={ {
+						display: 'flex',
+						gap: '24px',
+					} }
+				>
+					<div
+						css={ {
+							flex: 1,
+						} }
+					>
+						<span className="core-web-vitals-display__description-subheading">{ displayName }</span>
+						<div className={ `core-web-vitals-display__metric ${ statusClass }` }>
+							{ displayValue( activeTab as Metrics, value ) }
+						</div>
+						<p>
+							{ metricValuations[ activeTab ].explanation }
+							&nbsp;
+							<a href={ `https://web.dev/articles/${ activeTab }` }>
+								{ translate( 'Learn more ↗' ) }
+							</a>
+						</p>
+					</div>
+					<StatusSection value={ status } recommendationsQuantity={ 3 } />
+				</div>
+				<div className="core-web-vitals-display__ranges">
+					<div className="range">
+						<StatusIndicator speed="good" />
+						<div className="range-heading">{ translate( 'Excellent' ) }</div>
+						<div className="range-subheading">
+							{ translate( '(0–%(to)s%(unit)s)', {
+								args: { to: formatUnit( good ), unit: displayUnit() },
+								comment: 'Displaying a time range, eg. 0-1s',
+							} ) }
+						</div>
+					</div>
+					<div className="range">
+						<StatusIndicator speed="needsImprovement" />
+
+						<div className="range-heading">{ translate( 'Needs Improvement' ) }</div>
+						<div className="range-subheading">
+							{ translate( '(%(from)s–%(to)s%(unit)s)', {
+								args: {
+									from: formatUnit( good ),
+									to: formatUnit( needsImprovement ),
+									unit: displayUnit(),
+								},
+								comment: 'Displaying a time range, eg. 2-3s',
+							} ) }
+						</div>
+					</div>
+					<div className="range">
+						<StatusIndicator speed="bad" />
+
+						<div className="range-heading">{ translate( 'Poor' ) }</div>
+						<div className="range-subheading">
+							{ translate( '(Over %(from)s%(unit)s) ', {
+								args: {
+									from: formatUnit( needsImprovement ),
+									unit: displayUnit(),
+								},
+								comment: 'Displaying a time range, eg. >2s',
+							} ) }
+						</div>
+					</div>
+				</div>
+			</div>
+			<div className="core-web-vitals-display__history-graph-container">
+				<HistoryChart
+					data={ dataAvailable && historicalData }
+					range={ [
+						formatUnit( metricsTresholds[ activeTab ].good ),
+						formatUnit( metricsTresholds[ activeTab ].needsImprovement ),
+					] }
+					height={ 300 }
+					d3Format="%b %d"
+				/>
+			</div>
+		</div>
+	);
+};

--- a/client/performance-profiler/components/core-web-vitals-display/style.scss
+++ b/client/performance-profiler/components/core-web-vitals-display/style.scss
@@ -85,3 +85,31 @@ $blueberry-color: #3858e9;
 .core-web-vitals-display__description a {
 	color: $blueberry-color;
 }
+
+//v2
+.core-web-vitals-display__metric {
+	font-family: $font-sf-pro-display;
+	font-size: $font-size-header;
+	margin-bottom: 24px;
+
+
+	&.good {
+		color: #00ba37;
+	}
+
+	&.needs-improvement {
+		color: #d67709;
+	}
+
+	&.poor {
+		color: #d63638;
+	}
+}
+
+.core-web-vitals-display__history-graph-container {
+
+	.chart-container {
+		width: 100%;
+		max-width: 100%;
+	}
+}

--- a/client/performance-profiler/components/status-section/index.tsx
+++ b/client/performance-profiler/components/status-section/index.tsx
@@ -1,0 +1,52 @@
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import './style.scss';
+import { Valuation } from 'calypso/performance-profiler/types/performance-metrics';
+
+type StatusSectionProps = {
+	value: Valuation;
+	recommendationsQuantity?: number;
+};
+
+export const StatusSection = ( props: StatusSectionProps ) => {
+	const translate = useTranslate();
+
+	const { value, recommendationsQuantity } = props;
+	const getStatus = ( value: Valuation ) => {
+		if ( value === 'bad' ) {
+			return 'poor';
+		} else if ( value === 'needsImprovement' ) {
+			return 'neutral';
+		}
+		return 'good';
+	};
+	const status = getStatus( value );
+	const statusText = {
+		poor: translate( 'Poor' ),
+		neutral: translate( 'Needs improvement' ),
+		good: translate( 'Excellent' ),
+	}[ status ];
+
+	return (
+		<div className="status-section">
+			<div className={ clsx( 'status-badge', { [ status ]: true } ) }>{ statusText }</div>
+			<div className="recommendations-text">
+				{ recommendationsQuantity &&
+					translate(
+						'{{a}}View %(quantity)d recommendation{{/a}}',
+						'{{a}}View %(quantity)d recommendations{{/a}}',
+						{
+							count: recommendationsQuantity,
+							args: { quantity: recommendationsQuantity },
+							components: {
+								a: (
+									/* eslint-disable-next-line jsx-a11y/anchor-is-valid */
+									<a role="button" tabIndex={ 0 } />
+								),
+							},
+						}
+					) }
+			</div>
+		</div>
+	);
+};

--- a/client/performance-profiler/components/status-section/style.scss
+++ b/client/performance-profiler/components/status-section/style.scss
@@ -1,0 +1,42 @@
+.status-section {
+	font-size: $font-body-small;
+	color: #000;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 12px;
+
+
+	.status-badge {
+		display: flex;
+		padding: 6px 0;
+		justify-content: center;
+		align-items: center;
+		gap: 4px;
+		border-radius: 4px;
+		font-weight: 500;
+		flex-shrink: 0;
+		width: 100%;
+
+		&.poor {
+			background: var(--studio-red-5);
+			color: var(--studio-red-80);
+		}
+
+		&.neutral {
+			background: var(--studio-orange-5);
+			color: var(--studio-orange-80);
+		}
+
+		&.good {
+			background: var(--studio-green-5);
+			color: var(--studio-green-80);
+		}
+	}
+
+	.recommendations-text {
+		a {
+			cursor: pointer;
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9130

## Proposed Changes

* Create a v2 component that closely matches the new design
* This is only the details component
![image](https://github.com/user-attachments/assets/74570b55-be02-4abd-b329-e71d93aeb641)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test switch out V1 component `client/performance-profiler/components/core-web-vitals-display/index.tsx`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
