### PR TITLE
A4A: Remove 'a4a-multi-user-support' feature flag and conditional flows.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -161,8 +161,7 @@ const useMainMenuItems = ( path: string ) => {
 						},
 				  ]
 				: [] ),
-			...( isSectionNameEnabled( 'a8c-for-agencies-team' ) &&
-			config.isEnabled( 'a4a-multi-user-support' )
+			...( isSectionNameEnabled( 'a8c-for-agencies-team' )
 				? [
 						{
 							icon: people,
@@ -177,10 +176,7 @@ const useMainMenuItems = ( path: string ) => {
 				: [] ),
 		]
 			.map( ( item ) => createItem( item, path ) )
-			.filter( ( item ) =>
-				// If multi-user support is enabled, we need to check if the user has access to the current path
-				config.isEnabled( 'a4a-multi-user-support' ) ? isPathAllowed( item.link, agency ) : true
-			);
+			.filter( ( item ) => isPathAllowed( item.link, agency ) );
 	}, [ agency, path, translate ] );
 	return menuItems;
 };

--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 import { getQueryArgs, addQueryArgs } from '@wordpress/url';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
@@ -40,13 +39,7 @@ export const requireAccessContext: Callback = ( context, next ) => {
 	const agency = getActiveAgency( state );
 	const { pathname, search, hash } = window.location;
 
-	const isMultiUserSupportEnabled = config.isEnabled( 'a4a-multi-user-support' );
-
 	if ( agency ) {
-		if ( ! isMultiUserSupportEnabled ) {
-			next();
-			return;
-		}
 		// If multi-user support is enabled, we need to check if the user has access to the current path
 		handleMultiUserSupport( agency, pathname, next );
 		return;

--- a/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
@@ -65,9 +65,8 @@ export function OverviewPreviewPane( {
 
 	const { selectedSiteFeature, setSelectedSiteFeature } = useContext( SitesDashboardContext );
 
-	const isMultiUserSupportEnabled = isEnabled( 'a4a-multi-user-support' );
 	const { noWPAdminAccess } = useWPAdminAccessControl( { siteId: site.blog_id } );
-	const showNoAccess = isMultiUserSupportEnabled && noWPAdminAccess;
+	const showNoAccess = noWPAdminAccess;
 
 	useEffect( () => {
 		if ( selectedSiteFeature === undefined ) {

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -1,6 +1,5 @@
 // Required for modular state.
 import 'calypso/state/a8c-for-agencies/init';
-import { isEnabled } from '@automattic/calypso-config';
 import { A4AStore, APIError, Agency } from '../types';
 
 export function getActiveAgency( state: A4AStore ): Agency | null {
@@ -41,8 +40,8 @@ export function isAgencyClientUser( state: A4AStore ): boolean {
 }
 
 export function hasAgencyCapability( state: A4AStore, capability: string ): boolean {
-	// If the feature is not enabled, or the user is a client user, bypass the capability check.
-	if ( ! isEnabled( 'a4a-multi-user-support' ) || isAgencyClientUser( state ) ) {
+	// If the user is a client user, bypass the capability check.
+	if ( isAgencyClientUser( state ) ) {
 		return true;
 	}
 

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -41,8 +41,7 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
-		"a4a-dev-sites": true,
-		"a4a-multi-user-support": true
+		"a4a-dev-sites": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -34,8 +34,7 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
-		"a4a-dev-sites": false,
-		"a4a-multi-user-support": true
+		"a4a-dev-sites": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -34,8 +34,7 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
-		"a4a-dev-sites": false,
-		"a4a-multi-user-support": true
+		"a4a-dev-sites": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -37,8 +37,7 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
-		"a4a-dev-sites": false,
-		"a4a-multi-user-support": true
+		"a4a-dev-sites": false
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
This PR removes the 'a4a-multi-user-support' feature flag and its conditional flows.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/960

## Proposed Changes

* Remove the 'a4a-multi-user-support' feature flag in the environment files.
* Remove all references of the feature flag and its associated conditional flows.

## Why are these changes being made?

* Keep our codes clean and maintainable. 

## Testing Instructions

* Use the A4A live link and verify that the Multi-user support feature works without regression.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
