### PR TITLE
PlanNoticeCreditUpgrade: Replace support link with InlineSupportLink component

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -193,11 +193,7 @@ export const UnwrappedUpgradePlan: React.FunctionComponent< UpgradePlanProps > =
 				</div>
 			) }
 
-			<PlanNoticeCreditUpgrade
-				linkTarget="_blank"
-				siteId={ site.ID }
-				visiblePlans={ [ visiblePlan ] }
-			/>
+			<PlanNoticeCreditUpgrade siteId={ site.ID } visiblePlans={ [ visiblePlan ] } />
 
 			<UpgradePlanDetails
 				pricing={ pricing }

--- a/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
@@ -20,6 +20,11 @@ jest.mock( '../upgrade-plan-details', () => ( {
 	default: ( { children } ) => <div>{ children }</div>,
 } ) );
 
+// Mock the HelpCenter module
+jest.mock( 'calypso/components/inline-support-link', () => ( {
+	register: jest.fn(),
+} ) );
+
 jest.mock(
 	'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase',
 	() => jest.fn()

--- a/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
@@ -64,7 +64,15 @@ const PlanNoticeCreditUpgrade = ( {
 							},
 							components: {
 								b: <strong />,
-								a: <a href={ upgradeCreditDocsUrl } target={ linkTarget } />,
+								a: (
+									<a
+										href={ upgradeCreditDocsUrl }
+										target={ linkTarget }
+										onClick={ ( event ) => {
+											event.stopPropagation();
+										} }
+									/>
+								),
 							},
 						}
 					) }

--- a/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
@@ -2,6 +2,7 @@ import { formatCurrency } from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
 import { usePlanUpgradeCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable';
 import { useSelector } from 'calypso/state';
@@ -16,13 +17,7 @@ type Props = {
 	visiblePlans?: PlanSlug[];
 };
 
-const PlanNoticeCreditUpgrade = ( {
-	className,
-	onDismissClick,
-	linkTarget,
-	siteId,
-	visiblePlans,
-}: Props ) => {
+const PlanNoticeCreditUpgrade = ( { className, onDismissClick, siteId, visiblePlans }: Props ) => {
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
@@ -64,15 +59,7 @@ const PlanNoticeCreditUpgrade = ( {
 							},
 							components: {
 								b: <strong />,
-								a: (
-									<a
-										href={ upgradeCreditDocsUrl }
-										target={ linkTarget }
-										onClick={ ( event ) => {
-											event.stopPropagation();
-										} }
-									/>
-								),
+								a: <InlineSupportLink supportLink={ upgradeCreditDocsUrl } />,
 							},
 						}
 					) }

--- a/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
@@ -12,7 +12,6 @@ import type { PlanSlug } from '@automattic/calypso-products';
 type Props = {
 	className?: string;
 	onDismissClick?: () => void;
-	linkTarget?: string;
 	siteId: number;
 	visiblePlans?: PlanSlug[];
 };

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -160,7 +160,7 @@ describe( '<PlanNotice /> Tests', () => {
 			/>
 		);
 		expect( screen.getByRole( 'status' ).textContent ).toBe(
-			'You have $100.00 in upgrade credits available from your current plan. This credit will be applied to the pricing below at checkout if you upgrade today!'
+			'You have $100.00 in upgrade credits(opens in a new tab) available from your current plan. This credit will be applied to the pricing below at checkout if you upgrade today!'
 		);
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #83923

## Proposed Changes

* Fixes the redirection/linking issue when the user clicks on "upgrade credits" (more info: https://github.com/Automattic/wp-calypso/issues/83923)

<img width="1290" alt="Screenshot 2024-09-17 at 12 35 59" src="https://github.com/user-attachments/assets/cc6a8eb4-3417-4a1f-87bc-a42018b60be0">

## Why are these changes being made?

* The global router handler causes the issue, so we use the `InlineSupportLink` component to have a unified way of handling support page redirection.

## Testing Instructions

* Go to `/plans/{SITE_SLUG}` *it should be an atomic site
* Click on "upgrade credits"
* Check if you are redirected (in new tab) to "/support/manage-purchases/upgrade-your-plan/#upgrade-credit" -> Upgrade Credit section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?- 