### PR TITLE
Hosted Flow: Hide billing term dropdown for Wordcamp new hosted site flow checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -50,6 +50,9 @@ const hosting: Flow = {
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getCouponCode(),
 			[]
 		);
+
+		const query = useQuery();
+		const queryParams = Object.fromEntries( query );
 		const flowName = this.name;
 
 		const goBack = () => {
@@ -69,6 +72,11 @@ const hosting: Flow = {
 
 					setPlanCartItem( {
 						product_slug: productSlug,
+						extra: {
+							...( queryParams?.utm_source && {
+								hideProductVariants: queryParams.utm_source === 'wordcamp',
+							} ),
+						},
 					} );
 
 					if ( isFreeHostingTrial( productSlug ) ) {

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -116,6 +116,10 @@ export function CheckoutSidebarPlanUpsell() {
 		return null;
 	}
 
+	if ( plan.extra?.hideProductVariants ) {
+		return null;
+	}
+
 	const currentVariant = variants?.find( ( product ) => product.productId === plan.product_id );
 
 	if ( ! currentVariant ) {

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -5,7 +5,7 @@ import {
 	AKISMET_PRO_500_PRODUCTS,
 } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
-import { isCopySiteFlow, isNewHostedSiteCreationFlow } from '@automattic/onboarding';
+import { isCopySiteFlow } from '@automattic/onboarding';
 import {
 	canItemBeRemovedFromCart,
 	getCouponLineItemFromCart,
@@ -310,7 +310,7 @@ function LineItemWrapper( {
 		if ( has100YearPlanProduct ) {
 			return false;
 		}
-		if ( isNewHostedSiteCreationFlow( signupFlowName ) && product.extra?.hideProductVariants ) {
+		if ( product.extra?.hideProductVariants ) {
 			return false;
 		}
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -310,9 +310,7 @@ function LineItemWrapper( {
 		if ( has100YearPlanProduct ) {
 			return false;
 		}
-
-		// TODO: Also include condition to check if utm is wordcamp
-		if ( isNewHostedSiteCreationFlow( signupFlowName ) ) {
+		if ( isNewHostedSiteCreationFlow( signupFlowName ) && product.extra?.hideProductVariants ) {
 			return false;
 		}
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -5,7 +5,7 @@ import {
 	AKISMET_PRO_500_PRODUCTS,
 } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
-import { isCopySiteFlow } from '@automattic/onboarding';
+import { isCopySiteFlow, isNewHostedSiteCreationFlow } from '@automattic/onboarding';
 import {
 	canItemBeRemovedFromCart,
 	getCouponLineItemFromCart,
@@ -308,6 +308,11 @@ function LineItemWrapper( {
 		}
 
 		if ( has100YearPlanProduct ) {
+			return false;
+		}
+
+		// TODO: Also include condition to check if utm is wordcamp
+		if ( isNewHostedSiteCreationFlow( signupFlowName ) ) {
 			return false;
 		}
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -645,6 +645,7 @@ export interface ResponseCartProductExtra {
 	is_marketplace_product?: boolean;
 	product_slug?: string;
 	product_type?: 'marketplace_plugin' | 'marketplace_theme' | 'saas_plugin';
+	hideProductVariants?: boolean;
 }
 
 export interface ResponseCartGiftDetails {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -645,6 +645,15 @@ export interface ResponseCartProductExtra {
 	is_marketplace_product?: boolean;
 	product_slug?: string;
 	product_type?: 'marketplace_plugin' | 'marketplace_theme' | 'saas_plugin';
+
+	/**
+	 * True when:
+	 * - the product has variants ( e.g. annual plan vs. monthly plan vs. multi-year plan )
+	 * - we only want to show the single product selected by the user
+	 * - we want to prevent the user from switching to a variant
+	 *
+	 * This will hide product variant UI elements in checkout ( line item variant dropdown or variant upsells )
+	 */
 	hideProductVariants?: boolean;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pau2Xa-6lo-p2#comment-16139

## Proposed Changes

* Hide billing term dropdown for WordPress business plan line item if user originates from the Wordcamp new hosted site flow
* Adds a `hideProductVariants` property to `ResponseCart` extra metadata

**Note:**

I considered using query params to hide the term selector dropdown and the multi-year plan upsell. I opted not to because it would allow end users to modify their url to make the UI elements visible.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We only want to offer free **annual** business plans. No more, and no less.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Before
![calypso localhost_3000_checkout_meticulouscyber43 wordpress com_redirect_to=%2Fsetup%2Ftransferring-hosted-site%3FsiteId%3D237145139 coupon= (1)](https://github.com/user-attachments/assets/104aa1eb-3621-4e09-997e-9a316acb9c72)

### After
![calypso localhost_3000_checkout_meticulouscyber43 wordpress com_redirect_to=%2Fsetup%2Ftransferring-hosted-site%3FsiteId%3D237145139 coupon=](https://github.com/user-attachments/assets/7cff6ecc-70da-4a4b-863e-fd77fe533b66)

* Go to `/setup/new-hosted-site/plans?utm_source=wordcamp&utm_medium=automattic_referred`
* Confirm that only the Business plan is visible
* Select the Business plan
* Confirm that:
  *  At checkout, there is no longer a billing term dropdown under the business plan line item.
  *  At checkout, there is no longer a multi-year plan upsell in the checkout sidebar.
* Revisit `/setup/new-hosted-site/plans` **without** the wordcamp utm source
* Confirm that the Business plan and Commerce plan are visible 
* Select the Business plan
* Confirm that:
  *  At checkout, there _is_ a billing term dropdown under the business plan line item.
  *  At checkout, there _is_ a multi-year plan upsell in the checkout sidebar.
* Smoke test a `/start` signup flow to verify that the billing term dropdown is still shown in checkout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?