### PR TITLE
Paid Newsletter: Show subscriber import error

### DIFF
--- a/client/my-sites/importer/newsletter/subscribers/import-subscribers-error.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/import-subscribers-error.tsx
@@ -10,10 +10,15 @@ export default function PaidImportSubscribersError( { error }: Props ) {
 	const HANDLED_ERROR = {
 		IMPORT_LIMIT: 'subscriber_import_limit_reached',
 		IMPORT_BLOCKED: 'blocked_import',
+		IMPORT_RUNNING: 'import_running',
+		MISSING_ARGS: 'missing_arguments',
+		EMPTY_CSV_FILE: 'empty_csv_file',
+		CSV_UPLOAD_ERROR: 'csv_upload_error',
+		CSV_INVALID_TYPE: 'csv_invalid_type',
 	};
 
 	return (
-		<FormInputValidation icon="warning" isError={ false } isWarning>
+		<FormInputValidation icon="warning" isError={ false } isWarning text="">
 			<Icon icon={ warning } />
 			{ ( (): React.ReactNode => {
 				switch ( error.code ) {
@@ -22,6 +27,13 @@ export default function PaidImportSubscribersError( { error }: Props ) {
 
 					case HANDLED_ERROR.IMPORT_BLOCKED:
 						return 'We ran into a security issue with your subscriber list. It’s nothing to worry about. If you reach out to our support team when you’ve finished setting things up, they’ll help resolve this for you.';
+					case HANDLED_ERROR.IMPORT_RUNNING:
+						return 'An subscriber import has already started. Please wait till that one finished before starting a new one.';
+					case HANDLED_ERROR.MISSING_ARGS:
+					case HANDLED_ERROR.EMPTY_CSV_FILE:
+					case HANDLED_ERROR.CSV_UPLOAD_ERROR:
+					case HANDLED_ERROR.CSV_INVALID_TYPE:
+						return 'Please double check your CSV file to make sure that it contains emails.';
 
 					default:
 						return typeof error.message === 'string' ? error.message : '';

--- a/client/my-sites/importer/newsletter/subscribers/import-subscribers-error.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/import-subscribers-error.tsx
@@ -1,0 +1,32 @@
+import { FormInputValidation } from '@automattic/components';
+import { Subscriber } from '@automattic/data-stores';
+import { Icon, warning } from '@wordpress/icons';
+
+type Props = {
+	error: Subscriber.ImportSubscribersError;
+};
+
+export default function PaidImportSubscribersError( { error }: Props ) {
+	const HANDLED_ERROR = {
+		IMPORT_LIMIT: 'subscriber_import_limit_reached',
+		IMPORT_BLOCKED: 'blocked_import',
+	};
+
+	return (
+		<FormInputValidation icon="warning" isError={ false } isWarning>
+			<Icon icon={ warning } />
+			{ ( (): React.ReactNode => {
+				switch ( error.code ) {
+					case HANDLED_ERROR.IMPORT_LIMIT:
+						return 'We couldn’t import your subscriber list as you’ve hit the 100 email limit for our free plan. The good news? You can upload a list of any size after upgrading to any paid plan.';
+
+					case HANDLED_ERROR.IMPORT_BLOCKED:
+						return 'We ran into a security issue with your subscriber list. It’s nothing to worry about. If you reach out to our support team when you’ve finished setting things up, they’ll help resolve this for you.';
+
+					default:
+						return typeof error.message === 'string' ? error.message : '';
+				}
+			} )() }
+		</FormInputValidation>
+	);
+}

--- a/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
@@ -10,6 +10,7 @@ import FilePicker from 'calypso/components/file-picker';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../../importer-action-buttons/container';
+import ImportSubscribersError from './import-subscribers-error';
 
 type Props = {
 	nextStepUrl: string;
@@ -91,12 +92,16 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 					) }
 				</FilePicker>
 			</div>
-			{ isSelectedFileValid && selectedFile && (
+
+			{ isSelectedFileValid && selectedFile && ! importSelector?.error && (
 				<p>
 					By clicking "Continue," you represent that you've obtained the appropriate consent to
 					email each person. <a href={ localizeUrl( importSubscribersUrl ) }>Learn more</a>.
 				</p>
 			) }
+
+			{ importSelector?.error && <ImportSubscribersError error={ importSelector?.error } /> }
+
 			<ImporterActionButtonContainer noSpacing>
 				<ImporterActionButton
 					type="submit"
@@ -104,7 +109,7 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 					onClick={ () => {
 						recordTracksEvent( 'calypso_paid_importer_add_subscriber' );
 					} }
-					disabled={ ! ( isSelectedFileValid && selectedFile ) }
+					disabled={ ! ( ( isSelectedFileValid && selectedFile ) || importSelector?.error ) }
 				>
 					Continue
 				</ImporterActionButton>


### PR DESCRIPTION
This Pr Shows errors that folks might see when the go thought the subscriber import process. 

After:

<img width="794" alt="Screenshot 2024-09-17 at 10 17 53 AM" src="https://github.com/user-attachments/assets/a56eb64b-25a8-4e78-9e99-a913d5e5e5d8">

<img width="735" alt="Screenshot 2024-09-17 at 9 43 40 AM" src="https://github.com/user-attachments/assets/28b89d1d-09d1-45a9-b40b-dfabae0d811c">

## Why are these changes being made?
* They are done so that folks going thought the subscriber import process see meaningful errors. 

 
## Testing Instructions

* Upload a file that is a CSV but doesn't contain any email addresses. 
* Upload a file with lots of email rows. more then a 100 but you are on a free plan. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
