### PR TITLE
A4A Dev Sites: Adjust Launch site logic and related copy based on `referral_status`

### DIFF
--- a/client/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog.ts
+++ b/client/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog.ts
@@ -20,6 +20,7 @@ export default function useFetchAgencyFromBlog(
 				name: data?.name,
 				existing_wpcom_license_count: data?.existing_wpcom_license_count,
 				prices: data?.prices,
+				referral_status: data?.referral_status,
 			};
 		},
 		enabled: !! blogId && enabled,

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -91,7 +91,7 @@ const LaunchSite = () => {
 		btnComponent = (
 			<Button
 				onClick={ handleLaunchSiteClick }
-				disabled={ ! isLaunchable }
+				disabled={ ! isLaunchable || ( isDevelopmentSite && agencyLoading ) }
 				primary={ isDevelopmentSite }
 			>
 				{ btnText }

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -72,6 +72,7 @@ const LaunchSite = () => {
 	const existingWPCOMLicenseCount = agency?.existing_wpcom_license_count || 0;
 	const price = formatCurrency( agency?.prices?.actual_price, agency?.prices?.currency );
 	const siteReferralActive = agency?.referral_status === 'active';
+	const displayReferToClient = isDevelopmentSite && ! siteReferralActive && ! agencyLoading;
 
 	const handleLaunchSiteClick = () => {
 		if ( isDevelopmentSite && ! siteReferralActive ) {
@@ -179,7 +180,7 @@ const LaunchSite = () => {
 						{ isDevelopmentSite && ! siteReferralActive && <i>{ agencyBillingMessage }</i> }
 					</div>
 					<div className={ launchSiteClasses }>{ btnComponent }</div>
-					{ isDevelopmentSite && ! siteReferralActive && (
+					{ displayReferToClient && (
 						<div className={ launchSiteClasses }>
 							<Button onClick={ handleReferToClient } disabled={ false }>
 								{ translate( 'Refer to client' ) }

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -72,7 +72,8 @@ const LaunchSite = () => {
 	const existingWPCOMLicenseCount = agency?.existing_wpcom_license_count || 0;
 	const price = formatCurrency( agency?.prices?.actual_price, agency?.prices?.currency );
 	const siteReferralActive = agency?.referral_status === 'active';
-	const displayReferToClient = isDevelopmentSite && ! siteReferralActive && ! agencyLoading;
+	const shouldShowReferToClientButton =
+		isDevelopmentSite && ! siteReferralActive && ! agencyLoading;
 
 	const handleLaunchSiteClick = () => {
 		if ( isDevelopmentSite && ! siteReferralActive ) {
@@ -177,10 +178,10 @@ const LaunchSite = () => {
 										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
 								  ) }
 						</p>
-						{ isDevelopmentSite && ! siteReferralActive && <i>{ agencyBillingMessage }</i> }
+						{ shouldShowReferToClientButton && <i>{ agencyBillingMessage }</i> }
 					</div>
 					<div className={ launchSiteClasses }>{ btnComponent }</div>
-					{ displayReferToClient && (
+					{ shouldShowReferToClientButton && (
 						<div className={ launchSiteClasses }>
 							<Button onClick={ handleReferToClient } disabled={ false }>
 								{ translate( 'Refer to client' ) }

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -63,8 +63,18 @@ const LaunchSite = () => {
 		dispatch( launchSite( site.ID ) );
 	};
 
+	const {
+		data: agency,
+		error: agencyError,
+		isLoading: agencyLoading,
+	} = useFetchAgencyFromBlog( site?.ID, { enabled: !! site?.ID && isDevelopmentSite } );
+	const agencyName = agency?.name;
+	const existingWPCOMLicenseCount = agency?.existing_wpcom_license_count || 0;
+	const price = formatCurrency( agency?.prices?.actual_price, agency?.prices?.currency );
+	const siteReferralActive = agency?.referral_status === 'active';
+
 	const handleLaunchSiteClick = () => {
-		if ( isDevelopmentSite ) {
+		if ( isDevelopmentSite && ! siteReferralActive ) {
 			openLaunchConfirmationModal();
 		} else {
 			dispatchSiteLaunch();
@@ -106,15 +116,6 @@ const LaunchSite = () => {
 	const showPreviewLink = isComingSoon && hasSitePreviewLink;
 
 	const LaunchCard = showPreviewLink ? CompactCard : Card;
-
-	const {
-		data: agency,
-		error: agencyError,
-		isLoading: agencyLoading,
-	} = useFetchAgencyFromBlog( site?.ID, { enabled: !! site?.ID && isDevelopmentSite } );
-	const agencyName = agency?.name;
-	const existingWPCOMLicenseCount = agency?.existing_wpcom_license_count || 0;
-	const price = formatCurrency( agency?.prices?.actual_price, agency?.prices?.currency );
 
 	const handleReferToClient = () => {
 		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ siteId }`;
@@ -175,10 +176,10 @@ const LaunchSite = () => {
 										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
 								  ) }
 						</p>
-						{ isDevelopmentSite && <i>{ agencyBillingMessage }</i> }
+						{ isDevelopmentSite && ! siteReferralActive && <i>{ agencyBillingMessage }</i> }
 					</div>
 					<div className={ launchSiteClasses }>{ btnComponent }</div>
-					{ isDevelopmentSite && (
+					{ isDevelopmentSite && ! siteReferralActive && (
 						<div className={ launchSiteClasses }>
 							<Button onClick={ handleReferToClient } disabled={ false }>
 								{ translate( 'Refer to client' ) }


### PR DESCRIPTION
⚠️ This PR should not be merged until D161533-code has been merged and deployed to production already. ⚠️ 

---

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9036.

## Proposed Changes

* If `referral_status` is not `active`:
  * hide "Refer to client" button
  * hide copy informing on upcoming billing
  * disable "pre-launch" confirmation modal

(applies to free development sites only)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check if the related backend diff D161533-code has been already merged and deployed. If not, apply the diff as well and sandbox `public-api.wordpress.com`.
2. Apply the PR and build the app.
3. Navigate to `http://calypso.localhost:3000/settings/general/{blog-id/blog-slug}`. Where `{blog-id/blog-slug}` should belong to these kind of sites:
  A) an **agency free dev site** that **hasn't been referred** to a client
  B) an **agency free dev site** that **has been referred** to a client, but the client **hasn't added their payment details** yet
  C) an **agency free dev site** that **has been referred** to a client, but the client **has added their payment details** already 
4. Review the Launch site section for each kind of site. Please see the desired behavior for each case in the screenshots below.
5. Consider testing for regressions. For instance, open the Hosting (General) settings page on:
  a) a non-A4A site that hasn't been launched
  b) an A4A non-dev site that hasn't been launched
 There should be no "Refer to client" button, nor billing information. The "Launch site" button should not open any modal.

### Case A and B:

![Markup on 2024-09-18 at 11:26:17](https://github.com/user-attachments/assets/0462642a-4f63-464a-a09d-024d6747d0a0)

If you click on the `Launch site` button, a confirmation modal should display first.

### Case C:

![Markup on 2024-09-18 at 12:41:33](https://github.com/user-attachments/assets/28e5577a-5c3f-4900-a951-1f548c5bb317)

If you click on the `Launch site` button, there should be no confirmation modal and the site should just launch.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?