### PR TITLE
Calypso UI Components: DateRange: Refactor "header" and "footer" areas of component

### DIFF
--- a/client/components/date-range/README.md
+++ b/client/components/date-range/README.md
@@ -47,6 +47,7 @@ These props utilise the [Render Props](https://reactjs.org/docs/render-props.htm
 | ---------------------- | ---------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `renderTrigger(props)` | `Function` | undefined | render prop `Function` which will overide the default `DateRangeTrigger` component. Recieves same `props` object passed to `DateRangeTrigger` |
 | `renderHeader(props)`  | `Function` | undefined | render prop `Function` which will overide the default `DateRangeHeader` component. Recieves same `props` object passed to `DateRangeHeader`   |
+| `renderFooter(props)`  | `Function` | undefined | render prop `Function` which will overide the default `DateRangeFooter` component. Recieves same `props` object passed to `DateRangeFooter`   |
 | `renderInputs(props)`  | `Function` | undefined | render prop `Function` which will overide the default `DateRangeInputs` component. Recieves same `props` object passed to `DateRangeInputs`   |
 
 ### General guidelines

--- a/client/components/date-range/footer.tsx
+++ b/client/components/date-range/footer.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+interface Props {
+	onApplyClick: () => void;
+	onCancelClick: () => void;
+	applyButtonText: string | null | undefined;
+	cancelButtonText: string | null | undefined;
+}
+
+const DateRangeFooter: FunctionComponent< Props > = ( {
+	onCancelClick = noop,
+	onApplyClick = noop,
+	cancelButtonText,
+	applyButtonText,
+} ) => {
+	const translate = useTranslate();
+
+	const cancelText = cancelButtonText || translate( 'Cancel' );
+	const applyText = applyButtonText || translate( 'Apply' );
+
+	return (
+		<div className="date-range__popover-footer">
+			<Button
+				className="date-range__cancel-btn"
+				onClick={ onCancelClick }
+				compact
+				aria-label={ cancelText }
+			>
+				{ cancelText }
+			</Button>
+			<Button
+				className="date-range__apply-btn"
+				onClick={ onApplyClick }
+				primary
+				compact
+				aria-label={ applyText }
+			>
+				{ applyText }
+			</Button>
+		</div>
+	);
+};
+
+export default DateRangeFooter;

--- a/client/components/date-range/header.tsx
+++ b/client/components/date-range/header.tsx
@@ -1,5 +1,4 @@
-import { Gridicon } from '@automattic/components';
-import { Button } from '@wordpress/components';
+import { Gridicon, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 

--- a/client/components/date-range/header.tsx
+++ b/client/components/date-range/header.tsx
@@ -1,47 +1,73 @@
-import { Button } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
-
 interface Props {
-	onApplyClick: () => void;
-	onCancelClick: () => void;
-	applyButtonText: string | null | undefined;
-	cancelButtonText: string | null | undefined;
+	customTitle?: string;
+	startDate: Date | null;
+	endDate: Date | null;
+	resetDates: () => void;
 }
 
 const DateRangeHeader: FunctionComponent< Props > = ( {
-	onCancelClick = noop,
-	onApplyClick = noop,
-	cancelButtonText,
-	applyButtonText,
+	customTitle,
+	startDate,
+	endDate,
+	resetDates,
 } ) => {
 	const translate = useTranslate();
 
-	const cancelText = cancelButtonText || translate( 'Cancel' );
-	const applyText = applyButtonText || translate( 'Apply' );
+	// Add this check at the beginning of the component
+	if ( startDate === undefined || endDate === undefined || resetDates === undefined ) {
+		return null; // or return a loading state
+	}
+
+	const renderDateHelp = () => {
+		return (
+			<div className="date-range__info" role="status" aria-live="polite">
+				{ ! startDate &&
+					! endDate &&
+					translate( '{{icon/}} Please select the {{em}}first{{/em}} day.', {
+						components: {
+							icon: <Gridicon aria-hidden="true" icon="info" />,
+							em: <em />,
+						},
+					} ) }
+				{ startDate &&
+					! endDate &&
+					translate( '{{icon/}} Please select the {{em}}last{{/em}} day.', {
+						components: {
+							icon: <Gridicon aria-hidden="true" icon="info" />,
+							em: <em />,
+						},
+					} ) }
+				{ startDate && endDate && (
+					<Button
+						className="date-range__info-btn"
+						borderless
+						compact
+						onClick={ resetDates }
+						aria-label={ translate( 'Reset selected dates' ) }
+					>
+						{ translate( '{{icon/}} reset selected dates', {
+							components: { icon: <Gridicon aria-hidden="true" icon="cross-small" /> },
+						} ) }
+					</Button>
+				) }
+			</div>
+		);
+	};
 
 	return (
 		<div className="date-range__popover-header">
-			<Button
-				className="date-range__cancel-btn"
-				onClick={ onCancelClick }
-				compact
-				aria-label={ cancelText }
-			>
-				{ cancelText }
-			</Button>
-			<Button
-				className="date-range__apply-btn"
-				onClick={ onApplyClick }
-				primary
-				compact
-				aria-label={ applyText }
-			>
-				{ applyText }
-			</Button>
+			<div className="date-range__controls">
+				{ customTitle ? (
+					<div className="date-range__custom-title">{ customTitle }</div>
+				) : (
+					renderDateHelp()
+				) }
+			</div>
 		</div>
 	);
 };

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -497,7 +497,6 @@ export class DateRange extends Component {
 						{ this.renderDatePicker() }
 						{ this.props.renderHeader( headerProps ) }
 					</div>
-					<div className="date-range__controls">{ this.props.renderHeader( headerProps ) }</div>
 					{ /* Render shortcuts to the right of the calendar */ }
 					{ this.props.displayShortcuts && (
 						<div className="date-range-picker-shortcuts">

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -497,6 +497,7 @@ export class DateRange extends Component {
 						{ this.renderDatePicker() }
 						{ this.props.renderHeader( headerProps ) }
 					</div>
+					<div className="date-range__controls">{ this.props.renderHeader( headerProps ) }</div>
 					{ /* Render shortcuts to the right of the calendar */ }
 					{ this.props.displayShortcuts && (
 						<div className="date-range-picker-shortcuts">

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -1,4 +1,4 @@
-import { Button, Popover, Gridicon } from '@automattic/components';
+import { Popover } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -416,52 +416,16 @@ export class DateRange extends Component {
 		this.handleDateRangeChange( startDate, endDate, 'custom_date_range' );
 	};
 
-	renderDateHelp() {
-		const { startDate, endDate } = this.state;
-
-		return (
-			<div className="date-range__info" role="status" aria-live="polite">
-				{ ! startDate &&
-					! endDate &&
-					this.props.translate( '{{icon/}} Please select the {{em}}first{{/em}} day.', {
-						components: {
-							icon: <Gridicon aria-hidden="true" icon="info" />,
-							em: <em />,
-						},
-					} ) }
-				{ startDate &&
-					! endDate &&
-					this.props.translate( '{{icon/}} Please select the {{em}}last{{/em}} day.', {
-						components: {
-							icon: <Gridicon aria-hidden="true" icon="info" />,
-							em: <em />,
-						},
-					} ) }
-				{ startDate && endDate && (
-					<Button
-						className="date-range__info-btn"
-						borderless
-						compact
-						onClick={ this.resetDates }
-						aria-label={ this.props.translate( 'Reset selected dates' ) }
-					>
-						{ this.props.translate( '{{icon/}} reset selected dates', {
-							components: { icon: <Gridicon aria-hidden="true" icon="cross-small" /> },
-						} ) }
-					</Button>
-				) }
-			</div>
-		);
-	}
-
 	/**
 	 * Renders the Popover component
 	 * @returns {import('react').Element} the Popover component
 	 */
 	renderPopover() {
 		const headerProps = {
-			onApplyClick: this.commitDates,
-			onCancelClick: this.closePopoverAndRevert,
+			customTitle: this.props.customTitle,
+			startDate: this.state.startDate,
+			endDate: this.state.endDate,
+			resetDates: this.resetDates,
 		};
 
 		const footerProps = {
@@ -494,13 +458,6 @@ export class DateRange extends Component {
 						{ this.props.overlay && (
 							<div className="date-range__popover-inner-overlay">{ this.props.overlay }</div>
 						) }
-						<div className="date-range__controls">
-							{ this.props.customTitle ? (
-								<div className="date-range__custom-title">{ this.props.customTitle }</div>
-							) : (
-								this.renderDateHelp()
-							) }
-						</div>
 						{ this.props.renderHeader( headerProps ) }
 						{ this.props.renderInputs( inputsProps ) }
 						{ this.renderDatePicker() }

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import DateRangePicker from './date-range-picker';
+import DateRangeFooter from './footer';
 import DateRangeHeader from './header';
 import DateRangeInputs from './inputs';
 import Shortcuts from './shortcuts';
@@ -44,6 +45,7 @@ export class DateRange extends Component {
 		showTriggerClear: PropTypes.bool,
 		renderTrigger: PropTypes.func,
 		renderHeader: PropTypes.func,
+		renderFooter: PropTypes.func,
 		renderInputs: PropTypes.func,
 		displayShortcuts: PropTypes.bool,
 		rootClass: PropTypes.string,
@@ -60,6 +62,7 @@ export class DateRange extends Component {
 		showTriggerClear: true,
 		renderTrigger: ( props ) => <DateRangeTrigger { ...props } />,
 		renderHeader: ( props ) => <DateRangeHeader { ...props } />,
+		renderFooter: ( props ) => <DateRangeFooter { ...props } />,
 		renderInputs: ( props ) => <DateRangeInputs { ...props } />,
 		displayShortcuts: false,
 		rootClass: '',
@@ -461,6 +464,11 @@ export class DateRange extends Component {
 			onCancelClick: this.closePopoverAndRevert,
 		};
 
+		const footerProps = {
+			onApplyClick: this.commitDates,
+			onCancelClick: this.closePopoverAndRevert,
+		};
+
 		const inputsProps = {
 			startDateValue: this.state.textInputStartDate,
 			endDateValue: this.state.textInputEndDate,
@@ -493,9 +501,10 @@ export class DateRange extends Component {
 								this.renderDateHelp()
 							) }
 						</div>
+						{ this.props.renderHeader( headerProps ) }
 						{ this.props.renderInputs( inputsProps ) }
 						{ this.renderDatePicker() }
-						{ this.props.renderHeader( headerProps ) }
+						{ this.props.renderFooter( footerProps ) }
 					</div>
 					{ /* Render shortcuts to the right of the calendar */ }
 					{ this.props.displayShortcuts && (

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -156,8 +156,6 @@ $date-range-mobile-layout-switch: $break-small;
 .date-range__popover {
 	.DayPicker {
 		order: 3;
-		margin-top: 12px;
-		border-top: 1px solid var(--color-neutral-5);
 	}
 
 	.DayPicker-wrapper,
@@ -240,6 +238,7 @@ $date-range-mobile-layout-switch: $break-small;
 
 
 .date-range__picker {
+	--date-range-picker-highlight-color: rgba(var(--color-primary-light-rgb), 0.4);
 
 	.DayPicker-Day,
 	.DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),
@@ -255,36 +254,39 @@ $date-range-mobile-layout-switch: $break-small;
 			&:hover,
 			&:focus {
 				color: var(--color-text-inverted);
-				background-color: var(--color-primary);
+				background-color: var(--date-range-picker-highlight-color);
 			}
 		}
 	}
 
-	.DayPicker-Day--range,
-	.DayPicker-Day--start,
-	.DayPicker-Day--end {
-		.date-picker__day {
+	.DayPicker-Day--range .date-picker__day {
+		color: var(--color-text);
+		background-color: var(--date-range-picker-highlight-color);
+	}
+
+	.DayPicker-Day--start.DayPicker-Day--range-start,
+	.DayPicker-Day--end.DayPicker-Day--range-end {
+		& .date-picker__day {
 			color: var(--color-text-inverted);
 			background-color: var(--color-primary);
 		}
-	}
-
-	.DayPicker-Day--range:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),
-	.DayPicker-Day--start:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),
-	.DayPicker-Day--end:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-		background-color: var(--color-primary);
-		.date-picker__day {
-			&:hover,
-			&:focus {
-				background-color: var(--color-primary-light);
+		&:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+			border-radius: 200px; /* stylelint-disable-line scales/radii */
+			&.DayPicker-Day--range {
+				background-color: var(--color-primary);
+				.date-picker__day {
+					&:hover,
+					&:focus {
+						background-color: var(--date-range-picker-highlight-color);
+					}
+				}
 			}
 		}
 	}
-
-	.DayPicker-Day--start,
-	.DayPicker-Day--end {
-		&:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-			border-radius: 200px; /* stylelint-disable-line scales/radii */
+	.DayPicker-Day--range:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+		background-color: var(--date-range-picker-highlight-color);
+		.date-picker__day {
+			background-color: transparent;
 		}
 	}
 
@@ -310,7 +312,6 @@ $date-range-mobile-layout-switch: $break-small;
 		border-radius: 200px !important;
 	}
 }
-
 .date-range__popover-content { // Styling to fit optional shortcuts sidebar
 	display: flex;
 	align-items: stretch; // Ensure children stretch to full height

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -96,6 +96,12 @@ $date-range-mobile-layout-switch: $break-small;
 }
 
 .date-range__popover-header {
+	order: 1;
+	display: flex;
+	justify-content: left;
+}
+
+.date-range__popover-footer {
 	order: 4;
 	display: flex;
 	justify-content: flex-end;
@@ -150,6 +156,8 @@ $date-range-mobile-layout-switch: $break-small;
 .date-range__popover {
 	.DayPicker {
 		order: 3;
+		margin-top: 12px;
+		border-top: 1px solid var(--color-neutral-5);
 	}
 
 	.DayPicker-wrapper,
@@ -232,7 +240,6 @@ $date-range-mobile-layout-switch: $break-small;
 
 
 .date-range__picker {
-	--date-range-picker-highlight-color: rgba(var(--color-primary-light-rgb), 0.4);
 
 	.DayPicker-Day,
 	.DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),
@@ -248,40 +255,36 @@ $date-range-mobile-layout-switch: $break-small;
 			&:hover,
 			&:focus {
 				color: var(--color-text-inverted);
-				background-color: var(--date-range-picker-highlight-color);
+				background-color: var(--color-primary);
 			}
 		}
 	}
 
-	.DayPicker-Day--range .date-picker__day {
-		color: var(--color-text);
-		background-color: var(--date-range-picker-highlight-color);
-	}
-
-	.DayPicker-Day--start.DayPicker-Day--range-start,
-	.DayPicker-Day--end.DayPicker-Day--range-end {
-		& .date-picker__day {
+	.DayPicker-Day--range,
+	.DayPicker-Day--start,
+	.DayPicker-Day--end {
+		.date-picker__day {
 			color: var(--color-text-inverted);
 			background-color: var(--color-primary);
 		}
-		&:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-			border-radius: 200px; /* stylelint-disable-line scales/radii */
-			&.DayPicker-Day--range {
-				background-color: var(--color-primary);
-				.date-picker__day {
-					&:hover,
-					&:focus {
-						background-color: var(--date-range-picker-highlight-color);
-					}
-				}
+	}
+
+	.DayPicker-Day--range:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),
+	.DayPicker-Day--start:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),
+	.DayPicker-Day--end:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+		background-color: var(--color-primary);
+		.date-picker__day {
+			&:hover,
+			&:focus {
+				background-color: var(--color-primary-light);
 			}
 		}
 	}
 
-	.DayPicker-Day--range:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-		background-color: var(--date-range-picker-highlight-color);
-		.date-picker__day {
-			background-color: transparent;
+	.DayPicker-Day--start,
+	.DayPicker-Day--end {
+		&:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+			border-radius: 200px; /* stylelint-disable-line scales/radii */
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/178

* In order to move the buttons (the sole occupant of the header component) to the footer area, I refactored to add a new footer component for the buttons, and move the existing title/header info into the header component. 
* This also involved adding a new `renderFooter` function + adding this to the docs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To extend the Calypso DateRange picker component for use with the Stats Date Control update.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* open Calypso live branch
* navigate to `/devdocs/design/date-range`
* check the `default` demo at the top. Check that everything still displays correctly, including when selecting custom dates check that the `please select the first day` text changes to `please select the last day` to `reset` as you select date ranges
* check that the `cancel` + `apply` buttons display below the calendars now 
* now check the `With custom title` demo it at the top
* check the above things with the styling, location, buttons, etc.

| default header behaviour  | with custom title passed through |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/09ee128f-d299-4ac9-8029-75a29286b032)  | ![image](https://github.com/user-attachments/assets/8ae19bca-345a-415d-b403-430f0d1067f2)  |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
