### PR TITLE
Checkout variants show introductory offers for three-year plans in an inconsistent way

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -128,7 +128,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 			);
 			// translation example: $1 first month then $2 per month
 
-			// multiple period introductory offers (eg 3 months) there are no multi-year introductory offers
+			// multiple period introductory offers (eg 3 months)
 		} else if ( introCount > 1 ) {
 			if ( productBillingTermInMonths > 12 ) {
 				return introTerm === 'month'

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -78,10 +78,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 		};
 
 		//generic introductory offer to catch unexpected offer terms
-		if (
-			( introTerm !== 'month' && introTerm !== 'year' ) ||
-			( introCount > 2 && introTerm === 'year' )
-		) {
+		if ( introTerm !== 'month' && introTerm !== 'year' ) {
 			return translate( '%(formattedCurrentPrice)s introductory offer', { args } );
 			// translation example: $1 introductory offer
 		}


### PR DESCRIPTION
Fixes #94552

## Proposed Changes

The variant dropdown in checkout describes introductory offers for three-year plans in a different (and less helpful) way than the other introductory offers.  This pull request fixes it.

Before:

![before](https://github.com/user-attachments/assets/5e9afcec-4187-4706-807b-154eeb13fcf3)

After:

![after](https://github.com/user-attachments/assets/2476ce6b-2c1a-460a-8e79-94fda5eb6d9a)


## Testing Instructions

To test this, I started at https://wordpress.com/move/ then followed the process for beginning the import of an existing WordPress site (using `wordpress.org` works :grinning:) and went through the steps to create a new site and select a Business Plan and enter checkout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
