### PR TITLE
Enable Jetpack Scan for Atomic sites

### DIFF
--- a/client/my-sites/scan/controller.js
+++ b/client/my-sites/scan/controller.js
@@ -11,7 +11,6 @@ import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getSiteScanRequestStatus from 'calypso/state/selectors/get-site-scan-request-status';
 import getSiteScanState from 'calypso/state/selectors/get-site-scan-state';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isJetpackSiteMultiSite from 'calypso/state/sites/selectors/is-jetpack-site-multi-site';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import ScanHistoryPage from './history';
@@ -98,11 +97,8 @@ export function scan( context, next ) {
 }
 
 export function scanHistory( context, next ) {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-	const showScanNavigation = ! isAtomicSite( state, siteId ) && isJetpackCloud();
 	const { filter } = context.params;
-	context.primary = <ScanHistoryPage filter={ filter } showNavigation={ showScanNavigation } />;
+	context.primary = <ScanHistoryPage filter={ filter } />;
 	next();
 }
 

--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -18,7 +18,7 @@ interface Props {
 	showNavigation?: boolean;
 }
 
-export default function ScanHistoryPage( { filter, showNavigation = true }: Props ) {
+export default function ScanHistoryPage( { filter }: Props ) {
 	const translate = useTranslate();
 	const isJetpackPlatform = isJetpackCloud();
 
@@ -35,7 +35,7 @@ export default function ScanHistoryPage( { filter, showNavigation = true }: Prop
 				<NavigationHeader navigationItems={ [] } title={ translate( 'Jetpack Scan' ) } />
 			) }
 
-			{ showNavigation && <ScanNavigation section="history" /> }
+			<ScanNavigation section="history" />
 			<section className="history__body">
 				<p className="history__description">
 					{ translate(

--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -15,7 +15,6 @@ import './style.scss';
 
 interface Props {
 	filter: FilterValue;
-	showNavigation?: boolean;
 }
 
 export default function ScanHistoryPage( { filter }: Props ) {

--- a/client/my-sites/scan/index.js
+++ b/client/my-sites/scan/index.js
@@ -51,7 +51,7 @@ export default function () {
 		showJetpackIsDisconnected,
 		showUnavailableForMultisites,
 		showNotAuthorizedForNonAdmins,
-		notFoundIfNotEnabled(),
+		notFoundIfNotEnabled( { allowOnAtomic: true } ),
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -29,6 +29,7 @@ import { getCount } from 'calypso/state/persistent-counter/selectors';
 import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import getSiteScanIsInitial from 'calypso/state/selectors/get-site-scan-is-initial';
 import getSiteScanProgress from 'calypso/state/selectors/get-site-scan-progress';
+import getSiteScanRequestStatus from 'calypso/state/selectors/get-site-scan-request-status';
 import getSiteScanState from 'calypso/state/selectors/get-site-scan-state';
 import isRequestingJetpackScan from 'calypso/state/selectors/is-requesting-jetpack-scan';
 import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
@@ -50,6 +51,7 @@ interface Props {
 	isInitialScan?: boolean;
 	isRequestingScan?: boolean;
 	scanPageVisitCount?: number;
+	scanRequestStatus?: 'pending' | 'success' | 'failed';
 	timezone: string | null;
 	gmtOffset: number | null;
 	moment: {
@@ -240,7 +242,7 @@ class ScanPage extends Component< Props > {
 	}
 
 	renderScanState() {
-		const { site, scanState, isRequestingScan } = this.props;
+		const { site, scanState, isRequestingScan, scanRequestStatus } = this.props;
 
 		// We don't know yet which site we're looking at,
 		// so show a placeholder until data comes in
@@ -273,7 +275,7 @@ class ScanPage extends Component< Props > {
 
 		// We should have a scanState by now, since we're not requesting an update;
 		// if we don't, that's an error condition and we should display that
-		if ( ! scanState ) {
+		if ( ! scanState || scanRequestStatus === 'failed' ) {
 			return (
 				<>
 					{ ' ' }
@@ -379,6 +381,7 @@ export default connect(
 		const isRequestingScan = !! isRequestingJetpackScan( state, siteId );
 		const isInitialScan = getSiteScanIsInitial( state, siteId );
 		const scanPageVisitCount = getCount( state, SCAN_VISIT_COUNTER_NAME, false );
+		const scanRequestStatus = getSiteScanRequestStatus( state, siteId );
 
 		return {
 			site,
@@ -390,6 +393,7 @@ export default connect(
 			siteSettingsUrl,
 			isRequestingScan,
 			scanPageVisitCount,
+			scanRequestStatus,
 		};
 	},
 	{

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -29,6 +29,7 @@ import { getCount } from 'calypso/state/persistent-counter/selectors';
 import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import getSiteScanIsInitial from 'calypso/state/selectors/get-site-scan-is-initial';
 import getSiteScanProgress from 'calypso/state/selectors/get-site-scan-progress';
+import getSiteScanRequestRetryCount from 'calypso/state/selectors/get-site-scan-request-retry-count';
 import getSiteScanRequestStatus from 'calypso/state/selectors/get-site-scan-request-status';
 import getSiteScanState from 'calypso/state/selectors/get-site-scan-state';
 import isRequestingJetpackScan from 'calypso/state/selectors/is-requesting-jetpack-scan';
@@ -52,6 +53,7 @@ interface Props {
 	isRequestingScan?: boolean;
 	scanPageVisitCount?: number;
 	scanRequestStatus?: 'pending' | 'success' | 'failed';
+	scanRequestRetryCount?: number;
 	timezone: string | null;
 	gmtOffset: number | null;
 	moment: {
@@ -242,7 +244,8 @@ class ScanPage extends Component< Props > {
 	}
 
 	renderScanState() {
-		const { site, scanState, isRequestingScan, scanRequestStatus } = this.props;
+		const { site, scanState, isRequestingScan, scanRequestStatus, scanRequestRetryCount } =
+			this.props;
 
 		// We don't know yet which site we're looking at,
 		// so show a placeholder until data comes in
@@ -269,7 +272,8 @@ class ScanPage extends Component< Props > {
 
 		// *Now* we can show the loading placeholder,
 		// if in fact we're requesting a Scan status update
-		if ( isRequestingScan ) {
+		// but silently retry if pooling to avoid UI flicker
+		if ( isRequestingScan && scanRequestRetryCount === 0 ) {
 			return <ScanPlaceholder />;
 		}
 
@@ -382,6 +386,7 @@ export default connect(
 		const isInitialScan = getSiteScanIsInitial( state, siteId );
 		const scanPageVisitCount = getCount( state, SCAN_VISIT_COUNTER_NAME, false );
 		const scanRequestStatus = getSiteScanRequestStatus( state, siteId );
+		const scanRequestRetryCount = getSiteScanRequestRetryCount( state, siteId );
 
 		return {
 			site,
@@ -394,6 +399,7 @@ export default connect(
 			isRequestingScan,
 			scanPageVisitCount,
 			scanRequestStatus,
+			scanRequestRetryCount,
 		};
 	},
 	{

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -87,7 +87,7 @@ const fetchStatus = ( action ) => {
 
 const POOL_EVERY_MILLISECONDS = 5000;
 
-const MAX_RETRY_COUNT = 3;
+const MAX_RETRY_COUNT = 2;
 
 const onFetchStatusSuccess = ( action, scan ) => ( dispatch ) => {
 	[
@@ -108,7 +108,6 @@ const onFetchStatusSuccess = ( action, scan ) => ( dispatch ) => {
 				type: JETPACK_SCAN_REQUEST,
 				siteId: action.siteId,
 				pooling: true,
-				retryCount: action.retryCount || 0,
 			} );
 		}, POOL_EVERY_MILLISECONDS );
 	}
@@ -118,6 +117,7 @@ const onFetchStatusSuccess = ( action, scan ) => ( dispatch ) => {
 		( threat ) => threat.fixerStatus === 'in_progress'
 	);
 	if ( action.pooling && scan.state === 'idle' && threatsFixedInProgress.length > 0 ) {
+		// Stop pooling after MAX_RETRY_COUNT to prevent infinite rerendering
 		if ( action.retryCount >= MAX_RETRY_COUNT ) {
 			dispatch( {
 				type: JETPACK_SCAN_REQUEST_FAILURE,

--- a/client/state/jetpack-scan/reducer.js
+++ b/client/state/jetpack-scan/reducer.js
@@ -34,8 +34,18 @@ export const scan = keyedReducer( 'siteId', ( state, { type, payload } ) => {
 	return state;
 } );
 
+const requestStatusRetryCount = keyedReducer( 'siteId', ( state, { type, retryCount } ) => {
+	switch ( type ) {
+		case JETPACK_SCAN_REQUEST:
+			return retryCount;
+	}
+
+	return state || 0;
+} );
+
 export default combineReducers( {
 	requestStatus,
+	requestStatusRetryCount,
 	scan,
 	threatCounts: threatCountsReducer,
 	threats: threatsReducer,

--- a/client/state/jetpack-scan/reducer.js
+++ b/client/state/jetpack-scan/reducer.js
@@ -40,7 +40,7 @@ const requestStatusRetryCount = keyedReducer( 'siteId', ( state, { type, retryCo
 			return retryCount;
 	}
 
-	return state || 0;
+	return state;
 } );
 
 export default combineReducers( {

--- a/client/state/selectors/get-site-scan-request-retry-count.ts
+++ b/client/state/selectors/get-site-scan-request-retry-count.ts
@@ -1,0 +1,13 @@
+import 'calypso/state/data-layer/wpcom/sites/scan';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns the current Jetpack Scan request retry count for a given site.
+ * Returns undefined if the site is unknown, or if no information is available.
+ */
+export default function getSiteScanRequestRetryCount(
+	state: AppState,
+	siteId: number
+): number | undefined {
+	return state.jetpackScan.requestStatusRetryCount?.[ siteId ];
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7891

TODO
- [x] There is an issue where the Scan component rerenders indefinitely. Investigation shared in https://github.com/Automattic/wp-calypso/pull/94529#issuecomment-2351880805

https://github.com/user-attachments/assets/e889ad6c-5dbf-411a-926b-590035d80145

## Proposed Changes

Currently, we are only showing the history of already fixed issues, this PR enables the Jetpack Scanner where users can Scan their site on demand and also show a list of current vulnerabilities.

| Path | Before | After |
|--------|--------|--------|
| Calypso `/scan/:site` | <img src="https://github.com/user-attachments/assets/88fc28f9-9559-4f28-a797-0d69e0632d2f"> | <img src="https://github.com/user-attachments/assets/52a1ab6f-b035-477c-82c4-7c110a9fe6a7"> |
| Calypso `/scan/history/:site` | <img src="https://github.com/user-attachments/assets/27b601d8-19f3-4bd0-86c0-66936b24cb5b"> | <img src="https://github.com/user-attachments/assets/ebd7cc8e-a007-4237-b6ce-5e565f78012d"> |
| Jetpack Cloud `/scan/:site` | Not found | <img src="https://github.com/user-attachments/assets/4687a1aa-95a5-4b51-a7d8-af12b302fb1a"> | 
| Jetpack Cloud `/scan/history/:site` | <img src="https://github.com/user-attachments/assets/c450810c-d3ec-4b01-b8ce-06302fbe2db8"> | <img src="https://github.com/user-attachments/assets/511e9fd6-a071-4d65-8053-c74e05cbe81b"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The purpose is to expose existing vulnerabilities for all Atomic sites to highlight our Security features on WordPress.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Types of sites to test on:
* Simple - Not Found
* Atomic - Access to Scan and History
* Jetpack sites - See the upsell below
![upsell](https://github.com/user-attachments/assets/9813e13f-eb55-4dd3-80e6-3454f5f4df2a)

Environments to test in:
* Calypso
* Jetpack Cloud

1. Checkout to this branch or use the live link
2. Go to `/scan/:site`
3. Click on Scan and see if it works correctly, you can also install the same plugin as in the screenshot to trigger a vulnerability
4. Go to `/scan/history/:site` or by clicking the navigation
5. Check if everything looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
