### PR TITLE
Performance Profiler: Insights - Add scroll to wide elements like code blocks

### DIFF
--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -194,6 +194,7 @@ $blueberry-color: #3858e9;
 
 					&:only-child {
 						flex: 0 1 700px;
+						max-width: 700px; // If elements are wider, e.g. code blocks, there will be a horizontal scroll
 					}
 				}
 


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9163

## Proposed Changes

* Add a `max-width` to the content blocks in the Insights section. The `max-width` value is the same than the `flex-basis` and it prevents the scenarios where very wide elements, like code blow, make the section to grow.
* Additionally, imposing the `max-width` makes the `overflow: auto` existing code to work properly.

|Before | After|After when scrolling|
|-------|------|------|
| ![CleanShot 2024-09-18 at 15 46 55@2x](https://github.com/user-attachments/assets/270bc2ab-88bd-47d5-bc47-992a37c5035d)| ![CleanShot 2024-09-18 at 15 37 46@2x](https://github.com/user-attachments/assets/4061e25b-c37a-47f9-a9d9-2226ccf48026)   |  ![CleanShot 2024-09-18 at 15 38 14@2x](https://github.com/user-attachments/assets/35566167-3ffa-4c8c-b86f-aa52a960d0cd)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To facilitate the readability of the Insights section

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the Performance Profiler tool
* Run a test on a site that returns code blocks in the insights, e.g. `/speed-test-tool?url=https%3A%2F%2Fwww.spendbase.co%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzcxMn0.kNmVyGsHbcKvXbAvSQCi7WbmxfEuAJwuEwpZHQAuwBE&filter=all`
* Expand an Insights section that contains code block, for example `Image elements do not have explicit width and height`
* Check the code block is scrollable horizontally. 
* Check there is no visual regressions regarding width in the Insights section. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
