### PR TITLE
Checkout: Add bottom and left position to mobile pay button

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -535,6 +535,8 @@ export const CheckoutStepAreaWrapper = styled.div`
 export const SubmitButtonWrapper = styled.div`
 	background: ${ ( props ) => props.theme.colors.surface };
 	padding: 24px;
+	bottom: 0;
+	left: 0;
 	box-sizing: border-box;
 	width: 100%;
 	z-index: 10;


### PR DESCRIPTION
A bug was introduced in a [recent checkout fix](https://github.com/Automattic/wp-calypso/pull/94514/files#diff-b61d0f132448713532ffa2c4466843775577ee83ab3494995662ddc0946960e0L55-L56), where the bottom and left positioning of the SubmitButtonFooter was removed inadvertently.

This PR adds those values back to the SubmitButtonFooter component so that the 'pay' button is aligned to the bottom of mobile width viewports in Checkout.

Related to #94514

## Testing Instructions

* Go to checkout
* Shrink screen width to below 700px
* Ensure that the 'Pay' button is aligned to the bottom of the screen and click/tappable
