### PR TITLE
Enhances context to avoid suggesting to change theme.

### DIFF
--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -17,7 +17,7 @@ export const useSupportChatLLMQuery = (
 		'Answer me in two topics in bold: "Why is this important?" and "How to fix this?".';
 	const contextToInclude = `Use each of the following context: ${ context }. Visit any links provided for more information.`;
 	const suggestionsToInclude =
-		'Add if the issue can be fixed automatically with a WordPress setting, an editor block setting, or a plugin. Prefer Automattic owned plugins. Add relevant links. Provide code snippets as a last resort.';
+		"Add if the issue can be fixed automatically with a core WordPress setting, a WordPress Block Editor setting, or a plugin. Provide code snippets as a last resort. Prefer Automattic owned plugins. Add relevant links and format them in hyperlinks. Don't suggest changing theme.";
 	const wpcomOrSelfHostedSuggestions = ! is_wpcom
 		? 'Do not show suggestions that work only in WordPress.com. Do not show any references to documentation or support forums related to WordPress.com.'
 		: 'Provide suggestions that work only in WordPress.com. Use WordPress.com documentation if availabble.';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9074

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/speed-test-tool?url=https%3A%2F%2Fblecyclingclub.gr%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzY5MX0.WEeHP-Y_3lK2SG4zwCX8VBoEZ_Atnnqit_7xH4637vA&tab=desktop`
* Open LCP suggestions and make sure there is no suggestion to change theme.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
