### PR TITLE
White-labeled plugin: Update text on site instructions based on feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-get-your-site-ready.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-get-your-site-ready.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { recordMigrationInstructionsLinkClick } from '../tracking';
@@ -10,12 +11,16 @@ interface Props {
 
 export const StepGetYourSiteReady: FC< Props > = ( { fromUrl } ) => {
 	const translate = useTranslate();
+	const isWhiteLabeledPluginEnabled = config.isEnabled(
+		'migration-flow/enable-white-labeled-plugin'
+	);
+	const pluginName = isWhiteLabeledPluginEnabled ? 'Migrate to WordPress.com' : 'Migrate Guru';
 
 	return (
 		<>
 			<p>
 				{ translate(
-					'Head to the {{a}}Migrate Guru plugin screen on your source site{{/a}}, enter your email address, and click {{strong}}%(migrateLabel)s{{/strong}}.',
+					'Head to the {{a}}%(pluginName)s plugin screen on your source site{{/a}}, enter your email address, and click {{strong}}%(migrateLabel)s{{/strong}}.',
 					{
 						components: {
 							strong: <strong />,
@@ -31,11 +36,17 @@ export const StepGetYourSiteReady: FC< Props > = ( { fromUrl } ) => {
 								<strong />
 							),
 						},
-						args: { migrateLabel: 'Migrate' },
+						args: {
+							pluginName,
+							migrateLabel: isWhiteLabeledPluginEnabled ? 'Continue' : 'Migrate',
+						},
 					}
 				) }
 			</p>
-			<p>{ translate( 'Then, pick WordPress.com as your destination host.' ) }</p>
+			<p>
+				{ ! isWhiteLabeledPluginEnabled &&
+					translate( 'Then, pick WordPress.com as your destination host.' ) }
+			</p>
 			<p>
 				{ translate( 'All set? Click {{strong}}Next{{/strong}} below.', {
 					components: {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-install-migation-guru.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-install-migation-guru.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { recordMigrationInstructionsLinkClick } from '../tracking';
@@ -10,11 +11,15 @@ interface Props {
 
 export const StepInstallMigrationGuru: FC< Props > = ( { fromUrl } ) => {
 	const translate = useTranslate();
+	const isWhiteLabeledPluginEnabled = config.isEnabled(
+		'migration-flow/enable-white-labeled-plugin'
+	);
+	const pluginName = isWhiteLabeledPluginEnabled ? 'Migrate to WordPress.com' : 'Migrate Guru';
 
 	return (
 		<p>
 			{ translate(
-				"First you'll need to install and activate the {{a}}Migrate Guru plugin{{/a}} on the site you want to migrate. Click {{strong}}Next{{/strong}} when you're ready.",
+				"First you'll need to install and activate the {{a}}%(pluginName)s plugin{{/a}} on the site you want to migrate. Click {{strong}}Next{{/strong}} when you're ready.",
 				{
 					components: {
 						strong: <strong />,
@@ -28,6 +33,7 @@ export const StepInstallMigrationGuru: FC< Props > = ( { fromUrl } ) => {
 							/>
 						),
 					},
+					args: { pluginName },
 				}
 			) }
 		</p>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/use-steps.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -54,7 +55,13 @@ const useStepsData = ( {
 	return [
 		{
 			key: 'install-the-migrate-guru-plugin',
-			title: translate( 'Install the Migrate Guru plugin' ),
+			title: translate( 'Install the %(pluginName)s plugin', {
+				args: {
+					pluginName: config.isEnabled( 'migration-flow/enable-white-labeled-plugin' )
+						? 'Migrate to WordPress.com'
+						: 'Migrate Guru',
+				},
+			} ),
 			content: <StepInstallMigrationGuru fromUrl={ fromUrl } />,
 		},
 		{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/use-steps.tsx
@@ -61,7 +61,7 @@ const useStepsData = ( {
 						? 'Migrate to WordPress.com'
 						: 'Migrate Guru',
 				},
-			} ),
+			} ) as string,
 			content: <StepInstallMigrationGuru fromUrl={ fromUrl } />,
 		},
 		{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/94453

## Proposed Changes

* I realized we not only have to update the links, the copy needs to be updated when we're referencing the new Migrate to WordPress.com plugin, too.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Soon we will switch from Migrate Guru to the Move to WordPress.com plugin, and these changes need to be reflected on the front end during the migration signup flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR or use calypso.live
* Navigate to `/setup/migration-signup`
* Go through the flow until you reach the instructions step.
* You should see the following instructions referencing Migrate Guru - check both the first and second steps:

<img width="411" alt="Screenshot 2024-09-17 at 12 24 05 PM" src="https://github.com/user-attachments/assets/a9841c26-3eb9-41a3-ba8e-45b9666cdbf5">

<img width="413" alt="Screenshot 2024-09-17 at 12 24 58 PM" src="https://github.com/user-attachments/assets/8a817911-6353-4129-a88a-53a139a09f38">

* Now add `&flags=migration-flow/enable-white-labeled-plugin` to the URL and reload
* You should see the instructions update to reference Migrate to WordPress.com - check both the first and second steps, note the name of the "Migrate" action changes to "Continue" and the reference to selecting WordPress.com from the providers list should be removed:

<img width="405" alt="Screenshot 2024-09-17 at 12 23 15 PM" src="https://github.com/user-attachments/assets/37502c81-60cf-4372-b58c-3872ef6c5afd">

<img width="403" alt="Screenshot 2024-09-17 at 12 25 18 PM" src="https://github.com/user-attachments/assets/1a5ad8bd-6d8e-46c6-8904-87b7ae2e59ad">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
