### PR TITLE
Site Migration: Add a documentation for the useFlowNavigator hook

### DIFF
--- a/client/landing/stepper/declarative-flow/migration/hooks/use-flow-navigator.ts
+++ b/client/landing/stepper/declarative-flow/migration/hooks/use-flow-navigator.ts
@@ -8,14 +8,52 @@ interface Options {
 	persistedUrlParams: string[];
 }
 
+/**
+ * Custom hook for managing navigation within a flow, handling query parameters and step transitions.
+ * @param {Object} options - Configuration options for the hook.
+ * @param {Navigate<StepperStep[]>} options.navigate - Function to navigate between steps.
+ * @param {string[]} options.persistedUrlParams - Array of URL parameter keys to persist across navigation.
+ * @returns {Object} An object containing utility functions for flow navigation.
+ * @returns {Function} .getFromPropsOrUrl - Retrieves a value from props or URL query parameters.
+ * @returns {Function} .navigateWithQueryParams - Navigates to a step while managing query parameters.
+ * @example
+ * const { navigateWithQueryParams, getFromPropsOrUrl } = useFlowNavigator({
+ *   navigate: stepNavigationFunction,
+ *   persistedUrlParams: ['siteId', 'plan']
+ * });
+ */
+
 export const useFlowNavigator = ( { navigate, persistedUrlParams }: Options ) => {
 	const [ query ] = useSearchParams();
 
+	/**
+	 * Retrieves a value from either the provided props or the current URL query parameters.
+	 * @param {string} key - The key to look for in props or URL query parameters.
+	 * @param {ProvidedDependencies} [props] - Optional object containing provided dependencies.
+	 * @returns {Primitive | undefined} The value associated with the key, or undefined if not found or if the value is an object.
+	 *
+	 * This function first checks if the key exists in the provided props. If not found or if props are not provided,
+	 * it then looks for the key in the current URL query parameters. If the value is found but is an object,
+	 * the function returns undefined. This ensures that only primitive values are returned.
+	 */
 	const getFromPropsOrUrl = ( key: string, props?: ProvidedDependencies ): Primitive => {
 		const value = props?.[ key ] || query.get( key );
 		return typeof value === 'object' ? undefined : ( value as Primitive );
 	};
 
+	/**
+	 * Navigates to a specified step while preserving and updating query parameters.
+	 * @param {StepperStep} step - The step to navigate to.
+	 * @param {string[]} [keys] - Additional query parameter keys to include.
+	 * @param {ProvidedDependencies} [props] - Additional properties to consider for query params.
+	 * @param {Object} [options] - Navigation options.
+	 * @param {boolean} options.replaceHistory - If true, replaces the current history entry instead of adding a new one.
+	 * @returns {void}
+	 *
+	 * This function combines persisted URL parameters with additional specified keys,
+	 * retrieves their values from either props or the current URL, and navigates to
+	 * the given step with these parameters included in the URL.
+	 */
 	const navigateWithQueryParams = (
 		step: StepperStep,
 		keys: string[] = [],

--- a/client/landing/stepper/declarative-flow/migration/hooks/use-flow-navigator.ts
+++ b/client/landing/stepper/declarative-flow/migration/hooks/use-flow-navigator.ts
@@ -3,16 +3,25 @@ import { Primitive } from 'utility-types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { Navigate, ProvidedDependencies, StepperStep } from '../../internals/types';
 
+/**
+ * Interface defining the options for the useFlowNavigator hook.
+ */
 interface Options {
+	/**
+	 * A function to navigate between steps in the flow.
+	 * It accepts an array of StepperStep objects.
+	 */
 	navigate: Navigate< StepperStep[] >;
+
+	/**
+	 * An array of URL parameter names that should be persisted
+	 * across navigation within the flow.
+	 */
 	persistedUrlParams: string[];
 }
 
 /**
  * Custom hook for managing navigation within a flow, handling query parameters and step transitions.
- * @param {Object} options - Configuration options for the hook.
- * @param {Navigate<StepperStep[]>} options.navigate - Function to navigate between steps.
- * @param {string[]} options.persistedUrlParams - Array of URL parameter keys to persist across navigation.
  * @returns {Object} An object containing utility functions for flow navigation.
  * @returns {Function} .getFromPropsOrUrl - Retrieves a value from props or URL query parameters.
  * @returns {Function} .navigateWithQueryParams - Navigates to a step while managing query parameters.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add documentation to the useFlowNavigator hook, as I found it difficult to understand without looking at the definition.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection is enough, as it only adds documentation.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
