### PR TITLE
Site profile: add "Site icon" learn more link

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -357,6 +357,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/hosting-configuration/',
 		post_id: 160841,
 	},
+	'site-icons': {
+		link: 'https://wordpress.com/support/site-icons/',
+		post_id: 1327,
+	},
 };
 
 export default contextLinks;

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -211,7 +211,7 @@ class SiteIconSetting extends Component {
 							{
 								args: [ 512 ],
 								components: {
-									a: <InlineSupportLink supportContext="site-icons" />,
+									a: <InlineSupportLink supportContext="site-icons" showIcon={ false } />,
 								},
 							}
 						) }

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -1,5 +1,4 @@
 import { Button, FormLabel } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { isEqual, flow, compact, includes } from 'lodash';
 import PropTypes from 'prop-types';
@@ -212,11 +211,7 @@ class SiteIconSetting extends Component {
 							{
 								args: [ 512 ],
 								components: {
-									a: (
-										<InlineSupportLink
-											supportLink={ localizeUrl( 'https://wordpress.com/support/site-icons/' ) }
-										/>
-									),
+									a: <InlineSupportLink supportContext="site-icons" />,
 								},
 							}
 						) }

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -1,4 +1,5 @@
 import { Button, FormLabel } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { isEqual, flow, compact, includes } from 'lodash';
 import PropTypes from 'prop-types';
@@ -8,6 +9,7 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import AsyncLoad from 'calypso/components/async-load';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import InfoPopover from 'calypso/components/info-popover';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { withUploadSiteIcon } from 'calypso/data/media/with-upload-site-icon';
 import accept from 'calypso/lib/accept';
 import EditorMediaModalDialog from 'calypso/post-editor/media-modal/dialog';
@@ -205,8 +207,18 @@ class SiteIconSetting extends Component {
 					<InfoPopover position="bottom right">
 						{ translate(
 							'The Site Icon is used as a browser and app icon for your site.' +
-								' Icons must be square, and at least %s pixels wide and tall.',
-							{ args: [ 512 ] }
+								' Icons must be square, and at least %s pixels wide and tall.' +
+								' {{a}}Learn more{{/a}}',
+							{
+								args: [ 512 ],
+								components: {
+									a: (
+										<InlineSupportLink
+											supportLink={ localizeUrl( 'https://wordpress.com/support/site-icons/' ) }
+										/>
+									),
+								},
+							}
 						) }
 					</InfoPopover>
 				</FormLabel>

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -207,7 +207,7 @@ class SiteIconSetting extends Component {
 						{ translate(
 							'The Site Icon is used as a browser and app icon for your site.' +
 								' Icons must be square, and at least %s pixels wide and tall.' +
-								' {{a}}Learn more{{/a}}',
+								' {{a}}Learn more{{/a}}.',
 							{
 								args: [ 512 ],
 								components: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/83941

## Proposed Changes

* Add documentation "learn more" link

<img width="1238" alt="Screenshot 2024-09-17 at 16 57 51" src="https://github.com/user-attachments/assets/d35321cd-652f-406a-a098-4371628e7206">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Missing support link

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the "Site profile" on `/settings/general/{SITE_SLUG}`
* Click on (i) next to the site icon
* Check if there is a "Learn more" link directing to the `https://wordpress.com/support/site-icons/ ` page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
