### PR TITLE
Activate all hosting features modal: Improve design

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -20,6 +20,7 @@ import DataCenterPicker from 'calypso/blocks/data-center-picker';
 import ActionPanelLink from 'calypso/components/action-panel/link';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -202,7 +203,7 @@ export const EligibilityWarnings = ( {
 				<CompactCard>
 					<div className="eligibility-warnings__header">
 						<div className="eligibility-warnings__title">
-							{ translate( 'Activate hosting features' ) }
+							{ preventWidows( translate( 'Activate hosting features' ) ) }
 						</div>
 					</div>
 				</CompactCard>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -98,7 +98,8 @@ export const EligibilityWarnings = ( {
 			'eligibility-warnings__placeholder': isPlaceholder,
 			'eligibility-warnings--with-indent': showWarnings,
 			'eligibility-warnings--blocking-hold': hasBlockingHold( listHolds ),
-			'eligibility-warnings--without-title': context !== 'plugin-details',
+			'eligibility-warnings--without-title':
+				context !== 'plugin-details' && context !== 'hosting-features',
 		},
 		className
 	);
@@ -192,6 +193,16 @@ export const EligibilityWarnings = ( {
 										}
 								  )
 								: '' }
+						</div>
+					</div>
+				</CompactCard>
+			) }
+
+			{ context === 'hosting-features' && (
+				<CompactCard>
+					<div className="eligibility-warnings__header">
+						<div className="eligibility-warnings__title">
+							{ translate( 'Activate hosting features' ) }
 						</div>
 					</div>
 				</CompactCard>
@@ -302,6 +313,9 @@ function getProceedButtonText(
 	}
 	if ( siteRequiresGoingPublic( holds ) ) {
 		return translate( 'Make your site public and continue' );
+	}
+	if ( context === 'hosting-features' ) {
+		return translate( 'Activate hosting features' );
 	}
 
 	return translate( 'Continue' );

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -20,7 +20,6 @@ import DataCenterPicker from 'calypso/blocks/data-center-picker';
 import ActionPanelLink from 'calypso/components/action-panel/link';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -203,7 +202,7 @@ export const EligibilityWarnings = ( {
 				<CompactCard>
 					<div className="eligibility-warnings__header">
 						<div className="eligibility-warnings__title">
-							{ preventWidows( translate( 'Activate hosting features' ) ) }
+							{ translate( 'Activate hosting features' ) }
 						</div>
 					</div>
 				</CompactCard>

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -254,6 +254,22 @@
 			color: var(--studio-green-80);
 		}
 	}
+
+	@media (max-width: 660px) {
+		.card {
+			display: flex;
+			flex-direction: column-reverse;
+			flex-wrap: wrap;
+			gap: 10px;
+
+			.badge {
+				position: relative;
+				right: unset;
+				width: fit-content;
+				align-self: flex-start;
+			}
+		}
+	}
 }
 
 .eligibility-warnings__warnings-card {

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,7 +1,7 @@
 .eligibility-warnings {
 	// 16px from card padding + 32 = 48 gap from top|bottom
 	// 24px from card padding + 24 = 48 gab from left|right
-	padding: 24px;
+	padding: 8px 0;
 	overflow-wrap: anywhere;
 	background: #fff;
 	font-size: $font-body-small;
@@ -9,7 +9,7 @@
 	box-shadow: 0 0 0 1px var(--color-border-subtle);
 
 	@media (max-width: 660px) {
-		padding: 8px;
+		padding: 0;
 	}
 
 	.eligibility-warnings__confirm-buttons {
@@ -239,7 +239,7 @@
 
 	.card {
 		padding: 12px 16px;
-		margin-bottom: 5px;
+		margin-bottom: 4px;
 	}
 
 	.badge {
@@ -260,7 +260,7 @@
 			display: flex;
 			flex-direction: column-reverse;
 			flex-wrap: wrap;
-			gap: 10px;
+			gap: 4px;
 
 			.badge {
 				position: relative;

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -8,12 +8,18 @@
 	margin: 0;
 	box-shadow: 0 0 0 1px var(--color-border-subtle);
 
+	@media (max-width: 660px) {
+		padding: 8px;
+	}
+
 	.eligibility-warnings__confirm-buttons {
 		display: flex;
 		justify-content: space-between;
 
 		@media (max-width: 660px) {
-			display: block;
+			flex-direction: column-reverse;
+			flex-wrap: wrap;
+			gap: 20px;
 
 			.button {
 				width: 100%;
@@ -31,6 +37,10 @@
 
 		a {
 			text-decoration: underline;
+		}
+
+		@media (max-width: 660px) {
+			justify-content: center;
 		}
 	}
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -170,6 +170,10 @@
 	.eligibility-warnings__message-description {
 		color: var(--color-text-subtle);
 		font-size: $font-body;
+
+		&--hosting-features {
+			font-weight: 500;
+		}
 	}
 }
 
@@ -232,10 +236,12 @@
 		position: absolute;
 		right: 20px;
 		border-radius: 4px;
+		font-weight: 500;
+		font-size: $font-body-extra-small;
 
 		&.badge--success {
 			background: var(--studio-green-5);
-			color: var(--color-neutral-70);
+			color: var(--studio-green-80);
 		}
 	}
 }

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,7 +1,7 @@
 .eligibility-warnings {
 	// 16px from card padding + 32 = 48 gap from top|bottom
 	// 24px from card padding + 24 = 48 gab from left|right
-	padding: 32px 24px;
+	padding: 24px;
 	overflow-wrap: anywhere;
 	background: #fff;
 	font-size: $font-body-small;
@@ -27,7 +27,11 @@
 		display: flex;
 		gap: 5px;
 		color: var(--color-text-subtle);
-		font-size: 1rem;
+		font-size: 0.875rem;
+
+		a {
+			text-decoration: underline;
+		}
 	}
 
 	.card {
@@ -220,7 +224,7 @@
 	margin-top: 20px;
 
 	.card {
-		padding: 10px 24px;
+		padding: 12px 16px;
 		margin-bottom: 5px;
 	}
 
@@ -228,6 +232,11 @@
 		position: absolute;
 		right: 20px;
 		border-radius: 4px;
+
+		&.badge--success {
+			background: var(--studio-green-5);
+			color: var(--color-neutral-70);
+		}
 	}
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -293,5 +293,7 @@
 
 	.eligibility-warnings__message {
 		border-bottom: none;
+		padding-bottom: 0;
+		margin-bottom: 0;
 	}
 }

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -3,6 +3,7 @@ import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
 import ExternalLink from 'calypso/components/external-link';
+import { preventWidows } from 'calypso/lib/formatting';
 import type { DomainNames, EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
 
 interface ExternalProps {
@@ -123,13 +124,15 @@ function getWarningDescription(
 			);
 
 		case 'hosting-features':
-			return translate(
-				'By proceeding the following change will be made to the site:',
-				'By proceeding the following changes will be made to the site:',
-				{
-					count: warningCount,
-					args: warningCount,
-				}
+			return preventWidows(
+				translate(
+					'By proceeding the following change will be made to the site:',
+					'By proceeding the following changes will be made to the site:',
+					{
+						count: warningCount,
+						args: warningCount,
+					}
+				)
 			);
 
 		default:

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -21,7 +21,12 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 			{ getWarningDescription( context, warnings.length, translate, hasEnTranslation ) && (
 				<div className="eligibility-warnings__warning">
 					<div className="eligibility-warnings__message">
-						<span className="eligibility-warnings__message-description">
+						<span
+							className={ `eligibility-warnings__message-description ${
+								context === 'hosting-features' &&
+								'eligibility-warnings__message-description--hosting-features'
+							}` }
+						>
 							{ getWarningDescription( context, warnings.length, translate, hasEnTranslation ) }
 						</span>
 					</div>

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -3,7 +3,6 @@ import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
 import ExternalLink from 'calypso/components/external-link';
-import { preventWidows } from 'calypso/lib/formatting';
 import type { DomainNames, EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
 
 interface ExternalProps {
@@ -124,15 +123,13 @@ function getWarningDescription(
 			);
 
 		case 'hosting-features':
-			return preventWidows(
-				translate(
-					'By proceeding the following change will be made to the site:',
-					'By proceeding the following changes will be made to the site:',
-					{
-						count: warningCount,
-						args: warningCount,
-					}
-				)
+			return translate(
+				'By proceeding the following change will be made to the site:',
+				'By proceeding the following changes will be made to the site:',
+				{
+					count: warningCount,
+					args: warningCount,
+				}
 			);
 
 		default:

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -31,7 +31,7 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 			{ warnings.map( ( { name, description, supportUrl, domainNames }, index ) => (
 				<div className="eligibility-warnings__warning" key={ index }>
 					<div className="eligibility-warnings__message">
-						{ context !== 'plugin-details' && (
+						{ context !== 'plugin-details' && context !== 'hosting-features' && (
 							<Fragment>
 								<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
 							</Fragment>
@@ -121,20 +121,18 @@ function getWarningDescription(
 			);
 
 		case 'hosting-features':
-			return hasTranslation(
-				'By activating all hosting features the following change will be made to the site:'
-			)
+			return hasTranslation( 'By proceeding the following change will be made to the site:' )
 				? translate(
-						'By activating all hosting features the following change will be made to the site:',
-						'By activating all hosting features the following changes will be made to the site:',
+						'By proceeding the following change will be made to the site:',
+						'By proceeding the following changes will be made to the site:',
 						{
 							count: warningCount,
 							args: warningCount,
 						}
 				  )
 				: translate(
-						'By activating all developer tools the following change will be made to the site:',
-						'By activating all developer tools the following changes will be made to the site:',
+						'By activating all hosting features the following change will be made to the site:',
+						'By activating all hosting features the following changes will be made to the site:',
 						{
 							count: warningCount,
 							args: warningCount,

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,5 +1,4 @@
 import { Card, Badge } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
@@ -15,10 +14,9 @@ interface ExternalProps {
 type Props = ExternalProps & LocalizeProps;
 
 export const WarningList = ( { context, translate, warnings, showContact = true }: Props ) => {
-	const hasEnTranslation = useHasEnTranslation();
 	return (
 		<div>
-			{ getWarningDescription( context, warnings.length, translate, hasEnTranslation ) && (
+			{ getWarningDescription( context, warnings.length, translate ) && (
 				<div className="eligibility-warnings__warning">
 					<div className="eligibility-warnings__message">
 						<span
@@ -27,7 +25,7 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 								'eligibility-warnings__message-description--hosting-features'
 							}` }
 						>
-							{ getWarningDescription( context, warnings.length, translate, hasEnTranslation ) }
+							{ getWarningDescription( context, warnings.length, translate ) }
 						</span>
 					</div>
 				</div>
@@ -89,8 +87,7 @@ function displayDomainNames( domainNames: DomainNames ) {
 function getWarningDescription(
 	context: string | null,
 	warningCount: number,
-	translate: LocalizeProps[ 'translate' ],
-	hasTranslation: ( arg: string ) => boolean
+	translate: LocalizeProps[ 'translate' ]
 ) {
 	const defaultCopy = translate(
 		'By proceeding the following change will be made to the site:',
@@ -126,23 +123,14 @@ function getWarningDescription(
 			);
 
 		case 'hosting-features':
-			return hasTranslation( 'By proceeding the following change will be made to the site:' )
-				? translate(
-						'By proceeding the following change will be made to the site:',
-						'By proceeding the following changes will be made to the site:',
-						{
-							count: warningCount,
-							args: warningCount,
-						}
-				  )
-				: translate(
-						'By activating all hosting features the following change will be made to the site:',
-						'By activating all hosting features the following changes will be made to the site:',
-						{
-							count: warningCount,
-							args: warningCount,
-						}
-				  );
+			return translate(
+				'By proceeding the following change will be made to the site:',
+				'By proceeding the following changes will be made to the site:',
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
 
 		default:
 			return defaultCopy;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7727

## Proposed Changes

* Update modal copy and styles to match [the design](https://github.com/Automattic/dotcom-forge/issues/7727#issuecomment-2340253121).
* The new styles will be applied to other modals: warnings when adding themes or plugins.

Before | After
--- | ----
<img width="778" alt="Screen Shot 2024-09-16 at 3 54 54 PM" src="https://github.com/user-attachments/assets/90f79633-676a-4dd8-9fda-896a8a4f82bd"> | <img width="732" alt="Screen Shot 2024-09-17 at 4 07 46 PM" src="https://github.com/user-attachments/assets/9547fc2a-742d-4942-800d-24b8e30a13f2">
<img width="277" alt="Screen Shot 2024-09-17 at 10 26 44 AM" src="https://github.com/user-attachments/assets/1eecd915-860a-40ae-acd1-c05f004da344"> | <img width="282" alt="Screen Shot 2024-09-17 at 4 08 03 PM" src="https://github.com/user-attachments/assets/5a048fa1-2632-4370-8bcc-6f43c7772377">
<img width="273" alt="Screen Shot 2024-09-17 at 10 26 51 AM" src="https://github.com/user-attachments/assets/bc00ed02-ca18-41ad-9a7c-0698ba692fea"> | <img width="282" alt="Screen Shot 2024-09-17 at 4 08 22 PM" src="https://github.com/user-attachments/assets/3bea5358-34e4-44f2-8fa1-7feee5d2d498">


Additional planned changes for separate PRs:
- Bold the text "your domain will change."
- Change the data center picker to match the design.
- Update the close button to use the WordPress icon.
- Add snackbar notification.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the modal design and keep this interaction exciting for the user.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /hosting-features for a site that has a Business plan, but isn't yet Atomic.
* Click "Activate now."
* View the modal at different screen sizes.
* Go to /plugins and click to add a plugin. Check the modal at different screen sizes.
* Go to /themes and click to install a theme. Check the modal at different screen sizes.
* Go to the Design Picker page with a Marketplace theme selected /setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug. Theme slugs such as makoney and olsen-fse can be used. Check the modal at different screen sizes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
