### PR TITLE
Performance Profiler: Add landing page for unsubscribe email flow

### DIFF
--- a/client/data/site-profiler/use-unsubscribe-query.ts
+++ b/client/data/site-profiler/use-unsubscribe-query.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query';
+import { LeadMutationResponse } from 'calypso/data/site-profiler/types';
+import wp from 'calypso/lib/wp';
+
+export const useUnsubscribeMutation = ( url?: string, hash?: string ) => {
+	return useMutation( {
+		mutationKey: [ 'email-unsubscribe', url, hash ],
+		mutationFn: (): Promise< LeadMutationResponse > =>
+			wp.req.get(
+				{
+					path: '/site-profiler/emails/unsubscribe',
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					url,
+					hash,
+				}
+			),
+	} );
+};

--- a/client/performance-profiler/components/weekly-report/loader-text.tsx
+++ b/client/performance-profiler/components/weekly-report/loader-text.tsx
@@ -1,0 +1,54 @@
+import styled from '@emotion/styled';
+
+const LoaderText = styled.span`
+	display: flex;
+	align-items: center;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 24px;
+	position: relative;
+
+	&:before {
+		content: '';
+		display: inline-block;
+		border-radius: 50%;
+		margin-right: 10px;
+		content: '';
+		width: 16px;
+		height: 16px;
+		border: solid 2px #074ee8;
+		border-radius: 50%;
+		border-bottom-color: transparent;
+		-webkit-transition: all 0.5s ease-in;
+		-webkit-animation-name: rotate;
+		-webkit-animation-duration: 1s;
+		-webkit-animation-iteration-count: infinite;
+		-webkit-animation-timing-function: linear;
+
+		transition: all 0.5s ease-in;
+		animation-name: rotate;
+		animation-duration: 1s;
+		animation-iteration-count: infinite;
+		animation-timing-function: linear;
+	}
+
+	@keyframes rotate {
+		from {
+			transform: rotate( 0deg );
+		}
+		to {
+			transform: rotate( 360deg );
+		}
+	}
+
+	@-webkit-keyframes rotate {
+		from {
+			-webkit-transform: rotate( 0deg );
+		}
+		to {
+			-webkit-transform: rotate( 360deg );
+		}
+	}
+`;
+
+export default LoaderText;

--- a/client/performance-profiler/controller.tsx
+++ b/client/performance-profiler/controller.tsx
@@ -3,6 +3,7 @@ import { UniversalNavbarFooter, UniversalNavbarHeader } from '@automattic/wpcom-
 import { translate } from 'i18n-calypso';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
+import { WeeklyReportUnsubscribe } from 'calypso/performance-profiler/pages/weekly-report/unsubscribe';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { TabType } from './components/header';
 import { PerformanceProfilerDashboard } from './pages/dashboard';
@@ -66,6 +67,22 @@ export function WeeklyReportContext( context: Context, next: () => void ): void 
 	context.primary = (
 		<PerformanceProfilerWrapper isLoggedIn={ isLoggedIn }>
 			<WeeklyReport url={ url } hash={ context.query?.hash ?? '' } />
+		</PerformanceProfilerWrapper>
+	);
+
+	next();
+}
+
+export function WeeklyReportUnsubscribeContext( context: Context, next: () => void ): void {
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+
+	const url = context.query?.url?.startsWith( 'http' )
+		? context.query.url
+		: `https://${ context.query?.url ?? '' }`;
+
+	context.primary = (
+		<PerformanceProfilerWrapper isLoggedIn={ isLoggedIn }>
+			<WeeklyReportUnsubscribe url={ url } hash={ context.query?.hash ?? '' } />
 		</PerformanceProfilerWrapper>
 	);
 

--- a/client/performance-profiler/index.web.ts
+++ b/client/performance-profiler/index.web.ts
@@ -1,9 +1,20 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
-import { PerformanceProfilerDashboardContext, WeeklyReportContext, notFound } from './controller';
+import {
+	PerformanceProfilerDashboardContext,
+	WeeklyReportContext,
+	notFound,
+	WeeklyReportUnsubscribeContext,
+} from './controller';
 
 export default function () {
 	page( '/speed-test-tool/', PerformanceProfilerDashboardContext, makeLayout, clientRender );
 	page( '/speed-test-tool/weekly-report', WeeklyReportContext, makeLayout, clientRender );
+	page(
+		'/speed-test-tool/weekly-report/unsubscribe',
+		WeeklyReportUnsubscribeContext,
+		makeLayout,
+		clientRender
+	);
 	page( '/speed-test-tool*', notFound, makeLayout, clientRender );
 }

--- a/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
+++ b/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
@@ -67,7 +67,7 @@ export const WeeklyReportUnsubscribe = ( props: WeeklyReportProps ) => {
 					displayBadge
 					title={ translate( 'Unsubscribed!' ) }
 					message={ translate(
-						'You‘ll no longer receive weekly performance report for {{strong}}%s{{/strong}}',
+						'You‘ll no longer receive weekly performance reports for {{strong}}%s{{/strong}}',
 						{ args: [ siteUrl.host ], components: { strong: <strong /> } }
 					) }
 					ctaText={ translate( '← Back to speed test' ) }

--- a/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
+++ b/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
@@ -22,7 +22,7 @@ export const WeeklyReportUnsubscribe = ( props: WeeklyReportProps ) => {
 	}, [ mutate ] );
 
 	const secondaryMessage = translate(
-		'You can always resubscribe to receive performance change emails by opting in again for weekly reports at any time.'
+		'You can opt in again for weekly reports to receive performance change emails.'
 	);
 
 	return (

--- a/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
+++ b/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { useLeadMutation } from 'calypso/data/site-profiler/use-lead-query';
+import { useUnsubscribeMutation } from 'calypso/data/site-profiler/use-unsubscribe-query';
 import {
 	MessageDisplay,
 	ErrorSecondLine,
@@ -9,20 +9,20 @@ import {
 import LoaderText from 'calypso/performance-profiler/components/weekly-report/loader-text';
 import { WeeklyReportProps } from 'calypso/performance-profiler/types/weekly-report';
 
-export const WeeklyReport = ( props: WeeklyReportProps ) => {
+export const WeeklyReportUnsubscribe = ( props: WeeklyReportProps ) => {
 	const translate = useTranslate();
 	const { url, hash } = props;
 
 	const siteUrl = new URL( url );
 
-	const { mutate, isPending, isError, isSuccess } = useLeadMutation( url, hash );
+	const { mutate, isPending, isError, isSuccess } = useUnsubscribeMutation( url, hash );
 
 	useEffect( () => {
 		mutate();
 	}, [ mutate ] );
 
 	const secondaryMessage = translate(
-		'You can stop receiving performance reports at any time by clicking the Unsubscribe link in the email footer.'
+		'You can always resubscribe to receive performance change emails by opting in again for weekly reports at any time.'
 	);
 
 	return (
@@ -34,7 +34,7 @@ export const WeeklyReport = ( props: WeeklyReportProps ) => {
 					displayBadge
 					message={
 						<LoaderText>
-							{ translate( 'Enabling email reports for %s', {
+							{ translate( 'Unsubscribing email alerts for %s', {
 								args: [ siteUrl.host ],
 							} ) }
 						</LoaderText>
@@ -48,7 +48,7 @@ export const WeeklyReport = ( props: WeeklyReportProps ) => {
 					displayBadge
 					message={
 						<>
-							{ translate( 'Email reports could not be enabled for %s', {
+							{ translate( 'Failed to unsubscribe from email alerts for %s', {
 								args: [ siteUrl.host ],
 							} ) }
 							<br />
@@ -59,17 +59,15 @@ export const WeeklyReport = ( props: WeeklyReportProps ) => {
 							</ErrorSecondLine>
 						</>
 					}
-					ctaText={ translate( 'Enable email reports' ) }
-					ctaHref={ `/speed-test-tool/weekly-report?url=${ url }&hash=${ hash }` }
 					secondaryMessage={ secondaryMessage }
 				/>
 			) }
 			{ isSuccess && (
 				<MessageDisplay
 					displayBadge
-					title={ translate( 'You’re all set!' ) }
+					title={ translate( 'Unsubscribed!' ) }
 					message={ translate(
-						'We‘ll send you a weekly performance report for {{strong}}%s{{/strong}} so you can keep an eye on your site‘s speed. The first email is on it‘s way now.',
+						'You‘ll no longer receive weekly performance report for {{strong}}%s{{/strong}}',
 						{ args: [ siteUrl.host ], components: { strong: <strong /> } }
 					) }
 					ctaText={ translate( '← Back to speed test' ) }

--- a/client/performance-profiler/types/weekly-report.ts
+++ b/client/performance-profiler/types/weekly-report.ts
@@ -1,0 +1,4 @@
+export type WeeklyReportProps = {
+	url: string;
+	hash: string;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8824

## Proposed Changes

* Adds a landing page for unsubscribing weekly reports

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To allow subscribers to unsubscribe from weekly emails. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow test instructions **till 6th step** (Need to skip step 7.) from D161429-code.
* Visit the following page. Replace `HASH` and `URL`
```
/speed-test-tool/weekly-report/unsubscribe?url=URL&hash=HASH
``` 
- Continue testing from step 8 of the backend diff. 
- Verify copy & flow. 

![CleanShot 2024-09-13 at 17 38 33@2x](https://github.com/user-attachments/assets/5e78d791-b793-45ef-8b6a-e04a19acb44c)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?