### PR TITLE
Logged-In Performance Profiler:  Create metric bar v2 that overrides the styling of v1

### DIFF
--- a/client/performance-profiler/components/metric-tab-bar/index.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/index.tsx
@@ -28,6 +28,9 @@ export const MetricTabBar = ( props: Props ) => {
 					return null;
 				}
 
+				const status = mapThresholdsToStatus( key as Metrics, props[ key as Metrics ] );
+				const statusClassName = status === 'needsImprovement' ? 'needs-improvement' : status;
+
 				return (
 					<button
 						key={ key }
@@ -41,7 +44,7 @@ export const MetricTabBar = ( props: Props ) => {
 						</div>
 						<div className="metric-tab-bar__tab-text">
 							<div className="metric-tab-bar__tab-header">{ displayName }</div>
-							<div className="metric-tab-bar__tab-metric">
+							<div className={ `metric-tab-bar__tab-metric ${ statusClassName }` }>
 								{ displayValue( key as Metrics, props[ key as Metrics ] ) }
 							</div>
 						</div>

--- a/client/performance-profiler/components/metric-tab-bar/metric-tab-bar-v2.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/metric-tab-bar-v2.tsx
@@ -1,0 +1,12 @@
+import { Metrics } from 'calypso/data/site-profiler/types';
+import { MetricTabBar } from '.';
+import './style_v2.scss';
+
+type Props = Record< Metrics, number > & {
+	activeTab: Metrics;
+	setActiveTab: ( tab: Metrics ) => void;
+};
+
+export const MetricTabBarV2 = ( props: Props ) => {
+	return <MetricTabBar { ...props } />;
+};

--- a/client/performance-profiler/components/metric-tab-bar/style_v2.scss
+++ b/client/performance-profiler/components/metric-tab-bar/style_v2.scss
@@ -1,0 +1,103 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/components/src/styles/typography";
+
+$blueberry-color: #3858e9;
+
+.metric-tab-bar {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+
+	button {
+		color: inherit;
+	}
+}
+
+.metric-tab-bar__tab {
+	display: flex;
+	gap: 6px;
+	background: var(--studio-white);
+	border: 1.5px solid var(--studio-gray-5);
+	text-align: initial;
+	flex-grow: 1;
+	padding: 16px 22px 16px 22px;
+
+	&:not(.active) {
+		border-bottom: 1px solid var(--studio-gray-5);
+		&:not(:first-child) {
+			border-top: none;
+		}
+	}
+
+	&.active {
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 6px;
+		border: 1.5px solid $blueberry-color;
+		position: relative;
+
+		&::before {
+			left: -6px;
+			background-image: unset;
+		}
+
+		&::after {
+			right: -6px;
+			background-image: unset;
+		}
+
+	}
+
+	&:last-child {
+		/* stylelint-disable-next-line scales/radii */
+		border-bottom-right-radius: 6px;
+		/* stylelint-disable-next-line scales/radii */
+		border-bottom-left-radius: 6px;
+	}
+
+	&:first-child {
+		/* stylelint-disable-next-line scales/radii */
+		border-top-left-radius: 6px;
+		/* stylelint-disable-next-line scales/radii */
+		border-top-right-radius: 6px;
+	}
+
+	&:hover {
+		cursor: pointer;
+		color: $blueberry-color;
+	}
+}
+
+.metric-tab-bar__tab-status {
+	line-height: normal;
+	display: none;
+}
+
+.metric-tab-bar__tab-text {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+
+}
+
+.metric-tab-bar__tab-header {
+	font-family: $font-sf-pro-display;
+	font-size: $font-body-small;
+	font-weight: 500;
+}
+.metric-tab-bar__tab-metric {
+	font-family: $font-sf-pro-display;
+	font-size: $font-size-header-small;
+
+
+	&.good {
+		color: #00ba37;
+	}
+
+	&.needs-improvement {
+		color: #d67709;
+	}
+
+	&.bad {
+		color: #d63638;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Create a version 2 of the metric tab bar to match the new design
![image](https://github.com/user-attachments/assets/0495b106-1564-4eda-9f7e-1b895238e4c6)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Styling changes mostly, component is not used

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
