### PR TITLE
Theme Activation Modal: Fix Colour Scheming

### DIFF
--- a/client/my-sites/themes/activation-modal.scss
+++ b/client/my-sites/themes/activation-modal.scss
@@ -1,7 +1,4 @@
-@import "@automattic/typography/styles/variables";
 @import "@automattic/typography/styles/fonts";
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
 
 .dialog__content.themes__activation-modal {
 	position: relative;
@@ -12,19 +9,11 @@
 		@extend .wp-brand-font;
 		font-size: $font-title-large;
 		line-height: 1.1;
-		width: 100%;
 		margin-bottom: 32px;
 	}
 }
 
-.themes__theme-preview-wrapper {
-	display: flex;
-	flex-direction: column;
-}
-
 .themes__activation-modal-close-icon {
-	cursor: pointer;
-	color: var(--color-text-subtle);
 	position: absolute;
 	top: 4px;
 	right: 12px;
@@ -35,17 +24,6 @@
 	text-wrap: pretty;
 }
 
-.activation-modal__checkbox {
-	margin-bottom: 16px;
-	.components-base-control__field {
-		display: flex;
-		align-items: center;
-	}
-	.components-checkbox-control__label {
-		font-size: $font-body;
-	}
-}
-
 .activation-modal__actions {
 	display: flex;
 	justify-content: flex-end;
@@ -54,22 +32,5 @@
 		padding: 9px 25px;
 		border-radius: 4px;
 		font-weight: 500;
-		&.is-primary:not(:disabled) {
-			background-color: var(--studio-blue-50);
-			border-color: var(--studio-blue-50);
-			&:hover {
-				background-color: var(--studio-blue-60);
-				border-color: var(--studio-blue-60);
-			}
-			&:focus {
-				box-shadow: 0 0 0 2px var(--color-primary-light);
-				outline: 0;
-			}
-		}
-		&.is-primary:disabled {
-			color: var(--studio-white);
-			background-color: var(--studio-gray-5);
-			border-color: var(--studio-gray-5);
-		}
 	}
 }


### PR DESCRIPTION
Fixes #94015; related to #94107

## Proposed Changes

* Ensure that the colour scheming for the Theme Activation model applies. The current styles unnecessarily force a colour.
* Also removes some unused styles.

## Why are these changes being made?

The colours currently don't match the rest of the UI.

## Testing Instructions

Go to `/themes` and switch theme on your site. Confirm that the button now matches the colour scheme (and that removing the other styles has no adverse impact).

| Before | After |
|--------|--------|
| <img width="671" alt="Screenshot 2024-09-13 at 18 03 08" src="https://github.com/user-attachments/assets/01cbb9af-9cba-4aab-861e-4520083e874d"> | <img width="685" alt="Screenshot 2024-09-13 at 18 03 03" src="https://github.com/user-attachments/assets/73bba8b4-7e43-429a-b784-8bde000923e0"> | 

*Screenshots from the Classic Bright scheme

cc @taipeicoder, @Copons, @fushar 