### PR TITLE
A4A: Fix issue with selected site not always visible.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -18,7 +18,6 @@ function configureSitesContext( context: Context ) {
 	const category = context.params.category || A4A_SITES_DASHBOARD_DEFAULT_CATEGORY;
 	const siteUrl = context.params.siteUrl;
 	const siteFeature = context.params.feature || A4A_SITES_DASHBOARD_DEFAULT_FEATURE;
-	const hideListingInitialState = !! siteUrl;
 
 	const {
 		s: search,
@@ -41,7 +40,6 @@ function configureSitesContext( context: Context ) {
 			categoryInitialState={ category }
 			siteUrlInitialState={ siteUrl }
 			siteFeatureInitialState={ siteFeature }
-			hideListingInitialState={ hideListingInitialState }
 			showOnlyFavoritesInitialState={
 				is_favorite === '' || is_favorite === '1' || is_favorite === 'true'
 			}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Icon, starFilled } from '@wordpress/icons';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useContext, useMemo, useState, ReactNode } from 'react';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
@@ -193,7 +194,11 @@ export const JetpackSitesDataViews = ( {
 					const isDevSite = ( item.isDevSite && devSitesEnabled ) || false;
 
 					return (
-						<>
+						<div
+							className={ clsx( {
+								'is-site-selected': site.blog_id === dataViewsState.selectedItem?.blog_id,
+							} ) }
+						>
 							{ item.site.error && <span className="sites-dataview__site-error-span"></span> }
 							<SiteDataField
 								site={ site }
@@ -201,7 +206,7 @@ export const JetpackSitesDataViews = ( {
 								isDevSite={ isDevSite }
 								onSiteTitleClick={ openSitePreviewPane }
 							/>
-						</>
+						</div>
 					);
 				},
 				enableHiding: false,
@@ -448,6 +453,7 @@ export const JetpackSitesDataViews = ( {
 			pluginsRef,
 			actionsRef,
 			isLoading,
+			dataViewsState.selectedItem?.blog_id,
 			openSitePreviewPane,
 			renderField,
 			isNotProduction,

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
@@ -11,4 +11,19 @@
 	.dataviews-view-table__row {
 		cursor: pointer;
 	}
+
+	.dataviews-wrapper ul.dataviews-view-list .is-selected,
+	.dataviews-wrapper ul.dataviews-view-list li:has(.is-site-selected) {
+		border-block-start: 0;
+		background-color: var(--color-neutral-0);
+
+		.dataviews-view-list__item-wrapper {
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		}
+	}
+
+	.dataviews-view-list li.is-selected.is-selected + li {
+		border-block-start: 0;
+		/* border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12); */
+	}
 }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
@@ -24,6 +24,5 @@
 
 	.dataviews-view-list li.is-selected.is-selected + li {
 		border-block-start: 0;
-		/* border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12); */
 	}
 }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
@@ -16,10 +16,15 @@
 	.dataviews-wrapper ul.dataviews-view-list li:has(.is-site-selected) {
 		border-block-start: 0;
 		background-color: var(--color-neutral-0);
+	}
 
-		.dataviews-view-list__item-wrapper {
-			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-		}
+	// To avoid, conflicting state, we cancel the is-selected styling by replacing with base color
+	.dataviews-wrapper ul.dataviews-view-list .is-selected .dataviews-view-list__item-wrapper {
+		background-color: var(--color-surface);
+	}
+
+	.dataviews-wrapper ul.dataviews-view-list li:has(.is-site-selected) .dataviews-view-list__item-wrapper {
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 	}
 
 	.dataviews-view-list li.is-selected.is-selected + li {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -9,9 +9,6 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	selectedSiteFeature: undefined,
 	setSelectedSiteFeature: () => {},
 
-	hideListing: undefined,
-	setHideListing: () => {},
-
 	showOnlyFavorites: undefined,
 	setShowOnlyFavorites: () => {},
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -18,7 +18,6 @@ import type { Filter } from '@wordpress/dataviews';
 interface Props {
 	showOnlyFavoritesInitialState?: boolean;
 	showOnlyDevelopmentInitialState?: boolean;
-	hideListingInitialState?: boolean;
 	categoryInitialState?: string;
 	siteUrlInitialState?: string;
 	siteFeatureInitialState?: string;
@@ -46,7 +45,6 @@ const buildFilters = ( { issueTypes }: { issueTypes: string } ): Filter[] => {
 };
 
 export const SitesDashboardProvider = ( {
-	hideListingInitialState = false,
 	showOnlyFavoritesInitialState = false,
 	showOnlyDevelopmentInitialState = false,
 	categoryInitialState,
@@ -60,7 +58,6 @@ export const SitesDashboardProvider = ( {
 	sort,
 	featurePreview,
 }: Props ) => {
-	const [ hideListing, setHideListing ] = useState( hideListingInitialState );
 	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
 	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
 	const [ showOnlyFavorites, setShowOnlyFavorites ] = useState( showOnlyFavoritesInitialState );
@@ -131,7 +128,6 @@ export const SitesDashboardProvider = ( {
 		if ( ! siteUrlInitialState ) {
 			setShowOnlyFavorites( showOnlyFavoritesInitialState );
 			setShowOnlyDevelopmentSites( showOnlyDevelopmentInitialState );
-			setHideListing( false );
 		}
 
 		setDataViewsState( ( previousState ) => ( {
@@ -162,8 +158,6 @@ export const SitesDashboardProvider = ( {
 		setSelectedCategory: setSelectedCategory,
 		selectedSiteFeature: selectedSiteFeature,
 		setSelectedSiteFeature: setSelectedSiteFeature,
-		hideListing: hideListing,
-		setHideListing: setHideListing,
 		showOnlyFavorites: showOnlyFavorites,
 		setShowOnlyFavorites: setShowOnlyFavorites,
 		showOnlyDevelopmentSites: showOnlyDevelopmentSites,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -59,8 +59,6 @@ export default function SitesDashboard() {
 		setSelectedCategory: setCategory,
 		showOnlyFavorites,
 		showOnlyDevelopmentSites,
-		hideListing,
-		setHideListing,
 	} = useContext( SitesDashboardContext );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
@@ -134,7 +132,6 @@ export default function SitesDashboard() {
 	useEffect( () => {
 		if ( dataViewsState.selectedItem && ! initialSelectedSiteUrl ) {
 			setDataViewsState( { ...dataViewsState, type: DATAVIEWS_TABLE, selectedItem: undefined } );
-			setHideListing( false );
 			return;
 		}
 
@@ -156,11 +153,11 @@ export default function SitesDashboard() {
 		}
 		// Omitting sitesViewState to prevent infinite loop
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ data, isError, isLoading, initialSelectedSiteUrl, setDataViewsState, setHideListing ] );
+	}, [ data, isError, isLoading, initialSelectedSiteUrl, setDataViewsState ] );
 
 	useEffect( () => {
 		// If there isn't a selected site and we are showing only the preview pane we should wait for the selected site to load from the endpoint
-		if ( hideListing && ! dataViewsState.selectedItem ) {
+		if ( ! dataViewsState.selectedItem ) {
 			return;
 		}
 
@@ -195,15 +192,13 @@ export default function SitesDashboard() {
 		showOnlyFavorites,
 		showOnlyDevelopmentSites,
 		dataViewsState.sort,
-		hideListing,
 	] );
 
 	const closeSitePreviewPane = useCallback( () => {
 		if ( dataViewsState.selectedItem ) {
 			setDataViewsState( { ...dataViewsState, type: DATAVIEWS_TABLE, selectedItem: undefined } );
-			setHideListing( false );
 		}
-	}, [ dataViewsState, setDataViewsState, setHideListing ] );
+	}, [ dataViewsState, setDataViewsState ] );
 
 	useEffect( () => {
 		if ( jetpackSiteDisconnected ) {
@@ -245,56 +240,54 @@ export default function SitesDashboard() {
 			wide
 			title={ dataViewsState.selectedItem ? null : translate( 'Sites' ) }
 		>
-			{ ! hideListing && (
-				<LayoutColumn className="sites-overview" wide>
-					<LayoutTop withNavigation={ navItems.length > 1 }>
-						<ProvisioningSiteNotification />
+			<LayoutColumn className="sites-overview" wide>
+				<LayoutTop withNavigation={ navItems.length > 1 }>
+					<ProvisioningSiteNotification />
 
-						<LayoutHeader>
-							<Title>{ translate( 'Sites' ) }</Title>
-							<Actions>
-								<MobileSidebarNavigation />
-								<SitesHeaderActions onWPCOMImport={ () => refetch() } />
-							</Actions>
-						</LayoutHeader>
-						{ navItems.length > 1 && (
-							<LayoutNavigation { ...selectedItemProps }>
-								<NavigationTabs { ...selectedItemProps } items={ navItems } />
-							</LayoutNavigation>
-						) }
-					</LayoutTop>
+					<LayoutHeader>
+						<Title>{ translate( 'Sites' ) }</Title>
+						<Actions>
+							<MobileSidebarNavigation />
+							<SitesHeaderActions onWPCOMImport={ () => refetch() } />
+						</Actions>
+					</LayoutHeader>
+					{ navItems.length > 1 && (
+						<LayoutNavigation { ...selectedItemProps }>
+							<NavigationTabs { ...selectedItemProps } items={ navItems } />
+						</LayoutNavigation>
+					) }
+				</LayoutTop>
 
-					<SiteNotifications />
-					{ tourId && <GuidedTour defaultTourId={ tourId } /> }
-					<QueryReaderTeams />
-					<DashboardDataContext.Provider
-						value={ {
-							verifiedContacts: {
-								emails: verifiedContacts?.emails ?? [],
-								phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
-								refetchIfFailed: () => {
-									if ( fetchContactFailed ) {
-										refetchContacts();
-									}
-									return;
-								},
+				<SiteNotifications />
+				{ tourId && <GuidedTour defaultTourId={ tourId } /> }
+				<QueryReaderTeams />
+				<DashboardDataContext.Provider
+					value={ {
+						verifiedContacts: {
+							emails: verifiedContacts?.emails ?? [],
+							phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
+							refetchIfFailed: () => {
+								if ( fetchContactFailed ) {
+									refetchContacts();
+								}
+								return;
 							},
-							products: products ?? [],
-							isLargeScreen: isLargeScreen || false,
-						} }
-					>
-						<JetpackSitesDataViews
-							className={ clsx( 'sites-overview__content' ) }
-							data={ data }
-							isLoading={ isLoading }
-							isLargeScreen={ isLargeScreen || false }
-							setDataViewsState={ setDataViewsState }
-							dataViewsState={ dataViewsState }
-							onRefetchSite={ refetch }
-						/>
-					</DashboardDataContext.Provider>
-				</LayoutColumn>
-			) }
+						},
+						products: products ?? [],
+						isLargeScreen: isLargeScreen || false,
+					} }
+				>
+					<JetpackSitesDataViews
+						className={ clsx( 'sites-overview__content' ) }
+						data={ data }
+						isLoading={ isLoading }
+						isLargeScreen={ isLargeScreen || false }
+						setDataViewsState={ setDataViewsState }
+						dataViewsState={ dataViewsState }
+						onRefetchSite={ refetch }
+					/>
+				</DashboardDataContext.Provider>
+			</LayoutColumn>
 
 			{ dataViewsState.selectedItem && (
 				<LayoutColumn className="site-preview-pane" wide>

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -14,9 +14,6 @@ export interface SitesDashboardContextInterface {
 	dataViewsState: DataViewsState;
 	setDataViewsState: React.Dispatch< React.SetStateAction< DataViewsState > >;
 
-	hideListing?: boolean;
-	setHideListing: ( hideListing: boolean ) => void;
-
 	showOnlyFavorites?: boolean;
 	setShowOnlyFavorites: ( showOnlyFavorites: boolean ) => void;
 


### PR DESCRIPTION
This PR fixes an issue with the selected site not always visible.

<img width="1068" alt="Screenshot 2024-09-18 at 8 20 04 PM" src="https://github.com/user-attachments/assets/ca05c84b-d1f6-48f3-a114-d95e5a1d0d53">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1077

## Proposed Changes

* To ensure that the selected site is always highlighted in the site dashboard, we will add a CSS class name to the selected row. Using the class name, we can do a CSS query `:has(.is-site-selected)` and apply appropriate styling.
* Additionally, when we refresh the page, the site loses the site selector. This PR fixes this by ensuring we always display the list when there is a selected site.

## Why are these changes being made?

* Makes UI more polished which in return improves user experience.

## Testing Instructions

* Use the A4A live link and go to the `/sites` page.
* Select a site and confirm you see the highlight appear.
  <img width="961" alt="Screenshot 2024-09-18 at 8 26 15 PM" src="https://github.com/user-attachments/assets/83975762-030f-4b11-969e-6275b58ac03d">
* Refresh the page
* Confirm that the UI did not lost the site list at the right.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
