### PR TITLE
remove hasTranslation check added from 93926

### DIFF
--- a/packages/components/src/highlight-cards/highlight-cards-heading.tsx
+++ b/packages/components/src/highlight-cards/highlight-cards-heading.tsx
@@ -1,18 +1,13 @@
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 
 export default function HighlightCardsHeading( { children }: { children: React.ReactNode } ) {
 	const translate = useTranslate();
-	const hasEnTranslation = useHasEnTranslation();
-	const hasTranslation = hasEnTranslation( 'Updates every 30 minutes' );
 	return (
 		<div className="highlight-cards-heading__wrapper">
 			<h3 className="highlight-cards-heading">{ children }</h3>
-			{ hasTranslation && (
-				<div className="highlight-cards-heading__update-frequency">
-					<span>{ translate( 'Updates every 30 minutes' ) }</span>
-				</div>
-			) }
+			<div className="highlight-cards-heading__update-frequency">
+				<span>{ translate( 'Updates every 30 minutes' ) }</span>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/93926

## Proposed Changes

Removes the hasEnTranslation check that is no longer necessary since translations completed (https://github.com/Automattic/wp-calypso/pull/93926#issuecomment-2338434612)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* code cleanup

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify no observable changes and smoke test.
* The corresponding component is shown on the calypso stats pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
