### PR TITLE
Revert/legacy nps survey integration

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -370,7 +370,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'layout/guided-tours' ) && (
 					<AsyncLoad require="calypso/layout/guided-tours" placeholder={ null } />
 				) }
-				{ config.isEnabled( 'layout/nps-survey-notice' ) && ! isE2ETest() && (
+				{ config.isEnabled( 'marketing/nps-survey' ) && ! isE2ETest() && (
 					<AsyncLoad require="calypso/layout/nps-survey-notice" placeholder={ null } />
 				) }
 				<div className="layout__header-section">{ this.renderMasterbar( loadHelpCenter ) }</div>

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -27,6 +27,7 @@ import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
 import OfflineStatus from 'calypso/layout/offline-status';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import { isE2ETest } from 'calypso/lib/e2e';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWcMobileApp, isWpMobileApp } from 'calypso/lib/mobile-app';
@@ -368,6 +369,9 @@ class Layout extends Component {
 				<UserVerificationChecker />
 				{ config.isEnabled( 'layout/guided-tours' ) && (
 					<AsyncLoad require="calypso/layout/guided-tours" placeholder={ null } />
+				) }
+				{ config.isEnabled( 'layout/nps-survey-notice' ) && ! isE2ETest() && (
+					<AsyncLoad require="calypso/layout/nps-survey-notice" placeholder={ null } />
 				) }
 				<div className="layout__header-section">{ this.renderMasterbar( loadHelpCenter ) }</div>
 				<LayoutLoader />

--- a/client/layout/nps-survey-notice/index.jsx
+++ b/client/layout/nps-survey-notice/index.jsx
@@ -69,7 +69,7 @@ class NpsSurveyNotice extends Component {
 	};
 
 	componentDidMount() {
-		this.props.setupNpsSurveyEligibility();
+		this.props.setupNpsSurveyEligibility( SURVEY_NAME );
 		this.props.setupNpsSurveyDevTrigger();
 	}
 

--- a/client/state/nps-survey/actions.js
+++ b/client/state/nps-survey/actions.js
@@ -40,7 +40,7 @@ export function setupNpsSurveyEligibility() {
 		debug( 'Checking NPS eligibility...' );
 
 		return wpcom
-			.undocumented()
+			.nps()
 			.checkNPSSurveyEligibility()
 			.then( ( data ) => {
 				debug( '...Eligibility returned from endpoint.', data );
@@ -70,7 +70,7 @@ export function submitNpsSurvey( surveyName, score ) {
 		recordTracksEvent( 'calypso_nps_survey_submitted' );
 
 		return wpcom
-			.undocumented()
+			.nps()
 			.submitNPSSurvey( surveyName, score )
 			.then( () => {
 				debug( '...Successfully submitted NPS survey.' );
@@ -92,7 +92,7 @@ export function submitNpsSurveyWithNoScore( surveyName ) {
 		recordTracksEvent( 'calypso_nps_survey_dismissed' );
 
 		return wpcom
-			.undocumented()
+			.nps()
 			.dismissNPSSurvey( surveyName )
 			.then( () => {
 				debug( '...Successfully submitted NPS survey with no score.' );
@@ -114,7 +114,7 @@ export function sendNpsSurveyFeedback( surveyName, feedback ) {
 		recordTracksEvent( 'calypso_nps_survey_feedback_submitted' );
 
 		return wpcom
-			.undocumented()
+			.nps()
 			.sendNPSSurveyFeedback( surveyName, feedback )
 			.then( () => {
 				debug( '...Successfully sent NPS survey feedback.' );

--- a/client/state/nps-survey/actions.js
+++ b/client/state/nps-survey/actions.js
@@ -35,13 +35,13 @@ export function setNpsConciergeSessionAvailaibility( isAvailableForConciergeSess
 	};
 }
 
-export function setupNpsSurveyEligibility() {
+export function setupNpsSurveyEligibility( surveyName ) {
 	return ( dispatch ) => {
 		debug( 'Checking NPS eligibility...' );
 
 		return wpcom
 			.nps()
-			.checkNPSSurveyEligibility()
+			.checkNPSSurveyEligibility( surveyName )
 			.then( ( data ) => {
 				debug( '...Eligibility returned from endpoint.', data );
 				dispatch( setNpsSurveyEligibility( data.display_survey ) );

--- a/client/state/nps-survey/notice/actions.js
+++ b/client/state/nps-survey/notice/actions.js
@@ -19,7 +19,7 @@ export function setNpsSurveyDialogShowing( isShowing ) {
 
 export function setupNpsSurveyDevTrigger() {
 	return ( dispatch ) => {
-		if ( config.isEnabled( 'nps-survey/dev-trigger' ) ) {
+		if ( config.isEnabled( 'marketing/nps-survey' ) && process.env.NODE_ENV === 'development' ) {
 			window.npsSurvey = function ( isAvailableForSupportSession = false ) {
 				dispatch( setNpsSurveyEligibility( true ) );
 				dispatch( setNpsConciergeSessionAvailaibility( isAvailableForSupportSession ) );

--- a/client/state/nps-survey/notice/actions.js
+++ b/client/state/nps-survey/notice/actions.js
@@ -19,7 +19,7 @@ export function setNpsSurveyDialogShowing( isShowing ) {
 
 export function setupNpsSurveyDevTrigger() {
 	return ( dispatch ) => {
-		if ( config.isEnabled( 'marketing/nps-survey' ) && process.env.NODE_ENV === 'development' ) {
+		if ( config.isEnabled( 'marketing/nps-survey-dev-trigger' ) ) {
 			window.npsSurvey = function ( isAvailableForSupportSession = false ) {
 				dispatch( setNpsSurveyEligibility( true ) );
 				dispatch( setNpsConciergeSessionAvailaibility( isAvailableForSupportSession ) );

--- a/client/state/nps-survey/test/actions.js
+++ b/client/state/nps-survey/test/actions.js
@@ -16,7 +16,7 @@ import {
 
 // mock modules
 jest.mock( 'calypso/lib/wp', () => ( {
-	undocumented: () => ( {
+	nps: () => ( {
 		// TODO: use mockResolvedValue instead when we update jest to 22.2 or later
 		submitNPSSurvey: jest.fn().mockReturnValue( Promise.resolve() ),
 		dismissNPSSurvey: jest.fn().mockReturnValue( Promise.resolve() ),

--- a/packages/wpcom.js/src/index.js
+++ b/packages/wpcom.js/src/index.js
@@ -3,6 +3,7 @@ import Batch from './lib/batch';
 import Domain from './lib/domain';
 import Domains from './lib/domains';
 import Me from './lib/me';
+import Nps from './lib/nps';
 import Plans from './lib/plans';
 import Site from './lib/site';
 import Users from './lib/users';
@@ -136,6 +137,14 @@ WPCOM.prototype.batch = function () {
 };
 
 /**
+ * Return `Nps` object instance
+ * @returns {Nps} Nps instance
+ */
+WPCOM.prototype.nps = function () {
+	return new Nps( this );
+};
+
+/**
  * List Freshly Pressed Posts
  * @param {Object} [query] - query object
  * @param {Function} fn - callback function
@@ -173,6 +182,7 @@ WPCOM.Plans = Plans;
 WPCOM.Request = Request;
 WPCOM.Site = Site;
 WPCOM.Users = Users;
+WPCOM.Nps = Nps;
 
 if ( ! Promise.prototype.timeout ) {
 	/**

--- a/packages/wpcom.js/src/lib/nps.js
+++ b/packages/wpcom.js/src/lib/nps.js
@@ -44,11 +44,12 @@ export default class Nps {
 
 	/**
 	 * Check the eligibility status for the NPS Survey.
-	 * @param {Function}   fn             The callback function
+	 * @param {string} surveyName The name of the NPS survey
+	 * @param {Function} fn The callback function
 	 * @returns {Promise} A promise representing the request.
 	 */
-	checkNPSSurveyEligibility( fn ) {
-		return this.wpcom.req.get( { path: '/nps' }, { apiVersion: '1.2' }, {}, fn );
+	checkNPSSurveyEligibility( surveyName, fn ) {
+		return this.wpcom.req.get( '/nps', { apiVersion: '1.2', survey_name: surveyName }, fn );
 	}
 
 	/**

--- a/packages/wpcom.js/src/lib/nps.js
+++ b/packages/wpcom.js/src/lib/nps.js
@@ -1,0 +1,69 @@
+export default class Nps {
+	/**
+	 * `Nps` constructor.
+	 * @param {WPCOM} wpcom - wpcom instance
+	 * @returns {undefined} undefined
+	 */
+	constructor( wpcom ) {
+		if ( ! ( this instanceof Nps ) ) {
+			return new Nps( wpcom );
+		}
+
+		this.wpcom = wpcom;
+	}
+	/**
+	 * Submit a response to the NPS Survey.
+	 * @param {string}     surveyName     The name of the NPS survey being submitted
+	 * @param {number}	score          The value for the survey response
+	 * @param {Function}   fn             The callback function
+	 * @returns {Promise} A promise representing the request.
+	 */
+	submitNPSSurvey( surveyName, score, fn ) {
+		return this.wpcom.req.post(
+			{ path: `/nps/${ surveyName }` },
+			{ apiVersion: '1.2' },
+			{ score },
+			fn
+		);
+	}
+
+	/**
+	 * Dismiss the NPS Survey.
+	 * @param {string}     surveyName     The name of the NPS survey being submitted
+	 * @param {Function}   fn             The callback function
+	 * @returns {Promise} A promise representing the request.
+	 */
+	dismissNPSSurvey( surveyName, fn ) {
+		return this.wpcom.req.post(
+			{ path: `/nps/${ surveyName }` },
+			{ apiVersion: '1.2' },
+			{ dismissed: true },
+			fn
+		);
+	}
+
+	/**
+	 * Check the eligibility status for the NPS Survey.
+	 * @param {Function}   fn             The callback function
+	 * @returns {Promise} A promise representing the request.
+	 */
+	checkNPSSurveyEligibility( fn ) {
+		return this.wpcom.req.get( { path: '/nps' }, { apiVersion: '1.2' }, {}, fn );
+	}
+
+	/**
+	 * Send the optional feedback for the NPS Survey.
+	 * @param {string}   surveyName   The name of the NPS survey being submitted
+	 * @param {string}   feedback     The content
+	 * @param {Function} fn           The callback function
+	 * @returns {Promise} A promise representing the request.
+	 */
+	sendNPSSurveyFeedback( surveyName, feedback, fn ) {
+		return this.wpcom.req.post(
+			{ path: `/nps/${ surveyName }` },
+			{ apiVersion: '1.2' },
+			{ feedback },
+			fn
+		);
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Based on https://github.com/Automattic/wp-calypso/pull/94522 and https://github.com/Automattic/wp-calypso/pull/94467

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR is the final integration PR of resolving the request of bringing the deprecated NPS survey back: p1725885879720739-slack-CFFF01Q4V . Following its old pattern,

* The NPS survey component is embedded when `marketing/nps-survey` flag is enabled. 
* The development-only functionality of triggering it by running a function is added when `marketing/nps-survey-dev-trigger` is enabled.

Screencast:


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As part of the continuous effort of understanding our user's needs better, we want to bring the NPS survey back and further polish it to the higher standard. Instead of starting from scratch, we wanted to build upon our prior work, hence bringing the code back.

As a reference, the NPS survey code was previously removed by:

* https://github.com/Automattic/wp-calypso/pull/55232
* https://github.com/Automattic/wp-calypso/pull/58393

## Testing Instructions

No functional-wise change has been introduced here. Thus, as long as the build passes, it is all good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?