### PR TITLE
Performance Profiler: add email subscription tracks event

### DIFF
--- a/client/performance-profiler/pages/weekly-report/index.tsx
+++ b/client/performance-profiler/pages/weekly-report/index.tsx
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useLeadMutation } from 'calypso/data/site-profiler/use-lead-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	MessageDisplay,
 	ErrorSecondLine,
@@ -20,6 +21,15 @@ export const WeeklyReport = ( props: WeeklyReportProps ) => {
 	useEffect( () => {
 		mutate();
 	}, [ mutate ] );
+
+	useEffect( () => {
+		if ( isSuccess ) {
+			recordTracksEvent( 'calypso_performance_profiler_emails_subscribe', {
+				url,
+				hash,
+			} );
+		}
+	}, [ isSuccess, url, hash ] );
 
 	const secondaryMessage = translate(
 		'You can stop receiving performance reports at any time by clicking the Unsubscribe link in the email footer.'

--- a/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
+++ b/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useUnsubscribeMutation } from 'calypso/data/site-profiler/use-unsubscribe-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	MessageDisplay,
 	ErrorSecondLine,
@@ -20,6 +21,15 @@ export const WeeklyReportUnsubscribe = ( props: WeeklyReportProps ) => {
 	useEffect( () => {
 		mutate();
 	}, [ mutate ] );
+
+	useEffect( () => {
+		if ( isSuccess ) {
+			recordTracksEvent( 'calypso_performance_profiler_emails_unsubscribe', {
+				url,
+				hash,
+			} );
+		}
+	}, [ isSuccess, url, hash ] );
 
 	const secondaryMessage = translate(
 		'You can opt in again for weekly reports to receive performance change emails.'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8811

## Proposed Changes

* add email subscription tracks event
* add email unsubscription tracks event

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p1726234242762659-slack-C02JPCHEKDY

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Chrome devtools and in the Console tab, paste this command to enable analytics logging:
```
localStorage.setItem( 'debug', 'calypso:analytics*' );
```
* On the Console tab, set the `verbose` logging level, and add the `calypso_performance_profiler` filter: 
  ![CleanShot 2024-09-10 at 14 49 54@2x](https://github.com/user-attachments/assets/375f93c4-99df-430f-9ce4-e9c40657f989)
* Start a new test by adding the site URL as a parameter, eg.:
```
/speed-test-tool?url=google.com
```
  or go to a report page, eg.:
```
/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzA1N30.7KXaBL1qcm0y0GqvM8ymJ0pbST9ls6P09_hri8EaKSI
```
* Subscribe to the weekly reports for the test
* On the `/weekly-report` page, check in the logs that the tracks event is fired correctly once the API response is loaded

![CleanShot 2024-09-13 at 15 38 04@2x](https://github.com/user-attachments/assets/146c6655-f0c7-4464-b5bc-6356f6590e57)

* Copy the URL params to the `/speed-test-tool/weekly-report/unsubscribe` page
* check in the logs that the tracks event is fired correctly once the API response is loaded