### PR TITLE
Logged-in Performance Profiler: Sort page selector options by most visited

### DIFF
--- a/client/hosting/performance/hooks/useSitePages.ts
+++ b/client/hosting/performance/hooks/useSitePages.ts
@@ -71,7 +71,7 @@ export const useSitePages = ( { query = '' } ) => {
 				{
 					url: '/',
 					label: __( 'Home' ),
-					value: 'home',
+					value: '0',
 					wpcom_performance_url: homePagePerformanceUrl,
 				},
 				...( data ?? [] ),

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -1,11 +1,15 @@
 import page from '@automattic/calypso-router';
 import { useDebouncedInput } from '@wordpress/compose';
 import { translate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import moment from 'moment';
+import { useEffect, useMemo, useState } from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import { requestSiteStats } from 'calypso/state/stats/lists/actions';
+import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { PageSelector } from './components/PageSelector';
 import { PerformanceReport } from './components/PerformanceReport';
 import { DeviceTabControls, Tab } from './components/device-tab-control';
@@ -13,12 +17,45 @@ import { useSitePages } from './hooks/useSitePages';
 
 import './style.scss';
 
+const statType = 'statsTopPosts';
+
+const statsQuery = {
+	num: -1,
+	summarize: 1,
+	period: 'day',
+	date: moment().format( 'YYYY-MM-DD' ),
+	max: 0,
+};
+
 export const SitePerformance = () => {
 	const [ activeTab, setActiveTab ] = useState< Tab >( 'mobile' );
+
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+
+	const stats = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, statsQuery )
+	) as { id: number; value: number }[];
+
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		dispatch( requestSiteStats( siteId, statType, statsQuery ) );
+	}, [ dispatch, siteId ] );
 
 	const queryParams = useSelector( getCurrentQueryArguments );
 	const [ , setQuery, query ] = useDebouncedInput();
 	const pages = useSitePages( { query } );
+
+	const orderedPages = useMemo( () => {
+		return [ ...pages ].sort( ( a, b ) => {
+			const aVisits = stats.find( ( { id } ) => id === parseInt( a.value, 10 ) )?.value ?? 0;
+			const bVisits = stats.find( ( { id } ) => id === parseInt( b.value, 10 ) )?.value ?? 0;
+			return bVisits - aVisits;
+		} );
+	}, [ pages, stats ] );
 
 	const currentPageId = queryParams?.page_id?.toString();
 
@@ -43,7 +80,7 @@ export const SitePerformance = () => {
 				/>
 				<PageSelector
 					onFilterValueChange={ setQuery }
-					options={ pages }
+					options={ orderedPages }
 					onChange={ ( page_id ) => {
 						const url = new URL( window.location.href );
 


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9122.

## Proposed Changes

Title.

## Why are these changes being made?

Improve UX by ranking options by popularity.

## Testing Instructions

Open `/site-performance/%s` and check that the pages are coming unordered from the WP REST API request:

![image](https://github.com/user-attachments/assets/e156eafd-a7a8-44b5-ad5f-2cffffe66b85)

But are being ranked by most visited in the PageSelector options:

![image](https://github.com/user-attachments/assets/47544287-ad68-45e6-93c4-6897e93b2b56)
