### PR TITLE
A4A: update footer checkout wording

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -88,7 +88,12 @@ export default function NoticeSummary( { type }: Props ) {
 						}
 					),
 					translate(
-						'You will be billed on the first of every month. Your first bill will include a prorated amount for the current month, depending on which day you purchased these products. '
+						"{{strong}}You won't be billed today.{{/strong}} Invoices are sent on the first of every month and are based on the number of days your product licenses were active in the previous month. Your first invoice will be prorated.",
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
 					),
 				];
 			case 'request-client-payment':


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/939

## Proposed Changes

In order to reduce users confusion we are updating wording on Checkout footer pages for both, Regualar Purchases as well as referral purchases.

| Before | After |
| ---- | ---- |
| <img width="450" alt="Screenshot 2024-09-17 at 10 09 30 AM" src="https://github.com/user-attachments/assets/82f21fa1-2a77-4288-b6fe-59d5feb76285"> | <img width="343" alt="Screenshot 2024-09-17 at 9 58 43 AM" src="https://github.com/user-attachments/assets/1480d287-3f1a-48b6-9092-de4c0cb61bc9"> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below
- Navigate to marketplace`/marketplace/products`
- Add some products to the cart and navigate to checkout. Check the wording.
- In the marketplace `/marketplace/products`, make a referral (to client email).
- Using client logic, follow the referral to checkout and check the wording 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
