### PR TITLE
Purchases: Remove Advertising Card for Domain-Only Sites

### DIFF
--- a/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
+++ b/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
@@ -3,15 +3,20 @@ import { useTranslate } from 'i18n-calypso';
 import { PromoteWidgetStatus, usePromoteWidget } from 'calypso/lib/promote-post';
 import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export default function AccountLevelAdvertisingLinks() {
 	const translate = useTranslate();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+
 	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 	const advertisingUrl = useAdvertisingUrl();
 
-	if ( ! shouldShowAdvertisingOption || ! selectedSiteSlug ) {
+	const isDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, selectedSiteId ) );
+
+	if ( ! shouldShowAdvertisingOption || ! selectedSiteSlug || isDomainOnly ) {
 		return null;
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Removes the "View advertising campaigns" link for domain-only sites. 

## Why are these changes being made?

* Domain-only sites aren't able to launch an advertising campaign (the link doesn't work on this site currently, so it just defaults back to Calypso's opening page). 

## Testing Instructions

Go to `/purchases/subscriptions/example.com` and verify that "View advertising campaigns" no longer appears on a domain-only site, but that it does on normal sites. 

<img width="1126" alt="Screenshot 2024-09-17 at 19 06 12" src="https://github.com/user-attachments/assets/8af559d5-0959-4666-b57b-006f640d9a7a">

cc @michaeldcain, @sirbrillig 