### PR TITLE
Update discount badge

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/test/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/upgrade-plan-details.tsx
@@ -58,7 +58,7 @@ describe( 'UpgradePlanDetails', () => {
 		} );
 
 		await waitFor( () => {
-			expect( screen.getByText( 'One time offer' ) ).toBeInTheDocument();
+			expect( screen.getByText( '50% off your first year' ) ).toBeInTheDocument();
 
 			// Introductory offer price per month (calculated from the full price).
 			expect( screen.getByText( '12' ) ).toBeInTheDocument();
@@ -87,7 +87,7 @@ describe( 'UpgradePlanDetails', () => {
 		} );
 
 		await waitFor( () => {
-			expect( screen.queryByText( 'One time offer' ) ).toBeNull();
+			expect( screen.queryByText( '50% off your first year' ) ).toBeNull();
 
 			// Introductory offer price per month (calculated from the full price).
 			expect( screen.queryByText( '12' ) ).toBeNull();

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -142,9 +142,9 @@ const PlanPriceOffer = ( props: PlanPriceOfferProps ) => {
 				}
 		  );
 
-	const badgeText = hasEnTranslation( 'One time offer' )
-		? translate( 'One time offer' )
-		: translate( 'One time discount' );
+	const badgeText = hasEnTranslation( '50% off your first year' )
+		? translate( '50% off your first year' )
+		: translate( 'One time offer' );
 
 	return (
 		<UpgradePlanPrice billingTimeFrame={ billingTimeFrame }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

**Warning: This change needs to be deployed in sync with D161364-code**
See pdxWSz-1Mt-p2#comment-717

## Proposed Changes

* It updates the discount badge for the plan step in the migration flows.

<img width="584" alt="Screenshot 2024-09-16 at 15 39 23" src="https://github.com/user-attachments/assets/06450bf0-8eb9-4948-8ce4-86449d31026b">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make clear that the discount is only related to the first year.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to one of the migration flows. Example: `/setup/migration`.
* Navigate to the plan step, and make sure the badge is updated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?