### PR TITLE
Subscriber: show the exact number of subscribers

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -71,13 +71,8 @@ const SubscriberListContainer = ( {
 							className={ `subscriber-list-container__subscriber-count ${
 								isLoading ? 'loading-placeholder' : ''
 							}` }
-							title={
-								total > 1000
-									? formatNumber( total, getLocaleSlug() || undefined, { notation: 'standard' } )
-									: undefined
-							}
 						>
-							{ formatNumber( total, getLocaleSlug() || undefined ) }
+							{ formatNumber( total, getLocaleSlug() || undefined, { notation: 'standard' } ) }
 						</span>
 					</div>
 


### PR DESCRIPTION
Update the subscriber list to show the exact subscriber numbers. 

Before:
<img width="499" alt="Screenshot 2024-09-16 at 11 39 02 AM" src="https://github.com/user-attachments/assets/3cba176c-8865-4065-bf71-6cb2751db593">


After:
<img width="536" alt="Screenshot 2024-09-16 at 11 39 10 AM" src="https://github.com/user-attachments/assets/2979848c-b1cc-4963-b17a-9a65e76c4e98">


Related to p1726510663553929/1726144959.645139-slack-C052XEUUBL4

## Proposed Changes

* Show the exact number of subscribers always. 

## Why are these changes being made?
* This is one the cases where exact numbers are impotent to show instead of rounding up. 
* 

## Testing Instructions

* Load the PR and visit http://calypso.localhost:3000/subscribers/yoursite.com
notice the exact number shown in now. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?