### PR TITLE
e2e: update Form AI input parent selector

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -36,7 +36,7 @@ export class FormAiFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		const aiInputParentLocator = context.addedBlockLocator;
+		const aiInputParentLocator = await context.editorPage.getEditorCanvas();
 		const aiInputReadyLocator =
 			await aiInputParentLocator.getByPlaceholder( 'Ask Jetpack AI to edit…' );
 		const aiInputBusyLocator = await aiInputParentLocator.getByRole( 'button', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR updates the input parent selector in [the `configure` Form AI test](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts#L38).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

[Upgrading the Form blocks to the Block API v3](https://github.com/Automattic/jetpack/pull/38916/) seems to have modified the DOM structure of the block + AI extension combo from something like:
```
<V1BlockWrapper { ...blockProps } >
 <TheActualBlock/>
 <AiAssistantInput/>
</V1BlockWrapper>
```

to something like:
```
<>
 <TheActualV3Block { ...blockProps } />
 <AiAssistantInput/>
</>
```

See this conversation: p1725394422438789/1725364953.829049-slack-C034JEXD1RD 

The AI Assistant component no longer lives inside a component with a block id. Instead, it's now a sibling. This PR uses the editor canvas as a root element (instead of ` context.addedBlockLocator`) to locate the other elements. It may be worth iterating on this to provide a more refined solution.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts` from the repo root. All tests should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?