### PR TITLE
Logged-in Performance Profiler: Hide report thumbnail and migration banner

### DIFF
--- a/client/hosting/performance/components/PerformanceReport.tsx
+++ b/client/hosting/performance/components/PerformanceReport.tsx
@@ -34,6 +34,8 @@ export const PerformanceReport = ( {
 			performanceReport={ performanceReport }
 			url={ finalUrl ?? url }
 			hash={ hash }
+			displayScreenshots={ false }
+			displayMigrationBanner={ false }
 		/>
 	);
 };

--- a/client/hosting/performance/components/PerformanceReport.tsx
+++ b/client/hosting/performance/components/PerformanceReport.tsx
@@ -34,7 +34,8 @@ export const PerformanceReport = ( {
 			performanceReport={ performanceReport }
 			url={ finalUrl ?? url }
 			hash={ hash }
-			displayScreenshots={ false }
+			displayThumbnail={ false }
+			displayNewsletterBanner={ false }
 			displayMigrationBanner={ false }
 		/>
 	);

--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -17,7 +17,8 @@ type PerformanceProfilerDashboardContentProps = {
 	url: string;
 	hash: string;
 	filter?: string;
-	displayScreenshots?: boolean;
+	displayThumbnail?: boolean;
+	displayNewsletterBanner?: boolean;
 	displayMigrationBanner?: boolean;
 };
 
@@ -26,7 +27,8 @@ export const PerformanceProfilerDashboardContent = ( {
 	url,
 	hash,
 	filter,
-	displayScreenshots = true,
+	displayThumbnail = true,
+	displayNewsletterBanner = true,
 	displayMigrationBanner = true,
 }: PerformanceProfilerDashboardContentProps ) => {
 	const { overall_score, fcp, lcp, cls, inp, ttfb, tbt, audits, history, screenshots, is_wpcom } =
@@ -42,7 +44,7 @@ export const PerformanceProfilerDashboardContent = ( {
 						recommendationsQuantity={ Object.keys( audits ).length }
 						recommendationsRef={ insightsRef }
 					/>
-					{ displayScreenshots && (
+					{ displayThumbnail && (
 						<ScreenshotThumbnail
 							alt={ translate( 'Website thumbnail' ) }
 							src={ screenshots?.[ screenshots.length - 1 ].data }
@@ -58,14 +60,17 @@ export const PerformanceProfilerDashboardContent = ( {
 					tbt={ tbt }
 					history={ history }
 				/>
-				<NewsletterBanner
-					link={ `/speed-test-tool/weekly-report?url=${ url }&hash=${ hash }` }
-					onClick={ () => {
-						recordTracksEvent( 'calypso_performance_profiler_weekly_report_cta_click', {
-							url,
-						} );
-					} }
-				/>
+
+				{ displayNewsletterBanner && (
+					<NewsletterBanner
+						link={ `/speed-test-tool/weekly-report?url=${ url }&hash=${ hash }` }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_performance_profiler_weekly_report_cta_click', {
+								url,
+							} );
+						} }
+					/>
+				) }
 
 				<ScreenshotTimeline screenshots={ screenshots ?? [] } />
 				{ audits && (

--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -17,6 +17,8 @@ type PerformanceProfilerDashboardContentProps = {
 	url: string;
 	hash: string;
 	filter?: string;
+	displayScreenshots?: boolean;
+	displayMigrationBanner?: boolean;
 };
 
 export const PerformanceProfilerDashboardContent = ( {
@@ -24,6 +26,8 @@ export const PerformanceProfilerDashboardContent = ( {
 	url,
 	hash,
 	filter,
+	displayScreenshots = true,
+	displayMigrationBanner = true,
 }: PerformanceProfilerDashboardContentProps ) => {
 	const { overall_score, fcp, lcp, cls, inp, ttfb, tbt, audits, history, screenshots, is_wpcom } =
 		performanceReport;
@@ -38,10 +42,12 @@ export const PerformanceProfilerDashboardContent = ( {
 						recommendationsQuantity={ Object.keys( audits ).length }
 						recommendationsRef={ insightsRef }
 					/>
-					<ScreenshotThumbnail
-						alt={ translate( 'Website thumbnail' ) }
-						src={ screenshots?.[ screenshots.length - 1 ].data }
-					/>
+					{ displayScreenshots && (
+						<ScreenshotThumbnail
+							alt={ translate( 'Website thumbnail' ) }
+							src={ screenshots?.[ screenshots.length - 1 ].data }
+						/>
+					) }
 				</div>
 				<CoreWebVitalsDisplay
 					fcp={ fcp }
@@ -75,14 +81,16 @@ export const PerformanceProfilerDashboardContent = ( {
 			</div>
 
 			<Disclaimer />
-			<MigrationBanner
-				url={ url }
-				onClick={ () => {
-					recordTracksEvent( 'calypso_performance_profiler_migration_banner_cta_click', {
-						url,
-					} );
-				} }
-			/>
+			{ displayMigrationBanner && (
+				<MigrationBanner
+					url={ url }
+					onClick={ () => {
+						recordTracksEvent( 'calypso_performance_profiler_migration_banner_cta_click', {
+							url,
+						} );
+					} }
+				/>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9059.

## Proposed Changes

Title.

## Why are these changes being made?

The new version won't include screenshots, and the migration banner at the bottom doesn't make sense because the site is already on WPCOM.

