### PR TITLE
Paid subscribers importer some types fixes

### DIFF
--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -1,7 +1,7 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
-export type StepId = 'content' | 'subscribers' | 'paid-subscribers' | 'summary';
+export type StepId = 'content' | 'subscribers' | 'summary';
 export type StepStatus = 'initial' | 'skipped' | 'importing' | 'done';
 
 export interface ContentStepContent {}

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -4,9 +4,27 @@ import wp from 'calypso/lib/wp';
 export type StepId = 'content' | 'subscribers' | 'summary';
 export type StepStatus = 'initial' | 'skipped' | 'importing' | 'done';
 
-export interface ContentStepContent {}
+interface ContentStepContentProgress {
+	completed: number;
+	total: number;
+}
+
+// FIXME We're actually not using this data in the importing content step...
+export interface ContentStepContent {
+	progress: {
+		attachment: ContentStepContentProgress;
+		comment: ContentStepContentProgress;
+		page: ContentStepContentProgress;
+		post: ContentStepContentProgress;
+	};
+}
 
 export interface SubscribersStepContent {
+	available_tiers?: Product[];
+	connect_url?: string;
+	is_connected_stripe: boolean;
+	map_plans?: Record< string, string >;
+	plans?: Plan[];
 	meta?: {
 		email_count: string;
 		id: number;
@@ -38,14 +56,6 @@ export interface Plan {
 	product_id: string;
 }
 
-export interface PaidSubscribersStepContent {
-	available_tiers: Product[];
-	connect_url?: string;
-	is_connected_stripe: boolean;
-	map_plans: Record< string, string >;
-	plans: Plan[];
-}
-
 export interface SummaryStepContent {}
 
 interface Step< T > {
@@ -56,7 +66,6 @@ interface Step< T > {
 export interface Steps {
 	content: Step< ContentStepContent >;
 	subscribers: Step< SubscribersStepContent >;
-	'paid-subscribers': Step< PaidSubscribersStepContent >;
 	summary: Step< SummaryStepContent >;
 }
 

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -2,7 +2,7 @@ import { Card } from '@automattic/components';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { external } from '@wordpress/icons';
-import { useEffect, Dispatch, SetStateAction } from 'react';
+import { useEffect } from 'react';
 import exportSubstackDataImg from 'calypso/assets/images/importer/export-substack-content.png';
 import importerConfig from 'calypso/lib/importer/importer-config';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
@@ -13,15 +13,14 @@ import { getImporterStatusForSiteId } from 'calypso/state/imports/selectors';
 import FileImporter from './content-upload/file-importer';
 import type { SiteDetails } from '@automattic/data-stores';
 
-type ContentProps = {
+interface ContentProps {
 	nextStepUrl: string;
 	engine: string;
 	selectedSite: SiteDetails;
 	siteSlug: string;
 	fromSite: string;
 	skipNextStep: () => void;
-	setAutoFetchData: Dispatch< SetStateAction< boolean > >;
-};
+}
 
 export default function Content( {
 	nextStepUrl,

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -79,15 +79,20 @@ export default function NewsletterImporter( {
 		paidNewsletterData?.steps,
 	] );
 
-	let currentStepNumber = 0;
-	let nextStepSlug = stepSlugs[ 0 ];
+	const { currentStepNumber, nextStepSlug } = stepSlugs.reduce(
+		function ( result, curr, index ) {
+			if ( curr === step ) {
+				result.currentStepNumber = index;
+				result.nextStepSlug = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
+			}
 
-	stepSlugs.forEach( ( stepName, index ) => {
-		if ( stepName === step ) {
-			currentStepNumber = index;
-			nextStepSlug = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
+			return result;
+		},
+		{
+			currentStepNumber: 0,
+			nextStepSlug: stepSlugs[ 1 ],
 		}
-	} );
+	);
 
 	const { skipNextStep } = useSkipNextStepMutation();
 	const { resetPaidNewsletter, isPending: isResetPaidNewsletterPending } = useResetMutation();

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -23,8 +23,6 @@ import { getSetpProgressSteps } from './utils';
 
 import './importer.scss';
 
-const steps = [ Content, Subscribers, Summary ];
-
 const stepSlugs: StepId[] = [ 'content', 'subscribers', 'summary' ];
 
 const logoChainLogos = [
@@ -107,18 +105,9 @@ export default function NewsletterImporter( {
 		}
 	}, [ urlData, fromSite, engine, selectedSite, resetPaidNewsletter, step, validFromSite ] );
 
-	let stepContent = {};
-	let stepStatus: StatusType = 'initial';
-
-	if ( paidNewsletterData?.steps ) {
-		if ( step === 'summary' ) {
-			stepContent = paidNewsletterData.steps;
-		} else {
-			stepContent = paidNewsletterData.steps[ step ]?.content || {};
-		}
-
-		stepStatus = paidNewsletterData?.steps[ step ]?.status;
-	}
+	const stepContent =
+		step === 'summary' ? paidNewsletterData?.steps : paidNewsletterData?.steps[ step ]?.content;
+	const stepStatus: StatusType = paidNewsletterData?.steps[ step ]?.status || 'initial';
 
 	const stepsProgress = getSetpProgressSteps(
 		engine,
@@ -130,8 +119,6 @@ export default function NewsletterImporter( {
 	const nextStepUrl = addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`, {
 		from: fromSite,
 	} );
-
-	const Step = steps[ stepIndex ];
 
 	return (
 		<div className={ clsx( 'newsletter-importer', 'newsletter-importer__step-' + step ) }>
@@ -150,21 +137,40 @@ export default function NewsletterImporter( {
 				<StepProgress steps={ stepsProgress } currentStep={ stepIndex } />
 			) }
 
-			{ selectedSite && validFromSite && ! isResetPaidNewsletterPending && (
-				<Step
-					siteSlug={ siteSlug }
-					nextStepUrl={ nextStepUrl }
-					selectedSite={ selectedSite }
-					fromSite={ fromSite }
-					skipNextStep={ () => {
-						skipNextStep( selectedSite.ID, engine, nextStep, step );
-					} }
-					cardData={ stepContent }
-					engine={ engine }
-					status={ stepStatus }
-					isFetchingContent={ isFetchingPaidNewsletter }
-					setAutoFetchData={ setAutoFetchData }
-				/>
+			{ selectedSite && validFromSite && ! isResetPaidNewsletterPending && paidNewsletterData && (
+				<>
+					{ step === 'content' && (
+						<Content
+							nextStepUrl={ nextStepUrl }
+							engine={ engine }
+							selectedSite={ selectedSite }
+							fromSite={ fromSite }
+							siteSlug={ siteSlug }
+							skipNextStep={ () => {
+								skipNextStep( selectedSite.ID, engine, nextStep, step );
+							} }
+						/>
+					) }
+					{ step === 'subscribers' && (
+						<Subscribers
+							siteSlug={ siteSlug }
+							nextStepUrl={ nextStepUrl }
+							selectedSite={ selectedSite }
+							fromSite={ fromSite }
+							skipNextStep={ () => {
+								skipNextStep( selectedSite.ID, engine, nextStep, step );
+							} }
+							cardData={ stepContent }
+							engine={ engine }
+							status={ stepStatus }
+							isFetchingContent={ isFetchingPaidNewsletter }
+							setAutoFetchData={ setAutoFetchData }
+						/>
+					) }
+					{ step === 'summary' && (
+						<Summary selectedSite={ selectedSite } steps={ paidNewsletterData.steps } />
+					) }
+				</>
 			) }
 		</div>
 	);

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -97,19 +97,6 @@ export default function NewsletterImporter( {
 
 	const { data: urlData, isFetching } = useAnalyzeUrlQuery( fromSite );
 
-	let stepContent = {};
-	let stepStatus: StatusType = 'initial';
-	if ( paidNewsletterData?.steps ) {
-		// This is useful for the summary step.
-		if ( ! paidNewsletterData?.steps[ step ] ) {
-			stepContent = paidNewsletterData.steps;
-		} else {
-			stepContent = paidNewsletterData.steps[ step ]?.content ?? {};
-		}
-
-		stepStatus = paidNewsletterData?.steps[ step ]?.status;
-	}
-
 	useEffect( () => {
 		if ( urlData?.platform === engine ) {
 			if ( selectedSite && step === stepSlugs[ 0 ] && validFromSite === false ) {
@@ -120,14 +107,26 @@ export default function NewsletterImporter( {
 		}
 	}, [ urlData, fromSite, engine, selectedSite, resetPaidNewsletter, step, validFromSite ] );
 
-	const currentStepSlug = stepSlugs[ stepIndex ];
+	let stepContent = {};
+	let stepStatus: StatusType = 'initial';
+
+	if ( paidNewsletterData?.steps ) {
+		if ( step === 'summary' ) {
+			stepContent = paidNewsletterData.steps;
+		} else {
+			stepContent = paidNewsletterData.steps[ step ]?.content || {};
+		}
+
+		stepStatus = paidNewsletterData?.steps[ step ]?.status;
+	}
+
 	const stepsProgress = getSetpProgressSteps(
 		engine,
 		selectedSite?.slug || '',
 		fromSite,
 		paidNewsletterData
 	);
-	const stepUrl = `/import/newsletter/${ engine }/${ siteSlug }/${ currentStepSlug }`;
+	const stepUrl = `/import/newsletter/${ engine }/${ siteSlug }/${ step }`;
 	const nextStepUrl = addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`, {
 		from: fromSite,
 	} );
@@ -135,12 +134,10 @@ export default function NewsletterImporter( {
 	const Step = steps[ stepIndex ];
 
 	return (
-		<div
-			className={ clsx( 'newsletter-importer', 'newsletter-importer__step-' + currentStepSlug ) }
-		>
+		<div className={ clsx( 'newsletter-importer', 'newsletter-importer__step-' + step ) }>
 			<LogoChain logos={ logoChainLogos } />
-
 			<FormattedHeader headerText={ getTitle( urlData ) } />
+
 			{ ( ! validFromSite || isResetPaidNewsletterPending ) && (
 				<SelectNewsletterForm
 					stepUrl={ stepUrl }

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -116,9 +116,12 @@ export default function NewsletterImporter( {
 		paidNewsletterData
 	);
 	const stepUrl = `/import/newsletter/${ engine }/${ siteSlug }/${ step }`;
-	const nextStepUrl = addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`, {
-		from: fromSite,
-	} );
+	const nextStepUrl = addQueryArgs(
+		`/import/newsletter/${ engine }/${ siteSlug }/${ nextStepSlug }`,
+		{
+			from: fromSite,
+		}
+	);
 
 	return (
 		<div className={ clsx( 'newsletter-importer', 'newsletter-importer__step-' + step ) }>

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -18,7 +18,7 @@ import LogoChain from './logo-chain';
 import SelectNewsletterForm from './select-newsletter-form';
 import Subscribers from './subscribers';
 import Summary from './summary';
-import { EngineTypes, StatusType } from './types';
+import { EngineTypes } from './types';
 import { getSetpProgressSteps } from './utils';
 
 import './importer.scss';
@@ -55,10 +55,6 @@ export default function NewsletterImporter( {
 	const [ validFromSite, setValidFromSite ] = useState( false );
 	const [ autoFetchData, setAutoFetchData ] = useState( false );
 
-	// Steps
-	let stepIndex = 0;
-	let nextStep = stepSlugs[ 0 ];
-
 	const { data: paidNewsletterData, isFetching: isFetchingPaidNewsletter } = usePaidNewsletterQuery(
 		engine,
 		step,
@@ -83,10 +79,13 @@ export default function NewsletterImporter( {
 		paidNewsletterData?.steps,
 	] );
 
+	let currentStepNumber = 0;
+	let nextStepSlug = stepSlugs[ 0 ];
+
 	stepSlugs.forEach( ( stepName, index ) => {
 		if ( stepName === step ) {
-			stepIndex = index;
-			nextStep = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
+			currentStepNumber = index;
+			nextStepSlug = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
 		}
 	} );
 
@@ -104,10 +103,6 @@ export default function NewsletterImporter( {
 			setValidFromSite( true );
 		}
 	}, [ urlData, fromSite, engine, selectedSite, resetPaidNewsletter, step, validFromSite ] );
-
-	const stepContent =
-		step === 'summary' ? paidNewsletterData?.steps : paidNewsletterData?.steps[ step ]?.content;
-	const stepStatus: StatusType = paidNewsletterData?.steps[ step ]?.status || 'initial';
 
 	const stepsProgress = getSetpProgressSteps(
 		engine,
@@ -134,7 +129,7 @@ export default function NewsletterImporter( {
 			) }
 
 			{ validFromSite && ! isResetPaidNewsletterPending && (
-				<StepProgress steps={ stepsProgress } currentStep={ stepIndex } />
+				<StepProgress steps={ stepsProgress } currentStep={ currentStepNumber } />
 			) }
 
 			{ selectedSite && validFromSite && ! isResetPaidNewsletterPending && paidNewsletterData && (
@@ -147,7 +142,7 @@ export default function NewsletterImporter( {
 							fromSite={ fromSite }
 							siteSlug={ siteSlug }
 							skipNextStep={ () => {
-								skipNextStep( selectedSite.ID, engine, nextStep, step );
+								skipNextStep( selectedSite.ID, engine, nextStepSlug, step );
 							} }
 						/>
 					) }
@@ -158,11 +153,11 @@ export default function NewsletterImporter( {
 							selectedSite={ selectedSite }
 							fromSite={ fromSite }
 							skipNextStep={ () => {
-								skipNextStep( selectedSite.ID, engine, nextStep, step );
+								skipNextStep( selectedSite.ID, engine, nextStepSlug, step );
 							} }
-							cardData={ stepContent }
+							cardData={ paidNewsletterData.steps[ step ]?.content }
 							engine={ engine }
-							status={ stepStatus }
+							status={ paidNewsletterData.steps[ step ]?.status || 'initial' }
 							isFetchingContent={ isFetchingPaidNewsletter }
 							setAutoFetchData={ setAutoFetchData }
 						/>

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -2,7 +2,7 @@ import StepDone from './subscribers/step-done';
 import StepImporting from './subscribers/step-importing';
 import StepInitial from './subscribers/step-initial';
 import StepPending from './subscribers/step-pending';
-import { StepProps } from './types';
+import { SubscribersStepProps } from './types';
 
 export default function Subscribers( {
 	nextStepUrl,
@@ -15,7 +15,7 @@ export default function Subscribers( {
 	cardData,
 	engine,
 	setAutoFetchData,
-}: StepProps ) {
+}: SubscribersStepProps ) {
 	// The default step
 	let Step = StepInitial;
 	switch ( status ) {

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers.tsx
@@ -2,7 +2,7 @@ import { hasQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
 import { useDispatch } from 'calypso/state';
 import { infoNotice, successNotice } from 'calypso/state/notices/actions';
-import { StepProps } from '../types';
+import { SubscribersStepProps } from '../types';
 import ConnectStripe from './paid-subscribers/connect-stripe';
 import MapPlans from './paid-subscribers/map-plans';
 
@@ -17,7 +17,7 @@ export default function PaidSubscribers( {
 	engine,
 	setAutoFetchData,
 	status,
-}: StepProps ) {
+}: SubscribersStepProps ) {
 	const dispatch = useDispatch();
 	const isCancelled = hasQueryArg( window.location.href, 'stripe_connect_cancelled' );
 	const isSuccess = hasQueryArg( window.location.href, 'stripe_connect_success' );

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -4,7 +4,7 @@ import StripeLogo from 'calypso/assets/images/jetpack/stripe-logo-white.svg';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ImporterActionButton from '../../../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../../../importer-action-buttons/container';
-import { StepProps } from '../../types';
+import { SubscribersStepProps } from '../../types';
 
 /**
  * Update the connect URL with the from_site and engine parameters.
@@ -28,7 +28,7 @@ export default function ConnectStripe( {
 	fromSite,
 	engine,
 	isFetchingContent,
-}: StepProps ) {
+}: SubscribersStepProps ) {
 	if ( isFetchingContent || cardData?.connect_url === undefined ) {
 		return null;
 	}

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
@@ -12,7 +12,7 @@ import {
 import { Product } from 'calypso/my-sites/earn/types';
 import { useSelector } from 'calypso/state';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
-import { StepProps } from '../../types';
+import { SubscribersStepProps } from '../../types';
 import StartImportButton from './../start-import-button';
 import { MapPlan, TierToAdd } from './map-plan';
 
@@ -54,7 +54,7 @@ export default function MapPlans( {
 	engine,
 	siteSlug,
 	fromSite,
-}: StepProps ) {
+}: SubscribersStepProps ) {
 	const [ productToAdd, setProductToAdd ] = useState< TierToAdd | null >( null );
 
 	const currentStep = 'subscribers';

--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -5,7 +5,7 @@ import { useSelect } from '@wordpress/data';
 import { external } from '@wordpress/icons';
 import { useEffect, useRef } from 'react';
 import exportSubstackSubscribersImg from 'calypso/assets/images/importer/export-substack-subscribers.png';
-import { StepProps } from '../types';
+import { SubscribersStepProps } from '../types';
 import SubscriberUploadForm from './upload-form';
 
 export default function StepInitial( {
@@ -16,7 +16,7 @@ export default function StepInitial( {
 	cardData,
 	engine,
 	setAutoFetchData,
-}: StepProps ) {
+}: SubscribersStepProps ) {
 	const { importSelector } = useSelect( ( select ) => {
 		const subscriber = select( Subscriber.store );
 		return {

--- a/client/my-sites/importer/newsletter/subscribers/step-pending.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-pending.tsx
@@ -4,7 +4,7 @@ import { toInteger } from 'lodash';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../../importer-action-buttons/container';
-import { StepProps } from '../types';
+import { SubscribersStepProps } from '../types';
 import PaidSubscribers from './paid-subscribers';
 import StartImportButton from './start-import-button';
 
@@ -19,7 +19,7 @@ export default function StepPending( {
 	isFetchingContent,
 	setAutoFetchData,
 	status,
-}: StepProps ) {
+}: SubscribersStepProps ) {
 	const allEmailsCount = toInteger( cardData?.meta?.email_count ) || 0;
 
 	return (

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -1,29 +1,32 @@
 import { Card, ConfettiAnimation } from '@automattic/components';
+import { SiteDetails } from '@automattic/data-stores';
 import { Steps, StepStatus } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import ImporterActionButton from '../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../importer-action-buttons/container';
 import ContentSummary from './summary/content';
 import SubscribersSummary from './summary/subscribers';
-import { StepProps } from './types';
 
-function getImporterStatus( steps: Steps ): StepStatus {
-	if ( steps.content.status === 'done' && steps.subscribers.status === 'done' ) {
+function getImporterStatus(
+	contentStepStatus: StepStatus,
+	subscribersStepStatus: StepStatus
+): StepStatus {
+	if ( contentStepStatus === 'done' && subscribersStepStatus === 'done' ) {
 		return 'done';
 	}
 
-	if ( steps.content.status === 'done' && steps.subscribers.status === 'skipped' ) {
+	if ( contentStepStatus === 'done' && subscribersStepStatus === 'skipped' ) {
 		return 'done';
 	}
 
-	if ( steps.content.status === 'skipped' && steps.subscribers.status === 'done' ) {
+	if ( contentStepStatus === 'skipped' && subscribersStepStatus === 'done' ) {
 		return 'done';
 	}
 
-	if ( steps.content.status === 'skipped' && steps.subscribers.status === 'skipped' ) {
+	if ( contentStepStatus === 'skipped' && subscribersStepStatus === 'skipped' ) {
 		return 'skipped';
 	}
 
-	if ( steps.content.status === 'importing' || steps.subscribers.status === 'importing' ) {
+	if ( contentStepStatus === 'importing' || subscribersStepStatus === 'importing' ) {
 		return 'importing';
 	}
 
@@ -42,18 +45,23 @@ function getStepTitle( importerStatus: StepStatus ) {
 	return 'Summary';
 }
 
-export default function Summary( { cardData, selectedSite }: StepProps ) {
+interface SummaryProps {
+	selectedSite: SiteDetails;
+	steps: Steps;
+}
+
+export default function Summary( { steps, selectedSite }: SummaryProps ) {
 	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
-	const importerStatus = getImporterStatus( cardData );
+	const importerStatus = getImporterStatus( steps.content.status, steps.subscribers.status );
 
 	return (
 		<Card>
 			{ importerStatus === 'done' && <ConfettiAnimation trigger={ ! prefersReducedMotion } /> }
 			<h2>{ getStepTitle( importerStatus ) }</h2>
-			<ContentSummary cardData={ cardData.content.content } status={ cardData.content.status } />
+			<ContentSummary cardData={ steps.content.content } status={ steps.content.status } />
 			<SubscribersSummary
-				cardData={ cardData.subscribers.content }
-				status={ cardData.subscribers.status }
+				cardData={ steps.subscribers.content }
+				status={ steps.subscribers.status }
 			/>
 			<ImporterActionButtonContainer noSpacing>
 				<ImporterActionButton href={ '/settings/newsletter/' + selectedSite.slug } primary>

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -58,11 +58,16 @@ export default function Summary( { steps, selectedSite }: SummaryProps ) {
 		<Card>
 			{ importerStatus === 'done' && <ConfettiAnimation trigger={ ! prefersReducedMotion } /> }
 			<h2>{ getStepTitle( importerStatus ) }</h2>
-			<ContentSummary cardData={ steps.content.content } status={ steps.content.status } />
-			<SubscribersSummary
-				cardData={ steps.subscribers.content }
-				status={ steps.subscribers.status }
-			/>
+			{ steps.content.content && (
+				<ContentSummary stepContent={ steps.content.content } status={ steps.content.status } />
+			) }
+			{ steps.subscribers.content && (
+				<SubscribersSummary
+					stepContent={ steps.subscribers.content }
+					status={ steps.subscribers.status }
+				/>
+			) }
+
 			<ImporterActionButtonContainer noSpacing>
 				<ImporterActionButton href={ '/settings/newsletter/' + selectedSite.slug } primary>
 					Customize your newsletter

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -5,33 +5,7 @@ import ImporterActionButton from '../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../importer-action-buttons/container';
 import ContentSummary from './summary/content';
 import SubscribersSummary from './summary/subscribers';
-
-function getImporterStatus(
-	contentStepStatus: StepStatus,
-	subscribersStepStatus: StepStatus
-): StepStatus {
-	if ( contentStepStatus === 'done' && subscribersStepStatus === 'done' ) {
-		return 'done';
-	}
-
-	if ( contentStepStatus === 'done' && subscribersStepStatus === 'skipped' ) {
-		return 'done';
-	}
-
-	if ( contentStepStatus === 'skipped' && subscribersStepStatus === 'done' ) {
-		return 'done';
-	}
-
-	if ( contentStepStatus === 'skipped' && subscribersStepStatus === 'skipped' ) {
-		return 'skipped';
-	}
-
-	if ( contentStepStatus === 'importing' || subscribersStepStatus === 'importing' ) {
-		return 'importing';
-	}
-
-	return 'initial';
-}
+import { getImporterStatus } from './utils';
 
 function getStepTitle( importerStatus: StepStatus ) {
 	if ( importerStatus === 'done' ) {

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -1,4 +1,5 @@
 import { Icon, post } from '@wordpress/icons';
+import { ContentStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
 function getSummaryCopy( postsNumber: number, pagesNumber: number, attachmentsNumber: number ) {
 	if ( postsNumber > 0 && pagesNumber > 0 && attachmentsNumber > 0 ) {
@@ -63,12 +64,12 @@ function getSummaryCopy( postsNumber: number, pagesNumber: number, attachmentsNu
 	}
 }
 
-type Props = {
-	cardData: any;
+interface ContentSummaryProps {
+	stepContent: ContentStepContent;
 	status: string;
-};
+}
 
-export default function ContentSummary( { status, cardData }: Props ) {
+export default function ContentSummary( { status, stepContent }: ContentSummaryProps ) {
 	if ( status === 'skipped' ) {
 		return (
 			<div className="summary__content">
@@ -93,7 +94,7 @@ export default function ContentSummary( { status, cardData }: Props ) {
 	}
 
 	if ( status === 'done' ) {
-		const progress = cardData.progress;
+		const progress = stepContent.progress;
 
 		return (
 			<div className="summary__content">

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -2,31 +2,64 @@ import { Icon, post } from '@wordpress/icons';
 
 function getSummaryCopy( postsNumber: number, pagesNumber: number, attachmentsNumber: number ) {
 	if ( postsNumber > 0 && pagesNumber > 0 && attachmentsNumber > 0 ) {
-		return `We imported ${ postsNumber } posts, ${ pagesNumber } pages and ${ attachmentsNumber } media.`;
+		return (
+			<>
+				We imported <strong>{ postsNumber } posts</strong>, <strong>{ pagesNumber } pages</strong>{ ' ' }
+				and
+				<strong>{ attachmentsNumber } media</strong>.
+			</>
+		);
 	}
 
 	if ( postsNumber > 0 && pagesNumber > 0 ) {
-		return `We imported ${ postsNumber } posts and ${ pagesNumber } pages`;
+		return (
+			<>
+				We imported <strong>{ postsNumber } posts</strong> and{ ' ' }
+				<strong>{ pagesNumber } pages</strong>.
+			</>
+		);
 	}
 
 	if ( postsNumber > 0 && attachmentsNumber > 0 ) {
-		return `We imported ${ postsNumber } posts and ${ attachmentsNumber } media`;
+		return (
+			<>
+				We imported <strong>{ postsNumber } posts</strong> and{ ' ' }
+				<strong>{ attachmentsNumber } media</strong>.
+			</>
+		);
 	}
 
 	if ( pagesNumber > 0 && attachmentsNumber > 0 ) {
-		return `We imported ${ postsNumber } pages and ${ attachmentsNumber } media`;
+		return (
+			<>
+				We imported <strong>{ postsNumber }</strong> pages and{ ' ' }
+				<strong>{ attachmentsNumber } media</strong>.
+			</>
+		);
 	}
 
 	if ( postsNumber > 0 ) {
-		return `We imported ${ postsNumber } posts.`;
+		return (
+			<>
+				We imported <strong>{ postsNumber } posts</strong>.
+			</>
+		);
 	}
 
 	if ( pagesNumber > 0 ) {
-		return `We imported ${ postsNumber } pages.`;
+		return (
+			<>
+				We imported <strong>{ postsNumber } pages</strong>.
+			</>
+		);
 	}
 
 	if ( attachmentsNumber > 0 ) {
-		return `We imported ${ postsNumber } media.`;
+		return (
+			<>
+				We imported <strong>{ postsNumber } media</strong>.
+			</>
+		);
 	}
 }
 

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,13 +1,14 @@
 import { Icon, people, currencyDollar, atSymbol } from '@wordpress/icons';
+import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
-type Props = {
-	cardData: any;
+interface SubscriberSummaryProps {
+	stepContent: SubscribersStepContent;
 	status: string;
-};
+}
 
-export default function SubscriberSummary( { cardData, status }: Props ) {
-	const paidSubscribers = cardData?.meta?.paid_subscribers_count ?? 0;
-	const hasPaidSubscribers = parseInt( paidSubscribers ) > 0;
+export default function SubscriberSummary( { stepContent, status }: SubscriberSummaryProps ) {
+	const paidSubscribers = parseInt( stepContent?.meta?.paid_subscribers_count || '0' );
+	const hasPaidSubscribers = paidSubscribers > 0;
 
 	if ( status === 'skipped' ) {
 		return (
@@ -33,20 +34,21 @@ export default function SubscriberSummary( { cardData, status }: Props ) {
 	}
 
 	if ( status === 'done' ) {
-		const paid_subscribers = cardData?.meta?.paid_subscribers_count ?? 0;
-		const free_subscribers = cardData?.meta?.subscribed_count - paid_subscribers;
+		const paidSubscribersCount = parseInt( stepContent.meta?.paid_subscribers_count || '0' );
+		const subscribedCount = parseInt( stepContent.meta?.subscribed_count || '0' );
+		const freeSubscribersCount = subscribedCount - paidSubscribersCount;
 
 		return (
 			<div className="summary__content">
-				<p>We migrated { cardData.meta.subscribed_count } subscribers</p>
+				<p>We migrated { subscribedCount } subscribers</p>
 				<p>
 					<Icon icon={ people } />
-					<strong>{ free_subscribers }</strong> free subscribers
+					<strong>{ freeSubscribersCount }</strong> free subscribers
 				</p>
 				{ hasPaidSubscribers && (
 					<p>
 						<Icon icon={ currencyDollar } />
-						<strong>{ cardData.meta.paid_subscribers_count }</strong> paid subscribers
+						<strong>{ paidSubscribersCount }</strong> paid subscribers
 					</p>
 				) }
 			</div>

--- a/client/my-sites/importer/newsletter/types.ts
+++ b/client/my-sites/importer/newsletter/types.ts
@@ -6,10 +6,10 @@ export type EngineTypes = 'substack';
 
 export type StatusType = 'initial' | 'done' | 'pending' | 'skipped' | 'importing';
 
-export type StepProps = {
+export interface SubscribersStepProps {
 	cardData: any;
 	status: StatusType;
-	engine: EngineTypes;
+	engine: 'substack';
 	fromSite: QueryArgParsed;
 	isFetchingContent: boolean;
 	nextStepUrl: string;
@@ -17,4 +17,4 @@ export type StepProps = {
 	setAutoFetchData: Dispatch< SetStateAction< boolean > >;
 	siteSlug: string;
 	skipNextStep: () => void;
-};
+}

--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -25,7 +25,7 @@ export function getSetpProgressSteps(
 	engine: string,
 	selectedSiteSlug: string,
 	fromSite: string,
-	paidNewsletterData: PaidNewsletterData
+	paidNewsletterData?: PaidNewsletterData
 ) {
 	const result: ClickHandler[] = [
 		{

--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -25,7 +25,7 @@ export function getSetpProgressSteps(
 	engine: string,
 	selectedSiteSlug: string,
 	fromSite: string,
-	paidNewsletterData?: PaidNewsletterData
+	paidNewsletterData: PaidNewsletterData
 ) {
 	const result: ClickHandler[] = [
 		{
@@ -55,8 +55,41 @@ export function getSetpProgressSteps(
 		{
 			message: 'Summary',
 			onClick: noop,
+			indicator: getStepProgressIndicator(
+				getImporterStatus(
+					paidNewsletterData?.steps.content.status,
+					paidNewsletterData?.steps.subscribers.status
+				)
+			),
 		},
 	];
 
 	return result;
+}
+
+export function getImporterStatus(
+	contentStepStatus?: StepStatus,
+	subscribersStepStatus?: StepStatus
+): StepStatus {
+	if ( contentStepStatus === 'done' && subscribersStepStatus === 'done' ) {
+		return 'done';
+	}
+
+	if ( contentStepStatus === 'done' && subscribersStepStatus === 'skipped' ) {
+		return 'done';
+	}
+
+	if ( contentStepStatus === 'skipped' && subscribersStepStatus === 'done' ) {
+		return 'done';
+	}
+
+	if ( contentStepStatus === 'skipped' && subscribersStepStatus === 'skipped' ) {
+		return 'skipped';
+	}
+
+	if ( contentStepStatus === 'importing' || subscribersStepStatus === 'importing' ) {
+		return 'importing';
+	}
+
+	return 'initial';
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

It:
- makes some things more clear (hopefully)
- adds some missing types
- improves copy on the summary step (again)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
