### PR TITLE
Plans: Use consistent font size for storage feature between treatments

### DIFF
--- a/packages/plans-grid-next/src/_shared.scss
+++ b/packages/plans-grid-next/src/_shared.scss
@@ -80,14 +80,13 @@ $mobile-card-max-width: 440px;
 	padding: 4px 0;
 	font-weight: 400;
 	line-height: 20px;
-	font-size: $font-body-small;
+	font-size: $font-body-extra-small;
 
 	&.is-badge {
 		background: #f2f2f2;
 		/* stylelint-disable-next-line */
 		border-radius: 5px;
 		text-align: center;
-		font-size: $font-body-extra-small;
 		width: fit-content;
 		min-width: 64px;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3332

Slack discussion: p1726620799597029/1725482162.452359-slack-C07ABDFQEMS

## Proposed Changes

Reduces the font-size for the storage feature in the plans grid for Treatment B so that it matches Treatment A.

Context: For an upcoming experiment (pbxNRc-45y-p2) we are testing two treatment variants with different features listed for each plan. Although the storage feature is presented differently depending on the treatment (ie. as a badge, or as plain text), we want the font-size to match between treatments (and with the other features).

| Before | After |
| -- | -- |
|<img width=400 src="https://github.com/user-attachments/assets/fce004ca-e800-4367-a1bf-98b547f7cdd6" />|<img width=400 src="https://github.com/user-attachments/assets/dafa15d4-19eb-4b75-91bc-de3193fc0999" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To eliminate font-size for the storage feature as a potential variable for impact on the experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. View the plans grid with Treatment B applied: `/start/plans?flags=simplified-features-grid-b`
2. Check that the storage feature font-size matches Treatment A: `/start/plans?flags=simplified-features-grid-a`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?