### PR TITLE
Stepper: Handle `calypso_signup_actions_complete_step` tracking

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -25,6 +25,7 @@ export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK = 'calypso_signup_step_nav_ba
 export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT = 'calypso_signup_step_nav_next';
 export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO = 'calypso_signup_step_nav_go_to';
 export const STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW = 'calypso_signup_step_nav_exit_flow';
+export const STEPPER_TRACKS_EVENT_STEP_COMPLETE = 'calypso_signup_actions_complete_step';
 
 export const STEPPER_TRACKS_EVENTS_STEP_NAV = < const >[
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
@@ -34,4 +35,7 @@ export const STEPPER_TRACKS_EVENTS_STEP_NAV = < const >[
 	STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW,
 ];
 
-export const STEPPER_TRACKS_EVENTS = < const >[ ...STEPPER_TRACKS_EVENTS_STEP_NAV ];
+export const STEPPER_TRACKS_EVENTS = < const >[
+	...STEPPER_TRACKS_EVENTS_STEP_NAV,
+	STEPPER_TRACKS_EVENT_STEP_COMPLETE,
+];

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-complete.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-complete.ts
@@ -1,0 +1,20 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
+import { STEPPER_TRACKS_EVENT_STEP_COMPLETE } from 'calypso/landing/stepper/constants';
+
+export interface RecordStepCompleteProps {
+	flow: string;
+	step: string;
+	optionalProps?: Record< string, string | number | null >;
+}
+
+const recordStepComplete = ( { flow, step, optionalProps }: RecordStepCompleteProps ) => {
+	recordTracksEvent( STEPPER_TRACKS_EVENT_STEP_COMPLETE, {
+		flow,
+		step,
+		device: resolveDeviceTypeByViewPort(),
+		...optionalProps,
+	} );
+};
+
+export default recordStepComplete;

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -107,5 +107,5 @@ export const useStepRouteTracking = ( {
 		// We leave out intent and design from the dependency list, due to the ONBOARD_STORE being reset in the exit flow.
 		// The store reset causes these values to become empty, and may trigger this event again.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ flowName, hasRequestedSelectedSite, stepSlug, skipTracking, handleRecordStepComplete ] );
+	}, [ flowName, hasRequestedSelectedSite, stepSlug, skipTracking ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -68,7 +68,7 @@ export const useStepRouteTracking = ( {
 	useEffect( () => {
 		// We record the event only when the step is not empty. Additionally, we should not fire this event whenever the intent is changed
 		if ( ! hasRequestedSelectedSite || skipTracking ) {
-			return () => handleRecordStepComplete( { flowName, stepSlug, intent } );
+			return;
 		}
 
 		const signupCompleteFlowName = getSignupCompleteFlowNameAndClear();

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -52,9 +52,9 @@ export const useStepRouteTracking = ( {
 	const stepCompleteEventPropsRef = useRef< RecordStepCompleteProps | null >( null );
 
 	/**
-	 * Cleanup effect to record step-complete event when `StepRoute` unmounts.
-	 * This is to ensure that the event is recorded when the user navigates away from the step.
-	 * We only record this if step-start event gets recorded and `stepCompleteEventPropsRef.current` is populated (as a result).
+	 * Cleanup effect to record step-complete event when:
+	 * - a rendered step is navigated away
+	 * - a step-start event was recorded and `stepCompleteEventPropsRef.current` populated (as a result)
 	 */
 	useEffect( () => {
 		return () => {
@@ -62,8 +62,8 @@ export const useStepRouteTracking = ( {
 				recordStepComplete( stepCompleteEventPropsRef.current );
 			}
 		};
-		// IMPORTANT: Do not add dependencies to this effect, as it should only record when the component unmounts.
-	}, [] );
+		// IMPORTANT: Do not add dependencies to this effect, as it should only record when the component unmounts or step changes.
+	}, [ stepSlug ] );
 
 	useEffect( () => {
 		// We record the event only when the step is not empty. Additionally, we should not fire this event whenever the intent is changed

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -62,7 +62,7 @@ export const useStepRouteTracking = ( {
 				recordStepComplete( stepCompleteEventPropsRef.current );
 			}
 		};
-		// IMPORTANT: Do not add dependencies to this effect, as it should only run when the component unmounts.
+		// IMPORTANT: Do not add dependencies to this effect, as it should only record when the component unmounts.
 	}, [] );
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -52,9 +52,9 @@ export const useStepRouteTracking = ( {
 	const stepCompleteEventPropsRef = useRef< RecordStepCompleteProps | null >( null );
 
 	/**
-	 * Cleanup effect to record step-complete event when:
-	 * - a rendered step is navigated away
-	 * - a step-start event was recorded and `stepCompleteEventPropsRef.current` populated (as a result)
+	 * Cleanup effect to record step-complete event when `StepRoute` unmounts.
+	 * This is to ensure that the event is recorded when the user navigates away from the step.
+	 * We only record this if step-start event gets recorded and `stepCompleteEventPropsRef.current` is populated (as a result).
 	 */
 	useEffect( () => {
 		return () => {
@@ -62,8 +62,8 @@ export const useStepRouteTracking = ( {
 				recordStepComplete( stepCompleteEventPropsRef.current );
 			}
 		};
-		// IMPORTANT: Do not add dependencies to this effect, as it should only record when the component unmounts or step changes.
-	}, [ stepSlug ] );
+		// IMPORTANT: Do not add dependencies to this effect, as it should only record when the component unmounts.
+	}, [] );
 
 	useEffect( () => {
 		// We record the event only when the step is not empty. Additionally, we should not fire this event whenever the intent is changed

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -49,19 +49,20 @@ export const useStepRouteTracking = ( {
 	const { site, siteSlugOrId } = useSiteData();
 	const isRequestingSelectedSite = useIsRequestingSelectedSite( siteSlugOrId, site );
 	const hasRequestedSelectedSite = siteSlugOrId ? !! site && ! isRequestingSelectedSite : true;
-	const stepCompleteEventProps = useRef< RecordStepCompleteProps | null >( null );
+	const stepCompleteEventPropsRef = useRef< RecordStepCompleteProps | null >( null );
 
 	/**
 	 * Cleanup effect to record step-complete event when `StepRoute` unmounts.
 	 * This is to ensure that the event is recorded when the user navigates away from the step.
-	 * Only records if `stepCompleteEventProps.current` is populated when the step-start event fires.
+	 * We only record this if step-start event gets recorded and `stepCompleteEventPropsRef.current` is populated (as a result).
 	 */
 	useEffect( () => {
 		return () => {
-			if ( stepCompleteEventProps.current ) {
-				recordStepComplete( stepCompleteEventProps.current );
+			if ( stepCompleteEventPropsRef.current ) {
+				recordStepComplete( stepCompleteEventPropsRef.current );
 			}
 		};
+		// IMPORTANT: Do not add dependencies to this effect, as it should only run when the component unmounts.
 	}, [] );
 
 	useEffect( () => {
@@ -84,8 +85,8 @@ export const useStepRouteTracking = ( {
 				...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
 			} );
 
-			// Apply the props to record in the exit/complete event. We only record this if start event gets recorded.
-			stepCompleteEventProps.current = {
+			// Apply the props to record in the exit/step-complete event. We only record this if start event gets recorded.
+			stepCompleteEventPropsRef.current = {
 				flow: flowName,
 				step: stepSlug,
 				optionalProps: { intent },

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
@@ -7,6 +7,7 @@ import { waitFor } from '@testing-library/react';
 import { addQueryArgs } from '@wordpress/url';
 import React, { FC, Suspense } from 'react';
 import { MemoryRouter } from 'react-router';
+import { STEPPER_TRACKS_EVENT_STEP_COMPLETE } from 'calypso/landing/stepper/constants';
 import recordStepStart from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-step-start';
 import { useIntent } from 'calypso/landing/stepper/hooks/use-intent';
 import { useSelectedDesign } from 'calypso/landing/stepper/hooks/use-selected-design';
@@ -18,12 +19,11 @@ import {
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import StepRoute from '../';
-import { STEPPER_TRACKS_EVENT_STEP_COMPLETE } from '../../../../../constants';
-import type { NavigationControls } from '../../../types';
 import type {
 	Flow,
 	StepperStep,
 	StepProps,
+	NavigationControls,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
 
 jest.mock( 'calypso/signup/storageUtils' );

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
@@ -192,16 +192,14 @@ describe( 'StepRoute', () => {
 			expect( recordPageView ).not.toHaveBeenCalled();
 		} );
 
-		it( 'records step-complete event when the step is unmounted and step-start was previously recorded', () => {
+		it( 'tracks step-complete when the step is unmounted and step-start was previously recorded', () => {
 			( isUserLoggedIn as jest.Mock ).mockReturnValue( true );
 			( getSignupCompleteFlowNameAndClear as jest.Mock ).mockReturnValue( 'some-other-flow' );
 			( getSignupCompleteStepNameAndClear as jest.Mock ).mockReturnValue( 'some-other-step-slug' );
 			const { unmount } = render( { step: regularStep } );
 
 			expect( recordStepComplete ).not.toHaveBeenCalled();
-
 			unmount();
-
 			expect( recordStepComplete ).toHaveBeenCalledWith( {
 				step: 'some-step-slug',
 				flow: 'some-flow',
@@ -209,6 +207,16 @@ describe( 'StepRoute', () => {
 					intent: 'build',
 				},
 			} );
+		} );
+
+		it( 'skips tracking step-complete when the step is unmounted and step-start was not recorded', () => {
+			( getSignupCompleteFlowNameAndClear as jest.Mock ).mockReturnValue( 'some-flow' );
+			( getSignupCompleteStepNameAndClear as jest.Mock ).mockReturnValue( 'some-step-slug' );
+			const { unmount } = render( { step: regularStep } );
+
+			expect( recordStepStart ).not.toHaveBeenCalled();
+			unmount();
+			expect( recordStepComplete ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -209,6 +209,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 						path={ `/${ flow.variantSlug ?? flow.name }/${ step.slug }/:lang?` }
 						element={
 							<StepRoute
+								key={ step.slug }
 								step={ step }
 								flow={ flow }
 								showWooLogo={ isWooExpressFlow( flow.name ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/94414

## Proposed Changes

* Introduces `STEPPER_TRACKS_EVENT_STEP_COMPLETE` slug
* Tracks `calypso_signup_actions_complete_step` when any step unmounts

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Addresses https://github.com/Automattic/wp-calypso/issues/94414 from Stepper audit

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding`
* Go through the flow/steps and confirm `calypso_signup_actions_complete_step ` gets logged when leaving any step
  * can check by `localStorage.debug='calypso:analytics'` in the console or through the Network tab for a `t.gif` request

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
