### PR TITLE
DIFM Landing Page: Fix Style Issues

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -6,7 +6,6 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import DIFMLanding from 'calypso/my-sites/marketing/do-it-for-me/difm-landing';
 import type { Step } from '../../types';
 
-import './style.scss';
 const STEP_NAME = 'difmStartingPoint';
 const DIFMStartingPoint: Step = function ( { navigation } ) {
 	const { goNext, goBack, submit } = navigation;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
@@ -1,4 +1,0 @@
-.step-container.difmStartingPoint {
-	margin-top: 6vh;
-	max-width: 1224px;
-}

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.scss
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.scss
@@ -1,0 +1,9 @@
+.difm-starting-point {
+	.step-container.difmStartingPoint {
+		margin-top: 4vh;
+
+		.step-container__header {
+			padding-inline-end: 0;
+		}
+	}
+}

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -33,6 +33,8 @@ import {
 import { getSitePlan } from 'calypso/state/sites/selectors';
 import type { TranslateResult } from 'i18n-calypso';
 
+import './difm-landing.scss';
+
 const Placeholder = styled.span`
 	padding: 0 60px;
 	animation: loading-fade 800ms ease-in-out infinite;
@@ -55,12 +57,14 @@ const Placeholder = styled.span`
 const Wrapper = styled.div`
 	display: flex;
 	align-items: flex-start;
-	gap: 96px;
 	padding: 12px;
+	max-width: 1040px;
+	margin: 0 auto;
 `;
 
 const ContentSection = styled.div`
 	flex: 1;
+	padding-right: 10px;
 `;
 
 const ImageSection = styled.div`
@@ -76,9 +80,14 @@ const ImageSection = styled.div`
 `;
 
 const Header = styled( FormattedHeader )`
+	margin: 0 0 24px 0 !important;
 	.formatted-header__title {
-		font-size: 2.25rem;
+		font-size: 2.75rem;
 		line-height: 3rem;
+		text-wrap: nowrap;
+	}
+	.formatted-header__subtitle {
+		font-size: 1rem;
 	}
 `;
 
@@ -189,6 +198,7 @@ const CTASectionWrapper = styled.div`
 const StepContainer = styled.div`
 	display: flex;
 	gap: 20px;
+	margin-top: 0;
 `;
 
 const ProgressLine = styled.div`

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -84,7 +84,9 @@ const Header = styled( FormattedHeader )`
 	.formatted-header__title {
 		font-size: 2.75rem;
 		line-height: 3rem;
-		text-wrap: nowrap;
+		@media ( min-width: 400px ) {
+			text-wrap: nowrap;
+		}
 	}
 	.formatted-header__subtitle {
 		font-size: 1rem;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/94345

## Proposed Changes

* This PR addresses various style issues on the DIRM landing page.
  * It fixes an akward title wrap at medium width
  * It adjusts the spacing between elements
  * It sets the font size so it is the same between landing directly on the DIFM page or landing on it from /start flow.
  * If fixes a large top margin on page refresh when coming from /start
  * It adjusts the margin on small browser widths and mobile

Adjust spacing and fix title wrap
Before | After
--|--
<img width="1412" alt="Screenshot 2024-09-13 at 3 00 25 PM" src="https://github.com/user-attachments/assets/695de0e3-e0fe-47d7-88a1-6d59be6e67db">  | <img width="1414" alt="Screenshot 2024-09-13 at 3 00 16 PM" src="https://github.com/user-attachments/assets/dd1483f3-27f0-419b-a01c-b779a5cc97b0">


Small font size on header and sub-header on /start
Before | After
--|--
<img width="1411" alt="Screenshot 2024-09-13 at 3 02 02 PM" src="https://github.com/user-attachments/assets/d405e7bc-1983-4b2d-ad5b-a50acf990142">  | <img width="1413" alt="Screenshot 2024-09-13 at 3 02 20 PM" src="https://github.com/user-attachments/assets/f5813c20-c35c-4395-bc21-7d065f1e8c74">


Large top margin on /start after page refresh
Before | After
--|--
<img width="1412" alt="Screenshot 2024-09-13 at 3 02 51 PM" src="https://github.com/user-attachments/assets/070ce944-469b-40e9-965e-8949781d7e6e">  |  <img width="1411" alt="Screenshot 2024-09-13 at 3 03 04 PM" src="https://github.com/user-attachments/assets/23c30afe-4a71-43d9-a85e-9df7cc22a183">

Margin fix on small widths:
Before | After
--|--
<img width="650" alt="Screenshot 2024-09-13 at 3 04 12 PM" src="https://github.com/user-attachments/assets/e7ec1cc7-84cd-4f06-b820-163dbd0703ff">  | <img width="648" alt="Screenshot 2024-09-13 at 3 05 21 PM" src="https://github.com/user-attachments/assets/d60d4caa-f355-4d9f-a503-1840a18a2f1f">






## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve design and user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /start/do-it-for-me/new-or-existing-site and confirm it looks good on various widths and mobile
* Go ahead and step through the flow to confirm there are no regressions
* Now test DIFM by coming from the /start flow. Create a new site, and once you get to the "Goals" screen, choose the "Do it for me" option and continue.
* Confirm the DIFM page looks good on various widths and mobile.
* Refresh the page and see that the style and layout hasn't changed
* Go ahead and step through the flow to confirm there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
