### PR TITLE
Performance Profiler: Update loading text when generating a recommendation

### DIFF
--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -31,7 +31,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 	return (
 		<div className="metrics-insight-content">
 			{ isLoading ? (
-				<LLMMessage message={ translate( 'Finding the best solution…' ) } rotate />
+				<LLMMessage message={ translate( 'Finding the best solution for your site…' ) } rotate />
 			) : (
 				<>
 					<div className="description-area">


### PR DESCRIPTION
## Proposed Changes

* Update the loading text shown when generating a recommendation to highlight that it’s personalised to the user’s site.

`Finding the best solution…` → `Finding the best solution for your site…`

| Desktop | Mobile |
|--------|--------|
| <img width="1096" alt="Screenshot 2024-09-17 at 11 15 31" src="https://github.com/user-attachments/assets/5be9666e-dfa0-4e5c-8540-ca876c94d112"> | <img width="329" alt="Screenshot 2024-09-17 at 11 17 50" src="https://github.com/user-attachments/assets/4b9b030d-c646-48e3-8af3-a1db3a584a97"> | 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To highlight that recommendations are personalised.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `speed-test-tool?url=https%3A%2F%2Fmattwest.design%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzY5MH0.VB3tLylYEsBHkIkfJV9BO9McFvyNwS9bU9Jd7cneEwE `
* Open a recommendation
* Note that the loading message has changed
* Test at all viewport sizes