### PR TITLE
DIFM Landing Page: Remove break tag from translation

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -65,10 +65,12 @@ const Wrapper = styled.div`
 const ContentSection = styled.div`
 	flex: 1;
 	padding-right: 10px;
+	width: 50%;
 `;
 
 const ImageSection = styled.div`
-	width: 540px;
+	min-width: 540px;
+	width: 50%;
 	height: 562px;
 	padding-top: 75px;
 	display: flex;
@@ -84,9 +86,7 @@ const Header = styled( FormattedHeader )`
 	.formatted-header__title {
 		font-size: 2.75rem;
 		line-height: 3rem;
-		@media ( min-width: 400px ) {
-			text-wrap: nowrap;
-		}
+		text-wrap: pretty;
 	}
 	.formatted-header__subtitle {
 		font-size: 1rem;
@@ -361,7 +361,6 @@ export default function DIFMLanding( {
 		components: {
 			PriceWrapper: ! hasPriceDataLoaded ? <Placeholder /> : <span />,
 			sup: <sup />,
-			br: <br />,
 		},
 		args: {
 			displayCost,
@@ -370,11 +369,11 @@ export default function DIFMLanding( {
 	};
 	const headerText = isStoreFlow
 		? translate(
-				'Let us build your store{{br}}{{/br}}in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
+				'Let us build your store in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
 				headerTextTranslateArgs
 		  )
 		: translate(
-				'Let us build your site{{br}}{{/br}}in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
+				'Let us build your site in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
 				headerTextTranslateArgs
 		  );
 

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -57,9 +57,13 @@ const Placeholder = styled.span`
 const Wrapper = styled.div`
 	display: flex;
 	align-items: flex-start;
-	padding: 12px;
+	padding: 32px;
 	max-width: 1040px;
 	margin: 0 auto;
+
+	.difmStartingPoint & {
+		padding: 12px;
+	}
 `;
 
 const ContentSection = styled.div`
@@ -84,9 +88,9 @@ const ImageSection = styled.div`
 const Header = styled( FormattedHeader )`
 	margin: 0 0 24px 0 !important;
 	.formatted-header__title {
-		font-size: 2.75rem;
+		font-size: 2.75rem !important;
+		margin-bottom: 16px !important;
 		line-height: 3rem;
-		text-wrap: pretty;
 	}
 	.formatted-header__subtitle {
 		font-size: 1rem;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/94559

## Proposed Changes

* This is a follow up from https://github.com/Automattic/wp-calypso/pull/94559
* Removes the `<br>` tag from the translation so the header can be styled using CSS.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `br` tag is causing some strange breaks in the header. They were addressed with some "stopgap" CSS in https://github.com/Automattic/wp-calypso/pull/94559; however, removing the `br` tag from the translation and styling it with CSS is the more robust solution, and it guarantees languages other than English won't suffer from similar usual breaks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /start/do-it-for-me/new-or-existing-site and confirm it looks good on various widths and mobile
* Now test DIFM by coming from the /start flow. Create a new site, and once you get to the "Goals" screen, choose the "Do it for me" option and continue.
* Confirm the DIFM page looks good on various widths and mobile.
* Refresh the page and see that the style and layout hasn't changed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
