### PR TITLE
A4A Dev Site Actions: Enhance style for the dev site delete confirmation dialogue.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/dev-site-delete-confirmation-dialog/style.scss
+++ b/client/a8c-for-agencies/sections/sites/dev-site-delete-confirmation-dialog/style.scss
@@ -1,6 +1,6 @@
 .dev-site-delete-confirmation-dialog {
 	&.dialog.card {
-		max-width: 60%;
+		max-width: 800px;
 	}
 
 	p {
@@ -10,10 +10,15 @@
 
 	fieldset {
 		margin-top: 2rem;
+		margin-bottom: 0;
 
 		label {
 			font-size: 1rem;
 			font-weight: 500;
+
+			strong {
+				color: var(--color-scary-50);
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9133

## Proposed Changes

* Set max-width of the dialogue to 800px.
* Unset the margin-bottom of the dialogue's fieldset element.
* Display the domain to be typed-in for confirmation in red (same shade as the "Delete" button).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In order to improve the UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a free development site if you do not have one already.
  * In http://agencies.localhost:3000/?flags=a4a-dev-sites, click on "Add Sites", select the Free Development Sites banner and confirm the site config.
* Go to http://agencies.localhost:3000/sites
* Click on the "Site actions" elipsis of a dev site row.
* In the "Site actions" dropdown select "Delete site".
* You should see the confirmation dialogue with the enhanced styles applied.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/94330a91-84de-49ea-b088-833117115343" width="400" style="max-height:200px;"> | <img src="https://github.com/user-attachments/assets/e19f91a6-d477-449a-9c46-5cafe45b07de" width="400" style="max-height:200px;"> |
