### PR TITLE
Hosting features transfer modal: Update data center picker design

### DIFF
--- a/client/blocks/data-center-picker/README.md
+++ b/client/blocks/data-center-picker/README.md
@@ -16,4 +16,3 @@ function render() {
 
 - `onChange (func)` - A function to handle the event callback when choosing a data center or picking the recommended one.
 - `value (string)` - The picked data center (this is a controlled component).
-- `compact (boolean)` - Whether or not to display a version of the data center picker without the global map.

--- a/client/blocks/data-center-picker/docs/example.jsx
+++ b/client/blocks/data-center-picker/docs/example.jsx
@@ -8,9 +8,6 @@ const DataCenterPickerExample = () => {
 	return (
 		<div>
 			<Card compact>
-				<DataCenterPicker compact onChange={ setValue } value={ value } />
-			</Card>
-			<Card compact>
 				<DataCenterPicker onChange={ setValue } value={ value } />
 			</Card>
 		</div>

--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -1,16 +1,9 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
-import { Button } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { useState } from 'react';
-import amsImg from 'calypso/assets/images/data-center-picker/ams-240x180.png';
-import burImg from 'calypso/assets/images/data-center-picker/bur-240x180.png';
-import dcaImg from 'calypso/assets/images/data-center-picker/dca-240x180.png';
-import dfwImg from 'calypso/assets/images/data-center-picker/dfw-240x180.png';
-import worldImg from 'calypso/assets/images/data-center-picker/world-1082x180.png';
 import ExternalLink from 'calypso/components/external-link';
-import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
-import FormSelect from 'calypso/components/forms/form-select';
 
 interface ExternalProps {
 	value: string;
@@ -24,43 +17,33 @@ type Props = ExternalProps & LocalizeProps;
 
 const DataCenterOptions = [
 	{
+		value: '',
+		get label(): string {
+			return translate( 'Optimal data center' );
+		},
+	},
+	{
 		value: 'bur',
-		name: 'geo_affinity',
 		get label(): string {
 			return translate( 'US West' );
-		},
-		thumbnail: {
-			imageUrl: burImg,
 		},
 	},
 	{
 		value: 'dfw',
-		name: 'geo_affinity',
 		get label(): string {
 			return translate( 'US Central' );
-		},
-		thumbnail: {
-			imageUrl: dfwImg,
 		},
 	},
 	{
 		value: 'dca',
-		name: 'geo_affinity',
 		get label(): string {
 			return translate( 'US East' );
-		},
-		thumbnail: {
-			imageUrl: dcaImg,
 		},
 	},
 	{
 		value: 'ams',
-		name: 'geo_affinity',
 		get label(): string {
 			return translate( 'EU West' );
-		},
-		thumbnail: {
-			imageUrl: amsImg,
 		},
 	},
 ];
@@ -69,208 +52,50 @@ const Form = styled.div( {
 	maxWidth: '564px',
 } );
 
-const FormHeadingContainer = styled.div( {
-	display: 'flex',
-	alignItems: 'center',
-	marginBottom: '8px',
-} );
-
-const FormHeading = styled.h3( {
-	fontWeight: 600,
-	marginRight: '8px',
-} );
-
-const FormDescription = styled.p( {
-	marginBottom: '12px',
-} );
-
-const AutomaticFormLabel = styled.label( {
-	display: 'block',
-	marginBottom: '12px',
-	width: '100%',
-	maxWidth: '541px',
-	cursor: 'pointer',
-} );
-
-const CompactLabel = styled.label( {
-	cursor: 'pointer',
-	display: 'flex',
-	padding: '24px 16px',
-	border: '2px solid #DCDCDE',
-	borderRadius: '4px',
-
-	'&:hover': {
-		background: '#F9FBFD',
-	},
-
-	'&:has(input[type=radio]:checked)': {
-		background: '#F9FBFD',
-		borderColor: '#0675C4',
-	},
-} );
-
-const PickerOptions = styled.div( { display: 'flex', flexDirection: 'column', gap: '16px' } );
-
-const PickerOption = styled.div( {
-	display: 'flex',
-	flexDirection: 'column',
-	justifyContent: 'flex-start',
-	alignItems: 'flex-start',
-	gap: '8px',
-} );
-
-const PickerOptionLabel = styled.span( { lineHeight: '20px', fontWeight: 600, color: '#101517' } );
-
-const PickerRadio = styled.input( {
-	margin: '2px 16px 0 0',
-} );
-
-const CompactPickerSelect = styled( FormSelect )( {
-	width: 'fit-content',
-	borderRadius: '4px',
-} );
-
-const FormLabelThumbnail = styled.div( {
-	display: 'flex',
-	width: '100%',
-	height: '90px',
-	margin: '2px 0 8px',
-	backgroundColor: 'var(--color-surface)',
-	backgroundPosition: '50% 0',
-	backgroundSize: 'cover',
-	borderRadius: '2px',
-	boxShadow: '0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5), 0 1px 2px var(--color-neutral-0)',
-	transition: 'all 100ms ease-in-out',
-	overflow: 'hidden',
-	'&:hover': {
-		boxShadow: '0 0 0 1px var(--color-neutral-light), 0 2px 4px var(--color-neutral-10)',
-	},
-} );
-
-const FormLabelThumbnailImg = styled.img( {
-	objectFit: 'cover',
-} );
-
-const RECOMMENDED_DATA_CENTER = '';
+const CustomizeLink = styled.a`
+	color: var( --color-link );
+	text-decoration: underline;
+	cursor: pointer;
+`;
 
 const DataCenterPicker = ( {
 	onChange,
-	onClickHidePicker = () => null,
 	onClickShowPicker = () => null,
 	translate,
 	value,
-	compact = false,
 }: Props ) => {
 	const [ isFormShowing, setIsFormShowing ] = useState( false );
-
-	const onCancel = () => {
-		onChange( RECOMMENDED_DATA_CENTER );
-		onClickHidePicker();
-		setIsFormShowing( false );
-	};
-
-	const isRecommendedDataCenterPicked = value === RECOMMENDED_DATA_CENTER;
-
-	if ( compact ) {
-		return (
-			<div className="data-center-picker">
-				<FormHeadingContainer>
-					<FormHeading>{ translate( 'Pick your primary data center' ) }</FormHeading>
-				</FormHeadingContainer>
-				<FormDescription className="data-center-picker__description">
-					{ translate(
-						'Your site will replicate in real-time to a second data center in a different region. {{supportLink}}Learn more{{/supportLink}}.',
-						{
-							components: {
-								supportLink: (
-									<ExternalLink
-										target="_blank"
-										href={ localizeUrl(
-											'https://wordpress.com/support/choose-your-sites-primary-data-center/'
-										) }
-									/>
-								),
-							},
-						}
-					) }
-				</FormDescription>
-				<PickerOptions className="data-center-picker__options" role="radiogroup">
-					<CompactLabel>
-						<PickerRadio
-							className="form-radio"
-							type="radio"
-							name="geo_affinity"
-							onChange={ () => onChange( RECOMMENDED_DATA_CENTER ) }
-							checked={ isRecommendedDataCenterPicked }
-						/>
-						<PickerOption>
-							<PickerOptionLabel>{ translate( 'Optimal data center' ) }</PickerOptionLabel>
-							<span>
-								{ translate( 'Automatically place my site in the optimal data center.' ) }
-							</span>
-						</PickerOption>
-					</CompactLabel>
-					<CompactLabel>
-						<PickerRadio
-							className="form-radio"
-							type="radio"
-							name="geo_affinity"
-							onChange={ () => onChange( DataCenterOptions[ 0 ].value ) }
-							checked={ ! isRecommendedDataCenterPicked }
-						/>
-						<PickerOption>
-							<PickerOptionLabel>{ translate( 'Custom data center' ) }</PickerOptionLabel>
-							<span>{ translate( 'Choose the data center that best suits your needs.' ) }</span>
-							{ ! isRecommendedDataCenterPicked && (
-								<CompactPickerSelect
-									onChange={ ( event ) => onChange( event.currentTarget.value ) }
-									value={ value }
-								>
-									{ DataCenterOptions.map( ( option ) => (
-										<option key={ option.value } value={ option.value }>
-											{ option.label }
-										</option>
-									) ) }
-								</CompactPickerSelect>
-							) }
-						</PickerOption>
-					</CompactLabel>
-				</PickerOptions>
-			</div>
-		);
-	}
 
 	return (
 		<div>
 			{ ! isFormShowing && (
 				<div>
 					<span>
-						{ translate( 'Your site will be automatically placed in the optimal data center.' ) }
+						{ translate(
+							'Your site will be placed in the optimal data center, but you can {{customizeLink}}customize it{{/customizeLink}}.',
+							{
+								components: {
+									customizeLink: (
+										<CustomizeLink
+											onClick={ () => {
+												onClickShowPicker();
+												setIsFormShowing( ! isFormShowing );
+											} }
+										/>
+									),
+								},
+							}
+						) }
 					</span>
-					&nbsp;
-					<Button
-						variant="tertiary"
-						onClick={ () => {
-							onClickShowPicker();
-							setIsFormShowing( ! isFormShowing );
-						} }
-					>
-						{ translate( 'Choose a data center instead' ) }
-					</Button>
 				</div>
 			) }
 
 			{ isFormShowing && (
 				<Form>
-					<FormHeadingContainer>
-						<FormHeading>{ translate( 'Pick your primary data center' ) }</FormHeading>
-						<Button variant="tertiary" onClick={ onCancel }>
-							{ translate( 'Cancel' ) }
-						</Button>
-					</FormHeadingContainer>
-					<FormDescription>
-						{ translate(
-							'Choose a primary data center for your site. For redundancy, your site will replicate in real-time to a second data center in a different region. {{supportLink}}Learn more{{/supportLink}}.',
+					<SelectControl
+						label={ translate( 'Pick your primary data center' ) }
+						help={ translate(
+							'For redundancy, your site will replicate in real-time to a second data center in a different region. {{supportLink}}Learn more{{/supportLink}}.',
 							{
 								components: {
 									supportLink: (
@@ -285,35 +110,13 @@ const DataCenterPicker = ( {
 								},
 							}
 						) }
-					</FormDescription>
-					<div role="radiogroup">
-						<AutomaticFormLabel>
-							<FormLabelThumbnail>
-								<FormLabelThumbnailImg
-									src={ worldImg }
-									alt={ translate( 'Illustration of the world' ) }
-								/>
-							</FormLabelThumbnail>
-							<input
-								className="form-radio"
-								type="radio"
-								name="geo_affinity"
-								value=""
-								checked={ isRecommendedDataCenterPicked }
-								onChange={ () => onChange( RECOMMENDED_DATA_CENTER ) }
-							/>
-							<span>
-								{ translate( 'Automatically place my site in the optimal data center.' ) }
-							</span>
-						</AutomaticFormLabel>
-						<FormRadiosBar
-							isThumbnail
-							checked={ value }
-							onChange={ ( event ) => onChange( event.currentTarget.value ) }
-							items={ DataCenterOptions }
-							disabled={ false }
-						/>
-					</div>
+						options={ DataCenterOptions.map( ( option ) => ( {
+							label: option.label,
+							value: option.value,
+						} ) ) }
+						onChange={ ( value ) => onChange( value ) }
+						value={ value }
+					/>
 				</Form>
 			) }
 		</div>

--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -52,6 +52,10 @@ const Form = styled.div( {
 	maxWidth: '564px',
 } );
 
+const FormHidden = styled.div( {
+	fontSize: '0.75rem',
+} );
+
 const CustomizeLink = styled.a`
 	color: var( --color-link );
 	text-decoration: underline;
@@ -69,25 +73,23 @@ const DataCenterPicker = ( {
 	return (
 		<div>
 			{ ! isFormShowing && (
-				<div>
-					<span>
-						{ translate(
-							'Your site will be placed in the optimal data center, but you can {{customizeLink}}customize it{{/customizeLink}}.',
-							{
-								components: {
-									customizeLink: (
-										<CustomizeLink
-											onClick={ () => {
-												onClickShowPicker();
-												setIsFormShowing( ! isFormShowing );
-											} }
-										/>
-									),
-								},
-							}
-						) }
-					</span>
-				</div>
+				<FormHidden>
+					{ translate(
+						'Your site will be placed in the optimal data center, but you can {{customizeLink}}customize it{{/customizeLink}}.',
+						{
+							components: {
+								customizeLink: (
+									<CustomizeLink
+										onClick={ () => {
+											onClickShowPicker();
+											setIsFormShowing( ! isFormShowing );
+										} }
+									/>
+								),
+							},
+						}
+					) }
+				</FormHidden>
 			) }
 
 			{ isFormShowing && (

--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -1,7 +1,6 @@
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { SelectControl } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { useState } from 'react';
 
@@ -81,7 +80,7 @@ const DataCenterPicker = ( {
 	value,
 }: Props ) => {
 	const [ isFormShowing, setIsFormShowing ] = useState( false );
-	const { hasTranslation } = useI18n();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const supportLinkComponent = (
 		<SupportLink
@@ -117,7 +116,7 @@ const DataCenterPicker = ( {
 					<SelectControl
 						label={ <StyledLabel>{ translate( 'Pick your primary data center' ) }</StyledLabel> }
 						help={
-							hasTranslation(
+							hasEnTranslation(
 								'For redundancy, your site will be replicated in real-time to another region. {{supportLink}}Learn more{{/supportLink}}.'
 							)
 								? translate(

--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import { SelectControl } from '@wordpress/components';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { useState } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 
 interface ExternalProps {
 	value: string;
@@ -50,6 +49,9 @@ const DataCenterOptions = [
 
 const Form = styled.div( {
 	maxWidth: '564px',
+	border: '1px solid var( --color-border-subtle )',
+	borderRadius: '4px',
+	padding: '24px',
 } );
 
 const FormHidden = styled.div( {
@@ -57,9 +59,13 @@ const FormHidden = styled.div( {
 } );
 
 const CustomizeLink = styled.a`
-	color: var( --color-link );
 	text-decoration: underline;
 	cursor: pointer;
+`;
+
+const SupportLink = styled.a`
+	text-decoration: underline;
+	color: var( --color-text-subtle ) !important;
 `;
 
 const DataCenterPicker = ( {
@@ -101,8 +107,7 @@ const DataCenterPicker = ( {
 							{
 								components: {
 									supportLink: (
-										<ExternalLink
-											icon
+										<SupportLink
 											target="_blank"
 											href={ localizeUrl(
 												'https://wordpress.com/support/choose-your-sites-primary-data-center/'

--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -68,6 +68,12 @@ const SupportLink = styled.a`
 	color: var( --color-text-subtle ) !important;
 `;
 
+const StyledLabel = styled.div`
+	text-transform: none;
+	font-size: 0.875rem;
+	color: var( --studio-gray-50 );
+`;
+
 const DataCenterPicker = ( {
 	onChange,
 	onClickShowPicker = () => null,
@@ -101,7 +107,7 @@ const DataCenterPicker = ( {
 			{ isFormShowing && (
 				<Form>
 					<SelectControl
-						label={ translate( 'Pick your primary data center' ) }
+						label={ <StyledLabel>{ translate( 'Pick your primary data center' ) }</StyledLabel> }
 						help={ translate(
 							'For redundancy, your site will replicate in real-time to a second data center in a different region. {{supportLink}}Learn more{{/supportLink}}.',
 							{

--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -66,13 +66,6 @@ const CustomizeLink = styled.a`
 
 const SupportLink = styled.a`
 	text-decoration: underline;
-	color: var( --color-text-subtle ) !important;
-`;
-
-const StyledSelectControl = styled( SelectControl )`
-	.components-input-control__backdrop {
-		border-color: var( --studio-gray-10 ) !important;
-	}
 `;
 
 const StyledLabel = styled.div`
@@ -89,6 +82,13 @@ const DataCenterPicker = ( {
 }: Props ) => {
 	const [ isFormShowing, setIsFormShowing ] = useState( false );
 	const { hasTranslation } = useI18n();
+
+	const supportLinkComponent = (
+		<SupportLink
+			target="_blank"
+			href={ localizeUrl( 'https://wordpress.com/support/choose-your-sites-primary-data-center/' ) }
+		/>
+	);
 
 	return (
 		<div>
@@ -114,24 +114,17 @@ const DataCenterPicker = ( {
 
 			{ isFormShowing && (
 				<Form>
-					<StyledSelectControl
+					<SelectControl
 						label={ <StyledLabel>{ translate( 'Pick your primary data center' ) }</StyledLabel> }
 						help={
 							hasTranslation(
-								'For redundancy, your site will be replicated in real-time to another region.'
+								'For redundancy, your site will be replicated in real-time to another region. {{supportLink}}Learn more{{/supportLink}}.'
 							)
 								? translate(
 										'For redundancy, your site will be replicated in real-time to another region. {{supportLink}}Learn more{{/supportLink}}.',
 										{
 											components: {
-												supportLink: (
-													<SupportLink
-														target="_blank"
-														href={ localizeUrl(
-															'https://wordpress.com/support/choose-your-sites-primary-data-center/'
-														) }
-													/>
-												),
+												supportLink: supportLinkComponent,
 											},
 										}
 								  )
@@ -139,14 +132,7 @@ const DataCenterPicker = ( {
 										'For redundancy, your site will replicate in real-time to a second data center in a different region. {{supportLink}}Learn more{{/supportLink}}.',
 										{
 											components: {
-												supportLink: (
-													<SupportLink
-														target="_blank"
-														href={ localizeUrl(
-															'https://wordpress.com/support/choose-your-sites-primary-data-center/'
-														) }
-													/>
-												),
+												supportLink: supportLinkComponent,
 											},
 										}
 								  )

--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -69,6 +69,12 @@ const SupportLink = styled.a`
 	color: var( --color-text-subtle ) !important;
 `;
 
+const StyledSelectControl = styled( SelectControl )`
+	.components-input-control__backdrop {
+		border-color: var( --studio-gray-10 ) !important;
+	}
+`;
+
 const StyledLabel = styled.div`
 	text-transform: none;
 	font-size: 0.875rem;
@@ -108,7 +114,7 @@ const DataCenterPicker = ( {
 
 			{ isFormShowing && (
 				<Form>
-					<SelectControl
+					<StyledSelectControl
 						label={ <StyledLabel>{ translate( 'Pick your primary data center' ) }</StyledLabel> }
 						help={
 							hasTranslation(

--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -1,6 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { SelectControl } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { useState } from 'react';
 
@@ -81,6 +82,7 @@ const DataCenterPicker = ( {
 	value,
 }: Props ) => {
 	const [ isFormShowing, setIsFormShowing ] = useState( false );
+	const { hasTranslation } = useI18n();
 
 	return (
 		<div>
@@ -108,21 +110,41 @@ const DataCenterPicker = ( {
 				<Form>
 					<SelectControl
 						label={ <StyledLabel>{ translate( 'Pick your primary data center' ) }</StyledLabel> }
-						help={ translate(
-							'For redundancy, your site will replicate in real-time to a second data center in a different region. {{supportLink}}Learn more{{/supportLink}}.',
-							{
-								components: {
-									supportLink: (
-										<SupportLink
-											target="_blank"
-											href={ localizeUrl(
-												'https://wordpress.com/support/choose-your-sites-primary-data-center/'
-											) }
-										/>
-									),
-								},
-							}
-						) }
+						help={
+							hasTranslation(
+								'For redundancy, your site will be replicated in real-time to another region.'
+							)
+								? translate(
+										'For redundancy, your site will be replicated in real-time to another region. {{supportLink}}Learn more{{/supportLink}}.',
+										{
+											components: {
+												supportLink: (
+													<SupportLink
+														target="_blank"
+														href={ localizeUrl(
+															'https://wordpress.com/support/choose-your-sites-primary-data-center/'
+														) }
+													/>
+												),
+											},
+										}
+								  )
+								: translate(
+										'For redundancy, your site will replicate in real-time to a second data center in a different region. {{supportLink}}Learn more{{/supportLink}}.',
+										{
+											components: {
+												supportLink: (
+													<SupportLink
+														target="_blank"
+														href={ localizeUrl(
+															'https://wordpress.com/support/choose-your-sites-primary-data-center/'
+														) }
+													/>
+												),
+											},
+										}
+								  )
+						}
 						options={ DataCenterOptions.map( ( option ) => ( {
 							label: option.label,
 							value: option.value,

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -23,7 +23,6 @@
 
 			.button {
 				width: 100%;
-				margin-top: 20px;
 			}
 		}
 	}

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -297,3 +297,7 @@
 		margin-bottom: 0;
 	}
 }
+
+.eligibility-warnings__data-center-picker {
+	padding-top: 8px;
+}

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -298,6 +298,6 @@
 	}
 }
 
-.eligibility-warnings__data-center-picker {
-	padding-top: 8px;
+.card.eligibility-warnings__data-center-picker.is-compact {
+	padding-bottom: 8px;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7727

## Proposed Changes

* Update data center picker to match design in issue.

Before | After
---- | ----
<img width="715" alt="Screen Shot 2024-09-18 at 1 59 50 PM" src="https://github.com/user-attachments/assets/917607df-6b01-47a3-b8c7-53415ddb70f3"> | <img width="708" alt="Screen Shot 2024-10-01 at 3 00 27 PM" src="https://github.com/user-attachments/assets/a3865cd6-14f5-435d-95cf-b388185b5f9f">
<img width="734" alt="Screen Shot 2024-09-18 at 2 00 06 PM" src="https://github.com/user-attachments/assets/1bbf17df-1d0a-4a89-bbaa-112bcfa9839e"> | <img width="719" alt="Screen Shot 2024-10-06 at 4 14 09 PM" src="https://github.com/user-attachments/assets/9ba735ea-c0a9-4cc4-9fba-08dbd3518840">


Mobile:

Closed | Open | Selecting
---- | ---- | ----
<img width="294" alt="Screen Shot 2024-10-01 at 3 04 43 PM" src="https://github.com/user-attachments/assets/b872e579-8577-40bf-a513-bb0d3fdab81e"> | <img width="322" alt="Screen Shot 2024-10-06 at 4 13 56 PM" src="https://github.com/user-attachments/assets/529bd946-3d2a-49c9-9c40-c7bc4ba6bded"> | <img width="293" alt="Screen Shot 2024-10-01 at 3 00 40 PM" src="https://github.com/user-attachments/assets/598fdfd6-6ee5-423e-8f83-bb83e6a4ba2f">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the data center picker design and keep this interaction exciting for the user.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /hosting-features for a site that has a Business plan, but isn't yet Atomic.
* Click "Activate now."
* View the form closed state at different screen sizes.
* Click "customize it."
* View the form open state at different screen sizes.
* Pick a data center and click to activate the hosting features. Verify that the site is in the correct data center by going to Sever Settings > Web server settings > Primary data center.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
