### PR TITLE
Performance Profiler: adds more context to suggestions.

### DIFF
--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -189,6 +189,10 @@ $blueberry-color: #3858e9;
 					line-height: 24px;
 				}
 
+				ul {
+					margin: 0 0 1.5em 3em;
+				}
+
 				.performance-profiler-tip {
 					max-width: 300px;
 					min-width: unset;

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -92,7 +92,7 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 
 	const { insight, onClick, index, isWpcom, hash } = props;
 	const insightDetailsContext = insight?.details?.items?.reduce( ( context, item ) => {
-		context += `- ${ item.url } `;
+		context += `* '${ item.url }' `;
 		return context;
 	}, '' );
 

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -91,6 +91,7 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 	const translate = useTranslate();
 
 	const { insight, onClick, index, isWpcom, hash } = props;
+	// Creates a list of URLs from the insight details to be used as context for the LLM query.
 	const insightDetailsContext = insight?.details?.items?.reduce( ( context, item ) => {
 		context += `* '${ item.url }' `;
 		return context;

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -91,10 +91,15 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 	const translate = useTranslate();
 
 	const { insight, onClick, index, isWpcom, hash } = props;
+	const insightDetailsContext = insight?.details?.items?.reduce( ( context, item ) => {
+		context += `- ${ item.url } `;
+		return context;
+	}, '' );
 
 	const [ retrieveInsight, setRetrieveInsight ] = useState( false );
 	const { data: llmAnswer, isLoading: isLoadingLlmAnswer } = useSupportChatLLMQuery(
-		insight.description ?? '',
+		insight.title ?? '',
+		insightDetailsContext ?? '',
 		hash,
 		isWpcom,
 		isEnabled( 'performance-profiler/llm' ) && retrieveInsight

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -27,7 +27,7 @@ export const useSupportChatLLMQuery = (
 
 	return useQuery( {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps
-		queryKey: [ 'support', 'chat', context, is_wpcom ],
+		queryKey: [ 'support', 'chat', title, is_wpcom ],
 		queryFn: () =>
 			wp.req.post(
 				{

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -14,8 +14,11 @@ export const useSupportChatLLMQuery = (
 ) => {
 	const question = `I need to fix the following issue to improve the performance of my WordPress site: ${ title }.`;
 	const howToAnswer =
-		'Answer me in two topics in bold: "Why is this important?" and "How to fix this?"';
-	const message = `${ question } ${ howToAnswer } by using each of the following context: ${ context }`;
+		'Answer me in two topics in bold: "Why is this important?" and "How to fix this?".';
+	const contextToInclude = `Use each of the following context: ${ context }. Visit any links provided for more information.`;
+	const suggestionsToInclude =
+		'Add if the issue can be fixed automatically with a WordPress setting, an editor block setting, or a plugin. Prefer Automattic owned plugins. Add relevant links.';
+	const message = `${ question } ${ howToAnswer } ${ contextToInclude } ${ suggestionsToInclude }`;
 
 	return useQuery( {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -6,19 +6,20 @@ function mapResult( response: WPComSupportQueryResponse ) {
 }
 
 export const useSupportChatLLMQuery = (
-	description: string,
+	title: string,
+	context: string,
 	hash: string,
 	is_wpcom: boolean,
 	enable: boolean
 ) => {
-	const question = `I need to fix the following issue to improve the performance of site: ${ description }.`;
+	const question = `I need to fix the following issue to improve the performance of my WordPress site: ${ title }.`;
 	const howToAnswer =
 		'Answer me in two topics in bold: "Why is this important?" and "How to fix this?"';
-	const message = `${ question } ${ howToAnswer }`;
+	const message = `${ question } ${ howToAnswer } by using each of the following context: ${ context }`;
 
 	return useQuery( {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps
-		queryKey: [ 'support', 'chat', description, is_wpcom ],
+		queryKey: [ 'support', 'chat', context, is_wpcom ],
 		queryFn: () =>
 			wp.req.post(
 				{
@@ -31,7 +32,7 @@ export const useSupportChatLLMQuery = (
 			persist: false,
 		},
 		select: mapResult,
-		enabled: !! description && enable,
+		enabled: !! context && enable,
 		retry: false,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -17,8 +17,13 @@ export const useSupportChatLLMQuery = (
 		'Answer me in two topics in bold: "Why is this important?" and "How to fix this?".';
 	const contextToInclude = `Use each of the following context: ${ context }. Visit any links provided for more information.`;
 	const suggestionsToInclude =
-		'Add if the issue can be fixed automatically with a WordPress setting, an editor block setting, or a plugin. Prefer Automattic owned plugins. Add relevant links.';
-	const message = `${ question } ${ howToAnswer } ${ contextToInclude } ${ suggestionsToInclude }`;
+		'Add if the issue can be fixed automatically with a WordPress setting, an editor block setting, or a plugin. Prefer Automattic owned plugins. Add relevant links. Provide code snippets as a last resort.';
+	const wpcomOrSelfHostedSuggestions = ! is_wpcom
+		? 'Do not show suggestions that work only in WordPress.com. Do not show any references to documentation or support forums related to WordPress.com.'
+		: 'Provide suggestions that work only in WordPress.com. Use WordPress.com documentation if availabble.';
+	const otherDirectives =
+		'Do not suggest doing additional tests to identify the issue. Do not suggest any other tool/website/service for doing another test except WordPress Speed Test. Do not mention Lighthouse reports or any other tool. Rarely suggest subscribing to weekly emails feature of the Performance Profiler tool to monitor changes. Always provide links to the relevant plugin/theme or services. Do not ask follow-up questions or offer further assistance or ask for any feedback.';
+	const message = `${ question } ${ howToAnswer } ${ contextToInclude } ${ suggestionsToInclude } ${ wpcomOrSelfHostedSuggestions } ${ otherDirectives }`;
 
 	return useQuery( {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -40,7 +40,7 @@ export const useSupportChatLLMQuery = (
 			persist: false,
 		},
 		select: mapResult,
-		enabled: !! context && enable,
+		enabled: !! title && enable,
 		retry: false,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -22,7 +22,7 @@ export const useSupportChatLLMQuery = (
 		? 'Do not show suggestions that work only in WordPress.com. Do not show any references to documentation or support forums related to WordPress.com.'
 		: 'Provide suggestions that work only in WordPress.com. Use WordPress.com documentation if availabble.';
 	const otherDirectives =
-		'Do not suggest doing additional tests to identify the issue. Do not suggest any other tool/website/service for doing another test except WordPress Speed Test. Do not mention Lighthouse reports or any other tool. Rarely suggest subscribing to weekly emails feature of the Performance Profiler tool to monitor changes. Always provide links to the relevant plugin/theme or services. Do not ask follow-up questions or offer further assistance or ask for any feedback.';
+		'Do not suggest doing additional tests to identify the issue. Do not suggest any other tool/website/service for doing another test except WordPress Speed Test (https://wordpress.com/speed-test). Do not mention Lighthouse reports or any other tool. Rarely suggest subscribing to weekly emails feature of the Performance Profiler tool to monitor changes. Always provide links to the relevant plugin/theme or services. Do not ask follow-up questions or offer further assistance or ask for any feedback.';
 	const message = `${ question } ${ howToAnswer } ${ contextToInclude } ${ suggestionsToInclude } ${ wpcomOrSelfHostedSuggestions } ${ otherDirectives }`;
 
 	return useQuery( {

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -22,7 +22,7 @@ export const useSupportChatLLMQuery = (
 		? 'Do not show suggestions that work only in WordPress.com. Do not show any references to documentation or support forums related to WordPress.com.'
 		: 'Provide suggestions that work only in WordPress.com. Use WordPress.com documentation if availabble.';
 	const otherDirectives =
-		'Do not suggest doing additional tests to identify the issue. Do not suggest any other tool/website/service for doing another test except WordPress Speed Test (https://wordpress.com/speed-test). Do not mention Lighthouse reports or any other tool. Rarely suggest subscribing to weekly emails feature of the Performance Profiler tool to monitor changes. Always provide links to the relevant plugin/theme or services. Do not ask follow-up questions or offer further assistance or ask for any feedback.';
+		'Do not suggest doing additional tests to identify the issue. Do not suggest any other tool/website/service for doing another test except WordPress Speed Test (https://wordpress.com/speed-test). Do not mention Lighthouse reports or any other tool. Rarely suggest subscribing to weekly emails feature of the Performance Profiler tool to monitor changes. Do not ask follow-up questions or offer further assistance or ask for any feedback.';
 	const message = `${ question } ${ howToAnswer } ${ contextToInclude } ${ suggestionsToInclude } ${ wpcomOrSelfHostedSuggestions } ${ otherDirectives }`;
 
 	return useQuery( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9074

## Proposed Changes

|Before | After|
|-------|------|
|![CleanShot 2024-09-16 at 17 16 51](https://github.com/user-attachments/assets/c7ad55ea-02d3-42bc-be8e-27087908fe1f)|![CleanShot 2024-09-16 at 17 15 57](https://github.com/user-attachments/assets/79b4b185-ddf4-4841-bd85-f292dddec6a0)|
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `speed-test-tool?url=https%3A%2F%2Fautomattic.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzY4OX0.l-BeLFkyNQyq8UqrgTkpSm_s660DEEDisemufsMs4og&tab=mobile` explore suggestions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
