### PR TITLE
Stats: Add analytics to feedback modal and form actions

### DIFF
--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -13,8 +13,8 @@ import FeedbackModal from './modal';
 
 import './style.scss';
 
-const ACTION_LEAVE_REVIEW = 'action_leave_review';
-const ACTION_SEND_FEEDBACK = 'action_send_feedback';
+const ACTION_LEAVE_REVIEW = 'action_redirect_to_plugin_review_page';
+const ACTION_SEND_FEEDBACK = 'action_open_form_modal';
 const ACTION_DISMISS_FLOATING_PANEL = 'action_dismiss_floating_panel';
 
 const FEEDBACK_PANEL_PRESENTATION_DELAY = 3000;
@@ -96,9 +96,9 @@ function FeedbackPanel( { isOpen, clickHandler }: FeedbackPropsInternal ) {
 	};
 
 	const clickHandlerWithAnalytics = ( action: string ) => {
-		// stats_feedback_floating_panel_action_leave_review
-		// stats_feedback_floating_panel_action_send_feedback
-		trackStatsAnalyticsEvent( `stats_feedback_floating_panel_${ action }` );
+		// stats_feedback_action_redirect_to_plugin_review_page_from_floating_panel
+		// stats_feedback_action_open_form_modal_from_floating_panel
+		trackStatsAnalyticsEvent( `stats_feedback_${ action }_from_floating_panel` );
 
 		clickHandler( action );
 	};
@@ -129,9 +129,9 @@ function FeedbackPanel( { isOpen, clickHandler }: FeedbackPropsInternal ) {
 
 function FeedbackCard( { clickHandler }: FeedbackPropsInternal ) {
 	const clickHandlerWithAnalytics = ( action: string ) => {
-		// stats_feedback_persistent_section_action_leave_review
-		// stats_feedback_persistent_section_action_send_feedback
-		trackStatsAnalyticsEvent( `stats_feedback_persistent_section_${ action }` );
+		// stats_feedback_action_redirect_to_plugin_review_page_from_persistent_section
+		// stats_feedback_action_open_form_modal_from_persistent_section
+		trackStatsAnalyticsEvent( `stats_feedback_${ action }_from_persistent_section` );
 
 		clickHandler( action );
 	};
@@ -181,6 +181,12 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		}
 	};
 
+	const onModalClose = () => {
+		setIsOpen( false );
+
+		trackStatsAnalyticsEvent( 'stats_feedback_action_close_form_modal' );
+	};
+
 	if ( ! supportCommercialUse ) {
 		return null;
 	}
@@ -189,7 +195,7 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		<div className="stats-feedback-container">
 			<FeedbackCard clickHandler={ handleButtonClick } />
 			<FeedbackPanel isOpen={ isFloatingPanelOpen } clickHandler={ handleButtonClick } />
-			{ isOpen && <FeedbackModal siteId={ siteId } onClose={ () => setIsOpen( false ) } /> }
+			{ isOpen && <FeedbackModal siteId={ siteId } onClose={ onModalClose } /> }
 		</div>
 	);
 }

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -9,8 +9,8 @@ import {
 	NOTICES_KEY_SHOW_FLOATING_USER_FEEDBACK_PANEL,
 	useNoticeVisibilityQuery,
 } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
 import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 import useSubmitProductFeedback from './use-submit-product-feedback';
 
@@ -64,11 +64,9 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 			return;
 		}
 
-		dispatch(
-			recordTracksEvent( 'calypso_jetpack_stats_user_feedback_form_submit', {
-				feedback: content,
-			} )
-		);
+		trackStatsAnalyticsEvent( 'stats_feedback_action_submit_form', {
+			feedback: content,
+		} );
 
 		const sourceUrl = `${ window.location.origin }${ window.location.pathname }`;
 		submitFeedback( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/158

## Proposed Changes

* Add analytic events to the feedback modal and form actions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Add analytic events to track the user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Open the browser console network tab.
* Click on the `Not a fan? Help us improve` button.
* Ensure the analytic event is sent after the action is operated.

<img width="860" alt="截圖 2024-09-14 上午12 29 54" src="https://github.com/user-attachments/assets/feb83a37-cc0d-4387-8d1f-b3179a0cdb43">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
