### PR TITLE
Plans Grid: correctly show price if it is 0

### DIFF
--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -28,9 +28,9 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	 * then we do not show any discount messaging as per Automattic/martech#1927
 	 * We currently only support the `One time discount` in some currencies
 	 */
-	const isGridPlanOneTimeDiscounted = Boolean( discountedPrice.monthly );
-	const isAnyVisibleGridPlanOneTimeDiscounted = visibleGridPlans.some(
-		( { pricing } ) => pricing.discountedPrice.monthly
+	const isGridPlanOneTimeDiscounted = Number.isFinite( discountedPrice.monthly );
+	const isAnyVisibleGridPlanOneTimeDiscounted = visibleGridPlans.some( ( { pricing } ) =>
+		Number.isFinite( pricing.discountedPrice.monthly )
 	);
 
 	const isGridPlanOnIntroOffer = introOffer && ! introOffer.isOfferComplete;

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -64,8 +64,11 @@ export default function usePlanBillingDescription( {
 		yearlyVariantPricing &&
 		( ! introOffer || introOffer.isOfferComplete )
 	) {
-		const yearlyVariantMaybeDiscountedPrice =
-			yearlyVariantPricing.discountedPrice?.monthly || yearlyVariantPricing.originalPrice?.monthly;
+		const yearlyVariantMaybeDiscountedPrice = Number.isFinite(
+			yearlyVariantPricing.discountedPrice?.monthly
+		)
+			? yearlyVariantPricing.discountedPrice?.monthly
+			: yearlyVariantPricing.originalPrice?.monthly;
 
 		if (
 			yearlyVariantMaybeDiscountedPrice &&
@@ -85,7 +88,7 @@ export default function usePlanBillingDescription( {
 	}
 
 	const discountedPriceFullTermText =
-		currencyCode && discountedPrice?.full
+		currencyCode && typeof discountedPrice?.full === 'number'
 			? formatCurrency( discountedPrice.full, currencyCode, {
 					stripZeros: true,
 					isSmallestUnit: true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* If a plan's discounted price is 0, we incorrectly show the full price instead of the discounted price in the pricing grid. A plan's price can be 0 if there is a coupon that offers a 100% discount.

| Production | This PR |
|--------|--------|
|<img width="402" alt="image" src="https://github.com/user-attachments/assets/2175bdc4-3431-4f0e-bb9b-ae0684ddd9c5"> | <img width="373" alt="image" src="https://github.com/user-attachments/assets/314889bb-a2d3-4548-8ea2-c20e312b69fd">| 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the store sandbox. 
* Go to `/setup/new-hosted-site/plans?coupon=BF2A01`.
* Confirm that the price of the business plan is shown as 0.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
