### PR TITLE
Remove deprecated defaultProps from several components (part 3)

### DIFF
--- a/client/blocks/post-edit-button/index.jsx
+++ b/client/blocks/post-edit-button/index.jsx
@@ -1,11 +1,12 @@
 import { Gridicon } from '@automattic/components';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { getEditURL } from 'calypso/state/posts/utils';
 
 import './style.scss';
 
-const PostEditButton = ( { post, site, iconSize, onClick, translate } ) => {
+const PostEditButton = ( { post, site, iconSize = 24, onClick } ) => {
+	const translate = useTranslate();
 	const editUrl = getEditURL( post, site );
 	return (
 		<a className="post-edit-button" href={ editUrl } onClick={ onClick }>
@@ -22,8 +23,4 @@ PostEditButton.propTypes = {
 	onClick: PropTypes.func,
 };
 
-PostEditButton.defaultProps = {
-	iconSize: 24,
-};
-
-export default localize( PostEditButton );
+export default PostEditButton;

--- a/client/blocks/reader-author-link/README.md
+++ b/client/blocks/reader-author-link/README.md
@@ -8,8 +8,8 @@ This component does not dictate the content of the link, only the href and click
 
 The `ReaderAuthorLink` component can be used in much the same way that you would use an `<ExternalLink>` component. The link wraps whatever is placed between the ReaderAuthorLink elements.
 
-```html
-<ReaderAuthorLink author="{" author } siteUrl="{" siteUrl }>Your link text here</ReaderAuthorLink>
+```jsx
+<ReaderAuthorLink author={ author } siteUrl={ siteUrl }>Your link text here</ReaderAuthorLink>
 ```
 
 ## Props

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -6,8 +6,6 @@ import * as stats from 'calypso/reader/stats';
 
 import './style.scss';
 
-const noop = () => {};
-
 const ReaderAuthorLink = ( { author, post, siteUrl, children, className, onClick } ) => {
 	const recordAuthorClick = () => {
 		stats.recordAction( 'click_author' );
@@ -15,7 +13,7 @@ const ReaderAuthorLink = ( { author, post, siteUrl, children, className, onClick
 		if ( post ) {
 			stats.recordTrackForPost( 'calypso_reader_author_link_clicked', post );
 		}
-		onClick();
+		onClick?.();
 	};
 
 	if ( ! siteUrl ) {
@@ -47,10 +45,6 @@ ReaderAuthorLink.propTypes = {
 	author: PropTypes.object.isRequired,
 	post: PropTypes.object, // for stats only,
 	siteUrl: PropTypes.string, // used instead of author.URL if present
-};
-
-ReaderAuthorLink.defaultProps = {
-	onClick: noop,
 };
 
 export default ReaderAuthorLink;

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { localize, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import CommentButton from 'calypso/blocks/comment-button';
 import { shouldShowComments } from 'calypso/blocks/comments/helper';
@@ -13,8 +13,14 @@ import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 
 import './style.scss';
 
-const ReaderPostActions = ( props ) => {
-	const { post, site, onCommentClick, iconSize, className, fullPost } = props;
+const ReaderPostActions = ( {
+	post,
+	site,
+	onCommentClick,
+	iconSize = 20,
+	className,
+	fullPost,
+} ) => {
 	const translate = useTranslate();
 	const hasSites = !! useSelector( getPrimarySiteId );
 
@@ -23,11 +29,8 @@ const ReaderPostActions = ( props ) => {
 	const showComments = shouldShowComments( post );
 	const showLikes = shouldShowLikes( post );
 
-	const listClassnames = clsx( className, {
-		'reader-post-actions': true,
-	} );
+	const listClassnames = clsx( 'reader-post-actions', className );
 
-	/* eslint-disable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 	return (
 		<ul className={ listClassnames }>
 			{ showShare && (
@@ -61,7 +64,7 @@ const ReaderPostActions = ( props ) => {
 						post={ post }
 						onClick={ onCommentClick }
 						tagName="button"
-						icon={ ReaderCommentIcon( { iconSize: iconSize } ) }
+						icon={ ReaderCommentIcon( { iconSize } ) }
 						defaultLabel={ translate( 'Comment' ) }
 					/>
 				</li>
@@ -86,23 +89,14 @@ const ReaderPostActions = ( props ) => {
 			) }
 		</ul>
 	);
-	/* eslint-enable react/jsx-no-target-blank, wpcalypso/jsx-classname-namespace */
 };
 
 ReaderPostActions.propTypes = {
 	post: PropTypes.object.isRequired,
 	site: PropTypes.object,
 	onCommentClick: PropTypes.func,
-	showFollow: PropTypes.bool,
 	iconSize: PropTypes.number,
-	visitUrl: PropTypes.string,
 	fullPost: PropTypes.bool,
 };
 
-ReaderPostActions.defaultProps = {
-	showFollow: true,
-	showVisit: false,
-	iconSize: 20,
-};
-
-export default localize( ReaderPostActions );
+export default ReaderPostActions;

--- a/client/blocks/reader-related-card/index.jsx
+++ b/client/blocks/reader-related-card/index.jsx
@@ -1,6 +1,5 @@
 import { CompactCard as Card } from '@automattic/components';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { useState } from 'react';
 import { connect } from 'react-redux';
@@ -186,8 +185,6 @@ export function RelatedPostCard( {
 	);
 }
 
-export const LocalizedRelatedPostCard = localize( RelatedPostCard );
-
 export default connect( ( state, ownProps ) => {
 	const { post } = ownProps;
 	const actualPost = getPostById( state, post );
@@ -198,4 +195,4 @@ export default connect( ( state, ownProps ) => {
 		site,
 		siteId,
 	};
-} )( LocalizedRelatedPostCard );
+} )( RelatedPostCard );

--- a/client/components/action-panel/figure.jsx
+++ b/client/components/action-panel/figure.jsx
@@ -1,9 +1,8 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 
-const ActionPanelFigure = ( { inlineBodyText, align, children } ) => {
-	const figureClasses = clsx( {
-		'action-panel__figure': true,
+const ActionPanelFigure = ( { inlineBodyText = false, align = 'left', children } ) => {
+	const figureClasses = clsx( 'action-panel__figure', {
 		[ `align-${ 'left' === align ? 'left' : 'right' }` ]: true,
 		'is-inline-body-text': inlineBodyText,
 	} );
@@ -13,10 +12,7 @@ const ActionPanelFigure = ( { inlineBodyText, align, children } ) => {
 
 ActionPanelFigure.propTypes = {
 	inlineBodyText: PropTypes.bool, // above `480px` does figure align with body text (below title)
-};
-
-ActionPanelFigure.defaultProps = {
-	inlineBodyText: false,
+	align: PropTypes.string,
 };
 
 export default ActionPanelFigure;

--- a/client/components/action-panel/figure.jsx
+++ b/client/components/action-panel/figure.jsx
@@ -1,11 +1,12 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 
-const ActionPanelFigure = ( { inlineBodyText = false, align = 'left', children } ) => {
-	const figureClasses = clsx( 'action-panel__figure', {
-		[ `align-${ 'left' === align ? 'left' : 'right' }` ]: true,
-		'is-inline-body-text': inlineBodyText,
-	} );
+const ActionPanelFigure = ( { inlineBodyText = false, align = 'right', children } ) => {
+	const figureClasses = clsx(
+		'action-panel__figure',
+		'left' === align ? 'align-left' : 'align-right',
+		{ 'is-inline-body-text': inlineBodyText }
+	);
 
 	return <div className={ figureClasses }>{ children }</div>;
 };


### PR DESCRIPTION
Removes deprecated `defaultProps` from several functional components, mostly in Reader. There are also a few places where I did a simple migration from `localize` to `useTranslate` or removed an unneeded `localize` wrapper completely.

Similar to previous PRs: #93666 and #93988.