### PR TITLE
Hosting dashboard: Enable sorting for Plan and Status

### DIFF
--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -75,6 +75,7 @@ const siteSortingKeys = [
 	{ dataView: 'last-publish', sortKey: 'updatedAt' },
 	{ dataView: 'last-interacted', sortKey: 'lastInteractedWith' },
 	{ dataView: 'plan', sortKey: 'plan' },
+	{ dataView: 'status', sortKey: 'status' },
 ];
 
 const DEFAULT_PER_PAGE = 50;

--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -74,6 +74,7 @@ const siteSortingKeys = [
 	{ dataView: 'site', sortKey: 'alphabetically' },
 	{ dataView: 'last-publish', sortKey: 'updatedAt' },
 	{ dataView: 'last-interacted', sortKey: 'lastInteractedWith' },
+	{ dataView: 'plan', sortKey: 'plan' },
 ];
 
 const DEFAULT_PER_PAGE = 50;

--- a/client/hosting/sites/components/sites-dataviews/index.tsx
+++ b/client/hosting/sites/components/sites-dataviews/index.tsx
@@ -135,14 +135,14 @@ const DotcomSitesDataViews = ( {
 					<SitePlan site={ item } userId={ userId } />
 				),
 				enableHiding: false,
-				enableSorting: false,
+				enableSorting: true,
 			},
 			{
 				id: 'status',
 				label: __( 'Status' ),
 				render: ( { item }: { item: SiteExcerptData } ) => <SiteStatus site={ item } />,
 				enableHiding: false,
-				enableSorting: false,
+				enableSorting: true,
 				elements: siteStatusGroups,
 				filterBy: {
 					operators: [ 'is' ],

--- a/packages/sites/src/site-type.ts
+++ b/packages/sites/src/site-type.ts
@@ -17,7 +17,7 @@ export interface MinimumSite {
 		is_redirect?: boolean;
 		updated_at?: string;
 	};
-	plan: {
+	plan?: {
 		product_name_short: string;
 	};
 }

--- a/packages/sites/src/site-type.ts
+++ b/packages/sites/src/site-type.ts
@@ -17,4 +17,7 @@ export interface MinimumSite {
 		is_redirect?: boolean;
 		updated_at?: string;
 	};
+	plan: {
+		product_name_short: string;
+	};
 }

--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -1,5 +1,6 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useMemo } from 'react';
+import { getSiteLaunchStatus } from './site-status';
 import { MinimumSite } from './site-type';
 
 type SiteDetailsForSortingWithOptionalUserInteractions = Pick<
@@ -318,26 +319,9 @@ function sortByPlan< T extends SiteDetailsForSorting >( a: T, b: T, sortOrder: S
 	return sortOrder === 'asc' ? planA.localeCompare( planB ) : planB.localeCompare( planA );
 }
 
-function getStatus( site: SiteDetailsForSorting ): string {
-	// Sort by is_deleted, options.is_redirect, is_coming_soon, is_private, public
-	if ( site.is_deleted ) {
-		return 'deleted';
-	}
-	if ( site.options?.is_redirect ) {
-		return 'redirect';
-	}
-	if ( site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' ) ) {
-		return 'coming-soon';
-	}
-	if ( site.is_private ) {
-		return 'private';
-	}
-	return 'public';
-}
-
 function sortByStatus< T extends SiteDetailsForSorting >( a: T, b: T, sortOrder: SitesSortOrder ) {
-	const statusA = getStatus( a );
-	const statusB = getStatus( b );
+	const statusA = getSiteLaunchStatus( a );
+	const statusB = getSiteLaunchStatus( b );
 
 	if ( ! statusA || ! statusB ) {
 		return 0;

--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -13,6 +13,7 @@ type SiteDetailsForSortingWithOptionalUserInteractions = Pick<
 	| 'is_deleted'
 	| 'is_coming_soon'
 	| 'is_private'
+	| 'launch_status'
 >;
 
 type SiteDetailsForSortingWithUserInteractions = Pick<
@@ -25,6 +26,7 @@ type SiteDetailsForSortingWithUserInteractions = Pick<
 	| 'is_deleted'
 	| 'is_coming_soon'
 	| 'is_private'
+	| 'launch_status'
 > &
 	Required< Pick< MinimumSite, 'user_interactions' > >;
 
@@ -324,7 +326,7 @@ function getStatus( site: SiteDetailsForSorting ): string {
 	if ( site.options?.is_redirect ) {
 		return 'redirect';
 	}
-	if ( site.is_coming_soon ) {
+	if ( site.is_coming_soon || ( site.is_private && site.launch_status === 'unlaunched' ) ) {
 		return 'coming-soon';
 	}
 	if ( site.is_private ) {

--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -4,12 +4,12 @@ import { MinimumSite } from './site-type';
 
 type SiteDetailsForSortingWithOptionalUserInteractions = Pick<
 	MinimumSite,
-	'title' | 'user_interactions' | 'options' | 'is_wpcom_staging_site' | 'ID'
+	'title' | 'user_interactions' | 'options' | 'is_wpcom_staging_site' | 'ID' | 'plan'
 >;
 
 type SiteDetailsForSortingWithUserInteractions = Pick<
 	MinimumSite,
-	'title' | 'options' | 'is_wpcom_staging_site' | 'ID'
+	'title' | 'options' | 'is_wpcom_staging_site' | 'ID' | 'plan'
 > &
 	Required< Pick< MinimumSite, 'user_interactions' > >;
 
@@ -17,7 +17,7 @@ export type SiteDetailsForSorting =
 	| SiteDetailsForSortingWithOptionalUserInteractions
 	| SiteDetailsForSortingWithUserInteractions;
 
-const validSortKeys = [ 'lastInteractedWith', 'updatedAt', 'alphabetically' ] as const;
+const validSortKeys = [ 'lastInteractedWith', 'updatedAt', 'alphabetically', 'plan' ] as const;
 const validSortOrders = [ 'asc', 'desc' ] as const;
 
 export type SitesSortKey = ( typeof validSortKeys )[ number ];
@@ -52,6 +52,8 @@ export function useSitesListSorting< T extends SiteDetailsForSorting >(
 				return sortSitesAlphabetically( allSites, sortOrder );
 			case 'updatedAt':
 				return sortSitesByLastPublish( allSites, sortOrder );
+			case 'plan':
+				return sortSitesByPlan( allSites, sortOrder );
 			default:
 				return allSites;
 		}
@@ -280,6 +282,17 @@ function sortByLastPublish< T extends SiteDetailsForSorting >(
 	return 0;
 }
 
+function sortByPlan< T extends SiteDetailsForSorting >( a: T, b: T, sortOrder: SitesSortOrder ) {
+	const planA = a.plan?.product_name_short;
+	const planB = b.plan?.product_name_short;
+
+	if ( ! planA || ! planB ) {
+		return 0;
+	}
+
+	return sortOrder === 'asc' ? planA.localeCompare( planB ) : planB.localeCompare( planA );
+}
+
 function sortSitesAlphabetically< T extends SiteDetailsForSorting >(
 	sites: T[],
 	sortOrder: SitesSortOrder
@@ -292,6 +305,13 @@ function sortSitesByLastPublish< T extends SiteDetailsForSorting >(
 	sortOrder: SitesSortOrder
 ): T[] {
 	return [ ...sites ].sort( ( a, b ) => sortByLastPublish( a, b, sortOrder ) );
+}
+
+function sortSitesByPlan< T extends SiteDetailsForSorting >(
+	sites: T[],
+	sortOrder: SitesSortOrder
+): T[] {
+	return [ ...sites ].sort( ( a, b ) => sortByPlan( a, b, sortOrder ) );
 }
 
 type SitesSortingProps = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9150

## Proposed Changes

* Add sorting for Plan and Status.


https://github.com/user-attachments/assets/409f476a-8c4f-4d94-9092-9b6fce5b0770

No go: I'm not adding Plan filtering in this PR.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users expect to be able to sort by every data column. Also, every column is sortable by default in DataViews. See: pdtkmj-2VB-p2#comment-5647

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open /sites
* Verify that you can sort ascending and descending by Plan
* Verify that you can sort ascending and descending by Status
* Regression test that sorting by other columns (site, last published) still works correctly, and filtering by Status still works correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?