### PR TITLE
Language Picker: Fix checkboxes spacing

### DIFF
--- a/client/components/language-picker/modal.scss
+++ b/client/components/language-picker/modal.scss
@@ -38,6 +38,10 @@
 .language-picker__modal-empathy-mode {
 	display: flex;
 	align-items: center;
+
+	.form-label:last-child {
+		margin-bottom: 0;
+	}
 }
 
 .language-picker__modal-checkboxes {
@@ -47,13 +51,10 @@
 	text-align: left;
 }
 
-.language-picker__modal-buttons {
-	padding: 24px;
-	width: 100%;
-	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
-	justify-content: space-between;
+.language-picker__modal-locale-notice {
+	&:not(:last-child) {
+		margin-bottom: 5px;
+	}
 }
 
 .language-picker__modal-incomplete-locale-notice {
@@ -69,13 +70,16 @@
 
 .language-picker__modal-incomplete-locale-nudge-text {
 	font-weight: normal;
-	margin-block-start: 6px;
 	font-size: 0.875rem;
+	display: flex;
+	align-items: flex-start;
+
 	.material-icon {
-		margin: 0 4px -2px 0;
+		flex: 0 0 auto;
 		width: 16px;
 		height: 16px;
-		fill: #2c3338;
+		margin: 2px 8px 0 0;
+		fill: currentColor;
 	}
 }
 
@@ -83,7 +87,11 @@
 	margin-right: 8px;
 }
 
-.language-picker__modal-incomplete-locale-tooltip-text {
+.language-picker__modal-buttons {
+	padding: 24px;
+	width: 100%;
 	display: flex;
-	flex-direction: column;
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: space-between;
 }

--- a/client/components/language-picker/modal.tsx
+++ b/client/components/language-picker/modal.tsx
@@ -137,16 +137,18 @@ const LanguagePickerModal: React.FC< Props > = ( {
 					) }
 					<div className="language-picker__modal-incomplete-locale-nudge-text">
 						<MaterialIcon icon="emoji_language" />
-						{ __( 'You can help translate WordPress.com into your language.' ) }{ ' ' }
-						<a
-							className="language-picker__modal-incomplete-locale-nudge-link"
-							href="https://translate.wordpress.com/faq/"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ recordClick }
-						>
-							{ __( 'Learn more' ) }
-						</a>
+						<span>
+							{ __( 'You can help translate WordPress.com into your language.' ) }{ ' ' }
+							<a
+								className="language-picker__modal-incomplete-locale-nudge-link"
+								href="https://translate.wordpress.com/faq/"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ recordClick }
+							>
+								{ __( 'Learn more' ) }
+							</a>
+						</span>
 					</div>
 				</div>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to N/A

## Proposed Changes

* Fixes the spacing between empathy mode and translation nudge text.

**Before:**
![0JxlI5t2A7dX4Zcq](https://github.com/user-attachments/assets/86b0a487-b1fe-4e2f-a146-877898e0088c)

**After:**
![cgY1iysVYLE8Xf6K](https://github.com/user-attachments/assets/a5dcccce-cb13-4cdd-ad9d-1ec39683b7c9)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* More consistent spacing between sibling elements.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/me` and open the language picker.
* Select a language with translation percentage below 80%.
* Confirm the items are evenly spaced one from another.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
