### PR TITLE
Gutenberg e2e tests: Fixes am / pm button selector.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -23,7 +23,7 @@ const selectors = {
 	schedulePopoverCloseButton:
 		'[data-wp-component="Popover"][aria-label="Change publish date"] [aria-label="Close"]',
 	scheduleInput: ( name: string ) => `.editor-post-schedule__dialog label:has-text("${ name }")`,
-	scheduleMeridianButton: ( meridian: 'am' | 'pm' ) => `role=button[name="${ meridian }"i]`,
+	scheduleMeridianButton: ( meridian: 'AM' | 'PM' ) => `role=radio[value="${ meridian }"i]`,
 
 	// Category
 	categoryCheckbox: ( categoryName: string ) =>

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -23,8 +23,8 @@ const selectors = {
 	schedulePopoverCloseButton:
 		'[data-wp-component="Popover"][aria-label="Change publish date"] [aria-label="Close"]',
 	scheduleInput: ( name: string ) => `.editor-post-schedule__dialog label:has-text("${ name }")`,
-	scheduleMeridianButton: ( meridian: 'AM' | 'PM' ) => `role=radio[value="${ meridian }"i]`,
-
+	scheduleMeridianButton: ( meridian: 'AM' | 'PM' ) =>
+		`button[role=radio]:has-text("${ meridian }")`,
 	// Category
 	categoryCheckbox: ( categoryName: string ) =>
 		`${ panel } div[aria-label=Categories] label:text("${ categoryName }")`,

--- a/packages/calypso-e2e/src/lib/components/types.ts
+++ b/packages/calypso-e2e/src/lib/components/types.ts
@@ -28,7 +28,7 @@ export interface ArticlePublishSchedule {
 	date: number;
 	hours: number;
 	minutes: number;
-	meridian: 'am' | 'pm';
+	meridian: 'AM' | 'PM';
 }
 
 /**

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -69,7 +69,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 				date: date.getUTCDate(),
 				hours: 12,
 				minutes: 1,
-				meridian: 'am',
+				meridian: 'AM',
 			} );
 		} );
 
@@ -117,7 +117,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 				month: date.getUTCMonth(),
 				hours: 12,
 				minutes: 59,
-				meridian: 'pm',
+				meridian: 'PM',
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
 
* adjusts tests to the new markup

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Gutenberg html output has changed

![CleanShot 2024-09-18 at 14 12 11](https://github.com/user-attachments/assets/62514268-9e5b-4d89-a686-45897e54fe51)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that tests are passing related to this spec `yarn workspace wp-e2e-tests test -- specs/editor/editor__schedule.ts` in Teamcity or in your local machine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
