### PR TITLE
Performance Profiler: update history chart ticks on mobile

### DIFF
--- a/client/performance-profiler/components/charts/history-chart.jsx
+++ b/client/performance-profiler/components/charts/history-chart.jsx
@@ -97,10 +97,10 @@ const drawLine = ( svg, data, xScale, yScale ) => {
 };
 
 // Draw axes
-const drawAxes = ( svg, xScale, yScale, data, margin, width, height, d3Format ) => {
+const drawAxes = ( svg, xScale, yScale, data, margin, width, height, d3Format, isMobile ) => {
 	const dates = data.map( ( item ) => new Date( item.date ) );
 
-	svg
+	const axis = svg
 		.append( 'g' )
 		.attr( 'transform', `translate(0,${ height - margin.bottom })` )
 		.call(
@@ -110,6 +110,10 @@ const drawAxes = ( svg, xScale, yScale, data, margin, width, height, d3Format ) 
 				.tickPadding( 10 )
 		)
 		.call( ( g ) => g.select( '.domain' ).remove() );
+
+	if ( isMobile ) {
+		axis.selectAll( 'text' ).attr( 'transform', 'rotate(-45)' ).style( 'text-anchor', 'end' );
+	}
 
 	svg
 		.append( 'g' )
@@ -190,7 +194,7 @@ const generateSampleData = ( range ) => {
 	return data;
 };
 
-const HistoryChart = ( { data, range, height, d3Format = '%-m/%d' } ) => {
+const HistoryChart = ( { data, range, height, d3Format = '%-m/%d', isMobile } ) => {
 	const translate = useTranslate();
 	const svgRef = createRef();
 	const tooltipRef = createRef();
@@ -210,7 +214,7 @@ const HistoryChart = ( { data, range, height, d3Format = '%-m/%d' } ) => {
 		d3Select( svgRef.current ).selectAll( '*' ).remove();
 
 		const width = entry.width;
-		const margin = { top: 20, right: 20, bottom: 40, left: 50 };
+		const margin = { top: 20, right: 20, bottom: isMobile ? 60 : 40, left: 50 };
 
 		const { xScale, yScale, colorScale } = createScales( data, range, margin, width, height );
 
@@ -221,7 +225,7 @@ const HistoryChart = ( { data, range, height, d3Format = '%-m/%d' } ) => {
 		drawGrid( svg, yScale, width, margin );
 
 		dataAvailable && drawLine( svg, data, xScale, yScale );
-		drawAxes( svg, xScale, yScale, data, margin, width, height, d3Format );
+		drawAxes( svg, xScale, yScale, data, margin, width, height, d3Format, isMobile );
 
 		const tooltip = d3Select( tooltipRef.current ).attr( 'class', 'tooltip' );
 		dataAvailable && drawDots( svg, data, xScale, yScale, colorScale, range, tooltip );

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -172,6 +172,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 					] }
 					height={ 300 }
 					d3Format="%b %d"
+					isMobile={ isMobile }
 				/>
 			</div>
 		</div>

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
@@ -170,6 +170,7 @@ export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
 					] }
 					height={ 300 }
 					d3Format="%b %d"
+					isMobile={ false }
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/94487

## Proposed Changes

* rotate the X axis ticks on mobile

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pdt2If-1Jh-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/speed-test` and start a new test, or go to a results page eg. `/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzA1N30.7KXaBL1qcm0y0GqvM8ymJ0pbST9ls6P09_hri8EaKSI`
* Check the styling of the history chart

| Viewport | Before | After |
|--------|--------|--------|
| Mobile | <img width="338" alt="image" src="https://github.com/user-attachments/assets/6a2306cd-2592-4b29-add4-7b59d158cef6"> | <img width="374" alt="image" src="https://github.com/user-attachments/assets/443ab0e5-f6e0-4af0-b140-ad56ad29ce98"> |
| Desktop | <img width="494" alt="image" src="https://github.com/user-attachments/assets/0f0e6d4f-f140-4fee-9a1a-72c9e9b94c9e"> | <img width="511" alt="image" src="https://github.com/user-attachments/assets/412ec2a8-d275-440c-882f-6843ca5e0865"> | 