### PR TITLE
Checkout: Enable Payment Intents for Alipay in staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -184,7 +184,7 @@
 		"stats/user-feedback": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
-		"stripe-redirect-migration-alipay": false,
+		"stripe-redirect-migration-alipay": true,
 		"stripe-redirect-migration-bancontact": true,
 		"stripe-redirect-migration-ideal": true,
 		"stripe-redirect-migration-p24": true,


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/94119 which enables the new Payment Intent method of using Alipay in the staging environment, like the other migrated payment method APIs, so that we can run a Call for Testing.