### PR TITLE
Themes - fix issue with false upgrade CTA for some free themes.

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1546,7 +1546,9 @@ const ThemeSheetWithOptions = ( props ) => {
 		! ( isSiteWooExpressFreeTrial && isThemeBundleWooCommerce )
 	) {
 		defaultOption = 'upgradePlanForBundledThemes';
-	} else if ( themeTier === 'community' && ! canInstallThemes ) {
+	}
+	// isWporgTheme is true for some free themes we offer, so we need to check the tier instead.
+	else if ( themeTier === 'community' && ! canInstallThemes ) {
 		defaultOption = 'upgradePlanForDotOrgThemes';
 	} else {
 		defaultOption = 'activate';

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1502,7 +1502,6 @@ const ThemeSheetWithOptions = ( props ) => {
 		isPremium,
 		isThemePurchased,
 		isStandaloneJetpack,
-		isWporg,
 		demoUrl,
 		showTryAndCustomize,
 		isThemeInstalled,
@@ -1514,7 +1513,7 @@ const ThemeSheetWithOptions = ( props ) => {
 		isThemeBundleWooCommerce,
 	} = props;
 	const isThemeAllowed = useIsThemeAllowedOnSite( siteId, props.themeId );
-
+	const themeTier = useThemeTierForTheme( props.themeId );
 	let defaultOption;
 	let secondaryOption = 'tryandcustomize';
 	const needsJetpackPlanUpgrade = isStandaloneJetpack && isPremium && ! isThemePurchased;
@@ -1547,13 +1546,11 @@ const ThemeSheetWithOptions = ( props ) => {
 		! ( isSiteWooExpressFreeTrial && isThemeBundleWooCommerce )
 	) {
 		defaultOption = 'upgradePlanForBundledThemes';
-	} else if ( isWporg && ! canInstallThemes ) {
+	} else if ( themeTier === 'community' && ! canInstallThemes ) {
 		defaultOption = 'upgradePlanForDotOrgThemes';
 	} else {
 		defaultOption = 'activate';
 	}
-
-	const themeTier = useThemeTierForTheme( props.themeId );
 
 	return (
 		<ConnectedThemeSheet


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/94616

a regression from https://github.com/Automattic/wp-calypso/pull/94505

## Proposed Changes

Fixes an issue where free themes we offer that are also on dotorg require plan upgrade when they shouldn't.
* Changes the condition for prompting the upgrade for community themes to check the theme Tier instead of the isWporgTheme selector. The theme tier makes the most sense here as its more of a feature group. The isWporgTheme selector seems to be working as expected as the free themes in question are also Wporg themes, we just happen to also offer theme as free tier themes as well.


BEFORE (free plan)
<img width="625" alt="Screenshot 2024-09-17 at 2 02 58 PM" src="https://github.com/user-attachments/assets/879b0813-4513-4e87-96b5-e2d5f306f362">



AFTER (free plan)
<img width="597" alt="Screenshot 2024-09-17 at 2 02 04 PM" src="https://github.com/user-attachments/assets/3fb0dc69-e33b-43e2-befe-aeb8e9869989">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* the theme is free, there is no requirement to upgrade

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to */themes at the global level
* find Blask
* click the CTA and select a free site to activate that theme one
* at the individual theme page for the site, verify you can activate and are not prompted to upgrade.
* goto a community theme for the free site (such as Vividmono), verify the CTA is to upgrade since this requires the installation feature.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
