### PR TITLE
e2e: make block selector helper tag agnostic

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
@@ -19,7 +19,7 @@ interface FieldLabelDetails {
  * @returns A selector string to use to make a locator for the block.
  */
 export function makeSelectorFromBlockName( blockName: string ): string {
-	return `div[aria-label="Block: ${ blockName }"]`;
+	return `[aria-label="Block: ${ blockName }"]`;
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR updates the `makeSelectorFromBlockName` e2e test helper so that the selector relies only on the `aria-label` attribute and therefore become tag agnostic.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The `makeSelectorFromBlockName` helper assumes that Gutenberg blocks are all [contained in a `div` container.](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts#L22) However, that's not always true, especially in the case of [inner blocks](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/).

In this example, inner blocks (options) of the _Single Choice_ block match `li` tags in the DOM.

| UI | DOM Tree |
|-|-|
|<img width="198" alt="Screenshot 2024-09-16 at 12 03 17 PM" src="https://github.com/user-attachments/assets/507adc0d-c309-4223-8fd8-bd9784d97e01">|<img width="478" alt="Screenshot 2024-09-16 at 12 03 27 PM" src="https://github.com/user-attachments/assets/f74cfc91-af0b-4f1f-abbb-4076124524c2">|

_Note: the following e2e test (muted for now) is failing for that reason. The selector `'div[aria-label="Block: Single Choice Option"]'` returns no results._
<img width="811" alt="Screenshot 2024-09-16 at 12 16 41 PM" src="https://github.com/user-attachments/assets/58300944-4701-44a0-98e5-ccc2b8d37e9e">
<img width="1460" alt="Screenshot 2024-09-16 at 12 22 46 PM" src="https://github.com/user-attachments/assets/817daf6e-33f1-4f85-bfbe-1ff2414136af">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure the test mentioned above as well as the other block tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
