### PR TITLE
Fix punctuation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
@@ -34,14 +34,14 @@ export const SiteAddressField: React.FC< Props > = ( {
 				control={ control }
 				name="siteAddress"
 				rules={ {
-					required: translate( 'Please enter your WordPress site address.' ),
+					required: translate( 'Please enter your WordPress site address' ),
 					validate: validateSiteAddress,
 				} }
 				render={ ( { field } ) => (
 					<FormTextInput
 						id="site-address"
 						isError={ !! errors.siteAddress }
-						placeholder={ translate( 'Enter your WordPress site address.' ) }
+						placeholder={ translate( 'Enter your WordPress site address' ) }
 						readOnly={ !! importSiteQueryParam }
 						disabled={ !! importSiteQueryParam }
 						type="text"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
@@ -40,7 +40,7 @@ export const SiteAddressField: React.FC< Props > = ( {
 				control={ control }
 				name="siteAddress"
 				rules={ {
-					required: translate( 'Please enter your WordPress site address' ),
+					required: translate( 'Please enter your WordPress site address.' ),
 					validate: validateSiteAddress,
 				} }
 				render={ ( { field } ) => (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
@@ -1,4 +1,5 @@
 import { FormLabel } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { Controller, Control } from 'react-hook-form';
 import getValidationMessage from 'calypso/blocks/import/capture/url-validation-message-helper';
@@ -19,6 +20,7 @@ export const SiteAddressField: React.FC< Props > = ( {
 	importSiteQueryParam,
 } ) => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const validateSiteAddress = ( siteAddress: string ) => {
 		const isSiteAddressValid = CAPTURE_URL_RGX.test( siteAddress );
@@ -26,6 +28,10 @@ export const SiteAddressField: React.FC< Props > = ( {
 			return getValidationMessage( siteAddress, translate );
 		}
 	};
+
+	const placeholder = hasEnTranslation( 'Enter your WordPress site address' )
+		? translate( 'Enter your WordPress site address' )
+		: translate( 'Enter your WordPress site address.' );
 
 	return (
 		<div className="site-migration-credentials__form-field">
@@ -41,7 +47,7 @@ export const SiteAddressField: React.FC< Props > = ( {
 					<FormTextInput
 						id="site-address"
 						isError={ !! errors.siteAddress }
-						placeholder={ translate( 'Enter your WordPress site address' ) }
+						placeholder={ placeholder }
 						readOnly={ !! importSiteQueryParam }
 						disabled={ !! importSiteQueryParam }
 						type="text"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/special-instructions.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/special-instructions.tsx
@@ -1,3 +1,4 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Button, Icon } from '@wordpress/components';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -15,6 +16,7 @@ interface Props {
 
 export const SpecialInstructions: React.FC< Props > = ( { control, errors } ) => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const [ showNotes, setShowNotes ] = useState( false );
 
 	const toggleShowNotes = () => {
@@ -23,6 +25,12 @@ export const SpecialInstructions: React.FC< Props > = ( { control, errors } ) =>
 			show_notes: ! showNotes,
 		} );
 	};
+
+	const placeholder = hasEnTranslation(
+		'Share any other details that will help us access your site for the migration'
+	)
+		? translate( 'Share any other details that will help us access your site for the migration' )
+		: translate( 'Share any other details that will help us access your site for the migration.' );
 
 	return (
 		<div className="site-migration-credentials__special-instructions">
@@ -46,9 +54,7 @@ export const SpecialInstructions: React.FC< Props > = ( { control, errors } ) =>
 									type="text"
 									data-testid="special-instructions-textarea"
 									maxLength={ 1000 }
-									placeholder={ translate(
-										'Share any other details that will help us access your site for the migration.'
-									) }
+									placeholder={ placeholder }
 									{ ...field }
 									ref={ null }
 								/>


### PR DESCRIPTION
## Proposed Changes

This PR fixes some random punctuation on the migration information screen. 

## Why are these changes being made?

We currently have an extra period in the placeholder for the site address screen.

**Before**
<img width="620" alt="Screenshot 2024-09-13 at 16 06 41" src="https://github.com/user-attachments/assets/8e6cb64a-ebbe-4a36-a1eb-8fa34cec5ae3">

**After**
<img width="630" alt="Screenshot 2024-09-13 at 16 06 21" src="https://github.com/user-attachments/assets/951a17eb-149d-40a0-b690-0ae20ddf2ed2">

## Testing Instructions
* Visit `/setup/migration`
* Make your way through to the DIFM flow (or check the screeenshots)
