### PR TITLE
Gutenberg E2E test: Updates the publishedYouTubeIframe locator.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
@@ -10,7 +10,7 @@ const selectors = {
 	embedUrlInput: `${ blockParentSelector } input`,
 	embedButton: `${ blockParentSelector } button:has-text("Embed")`,
 	editorYouTubeIframe: 'iframe[title="Embedded content from www.youtube.com"]',
-	publishedYouTubeIframe: `iframe.youtube-player`,
+	publishedYouTubeIframe: 'iframe[title="Getting started on @wordpressdotcom"]',
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
@@ -6,12 +6,6 @@ interface ConfigurationData {
 }
 
 const blockParentSelector = '[aria-label*="Block: YouTube"]:has-text("YouTube")';
-const selectors = {
-	embedUrlInput: `${ blockParentSelector } input`,
-	embedButton: `${ blockParentSelector } button:has-text("Embed")`,
-	editorYouTubeIframe: 'iframe[title="Embedded content from www.youtube.com"]',
-	publishedYouTubeIframe: 'iframe[title="Getting started on @wordpressdotcom"]',
-};
 
 /**
  * Class representing the flow of using a YouTube block in the editor.
@@ -32,6 +26,13 @@ export class YouTubeBlockFlow implements BlockFlow {
 	blockTestFallBackName = 'YouTube';
 	blockEditorSelector = blockParentSelector;
 
+	selectors = {
+		embedUrlInput: `${ blockParentSelector } input`,
+		embedButton: `${ blockParentSelector } button:has-text("Embed")`,
+		editorYouTubeIframe: 'iframe[title="Embedded content from www.youtube.com"]',
+		publishedYouTubeIframe: `iframe[title="${ this.configurationData.expectedVideoTitle }"]`,
+	};
+
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor.
 	 *
@@ -40,14 +41,14 @@ export class YouTubeBlockFlow implements BlockFlow {
 	async configure( context: EditorContext ): Promise< void > {
 		const editorCanvas = await context.editorPage.getEditorCanvas();
 
-		const urlInputLocator = editorCanvas.locator( selectors.embedUrlInput );
+		const urlInputLocator = editorCanvas.locator( this.selectors.embedUrlInput );
 		await urlInputLocator.fill( this.configurationData.embedUrl );
 
-		const embedButtonLocator = editorCanvas.locator( selectors.embedButton );
+		const embedButtonLocator = editorCanvas.locator( this.selectors.embedButton );
 		await embedButtonLocator.click();
 
 		// We should make sure the actual Iframe loads, because it takes a second.
-		const youTubeIframeLocator = editorCanvas.locator( selectors.editorYouTubeIframe );
+		const youTubeIframeLocator = editorCanvas.locator( this.selectors.editorYouTubeIframe );
 		await youTubeIframeLocator.waitFor();
 	}
 
@@ -57,10 +58,7 @@ export class YouTubeBlockFlow implements BlockFlow {
 	 * @param context The current context for the published post at the point of test execution.
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
-		const expectedVideoTitleLocator = context.page
-			.frameLocator( selectors.publishedYouTubeIframe )
-			.locator( `text=${ this.configurationData.expectedVideoTitle }` )
-			.first(); // The video title may be multiple places in the frame.
+		const expectedVideoTitleLocator = context.page.locator( this.selectors.publishedYouTubeIframe );
 
 		await expectedVideoTitleLocator.waitFor();
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* uses `iframe` title instead of classname

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make sure gutenberg e2e tests for this branch pass in teamcity

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
