### PR TITLE
A4A: Increase the filter selector height to show part of the next item

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -61,6 +61,10 @@
 			border-radius: 4px;
 		}
 	}
+
+	.dataviews-filters__search-widget-listbox {
+		max-height: 195px;
+	}
 }
 
 .sites-dashboard__layout:not(.preview-hidden) {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1080

## Proposed Changes

* Increase the filter selector height to show part of the next item, indicating more options.

<img width="292" alt="Screenshot 2024-09-16 at 18 04 27" src="https://github.com/user-attachments/assets/77824a3b-2149-4bc6-96cd-beddc762f996">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live link
* Go to Sites.
* Toggle the filter display view
* Click "Status"
* Confirm you see half of the next (hidden) item in the popover.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
