### PR TITLE
Jetpack Stats: Hide tooltips for new sites

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -10,7 +10,6 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import version_compare from 'calypso/lib/version-compare';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
-import { isSiteNew } from 'calypso/my-sites/stats/hooks/use-site-compulsory-plan-selection-qualified-check';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isGoogleMyBusinessLocationConnectedSelector from 'calypso/state/selectors/is-google-my-business-location-connected';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
@@ -237,6 +236,13 @@ class StatsNavigation extends Component {
 
 export default connect(
 	( state, { siteId, selectedItem } ) => {
+		const siteCreatedTimeStamp = getSiteOption( state, siteId, 'created_at' );
+		const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
+		// Check if the site is created within a week.
+		const isNewSite =
+			siteCreatedTimeStamp &&
+			new Date( siteCreatedTimeStamp ) > new Date( Date.now() - WEEK_IN_MILLISECONDS );
+
 		return {
 			isGoogleMyBusinessLocationConnected: isGoogleMyBusinessLocationConnectedSelector(
 				state,
@@ -250,7 +256,7 @@ export default connect(
 			pageModuleToggles: getModuleToggles( state, siteId, [ selectedItem ] ),
 			statsAdminVersion: getJetpackStatsAdminVersion( state, siteId ),
 			adminUrl: getSiteAdminUrl( state, siteId ),
-			isNewSite: isSiteNew( state, siteId ),
+			isNewSite,
 		};
 	},
 	{ requestModuleToggles, updateModuleToggles }

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -10,6 +10,7 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import version_compare from 'calypso/lib/version-compare';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import { isSiteNew } from 'calypso/my-sites/stats/hooks/use-site-compulsory-plan-selection-qualified-check';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isGoogleMyBusinessLocationConnectedSelector from 'calypso/state/selectors/is-google-my-business-location-connected';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
@@ -149,6 +150,7 @@ class StatsNavigation extends Component {
 			statsAdminVersion,
 			showLock,
 			hideModuleSettings,
+			isNewSite,
 		} = this.props;
 		const { pageModules, isPageSettingsTooltipDismissed } = this.state;
 		const { label, showIntervals, path } = navItems[ selectedItem ];
@@ -222,7 +224,9 @@ class StatsNavigation extends Component {
 							availableModules={ AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] }
 							pageModules={ pageModules }
 							onToggleModule={ this.onToggleModule }
-							isTooltipShown={ showSettingsTooltip && ! isPageSettingsTooltipDismissed }
+							isTooltipShown={
+								showSettingsTooltip && ! isPageSettingsTooltipDismissed && ! isNewSite
+							}
 							onTooltipDismiss={ this.onTooltipDismiss }
 						/>
 					) }
@@ -246,6 +250,7 @@ export default connect(
 			pageModuleToggles: getModuleToggles( state, siteId, [ selectedItem ] ),
 			statsAdminVersion: getJetpackStatsAdminVersion( state, siteId ),
 			adminUrl: getSiteAdminUrl( state, siteId ),
+			isNewSite: isSiteNew( state, siteId ),
 		};
 	},
 	{ requestModuleToggles, updateModuleToggles }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8777

## Proposed Changes

* Update check on when to show the tooltip on Jetpack stats page to include a check that the site is at least a week old

## Before
<img width="1317" alt="Screenshot 2024-09-16 at 11 36 49" src="https://github.com/user-attachments/assets/21577c22-1483-4881-8ab0-d5d948e32c32">

## After
<img width="1318" alt="Screenshot 2024-09-16 at 11 36 14" src="https://github.com/user-attachments/assets/8144d491-47e0-4c1d-ba43-809dcf139b6d">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Doesn't make sense highlighting how to use stats on a new site since it won't have any traffic

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site and buy a personal plan (with coupon or credit)
* Go to stats page - '/stats/day/[test site].wordpress.com'
* Confirm you see the tooltip
* Go to the calypso live branch and confirm the tooltip is not visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
