### PR TITLE
Paid subscribers importer URL validation fixes

### DIFF
--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -37,7 +37,7 @@ type NewsletterImporterProps = {
 };
 
 function getTitle( engine: EngineTypes, urlData?: UrlData ) {
-	if ( urlData?.platform === engine && urlData?.meta?.title ) {
+	if ( urlData?.meta?.title && urlData?.platform === engine ) {
 		return `Import ${ urlData.meta.title }`;
 	}
 

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -100,7 +100,7 @@ export default function NewsletterImporter( {
 	const {
 		data: urlData,
 		isFetching: isUrlFetching,
-		isError: urlError,
+		isError: isUrlError,
 	} = useAnalyzeUrlQuery( fromSite );
 
 	useEffect( () => {
@@ -139,7 +139,7 @@ export default function NewsletterImporter( {
 					isLoading={ isUrlFetching || isResetPaidNewsletterPending }
 					engine={ engine }
 					value={ fromSite }
-					urlError={ urlError }
+					urlError={ isUrlError }
 				/>
 			) }
 

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -134,7 +134,7 @@ export default function NewsletterImporter( {
 
 			{ ( ! validFromSite || isResetPaidNewsletterPending ) && (
 				<SelectNewsletterForm
-					stepUrl={ stepUrl }
+					redirectUrl={ stepUrl }
 					urlData={ urlData }
 					isLoading={ isUrlFetching || isResetPaidNewsletterPending }
 					engine={ engine }

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -97,7 +97,11 @@ export default function NewsletterImporter( {
 	const { skipNextStep } = useSkipNextStepMutation();
 	const { resetPaidNewsletter, isPending: isResetPaidNewsletterPending } = useResetMutation();
 
-	const { data: urlData, isFetching } = useAnalyzeUrlQuery( fromSite );
+	const {
+		data: urlData,
+		isFetching: isUrlFetching,
+		isError: urlError,
+	} = useAnalyzeUrlQuery( fromSite );
 
 	useEffect( () => {
 		if ( urlData?.platform === engine ) {
@@ -132,7 +136,10 @@ export default function NewsletterImporter( {
 				<SelectNewsletterForm
 					stepUrl={ stepUrl }
 					urlData={ urlData }
-					isLoading={ isFetching || isResetPaidNewsletterPending }
+					isLoading={ isUrlFetching || isResetPaidNewsletterPending }
+					engine={ engine }
+					value={ fromSite }
+					urlError={ urlError }
 				/>
 			) }
 

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -37,7 +37,7 @@ type NewsletterImporterProps = {
 };
 
 function getTitle( urlData?: UrlData ) {
-	if ( urlData?.meta?.title ) {
+	if ( urlData?.platform === 'substack' && urlData?.meta?.title ) {
 		return `Import ${ urlData.meta.title }`;
 	}
 

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -135,11 +135,9 @@ export default function NewsletterImporter( {
 			{ ( ! validFromSite || isResetPaidNewsletterPending ) && (
 				<SelectNewsletterForm
 					redirectUrl={ stepUrl }
-					urlData={ urlData }
-					isLoading={ isUrlFetching || isResetPaidNewsletterPending }
-					engine={ engine }
 					value={ fromSite }
-					urlError={ isUrlError }
+					isLoading={ isUrlFetching || isResetPaidNewsletterPending }
+					isError={ isUrlError || ( !! urlData?.platform && urlData.platform !== engine ) }
 				/>
 			) }
 

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -36,8 +36,8 @@ type NewsletterImporterProps = {
 	step?: StepId;
 };
 
-function getTitle( urlData?: UrlData ) {
-	if ( urlData?.platform === 'substack' && urlData?.meta?.title ) {
+function getTitle( engine: EngineTypes, urlData?: UrlData ) {
+	if ( urlData?.platform === engine && urlData?.meta?.title ) {
 		return `Import ${ urlData.meta.title }`;
 	}
 
@@ -130,7 +130,7 @@ export default function NewsletterImporter( {
 	return (
 		<div className={ clsx( 'newsletter-importer', 'newsletter-importer__step-' + step ) }>
 			<LogoChain logos={ logoChainLogos } />
-			<FormattedHeader headerText={ getTitle( urlData ) } />
+			<FormattedHeader headerText={ getTitle( engine, urlData ) } />
 
 			{ ( ! validFromSite || isResetPaidNewsletterPending ) && (
 				<SelectNewsletterForm

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -2,27 +2,21 @@ import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
-import { UrlData } from 'calypso/blocks/import/types';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
 import { isValidUrl, parseUrl } from 'calypso/lib/importer/url-validation';
-import { EngineTypes } from './types';
 
 interface SelectNewsletterFormProps {
 	redirectUrl: string;
-	urlData?: UrlData;
-	isLoading: boolean;
-	engine: EngineTypes;
 	value: string;
-	urlError: boolean;
+	isLoading: boolean;
+	isError: boolean;
 }
 
 export default function SelectNewsletterForm( {
 	redirectUrl,
-	urlData,
-	isLoading,
-	engine,
 	value,
-	urlError,
+	isLoading,
+	isError,
 }: SelectNewsletterFormProps ) {
 	const [ isUrlInvalid, setIsUrlInvalid ] = useState( false );
 
@@ -32,8 +26,10 @@ export default function SelectNewsletterForm( {
 			return;
 		}
 
-		const { hostname } = parseUrl( fromSite );
-		page( addQueryArgs( redirectUrl, { from: hostname } ) );
+		const { hostname, pathname } = parseUrl( fromSite );
+		const from = pathname.match( /^\/@\w+$/ ) ? hostname + pathname : hostname;
+
+		page( addQueryArgs( redirectUrl, { from } ) );
 	};
 
 	if ( isLoading ) {
@@ -44,7 +40,7 @@ export default function SelectNewsletterForm( {
 		);
 	}
 
-	const isError = isUrlInvalid || urlError || ( urlData?.platform && urlData.platform !== engine );
+	const hasError = isUrlInvalid || isError;
 
 	return (
 		<Card className="select-newsletter-form">
@@ -52,13 +48,13 @@ export default function SelectNewsletterForm( {
 				onAction={ handleAction }
 				placeholder="https://example.substack.com"
 				action="Continue"
-				isError={ isError }
+				isError={ hasError }
 				defaultValue={ value }
 			/>
-			{ isError && (
+			{ hasError && (
 				<p className="select-newsletter-form__help is-error">Please enter a valid Substack URL.</p>
 			) }
-			{ ! isError && (
+			{ ! hasError && (
 				<p className="select-newsletter-form__help">
 					Enter the URL of the Substack newsletter that you wish to import.
 				</p>

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -5,19 +5,30 @@ import { useState } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
 import { isValidUrl, parseUrl } from 'calypso/lib/importer/url-validation';
+import { EngineTypes } from './types';
 
 type Props = {
 	stepUrl: string;
 	urlData?: UrlData;
 	isLoading: boolean;
+	engine: EngineTypes;
+	value: string;
+	urlError: boolean;
 };
 
-export default function SelectNewsletterForm( { stepUrl, urlData, isLoading }: Props ) {
-	const [ hasError, setHasError ] = useState( false );
+export default function SelectNewsletterForm( {
+	stepUrl,
+	urlData,
+	isLoading,
+	engine,
+	value,
+	urlError,
+}: Props ) {
+	const [ isUrlInvalid, setIsUrlInvalid ] = useState( false );
 
 	const handleAction = ( fromSite: string ) => {
 		if ( ! isValidUrl( fromSite ) ) {
-			setHasError( true );
+			setIsUrlInvalid( true );
 			return;
 		}
 
@@ -34,6 +45,8 @@ export default function SelectNewsletterForm( { stepUrl, urlData, isLoading }: P
 		);
 	}
 
+	const hasError = isUrlInvalid || urlError || ( urlData?.platform && urlData.platform !== engine );
+
 	return (
 		<Card className="select-newsletter-form">
 			<FormTextInputWithAction
@@ -41,7 +54,7 @@ export default function SelectNewsletterForm( { stepUrl, urlData, isLoading }: P
 				placeholder="https://example.substack.com"
 				action="Continue"
 				isError={ hasError }
-				defaultValue={ urlData?.url }
+				defaultValue={ value }
 			/>
 			{ hasError && (
 				<p className="select-newsletter-form__help is-error">Please enter a valid Substack URL.</p>

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -7,23 +7,23 @@ import FormTextInputWithAction from 'calypso/components/forms/form-text-input-wi
 import { isValidUrl, parseUrl } from 'calypso/lib/importer/url-validation';
 import { EngineTypes } from './types';
 
-type Props = {
-	stepUrl: string;
+interface SelectNewsletterFormProps {
+	redirectUrl: string;
 	urlData?: UrlData;
 	isLoading: boolean;
 	engine: EngineTypes;
 	value: string;
 	urlError: boolean;
-};
+}
 
 export default function SelectNewsletterForm( {
-	stepUrl,
+	redirectUrl,
 	urlData,
 	isLoading,
 	engine,
 	value,
 	urlError,
-}: Props ) {
+}: SelectNewsletterFormProps ) {
 	const [ isUrlInvalid, setIsUrlInvalid ] = useState( false );
 
 	const handleAction = ( fromSite: string ) => {
@@ -33,8 +33,7 @@ export default function SelectNewsletterForm( {
 		}
 
 		const { hostname } = parseUrl( fromSite );
-		page( addQueryArgs( stepUrl, { from: hostname } ) );
-		return;
+		page( addQueryArgs( redirectUrl, { from: hostname } ) );
 	};
 
 	if ( isLoading ) {
@@ -45,7 +44,7 @@ export default function SelectNewsletterForm( {
 		);
 	}
 
-	const hasError = isUrlInvalid || urlError || ( urlData?.platform && urlData.platform !== engine );
+	const isError = isUrlInvalid || urlError || ( urlData?.platform && urlData.platform !== engine );
 
 	return (
 		<Card className="select-newsletter-form">
@@ -53,13 +52,13 @@ export default function SelectNewsletterForm( {
 				onAction={ handleAction }
 				placeholder="https://example.substack.com"
 				action="Continue"
-				isError={ hasError }
+				isError={ isError }
 				defaultValue={ value }
 			/>
-			{ hasError && (
+			{ isError && (
 				<p className="select-newsletter-form__help is-error">Please enter a valid Substack URL.</p>
 			) }
-			{ ! hasError && (
+			{ ! isError && (
 				<p className="select-newsletter-form__help">
 					Enter the URL of the Substack newsletter that you wish to import.
 				</p>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

It:
- keeps the input value in case of an error
- adds support for `https://substack.com/@enej0077` URLs
- shows the site title only when the detected engine is correct

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
