### PR TITLE
Checkout: Add Payment Intent version of Wechat Pay

### DIFF
--- a/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
@@ -6,6 +6,7 @@ const isAlipayRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-ali
 const isBancontactRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-bancontact' );
 const isIdealRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-ideal' );
 const isP24RedirectEnabled = config.isEnabled( 'stripe-redirect-migration-p24' );
+const isWechatPayRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-wechat' );
 
 /**
  * Convert a WPCOM payment method class name to a checkout payment method slug
@@ -46,6 +47,7 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 			return 'sofort';
 		case 'WPCOM_Billing_Stripe_Source_Three_D_Secure':
 			return 'stripe-three-d-secure';
+		case 'WPCOM_Billing_Stripe_Wechat_Pay':
 		case 'WPCOM_Billing_Stripe_Source_Wechat':
 			return 'wechat';
 		case 'WPCOM_Billing_Dlocal_Redirect_India_Netbanking':
@@ -111,6 +113,9 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 		case 'stripe-three-d-secure':
 			return 'WPCOM_Billing_Stripe_Source_Three_D_Secure';
 		case 'wechat':
+			if ( isWechatPayRedirectEnabled ) {
+				return 'WPCOM_Billing_Stripe_Wechat_Pay';
+			}
 			return 'WPCOM_Billing_Stripe_Source_Wechat';
 		case 'apple-pay':
 		case 'google-pay':
@@ -137,6 +142,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 		case 'WPCOM_Billing_Stripe_Bancontact':
 		case 'WPCOM_Billing_Stripe_Ideal':
 		case 'WPCOM_Billing_Stripe_P24':
+		case 'WPCOM_Billing_Stripe_Wechat_Pay':
 		case 'WPCOM_Billing_Stripe_Source_Alipay':
 		case 'WPCOM_Billing_Stripe_Source_Bancontact':
 		case 'WPCOM_Billing_Stripe_Source_Eps':

--- a/config/development.json
+++ b/config/development.json
@@ -224,6 +224,7 @@
 		"stripe-redirect-migration-bancontact": true,
 		"stripe-redirect-migration-ideal": true,
 		"stripe-redirect-migration-p24": true,
+		"stripe-redirect-migration-wechat": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -149,6 +149,7 @@
 		"stripe-redirect-migration-bancontact": false,
 		"stripe-redirect-migration-ideal": false,
 		"stripe-redirect-migration-p24": false,
+		"stripe-redirect-migration-wechat": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/production.json
+++ b/config/production.json
@@ -195,6 +195,7 @@
 		"stripe-redirect-migration-bancontact": false,
 		"stripe-redirect-migration-ideal": false,
 		"stripe-redirect-migration-p24": false,
+		"stripe-redirect-migration-wechat": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -188,6 +188,7 @@
 		"stripe-redirect-migration-bancontact": true,
 		"stripe-redirect-migration-ideal": true,
 		"stripe-redirect-migration-p24": true,
+		"stripe-redirect-migration-wechat": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -188,6 +188,7 @@
 		"stripe-redirect-migration-bancontact": false,
 		"stripe-redirect-migration-ideal": false,
 		"stripe-redirect-migration-p24": false,
+		"stripe-redirect-migration-wechat": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -356,6 +356,7 @@ export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_Stripe_Source_Sofort'
 	| 'WPCOM_Billing_Stripe_Source_Three_D_Secure'
 	| 'WPCOM_Billing_Stripe_Source_Wechat'
+	| 'WPCOM_Billing_Stripe_Wechat_Pay'
 	| 'WPCOM_Billing_Web_Payment'
 	| 'WPCOM_Billing_Ebanx_Redirect_Brazil_Pix'
 	| 'WPCOM_Billing_Razorpay';


### PR DESCRIPTION
Parent issue: https://github.com/Automattic/payments-shilling/issues/2975

## Proposed Changes

In D161587-code, we enabled a new version of the Wechat Pay payment method which, unlike the currently available one, uses the Stripe redirect API with a Payment Intent instead of the Stripe Sources API, the latter of which is deprecated and will be disabled soon.

## Testing Instructions

- Sandbox the API so that the purchase will be made in test mode.
- Add a product to your cart and visit checkout using localhost calypso (the calypso.live links won't work for this since that environment is not enabled).
- Inside checkout, set your country code to "China" and any valid postal code (like `510000`).
- In the payment method step, verify that you see "Wechat Pay" as an option.
- Select Wechat Pay, enter any name in the field, and submit the payment.
- You should see a QR code appear.
- Click the link below the QR code ("click here") **but open it in a new tab**.
- In the new tab, click to confirm the purchase. It may display an error but you can ignore that and close the tab.
- In the checkout tab, verify that the purchase was completed successfully (it may take a while).
- Verify on the backend that the order was not made with a payment method that's `stripe-source` but was instead `stripe-redirect`.
