### PR TITLE
A4A: Hide all the 'Manage in Pressable' links to the team members.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -226,7 +226,7 @@ export default function PlanSelectionDetails( {
 									className="pressable-overview-plan-selection__tooltip"
 								>
 									{ translate(
-										"This Pressable account is managed by the Agency Owner user on your account. If you'd like access to this Pressalbe account, you can just request they add you as a user in Pressable."
+										"This Pressable account is managed by the Agency Owner user on your account. If you'd like access to this Pressable account, you can just request they add you as a user in Pressable."
 									) }
 								</Tooltip>
 							</>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -226,7 +226,7 @@ export default function PlanSelectionDetails( {
 									className="pressable-overview-plan-selection__tooltip"
 								>
 									{ translate(
-										"This Pressable account is managed by the Agency Owner user on your account. If you'd like access to this Pressable account, you can just request they add you as a user in Pressable."
+										"This Pressable account is managed by the Agency Owner user on your account. If you'd like access to this Pressable account, request that they add you as a user in Pressable."
 									) }
 								</Tooltip>
 							</>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -1,10 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button } from '@automattic/components';
+import { Button, Tooltip } from '@automattic/components';
 import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import formatCurrency from '@automattic/format-currency';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
 import { useDispatch, useSelector } from 'calypso/state';
 import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -44,6 +44,10 @@ export default function PlanSelectionDetails( {
 	const { getProductPricingInfo } = useGetProductPricingInfo();
 
 	const isOwner = useSelector( isAgencyOwner );
+
+	const managedButtonRef = useRef< HTMLDivElement | null >( null );
+
+	const [ showManagedTooltip, setShowManagedTooltip ] = useState( false );
 
 	const { discountedCost } = selectedPlan
 		? getProductPricingInfo( userProducts, selectedPlan, 1 )
@@ -175,17 +179,27 @@ export default function PlanSelectionDetails( {
 						{ selectedPlan && (
 							<>
 								{ isRegularOwnership ? (
-									<Button
-										target="_blank"
-										rel="norefferer nooppener"
-										href="https://my.pressable.com/agency/auth"
-										disabled={ ! isOwner }
+									<div
+										className="pressable-overview-plan-selection__manage-account-button-container"
+										ref={ managedButtonRef }
+										role="button"
+										tabIndex={ 0 }
+										onMouseEnter={ () => setShowManagedTooltip( true ) }
+										onMouseLeave={ () => setShowManagedTooltip( false ) }
+										onMouseDown={ () => setShowManagedTooltip( false ) }
 									>
-										{ isOwner
-											? translate( 'Manage in Pressable' )
-											: translate( 'Managed by Agency owner' ) }
-										{ isOwner && <Icon icon={ external } size={ 18 } /> }
-									</Button>
+										<Button
+											target="_blank"
+											rel="norefferer nooppener"
+											href="https://my.pressable.com/agency/auth"
+											disabled={ ! isOwner }
+										>
+											{ isOwner
+												? translate( 'Manage in Pressable' )
+												: translate( 'Managed by agency owner' ) }
+											{ isOwner && <Icon icon={ external } size={ 18 } /> }
+										</Button>
+									</div>
 								) : (
 									<Button
 										className="pressable-overview-plan-selection__details-card-cta-button"
@@ -204,6 +218,17 @@ export default function PlanSelectionDetails( {
 											  } ) }
 									</Button>
 								) }
+
+								<Tooltip
+									context={ managedButtonRef.current }
+									isVisible={ ! isOwner && showManagedTooltip }
+									position="bottom"
+									className="pressable-overview-plan-selection__tooltip"
+								>
+									{ translate(
+										"This Pressable account is managed by the Agency Owner user on your account. If you'd like access to this Pressalbe account, you can just request they add you as a user in Pressable."
+									) }
+								</Tooltip>
 							</>
 						) }
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -7,6 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
 import { useDispatch, useSelector } from 'calypso/state';
+import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getProductsList } from 'calypso/state/products-list/selectors';
@@ -41,6 +42,8 @@ export default function PlanSelectionDetails( {
 
 	const userProducts = useSelector( getProductsList );
 	const { getProductPricingInfo } = useGetProductPricingInfo();
+
+	const isOwner = useSelector( isAgencyOwner );
 
 	const { discountedCost } = selectedPlan
 		? getProductPricingInfo( userProducts, selectedPlan, 1 )
@@ -176,9 +179,12 @@ export default function PlanSelectionDetails( {
 										target="_blank"
 										rel="norefferer nooppener"
 										href="https://my.pressable.com/agency/auth"
+										disabled={ ! isOwner }
 									>
-										{ translate( 'Manage in Pressable' ) }
-										<Icon icon={ external } size={ 18 } />
+										{ isOwner
+											? translate( 'Manage in Pressable' )
+											: translate( 'Managed by Agency owner' ) }
+										{ isOwner && <Icon icon={ external } size={ 18 } /> }
 									</Button>
 								) : (
 									<Button

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -273,3 +273,14 @@
 		}
 	}
 }
+
+.pressable-overview-plan-selection__manage-account-button-container {
+	&,
+	a.button {
+		width: 100%;
+	}
+}
+
+.pressable-overview-plan-selection__tooltip {
+	max-width: 500px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -282,5 +282,5 @@
 }
 
 .pressable-overview-plan-selection__tooltip {
-	max-width: 500px;
+	max-width: 400px;
 }

--- a/client/a8c-for-agencies/sections/overview/body/hosting/pressable-oferring.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/pressable-oferring.tsx
@@ -5,7 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { getActiveAgency, isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 
 const pressableUrl = 'https://my.pressable.com/agency/auth';
@@ -50,6 +50,8 @@ const PressableOffering = () => {
 		</div>
 	);
 
+	const isOwner = useSelector( isAgencyOwner );
+
 	return (
 		<FoldableCard
 			className="a4a-oferring-item-pressable a4a-offering-item__card"
@@ -76,16 +78,18 @@ const PressableOffering = () => {
 					{ translate( 'Explore Pressable' ) }
 				</Button>
 			) : (
-				<Button
-					className="a4a-offering-item__button"
-					primary
-					target="_blank"
-					rel="norefferer nooppener"
-					href={ pressableUrl }
-				>
-					{ translate( 'View your dashboard' ) }
-					<Icon icon={ external } size={ 18 } />
-				</Button>
+				isOwner && (
+					<Button
+						className="a4a-offering-item__button"
+						primary
+						target="_blank"
+						rel="norefferer nooppener"
+						href={ pressableUrl }
+					>
+						{ translate( 'View your dashboard' ) }
+						<Icon icon={ external } size={ 18 } />
+					</Button>
+				)
 			) }
 		</FoldableCard>
 	);

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -208,7 +208,7 @@ export default function LicensePreview( {
 										<Icon className="gridicon" icon={ external } size={ 18 } />
 									</a>
 								) : (
-									translate( 'Managed by Agency owner' )
+									translate( 'Managed by agency owner' )
 								) ) }
 							{ ! domain && licenseState === LicenseState.Detached && (
 								<span className="license-preview__unassigned">

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -32,6 +32,10 @@ export function hasAgency( state: A4AStore ): boolean {
 	return Array.isArray( agencies ) && agencies.length > 0;
 }
 
+export function isAgencyOwner( state: A4AStore ): boolean {
+	return getActiveAgency( state )?.user?.role === 'a4a_administrator';
+}
+
 export function isAgencyClientUser( state: A4AStore ): boolean {
 	return state.a8cForAgencies.agencies.isAgencyClientUser;
 }


### PR DESCRIPTION
Currently, Pressable users do not have access to the Multi-user support feature, and the 'Manage in Pressable' links direct users to a broken workflow. This PR resolves the issue by hiding those buttons from team members.

| Page | Before | After |
|--------|--------|--------|
| Licenses page | <img width="1533" alt="Screenshot 2024-09-16 at 2 27 00 PM" src="https://github.com/user-attachments/assets/b878159a-c750-41eb-92db-070335e1889a"> | <img width="1320" alt="Screenshot 2024-09-16 at 2 27 16 PM" src="https://github.com/user-attachments/assets/515e24d6-d6ae-4784-8060-88802ea0ebc2"> |
| Marketplace - Pressable section for agency that has no-regular ownership | <img width="512" alt="Screenshot 2024-09-16 at 2 28 41 PM" src="https://github.com/user-attachments/assets/e21586e4-a993-4fca-b937-b7283cbb6218"> | <img width="489" alt="Screenshot 2024-09-16 at 2 28 52 PM" src="https://github.com/user-attachments/assets/2a323ec4-60ce-4214-baa7-16e0c796a89c"> |
| Overview page | <img width="1019" alt="Screenshot 2024-09-16 at 2 33 10 PM" src="https://github.com/user-attachments/assets/627d22a9-f9fc-4319-9132-4d342d234f97"> | <img width="875" alt="Screenshot 2024-09-16 at 2 33 19 PM" src="https://github.com/user-attachments/assets/b55b6bb3-778d-4589-8091-7fe43594155c"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1086

## Proposed Changes

* Create a isAgencyOwner selector to quickly check if current session is agency owner.
* Replace all 'Manage on Pressable' buttons with 'Manage by Agency owner' text when the session is not owned.
* Hide actions for Pressable licenses when the session is not agency owner. Since no action left for team member.

## Why are these changes being made?

* Pressable users lack integration with Multi-user support, so the 'Manage in Pressable' links are broken. This PR fixes the issue.

## Testing Instructions

* Login as a Team member.
* Purchase a Pressable license if you haven't.
* Use the A4A live link and test all the pages where 'Manage in Pressable' button is visible.
* Confirm that you no longer see the 'Manage in Pressable' button.
* Test the same flow for Agency owners and confirm the buttons are visible.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
