### PR TITLE
Domains: Enable DNSSEC changes only for domains with WordPress.com name servers

### DIFF
--- a/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
+++ b/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
@@ -16,32 +16,42 @@ const withDomainNameservers = createHigherOrderComponent( ( Wrapped ) => {
 		const { selectedDomainName } = props;
 		const dispatch = useDispatch();
 		const translate = useTranslate();
-		const { data, isLoading, isError, error } = useDomainNameserversQuery( selectedDomainName );
-		const { updateNameservers, isPending } = useUpdateNameserversMutation( selectedDomainName, {
-			onSuccess() {
-				dispatch(
-					successNotice(
-						translate( 'Yay, the name servers have been successfully updated!' ),
-						noticeOptions
-					)
-				);
-			},
-			onError( err ) {
-				dispatch(
-					errorNotice(
-						err.message ?? translate( 'An error occurred while updating the nameservers.' ),
-						noticeOptions
-					)
-				);
-			},
-		} );
+		const {
+			data,
+			isLoading: isLoadingNameservers,
+			isFetching: isFetchingNameservers,
+			isError,
+			error,
+		} = useDomainNameserversQuery( selectedDomainName );
+		const { updateNameservers, isPending: isUpdatingNameservers } = useUpdateNameserversMutation(
+			selectedDomainName,
+			{
+				onSuccess() {
+					dispatch(
+						successNotice(
+							translate( 'Yay, the name servers have been successfully updated!' ),
+							noticeOptions
+						)
+					);
+				},
+				onError( err ) {
+					dispatch(
+						errorNotice(
+							err.message ?? translate( 'An error occurred while updating the nameservers.' ),
+							noticeOptions
+						)
+					);
+				},
+			}
+		);
 
 		return (
 			<Wrapped
 				{ ...props }
 				nameservers={ data }
-				isLoadingNameservers={ isLoading }
-				isUpdatingNameservers={ isPending }
+				isLoadingNameservers={ isLoadingNameservers }
+				isFetchingNameservers={ isFetchingNameservers }
+				isUpdatingNameservers={ isUpdatingNameservers }
 				loadingNameserversError={ isError && error }
 				updateNameservers={ updateNameservers }
 			/>

--- a/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
+++ b/client/my-sites/domains/domain-management/name-servers/with-domain-nameservers.js
@@ -17,7 +17,7 @@ const withDomainNameservers = createHigherOrderComponent( ( Wrapped ) => {
 		const dispatch = useDispatch();
 		const translate = useTranslate();
 		const { data, isLoading, isError, error } = useDomainNameserversQuery( selectedDomainName );
-		const { updateNameservers } = useUpdateNameserversMutation( selectedDomainName, {
+		const { updateNameservers, isPending } = useUpdateNameserversMutation( selectedDomainName, {
 			onSuccess() {
 				dispatch(
 					successNotice(
@@ -41,6 +41,7 @@ const withDomainNameservers = createHigherOrderComponent( ( Wrapped ) => {
 				{ ...props }
 				nameservers={ data }
 				isLoadingNameservers={ isLoading }
+				isUpdatingNameservers={ isPending }
 				loadingNameserversError={ isError && error }
 				updateNameservers={ updateNameservers }
 			/>

--- a/client/my-sites/domains/domain-management/settings/cards/dnssec-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/dnssec-card.tsx
@@ -22,9 +22,10 @@ const noticeOptions = {
 interface Props {
 	domain: ResponseDomain;
 	nameservers: string[] | null;
+	isUpdatingNameservers: boolean;
 }
 
-export default function DnssecCard( { domain, nameservers }: Props ) {
+export default function DnssecCard( { domain, nameservers, isUpdatingNameservers }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const selectedSiteId = useSelector( getSelectedSiteId );
@@ -135,7 +136,7 @@ export default function DnssecCard( { domain, nameservers }: Props ) {
 			<div className="domain-dnssec-card">
 				<ToggleControl
 					checked={ isEnabled }
-					disabled={ isUpdating || ! domainHasDefaultWpcomNameservers }
+					disabled={ isUpdating || ! domainHasDefaultWpcomNameservers || isUpdatingNameservers }
 					label={ getToggleLabel() }
 					onChange={ onToggle }
 				/>
@@ -167,7 +168,7 @@ export default function DnssecCard( { domain, nameservers }: Props ) {
 			expanded={ expanded }
 			onOpen={ () => setIsExpanded( true ) }
 			onClose={ () => setIsExpanded( false ) }
-			isDisabled={ ! domainHasDefaultWpcomNameservers }
+			isDisabled={ ! domainHasDefaultWpcomNameservers || isUpdatingNameservers }
 		>
 			{ renderDnssecCard() }
 		</Accordion>

--- a/client/my-sites/domains/domain-management/settings/cards/dnssec-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/dnssec-card.tsx
@@ -23,9 +23,15 @@ interface Props {
 	domain: ResponseDomain;
 	nameservers: string[] | null;
 	isUpdatingNameservers: boolean;
+	isLoadingNameservers: boolean;
 }
 
-export default function DnssecCard( { domain, nameservers, isUpdatingNameservers }: Props ) {
+export default function DnssecCard( {
+	domain,
+	nameservers,
+	isUpdatingNameservers,
+	isLoadingNameservers,
+}: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const selectedSiteId = useSelector( getSelectedSiteId );
@@ -47,6 +53,8 @@ export default function DnssecCard( { domain, nameservers, isUpdatingNameservers
 			dispatch( errorNotice( error.message, noticeOptions ) );
 		},
 	} );
+
+	const domainHasDefaultWpcomNameservers = hasDefaultWpcomNameservers( nameservers );
 
 	const { enableDnssec } = useEnableDnssecMutation( domain.name, {
 		onSuccess( success ) {
@@ -129,10 +137,8 @@ export default function DnssecCard( { domain, nameservers, isUpdatingNameservers
 		return isEnabled ? translate( 'DNSSEC enabled' ) : translate( 'DNSSEC disabled' );
 	};
 
-	const domainHasDefaultWpcomNameservers = hasDefaultWpcomNameservers( nameservers );
-
 	const renderDnssecCard = () => {
-		if ( ! domainHasDefaultWpcomNameservers ) {
+		if ( ! nameservers || ! domainHasDefaultWpcomNameservers || isLoadingNameservers ) {
 			return null;
 		}
 
@@ -172,7 +178,9 @@ export default function DnssecCard( { domain, nameservers, isUpdatingNameservers
 			expanded={ expanded }
 			onOpen={ () => setIsExpanded( true ) }
 			onClose={ () => setIsExpanded( false ) }
-			isDisabled={ ! domainHasDefaultWpcomNameservers || isUpdatingNameservers }
+			isDisabled={
+				! domainHasDefaultWpcomNameservers || isUpdatingNameservers || isLoadingNameservers
+			}
 		>
 			{ renderDnssecCard() }
 		</Accordion>

--- a/client/my-sites/domains/domain-management/settings/cards/dnssec-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/dnssec-card.tsx
@@ -168,7 +168,7 @@ export default function DnssecCard( {
 		? dnssecStatus
 		: translate( 'DNSSEC is only available for domains using WordPress.com nameservers' );
 
-	const expanded = domainHasDefaultWpcomNameservers ? false : isExpanded;
+	const expanded = ! domainHasDefaultWpcomNameservers ? false : isExpanded;
 
 	return (
 		<Accordion

--- a/client/my-sites/domains/domain-management/settings/cards/dnssec-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/dnssec-card.tsx
@@ -132,11 +132,15 @@ export default function DnssecCard( { domain, nameservers, isUpdatingNameservers
 	const domainHasDefaultWpcomNameservers = hasDefaultWpcomNameservers( nameservers );
 
 	const renderDnssecCard = () => {
+		if ( ! domainHasDefaultWpcomNameservers ) {
+			return null;
+		}
+
 		return (
 			<div className="domain-dnssec-card">
 				<ToggleControl
 					checked={ isEnabled }
-					disabled={ isUpdating || ! domainHasDefaultWpcomNameservers || isUpdatingNameservers }
+					disabled={ isUpdating || isUpdatingNameservers }
 					label={ getToggleLabel() }
 					onChange={ onToggle }
 				/>

--- a/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/name-servers-card.tsx
@@ -14,6 +14,7 @@ import {
 } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
 import CustomNameserversForm from 'calypso/my-sites/domains/domain-management/name-servers/custom-nameservers-form';
 import FetchError from 'calypso/my-sites/domains/domain-management/name-servers/fetch-error';
+import { hasDefaultWpcomNameservers } from 'calypso/my-sites/domains/domain-management/settings/cards/utils';
 import { useDispatch } from 'calypso/state';
 import {
 	composeAnalytics,
@@ -59,19 +60,6 @@ const NameServersCard = ( {
 	const [ nameServersBeforeEditing, setNameServersBeforeEditing ] = useState< string[] | null >(
 		null
 	);
-
-	const hasDefaultWpcomNameservers = ( nameserversToCheck: string[] | null = nameservers ) => {
-		if ( ! nameserversToCheck || nameserversToCheck.length === 0 ) {
-			return false;
-		}
-
-		return (
-			nameserversToCheck.length === WPCOM_DEFAULT_NAMESERVERS.length &&
-			nameserversToCheck.every( ( nameserver ) => {
-				return WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
-			} )
-		);
-	};
 
 	const handleUpdateNameservers = useCallback(
 		async ( nameservers: string[] ) => {
@@ -202,7 +190,7 @@ const NameServersCard = ( {
 
 	const handleToggle = () => {
 		setIsEditingNameServers( ! isEditingNameServers );
-		if ( hasDefaultWpcomNameservers() ) {
+		if ( hasDefaultWpcomNameservers( nameservers ) ) {
 			setNameServersBeforeEditing( nameservers );
 			setNameservers( [] );
 			setIsEditingNameServers( true );
@@ -220,7 +208,7 @@ const NameServersCard = ( {
 			<NameServersToggle
 				selectedDomainName={ selectedDomainName }
 				onToggle={ handleToggle }
-				enabled={ hasDefaultWpcomNameservers() && ! isEditingNameServers }
+				enabled={ hasDefaultWpcomNameservers( nameservers ) && ! isEditingNameServers }
 				isSaving={ isSavingNameServers }
 			/>
 		);
@@ -256,7 +244,7 @@ const NameServersCard = ( {
 		if (
 			! nameservers ||
 			isPendingTransfer() ||
-			( hasDefaultWpcomNameservers() && ! isEditingNameServers )
+			( hasDefaultWpcomNameservers( nameservers ) && ! isEditingNameServers )
 		) {
 			return null;
 		}

--- a/client/my-sites/domains/domain-management/settings/cards/utils/index.jsx
+++ b/client/my-sites/domains/domain-management/settings/cards/utils/index.jsx
@@ -1,0 +1,2 @@
+export { validateDomainForwarding } from './domain-forwarding';
+export { hasDefaultWpcomNameservers } from './name-servers';

--- a/client/my-sites/domains/domain-management/settings/cards/utils/name-servers.ts
+++ b/client/my-sites/domains/domain-management/settings/cards/utils/name-servers.ts
@@ -1,0 +1,17 @@
+import {
+	WPCOM_DEFAULT_NAMESERVERS,
+	WPCOM_DEFAULT_NAMESERVERS_REGEX,
+} from 'calypso/my-sites/domains/domain-management/name-servers/constants';
+
+export const hasDefaultWpcomNameservers = ( nameserversToCheck: string[] | null ) => {
+	if ( ! nameserversToCheck || nameserversToCheck.length === 0 ) {
+		return false;
+	}
+
+	return (
+		nameserversToCheck.length === WPCOM_DEFAULT_NAMESERVERS.length &&
+		nameserversToCheck.every( ( nameserver ) => {
+			return WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
+		} )
+	);
+};

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -82,6 +82,7 @@ const Settings = ( {
 	domains,
 	isLoadingPurchase,
 	isLoadingNameservers,
+	isUpdatingNameservers,
 	loadingNameserversError,
 	nameservers,
 	dns,
@@ -707,7 +708,13 @@ const Settings = ( {
 			return null;
 		}
 
-		return <DnssecCard domain={ domain } nameservers={ nameservers } />;
+		return (
+			<DnssecCard
+				domain={ domain }
+				nameservers={ nameservers }
+				isUpdatingNameservers={ isUpdatingNameservers }
+			/>
+		);
 	};
 
 	const renderMainContent = () => {

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -707,7 +707,7 @@ const Settings = ( {
 			return null;
 		}
 
-		return <DnssecCard domain={ domain } />;
+		return <DnssecCard domain={ domain } nameservers={ nameservers } />;
 	};
 
 	const renderMainContent = () => {

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -80,6 +80,7 @@ const Settings = ( {
 	currentRoute,
 	domain,
 	domains,
+	isFetchingNameservers,
 	isLoadingPurchase,
 	isLoadingNameservers,
 	isUpdatingNameservers,
@@ -713,6 +714,7 @@ const Settings = ( {
 				domain={ domain }
 				nameservers={ nameservers }
 				isUpdatingNameservers={ isUpdatingNameservers }
+				isLoadingNameservers={ isLoadingNameservers || isFetchingNameservers }
 			/>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -40,6 +40,7 @@ export type SettingsPageConnectedProps = {
 
 export type SettingsPageNameServerHocProps = {
 	isLoadingNameservers: boolean;
+	isFetchingNameservers: boolean;
 	loadingNameserversError: boolean;
 	isUpdatingNameservers: boolean;
 	nameservers: string[] | null;

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -41,6 +41,7 @@ export type SettingsPageConnectedProps = {
 export type SettingsPageNameServerHocProps = {
 	isLoadingNameservers: boolean;
 	loadingNameserversError: boolean;
+	isUpdatingNameservers: boolean;
 	nameservers: string[] | null;
 	updateNameservers: ( nameServers: string[] ) => Promise< UpdateNameServersReponse >;
 };


### PR DESCRIPTION
## Proposed Changes
Prevents the DNSSEC card from being interacted with if the user doesn't use the WordPress.com name servers.

## Why are these changes being made?
For our current implementation strategy, we should allow DNSSEC only for domains with our name servers.

## Testing Instructions
Go to the management page of a domain you own (`/domains/manage/:domain/edit/:siteSlug`), and then:

- Switch to our name servers with the "Use WordPress.com name servers" toggle on the "Name servers" card and ensure you see the DNSSEC card enabled;
- Switch to custom name servers and ensure the card is disabled. Additionally, you shouldn't be able to interact with the toggle/card during the name server update.

## Preview
https://github.com/user-attachments/assets/ed975d21-2882-48d9-88bd-b7082f51c65f


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
