### PR TITLE
Stats: Release the user feedback panel and form modal

### DIFF
--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -75,7 +75,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 			source_url: sourceUrl,
 			product_name: 'Jetpack Stats',
 			feedback: content,
-			is_testing: true,
+			is_testing: false,
 		} );
 	}, [ dispatch, content, submitFeedback ] );
 

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -142,7 +142,7 @@
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
-		"stats/user-feedback": false,
+		"stats/user-feedback": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"stripe-redirect-migration-p24": false,

--- a/config/production.json
+++ b/config/production.json
@@ -188,7 +188,7 @@
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
-		"stats/user-feedback": false,
+		"stats/user-feedback": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"stripe-redirect-migration-p24": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -181,7 +181,7 @@
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
-		"stats/user-feedback": false,
+		"stats/user-feedback": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"stripe-redirect-migration-p24": true,

--- a/config/test.json
+++ b/config/test.json
@@ -130,7 +130,7 @@
 		"stats/date-picker-calendar": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/user-feedback": false,
+		"stats/user-feedback": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -181,7 +181,7 @@
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
-		"stats/user-feedback": false,
+		"stats/user-feedback": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"stripe-redirect-migration-p24": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/175

## Proposed Changes

* Flip the feature flag `stats/user-feedback` to true on production.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Release the functionalities tackled for the project pejTkB-1Ce-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Prepare a Jetpack site with a Stats commercial license or Jetpack Complete / Professional plan.
* Navigate to Stats > Traffic page.
* Scroll down the page and ensure the fixed feedback section is at the bottom.

<img width="1281" alt="截圖 2024-09-13 下午9 39 53" src="https://github.com/user-attachments/assets/7e7aac27-c914-4ab5-a808-eba590b08c5c">

* Ensure the floating feedback panel shows.

<img width="1358" alt="截圖 2024-09-13 下午9 45 23" src="https://github.com/user-attachments/assets/2a65e6e9-1a72-430b-9cb5-8c84ea64c926">

* Click on the `Love it? Leave a review ↗` button.
* Ensure a new tab is navigated to the wordpress.org plugin review page.
* Click on the `Not a fan? Help us improve` button.
* Ensure a feedback form modal is launched.
* Enter some feedback content and click the `Submit` button.

<img width="780" alt="截圖 2024-09-13 下午9 46 22" src="https://github.com/user-attachments/assets/a3b87883-2b1e-436d-bfda-b2baea43c311">

* Ensure the feedback is sent and a message comes into the support feedback chanel.
* Reload the page.
* Ensure the floating panel is not showing again.
* Click on the `Not a fan? Help us improve` button from the bottom section.
* Ensure the feedback form shows a waiting time of 5 minutes for the next feedback submission.

<img width="745" alt="截圖 2024-09-13 下午9 39 08" src="https://github.com/user-attachments/assets/4755d838-ba76-40ad-b574-61c5778a6ad4">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?