### PR TITLE
Paid newsletter importer content importing done / in progress states handling

### DIFF
--- a/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
@@ -1,4 +1,5 @@
 import { ProgressBar, Spinner } from '@automattic/components';
+import { Notice } from '@wordpress/components';
 import clsx from 'clsx';
 import { numberFormat, localize } from 'i18n-calypso';
 import { omit } from 'lodash';
@@ -193,7 +194,7 @@ export class ImportingPane extends PureComponent {
 		if ( sourceType === 'Substack' && isFinished ) {
 			return (
 				<ImporterActionButtonContainer noSpacing>
-					<ImporterActionButton href={ nextStepUrl } primary>
+					<ImporterActionButton href={ nextStepUrl }>
 						{ this.props.translate( 'Continue' ) }
 					</ImporterActionButton>
 				</ImporterActionButtonContainer>
@@ -246,7 +247,6 @@ export class ImportingPane extends PureComponent {
 
 		if ( this.isFinished() ) {
 			percentComplete = 100;
-			statusMessage = this.getSuccessText();
 		}
 
 		if ( this.isImporting() && hasProgressInfo( progress ) ) {
@@ -295,6 +295,14 @@ export class ImportingPane extends PureComponent {
 					<div>
 						<p className="importer__status-message">{ statusMessage }</p>
 					</div>
+				) }
+				{ this.isFinished() && ! this.isError() && (
+					<>
+						<h2>Import your content to WordPress.com</h2>
+						<Notice status="success" className="importer__notice" isDismissible={ false }>
+							Success! Your content has been imported!
+						</Notice>
+					</>
 				) }
 				{ this.renderActionButtons( sourceType ) }
 			</div>

--- a/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
@@ -1,5 +1,4 @@
-import { ProgressBar } from '@automattic/components';
-import { Notice } from '@wordpress/components';
+import { ProgressBar, Notice } from '@wordpress/components';
 import { numberFormat, localize } from 'i18n-calypso';
 import { omit } from 'lodash';
 import PropTypes from 'prop-types';
@@ -269,7 +268,7 @@ export class ImportingPane extends PureComponent {
 						<h2>Import your content to WordPress.com</h2>
 						<p>Please, wait while we import your content…</p>
 						<div className="importer__import-progress">
-							<ProgressBar value={ percentComplete || undefined } />
+							<ProgressBar className="importer__import-progress-bar" value={ percentComplete } />
 							{ blockingMessage && <p>{ blockingMessage }</p> }
 						</div>
 					</>

--- a/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
@@ -1,6 +1,5 @@
-import { ProgressBar, Spinner } from '@automattic/components';
+import { ProgressBar } from '@automattic/components';
 import { Notice } from '@wordpress/components';
-import clsx from 'clsx';
 import { numberFormat, localize } from 'i18n-calypso';
 import { omit } from 'lodash';
 import PropTypes from 'prop-types';
@@ -8,7 +7,6 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { navigate } from 'calypso/lib/navigate';
 import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';
-import BusyImportingButton from 'calypso/my-sites/importer/importer-action-buttons/busy-importing-button';
 import ImporterCloseButton from 'calypso/my-sites/importer/importer-action-buttons/close-button';
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -116,10 +114,6 @@ export class ImportingPane extends PureComponent {
 		return description;
 	};
 
-	getHeadingTextProcessing = () => {
-		return this.props.translate( 'Processing your file. Please wait a few moments.' );
-	};
-
 	getSuccessText = () => {
 		return this.props.translate( 'Success! Your content has been imported.' );
 	};
@@ -193,7 +187,9 @@ export class ImportingPane extends PureComponent {
 			<ImporterActionButtonContainer noSpacing>
 				{ isImporting && (
 					<>
-						<BusyImportingButton />
+						<ImporterActionButton primary busy disabled>
+							Importing
+						</ImporterActionButton>
 						<ImporterActionButton href={ nextStepUrl }>
 							{ this.props.translate( 'Continue' ) }
 						</ImporterActionButton>
@@ -222,9 +218,6 @@ export class ImportingPane extends PureComponent {
 			invalidateCardData,
 		} = this.props;
 		const { customData } = importerStatus;
-		const progressClasses = clsx( 'importer__import-progress', {
-			'is-complete': this.isFinished(),
-		} );
 
 		let { percentComplete, statusMessage } = this.props.importerStatus;
 		const { progress } = this.props.importerStatus;
@@ -250,7 +243,6 @@ export class ImportingPane extends PureComponent {
 
 		return (
 			<div className="importer__importing-pane">
-				{ this.isProcessing() && <p>{ this.getHeadingTextProcessing() }</p> }
 				{ this.isMapping() && (
 					<AuthorMappingPane
 						onMap={ this.handleOnMap }
@@ -272,17 +264,15 @@ export class ImportingPane extends PureComponent {
 						site={ site }
 					/>
 				) }
-				{ ( this.isImporting() || this.isProcessing() ) &&
-					( percentComplete >= 0 ? (
-						<ProgressBar className={ progressClasses } value={ percentComplete } />
-					) : (
-						<div>
-							<Spinner className="importer__import-spinner" />
-							<br />
+				{ ( this.isImporting() || this.isProcessing() ) && (
+					<>
+						<h2>Import your content to WordPress.com</h2>
+						<p>Please, wait while we import your content…</p>
+						<div className="importer__import-progress">
+							<ProgressBar value={ percentComplete || undefined } />
+							{ blockingMessage && <p>{ blockingMessage }</p> }
 						</div>
-					) ) }
-				{ blockingMessage && (
-					<div className="importer__import-progress-message">{ blockingMessage }</div>
+					</>
 				) }
 				{ statusMessage && (
 					<div>

--- a/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
@@ -11,7 +11,6 @@ import ImporterActionButton from 'calypso/my-sites/importer/importer-action-butt
 import BusyImportingButton from 'calypso/my-sites/importer/importer-action-buttons/busy-importing-button';
 import ImporterCloseButton from 'calypso/my-sites/importer/importer-action-buttons/close-button';
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
-import ImporterDoneButton from 'calypso/my-sites/importer/importer-action-buttons/done-button';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { mapAuthor, resetImport, startImporting } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
@@ -176,7 +175,7 @@ export class ImportingPane extends PureComponent {
 		this.props.resetImport( this.props.site.ID, this.props.importerStatus.importerId );
 	};
 
-	renderActionButtons = ( sourceType ) => {
+	renderActionButtons = () => {
 		if ( this.isProcessing() || this.isMapping() ) {
 			// We either don't want to show buttons while processing
 			// or, in the case of `isMapping`, we let another component (author-mapping-pane)
@@ -190,18 +189,6 @@ export class ImportingPane extends PureComponent {
 		const isError = this.isError();
 		const showFallbackButton = isError || ( ! isImporting && ! isFinished );
 
-		// After Substack importer we nudge to view posts or
-		if ( sourceType === 'Substack' && isFinished ) {
-			return (
-				<ImporterActionButtonContainer noSpacing>
-					<ImporterActionButton href={ nextStepUrl }>
-						{ this.props.translate( 'Continue' ) }
-					</ImporterActionButton>
-				</ImporterActionButtonContainer>
-			);
-		}
-
-		// Other importers nudge to view the site
 		return (
 			<ImporterActionButtonContainer noSpacing>
 				{ isImporting && (
@@ -212,7 +199,13 @@ export class ImportingPane extends PureComponent {
 						</ImporterActionButton>
 					</>
 				) }
-				{ isFinished && <ImporterDoneButton importerStatus={ importerStatus } site={ site } /> }
+				{ isFinished && (
+					<ImporterActionButtonContainer noSpacing>
+						<ImporterActionButton href={ nextStepUrl }>
+							{ this.props.translate( 'Continue' ) }
+						</ImporterActionButton>
+					</ImporterActionButtonContainer>
+				) }
 				{ showFallbackButton && (
 					<ImporterCloseButton importerStatus={ importerStatus } site={ site } isEnabled />
 				) }
@@ -304,7 +297,7 @@ export class ImportingPane extends PureComponent {
 						</Notice>
 					</>
 				) }
-				{ this.renderActionButtons( sourceType ) }
+				{ this.renderActionButtons() }
 			</div>
 		);
 	}

--- a/client/my-sites/importer/newsletter/content-upload/importing-pane.scss
+++ b/client/my-sites/importer/newsletter/content-upload/importing-pane.scss
@@ -1,39 +1,30 @@
-.importer__import-progress {
-	&.progress-bar {
-		display: block;
-		margin-bottom: 0.25em;
-		margin-left: auto;
-		margin-right: auto;
-		width: 80%;
+.importer__importing-pane {
+	h2 + p {
+		margin-top: -10px;
 	}
 
-	.progress-bar__progress {
-		background-color: var(--color-accent);
+	.importer__import-progress {
+		margin: 60px;
+
+		.progress-bar {
+			display: block;
+			margin-left: auto;
+			margin-right: auto;
+			margin-bottom: 10px;
+			width: 160px;
+			height: 5px;
+			border-radius: 3px;
+		}
+
+		p {
+			text-align: center;
+		}
 	}
 
-	&.is-complete .progress-bar__progress {
-		background-color: var(--color-success);
+	.importer__status-message {
+		font-size: $font-body-small;
+		color: var(--color-text-subtle);
+		text-align: center;
+		margin: 3em 0;
 	}
-}
-
-.importer__import-progress-message {
-	text-align: center;
-	color: var(--color-text-subtle);
-}
-
-.importer__start {
-	float: none !important;
-}
-
-.importer__import-spinner {
-	position: absolute;
-	left: 50%;
-	transform: translateX(-50%);
-}
-
-.importer__status-message {
-	font-size: $font-body-small;
-	color: var(--color-text-subtle);
-	text-align: center;
-	margin: 3em 0;
 }

--- a/client/my-sites/importer/newsletter/content-upload/importing-pane.scss
+++ b/client/my-sites/importer/newsletter/content-upload/importing-pane.scss
@@ -6,7 +6,7 @@
 	.importer__import-progress {
 		margin: 60px;
 
-		.progress-bar {
+		.importer__import-progress-bar {
 			display: block;
 			margin-left: auto;
 			margin-right: auto;

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -71,7 +71,6 @@ export default function Content( {
 	const showExportDataHint =
 		importerStatus?.importerState !== appStates.MAP_AUTHORS &&
 		importerStatus?.importerState !== appStates.IMPORTING &&
-		importerStatus?.importerState !== appStates.UPLOAD_PROCESSING &&
 		importerStatus?.importerState !== appStates.IMPORT_SUCCESS;
 
 	return (

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -68,11 +68,17 @@ export default function Content( {
 		siteTitle,
 	} ).substack;
 
+	const showExportDataHint =
+		importerStatus?.importerState !== appStates.MAP_AUTHORS &&
+		importerStatus?.importerState !== appStates.IMPORTING &&
+		importerStatus?.importerState !== appStates.UPLOAD_PROCESSING &&
+		importerStatus?.importerState !== appStates.IMPORT_SUCCESS;
+
 	return (
 		<Card>
 			<Interval onTick={ fetchImporters } period={ EVERY_FIVE_SECONDS } />
 
-			{ importerStatus?.importerState !== appStates.MAP_AUTHORS && (
+			{ showExportDataHint && (
 				<>
 					<h2>Step 1: Export your content from Substack</h2>
 					<p>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

It fixes the UI for the in progress and done content import states.

<img width="762" alt="Screenshot 2024-09-16 at 14 56 40" src="https://github.com/user-attachments/assets/758fab3f-37ef-4b96-b2a2-ef3f3144ca2e">

<img width="762" alt="Screenshot 2024-09-16 at 14 54 17" src="https://github.com/user-attachments/assets/f37c7e6b-c298-479c-849d-7341c7107f54">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
