### PR TITLE
A4A: fix checkout discout price indicator

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -35,6 +35,7 @@ export default function PricingSummary( {
 
 	// Agency checkout is when the user is not purchasing automated referrals and not a client
 	const isAgencyCheckout = ! isAutomatedReferrals && ! isClient;
+	const showOriginalPrice = isAgencyCheckout && totalCost !== actualCost;
 
 	return (
 		<div className="checkout__summary">
@@ -44,7 +45,7 @@ export default function PricingSummary( {
 				</span>
 				{
 					// Show the discounted price only if it is agency checkout
-					isAgencyCheckout && (
+					showOriginalPrice && (
 						<span className="checkout__summary-pricing-original">
 							{ formatCurrency( actualCost, currency ) }
 						</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/794

## Proposed Changes

Currently, we show crossed-out price on checkout pages for all purchases. Instead, we only need to show it when actual and discounted prices are mismatch.

| Before | After |
| ---- | ---- |
| <img width="508" alt="Screenshot 2024-09-17 at 2 25 30 PM" src="https://github.com/user-attachments/assets/067ec1a1-891c-4933-a72a-334ae2fbdd77"> | <img width="498" alt="Screenshot 2024-09-17 at 2 25 20 PM" src="https://github.com/user-attachments/assets/1baad454-b9a7-4091-956c-5e229bb32a54"> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below
- Navigate to marketplace `/marketplace/products`
- Add any single product to the cart
- Using volume pricing add some `bundle` (eg 5 items) of any product
- Navigate to checkout `/marketplace/checkout`
- Check that you see discounted price as well as full price crossed out
<img width="499" alt="Screenshot 2024-09-17 at 2 25 12 PM" src="https://github.com/user-attachments/assets/6137be91-ef15-4ae3-bb89-506c9fdd80e0">

- Remove bundle items from the cart and you should see only full price
<img width="498" alt="Screenshot 2024-09-17 at 2 25 20 PM" src="https://github.com/user-attachments/assets/8a01dc2a-f446-43d0-8d74-d7a271cca2f3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
