### PR TITLE
Performance Profiler: adjusts error cases and messaging.

### DIFF
--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -29,9 +29,19 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 	const isSavedReport = useRef( !! hash );
 	const testStartTime = useRef( 0 );
 	const [ activeTab, setActiveTab ] = React.useState< TabType >( tab );
-	const { data: basicMetrics, isError, isFetched } = useUrlBasicMetricsQuery( url, hash, true );
+	const {
+		data: basicMetrics,
+		isError: isBasicMetricsError,
+		isFetched,
+	} = useUrlBasicMetricsQuery( url, hash, true );
 	const { final_url: finalUrl, token } = basicMetrics || {};
-	const { data: performanceInsights } = useUrlPerformanceInsightsQuery( url, hash );
+	const { data: performanceInsights, isError: isPerformanceInsightsError } =
+		useUrlPerformanceInsightsQuery( url, hash );
+	const isError =
+		isBasicMetricsError ||
+		isPerformanceInsightsError ||
+		'failed' === performanceInsights?.mobile ||
+		'failed' === performanceInsights?.desktop;
 	const desktopLoaded = 'completed' === performanceInsights?.status;
 	const mobileLoaded = typeof performanceInsights?.mobile === 'object';
 
@@ -92,7 +102,9 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 							} ) }
 							<br />
 							<ErrorSecondLine>
-								{ translate( 'Please check that the domain is correct and try again.' ) }
+								{ translate(
+									'We were unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests. '
+								) }
 							</ErrorSecondLine>
 						</>
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9157

## Proposed Changes

* returns an error screen when PSI tests fail `'failed' === performanceInsights?.mobile || 'failed' === performanceInsights?.desktop`

![CleanShot 2024-09-17 at 17 07 31](https://github.com/user-attachments/assets/defa3218-c99f-4ff5-9f90-67f7a79cb772)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Works with D161648-code

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?