### PR TITLE
Performance Profiler: sort High Impact insights to the top of the list

### DIFF
--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -25,9 +25,16 @@ export const InsightsSection = forwardRef(
 		const translate = useTranslate();
 		const { audits, fullPageScreenshot, isWpcom, hash, filter } = props;
 		const [ selectedFilter, setSelectedFilter ] = useState( filter ?? 'all' );
-		const filteredAudits = Object.keys( audits ).filter( ( key ) =>
-			filterRecommendations( selectedFilter, audits[ key ] )
-		);
+
+		const sumMetricSavings = ( key: string ) =>
+			Object.values( audits[ key ].metricSavings ?? {} ).reduce( ( acc, val ) => acc + val, 0 );
+
+		const sortInsightKeys = ( a: string, b: string ) =>
+			sumMetricSavings( b ) - sumMetricSavings( a );
+
+		const filteredAudits = Object.keys( audits )
+			.filter( ( key ) => filterRecommendations( selectedFilter, audits[ key ] ) )
+			.sort( sortInsightKeys );
 		const onFilter = useCallback( ( option: { label: string; value: string } ) => {
 			setSelectedFilter( option.value );
 			updateQueryParams( { filter: option.value }, true );

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -83,6 +83,17 @@ $blueberry-color: #3858e9;
 
 			.insight-header-container {
 				display: flex;
+				align-items: baseline;
+
+				p {
+					margin: 0;
+					line-height: 26px;
+				}
+
+				div {
+					width: 100%;
+				}
+
 			}
 
 			.counter {

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -42,10 +42,6 @@ const Header = styled.div`
 	font-size: 16px;
 	width: 100%;
 
-	.insight-header-container > div {
-		width: 100%;
-	}
-
 	p {
 		display: inline;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9113

## Proposed Changes

* add sorting to the impact list
* vertically align insights header with impact badge

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/dotcom-forge/issues/9113

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/speed-test` and start a new test, or go to a results page eg. `/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzA1N30.7KXaBL1qcm0y0GqvM8ymJ0pbST9ls6P09_hri8EaKSI`
* Check that `High Impact` items are shown at the top of the insights list
* Check that the header text is vertically aligned with the `High Impact` badge

| Before | After |
|--------|--------|
| <img width="1074" alt="image" src="https://github.com/user-attachments/assets/30ade00e-6bed-495a-8d8c-7f463c2203b7"> | <img width="1077" alt="image" src="https://github.com/user-attachments/assets/d622a66a-406e-4d53-bafd-c02a5fea3096"> |
| <img width="1235" alt="image" src="https://github.com/user-attachments/assets/26005ae7-de33-4c5e-9cde-e01fda26bffa"> | <img width="1260" alt="image" src="https://github.com/user-attachments/assets/37d0ec6f-d39b-4d1c-acb9-4089584a3a8a"> |
