### PR TITLE
Paid Newsletter: Add Import link and redirect for substack importer

### DIFF
--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -27,6 +27,14 @@ export function importSite( context, next ) {
 		if ( fromSite ) {
 			path += '?from-site=' + fromSite;
 		}
+		if ( engine === 'substack' && config.isEnabled( 'importers/newsletter' ) ) {
+			if ( fromSite ) {
+				page.redirect( `/import/newsletter/substack/${ siteSlug }?from=${ fromSite }` );
+				return;
+			}
+			page.redirect( `/import/newsletter/substack/${ siteSlug }` );
+			return;
+		}
 		page.replace( path );
 	};
 

--- a/client/my-sites/importer/importer-substack.jsx
+++ b/client/my-sites/importer/importer-substack.jsx
@@ -53,6 +53,7 @@ class ImporterSubstack extends PureComponent {
 						importerStatus={ this.props.importerStatus }
 						icon={ importerData.icon }
 						title={ importerData.title }
+						description={ importerData.description }
 					/>
 				</CompactCard>
 			);

--- a/client/my-sites/importer/importer-substack.jsx
+++ b/client/my-sites/importer/importer-substack.jsx
@@ -1,8 +1,13 @@
+import config from '@automattic/calypso-config';
+import { CompactCard } from '@automattic/components';
+import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import importerConfig from 'calypso/lib/importer/importer-config';
+import { appStates } from 'calypso/state/imports/constants';
 import FileImporter from './file-importer';
+import ImporterHeader from './importer-header';
 
 class ImporterSubstack extends PureComponent {
 	static displayName = 'ImporterSubstack';
@@ -32,6 +37,26 @@ class ImporterSubstack extends PureComponent {
 			siteSlug: this.props.siteSlug,
 			siteTitle: this.props.siteTitle,
 		} ).substack;
+
+		if ( config.isEnabled( 'importers/newsletter' ) ) {
+			const isEnabled = appStates.DISABLED !== this.props.importerStatus.importerState;
+			const classNames = clsx( 'importer__site-importer-card', {
+				'is-disabled': ! isEnabled,
+			} );
+
+			return (
+				<CompactCard
+					className={ classNames }
+					href={ `/import/newsletter/substack/${ this.props.siteSlug }` }
+				>
+					<ImporterHeader
+						importerStatus={ this.props.importerStatus }
+						icon={ importerData.icon }
+						title={ importerData.title }
+					/>
+				</CompactCard>
+			);
+		}
 
 		if ( this.props.hideUploadDescription ) {
 			delete importerData.uploadDescription;


### PR DESCRIPTION

## Proposed Changes

* Add code that checks the config and adds the link to the new substack importer. 

## Why are these changes being made?

* We are making these changes so that lunching this feature will be easier to do. 

## Testing Instructions

* visit /import select a site and click/select on the substack import. 
* visit 
* /import?engine=substack selecting a site should take you to the new importer 
* /import/example.com?engine=substack should take you to the new importer
* /import/example.com?engine=substack&from-site=enej0077.substack.com should take you to the new importer and you shouldn't have to select the substack site. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
