### PR TITLE
Me: Add setSelectedSiteIdByOrigin for "My Profile"

### DIFF
--- a/client/me/index.js
+++ b/client/me/index.js
@@ -1,11 +1,18 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender, setSelectedSiteIdByOrigin } from 'calypso/controller';
 import * as controller from './controller';
 
 import './style.scss';
 
 export default function () {
-	page( '/me', controller.sidebar, controller.profile, makeLayout, clientRender );
+	page(
+		'/me',
+		controller.sidebar,
+		setSelectedSiteIdByOrigin,
+		controller.profile,
+		makeLayout,
+		clientRender
+	);
 
 	// Redirect previous URLs
 	page( '/me/profile', controller.profileRedirect, makeLayout, clientRender );


### PR DESCRIPTION
## Proposed Changes

* Runs `setSelectedSiteIdByOrigin` for `/me`

## Why are these changes being made?

See below but it's basically a bug fix. 

## Testing Instructions

This is a slightly odd and minor bug to explain so please bear with me. You need two sites:

1. Have Site A as a primary site (eg. `cat.com`)
2. Navigate to WP-Admin of Site B (eg. `dog.com`)
3. Select "My Account" in the Masterbar for Site B

<img width="294" alt="Screenshot 2024-09-18 at 15 01 02" src="https://github.com/user-attachments/assets/7ac1dc13-e2bc-4579-8300-a1a56af460ed">

4. You'll note that we pass an `origin_site_id` parameter to the link. By running `setSelectedSiteIdByOrigin`, we should see **dog.com** as the site to navigate back to in the Masterbar. At the moment, it's **cat.com**. So the parameter is a bit useless without this change.
5. But because we pass `origin_site_id`, the sidebar items aren't highlighted since they rely on the parameter being removed, which means that "My Profile" isn't highlighted when it should be 

<img width="1469" alt="Screenshot 2024-09-18 at 15 03 48" src="https://github.com/user-attachments/assets/f585bbda-fe5e-41f1-b5a8-0fac40c099d6">

6. Confirm that these two issues are fixed with this change.

cc @okmttdhr, @Addison-Stavlo, @fushar - it looks like the parameter was added in Automattic/jetpack#38401