### PR TITLE
Paid newsletter importer summary step UI fixes

### DIFF
--- a/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
@@ -31,7 +31,7 @@ const sum = ( a, b ) => a + b;
  *     …
  * }
  */
-export const calculateProgress = ( progress ) => {
+const calculateProgress = ( progress ) => {
 	// The backend does not output the 'progress' field for all the enqueued not running imports.
 	if ( ! progress ) {
 		return 0;
@@ -55,13 +55,13 @@ export const calculateProgress = ( progress ) => {
 	return ( 100 * percentages.reduce( sum, 0 ) ) / percentages.length;
 };
 
-export const resourcesRemaining = ( progress ) =>
+const resourcesRemaining = ( progress ) =>
 	Object.keys( progress )
 		.map( ( k ) => progress[ k ] )
 		.map( ( { completed, total } ) => total - completed )
 		.reduce( sum, 0 );
 
-export const hasProgressInfo = ( progress ) => {
+const hasProgressInfo = ( progress ) => {
 	if ( ! progress ) {
 		return false;
 	}

--- a/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
@@ -1,4 +1,3 @@
-import { FormInputValidation, FormLabel } from '@automattic/components';
 import { ProgressBar } from '@wordpress/components';
 import { Icon, cloudUpload } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -9,8 +8,6 @@ import { createRef, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { WPImportError, FileTooLarge } from 'calypso/blocks/importer/wordpress/types';
 import DropZone from 'calypso/components/drop-zone';
-import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import TextInput from 'calypso/components/forms/form-text-input';
 import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
 import {
@@ -93,9 +90,6 @@ export class UploadingPane extends PureComponent {
 		switch ( importerState ) {
 			case appStates.READY_FOR_UPLOAD:
 			case appStates.UPLOAD_FAILURE:
-				if ( this.state.fileToBeUploaded ) {
-					return <p>{ this.state?.fileToBeUploaded?.name?.substring?.( 0, 100 ) }</p>;
-				}
 				return (
 					<p>
 						{ this.props.translate(
@@ -106,6 +100,7 @@ export class UploadingPane extends PureComponent {
 						) }
 					</p>
 				);
+
 			case appStates.UPLOAD_PROCESSING:
 			case appStates.UPLOADING: {
 				const uploadPercent = percentComplete;
@@ -124,7 +119,8 @@ export class UploadingPane extends PureComponent {
 					</div>
 				);
 			}
-			case appStates.UPLOAD_SUCCESS:
+
+			case appStates.UPLOAD_SUCCESS: {
 				if ( importerFileType === 'playground' ) {
 					return (
 						<div className="importer-upload-warning">
@@ -147,11 +143,9 @@ export class UploadingPane extends PureComponent {
 						</div>
 					);
 				}
-				return (
-					<div>
-						<p>{ this.props.translate( 'Success! File uploaded.' ) }</p>
-					</div>
-				);
+
+				return <p>{ this.props.translate( 'Success! File uploaded.' ) }</p>;
+			}
 		}
 	};
 
@@ -233,17 +227,12 @@ export class UploadingPane extends PureComponent {
 	};
 
 	render() {
-		const { importerStatus, fromSite, acceptedFileTypes, nextStepUrl, skipNextStep } = this.props;
+		const { importerStatus, acceptedFileTypes, nextStepUrl, skipNextStep } = this.props;
 		const isReadyForImport = this.isReadyForImport();
 		const importerStatusClasses = clsx(
 			'importer__upload-content',
 			this.props.importerStatus.importerState
 		);
-		const hasEnteredUrl = this.state.urlInput && this.state.urlInput !== '';
-		const isValidUrl = this.validateUrl( this.state.urlInput );
-		const urlDescription = isValidUrl
-			? this.props?.optionalUrl?.description
-			: this.props?.optionalUrl?.invalidDescription;
 		const skipButtonDisabled = importerStatus.importerState === appStates.UPLOAD_PROCESSING;
 
 		return (
@@ -270,24 +259,6 @@ export class UploadingPane extends PureComponent {
 					) }
 					<DropZone onFilesDrop={ isReadyForImport ? this.initiateFromDrop : noop } />
 				</div>
-				{ this.props.optionalUrl && ! fromSite && (
-					<div className="importer__uploading-pane-url-input">
-						<FormLabel>
-							{ this.props.optionalUrl.title }
-							<TextInput
-								label={ this.props.optionalUrl.title }
-								onChange={ this.setUrl }
-								value={ this.state.urlInput }
-								placeholder="https://newsletter.substack.com/"
-							/>
-						</FormLabel>
-						{ hasEnteredUrl ? (
-							<FormInputValidation isError={ ! isValidUrl }>{ urlDescription }</FormInputValidation>
-						) : (
-							<FormSettingExplanation>{ urlDescription }</FormSettingExplanation>
-						) }
-					</div>
-				) }
 				<ImporterActionButtonContainer noSpacing>
 					<ImporterActionButton
 						href={ nextStepUrl }

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -36,10 +36,10 @@ function getStepTitle( importerStatus: StepStatus ) {
 	}
 
 	if ( importerStatus === 'importing' ) {
-		return 'Still working!';
+		return 'Almost there…';
 	}
 
-	return 'Nothing to import';
+	return 'Summary';
 }
 
 export default function Summary( { cardData, selectedSite }: StepProps ) {

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -10,7 +10,7 @@ export default function ContentSummary( { status, cardData }: Props ) {
 		return (
 			<div className="summary__content">
 				<p>
-					<Icon icon={ post } /> Content importing was <strong>skipped</strong>
+					<Icon icon={ post } /> You <strong>skipped</strong> content importing.
 				</p>
 			</div>
 		);

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -16,7 +16,7 @@ export default function ContentSummary( { status, cardData }: Props ) {
 		);
 	}
 
-	if ( status === 'importing' || status === 'processing' || status === 'done' ) {
+	if ( status === 'importing' || status === 'processing' ) {
 		return (
 			<div className="summary__content">
 				<p>
@@ -29,7 +29,7 @@ export default function ContentSummary( { status, cardData }: Props ) {
 		);
 	}
 
-	if ( status === 'donee' ) {
+	if ( status === 'done' ) {
 		const progress = cardData.progress;
 
 		// TODO Let's fix this copy when applying translations

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -1,5 +1,35 @@
 import { Icon, post } from '@wordpress/icons';
 
+function getSummaryCopy( postsNumber: number, pagesNumber: number, attachmentsNumber: number ) {
+	if ( postsNumber > 0 && pagesNumber > 0 && attachmentsNumber > 0 ) {
+		return `We imported ${ postsNumber } posts, ${ pagesNumber } pages and ${ attachmentsNumber } media.`;
+	}
+
+	if ( postsNumber > 0 && pagesNumber > 0 ) {
+		return `We imported ${ postsNumber } posts and ${ pagesNumber } pages`;
+	}
+
+	if ( postsNumber > 0 && attachmentsNumber > 0 ) {
+		return `We imported ${ postsNumber } posts and ${ attachmentsNumber } media`;
+	}
+
+	if ( pagesNumber > 0 && attachmentsNumber > 0 ) {
+		return `We imported ${ postsNumber } pages and ${ attachmentsNumber } media`;
+	}
+
+	if ( postsNumber > 0 ) {
+		return `We imported ${ postsNumber } posts.`;
+	}
+
+	if ( pagesNumber > 0 ) {
+		return `We imported ${ postsNumber } pages.`;
+	}
+
+	if ( attachmentsNumber > 0 ) {
+		return `We imported ${ postsNumber } media.`;
+	}
+}
+
 type Props = {
 	cardData: any;
 	status: string;
@@ -32,20 +62,15 @@ export default function ContentSummary( { status, cardData }: Props ) {
 	if ( status === 'done' ) {
 		const progress = cardData.progress;
 
-		// TODO Let's fix this copy when applying translations
 		return (
 			<div className="summary__content">
 				<p>
-					<Icon icon={ post } /> We imported&nbsp;
-					{ progress.post.completed !== 0 && <strong>{ progress.post.completed } posts</strong> }
-					{ progress.page.completed !== 0 && <strong>{ progress.page.completed } pages</strong> }
-					{ progress.attachment.completed !== 0 && (
-						<strong>{ progress.attachment.completed } media</strong>
+					<Icon icon={ post } />
+					{ getSummaryCopy(
+						progress.post.completed,
+						progress.page.completed,
+						progress.attachment.completed
 					) }
-					{ progress.comment.completed !== 0 && (
-						<strong>{ progress.comment.completed } comments</strong>
-					) }
-					.
 				</p>
 			</div>
 		);

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -1,4 +1,4 @@
-import { Icon, post, media, comment, page } from '@wordpress/icons';
+import { Icon, post } from '@wordpress/icons';
 
 type Props = {
 	cardData: any;
@@ -16,49 +16,36 @@ export default function ContentSummary( { status, cardData }: Props ) {
 		);
 	}
 
-	if ( status === 'done' ) {
-		const progress = cardData.progress;
-
+	if ( status === 'importing' || status === 'processing' || status === 'done' ) {
 		return (
 			<div className="summary__content">
-				<p>We imported:</p>
-
-				{ progress.post.completed !== 0 && (
-					<p>
-						<Icon icon={ post } />
-						<strong>{ progress.post.completed }</strong> posts
-					</p>
-				) }
-
-				{ progress.page.completed !== 0 && (
-					<p>
-						<Icon icon={ page } />
-						<strong>{ progress.page.completed }</strong> pages
-					</p>
-				) }
-
-				{ progress.attachment.completed !== 0 && (
-					<p>
-						<Icon icon={ media } />
-						<strong>{ progress.attachment.completed }</strong> media
-					</p>
-				) }
-
-				{ progress.comment.completed !== 0 && (
-					<p>
-						<Icon icon={ comment } />
-						<strong>{ progress.comment.completed }</strong> comments
-					</p>
-				) }
+				<p>
+					<Icon icon={ post } /> <strong>We're importing your content.</strong>
+					<br />
+					This may take a few minutes. Feel free to leave this window – we'll let you know when it's
+					done.
+				</p>
 			</div>
 		);
 	}
 
-	if ( status === 'importing' || status === 'processing' ) {
+	if ( status === 'donee' ) {
+		const progress = cardData.progress;
+
+		// TODO Let's fix this copy when applying translations
 		return (
 			<div className="summary__content">
 				<p>
-					<Icon icon={ post } /> Content is importing...
+					<Icon icon={ post } /> We imported&nbsp;
+					{ progress.post.completed !== 0 && <strong>{ progress.post.completed } posts</strong> }
+					{ progress.page.completed !== 0 && <strong>{ progress.page.completed } pages</strong> }
+					{ progress.attachment.completed !== 0 && (
+						<strong>{ progress.attachment.completed } media</strong>
+					) }
+					{ progress.comment.completed !== 0 && (
+						<strong>{ progress.comment.completed } comments</strong>
+					) }
+					.
 				</p>
 			</div>
 		);

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -23,7 +23,10 @@ export default function SubscriberSummary( { cardData, status }: Props ) {
 		return (
 			<div className="summary__content">
 				<p>
-					<Icon icon={ people } /> Importing subscribers...
+					<Icon icon={ people } /> <strong>We're importing your subscribers.</strong>
+					<br />
+					This may take a few minutes. Feel free to leave this window – we'll let you know when it's
+					done.
 				</p>
 			</div>
 		);

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -13,7 +13,7 @@ export default function SubscriberSummary( { cardData, status }: Props ) {
 		return (
 			<div className="summary__content">
 				<p>
-					<Icon icon={ atSymbol } /> Subscriber importing was <strong>skipped</strong>
+					<Icon icon={ atSymbol } /> You <strong>skipped</strong> subscriber importing.
 				</p>
 			</div>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

It:
- fixes some copy on summary step
- does some cleanup

<img width="750" alt="Screenshot 2024-09-17 at 14 56 14" src="https://github.com/user-attachments/assets/5cb6e07f-1f68-4955-8876-e257ab3bef05">

<img width="750" alt="Screenshot 2024-09-17 at 15 01 16" src="https://github.com/user-attachments/assets/428dbbc9-6bfb-4cca-8ff7-d25b28578175">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
