### PR TITLE
Always consider redirect_to in Jetpack Free button

### DIFF
--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -72,7 +72,6 @@ export default function useJetpackFreeButtonProps(
 		: recommendationsUrl;
 
 	if (
-		! siteWpAdminUrl &&
 		urlQueryArgs?.redirect_to &&
 		urlQueryArgs.redirect_to.toLowerCase().includes( 'wp-admin/admin.php?page=my-jetpack' )
 	) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/88492 and https://github.com/Automattic/wp-calypso/pull/93575

Video showcasing the issue:

https://github.com/user-attachments/assets/afaeaaab-7832-49c8-a38c-8e2779aca71a


## Proposed Changes

It's an extension of what @jboland88 improved here. The redirect works if the user decides to purchase the product, but if user clicks "Jetpack Free" button - they are getting redirected to Dashboard without considering redirect_to path. That happens because `getJetpackRecommendationsUrl()` always return the url when Jetpack plugin is active on the site - making it completely ignore the my-jetpack redirect condition.

It's a simple change to consider the redirect_to, and redirect user to My Jetpack when they decide to continue with free offering.

## Testing Instructions

1. Spin the JN with Jetpack plugin installed
2. In My Jetpack, click connect the site, then scroll to the bottom and click "Sign in"

![CleanShot 2024-09-18 at 11 30 24](https://github.com/user-attachments/assets/a919d4fa-fb1b-44ad-9613-8ee7fb81b70f)

3. Establish user connection, and on the plans page - replace `wordpress.com` with slug of your Calypso Live url.
4. Then, scroll to the bottom and click "Start with Jetpack Free"
5. You should be redirected correctly to My Jetpack page


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
