### PR TITLE
Dialog component: Use WordPress Icon instead of Gridicon for close button

### DIFF
--- a/client/my-sites/marketplace/components/reviews-modal/styles.scss
+++ b/client/my-sites/marketplace/components/reviews-modal/styles.scss
@@ -84,8 +84,3 @@ $border-color: #eee;
 		fill: var(--studio-yellow-20);
 	}
 }
-
-.dialog__action-buttons-close {
-	padding: 16px 24px 5px 5px;
-	background-color: #fff;
-}

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/style.scss
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/style.scss
@@ -22,7 +22,6 @@
 }
 
 .plugin-custom-domain-dialog__install_plugin {
-	max-width: 200px;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/components/src/dialog/index.tsx
+++ b/packages/components/src/dialog/index.tsx
@@ -1,7 +1,7 @@
+import { Icon, close as closeIcon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useCallback } from 'react';
 import Modal from 'react-modal';
-import Gridicon from '../gridicon';
 import ButtonBar from './button-bar';
 import type { BaseButton } from './button-bar';
 import type { PropsWithChildren } from 'react';
@@ -91,7 +91,7 @@ const Dialog = ( {
 					className="dialog__action-buttons-close"
 					onClick={ () => onClose?.( this ) }
 				>
-					<Gridicon icon="cross" size={ 24 } />
+					<Icon icon={ closeIcon } size={ 24 } />
 				</button>
 			) }
 			<div className={ contentClassName } tabIndex={ -1 }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7727

## Proposed Changes

* Change Gridicon to WordPress Icon.
* Fix close button style issue on the Plugin Dialog.
* Fix plugin install button style issue.

Before | After
----- | -----
<img width="708" alt="Screen Shot 2024-09-18 at 3 21 38 PM" src="https://github.com/user-attachments/assets/2472564a-2e2c-4316-b407-811871d5b3a9"> | <img width="708" alt="Screen Shot 2024-09-18 at 3 21 23 PM" src="https://github.com/user-attachments/assets/105bafb3-5bbe-4e61-b9d9-b377df10db35">
<img width="251" alt="Screen Shot 2024-09-18 at 3 22 36 PM" src="https://github.com/user-attachments/assets/b81bc4b6-6946-4695-b868-0a4340053d15"> | <img width="254" alt="Screen Shot 2024-09-18 at 3 23 55 PM" src="https://github.com/user-attachments/assets/70b7be52-dfcd-4288-a6e7-b0630c13c93b">
<img width="251" alt="Screen Shot 2024-09-18 at 3 22 44 PM" src="https://github.com/user-attachments/assets/f00c101b-b2aa-42ea-8828-3393fa8ae18a"> | <img width="254" alt="Screen Shot 2024-09-18 at 3 22 15 PM" src="https://github.com/user-attachments/assets/ec5cc9d1-67fd-4ce4-837a-5a9cd94c07b3">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To align with the design and core.
* To fix style issues with the plugin install flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /hosting-features for a site that has a Business plan, but isn't yet Atomic.
* Click "Activate now."
* View the close button on different screen sizes.
* Close the Dialog.
* Go to /plugins/{site}
* Choose a free plugin and click to install it.
* Click install again.
* View the eligibility warnings Dialog on different screen sizes.
* Close the Dialog.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
