### PR TITLE
Tags page: Add a translated meta description and hreflang links

### DIFF
--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import wpcom from 'calypso/lib/wp';
 import performanceMark, { PartialContext } from 'calypso/server/lib/performance-mark';
@@ -27,13 +27,30 @@ export interface AlphabeticTagsResult {
 	[ key: string ]: Tag[];
 }
 
+const TagsPageDocumentHead = () => {
+	const translate = useTranslate();
+
+	const title = translate( 'Popular Tags and Posts ‹ Reader' );
+	const meta = [
+		{
+			name: 'description',
+			content: translate(
+				"Discover the most popular tags and posts on WordPress.com. For every one of your interests, there's a tag on WordPress.com."
+			),
+		},
+	];
+
+	return <DocumentHead title={ title } meta={ meta } />;
+};
+
 export const tagsListing = ( context: PageJSContext, next: () => void ) => {
 	if ( ! isUserLoggedIn( context.store.getState() ) ) {
 		context.renderHeaderSection = renderHeaderSection;
 	}
+
 	context.primary = (
 		<>
-			<DocumentHead title={ translate( 'Popular Tags and Posts ‹ Reader' ) } />
+			<TagsPageDocumentHead />
 			<TagsPage
 				trendingTags={ context.params.trendingTags }
 				alphabeticTags={ context.params.alphabeticTags }
@@ -43,7 +60,9 @@ export const tagsListing = ( context: PageJSContext, next: () => void ) => {
 	next();
 };
 
-function renderHeaderSection() {
+const TagsPageHeaderSection = () => {
+	const translate = useTranslate();
+
 	return (
 		<>
 			<h1>
@@ -55,6 +74,10 @@ function renderHeaderSection() {
 			<p>{ translate( "For every one of your interests, there's a tag on WordPress.com." ) }</p>
 		</>
 	);
+};
+
+function renderHeaderSection() {
+	return <TagsPageHeaderSection />;
 }
 
 export const fetchTrendingTags = ( context: PageJSContext, next: ( e?: Error ) => void ) => {

--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -35,7 +35,7 @@ const TagsPageDocumentHead = () => {
 		{
 			name: 'description',
 			content: translate(
-				"Discover the most popular tags and posts on WordPress.com. For every one of your interests, there's a tag on WordPress.com."
+				'Discover the most popular tags on WordPress.com. Whatever your interests, find a tag and dive into posts that inspire and inform.'
 			),
 		},
 	];

--- a/client/reader/tags/index.node.js
+++ b/client/reader/tags/index.node.js
@@ -1,5 +1,6 @@
 import { getLanguageRouteParam, getAnyLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
+import { setHrefLangLinks } from 'calypso/controller/localized-links';
 import { tagsListing, fetchTrendingTags, fetchAlphabeticTags } from './controller';
 
 export default function ( router ) {
@@ -9,6 +10,7 @@ export default function ( router ) {
 	router(
 		[ '/tags', `/${ langParam }/tags`, `/${ anyLangParam }/tags` ],
 		ssrSetupLocale,
+		setHrefLangLinks,
 		fetchTrendingTags,
 		fetchAlphabeticTags,
 		tagsListing,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pxLjZ-8N9-p2.

## Proposed Changes

* Add a meta description to the `/tags` page.
* Add hreflang links for the Magnificent 16 locales by using the `setHrefLangLinks` middleware.
* Refactor the code in `controller.tsx` to use `useTranslate` instead of calling `translate` statically.
  * This also fixes SSR for the page title, allowing it to show up translated in search engine results.
  * This also fixes SSR for the header text translations on the page itself ("All the Tags" and "For every one of your interests, there's a tag on WordPress.com.").

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The search engine result for `/tags` has an untranslated title and no real description: ![image](https://github.com/user-attachments/assets/250f2b9e-232b-485d-95b6-a37c9c951308) The above changes fix this, which will improve SEO.
* The page didn't have hreflang links. Adding them makes it easier for search engines to understand that the localized URLs are essentially the same page, but for different locales.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/[locale]/tags` while logged out and view its source.
* Verify that there's now a `<meta name="description" [...]` tag. Since it's a new string, the text is still untranslated, but it will be translated soon.
* Verify that there are 18 hreflang links (`x-default`, `en`, and the Mag-16 locales).
* Click some of the hreflang URLs and verify that they're working.
* Visit `/tags` while logged in and verify that the page is still working normally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
