### PR TITLE
Email varification dialog - update copies and CTAs

### DIFF
--- a/client/components/email-verification/email-verification-dialog/index.jsx
+++ b/client/components/email-verification/email-verification-dialog/index.jsx
@@ -57,8 +57,13 @@ class VerifyEmailDialog extends Component {
 			confirmHeading: this.props.translate( 'Verify your email' ),
 
 			confirmExplanation: this.props.translate(
-				"Check your inbox at %(email)s for the confirmation email, or click 'Resend Email' to get a new one.",
+				"Check your inbox at {{wrapper}}%(email)s{{/wrapper}} for the confirmation email, or click 'Resend Email' to get a new one.",
 				{
+					components: {
+						wrapper: (
+							<span className="email-verification-dialog__confirmation-dialog-email-wrapper" />
+						),
+					},
 					args: {
 						email: this.props.email,
 					},

--- a/client/components/email-verification/email-verification-dialog/index.jsx
+++ b/client/components/email-verification/email-verification-dialog/index.jsx
@@ -70,7 +70,7 @@ class VerifyEmailDialog extends Component {
 			),
 
 			confirmEmail: this.props.translate(
-				"Can't access that email? {{emailPreferences}}Click here to update it.{{/emailPreferences}}",
+				"Can't access that email? {{emailPreferences}}Click here to update it{{/emailPreferences}}.",
 				{
 					components: {
 						emailPreferences: <a href="/me/account" />,
@@ -89,7 +89,7 @@ class VerifyEmailDialog extends Component {
 				<h1 className="email-verification-dialog__confirmation-dialog-heading is-variable-height">
 					{ strings.confirmHeading }
 				</h1>
-				<p className="email-verification-dialog__confirmation-dialog-reasoning">
+				<p className="email-verification-dialog__confirmation-dialog-explanation">
 					{ strings.confirmReasoning }
 				</p>
 				<p className="email-verification-dialog__confirmation-dialog-explanation">

--- a/client/components/email-verification/email-verification-dialog/index.jsx
+++ b/client/components/email-verification/email-verification-dialog/index.jsx
@@ -20,12 +20,12 @@ class VerifyEmailDialog extends Component {
 			'sent' === this.props.emailVerificationStatus ||
 			'error' === this.props.emailVerificationStatus
 		) {
-			return this.props.translate( 'Email Sent' );
+			return this.props.translate( 'Email sent' );
 		}
 		if ( 'requesting' === this.props.emailVerificationStatus ) {
 			return <Spinner className="email-verification-dialog__confirmation-dialog-spinner" />;
 		}
-		return this.props.translate( 'Resend Email' );
+		return this.props.translate( 'Resend email' );
 	}
 
 	handleClose = () => {

--- a/client/components/email-verification/email-verification-dialog/index.jsx
+++ b/client/components/email-verification/email-verification-dialog/index.jsx
@@ -35,9 +35,12 @@ class VerifyEmailDialog extends Component {
 
 	getDialogButtons() {
 		return [
+			<Button key="close" onClick={ this.handleClose }>
+				{ this.props.translate( 'Cancel' ) }
+			</Button>,
 			<Button
 				key="resend"
-				primary={ false }
+				primary
 				disabled={ includes(
 					[ 'requesting', 'sent', 'error' ],
 					this.props.emailVerificationStatus
@@ -46,37 +49,31 @@ class VerifyEmailDialog extends Component {
 			>
 				{ this.getResendButtonLabel() }
 			</Button>,
-			<Button key="close" primary onClick={ this.handleClose }>
-				{ this.props.translate( 'OK' ) }
-			</Button>,
 		];
 	}
 
 	render() {
 		const strings = {
-			confirmHeading: this.props.translate( 'Please verify your email address:' ),
+			confirmHeading: this.props.translate( 'Verify your email' ),
 
 			confirmExplanation: this.props.translate(
-				'When you first signed up for a WordPress.com account we sent you an email. ' +
-					'Please open it and click on the blue button to verify your email address.'
+				"Check your inbox at %(email)s for the confirmation email, or click 'Resend Email' to get a new one.",
+				{
+					args: {
+						email: this.props.email,
+					},
+				}
 			),
 
 			confirmReasoning: this.props.translate(
-				'Verifying your email allows us to assist you if you ' +
-					'ever lose access to your account in the future.'
+				'Verify your email to secure your account and access more features.'
 			),
 
 			confirmEmail: this.props.translate(
-				'{{wrapper}}%(email)s{{/wrapper}} {{emailPreferences}}change{{/emailPreferences}}',
+				"Can't access that email? {{emailPreferences}}Click here to update it.{{/emailPreferences}}",
 				{
 					components: {
-						wrapper: (
-							<span className="email-verification-dialog__confirmation-dialog-email-wrapper" />
-						),
 						emailPreferences: <a href="/me/account" />,
-					},
-					args: {
-						email: this.props.email,
 					},
 				}
 			),
@@ -92,14 +89,14 @@ class VerifyEmailDialog extends Component {
 				<h1 className="email-verification-dialog__confirmation-dialog-heading is-variable-height">
 					{ strings.confirmHeading }
 				</h1>
-				<p className="email-verification-dialog__confirmation-dialog-email">
-					{ strings.confirmEmail }
+				<p className="email-verification-dialog__confirmation-dialog-reasoning">
+					{ strings.confirmReasoning }
 				</p>
 				<p className="email-verification-dialog__confirmation-dialog-explanation">
 					{ strings.confirmExplanation }
 				</p>
-				<p className="email-verification-dialog__confirmation-dialog-reasoning">
-					{ strings.confirmReasoning }
+				<p className="email-verification-dialog__confirmation-dialog-email">
+					{ strings.confirmEmail }
 				</p>
 			</Dialog>
 		);

--- a/client/components/email-verification/email-verification-dialog/style.scss
+++ b/client/components/email-verification/email-verification-dialog/style.scss
@@ -1,10 +1,8 @@
 .email-verification-dialog__confirmation-dialog.is-narrow {
 	max-width: 100%;
-	border-radius: 0;
 
 	@include breakpoint-deprecated( ">660px" ) {
 		max-width: 550px;
-		border-radius: 2px;
 	}
 }
 

--- a/client/components/email-verification/email-verification-dialog/style.scss
+++ b/client/components/email-verification/email-verification-dialog/style.scss
@@ -35,12 +35,7 @@
 }
 
 .email-verification-dialog__confirmation-dialog-email-wrapper {
-	display: inline-block;
-	max-width: 70%;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	margin-right: 5px;
-	vertical-align: bottom;
+	font-weight: bold;
 }
 
 .email-verification-dialog__confirmation-dialog-spinner {

--- a/client/components/email-verification/email-verification-dialog/style.scss
+++ b/client/components/email-verification/email-verification-dialog/style.scss
@@ -19,15 +19,19 @@
 }
 
 .email-verification-dialog__confirmation-dialog-email,
-.email-verification-dialog__confirmation-dialog-explanation,
-.email-verification-dialog__confirmation-dialog-reasoning {
+.email-verification-dialog__confirmation-dialog-explanation {
 	color: var(--color-neutral-60);
-	margin: 0 0 8px;
+	margin: 24px 0;
 }
 
 .email-verification-dialog__confirmation-dialog-email {
 	margin-bottom: 16px;
 	color: var(--color-neutral-40);
+	font-size: $font-body-small;
+	a {
+		color: inherit;
+		text-decoration: underline;
+	}
 }
 
 .email-verification-dialog__confirmation-dialog-email-wrapper {
@@ -37,12 +41,6 @@
 	text-overflow: ellipsis;
 	margin-right: 5px;
 	vertical-align: bottom;
-}
-
-.email-verification-dialog__confirmation-dialog-reasoning {
-	color: var(--color-neutral-40);
-	font-size: $font-body-small;
-	margin-bottom: 24px;
 }
 
 .email-verification-dialog__confirmation-dialog-spinner {

--- a/client/components/email-verification/email-verification-dialog/style.scss
+++ b/client/components/email-verification/email-verification-dialog/style.scss
@@ -21,7 +21,7 @@
 .email-verification-dialog__confirmation-dialog-email,
 .email-verification-dialog__confirmation-dialog-explanation {
 	color: var(--color-neutral-60);
-	margin: 24px 0;
+	margin: 20px 0;
 }
 
 .email-verification-dialog__confirmation-dialog-email {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/93895

## Proposed Changes

Updates the copies and styles on the email verification dialog as per designs laid out in issue linked above.

BEFORE
<img width="571" alt="Screenshot 2024-09-17 at 12 22 38 PM" src="https://github.com/user-attachments/assets/7194f1f2-8094-45c0-ab6a-5ac97f51f748">


AFTER
<img width="575" alt="Screenshot 2024-09-18 at 10 01 45 AM" src="https://github.com/user-attachments/assets/b58c448d-c66c-4dd1-9e8f-2772e9c182e5">




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p9Jlb4-dYD-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Verify the email confirmation dialog has updated copy and styles as per laid out in the issue.
* Smoke test functionality.
* Note - you can also get the dialog to appear by commenting out [this return](https://github.com/Automattic/wp-calypso/blob/d4178e37f38de3b60eca1b60330e20d56199ea5a/client/blocks/edit-gravatar/index.jsx#L143) and clicking on the gravatar image/upload circle in the profile form at the top of /me

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?