### PR TITLE
Domains: Add loading state for Name Servers card in the Settings page

### DIFF
--- a/client/data/domains/nameservers/types.ts
+++ b/client/data/domains/nameservers/types.ts
@@ -1,0 +1,3 @@
+export type UpdateNameServersReponse = {
+	success: boolean;
+};

--- a/client/data/domains/nameservers/use-update-nameservers-mutation.js
+++ b/client/data/domains/nameservers/use-update-nameservers-mutation.js
@@ -18,9 +18,12 @@ function useUpdateNameserversMutation( domainName, queryOptions = {} ) {
 		},
 	} );
 
-	const { mutate } = mutation;
+	const { mutateAsync } = mutation;
 
-	const updateNameservers = useCallback( ( nameservers ) => mutate( { nameservers } ), [ mutate ] );
+	const updateNameservers = useCallback(
+		( nameservers ) => mutateAsync( { nameservers } ),
+		[ mutateAsync ]
+	);
 
 	return { updateNameservers, ...mutation };
 }

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -70,7 +70,7 @@ class CustomNameserversForm extends PureComponent {
 	};
 
 	rows() {
-		const { translate } = this.props;
+		const { translate, isSaving } = this.props;
 
 		// Remove the empty values from the end, and add one empty one
 		const nameservers = dropRightWhileEmpty( this.props.nameservers );
@@ -103,6 +103,7 @@ class CustomNameserversForm extends PureComponent {
 					selectedDomainName={ this.props.selectedDomainName }
 					onChange={ this.handleChange }
 					onRemove={ this.handleRemove }
+					isSaving={ isSaving }
 				/>
 			);
 		} );

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -42,6 +42,7 @@ class CustomNameserversForm extends PureComponent {
 		onSubmit: PropTypes.func.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		submitDisabled: PropTypes.bool.isRequired,
+		isSaving: PropTypes.bool,
 		notice: PropTypes.element,
 		redesign: PropTypes.bool,
 	};
@@ -167,17 +168,29 @@ class CustomNameserversForm extends PureComponent {
 						<FormButton
 							isPrimary
 							onClick={ this.handleSubmit }
-							disabled={ this.props.submitDisabled }
+							disabled={ this.props.submitDisabled || this.props.isSaving }
 						>
 							{ translate( 'Save custom name servers' ) }
 						</FormButton>
 
 						{ ! redesign ? (
-							<FormButton type="button" isPrimary={ false } onClick={ this.handleReset }>
+							<FormButton
+								type="button"
+								isPrimary={ false }
+								onClick={ this.handleReset }
+								busy={ this.props.isSaving }
+								disabled={ this.props.isSaving }
+							>
 								{ translate( 'Reset to defaults' ) }
 							</FormButton>
 						) : (
-							<FormButton type="button" isPrimary={ false } onClick={ this.handleCancel }>
+							<FormButton
+								type="button"
+								isPrimary={ false }
+								onClick={ this.handleCancel }
+								busy={ this.props.isSaving }
+								disabled={ this.props.isSaving }
+							>
 								{ translate( 'Cancel' ) }
 							</FormButton>
 						) }

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-row.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-row.jsx
@@ -16,6 +16,7 @@ class CustomNameserversRow extends PureComponent {
 		nameserver: PropTypes.string,
 		onChange: PropTypes.func,
 		onRemove: PropTypes.func,
+		isSaving: PropTypes.bool,
 	};
 
 	renderRemoveIcon() {
@@ -24,7 +25,7 @@ class CustomNameserversRow extends PureComponent {
 		}
 
 		return (
-			<Button borderless compact onClick={ this.handleRemove }>
+			<Button borderless compact onClick={ this.handleRemove } disabled={ this.props.isSaving }>
 				<Gridicon icon="trash" />
 			</Button>
 		);
@@ -39,6 +40,7 @@ class CustomNameserversRow extends PureComponent {
 						onChange={ this.handleChange }
 						onFocus={ this.handleFocus }
 						value={ this.props.nameserver }
+						disabled={ this.props.isSaving }
 					/>
 
 					{ this.renderRemoveIcon() }

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -211,6 +211,7 @@ const NameServersCard = ( {
 				selectedDomainName={ selectedDomainName }
 				onToggle={ handleToggle }
 				enabled={ hasDefaultWpcomNameservers() && ! isEditingNameServers }
+				isSaving={ isSavingNameServers }
 			/>
 		);
 	};
@@ -228,8 +229,7 @@ const NameServersCard = ( {
 	};
 
 	const handleSubmit = () => {
-		updateNameservers( nameservers || [] );
-		setIsEditingNameServers( false );
+		handleUpdateNameservers( nameservers || [] );
 	};
 
 	const editCustomNameServers = () => {
@@ -271,6 +271,7 @@ const NameServersCard = ( {
 					onCancel={ handleCancel }
 					onReset={ handleReset }
 					onSubmit={ handleSubmit }
+					isSaving={ isSavingNameServers }
 					submitDisabled={ isLoading() || hasWpcomNameservers() }
 					notice={ warning() }
 					redesign

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -3,7 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { CHANGE_NAME_SERVERS } from '@automattic/urls';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import DomainWarnings from 'calypso/my-sites/domains/components/domain-warnings';
 import NonPrimaryDomainPlanUpsell from 'calypso/my-sites/domains/domain-management/components/domain/non-primary-domain-plan-upsell';
 import IcannVerificationCard from 'calypso/my-sites/domains/domain-management/components/icann-verification';
@@ -55,8 +55,24 @@ const NameServersCard = ( {
 	const [ nameservers, setNameservers ] = useState( nameserversProps || null );
 	const [ shouldPersistNameServers, setShouldPersistNameServers ] = useState( false );
 	const [ isEditingNameServers, setIsEditingNameServers ] = useState( false );
+	const [ isSavingNameServers, setSavingNameServers ] = useState( false );
 	const [ nameServersBeforeEditing, setNameServersBeforeEditing ] = useState< string[] | null >(
 		null
+	);
+
+	const handleUpdateNameservers = useCallback(
+		async ( nameservers: string[] ) => {
+			setSavingNameServers( true );
+			setShouldPersistNameServers( false );
+			try {
+				await updateNameservers( nameservers );
+			} catch ( error ) {
+				setNameservers( nameserversProps || null );
+			} finally {
+				setSavingNameServers( false );
+			}
+		},
+		[ updateNameservers, nameserversProps ]
 	);
 
 	useEffect( () => {
@@ -65,10 +81,9 @@ const NameServersCard = ( {
 
 	useEffect( () => {
 		if ( shouldPersistNameServers ) {
-			updateNameservers( nameservers || [] );
-			setShouldPersistNameServers( false );
+			handleUpdateNameservers( nameservers || [] );
 		}
-	}, [ shouldPersistNameServers, nameservers ] );
+	}, [ shouldPersistNameServers, nameservers, handleUpdateNameservers ] );
 
 	const hasWpcomNameservers = () => {
 		if ( ! nameservers || nameservers.length === 0 ) {

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -60,6 +60,19 @@ const NameServersCard = ( {
 		null
 	);
 
+	const hasDefaultWpcomNameservers = ( nameserversToCheck: string[] | null = nameservers ) => {
+		if ( ! nameserversToCheck || nameserversToCheck.length === 0 ) {
+			return false;
+		}
+
+		return (
+			nameserversToCheck.length === WPCOM_DEFAULT_NAMESERVERS.length &&
+			nameserversToCheck.every( ( nameserver ) => {
+				return WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
+			} )
+		);
+	};
+
 	const handleUpdateNameservers = useCallback(
 		async ( nameservers: string[] ) => {
 			setSavingNameServers( true );
@@ -103,19 +116,6 @@ const NameServersCard = ( {
 		return nameservers.every( ( nameserver ) => {
 			return ! nameserver || CLOUDFLARE_NAMESERVERS_REGEX.test( nameserver );
 		} );
-	};
-
-	const hasDefaultWpcomNameservers = () => {
-		if ( ! nameservers || nameservers.length === 0 ) {
-			return false;
-		}
-
-		return (
-			nameservers.length === WPCOM_DEFAULT_NAMESERVERS.length &&
-			nameservers.every( ( nameserver ) => {
-				return WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
-			} )
-		);
 	};
 
 	const isPendingTransfer = () => {
@@ -186,7 +186,12 @@ const NameServersCard = ( {
 
 	const resetToWpcomNameservers = () => {
 		setNameservers( WPCOM_DEFAULT_NAMESERVERS );
-		setShouldPersistNameServers( true );
+		// Only persist the changes if we had custom nameservers previously.
+		// Otherwise, we'd be switching from default nameservers to default nameservers
+		// a no-op probably coming from toggling the switch on and off.
+		if ( ! hasDefaultWpcomNameservers( nameserversProps ) ) {
+			setShouldPersistNameServers( true );
+		}
 		setIsEditingNameServers( false );
 	};
 

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -79,8 +79,13 @@ const NameServersCard = ( {
 			setShouldPersistNameServers( false );
 			try {
 				await updateNameservers( nameservers );
+				setIsEditingNameServers( false );
 			} catch ( error ) {
-				setNameservers( nameserversProps || null );
+				// Assume we shouldn't default to the previous nameservers if
+				// there was an error when editing the custom nameservers.
+				if ( ! hasDefaultWpcomNameservers( nameserversProps || null ) ) {
+					setNameservers( nameserversProps || null );
+				}
 			} finally {
 				setSavingNameServers( false );
 			}

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-toggle.tsx
@@ -28,7 +28,12 @@ const wpcomNameServersToggleButtonClick = ( domainName: string, enabled: boolean
 	);
 };
 
-const NameserversToggle = ( { enabled, onToggle, selectedDomainName }: NameServersToggleProps ) => {
+const NameserversToggle = ( {
+	enabled,
+	onToggle,
+	selectedDomainName,
+	isSaving,
+}: NameServersToggleProps ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -42,6 +47,7 @@ const NameserversToggle = ( { enabled, onToggle, selectedDomainName }: NameServe
 			<ToggleControl
 				onChange={ handleToggle }
 				checked={ enabled }
+				disabled={ isSaving }
 				label={ translate( 'Use WordPress.com name servers' ) }
 			/>
 		</form>

--- a/client/my-sites/domains/domain-management/settings/cards/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/types.tsx
@@ -22,7 +22,7 @@ export type NameServersCardProps = {
 	nameservers: string[] | null;
 	selectedDomainName: string;
 	selectedSite: SiteDetails;
-	updateNameservers: ( nameServers: string[] ) => void;
+	updateNameservers: ( nameServers: string[] ) => Promise< any >;
 };
 
 export type NameServersToggleProps = {

--- a/client/my-sites/domains/domain-management/settings/cards/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/types.tsx
@@ -27,6 +27,7 @@ export type NameServersCardProps = {
 
 export type NameServersToggleProps = {
 	enabled: boolean;
+	isSaving: boolean;
 	onToggle: () => void;
 	selectedDomainName: string;
 };

--- a/client/my-sites/domains/domain-management/settings/cards/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/types.tsx
@@ -1,4 +1,5 @@
 import type { SiteDetails } from '@automattic/data-stores';
+import type { UpdateNameServersReponse } from 'calypso/data/domains/nameservers/types';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
@@ -22,7 +23,7 @@ export type NameServersCardProps = {
 	nameservers: string[] | null;
 	selectedDomainName: string;
 	selectedSite: SiteDetails;
-	updateNameservers: ( nameServers: string[] ) => Promise< any >;
+	updateNameservers: ( nameServers: string[] ) => Promise< UpdateNameServersReponse >;
 };
 
 export type NameServersToggleProps = {

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { SiteDetails } from '@automattic/data-stores';
+import type { UpdateNameServersReponse } from 'calypso/data/domains/nameservers/types';
 import type { DnsRequest, ResponseDomain } from 'calypso/lib/domains/types';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
@@ -41,7 +42,7 @@ export type SettingsPageNameServerHocProps = {
 	isLoadingNameservers: boolean;
 	loadingNameserversError: boolean;
 	nameservers: string[] | null;
-	updateNameservers: ( nameServers: string[] ) => void;
+	updateNameservers: ( nameServers: string[] ) => Promise< UpdateNameServersReponse >;
 };
 
 export type SettingsPageConnectedDispatchProps = {


### PR DESCRIPTION
## Proposed Changes
It adds a loading state and fixes bugs to the name server's card on the domain's management page.

## Why are these changes being made?
There is no loading state for the name server's card currently, which could lead to poor usability, as shown in the screen recording. We need to add changes that rely on the name servers' state and their values, so these changes will also be required to ensure integrity.

## Testing Instructions
Go to the management page of a domain you own (`/domains/manage/:domain/edit/:siteSlug`), and then:
- Enable the "Use WordPress.com name servers" toggle and ensure it gets disabled during the update;
  - You shouldn't be able to double-click it;
  - You shouldn't be able to change the custom name servers value while the update is performed;
- Enable and disable the toggle, and ensure no request is performed:
  - We shouldn't try updating the name servers if the user switches the toggle on and off sequentially - it should be updated back to the default values only if they successfully updated the name servers to custom ones.

## Preview

### Before
https://github.com/user-attachments/assets/572f0428-85bd-4fd0-a7e1-5da6a3c3ebe3

### After
https://github.com/user-attachments/assets/75af1c23-18b4-45a9-8859-91380f2d3f32

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
