### PR TITLE
Plans: Use consistent font-size & padding for features between treatments

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -846,9 +846,6 @@ const PlansFeaturesMain = ( {
 										enableCategorisedFeatures={
 											simplifiedFeaturesGridExperimentVariant === 'simplified'
 										}
-										enableLargeFeatureTitles={
-											simplifiedFeaturesGridExperimentVariant === 'simplified'
-										}
 										enableStorageAsBadge={
 											simplifiedFeaturesGridExperimentVariant !== 'simplified'
 										}

--- a/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
@@ -166,7 +166,6 @@ export const FewerFeaturesExperimentTreatmentVariantB = {
 		intent: 'plans-default-wpcom',
 		isInSignup: true,
 		enableCategorisedFeatures: true,
-		enableLargeFeatureTitles: true,
 		enableStorageAsBadge: false,
 		enableReducedFeatureGroupSpacing: true,
 		enableLogosOnlyForEnterprisePlan: true,

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -379,7 +379,6 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		className,
 		enableFeatureTooltips,
 		enableCategorisedFeatures,
-		enableLargeFeatureTitles,
 		enableStorageAsBadge,
 		enableReducedFeatureGroupSpacing,
 		enableLogosOnlyForEnterprisePlan,
@@ -425,7 +424,6 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 				allFeaturesList={ allFeaturesList }
 				enableFeatureTooltips={ enableFeatureTooltips }
 				enableCategorisedFeatures={ enableCategorisedFeatures }
-				enableLargeFeatureTitles={ enableLargeFeatureTitles }
 				enableStorageAsBadge={ enableStorageAsBadge }
 				enableReducedFeatureGroupSpacing={ enableReducedFeatureGroupSpacing }
 				enableLogosOnlyForEnterprisePlan={ enableLogosOnlyForEnterprisePlan }

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -159,12 +159,6 @@
 	.plan-features-2023-grid__highlighted-feature .plan-features-2023-grid__item {
 		padding-bottom: 24px;
 	}
-
-	.plans-grid-next-features-grid__feature-group-row {
-		&.is-reduced-feature-group-spacing > .plan-features-2023-grid__table-item {
-			padding-top: 0;
-		}
-	}
 }
 
 .plan-features-2023-grid__table {
@@ -332,7 +326,7 @@
 	}
 
 	&.is-reduced-feature-group-spacing > .plan-features-2023-grid__table-item {
-		padding-top: 16px;
+		padding-top: 0;
 	}
 }
 
@@ -359,10 +353,6 @@
 		@include plans-grid-medium-large {
 			font-size: $font-body-extra-small;
 			line-height: 16px;
-
-			&.is-large {
-				font-size: $font-body-small;
-			}
 		}
 	}
 

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -72,7 +72,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	setActiveTooltipId,
 } ) => {
 	const translate = useTranslate();
-	const { enableFeatureTooltips, enableLargeFeatureTitles } = usePlansGridContext();
+	const { enableFeatureTooltips } = usePlansGridContext();
 
 	return (
 		<>
@@ -106,7 +106,6 @@ const PlanFeatures2023GridFeatures: React.FC< {
 				} );
 				const itemTitleClasses = clsx( 'plan-features-2023-grid__item-title', {
 					'is-bold': isHighlightedFeature,
-					'is-large': enableLargeFeatureTitles,
 				} );
 
 				return (

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -22,7 +22,6 @@ interface PlansGridContext {
 	 * for rendering features with categories based on available/associated feature group map.
 	 */
 	enableCategorisedFeatures?: boolean;
-	enableLargeFeatureTitles?: boolean;
 	enableStorageAsBadge?: boolean;
 	enableReducedFeatureGroupSpacing?: boolean;
 	enableLogosOnlyForEnterprisePlan?: boolean;
@@ -46,7 +45,6 @@ const PlansGridContextProvider = ( {
 	coupon,
 	enableFeatureTooltips,
 	enableCategorisedFeatures,
-	enableLargeFeatureTitles,
 	enableStorageAsBadge,
 	enableReducedFeatureGroupSpacing,
 	enableLogosOnlyForEnterprisePlan,
@@ -79,7 +77,6 @@ const PlansGridContextProvider = ( {
 				coupon,
 				enableFeatureTooltips,
 				enableCategorisedFeatures,
-				enableLargeFeatureTitles,
 				enableStorageAsBadge,
 				enableReducedFeatureGroupSpacing,
 				enableLogosOnlyForEnterprisePlan,

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -207,11 +207,6 @@ export type GridContextProps = {
 	enableCategorisedFeatures?: boolean;
 
 	/**
-	 * Display the feature titles with a slightly larger font size
-	 */
-	enableLargeFeatureTitles?: boolean;
-
-	/**
 	 * Display the plan storage limit as a badge like "50GB" or as plain text like "50GB storage"
 	 */
 	enableStorageAsBadge?: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3332

Slack discussion: p1726620799597029/1725482162.452359-slack-C07ABDFQEMS

## Proposed Changes

This change updates the font-size & padding for features in Treatment B so that it matches Treatment A.

Context: For an upcoming experiment (pbxNRc-45y-p2) we are testing two treatment variants with different features listed for each plan. We were planning to increase the font-size/padding for features in Treatment B as part of this experiment, however we have decided to avoid this additional change and focus the experiment on the features themselves.

| Before | After |
| -- | -- |
|<img width=370 src="https://github.com/user-attachments/assets/1054dd04-fdc2-45cf-8dea-b4049ccf8ca3" />|<img width=370 src="https://github.com/user-attachments/assets/0711bcb5-80b1-4231-828b-cc96192b278f" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To eliminate font-size and padding as a potential variable for impact on the experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View the plans grid with Treatment B applied: `/plans/:site?flags=simplified-features-grid-b`
* Check that the feature font-size matches Treatment A: `/plans/:site?flags=simplified-features-grid-a`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?