### PR TITLE
A4A: Fix header alignment with the DataViews table

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -209,7 +209,7 @@
 				padding: 0;
 
 				.a4a-layout__viewport {
-					padding-inline: 16px;
+					padding-inline: 24px;
 				}
 
 				.a4a-layout__header-title {
@@ -454,6 +454,13 @@
 	}
 
 	&.sites-dashboard__layout {
+		.a4a-layout__viewport {
+			padding-inline: 24px;
+
+			@media (min-width: 720px) {
+				padding-inline: 48px;
+			}
+		}
 
 		.activity-card-list .activity-card .activity-card__time {
 			background: none;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -50,6 +50,33 @@
 		border-radius: 4px;
 	}
 
+	.dataviews__view-actions,
+	.dataviews-filters__container {
+		padding: 16px;
+
+		@media (min-width: $break-small) {
+			padding: 16px 64px;
+		}
+	}
+
+	.dataviews-view-table tr td:first-child,
+	.dataviews-view-table tr th:first-child {
+		padding-left: 16px;
+
+		@media (min-width: $break-small) {
+			padding-left: 64px;
+		}
+	}
+
+	.dataviews-view-table tr td:last-child,
+	.dataviews-view-table tr th:last-child {
+		padding-right: 16px;
+
+		@media (min-width: $break-small) {
+			padding-right: 64px;
+		}
+	}
+
 	@media (min-width: $break-large) {
 		background: inherit;
 
@@ -209,7 +236,7 @@
 				padding: 0;
 
 				.a4a-layout__viewport {
-					padding-inline: 24px;
+					padding-inline: 16px;
 				}
 
 				.a4a-layout__header-title {
@@ -454,13 +481,6 @@
 	}
 
 	&.sites-dashboard__layout {
-		.a4a-layout__viewport {
-			padding-inline: 24px;
-
-			@media (min-width: 720px) {
-				padding-inline: 48px;
-			}
-		}
 
 		.activity-card-list .activity-card .activity-card__time {
 			background: none;


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1081

## Proposed Changes

* Fixes the header alignment across different breakpoints.

| Before | After |
| ------------- | ------------- |
|  <img width="530" alt="Screenshot 2024-09-16 at 19 10 19" src="https://github.com/user-attachments/assets/4c7f3456-5bcb-421f-bc30-e19b36bdcda1"> | <img width="509" alt="Screenshot 2024-09-16 at 19 09 47" src="https://github.com/user-attachments/assets/17b3e414-ad6a-4abe-9aa6-6eed017e910f"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live link
* Go to the Sites list
* Confirm that the header now aligns with the rest of the UI elements.
* Resize the browser (or use developer tools) to check other breakpoints.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
