### PR TITLE
Stats: Date control update: Improve date selection behaviour

### DIFF
--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -2,6 +2,7 @@ import moment, { Moment } from 'moment';
 import React, { useEffect } from 'react';
 import DatePicker from 'calypso/components/date-picker';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { addDayToRange } from './utils';
 
 type MomentOrNull = Moment | null;
 
@@ -17,50 +18,11 @@ interface DateRangePickerProps {
 	useArrowNavigation?: boolean;
 }
 
-interface DateRange {
-	from: MomentOrNull;
-	to: MomentOrNull;
-}
-
 /**
  * Module variables
  */
 const NO_DATE_SELECTED_VALUE = null;
 const noop = () => {};
-
-export function addDayToRange( day: Moment, range: DateRange ): DateRange {
-	if ( ! day || ! day.isValid() ) {
-		return range;
-	}
-
-	const { from, to } = range;
-
-	if ( from?.isSame( day ) ) {
-		return { ...range, from: null };
-	}
-	if ( to?.isSame( day ) ) {
-		return { ...range, to: null };
-	}
-
-	if ( ! from ) {
-		return { ...range, from: day };
-	}
-	if ( ! to ) {
-		return { ...range, to: day };
-	}
-
-	if ( day.isBefore( from ) ) {
-		return { ...range, from: day };
-	}
-	if ( day.isAfter( to ) ) {
-		return { ...range, to: day };
-	}
-
-	const daysFromStart = Math.abs( from.diff( day, 'days' ) );
-	const daysFromEnd = Math.abs( to.diff( day, 'days' ) );
-
-	return daysFromStart < daysFromEnd ? { ...range, from: day } : { ...range, to: day };
-}
 
 const DateRangePicker = ( {
 	firstSelectableDate,

--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -17,45 +17,49 @@ interface DateRangePickerProps {
 	useArrowNavigation?: boolean;
 }
 
+interface DateRange {
+	from: MomentOrNull;
+	to: MomentOrNull;
+}
+
 /**
  * Module variables
  */
 const NO_DATE_SELECTED_VALUE = null;
 const noop = () => {};
 
-export function addDayToRange(
-	day: Moment,
-	{ from, to }: { from: MomentOrNull; to: MomentOrNull }
-) {
-	let newStartDate = from;
-	let newEndDate = to;
-	let daysFromStartDate;
-	let daysFromEndDate;
-
-	if ( newStartDate && newEndDate ) {
-		daysFromStartDate = Math.abs( newStartDate.diff( day, 'days' ) );
-		daysFromEndDate = Math.abs( newEndDate.diff( day, 'days' ) );
+export function addDayToRange( day: Moment, range: DateRange ): DateRange {
+	if ( ! day || ! day.isValid() ) {
+		return range;
 	}
 
-	if ( newStartDate && newStartDate.isSame( day ) ) {
-		newStartDate = null;
-	} else if ( newEndDate && newEndDate.isSame( day ) ) {
-		newEndDate = null;
-	} else if ( ! newStartDate ) {
-		newStartDate = day;
-	} else if ( ! newEndDate ) {
-		newEndDate = day;
-	} else if ( day.isBefore( newStartDate ) ) {
-		newStartDate = day;
-	} else if ( day.isAfter( newEndDate ) ) {
-		newEndDate = day;
-	} else if ( daysFromStartDate && daysFromEndDate && daysFromStartDate < daysFromEndDate ) {
-		newStartDate = day;
-	} else {
-		newEndDate = day;
+	const { from, to } = range;
+
+	if ( from?.isSame( day ) ) {
+		return { ...range, from: null };
+	}
+	if ( to?.isSame( day ) ) {
+		return { ...range, to: null };
 	}
 
-	return { from: newStartDate, to: newEndDate };
+	if ( ! from ) {
+		return { ...range, from: day };
+	}
+	if ( ! to ) {
+		return { ...range, to: day };
+	}
+
+	if ( day.isBefore( from ) ) {
+		return { ...range, from: day };
+	}
+	if ( day.isAfter( to ) ) {
+		return { ...range, to: day };
+	}
+
+	const daysFromStart = Math.abs( from.diff( day, 'days' ) );
+	const daysFromEnd = Math.abs( to.diff( day, 'days' ) );
+
+	return daysFromStart < daysFromEnd ? { ...range, from: day } : { ...range, to: day };
 }
 
 const DateRangePicker = ( {

--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -23,7 +23,10 @@ interface DateRangePickerProps {
 const NO_DATE_SELECTED_VALUE = null;
 const noop = () => {};
 
-function addDayToRange( day: Moment, { from, to }: { from: MomentOrNull; to: MomentOrNull } ) {
+export function addDayToRange(
+	day: Moment,
+	{ from, to }: { from: MomentOrNull; to: MomentOrNull }
+) {
 	let newStartDate = from;
 	let newEndDate = to;
 	let daysFromStartDate;

--- a/client/components/date-range/test/add-date-to-range.js
+++ b/client/components/date-range/test/add-date-to-range.js
@@ -1,88 +1,66 @@
 import moment from 'moment';
-import { addDayToRange } from '../date-range-picker';
-
-// Mock Moment.js
-jest.mock( 'moment', () => {
-	const mMoment = {
-		isSame: jest.fn(),
-		isBefore: jest.fn(),
-		isAfter: jest.fn(),
-		diff: jest.fn(),
-		default: { locale: jest.fn() },
-	};
-	return jest.fn( () => mMoment );
-} );
+import { addDayToRange } from '../utils';
 
 describe( 'addDayToRange', () => {
-	let mockMoment;
-
-	beforeEach( () => {
-		mockMoment = moment();
-		jest.clearAllMocks();
+	test( 'should return the same range if day is invalid', () => {
+		const range = { from: moment( '2023-01-01' ), to: moment( '2023-01-05' ) };
+		const result = addDayToRange( null, range );
+		expect( result ).toEqual( range );
 	} );
 
-	test( 'should set start date when range is empty', () => {
-		const result = addDayToRange( mockMoment, { from: null, to: null } );
-		expect( result ).toEqual( { from: mockMoment, to: null } );
+	test( 'should set "from" to null if day is the same as "from"', () => {
+		const range = { from: moment( '2023-01-01' ), to: moment( '2023-01-05' ) };
+		const result = addDayToRange( moment( '2023-01-01' ), range );
+		expect( result.from ).toBeNull();
+		expect( result.to ).toEqual( range.to );
 	} );
 
-	test( 'should set end date when start date is set but end date is null', () => {
-		const mockFrom = moment();
-		const result = addDayToRange( mockMoment, { from: mockFrom, to: null } );
-		expect( result ).toEqual( { from: mockFrom, to: mockMoment } );
+	test( 'should set "to" to null if day is the same as "to"', () => {
+		const range = { from: moment( '2023-01-01' ), to: moment( '2023-01-05' ) };
+		const result = addDayToRange( moment( '2023-01-05' ), range );
+		expect( result.from ).toEqual( range.from );
+		expect( result.to ).toBeNull();
 	} );
 
-	test( 'should clear start date when day is same as start date', () => {
-		const mockFrom = moment();
-		mockFrom.isSame.mockReturnValue( true );
-		const result = addDayToRange( mockMoment, { from: mockFrom, to: null } );
-		expect( result ).toEqual( { from: null, to: null } );
+	test( 'should set "from" if it is null', () => {
+		const range = { from: null, to: moment( '2023-01-05' ) };
+		const result = addDayToRange( moment( '2023-01-01' ), range );
+		expect( result.from ).toEqual( moment( '2023-01-01' ) );
+		expect( result.to ).toEqual( range.to );
 	} );
 
-	test( 'should clear end date when day is same as end date', () => {
-		const mockFrom = moment();
-		const mockTo = moment();
-		mockTo.isSame.mockReturnValue( true );
-		const result = addDayToRange( mockMoment, { from: mockFrom, to: mockTo } );
-		expect( result ).toEqual( { from: mockFrom, to: null } );
+	test( 'should set "to" if it is null', () => {
+		const range = { from: moment( '2023-01-01' ), to: null };
+		const result = addDayToRange( moment( '2023-01-05' ), range );
+		expect( result.from ).toEqual( range.from );
+		expect( result.to ).toEqual( moment( '2023-01-05' ) );
 	} );
 
-	test( 'should set start date when day is before current range', () => {
-		const mockFrom = moment();
-		const mockTo = moment();
-		mockMoment.isBefore.mockReturnValue( true );
-		const result = addDayToRange( mockMoment, { from: mockFrom, to: mockTo } );
-		expect( result ).toEqual( { from: mockMoment, to: mockTo } );
+	test( 'should update "from" if day is before current "from"', () => {
+		const range = { from: moment( '2023-01-05' ), to: moment( '2023-01-10' ) };
+		const result = addDayToRange( moment( '2023-01-01' ), range );
+		expect( result.from ).toEqual( moment( '2023-01-01' ) );
+		expect( result.to ).toEqual( range.to );
 	} );
 
-	test( 'should set end date when day is after current range', () => {
-		const mockFrom = moment();
-		const mockTo = moment();
-		mockMoment.isBefore.mockReturnValue( false );
-		mockMoment.isAfter.mockReturnValue( true );
-		const result = addDayToRange( mockMoment, { from: mockFrom, to: mockTo } );
-		expect( result ).toEqual( { from: mockFrom, to: mockMoment } );
+	test( 'should update "to" if day is after current "to"', () => {
+		const range = { from: moment( '2023-01-01' ), to: moment( '2023-01-05' ) };
+		const result = addDayToRange( moment( '2023-01-10' ), range );
+		expect( result.from ).toEqual( range.from );
+		expect( result.to ).toEqual( moment( '2023-01-10' ) );
 	} );
 
-	test( 'should set start date when day is closer to start', () => {
-		const mockFrom = moment();
-		const mockTo = moment();
-		mockMoment.isBefore.mockReturnValue( false );
-		mockMoment.isAfter.mockReturnValue( false );
-		mockFrom.diff.mockReturnValue( 1 );
-		mockTo.diff.mockReturnValue( 2 );
-		const result = addDayToRange( mockMoment, { from: mockFrom, to: mockTo } );
-		expect( result ).toEqual( { from: mockMoment, to: mockTo } );
+	test( 'should update "from" if day is closer to "from" than "to"', () => {
+		const range = { from: moment( '2023-01-01' ), to: moment( '2023-01-10' ) };
+		const result = addDayToRange( moment( '2023-01-04' ), range );
+		expect( result.from ).toEqual( moment( '2023-01-04' ) );
+		expect( result.to ).toEqual( range.to );
 	} );
 
-	test( 'should set end date when day is closer to end', () => {
-		const mockFrom = moment();
-		const mockTo = moment();
-		mockMoment.isBefore.mockReturnValue( false );
-		mockMoment.isAfter.mockReturnValue( false );
-		mockFrom.diff.mockReturnValue( 2 );
-		mockTo.diff.mockReturnValue( 1 );
-		const result = addDayToRange( mockMoment, { from: mockFrom, to: mockTo } );
-		expect( result ).toEqual( { from: mockFrom, to: mockMoment } );
+	test( 'should update "to" if day is closer to "to" than "from"', () => {
+		const range = { from: moment( '2023-01-01' ), to: moment( '2023-01-10' ) };
+		const result = addDayToRange( moment( '2023-01-07' ), range );
+		expect( result.from ).toEqual( range.from );
+		expect( result.to ).toEqual( moment( '2023-01-07' ) );
 	} );
 } );

--- a/client/components/date-range/test/add-date-to-range.js
+++ b/client/components/date-range/test/add-date-to-range.js
@@ -8,7 +8,7 @@ jest.mock( 'moment', () => {
 		isBefore: jest.fn(),
 		isAfter: jest.fn(),
 		diff: jest.fn(),
-		locale: jest.fn(),
+		default: { locale: jest.fn() },
 	};
 	return jest.fn( () => mMoment );
 } );

--- a/client/components/date-range/test/add-date-to-range.js
+++ b/client/components/date-range/test/add-date-to-range.js
@@ -1,0 +1,88 @@
+import moment from 'moment';
+import { addDayToRange } from '../date-range-picker';
+
+// Mock Moment.js
+jest.mock( 'moment', () => {
+	const mMoment = {
+		isSame: jest.fn(),
+		isBefore: jest.fn(),
+		isAfter: jest.fn(),
+		diff: jest.fn(),
+		locale: jest.fn(),
+	};
+	return jest.fn( () => mMoment );
+} );
+
+describe( 'addDayToRange', () => {
+	let mockMoment;
+
+	beforeEach( () => {
+		mockMoment = moment();
+		jest.clearAllMocks();
+	} );
+
+	test( 'should set start date when range is empty', () => {
+		const result = addDayToRange( mockMoment, { from: null, to: null } );
+		expect( result ).toEqual( { from: mockMoment, to: null } );
+	} );
+
+	test( 'should set end date when start date is set but end date is null', () => {
+		const mockFrom = moment();
+		const result = addDayToRange( mockMoment, { from: mockFrom, to: null } );
+		expect( result ).toEqual( { from: mockFrom, to: mockMoment } );
+	} );
+
+	test( 'should clear start date when day is same as start date', () => {
+		const mockFrom = moment();
+		mockFrom.isSame.mockReturnValue( true );
+		const result = addDayToRange( mockMoment, { from: mockFrom, to: null } );
+		expect( result ).toEqual( { from: null, to: null } );
+	} );
+
+	test( 'should clear end date when day is same as end date', () => {
+		const mockFrom = moment();
+		const mockTo = moment();
+		mockTo.isSame.mockReturnValue( true );
+		const result = addDayToRange( mockMoment, { from: mockFrom, to: mockTo } );
+		expect( result ).toEqual( { from: mockFrom, to: null } );
+	} );
+
+	test( 'should set start date when day is before current range', () => {
+		const mockFrom = moment();
+		const mockTo = moment();
+		mockMoment.isBefore.mockReturnValue( true );
+		const result = addDayToRange( mockMoment, { from: mockFrom, to: mockTo } );
+		expect( result ).toEqual( { from: mockMoment, to: mockTo } );
+	} );
+
+	test( 'should set end date when day is after current range', () => {
+		const mockFrom = moment();
+		const mockTo = moment();
+		mockMoment.isBefore.mockReturnValue( false );
+		mockMoment.isAfter.mockReturnValue( true );
+		const result = addDayToRange( mockMoment, { from: mockFrom, to: mockTo } );
+		expect( result ).toEqual( { from: mockFrom, to: mockMoment } );
+	} );
+
+	test( 'should set start date when day is closer to start', () => {
+		const mockFrom = moment();
+		const mockTo = moment();
+		mockMoment.isBefore.mockReturnValue( false );
+		mockMoment.isAfter.mockReturnValue( false );
+		mockFrom.diff.mockReturnValue( 1 );
+		mockTo.diff.mockReturnValue( 2 );
+		const result = addDayToRange( mockMoment, { from: mockFrom, to: mockTo } );
+		expect( result ).toEqual( { from: mockMoment, to: mockTo } );
+	} );
+
+	test( 'should set end date when day is closer to end', () => {
+		const mockFrom = moment();
+		const mockTo = moment();
+		mockMoment.isBefore.mockReturnValue( false );
+		mockMoment.isAfter.mockReturnValue( false );
+		mockFrom.diff.mockReturnValue( 2 );
+		mockTo.diff.mockReturnValue( 1 );
+		const result = addDayToRange( mockMoment, { from: mockFrom, to: mockTo } );
+		expect( result ).toEqual( { from: mockFrom, to: mockMoment } );
+	} );
+} );

--- a/client/components/date-range/utils.ts
+++ b/client/components/date-range/utils.ts
@@ -1,0 +1,42 @@
+import { Moment } from 'moment';
+
+interface DateRange {
+	from: Moment | null;
+	to: Moment | null;
+}
+
+function addDayToRange( day: Moment, range: DateRange ): DateRange {
+	if ( ! day || ! day.isValid() ) {
+		return range;
+	}
+
+	const { from, to } = range;
+
+	if ( from?.isSame( day ) ) {
+		return { ...range, from: null };
+	}
+	if ( to?.isSame( day ) ) {
+		return { ...range, to: null };
+	}
+
+	if ( ! from ) {
+		return { ...range, from: day };
+	}
+	if ( ! to ) {
+		return { ...range, to: day };
+	}
+
+	if ( day.isBefore( from ) ) {
+		return { ...range, from: day };
+	}
+	if ( day.isAfter( to ) ) {
+		return { ...range, to: day };
+	}
+
+	const daysFromStart = Math.abs( from.diff( day, 'days' ) );
+	const daysFromEnd = Math.abs( to.diff( day, 'days' ) );
+
+	return daysFromStart < daysFromEnd ? { ...range, from: day } : { ...range, to: day };
+}
+
+export { addDayToRange };


### PR DESCRIPTION
## Proposed Changes

* The PR implement part of the smart date range selection behavior proposed in p9X8ns-54k-p2

## Why are these changes being made?
* Improve date range selection experience

## Testing Instructions

* should set start date when range is empty
* should set end date when start date is set but end date is null
* should clear start date when day is same as start date
* should clear end date when day is same as end date
* should set start date when day is before current range
* should set end date when day is after current range
* should set start date when day is closer to start
* should set end date when day is closer to end
* Ensure all tests pass


https://github.com/user-attachments/assets/65263581-e49f-499d-93a2-5cedb0f14627



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?