### PR TITLE
A4A: Improve how we track the provisioning status of a site.

### DIFF
--- a/client/a8c-for-agencies/hooks/use-site-created-callback.ts
+++ b/client/a8c-for-agencies/hooks/use-site-created-callback.ts
@@ -1,49 +1,22 @@
 import page from '@automattic/calypso-router';
-import { getQueryArg, addQueryArgs } from '@wordpress/url';
-import { useCallback, useContext, useEffect } from 'react';
+import { useCallback } from 'react';
 import { A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
-import SitesDashboardContext from '../sections/sites/sites-dashboard-context';
+import useTrackProvisioningSites from './use-track-provisioning-sites';
 
 const useSiteCreatedCallback = ( refetchRandomSiteName: () => Promise< void > ) => {
-	const createdSiteId = getQueryArg( window.location.href, 'created_site' ) ?? null;
-	const createdDevSiteId = getQueryArg( window.location.href, 'created_dev_site' ) ?? null;
-
-	const recentlyCreatedSite = createdSiteId || createdDevSiteId;
-	const { setRecentlyCreatedSiteId, setIsRecentlyCreatedSiteDevelopment } =
-		useContext( SitesDashboardContext );
 	const { refetch: refetchPendingSites } = useFetchPendingSites();
 
-	useEffect( () => {
-		if ( recentlyCreatedSite ) {
-			setRecentlyCreatedSiteId( Number( recentlyCreatedSite ) );
-		}
-		if ( createdDevSiteId ) {
-			setIsRecentlyCreatedSiteDevelopment( true );
-		}
-	}, [
-		createdDevSiteId,
-		recentlyCreatedSite,
-		setIsRecentlyCreatedSiteDevelopment,
-		setRecentlyCreatedSiteId,
-	] );
+	const { trackSiteId } = useTrackProvisioningSites();
 
 	return useCallback(
 		( id: number, isDevSite?: boolean ) => {
 			refetchPendingSites();
 			refetchRandomSiteName();
-			setRecentlyCreatedSiteId( id );
-			setIsRecentlyCreatedSiteDevelopment( !! isDevSite );
-
-			const queryParams = isDevSite ? { created_dev_site: id } : { created_site: id };
-			page( addQueryArgs( A4A_SITES_LINK, queryParams ) );
+			trackSiteId( id, { development: !! isDevSite } );
+			page( A4A_SITES_LINK );
 		},
-		[
-			refetchPendingSites,
-			refetchRandomSiteName,
-			setRecentlyCreatedSiteId,
-			setIsRecentlyCreatedSiteDevelopment,
-		]
+		[ refetchPendingSites, refetchRandomSiteName, trackSiteId ]
 	);
 };
 

--- a/client/a8c-for-agencies/hooks/use-track-provisioning-sites.ts
+++ b/client/a8c-for-agencies/hooks/use-track-provisioning-sites.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const TTL_DURATION = 300000; // 5 minutes in miliseconds
+
+type ProvisioningSite = {
+	id: number;
+	migration?: boolean;
+	ttl: number;
+};
+
+export default function useTrackProvisioningSites() {
+	const [ provisioningSites, setProvisioningSites ] = useState< ProvisioningSite[] >( [] );
+
+	useEffect( () => {
+		const storedSites = localStorage.getItem( 'provisioningSites' );
+		if ( storedSites ) {
+			setProvisioningSites( JSON.parse( storedSites ) );
+		}
+	}, [] );
+
+	const trackSiteId = useCallback( ( siteId: number, migration?: boolean ) => {
+		setProvisioningSites( ( prevSites ) => {
+			const updatedSites = [
+				...prevSites,
+				{ id: siteId, migration, ttl: new Date().getTime() + TTL_DURATION },
+			];
+
+			localStorage.setItem( 'provisioningSites', JSON.stringify( updatedSites ) );
+			return updatedSites;
+		} );
+	}, [] );
+
+	return {
+		trackSiteId,
+		provisioningSites,
+	};
+}

--- a/client/a8c-for-agencies/hooks/use-track-provisioning-sites.ts
+++ b/client/a8c-for-agencies/hooks/use-track-provisioning-sites.ts
@@ -5,6 +5,7 @@ const TTL_DURATION = 300000; // 5 minutes in miliseconds
 type ProvisioningSite = {
 	id: number;
 	migration?: boolean;
+	development?: boolean;
 	ttl: number;
 };
 
@@ -18,17 +19,23 @@ export default function useTrackProvisioningSites() {
 		}
 	}, [] );
 
-	const trackSiteId = useCallback( ( siteId: number, migration?: boolean ) => {
-		setProvisioningSites( ( prevSites ) => {
-			const updatedSites = [
-				...prevSites,
-				{ id: siteId, migration, ttl: new Date().getTime() + TTL_DURATION },
-			];
+	const trackSiteId = useCallback(
+		(
+			siteId: number,
+			{ migration, development }: { migration?: boolean; development?: boolean } = {}
+		) => {
+			setProvisioningSites( ( prevSites ) => {
+				const updatedSites = [
+					...prevSites,
+					{ id: siteId, migration, development, ttl: new Date().getTime() + TTL_DURATION },
+				];
 
-			localStorage.setItem( 'provisioningSites', JSON.stringify( updatedSites ) );
-			return updatedSites;
-		} );
-	}, [] );
+				localStorage.setItem( 'provisioningSites', JSON.stringify( updatedSites ) );
+				return updatedSites;
+			} );
+		},
+		[]
+	);
 
 	return {
 		trackSiteId,

--- a/client/a8c-for-agencies/hooks/use-track-provisioning-sites.ts
+++ b/client/a8c-for-agencies/hooks/use-track-provisioning-sites.ts
@@ -35,7 +35,7 @@ export default function useTrackProvisioningSites() {
 			];
 
 			localStorage.setItem( 'provisioningSites', JSON.stringify( updatedSites ) );
-			window.dispatchEvent( new Event( 'storage' ) );
+			window.dispatchEvent( new CustomEvent( 'a4a-provisioning-site-change' ) );
 		},
 		[ provisioningSites ]
 	);
@@ -45,17 +45,17 @@ export default function useTrackProvisioningSites() {
 			const updatedSites = provisioningSites.filter( ( { id } ) => id !== siteId );
 
 			localStorage.setItem( 'provisioningSites', JSON.stringify( updatedSites ) );
-			window.dispatchEvent( new Event( 'storage' ) );
+			window.dispatchEvent( new CustomEvent( 'a4a-provisioning-site-change' ) );
 		},
 		[ provisioningSites ]
 	);
 
 	useEffect( () => {
-		window.addEventListener( 'storage', reload );
+		window.addEventListener( 'a4a-provisioning-site-change', reload );
 		reload();
 
 		return () => {
-			window.removeEventListener( 'storage', reload );
+			window.removeEventListener( 'a4a-provisioning-site-change', reload );
 		};
 	}, [ reload ] );
 

--- a/client/a8c-for-agencies/hooks/use-track-provisioning-sites.ts
+++ b/client/a8c-for-agencies/hooks/use-track-provisioning-sites.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 
-const TTL_DURATION = 300000; // 5 minutes in miliseconds
+const PROVISIONING_SITE_CHANGE_EVENT = 'a4a-provisioning-site-change';
+const PROVISIONING_TIMEOUT = 300000; // 5 minutes in miliseconds
 
 type ProvisioningSite = {
 	id: number;
@@ -31,11 +32,11 @@ export default function useTrackProvisioningSites() {
 		) => {
 			const updatedSites = [
 				...provisioningSites,
-				{ id: siteId, migration, development, ttl: new Date().getTime() + TTL_DURATION },
+				{ id: siteId, migration, development, ttl: new Date().getTime() + PROVISIONING_TIMEOUT },
 			];
 
 			localStorage.setItem( 'provisioningSites', JSON.stringify( updatedSites ) );
-			window.dispatchEvent( new CustomEvent( 'a4a-provisioning-site-change' ) );
+			window.dispatchEvent( new CustomEvent( PROVISIONING_SITE_CHANGE_EVENT ) );
 		},
 		[ provisioningSites ]
 	);
@@ -45,17 +46,17 @@ export default function useTrackProvisioningSites() {
 			const updatedSites = provisioningSites.filter( ( { id } ) => id !== siteId );
 
 			localStorage.setItem( 'provisioningSites', JSON.stringify( updatedSites ) );
-			window.dispatchEvent( new CustomEvent( 'a4a-provisioning-site-change' ) );
+			window.dispatchEvent( new CustomEvent( PROVISIONING_SITE_CHANGE_EVENT ) );
 		},
 		[ provisioningSites ]
 	);
 
 	useEffect( () => {
-		window.addEventListener( 'a4a-provisioning-site-change', reload );
+		window.addEventListener( PROVISIONING_SITE_CHANGE_EVENT, reload );
 		reload();
 
 		return () => {
-			window.removeEventListener( 'a4a-provisioning-site-change', reload );
+			window.removeEventListener( PROVISIONING_SITE_CHANGE_EVENT, reload );
 		};
 	}, [ reload ] );
 

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -1,7 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
@@ -19,6 +18,7 @@ import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-conf
 import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
+import useTrackProvisioningSites from 'calypso/a8c-for-agencies/hooks/use-track-provisioning-sites';
 import SitesHeaderActions from '../sites-header-actions';
 import ClientSite from './client-site';
 import { AvailablePlans } from './plan-field';
@@ -57,6 +57,8 @@ export default function NeedSetup( { licenseKey }: Props ) {
 	const { data: pendingSites, isFetching, refetch: refetchPendingSites } = useFetchPendingSites();
 
 	const { mutate: createWPCOMSite, isPending: isCreatingSite } = useCreateWPCOMSiteMutation();
+
+	const { trackSiteId } = useTrackProvisioningSites();
 
 	const allAvailableSites =
 		pendingSites?.filter(
@@ -153,12 +155,13 @@ export default function NeedSetup( { licenseKey }: Props ) {
 				{
 					onSuccess: () => {
 						refetchPendingSites();
-						page( addQueryArgs( A4A_SITES_LINK, { created_site: id, migration: true } ) );
+						trackSiteId( id, { migration: true } );
+						page( A4A_SITES_LINK );
 					},
 				}
 			);
 		},
-		[ createWPCOMSite, refetchPendingSites ]
+		[ createWPCOMSite, refetchPendingSites, trackSiteId ]
 	);
 
 	return (

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -41,12 +41,6 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 
 	isPopoverOpen: false,
 	setIsPopoverOpen: () => {},
-
-	recentlyCreatedSiteId: null,
-	setRecentlyCreatedSiteId: () => {},
-
-	isRecentlyCreatedSiteDevelopment: false,
-	setIsRecentlyCreatedSiteDevelopment: () => {},
 } );
 
 export default SitesDashboardContext;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -73,9 +73,6 @@ export const SitesDashboardProvider = ( {
 	const [ mostRecentConnectedSite, setMostRecentConnectedSite ] = useState< string | null >( null );
 	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
 	const [ initialSelectedSiteUrl, setInitialSelectedSiteUrl ] = useState( siteUrlInitialState );
-	const [ recentlyCreatedSiteId, setRecentlyCreatedSiteId ] = useState< number | null >( null );
-	const [ isRecentlyCreatedSiteDevelopment, setIsRecentlyCreatedSiteDevelopment ] =
-		useState< boolean >( false );
 
 	const handleSetBulkManagementActive = ( isActive: boolean ) => {
 		setIsBulkManagementActive( isActive );
@@ -188,10 +185,6 @@ export const SitesDashboardProvider = ( {
 		dataViewsState,
 		setDataViewsState,
 		featurePreview,
-		recentlyCreatedSiteId,
-		setRecentlyCreatedSiteId,
-		isRecentlyCreatedSiteDevelopment,
-		setIsRecentlyCreatedSiteDevelopment,
 	};
 	return (
 		<SitesDashboardContext.Provider value={ sitesDashboardContextValue }>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -1,6 +1,5 @@
 import page from '@automattic/calypso-router';
 import { isWithinBreakpoint } from '@automattic/viewport';
-import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useContext, useEffect, useCallback, useState, useRef } from 'react';
@@ -51,8 +50,6 @@ export default function SitesDashboard() {
 
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const migrationIntent = getQueryArg( window.location.href, 'migration' ) ?? null;
-
 	const {
 		dataViewsState,
 		setDataViewsState,
@@ -64,8 +61,6 @@ export default function SitesDashboard() {
 		showOnlyDevelopmentSites,
 		hideListing,
 		setHideListing,
-		recentlyCreatedSiteId,
-		isRecentlyCreatedSiteDevelopment,
 	} = useContext( SitesDashboardContext );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
@@ -250,13 +245,7 @@ export default function SitesDashboard() {
 			{ ! hideListing && (
 				<LayoutColumn className="sites-overview" wide>
 					<LayoutTop withNavigation={ navItems.length > 1 }>
-						{ recentlyCreatedSiteId && (
-							<ProvisioningSiteNotification
-								siteId={ Number( recentlyCreatedSiteId ) }
-								migrationIntent={ !! migrationIntent }
-								isDevelopmentSite={ !! isRecentlyCreatedSiteDevelopment }
-							/>
-						) }
+						<ProvisioningSiteNotification />
 
 						<LayoutHeader>
 							<Title>{ translate( 'Sites' ) }</Title>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -11,9 +11,10 @@ type BannerProps = {
 	siteId: number;
 	migration?: boolean;
 	development?: boolean;
+	onDismiss?: () => void;
 };
 
-function Banner( { siteId, migration, development }: BannerProps ) {
+function Banner( { siteId, migration, development, onDismiss }: BannerProps ) {
 	const { isReady, site } = useIsSiteReady( { siteId } );
 	const [ showBanner, setShowBanner ] = useState( true );
 
@@ -52,12 +53,17 @@ function Banner( { siteId, migration, development }: BannerProps ) {
 				}
 		  );
 
+	const onClose = () => {
+		setShowBanner( false );
+		onDismiss?.();
+	};
+
 	return (
 		showBanner && (
 			<NoticeBanner
 				level={ isReady ? 'success' : 'warning' }
 				hideCloseButton={ ! isReady }
-				onClose={ () => setShowBanner( false ) }
+				onClose={ onClose }
 				title={
 					isReady
 						? translate( 'Your WordPress.com site is ready!' )
@@ -90,7 +96,7 @@ function Banner( { siteId, migration, development }: BannerProps ) {
 }
 
 export default function ProvisioningSiteNotification() {
-	const { provisioningSites } = useTrackProvisioningSites();
+	const { provisioningSites, untrackSiteId } = useTrackProvisioningSites();
 
 	return provisioningSites.map( ( { id, migration, development } ) => {
 		return (
@@ -99,6 +105,7 @@ export default function ProvisioningSiteNotification() {
 				siteId={ id }
 				migration={ migration }
 				development={ development }
+				onDismiss={ () => untrackSiteId( id ) }
 			/>
 		);
 	} );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -1,30 +1,21 @@
 import { Button } from '@automattic/components';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { A4A_SITES_LINK_DEVELOPMENT } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useIsSiteReady from 'calypso/a8c-for-agencies/data/sites/use-is-site-ready';
+import useTrackProvisioningSites from 'calypso/a8c-for-agencies/hooks/use-track-provisioning-sites';
 import { addQueryArgs } from 'calypso/lib/url';
 
-type Props = {
+type BannerProps = {
 	siteId: number;
-	migrationIntent: boolean;
-	isDevelopmentSite?: boolean;
+	migration?: boolean;
+	development?: boolean;
 };
 
-export default function ProvisioningSiteNotification( {
-	siteId,
-	migrationIntent,
-	isDevelopmentSite,
-}: Props ) {
+function Banner( { siteId, migration, development }: BannerProps ) {
 	const { isReady, site } = useIsSiteReady( { siteId } );
 	const [ showBanner, setShowBanner ] = useState( true );
-
-	useEffect( () => {
-		if ( siteId ) {
-			setShowBanner( true );
-		}
-	}, [ siteId ] );
 
 	const translate = useTranslate();
 
@@ -38,7 +29,7 @@ export default function ProvisioningSiteNotification( {
 		'https://wordpress.com/setup/hosted-site-migration/site-migration-identify'
 	);
 
-	const readySiteMessage = isDevelopmentSite
+	const readySiteMessage = development
 		? translate(
 				'{{a}}%(siteURL)s{{/a}} is now ready. It may take a few minutes for it to show up in the site list below. Before the site launches, you will be able to find it under {{developmentTabLink}}Development{{/developmentTabLink}}.',
 				{
@@ -75,7 +66,7 @@ export default function ProvisioningSiteNotification( {
 				actions={
 					isReady
 						? [
-								migrationIntent ? (
+								migration ? (
 									<Button href={ wpMigrationUrl } target="_blank" rel="noreferrer" primary>
 										{ translate( 'Migrate to this site' ) }
 									</Button>
@@ -96,4 +87,19 @@ export default function ProvisioningSiteNotification( {
 			</NoticeBanner>
 		)
 	);
+}
+
+export default function ProvisioningSiteNotification() {
+	const { provisioningSites } = useTrackProvisioningSites();
+
+	return provisioningSites.map( ( { id, migration, development } ) => {
+		return (
+			<Banner
+				key={ `provisioning_site_banner_${ id }` }
+				siteId={ id }
+				migration={ migration }
+				development={ development }
+			/>
+		);
+	} );
 }

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -44,10 +44,4 @@ export interface SitesDashboardContextInterface {
 	setIsPopoverOpen: Dispatch< SetStateAction< boolean > >;
 
 	featurePreview: ReactNode | null;
-
-	recentlyCreatedSiteId: number | null;
-	setRecentlyCreatedSiteId: ( value: number ) => void;
-
-	isRecentlyCreatedSiteDevelopment: boolean;
-	setIsRecentlyCreatedSiteDevelopment: ( value: boolean ) => void;
 }


### PR DESCRIPTION
The primary objective of this pull request is to address a bug related to the site provisioning banner not consistently displaying. While addressing this issue, it has become evident that the 'created_site' query parameter is not the suitable method for tracking the status within the site dashboard. One major drawback of this approach is that when we switch to a different URL, the banner is lost, resulting in a poor user experience.

To resolve this issue, the pull request includes updates to the implementation of how we track the status.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1087

## Proposed Changes

* To improve the reliability of tracking the status of a site during provisioning, we will now use local storage as our main method for keeping records of sites under provision. This PR introduces the `useTrackProvisioningSites` hook to encapsulate this functionality. With this approach, we prevent the UI from losing the status banner when changing the URL.
* Additionally, we now updated the site dashboard to support tracking multiple sites under provision. This is one improvement we included in this PR.
  
    <img width="1384" alt="Screenshot 2024-09-17 at 5 58 24 PM" src="https://github.com/user-attachments/assets/928c9c16-2be2-42f1-94eb-10958e2369dc">

* The provisioning site banner is designed to remain on the screen until the user dismisses it or until 5 minutes have passed. This ensures that users do not accidentally lose the site name. Additionally, the 5-minute expiration serves as a safeguard in case a site ID begins provisioning and gets stuck in a loop due to unexpected issues. We do not want to keep the banner in the UI for more than 5 minutes to keep the site dashboard clean.

    <img width="1349" alt="Screenshot 2024-09-17 at 5 59 04 PM" src="https://github.com/user-attachments/assets/d00cbcd3-cb23-42a3-8eaa-b9d674b622a3">


## Why are these changes being made?

* This improves the reliability of how we track the provisioning status of sites in the UI.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace` page.
* Purchase a WPCOM plans.
* Then go to the `Need setup` page.
* Provision of a site.
* Confirm that you are redirected to the Sites dashboard with the provisioning banner.
* Move to a different URL or try to refresh the page.
* Confirm that the banner still appears.
* Dismiss the banner.
* Confirm that the banner does not show again when refreshing the page.

**Banner expiration**
* Provision a site
* Do not dismiss the banner and wait until 5 minutes or more.
* Confirm that when refreshing the page, the banner no longer appears.

**Provisioning Multiple sites**
* Provision multiple sites at the same time.
* Confirm that you see multiple banners.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
