### PR TITLE
Plans: Expand plan features on mobile

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -840,6 +840,9 @@ const PlansFeaturesMain = ( {
 										enableFeatureTooltips
 										featureGroupMap={ featureGroupMapForFeaturesGrid }
 										enterpriseFeaturesList={ enterpriseFeaturesList }
+										enableShowAllFeaturesButton={
+											simplifiedFeaturesGridExperimentVariant !== 'simplified'
+										}
 										enableCategorisedFeatures={
 											simplifiedFeaturesGridExperimentVariant === 'simplified'
 										}

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -49,6 +49,7 @@ type MobileViewProps = {
 	renderedGridPlans: GridPlan[];
 	selectedFeature?: string;
 	showUpgradeableStorage: boolean;
+	enableShowAllFeaturesButton?: boolean;
 };
 
 const CardContainer = (
@@ -65,6 +66,41 @@ const CardContainer = (
 	);
 };
 
+const FeaturesContainer = ( props: {
+	children: ( featureGroupSlug: FeatureGroupSlug ) => JSX.Element;
+	featureGroups: FeatureGroupSlug[];
+	gridPlan: GridPlan;
+} ) => {
+	const { children, gridPlan, featureGroups } = props;
+	const {
+		enableCategorisedFeatures,
+		enableLogosOnlyForEnterprisePlan,
+		enableReducedFeatureGroupSpacing,
+	} = usePlansGridContext();
+
+	return (
+		<>
+			<EnterpriseFeatures
+				renderedGridPlans={ [ gridPlan ] }
+				options={ { isLogosOnly: enableLogosOnlyForEnterprisePlan } }
+			/>
+			{ ! enableCategorisedFeatures && (
+				<PreviousFeaturesIncludedTitle renderedGridPlans={ [ gridPlan ] } />
+			) }
+			{ featureGroups.map( ( featureGroupSlug: FeatureGroupSlug ) => (
+				<div
+					className={ clsx( 'plans-grid-next-features-grid__feature-group-row', {
+						'is-reduced-feature-group-spacing': enableReducedFeatureGroupSpacing,
+					} ) }
+					key={ featureGroupSlug }
+				>
+					{ children( featureGroupSlug ) }
+				</div>
+			) ) }
+		</>
+	);
+};
+
 const MobileView = ( {
 	currentSitePlanSlug,
 	generatedWPComSubdomain,
@@ -78,14 +114,10 @@ const MobileView = ( {
 	planActionOverrides,
 	selectedFeature,
 	showUpgradeableStorage,
+	enableShowAllFeaturesButton,
 }: MobileViewProps ) => {
 	const translate = useTranslate();
-	const {
-		featureGroupMap,
-		enableCategorisedFeatures,
-		enableLogosOnlyForEnterprisePlan,
-		enableReducedFeatureGroupSpacing,
-	} = usePlansGridContext();
+	const { featureGroupMap } = usePlansGridContext();
 	const featureGroups = useMemo(
 		() =>
 			Object.keys( featureGroupMap ).filter(
@@ -111,6 +143,23 @@ const MobileView = ( {
 
 			const isNotFreePlan = ! isFreePlan( gridPlan.planSlug );
 			const isEnterprisePlan = isWpcomEnterpriseGridPlan( gridPlan.planSlug );
+			const featuresEl = (
+				<FeaturesContainer gridPlan={ gridPlan } featureGroups={ featureGroups }>
+					{ ( featureGroupSlug: FeatureGroupSlug ) => (
+						<PlanFeaturesList
+							renderedGridPlans={ [ gridPlan ] }
+							selectedFeature={ selectedFeature }
+							paidDomainName={ paidDomainName }
+							hideUnavailableFeatures={ hideUnavailableFeatures }
+							generatedWPComSubdomain={ generatedWPComSubdomain }
+							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+							featureGroupSlug={ featureGroupSlug }
+							onStorageAddOnClick={ onStorageAddOnClick }
+							showUpgradeableStorage={ showUpgradeableStorage }
+						/>
+					) }
+				</FeaturesContainer>
+			);
 
 			const planCardJsx = (
 				<div className={ planCardClasses } key={ `${ gridPlan.planSlug }-${ index }` }>
@@ -149,46 +198,26 @@ const MobileView = ( {
 						currentSitePlanSlug={ currentSitePlanSlug }
 						planActionOverrides={ planActionOverrides }
 					/>
-					<CardContainer
-						header={ translate( 'Show all features' ) }
-						planSlug={ gridPlan.planSlug }
-						key={ `${ gridPlan.planSlug }-${ index }` }
-						className="plans-grid-next-features-grid__mobile-plan-card-foldable-container"
-						expanded={
-							selectedFeature &&
-							gridPlan.features.wpcomFeatures.some(
-								( feature ) => feature.getSlug() === selectedFeature
-							)
-						}
-					>
-						<EnterpriseFeatures
-							renderedGridPlans={ [ gridPlan ] }
-							options={ { isLogosOnly: enableLogosOnlyForEnterprisePlan } }
-						/>
-						{ ! enableCategorisedFeatures && (
-							<PreviousFeaturesIncludedTitle renderedGridPlans={ [ gridPlan ] } />
-						) }
-						{ featureGroups.map( ( featureGroupSlug ) => (
-							<div
-								className={ clsx( 'plans-grid-next-features-grid__feature-group-row', {
-									'is-reduced-feature-group-spacing': enableReducedFeatureGroupSpacing,
-								} ) }
-								key={ featureGroupSlug }
-							>
-								<PlanFeaturesList
-									renderedGridPlans={ [ gridPlan ] }
-									selectedFeature={ selectedFeature }
-									paidDomainName={ paidDomainName }
-									hideUnavailableFeatures={ hideUnavailableFeatures }
-									generatedWPComSubdomain={ generatedWPComSubdomain }
-									isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-									featureGroupSlug={ featureGroupSlug }
-									onStorageAddOnClick={ onStorageAddOnClick }
-									showUpgradeableStorage={ showUpgradeableStorage }
-								/>
-							</div>
-						) ) }
-					</CardContainer>
+					{ enableShowAllFeaturesButton ? (
+						<CardContainer
+							header={ translate( 'Show all features' ) }
+							planSlug={ gridPlan.planSlug }
+							key={ `${ gridPlan.planSlug }-${ index }` }
+							className="plans-grid-next-features-grid__mobile-plan-card-foldable-container"
+							expanded={
+								selectedFeature &&
+								gridPlan.features.wpcomFeatures.some(
+									( feature ) => feature.getSlug() === selectedFeature
+								)
+							}
+						>
+							{ featuresEl }
+						</CardContainer>
+					) : (
+						<div className="plans-grid-next-features-grid__mobile-plan-card-no-foldable-container">
+							{ featuresEl }
+						</div>
+					) }
 				</div>
 			);
 			return planCardJsx;
@@ -283,6 +312,7 @@ const FeaturesGrid = ( {
 	showRefundPeriod,
 	showUpgradeableStorage,
 	stickyRowOffset,
+	enableShowAllFeaturesButton,
 }: FeaturesGridProps ) => {
 	const spotlightPlanProps = {
 		currentSitePlanSlug,
@@ -322,7 +352,10 @@ const FeaturesGrid = ( {
 						) }
 						{ 'small' === gridSize && (
 							<div className="plan-features-2023-grid__mobile-view">
-								<MobileView { ...planFeaturesProps } />
+								<MobileView
+									{ ...planFeaturesProps }
+									enableShowAllFeaturesButton={ enableShowAllFeaturesButton }
+								/>
 							</div>
 						) }
 					</div>

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -115,6 +115,10 @@
 	}
 }
 
+.plans-grid-next-features-grid__mobile-plan-card-no-foldable-container {
+	margin-top: 24px;
+}
+
 .plan-features-2023-grid__mobile-view {
 	display: flex;
 	flex-direction: column;

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -127,6 +127,7 @@ export interface FeaturesGridProps extends CommonGridProps {
 	isCustomDomainAllowedOnFreePlan: boolean; // indicate when a custom domain is allowed to be used with the Free plan.
 	paidDomainName?: string;
 	showLegacyStorageFeature: boolean;
+	enableShowAllFeaturesButton?: boolean;
 }
 
 export interface ComparisonGridProps extends CommonGridProps {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3332

Discussion: p5uIfZ-fIJ-p2#comment-23834

Context: We will soon be running an experiment to test different treatments of the plans grid. For further details, please view the project thread (p5uIfZ-fIN-p2).

## Proposed Changes

When a user is assigned to Treatment B (the 'simplified' plans grid) for this experiment (pbxNRc-45y-p2), we now display all plan features on mobile rather than hiding them behind a 'Show all features' button.

| Before | After |
| -- | -- |
|<img width="300" src="https://github.com/user-attachments/assets/94db10e5-3736-4aa5-8468-2bc21f2c9c0d" />|<img width="300" src="https://github.com/user-attachments/assets/c516aa61-5056-46cf-9dcb-05ab350a1800" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

For Treatment B (the ‘simplified’ plans grid) we are displaying far fewer features, so the 'Show all features' toggle feels quite strange — particularly for the ‘Free’ plan where only a single feature is displayed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable your browser's mobile viewport
2. Load `/plans/:site?flags=simplified-features-grid-b` (target treatment)
3. Scroll down the list of plans and check that features are visible (without a 'View all features' button)
4. Load `/plans/:site` (no treatment) and `/plans/:site?flags=simplified-features-grid-a` (different treatment)
5. Scroll down the list of plans and check that features are hidden behind a 'View all features' button
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?