### PR TITLE
Disable Migrate Guru install when the white labeled plugin is used

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -8,7 +8,7 @@ import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-mig
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import {
 	usePrepareSiteForMigrationWithMigrateGuru,
-	usePrepareSiteForMigrationWithMoveToWPCOM,
+	usePrepareSiteForMigrationWithMigrateToWPCOM,
 } from 'calypso/landing/stepper/hooks/use-prepare-site-for-migration';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -100,7 +100,7 @@ const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
 		error: preparationError,
 		migrationKey,
 	} = config.isEnabled( 'migration-flow/enable-white-labeled-plugin' )
-		? usePrepareSiteForMigrationWithMoveToWPCOM( siteId ) // eslint-disable-line react-hooks/rules-of-hooks -- Temporary workaround until we completely replace the migrate guru hook.
+		? usePrepareSiteForMigrationWithMigrateToWPCOM( siteId ) // eslint-disable-line react-hooks/rules-of-hooks -- Temporary workaround until we completely replace the migrate guru hook.
 		: usePrepareSiteForMigrationWithMigrateGuru( siteId ); // eslint-disable-line react-hooks/rules-of-hooks
 	const migrationKeyStatus = detailedStatus.migrationKey;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/index.tsx
@@ -27,7 +27,7 @@ export const Provisioning: FC< ProvisioningProps > = ( { status } ) => {
 		{ status: siteTransferStatus, text: translate( 'Provisioning your new site' ) },
 		{ status: pluginInstallationStatus, text: translate( 'Installing the required plugins' ) },
 		{ status: migrationKeyStatus, text: translate( 'Getting the migration key' ) },
-	];
+	].filter( ( action ) => action.status );
 
 	const currentActionIndex = actions.findIndex( ( action ) => action.status !== 'success' );
 	const currentAction = actions[ currentActionIndex ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/index.tsx
@@ -11,16 +11,16 @@ export type Status = 'idle' | 'pending' | 'success' | 'error';
 interface ProvisioningProps {
 	status: {
 		siteTransfer: Status;
-		pluginInstallation: Status;
 		migrationKey: Status;
+		pluginInstallation?: Status;
 	};
 }
 
 export const Provisioning: FC< ProvisioningProps > = ( { status } ) => {
 	const {
 		siteTransfer: siteTransferStatus,
-		pluginInstallation: pluginInstallationStatus,
 		migrationKey: migrationKeyStatus,
+		pluginInstallation: pluginInstallationStatus,
 	} = status;
 
 	const actions = [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-migration-sticker';
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
-import { usePrepareSiteForMigration } from 'calypso/landing/stepper/hooks/use-prepare-site-for-migration';
+import { usePrepareSiteForMigrationWithMigrateGuru } from 'calypso/landing/stepper/hooks/use-prepare-site-for-migration';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -49,7 +49,7 @@ describe( 'SiteMigrationInstructions', () => {
 			deleteMigrationSticker: jest.fn(),
 		} );
 
-		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
+		( usePrepareSiteForMigrationWithMigrateGuru as jest.Mock ).mockReturnValue( {
 			detailedStatus: {},
 			completed: false,
 			migrationKey: 'migration-key-here',
@@ -160,7 +160,7 @@ describe( 'SiteMigrationInstructions', () => {
 	} );
 
 	it( 'should display a fallback in the last step when preparation completes and there is an error with the migration key', async () => {
-		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
+		( usePrepareSiteForMigrationWithMigrateGuru as jest.Mock ).mockReturnValue( {
 			detailedStatus: { migrationKey: 'error' },
 			completed: true,
 			migrationKey: '',
@@ -178,7 +178,7 @@ describe( 'SiteMigrationInstructions', () => {
 	} );
 
 	it( 'should animate skeleton when waiting for completion', async () => {
-		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
+		( usePrepareSiteForMigrationWithMigrateGuru as jest.Mock ).mockReturnValue( {
 			detailedStatus: {},
 			completed: false,
 			migrationKey: '',
@@ -196,7 +196,7 @@ describe( 'SiteMigrationInstructions', () => {
 	} );
 
 	it( 'should not animate skeleton when error happens', async () => {
-		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
+		( usePrepareSiteForMigrationWithMigrateGuru as jest.Mock ).mockReturnValue( {
 			detailedStatus: {},
 			completed: false,
 			migrationKey: '',

--- a/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
+++ b/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
@@ -7,7 +7,7 @@ import nock from 'nock';
 import React from 'react';
 import {
 	usePrepareSiteForMigrationWithMigrateGuru,
-	usePrepareSiteForMigrationWithMoveToWPCOM,
+	usePrepareSiteForMigrationWithMigrateToWPCOM,
 } from '../use-prepare-site-for-migration';
 import { replyWithError, replyWithSuccess } from './helpers/nock';
 
@@ -195,7 +195,7 @@ describe( 'usePrepareSiteForMigrationWithMoveToWPCOM', () => {
 	const render = ( { siteId } ) => {
 		const queryClient = new QueryClient();
 
-		const renderResult = renderHook( () => usePrepareSiteForMigrationWithMoveToWPCOM( siteId ), {
+		const renderResult = renderHook( () => usePrepareSiteForMigrationWithMigrateToWPCOM( siteId ), {
 			wrapper: Wrapper( queryClient ),
 		} );
 

--- a/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
+++ b/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import React from 'react';
-import { usePrepareSiteForMigration } from '../use-prepare-site-for-migration';
+import { usePrepareSiteForMigrationWithMigrateGuru } from '../use-prepare-site-for-migration';
 import { replyWithError, replyWithSuccess } from './helpers/nock';
 
 const TRANSFER_ACTIVE = ( siteId: number ) => ( {
@@ -40,7 +40,7 @@ describe( 'usePrepareSiteForMigration', () => {
 	const render = ( { siteId } ) => {
 		const queryClient = new QueryClient();
 
-		const renderResult = renderHook( () => usePrepareSiteForMigration( siteId ), {
+		const renderResult = renderHook( () => usePrepareSiteForMigrationWithMigrateGuru( siteId ), {
 			wrapper: Wrapper( queryClient ),
 		} );
 

--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -200,10 +200,10 @@ export const usePrepareSiteForMigrationWithMigrateGuru = ( siteId?: number ) => 
 };
 
 /**
- *  Hook to manage the site to prepare a site for migration using the Move to WordPress.com plugin.
+ *  Hook to manage the site to prepare a site for migration using the Migrate to WordPress.com plugin.
  *  This hook manages the site transfer.
  */
-export const usePrepareSiteForMigrationWithMoveToWPCOM = ( siteId?: number ) => {
+export const usePrepareSiteForMigrationWithMigrateToWPCOM = ( siteId?: number ) => {
 	const siteTransferState = useSiteTransfer( siteId );
 	const transferTimingTracked = useRef( false );
 

--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -59,9 +59,45 @@ const safeLogToLogstash = ( message: string, properties: Record< string, unknown
 	}
 };
 
+const useLogMigration = (
+	completed: boolean,
+	siteTransferStatus: Status,
+	error?: Error | null,
+	siteId?: number
+) => {
+	useEffect( () => {
+		if ( siteTransferStatus === 'pending' ) {
+			return safeLogToLogstash( 'Site migration preparation started', {
+				status: 'started',
+				site_id: siteId,
+			} );
+		}
+	}, [ siteTransferStatus, siteId ] );
+
+	useEffect( () => {
+		if ( error ) {
+			return safeLogToLogstash( 'Site migration preparation failed', {
+				status: 'error',
+				error: error.message,
+				error_type: error.name,
+				site_id: siteId,
+			} );
+		}
+	}, [ error, siteId ] );
+
+	useEffect( () => {
+		if ( completed ) {
+			return safeLogToLogstash( 'Site migration preparation completed', {
+				status: 'success',
+				site_id: siteId,
+			} );
+		}
+	}, [ completed, siteId ] );
+};
+
 const useTransferTimeTracking = (
 	siteTransferState: TransferState,
-	pluginInstallationState: TransferState
+	pluginInstallationState?: TransferState
 ): TimeTrackingResult => {
 	const siteTransferStart = useRef( 0 );
 	const siteTransferEnd = useRef( 0 );
@@ -84,6 +120,10 @@ const useTransferTimeTracking = (
 
 	// Time the plugin installation
 	useEffect( () => {
+		if ( ! pluginInstallationState ) {
+			return;
+		}
+
 		if (
 			! pluginInstallationState.completed &&
 			'pending' === pluginInstallationState.status &&
@@ -103,7 +143,7 @@ const useTransferTimeTracking = (
  *  Hook to manage the site to prepare a site for migration using Migrate Guru plugin.
  *  This hook manages the site transfer, plugin installation and migration key fetching.
  */
-export const usePrepareSiteForMigration = ( siteId?: number ) => {
+export const usePrepareSiteForMigrationWithMigrateGuru = ( siteId?: number ) => {
 	const siteTransferState = useSiteTransfer( siteId );
 	const pluginInstallationState = usePluginAutoInstallation( PLUGIN, siteId, {
 		enabled: Boolean( siteTransferState.completed ),
@@ -149,39 +189,51 @@ export const usePrepareSiteForMigration = ( siteId?: number ) => {
 			: getMigrationKeyStatus( migrationKey, migrationKeyFetchStatus, migrationKeyError ),
 	};
 
-	useEffect( () => {
-		if ( siteTransferState.status === 'pending' ) {
-			return safeLogToLogstash( 'Site migration preparation started', {
-				status: 'started',
-				site_id: siteId,
-			} );
-		}
-	}, [ siteTransferState.status, siteId ] );
-
-	useEffect( () => {
-		if ( criticalError ) {
-			return safeLogToLogstash( 'Site migration preparation failed', {
-				status: 'error',
-				error: criticalError.message,
-				error_type: criticalError.name,
-				site_id: siteId,
-			} );
-		}
-	}, [ completed, criticalError, siteTransferState, siteId ] );
-
-	useEffect( () => {
-		if ( completed ) {
-			return safeLogToLogstash( 'Site migration preparation completed', {
-				status: 'success',
-				site_id: siteId,
-			} );
-		}
-	}, [ completed, siteId ] );
+	useLogMigration( completed, siteTransferState.status, criticalError, siteId );
 
 	return {
 		detailedStatus,
 		completed,
 		error,
 		migrationKey: migrationKey ?? null,
+	};
+};
+
+/**
+ *  Hook to manage the site to prepare a site for migration using the Move to WordPress.com plugin.
+ *  This hook manages the site transfer.
+ */
+export const usePrepareSiteForMigrationWithMoveToWPCOM = ( siteId?: number ) => {
+	const siteTransferState = useSiteTransfer( siteId );
+	const transferTimingTracked = useRef( false );
+
+	const { siteTransferStart, siteTransferEnd } = useTransferTimeTracking( siteTransferState );
+
+	const completed = siteTransferState.completed;
+	const error = siteTransferState.error;
+	const hasAllTimingInfo = siteTransferEnd.current !== 0;
+
+	if ( completed && hasAllTimingInfo && ! transferTimingTracked.current ) {
+		const siteTransferElapsed = siteTransferEnd.current - siteTransferStart.current;
+
+		recordTracksEvent( 'calypso_onboarding_site_migration_transfer_timing', {
+			error,
+			migration_setup_elapsed: siteTransferElapsed,
+		} );
+
+		transferTimingTracked.current = true;
+	}
+
+	const detailedStatus = {
+		siteTransfer: siteTransferState.status,
+	};
+
+	useLogMigration( completed, siteTransferState.status, error, siteId );
+
+	return {
+		detailedStatus,
+		completed,
+		error,
+		migrationKey: null,
 	};
 };

--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -207,10 +207,17 @@ export const usePrepareSiteForMigrationWithMigrateToWPCOM = ( siteId?: number ) 
 	const siteTransferState = useSiteTransfer( siteId );
 	const transferTimingTracked = useRef( false );
 
+	const {
+		data: { migrationKey } = {},
+		error: migrationKeyError,
+		fetchStatus: migrationKeyFetchStatus,
+	} = useSiteMigrationKey( siteId );
+
 	const { siteTransferStart, siteTransferEnd } = useTransferTimeTracking( siteTransferState );
 
 	const completed = siteTransferState.completed;
-	const error = siteTransferState.error;
+	const error = siteTransferState.error || migrationKeyError;
+	const criticalError = siteTransferState.error;
 	const hasAllTimingInfo = siteTransferEnd.current !== 0;
 
 	if ( completed && hasAllTimingInfo && ! transferTimingTracked.current ) {
@@ -226,14 +233,15 @@ export const usePrepareSiteForMigrationWithMigrateToWPCOM = ( siteId?: number ) 
 
 	const detailedStatus = {
 		siteTransfer: siteTransferState.status,
+		migrationKey: getMigrationKeyStatus( migrationKey, migrationKeyFetchStatus, migrationKeyError ),
 	};
 
-	useLogMigration( completed, siteTransferState.status, error, siteId );
+	useLogMigration( completed, siteTransferState.status, criticalError, siteId );
 
 	return {
 		detailedStatus,
 		completed,
 		error,
-		migrationKey: null,
+		migrationKey: migrationKey ?? null,
 	};
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/94576

## Proposed Changes

* Create a new hook that won't install the Migrate Guru plugin and won't try to fetch the migration key from it.
* Update the provisioning component to not show the following steps: `Installing the required plugins` and `Getting the migration key`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/setup/hosted-site-migration/.
* Go through the flow until you reach the instructions step.
* You should see the following instructions referencing Migrate Guru:

<img width="411" alt="Screenshot 2024-09-17 at 12 24 05 PM" src="https://github.com/user-attachments/assets/a9841c26-3eb9-41a3-ba8e-45b9666cdbf5">

<img width="413" alt="Screenshot 2024-09-17 at 12 24 58 PM" src="https://github.com/user-attachments/assets/8a817911-6353-4129-a88a-53a139a09f38">

* Go to your AT site and make sure the Migrate Guru plugin is installed as before.
* Delete the Migrate Guru plugin from the AT site.
* Now add `&flags=migration-flow/enable-white-labeled-plugin` to the URL and reload.
* You should see the updated instructions referencing Migrate to WordPress.com:

<img width="405" alt="Screenshot 2024-09-17 at 12 23 15 PM" src="https://github.com/user-attachments/assets/37502c81-60cf-4372-b58c-3872ef6c5afd">

<img width="403" alt="Screenshot 2024-09-17 at 12 25 18 PM" src="https://github.com/user-attachments/assets/1a5ad8bd-6d8e-46c6-8904-87b7ae2e59ad">

* Go to your AT site and make sure the Migrate Guru is not installed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
