### PR TITLE
Hide Delete site button from A4A development sites.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -53,7 +53,8 @@ export default function useSiteActions( {
 	const canRemove = ! isDevSite && hasRemoveManagedSitesCapability;
 
 	// Whether to enable the Delete site action. The action will remove the site from the A4A dashboard and delete the site and its license.
-	const canDelete = isDevSite && hasRemoveManagedSitesCapability;
+	// We are temporarily forcing canDelete to false to hide the option while the feature is not working as expected.
+	const canDelete = isDevSite && hasRemoveManagedSitesCapability && false;
 
 	return useMemo( () => {
 		if ( ! siteValue ) {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9170

## Proposed Changes
| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/293879f0-c196-4473-b4a2-f41f2e427968)  | ![image](https://github.com/user-attachments/assets/c5c0bf04-aa60-4313-9a4d-484908710140)   |

The Delete site for A4A development sites is not working as expected.
We are hiding the button until the feature is fixed.

## Testing Instructions
Apply the patch locally or use the live preview link.
If you don't have a development site, create one.
On the sites page, click on the popover menu for a development site on the list. You should not see neither `Delete site` or `Remove site` buttons as options on the menu.
Click on the popover menu for a **non development** site on the list. You should be able to still see the `Remove site` button as an option on the menu


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
