### PR TITLE
A4A: Enable the multi-user support feature in production.

### DIFF
--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -35,7 +35,7 @@
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": false,
-		"a4a-multi-user-support": false
+		"a4a-multi-user-support": true
 	},
 	"enable_all_sections": false,
 	"sections": {
@@ -53,7 +53,7 @@
 		"a8c-for-agencies-partner-directory": true,
 		"a8c-for-agencies-migrations": true,
 		"a8c-for-agencies-client": true,
-		"a8c-for-agencies-team": false
+		"a8c-for-agencies-team": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
This PR enables the multi-user support feature in production, officially launching the product.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/958

## Proposed Changes

* Enabled the `a4a-multi-user-support` feature flag and `a8c-for-agencies-team` section in production environment.

## Why are these changes being made?

*

## Testing Instructions

* Verify changes are good.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
