### PR TITLE
Logged-in Performance Profiler: Add unavailable state

### DIFF
--- a/client/hosting/performance/components/ReportUnavailable.tsx
+++ b/client/hosting/performance/components/ReportUnavailable.tsx
@@ -1,0 +1,34 @@
+import { NoticeBanner } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+
+export const ReportUnavailable = ( {
+	isLaunching,
+	onLaunchSiteClick,
+}: {
+	isLaunching: boolean;
+	onLaunchSiteClick(): void;
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<NoticeBanner
+			level="info"
+			title={ translate( 'Launch your site to start measuring performance' ) }
+			hideCloseButton
+			actions={ [
+				<Button
+					disabled={ isLaunching }
+					isBusy={ isLaunching }
+					key="launch-site"
+					variant="primary"
+					onClick={ onLaunchSiteClick }
+				>
+					{ translate( 'Launch your site' ) }
+				</Button>,
+			] }
+		>
+			{ translate( 'Performance statistics are only available for public sites.' ) }
+		</NoticeBanner>
+	);
+};

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -11,11 +11,14 @@ import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basi
 import { useUrlPerformanceInsightsQuery } from 'calypso/data/site-profiler/use-url-performance-insights';
 import { useDispatch, useSelector } from 'calypso/state';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getRequest from 'calypso/state/selectors/get-request';
+import { launchSite } from 'calypso/state/sites/launch/actions';
 import { requestSiteStats } from 'calypso/state/stats/lists/actions';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PageSelector } from './components/PageSelector';
 import { PerformanceReport } from './components/PerformanceReport';
+import { ReportUnavailable } from './components/ReportUnavailable';
 import { DeviceTabControls, Tab } from './components/device-tab-control';
 import { getSitePagesQueryKey, useSitePages } from './hooks/useSitePages';
 
@@ -77,7 +80,8 @@ const usePerformanceReport = (
 export const SitePerformance = () => {
 	const [ activeTab, setActiveTab ] = useState< Tab >( 'mobile' );
 	const dispatch = useDispatch();
-	const siteId = useSelector( getSelectedSiteId );
+	const site = useSelector( getSelectedSite );
+	const siteId = site?.ID;
 
 	const stats = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, statsQuery )
@@ -126,6 +130,17 @@ export const SitePerformance = () => {
 	};
 
 	const performanceReport = usePerformanceReport( wpcom_performance_url, activeTab );
+
+	const isSitePublic =
+		site && ! site.is_coming_soon && ! site.is_private && site.launch_status === 'launched';
+
+	const siteIsLaunching = useSelector(
+		( state ) => getRequest( state, launchSite( siteId ) )?.isLoading ?? false
+	);
+
+	const onLaunchSiteClick = () => {
+		dispatch( launchSite( siteId! ) );
+	};
 
 	return (
 		<div className="site-performance">
@@ -188,12 +203,19 @@ export const SitePerformance = () => {
 				/>
 				<DeviceTabControls onDeviceTabChange={ setActiveTab } value={ activeTab } />
 			</div>
-			{ currentPage && (
-				<PerformanceReport
-					{ ...performanceReport }
-					pageTitle={ currentPage.label }
-					onRetestClick={ retestPage }
+			{ ! isSitePublic ? (
+				<ReportUnavailable
+					isLaunching={ siteIsLaunching }
+					onLaunchSiteClick={ onLaunchSiteClick }
 				/>
+			) : (
+				currentPage && (
+					<PerformanceReport
+						{ ...performanceReport }
+						pageTitle={ currentPage.label }
+						onRetestClick={ retestPage }
+					/>
+				)
 			) }
 		</div>
 	);


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9156.

## Proposed Changes

![image](https://github.com/user-attachments/assets/9a17624a-f302-49a1-a046-189336a1d06d)

## Testing Instructions

Go to a private site, or a site in coming soon state, then visit `/site-performance/%s`. Click the Launch button, observe it becomes disabled and after a few moments the notice disappears.