### PR TITLE
Calypso UI Components: DateRange: Move Buttons to Bottom

### DIFF
--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -496,8 +496,8 @@ export class DateRange extends Component {
 						</div>
 						{ this.props.renderInputs( inputsProps ) }
 						{ this.renderDatePicker() }
+						{ this.props.renderHeader( headerProps ) }
 					</div>
-					<div className="date-range__controls">{ this.props.renderHeader( headerProps ) }</div>
 					{ /* Render shortcuts to the right of the calendar */ }
 					{ this.props.displayShortcuts && (
 						<div className="date-range-picker-shortcuts">

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -487,7 +487,6 @@ export class DateRange extends Component {
 							<div className="date-range__popover-inner-overlay">{ this.props.overlay }</div>
 						) }
 						<div className="date-range__controls">
-							{ this.props.renderHeader( headerProps ) }
 							{ this.props.customTitle ? (
 								<div className="date-range__custom-title">{ this.props.customTitle }</div>
 							) : (

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -497,6 +497,7 @@ export class DateRange extends Component {
 						{ this.props.renderInputs( inputsProps ) }
 						{ this.renderDatePicker() }
 					</div>
+					<div className="date-range__controls">{ this.props.renderHeader( headerProps ) }</div>
 					{ /* Render shortcuts to the right of the calendar */ }
 					{ this.props.displayShortcuts && (
 						<div className="date-range-picker-shortcuts">

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -60,7 +60,8 @@ $date-range-mobile-layout-switch: $break-small;
 		position: relative;
 		.date-range__controls,
 		.date-range__date-inputs,
-		.date-range__picker {
+		.date-range__picker,
+		.date-range__popover-header { // Add this line
 			filter: blur(10px);
 			z-index: 0;
 		}
@@ -78,6 +79,7 @@ $date-range-mobile-layout-switch: $break-small;
 }
 
 .date-range__controls {
+	order: 1;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -94,11 +96,18 @@ $date-range-mobile-layout-switch: $break-small;
 }
 
 .date-range__popover-header {
-	order: 2;
+	order: 4;
+	display: flex;
+	justify-content: flex-end; // This will align the content to the right
+	padding: 10px 0 0; // Add some top padding if needed
 
 	.button {
-		margin: 0 0.5em;
+		margin-left: 0.5em; // Change right margin to left
+		margin-right: 0; // Remove right margin
 	}
+
+	// If you want to add some space between the header and the content above it
+	margin-top: 10px;
 }
 
 .date-range__info {

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -61,7 +61,7 @@ $date-range-mobile-layout-switch: $break-small;
 		.date-range__controls,
 		.date-range__date-inputs,
 		.date-range__picker,
-		.date-range__popover-header { // Add this line
+		.date-range__popover-header {
 			filter: blur(10px);
 			z-index: 0;
 		}
@@ -98,15 +98,13 @@ $date-range-mobile-layout-switch: $break-small;
 .date-range__popover-header {
 	order: 4;
 	display: flex;
-	justify-content: flex-end; // This will align the content to the right
-	padding: 10px 0 0; // Add some top padding if needed
+	justify-content: flex-end;
+	padding: 10px 0 0;
 
 	.button {
-		margin-left: 0.5em; // Change right margin to left
-		margin-right: 0; // Remove right margin
+		margin-left: 0.5em;
+		margin-right: 0;
 	}
-
-	// If you want to add some space between the header and the content above it
 	margin-top: 10px;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/135

## Note:

* This whole area is known as the header. The renderHeader function is built into it. It is no longer being used as a "header" so in the next follow PR I will be refactoring for this. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To extend the Calypso DateRange picker component for use with the Stats Date Control update.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* open Calypso live branch
* navigate to `/devdocs/design/date-range`
* click on any of the demos
* check that the `cancel` + `apply` buttons display below the calendars now
* also thoroughly check on mobile and small displays

![image](https://github.com/user-attachments/assets/00e4a2c5-ce77-41cc-a52d-ea2320326146)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
