### PR TITLE
e2e: Skip long-failing VideoPress test

### DIFF
--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -121,7 +121,8 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		} );
 
 		// If this starts failing, check whether Premium or higher plan is enabled.
-		it( `${ VideoPressBlock.blockName } block: upload video file`, async function () {
+		// 2024-09-16: Skipping. This has been failing all year, seems to be a problem with the backend and the way the test sites get cleaned up. p1707923887553869-slack-C034JEXD1RD
+		it.skip( `${ VideoPressBlock.blockName } block: upload video file`, async function () {
 			await editorPage.addBlockFromSidebar(
 				VideoPressBlock.blockName,
 				VideoPressBlock.blockEditorSelector,
@@ -162,7 +163,8 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 			await FileBlock.validatePublishedContent( page, [ testFiles.audio.filename ] );
 		} );
 
-		it( `VideoPress block is visible`, async function () {
+		// Skipped above.
+		it.skip( `VideoPress block is visible`, async function () {
 			await VideoPressBlock.validatePublishedContent( page );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Skip the "Media (Upload): Populate post with media blocks: VideoPress block: upload video file" test.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We've been muting this since February, and the failure seems to be specific to the test sites. Time to just `.skip` it until the team gets a chance to fix it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the test against Jetpackedge sites. Passes, with the VideoPress test skipped.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
