### PR TITLE
Calypso UI Components: DateRange: firefox alignment fix

### DIFF
--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -189,6 +189,14 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 }
 
+.date-picker {
+
+	display: flex;
+	justify-content: center; /* Centers horizontally */
+	align-items: center;     /* Centers vertically */
+
+}
+
 .date-range__popover .date-picker--2up {
 
 	.DayPicker-wrapper,

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -232,6 +232,7 @@ $date-range-mobile-layout-switch: $break-small;
 
 .date-range__date-input {
 	flex: 1;
+	max-width: 224px;
 
 	.form-label {
 		font-size: $font-body-extra-small;

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -189,7 +189,7 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 }
 
-.date-picker {
+.date-range__popover-content .date-picker {
 
 	display: flex;
 	justify-content: center; /* Centers horizontally */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fixes the issue in FireFox only where the calendar is not centre aligned, creating an odd spacing/gap to the right. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Use the Jetpack Cloud live link **using FireFox (important!)**
* Navigate to the `Activity Log`
* Check that the odd alignment issue is resolved
* Check in other browser to ensure consistency & no regressions

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/d59cef62-89cf-4bc9-be1a-7ccb788a66a5)  | ![image](https://github.com/user-attachments/assets/0d61833a-3b46-4331-bf25-a969b8b68cf3)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
