### PR TITLE
Stats: Animate the feedback panel on initial presentation

### DIFF
--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
@@ -25,6 +26,13 @@ const FEEDBACK_LEAVE_REVIEW_URL = 'https://wordpress.org/support/plugin/jetpack/
 
 const FEEDBACK_SHOULD_SHOW_PANEL_API_KEY = NOTICES_KEY_SHOW_FLOATING_USER_FEEDBACK_PANEL;
 const FEEDBACK_SHOULD_SHOW_PANEL_API_HIBERNATION_DELAY = 3600 * 24 * 30 * 6; // 6 months
+
+// These values control the animation of the floating panel.
+// For available animations see: https://animate.style/
+// The delay value allows the animation to run before the component is removed from the DOM.
+const FEEDBACK_PANEL_ANIMATION_NAME_ENTRY = 'animate__bounceInUp';
+const FEEDBACK_PANEL_ANIMATION_NAME_EXIT = 'animate__fadeOutDownBig';
+const FEEDBACK_PANEL_ANIMATION_DELAY_EXIT = 500;
 
 function useNoticeVisibilityHooks( siteId: number ) {
 	const {
@@ -93,9 +101,13 @@ function FeedbackContent( { clickHandler }: FeedbackPropsInternal ) {
 
 function FeedbackPanel( { isOpen, clickHandler }: FeedbackPropsInternal ) {
 	const translate = useTranslate();
+	const [ animationClassName, setAnimationClassName ] = useState(
+		FEEDBACK_PANEL_ANIMATION_NAME_ENTRY
+	);
 
 	const handleCloseButtonClicked = () => {
 		clickHandler( ACTION_DISMISS_FLOATING_PANEL );
+		setAnimationClassName( FEEDBACK_PANEL_ANIMATION_NAME_EXIT );
 	};
 
 	const clickHandlerWithAnalytics = ( action: string ) => {
@@ -111,7 +123,7 @@ function FeedbackPanel( { isOpen, clickHandler }: FeedbackPropsInternal ) {
 	}
 
 	return (
-		<div className="stats-feedback-panel animate__animated animate__bounceInUp">
+		<div className={ clsx( 'stats-feedback-panel', 'animate__animated', animationClassName ) }>
 			<Button
 				className="stats-feedback-panel__close-button"
 				onClick={ handleCloseButtonClicked }
@@ -163,6 +175,13 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		}
 	}, [ isPending, isError, shouldShowFeedbackPanel ] );
 
+	const dismissPanelWithDelay = () => {
+		// Allows the animation to run first.
+		setTimeout( () => {
+			setIsFloatingPanelOpen( false );
+		}, FEEDBACK_PANEL_ANIMATION_DELAY_EXIT );
+	};
+
 	const handleButtonClick = ( action: string ) => {
 		switch ( action ) {
 			case ACTION_SEND_FEEDBACK:
@@ -170,10 +189,8 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 				setIsOpen( true );
 				break;
 			case ACTION_DISMISS_FLOATING_PANEL:
-				setIsFloatingPanelOpen( false );
+				dismissPanelWithDelay();
 				updateFeedbackPanelHibernationDelay();
-
-				// stats_feedback_action_dismiss_floating_panel
 				trackStatsAnalyticsEvent( `stats_feedback_${ ACTION_DISMISS_FLOATING_PANEL }` );
 				break;
 			case ACTION_LEAVE_REVIEW:

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -11,6 +11,9 @@ import {
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import FeedbackModal from './modal';
 
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'animate.css';
+
 import './style.scss';
 
 const ACTION_LEAVE_REVIEW = 'action_redirect_to_plugin_review_page';
@@ -108,7 +111,7 @@ function FeedbackPanel( { isOpen, clickHandler }: FeedbackPropsInternal ) {
 	}
 
 	return (
-		<div className="stats-feedback-panel">
+		<div className="stats-feedback-panel animate__animated animate__bounceInUp">
 			<Button
 				className="stats-feedback-panel__close-button"
 				onClick={ handleCloseButtonClicked }

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
 		"@wordpress/primitives": "^4.2.0",
 		"@wordpress/rich-text": "^7.2.0",
 		"@wordpress/url": "^4.2.0",
+		"animate.css": "^4.1.1",
 		"browserslist": "^4.16.0",
 		"calypso": "workspace:^",
 		"calypso-codemods": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10846,6 +10846,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"animate.css@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "animate.css@npm:4.1.1"
+  checksum: 28fcf5a5f502e4c12186846d22aa1cd63b835955160a97116930c78bff8a89135aa5c57f94010252a29456ada7cfc8ed8791cac02521ec6402befaf883937159
+  languageName: node
+  linkType: hard
+
 "ansi-align@npm:^3.0.0":
   version: 3.0.0
   resolution: "ansi-align@npm:3.0.0"
@@ -34557,6 +34564,7 @@ __metadata:
     "@wordpress/rich-text": "npm:^7.2.0"
     "@wordpress/stylelint-config": "npm:^22.2.0"
     "@wordpress/url": "npm:^4.2.0"
+    animate.css: "npm:^4.1.1"
     babel-loader: "npm:^8.2.3"
     browserslist: "npm:^4.16.0"
     bunyan: "npm:^1.8.15"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/173

## Proposed Changes

Adds animated transitions to the floating feedback panel using [the Animate.css framework](https://animate.style/). Check it out:

https://github.com/user-attachments/assets/9da56273-821d-4ced-b6b2-2fcfe6939412

Looks pretty sharp. Adding in a `try` branch as I wasn't sure about adding an external dependancy like this. It appears to have added very little to the bundle size though.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of the User Feedback project.

pejTkB-1Ce-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on a site with a commercial Stats plan.
* Visit the Traffic page.
* Enable the feature flag: `?flags=stats/user-feedback`
* Refresh the page and confirm the floating panel is presented with an animation (after a short delay).
* Click the "x" button or the Dismiss link.
* Confirm the floating panel is removed with a nice animated transition off the bottom of the page.

PS: To prevent sleeping the panel for 6 months, disable the call to `updateFeedbackPanelHibernationDelay()` on line 173.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
