### PR TITLE
A4A: Add missing track events for the Multi-user support feature.

### DIFF
--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
@@ -24,6 +24,14 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_joining_agency_click' ) );
 	};
 
+	const onContactSupportClick = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_team_contact_support_click' ) );
+	};
+
+	const onCurrentAgencyLinkClick = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_team_current_agency_link_click' ) );
+	};
+
 	return (
 		<>
 			<div className="team-accept-invite__heading">
@@ -65,6 +73,7 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 										href={ A4A_TEAM_LINK }
 										target="_blank"
 										rel="noreferrer"
+										onClick={ onCurrentAgencyLinkClick }
 									/>
 								),
 							},
@@ -108,6 +117,7 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 					variant="link"
 					target="_blank"
 					href={ `${ A4A_OVERVIEW_LINK }#contact-support` }
+					onClick={ onContactSupportClick }
 				>
 					{ translate( 'Contact support' ) }
 					<Icon icon={ external } size={ 18 } />

--- a/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
@@ -76,22 +76,10 @@ export default function TeamInvite() {
 		);
 	}, [ dispatch, message, sendInvite, translate, username ] );
 
-	const onUsernameChange = useCallback(
-		( value: string ) => {
-			setError( '' );
-			setUsername( value );
-			dispatch( recordTracksEvent( 'calypso_a4a_team_invite_username_change' ) );
-		},
-		[ dispatch ]
-	);
-
-	const onMessageChange = useCallback(
-		( value: string ) => {
-			setMessage( value );
-			dispatch( recordTracksEvent( 'calypso_a4a_team_invite_message_change' ) );
-		},
-		[ dispatch ]
-	);
+	const onUsernameChange = useCallback( ( value: string ) => {
+		setError( '' );
+		setUsername( value );
+	}, [] );
 
 	return (
 		<Layout className="team-invite" title={ title } wide compact>
@@ -123,6 +111,9 @@ export default function TeamInvite() {
 								placeholder={ translate( 'team-member@example.com' ) }
 								value={ username }
 								onChange={ onUsernameChange }
+								onClick={ () =>
+									dispatch( recordTracksEvent( 'calypso_a4a_team_invite_username_click' ) )
+								}
 							/>
 						</FormField>
 
@@ -132,7 +123,13 @@ export default function TeamInvite() {
 								'Optional: Include a custom message to provide more context to your team member.'
 							) }
 						>
-							<TextareaControl value={ message } onChange={ onMessageChange } />
+							<TextareaControl
+								value={ message }
+								onChange={ setMessage }
+								onClick={ () =>
+									dispatch( recordTracksEvent( 'calypso_a4a_team_invite_message_click' ) )
+								}
+							/>
 						</FormField>
 					</FormSection>
 

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -40,6 +40,7 @@ type Tab = {
 	selected: boolean;
 	path: string;
 	content: ReactNode;
+	onClick: () => void;
 };
 
 export default function TeamList( { currentTab }: Props ) {
@@ -66,6 +67,7 @@ export default function TeamList( { currentTab }: Props ) {
 				selected: currentTab === TAB_ACTIVE_MEMBERS,
 				path: `${ A4A_TEAM_LINK }/${ TAB_ACTIVE_MEMBERS }`,
 				content: <TeamMemberTable members={ activeMembers } onRefresh={ refetch } />,
+				onClick: () => dispatch( recordTracksEvent( 'calypso_a4a_team_active_members_tab_view' ) ),
 			},
 			{
 				key: TAB_INVITED_MEMBERS,
@@ -74,6 +76,7 @@ export default function TeamList( { currentTab }: Props ) {
 				selected: currentTab === TAB_INVITED_MEMBERS,
 				path: `${ A4A_TEAM_LINK }/${ TAB_INVITED_MEMBERS }`,
 				content: <TeamInviteTable members={ invitedMembers } onRefresh={ refetch } />,
+				onClick: () => dispatch( recordTracksEvent( 'calypso_a4a_team_invited_members_tab_view' ) ),
 			},
 		];
 
@@ -83,7 +86,7 @@ export default function TeamList( { currentTab }: Props ) {
 			items,
 			selected,
 		};
-	}, [ activeMembers, currentTab, invitedMembers, refetch, translate ] );
+	}, [ activeMembers, currentTab, dispatch, invitedMembers, refetch, translate ] );
 
 	if ( isPending ) {
 		return <PagePlaceholder />;


### PR DESCRIPTION
This PR adds missing track events for the new Multi-user support feature.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/959

## Proposed Changes

* Add track events on the Invite team member page.
    <img width="805" alt="Screenshot 2024-09-16 at 3 13 35 PM" src="https://github.com/user-attachments/assets/f48ac37f-a5c2-49d6-845b-0ba70bf29ad0">
   1. **calypso_a4a_team_invite_username_click**
   2. **calypso_a4a_team_invite_message_click**
   3. **calypso_a4a_team_invite_submit**
   4. **calypso_a4a_team_invite_success**
   5. **calypso_a4a_team_invite_error**


* Add track events on the team list tabs.
  <img width="657" alt="Screenshot 2024-09-16 at 3 10 18 PM" src="https://github.com/user-attachments/assets/3fa516e4-93d0-43ed-a88e-35472b9789b9">
   1. **calypso_a4a_team_active_members_tab_view**
   2. **calypso_a4a_team_invited_members_tab_view**

* Add track events on the No multiple agency message screen.
<img width="1557" alt="Screenshot 2024-09-16 at 3 28 31 PM" src="https://github.com/user-attachments/assets/394d852e-dccd-41cc-82ac-009b2f3fc32f">
   1.  calypso_a4a_team_current_agency_link_click
   2. calypso_a4a_team_contact_support_click

## Why are these changes being made?

*Tracking user behaviors is essential to improving our UIs.

## Testing Instructions

**How to check if tracking is triggered?**
In your browser's developer tool, go to the network tab and filter all requests with .gif. Note that the image below uses a Chrome browser. Please look for the equivalent function with your browser.

<img width="1187" alt="Screenshot 2024-09-16 at 3 08 46 PM" src="https://github.com/user-attachments/assets/c2149040-0709-4205-8bf0-b86eba0763e6">


Test the screens above and verify if the events are tracked.




## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
