### PR TITLE
POC: Add 'migration' as site_intent option

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Site } from '@automattic/data-stores';
 import { FREE_THEME } from '@automattic/design-picker';
 import {
@@ -205,7 +206,11 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			};
 		}
 
-		const siteIntent = isMigrationSignupFlow( flow ) ? 'migration' : '';
+		const siteIntent =
+			config.isEnabled( 'migration-flow/enable-white-labeled-plugin' ) &&
+			isMigrationSignupFlow( flow )
+				? 'migration'
+				: '';
 
 		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
 		const site = await createSiteWithCart(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -205,6 +205,8 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			};
 		}
 
+		const siteIntent = isMigrationSignupFlow( flow ) ? 'migration' : '';
+
 		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
 		const site = await createSiteWithCart(
 			flow,
@@ -222,7 +224,8 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			mergedDomainCartItems,
 			siteUrl,
 			domainItem,
-			sourceSlug
+			sourceSlug,
+			siteIntent
 		);
 
 		if ( preselectedThemeSlug && site?.siteSlug ) {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -29,6 +29,7 @@ interface GetNewSiteParams {
 	siteVisibility: Site.Visibility;
 	username: string;
 	sourceSlug?: string;
+	siteIntent?: string;
 }
 
 type NewSiteParams = {
@@ -49,6 +50,7 @@ type NewSiteParams = {
 		timezone_string?: string;
 		wpcom_public_coming_soon: 0 | 1;
 		site_accent_color?: string;
+		site_intent?: string;
 	};
 	validate: boolean;
 };
@@ -105,6 +107,7 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 		useThemeHeadstart = false,
 		siteVisibility,
 		sourceSlug,
+		siteIntent,
 	} = params;
 
 	// We will use the default annotation instead of theme annotation as fallback,
@@ -127,6 +130,7 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 			...( sourceSlug && { site_source_slug: sourceSlug } ),
 			...( siteAccentColor && { site_accent_color: siteAccentColor } ),
 			...( themeSlugWithRepo && { theme: themeSlugWithRepo } ),
+			...( siteIntent && { site_intent: siteIntent } ),
 		},
 		validate: false,
 	};
@@ -147,7 +151,8 @@ export const createSiteWithCart = async (
 	domainCartItems: MinimalRequestCartProduct[],
 	storedSiteUrl?: string,
 	domainItem?: DomainSuggestion,
-	sourceSlug?: string
+	sourceSlug?: string,
+	siteIntent?: string
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );
@@ -163,6 +168,7 @@ export const createSiteWithCart = async (
 		siteVisibility,
 		username,
 		sourceSlug,
+		siteIntent,
 	} );
 
 	// if ( isEmpty( bearerToken ) && 'onboarding-registrationless' === flowToCheck ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94638

## Proposed Changes

* Mark sites that come through the migration flow with the `migration` `site_intent` so we can access that property on the backend to determine whether to install the new software.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to distinguish sites that come through the migration flow on the backend so we know when to install the new white-labeled plugin. This proposes we use an established site option, `site_intent`, with a unique value to do so.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/setup/migration-signup?flags=migration-flow/enable-white-labeled-plugin`
* A new site should be created; grab the new site's address from the URL and get its ID
* `wpsh` into your sandbox, then `switch_to_blog( NEW_BLOG_ID );` and `echo get_option( 'site_intent' );`
* You should see `migration` printed.

<img width="597" alt="Screenshot 2024-09-17 at 3 28 27 PM" src="https://github.com/user-attachments/assets/ab0f18cd-2a93-4700-b134-78baea2d4881">

* Go through the flow without the flag enabled. Repeat the check and you should not see a `site_intent` defined.
* Go through a different flow (like from `/start`). You should not see the `site_intent` defined when the site is created.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
