### PR TITLE
Plans: Display control variant when clicking 'View all plans' under a tailored plans grid

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -330,7 +330,9 @@ const PlansFeaturesMain = ( {
 
 	const {
 		isLoading: isLoadingSimplifiedFeaturesGridExperiment,
+		isTargetedView: isTargetedViewForSimplifiedFeaturesGridExperiment,
 		variant: simplifiedFeaturesGridExperimentVariant,
+		setVariantOverride: setSimplifiedFeaturesGridExperimentVariantOverride,
 	} = useSimplifiedFeaturesGridExperiment( {
 		flowName,
 		isInSignup,
@@ -717,6 +719,23 @@ const PlansFeaturesMain = ( {
 		[ simplifiedFeaturesGridExperimentVariant, translate ]
 	);
 
+	const viewAllPlansButton = (
+		<div className="plans-features-main__escape-hatch">
+			<Button
+				borderless
+				onClick={ () => {
+					if ( ! isTargetedViewForSimplifiedFeaturesGridExperiment ) {
+						setSimplifiedFeaturesGridExperimentVariantOverride( 'control' );
+					}
+
+					setForceDefaultPlans( true );
+				} }
+			>
+				{ translate( 'View all plans' ) }
+			</Button>
+		</div>
+	);
+
 	return (
 		<>
 			<div className={ clsx( 'plans-features-main', 'is-pricing-grid-2023-plans-features-main' ) }>
@@ -841,26 +860,14 @@ const PlansFeaturesMain = ( {
 										}
 									/>
 								) }
-								{ showEscapeHatch && hidePlansFeatureComparison && (
-									<div className="plans-features-main__escape-hatch">
-										<Button borderless onClick={ () => setForceDefaultPlans( true ) }>
-											{ translate( 'View all plans' ) }
-										</Button>
-									</div>
-								) }
+								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }
 								{ ! hidePlansFeatureComparison && (
 									<>
 										<ComparisonGridToggle
 											onClick={ toggleShowPlansComparisonGrid }
 											label={ getComparisonGridToggleLabel() }
 										/>
-										{ showEscapeHatch && (
-											<div className="plans-features-main__escape-hatch">
-												<Button borderless onClick={ () => setForceDefaultPlans( true ) }>
-													{ translate( 'View all plans' ) }
-												</Button>
-											</div>
-										) }
+										{ showEscapeHatch && viewAllPlansButton }
 										<div
 											ref={ plansComparisonGridRef }
 											className={ comparisonGridContainerClasses }
@@ -916,13 +923,7 @@ const PlansFeaturesMain = ( {
 												onClick={ toggleShowPlansComparisonGrid }
 												label={ translate( 'Hide comparison' ) }
 											/>
-											{ showEscapeHatch && (
-												<div className="plans-features-main__escape-hatch">
-													<Button borderless onClick={ () => setForceDefaultPlans( true ) }>
-														{ translate( 'View all plans' ) }
-													</Button>
-												</div>
-											) }
+											{ showEscapeHatch && viewAllPlansButton }
 										</div>
 									</>
 								) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3332

Discussion: p5uIfZ-fIJ-p2#comment-23848

Context: We will soon be running an experiment to test different treatments of the plans grid. For further details, please view the project thread (p5uIfZ-fIN-p2).

## Proposed Changes

When clicking 'View all plans' below a tailored version of the plans grid (eg. a newsletter site), as a user assigned to a treatment variant, override the treatment assignment and display the control variant of the plans grid.

![CleanShot 2024-09-17 at 10 10 24@2x](https://github.com/user-attachments/assets/64e111ba-a039-43df-9b6c-36e1ab5e688f)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To avoid confusing users. This experiment (pbxNRc-45y-p2) does not apply to tailored versions of the plans grid (eg. a newsletter site), so we want to avoid displaying treatment changes when clicking 'View all plans'.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View the plans grid for a newsletter site with a treatment flag enabled
  * eg. `/plans/:site?flags=simplified-features-grid-b`
* Click 'View all plans' below the plans grid
* Check that the displayed plans grid is not a treatment variant

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?