### PR TITLE
Stats: Add modal close event for form submission

### DIFF
--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -181,10 +181,14 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		}
 	};
 
-	const onModalClose = () => {
+	const onModalClose = ( isAfterSubmission: boolean ) => {
 		setIsOpen( false );
 
-		trackStatsAnalyticsEvent( 'stats_feedback_action_close_form_modal' );
+		if ( isAfterSubmission ) {
+			trackStatsAnalyticsEvent( 'stats_feedback_action_close_form_modal_after_submission' );
+		} else {
+			trackStatsAnalyticsEvent( 'stats_feedback_action_close_form_modal' );
+		}
 	};
 
 	if ( ! supportCommercialUse ) {

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -181,14 +181,8 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		}
 	};
 
-	const onModalClose = ( isAfterSubmission: boolean ) => {
+	const onModalClose = () => {
 		setIsOpen( false );
-
-		if ( isAfterSubmission ) {
-			trackStatsAnalyticsEvent( 'stats_feedback_action_close_form_modal_after_submission' );
-		} else {
-			trackStatsAnalyticsEvent( 'stats_feedback_action_close_form_modal' );
-		}
 	};
 
 	if ( ! supportCommercialUse ) {

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -18,7 +18,7 @@ import './style.scss';
 
 interface ModalProps {
 	siteId: number;
-	onClose: () => void;
+	onClose: ( isAfterSubmission: boolean ) => void;
 }
 
 const FEEDBACK_SHOULD_SHOW_PANEL_API_KEY = NOTICES_KEY_SHOW_FLOATING_USER_FEEDBACK_PANEL;
@@ -53,11 +53,14 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 	const { isSubmittingFeedback, submitFeedback, isSubmissionSuccessful } =
 		useSubmitProductFeedback( siteId );
 
-	const handleClose = useCallback( () => {
-		setTimeout( () => {
-			onClose();
-		}, 200 );
-	}, [ onClose ] );
+	const handleClose = useCallback(
+		( isAfterSubmission: boolean ) => {
+			setTimeout( () => {
+				onClose( isAfterSubmission );
+			}, 200 );
+		},
+		[ onClose ]
+	);
 
 	const onFormSubmit = useCallback( () => {
 		if ( ! content ) {
@@ -75,7 +78,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 			feedback: content,
 			is_testing: false,
 		} );
-	}, [ dispatch, content, submitFeedback ] );
+	}, [ content, submitFeedback ] );
 
 	useEffect( () => {
 		if ( isSubmissionSuccessful ) {
@@ -91,7 +94,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 				refetchNotices();
 			} );
 
-			handleClose();
+			handleClose( true );
 		}
 	}, [
 		dispatch,
@@ -104,10 +107,18 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 	] );
 
 	return (
-		<Modal className="stats-feedback-modal" onRequestClose={ handleClose } __experimentalHideHeader>
+		<Modal
+			className="stats-feedback-modal"
+			onRequestClose={ () => {
+				handleClose( false );
+			} }
+			__experimentalHideHeader
+		>
 			<Button
 				className="stats-feedback-modal__close-button"
-				onClick={ handleClose }
+				onClick={ () => {
+					handleClose( false );
+				} }
 				icon={ close }
 				label={ translate( 'Close' ) }
 			/>

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -18,7 +18,7 @@ import './style.scss';
 
 interface ModalProps {
 	siteId: number;
-	onClose: ( isAfterSubmission: boolean ) => void;
+	onClose: () => void;
 }
 
 const FEEDBACK_SHOULD_SHOW_PANEL_API_KEY = NOTICES_KEY_SHOW_FLOATING_USER_FEEDBACK_PANEL;
@@ -54,9 +54,13 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 		useSubmitProductFeedback( siteId );
 
 	const handleClose = useCallback(
-		( isAfterSubmission: boolean ) => {
+		( isDirectClose: boolean = false ) => {
 			setTimeout( () => {
-				onClose( isAfterSubmission );
+				onClose();
+
+				if ( isDirectClose ) {
+					trackStatsAnalyticsEvent( 'stats_feedback_action_directly_close_form_modal' );
+				}
 			}, 200 );
 		},
 		[ onClose ]
@@ -67,16 +71,16 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 			return;
 		}
 
-		trackStatsAnalyticsEvent( 'stats_feedback_action_submit_form', {
-			feedback: content,
-		} );
-
 		const sourceUrl = `${ window.location.origin }${ window.location.pathname }`;
 		submitFeedback( {
 			source_url: sourceUrl,
 			product_name: 'Jetpack Stats',
 			feedback: content,
 			is_testing: false,
+		} );
+
+		trackStatsAnalyticsEvent( 'stats_feedback_action_submit_form', {
+			feedback: content,
 		} );
 	}, [ content, submitFeedback ] );
 
@@ -94,7 +98,7 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 				refetchNotices();
 			} );
 
-			handleClose( true );
+			handleClose();
 		}
 	}, [
 		dispatch,
@@ -110,14 +114,14 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 		<Modal
 			className="stats-feedback-modal"
 			onRequestClose={ () => {
-				handleClose( false );
+				handleClose( true );
 			} }
 			__experimentalHideHeader
 		>
 			<Button
 				className="stats-feedback-modal__close-button"
 				onClick={ () => {
-					handleClose( false );
+					handleClose( true );
 				} }
 				icon={ close }
 				label={ translate( 'Close' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/94553#pullrequestreview-2305938817

## Proposed Changes

* Add the modal close event for form submission: `stats_feedback_action_close_form_modal_after_submission`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Add a more dedicated tracking event.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live branch.
* Navigate to Stats > Traffic page with sites having a Stats commercial license.
* Scroll down to the bottom of the page.
* Click on the `Not a fan? Help us improve` button.
* Submit the feedback from.
* Ensure the tracking event is sent with `stats_feedback_action_close_form_modal_after_submission`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
