### PR TITLE
Passwordless Auth - Adjust font and spacing 

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -24,6 +24,8 @@ $breakpoint-mobile: 660px;
 	$woo-form-divider-border: 1px solid #e6e6e6;
 	$gray-60: #50575e;
 	$gray-50: #646970;
+	$woo-sfpro-display-font:  "SF Pro Display", -apple-system, system-ui, sans-serif;
+	$woo-sfpro-text-font:  "SF Pro Text", -apple-system, system-ui, sans-serif;
 
 	background: #fff;
 	min-height: 100%;
@@ -1898,14 +1900,14 @@ $breakpoint-mobile: 660px;
 	// Core Profiler + Passwordless
 	&.is-woocommerce-core-profiler-flow.is-woo-passwordless {
 		* {
-			font-family: "SF Pro Text", -apple-system, system-ui, sans-serif;
+			font-family: $woo-sfpro-text-font;
 			font-weight: 400;
 		}
 
 		h3,
 		h1.formatted-header__title,
 		h1.magic-login__form-header {
-			font-family: "SF Pro Display", -apple-system, system-ui, sans-serif;
+			font-family: $woo-sfpro-display-font;
 			font-weight: 500;
 			margin-bottom: 15px;
 		}
@@ -2048,6 +2050,9 @@ $breakpoint-mobile: 660px;
 					span {
 						font-size: 0.875rem;
 						letter-spacing: 0.32px;
+						font-family: $woo-sfpro-display-font;
+						font-weight: 500;
+						margin-left: 0;
 					}
 				}
 			}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -2058,7 +2058,8 @@ $breakpoint-mobile: 660px;
 			}
 		}
 
-		.login__form-action {
+		.login__form-action,
+		.logged-out-form {
 			button.is-primary {
 				font-size: rem(14px);
 			}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1903,7 +1903,8 @@ $breakpoint-mobile: 660px;
 		}
 
 		h3,
-		h1.formatted-header__title {
+		h1.formatted-header__title,
+		h1.magic-login__form-header {
 			font-family: "SF Pro Display", -apple-system, system-ui, sans-serif;
 			font-weight: 500;
 			margin-bottom: 15px;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1895,10 +1895,20 @@ $breakpoint-mobile: 660px;
 
 	}
 
+	// Core Profiler + Passwordless
 	&.is-woocommerce-core-profiler-flow.is-woo-passwordless {
-		h3 {
-			font-family: inherit;
+		* {
+			font-family: "SF Pro Text", -apple-system, system-ui, sans-serif;
+			font-weight: 400;
 		}
+
+		h3,
+		h1.formatted-header__title {
+			font-family: "SF Pro Display", -apple-system, system-ui, sans-serif;
+			font-weight: 500;
+			margin-bottom: 15px;
+		}
+
 		.login__lost-password-link {
 			color: var(--wp-admin-theme-color);
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR updates the CSS styles for the passwordless auth pages.

## Proposed Changes

- Base font is `SF Pro Text`
- H1 and H3 headers use `SF Pro Display`
- Fixed styling issues with the social buttons due to changes from the trunk. The buttons should have `SF Pro Display` font family and centered.
- Spacing between headers and the subtitles should be 15px.

The SF Pro font family isn't available on Windows systems. I explored the option of using the web font version but am uncertain about its legal usage. I'm looking into it.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To reflect the Figma design

## Testing Instructions

1. Setup https://github.com/woocommerce/woocommerce-start-dev-env 
2. Once https://github.com/woocommerce/woocommerce-start-dev-env is ready, cd to wp-calypso
3. Open `config/development.json` and enable [woocommerce/core-profiler-passwordless-auth](https://github.com/Automattic/wp-calypso/blob/trunk/config/development.json#L250)
4. Run `yarn start`
5. Open a new incognito window (Make sure you're logged out from WPCOM)
6. Create a new JN site with the latest WooCommerce
7. Go through the core profiler and make sure to select Jetpack on the plugins page.
8. Once you get to the jetpack connect page, right click on `One last step!` header and inspect it.
9. Make sure the rendered font is `SF Pro Display`.
10. Right click on the subtitle and inspect it. Make sure the rendered font is `SF Pro Text`
11. Confirm the spacing between the header and the subtitle is 15px.
12. Click on the `Log in` link
13. Inspect the header and the subtitle and confirm the rendered font.
14. Confirm the social buttons are correctly centered and use `SF Pro Display` font.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
