### PR TITLE
Help: Fix Links for Writing Settings

### DIFF
--- a/packages/data-stores/src/contextual-help/admin-sections.ts
+++ b/packages/data-stores/src/contextual-help/admin-sections.ts
@@ -249,7 +249,7 @@ export function generateAdminSections(
 		},
 		{
 			title: __( 'Manage post categories', __i18n_text_domain__ ),
-			link: `/settings/writing/${ siteSlug }`,
+			link: `/settings/taxonomies/category/${ siteSlug }`,
 			synonyms: [ 'post', 'category' ],
 			icon: 'cog',
 		},
@@ -261,7 +261,7 @@ export function generateAdminSections(
 		},
 		{
 			title: __( 'Set up a podcast', __i18n_text_domain__ ),
-			link: `/settings/writing/${ siteSlug }#podcasting-details__link-header`,
+			link: `/settings/podcasting/${ siteSlug }`,
 			synonyms: [ 'podcast', 'radio', 'audio' ],
 			icon: 'cog',
 		},


### PR DESCRIPTION
## Proposed Changes

* Fixes the links for two `/settings/writing` items which currently are incorrect. 

## Why are these changes being made?

The two links are wrong, and have no options under Settings > Writing.  

- Categories should be accessed under `/settings/taxonomies/category/`. I believe that's always been the case.
- Podcasts were more recently moved to `/settings/podcasting`. 

## Testing Instructions

Search for these two links under "Get help" on the My Home section, and confirm that the new links are correct.

<img width="745" alt="Screenshot 2024-09-17 at 20 40 58" src="https://github.com/user-attachments/assets/7f805fbb-4c9e-4bc5-9eb6-3f986a8d9db5">

cc @escapemanuele, @arcangelini 