### PR TITLE
Sites dashboard - Surface Site and General settings for classic view sites in actions/ellipsis menu.

### DIFF
--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -20,7 +20,7 @@ import './style.scss';
 
 const getTitle = ( adminInterfaceIsWPAdmin ) => {
 	if ( adminInterfaceIsWPAdmin ) {
-		return translate( 'Settings' );
+		return translate( 'Site Settings' );
 	}
 	return translate( 'General Settings' );
 };

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -102,15 +102,37 @@ const PrepareForLaunchItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	);
 };
 
-const SettingsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
+const SettingsItem = ( { site, recordTracks, isWpAdminInterface }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
+
+	// We call this "Site Settings" for classic sites, to differentiate from "General Settings" in wp-admin.
+	const settingsLabel = isWpAdminInterface ? __( 'Site Settings' ) : __( 'Settings' );
 
 	return (
 		<MenuItemLink
 			href={ getSettingsUrl( site.slug ) }
 			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_settings_click' ) }
 		>
-			{ __( 'Settings' ) }
+			{ settingsLabel }
+		</MenuItemLink>
+	);
+};
+
+const GeneralWPAdminSettingsItem = ( {
+	recordTracks,
+	isWpAdminInterface,
+	wpAdminUrl,
+}: SitesMenuItemProps ) => {
+	const { __ } = useI18n();
+	if ( ! isWpAdminInterface ) {
+		return;
+	}
+	return (
+		<MenuItemLink
+			href={ wpAdminUrl + 'options-general.php' }
+			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_wpadmin_settings_click' ) }
+		>
+			{ __( 'General Settings' ) }
 		</MenuItemLink>
 	);
 };
@@ -524,6 +546,7 @@ export const SitesEllipsisMenu = ( {
 					<PrepareForLaunchItem { ...props } />
 				) }
 				<SettingsItem { ...props } />
+				<GeneralWPAdminSettingsItem { ...props } />
 				{ hasHostingFeatures && <HostingConfigurationSubmenu { ...props } /> }
 				{ site.is_wpcom_atomic && <SiteMonitoringItem { ...props } /> }
 				{ ! isP2Site( site ) && <ManagePluginsItem { ...props } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-migrations#770

## Proposed Changes

For 'classic' view sites we:
* Rename the "Settings" site action option to be called "Site Settings".
* Add a "General Settings" link next to it for the general wp-admin settings page.
* Rename the "Settings" page in calypso for these sites to "Site Settings".
* Handles renaming the sidebar item in https://github.com/Automattic/jetpack/pull/39411 separately.

'Default' view sites should be unaffected. "Settings" will still lead to the calypso settings page and continue to be titled "General Settings" as they do today.

BEFORE
<img width="300" alt="Screenshot 2024-09-16 at 12 21 49 PM" src="https://github.com/user-attachments/assets/e65bc99e-e936-49b0-9c14-65b2a5325256">
<img width="1216" alt="Screenshot 2024-09-16 at 12 22 53 PM" src="https://github.com/user-attachments/assets/29b11ffb-79e0-4935-811a-6f8cce3a1aaf">


AFTER
<img width="300" alt="Screenshot 2024-09-16 at 12 21 38 PM" src="https://github.com/user-attachments/assets/1ae8ba71-44cc-4995-90ca-c2862da820f7">
<img width="1236" alt="Screenshot 2024-09-16 at 12 23 08 PM" src="https://github.com/user-attachments/assets/f59e897c-4962-4adc-b3b1-a51c7d67f872">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Confusion for classic view sites on how to get to their general settings page from the dashboard, especially after migrations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the sites dashboard.
* For a classic view site, verify site actions now has both "Site Settings" and "General Settings" options.
* Verify Site Settings goes to the calypso settings page and is titled the same.
* Verify General Settings leads to the wp-admin settings page.
* Go back to the dashboard, test a default view site and verify there are no changes.

You can also patch https://github.com/Automattic/jetpack/pull/39411 to your site and verify the name in the sidebar menu changes as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
