### PR TITLE
Redirect user to wp-admin when a site has the “Classic style” after the /hosting flow purchase

### DIFF
--- a/client/landing/stepper/declarative-flow/test/transferring-hosted-site-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/transferring-hosted-site-flow.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { waitFor } from '@testing-library/react';
+import transferringHostedSite from '../transferring-hosted-site-flow';
+import { getFlowLocation, renderFlow } from './helpers';
+
+// we need to save the original object for later to not affect tests from other files
+const originalLocation = window.location;
+let mockIsAdminInterfaceWPAdminMock = true;
+const mockSiteId = 123;
+
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	isAdminInterfaceWPAdmin: jest.fn( () => mockIsAdminInterfaceWPAdminMock ),
+} ) );
+jest.mock( '../../hooks/use-site-id-param', () => ( {
+	useSiteIdParam: jest.fn( () => mockSiteId ),
+} ) );
+
+jest.mock( '@wordpress/data', () => {
+	const actualModule = jest.requireActual( '@wordpress/data' );
+
+	return new Proxy( actualModule, {
+		get: ( target, property ) => {
+			switch ( property ) {
+				case 'useSelect': {
+					return jest.fn( () => {
+						return {
+							options: {
+								admin_url: 'https://mysite.com/wp-admin',
+							},
+						};
+					} );
+				}
+				// fallback to the original module
+				default: {
+					return target[ property ];
+				}
+			}
+		},
+	} );
+} );
+
+describe( 'Transferring hosted site flow submit redirects', () => {
+	beforeAll( () => {
+		Object.defineProperty( window, 'location', {
+			value: { ...originalLocation, assign: jest.fn() },
+		} );
+	} );
+
+	describe( 'navigation', () => {
+		const { runUseStepNavigationSubmit } = renderFlow( transferringHostedSite );
+
+		it( 'redirects the user to the wp-admin when isAdminInterfaceWPAdmin', async () => {
+			runUseStepNavigationSubmit( {
+				currentURL: '/setup/hosted-site-migration',
+				currentStep: 'processing',
+				dependencies: {
+					action: 'continue',
+					platform: 'wordpress',
+					from: 'https://site-to-be-migrated.com',
+				},
+			} );
+
+			await waitFor( () => {
+				expect( getFlowLocation() ).toEqual( {
+					path: `/setup/hosted-site-migration`,
+					state: null,
+				} );
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith( 'https://mysite.com/wp-admin' );
+		} );
+
+		it( 'redirects the user to the /home when is not wp-admin', async () => {
+			mockIsAdminInterfaceWPAdminMock = false;
+
+			runUseStepNavigationSubmit( {
+				currentStep: 'processing',
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith( '/home/' + mockSiteId );
+		} );
+
+		it( 'redirects the user to the redirectTo when it is provided', async () => {
+			mockIsAdminInterfaceWPAdminMock = false;
+
+			runUseStepNavigationSubmit( {
+				currentStep: 'processing',
+				dependencies: {
+					redirectTo: '/redirect-to-some-page',
+				},
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith( '/redirect-to-some-page' );
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -5,7 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import { useSelector } from 'calypso/state';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
-import { getSiteOption } from 'calypso/state/sites/selectors';
+import { isAdminInterfaceWPAdmin } from 'calypso/state/sites/selectors';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { ONBOARD_STORE } from '../stores';
 import ErrorStep from './internals/steps-repository/error-step';
@@ -35,8 +35,8 @@ const transferringHostedSite: Flow = {
 			( select ) => ( siteId && ( select( SITE_STORE ) as SiteSelect ).getSite( siteId ) ) || null,
 			[ siteId ]
 		);
-		const wpcomAdminInterface = useSelector( ( state ) =>
-			getSiteOption( state, parseInt( siteId! ), 'wpcom_admin_interface' )
+		const adminInterfaceIsWPAdmin = useSelector( ( state ) =>
+			isAdminInterfaceWPAdmin( state, parseInt( siteId! ) )
 		);
 		const exitFlow = ( to: string ) => {
 			window.location.assign( to );
@@ -48,7 +48,7 @@ const transferringHostedSite: Flow = {
 				return providedDependencies.redirectTo as string;
 			}
 
-			if ( wpcomAdminInterface === 'wp-admin' ) {
+			if ( adminInterfaceIsWPAdmin ) {
 				return site?.options?.admin_url as string;
 			}
 


### PR DESCRIPTION
Related to: pet6gk-1yJ-p2#redirect-to-wp-admin

## Proposed Changes

* Sites created in the "Classic style" should redirect to their /wp-admin instead of Calypso home

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site from the /hosting flow and make sure it redirects to /wp-admin interface. 
Here's the hosting flow, local URL: http://calypso.localhost:3000/setup/new-hosted-site/plans?ref=hosting-lp&section=hero

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?