### PR TITLE
A4A: Add migrated badge with popover with billing start date

### DIFF
--- a/client/a8c-for-agencies/data/purchases/lib/format-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/lib/format-licenses.ts
@@ -1,5 +1,5 @@
 import type { ReferralAPIResponse } from 'calypso/a8c-for-agencies/sections/referrals/types';
-import type { License } from 'calypso/state/partner-portal/types';
+import type { License, LicenseMeta } from 'calypso/state/partner-portal/types';
 
 interface APILicense {
 	license_id: number;
@@ -17,6 +17,7 @@ interface APILicense {
 	owner_type: string | null;
 	quantity: number | null;
 	parent_license_id: number | null;
+	meta: LicenseMeta | null;
 	referral: ReferralAPIResponse;
 }
 
@@ -37,6 +38,7 @@ export default function formatLicenses( items: APILicense[] ): License[] {
 		ownerType: item.owner_type,
 		quantity: item.quantity,
 		parentLicenseId: item.parent_license_id,
+		meta: item.meta,
 		referral: item.referral,
 	} ) );
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -100,6 +100,7 @@ export default function LicenseList() {
 								}
 								quantity={ license.quantity }
 								isChildLicense={ !! license.parentLicenseId }
+								meta={ license.meta }
 								referral={ license.referral }
 							/>
 						</LicenseTransition>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -153,8 +153,20 @@ export default function LicensePreview( {
 		</Badge>
 	);
 
-	const isMigratedSubscription = !! meta?.a4a_transferred_subscription_expiration;
-	const MigratedBadge = () => {
+	const shouldShowTransferredBadge = () => {
+		const transferredDate = meta?.a4a_transferred_subscription_expiration;
+
+		if ( ! transferredDate ) {
+			return false;
+		}
+
+		// Only show the badge from now until 60 days after the transferred date.
+		const sixtyDaysAfter = new Date( transferredDate );
+		sixtyDaysAfter.setDate( sixtyDaysAfter.getDate() + 60 );
+		return new Date() < sixtyDaysAfter;
+	};
+
+	const TransferredBadge = () => {
 		const [ showPopover, setShowPopover ] = useState( false );
 		const wrapperRef = useRef< HTMLSpanElement | null >( null );
 
@@ -333,7 +345,7 @@ export default function LicensePreview( {
 
 				<div className="license-preview__badge-container">
 					{ !! isParentLicense && bundleCountContent }
-					{ !! isMigratedSubscription && <MigratedBadge /> }
+					{ shouldShowTransferredBadge() && <TransferredBadge /> }
 				</div>
 
 				<div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -6,7 +6,8 @@ import { Icon, external } from '@wordpress/icons';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState, useContext } from 'react';
+import { useCallback, useEffect, useState, useContext, useRef } from 'react';
+import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
 	isPressableHostingProduct,
@@ -33,6 +34,7 @@ import LicensesOverviewContext from '../licenses-overview/context';
 import LicenseActions from './license-actions';
 import LicenseBundleDropDown from './license-bundle-dropdown';
 import type { ReferralAPIResponse } from 'calypso/a8c-for-agencies/sections/referrals/types';
+import type { LicenseMeta } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
 
@@ -49,6 +51,7 @@ interface Props {
 	parentLicenseId?: number | null;
 	quantity?: number | null;
 	isChildLicense?: boolean;
+	meta?: LicenseMeta | null;
 	referral?: ReferralAPIResponse | null;
 }
 
@@ -65,6 +68,7 @@ export default function LicensePreview( {
 	parentLicenseId,
 	quantity,
 	isChildLicense,
+	meta,
 	referral,
 }: Props ) {
 	const translate = useTranslate();
@@ -148,6 +152,68 @@ export default function LicensePreview( {
 			} ) }
 		</Badge>
 	);
+
+	const isMigratedSubscription = !! meta?.a4a_transferred_subscription_expiration;
+	const MigratedBadge = () => {
+		const [ showPopover, setShowPopover ] = useState( false );
+		const wrapperRef = useRef< HTMLSpanElement | null >( null );
+
+		return (
+			<span
+				className="license-preview__migration-wrapper"
+				onClick={ () => setShowPopover( true ) }
+				role="button"
+				tabIndex={ 0 }
+				ref={ wrapperRef }
+				onKeyDown={ ( event ) => {
+					if ( event.key === 'Enter' ) {
+						setShowPopover( true );
+					}
+				} }
+			>
+				<Badge className="license-preview__migration-badge" type="info-green">
+					{ translate( 'Migration' ) }
+				</Badge>
+				{ showPopover && (
+					<A4APopover
+						title=""
+						offset={ 12 }
+						wrapperRef={ wrapperRef }
+						onFocusOutside={ () => setShowPopover( false ) }
+					>
+						<div className="license-preview__migration-content">
+							{ translate(
+								"Your site is now with Automattic for Agencies. You won't be billed until {{bold}}%(date)s{{/bold}}.{{br/}}{{a}}Learn about billing for migrated sites{{icon/}}{{/a}}",
+								{
+									components: {
+										bold: <strong />,
+										br: <br />,
+										a: (
+											<a
+												href="https://agencieshelp.automattic.com/"
+												target="_blank"
+												rel="noreferrer noopener"
+											/>
+										),
+										icon: (
+											<Gridicon
+												icon="external"
+												size={ 16 }
+												className="license-preview__migration-external-icon"
+											/>
+										),
+									},
+									args: {
+										date: meta?.a4a_transferred_subscription_expiration ?? '',
+									},
+								}
+							) }
+						</div>
+					</A4APopover>
+				) }
+			</span>
+		);
+	};
 
 	// TODO: We are removing Creator's product name in the frontend because we want to leave it in the backend for the time being,
 	//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
@@ -267,6 +333,7 @@ export default function LicensePreview( {
 
 				<div className="license-preview__badge-container">
 					{ !! isParentLicense && bundleCountContent }
+					{ !! isMigratedSubscription && <MigratedBadge /> }
 				</div>
 
 				<div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -172,7 +172,7 @@ export default function LicensePreview( {
 				} }
 			>
 				<Badge className="license-preview__migration-badge" type="info-green">
-					{ translate( 'Migration' ) }
+					{ translate( 'Transferred' ) }
 				</Badge>
 				{ showPopover && (
 					<A4APopover
@@ -190,7 +190,7 @@ export default function LicensePreview( {
 										br: <br />,
 										a: (
 											<a
-												href="https://agencieshelp.automattic.com/"
+												href="https://agencieshelp.automattic.com/knowledge-base/moving-existing-wordpress-com-plans-into-the-automattic-for-agencies-billing-system/"
 												target="_blank"
 												rel="noreferrer noopener"
 											/>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -216,3 +216,32 @@ button.button.is-borderless.license-bundle-dropdown__button {
 		}
 	}
 }
+
+.license-preview__migration-badge {
+	cursor: pointer;
+}
+
+.license-preview__migration-content {
+	min-width: 200px;
+	@include a4a-font-body-md;
+
+	@include break-mobile {
+		min-width: 300px;
+	}
+
+	a,
+	a:visited {
+		display: inline-block;
+		margin-block-start: 10px;
+		color: var(--color-neutral-100);
+		text-decoration: underline;
+	}
+	a:focus {
+		outline: none;
+	}
+}
+
+.license-preview__migration-external-icon {
+	vertical-align: text-bottom;
+	margin-inline-start: 3px;
+}

--- a/client/state/partner-portal/licenses/handlers.ts
+++ b/client/state/partner-portal/licenses/handlers.ts
@@ -16,6 +16,7 @@ import {
 	DispatchRequest,
 	HttpAction,
 	License,
+	LicenseMeta,
 	LicenseCounts,
 	PaginatedItems,
 } from 'calypso/state/partner-portal/types';
@@ -40,6 +41,7 @@ interface APILicense {
 	owner_type: string | null;
 	quantity: number | null;
 	parent_license_id: number | null;
+	meta: LicenseMeta | null;
 	referral: ReferralAPIResponse | null;
 }
 
@@ -117,6 +119,7 @@ export function formatLicenses( items: APILicense[] ): License[] {
 		ownerType: item.owner_type,
 		quantity: item.quantity,
 		parentLicenseId: item.parent_license_id,
+		meta: item.meta,
 		referral: item.referral,
 	} ) );
 }

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -251,6 +251,7 @@ export interface License {
 	ownerType: string | null;
 	quantity: number | null;
 	parentLicenseId: number | null;
+	meta: LicenseMeta | null;
 	referral: ReferralAPIResponse | null;
 }
 
@@ -261,6 +262,15 @@ export interface LicenseCounts {
 	not_revoked: number;
 	all: number;
 	standard: number;
+}
+
+export interface LicenseMeta {
+	a4a_is_dev_site?: boolean;
+	a4a_was_dev_site?: boolean;
+	a4a_dev_site_period_start?: string;
+	a4a_dev_site_period_end?: string;
+	a4a_transferred_subscription_id?: string;
+	a4a_transferred_subscription_expiration?: string;
 }
 
 export interface LicensesStore {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/854

## Proposed Changes

* Adds a new "Migrated" badge with a popover that has the date for when a migrated subscription will start getting billed through A4A. 

<img width="415" alt="Screenshot 2024-09-16 at 14 48 05" src="https://github.com/user-attachments/assets/5a6f10b5-0320-48c3-ad23-c0cb75dd724e">

## Testing Instructions

* In your sandbox, apply D161488-code and sandbox `public-api.wordpress.com` 
* Login as the `a4ademo` user (credentials in secret store)
* Go to `/purchases/licenses`. You should see a "Migrated" badge in some of the licenses on the list.
* Click on the badge to open the popover.

Note: The link is not redirecting the correct place because we're still waiting on the knowledge base article to be created. I'll update the link before this is merged.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?