### PR TITLE
Add Site Title to Purchases List

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -383,7 +383,7 @@ class PurchaseItem extends Component {
 
 		const productType = purchaseType( purchase );
 		if ( showSite && site ) {
-			if ( productType ) {
+			if ( productType && site.name ) {
 				return translate(
 					'%(purchaseType)s for {{button}}%(siteName)s{{/button}} ({{link}}%(siteDomain)s{{/link}})',
 					{
@@ -424,6 +424,32 @@ class PurchaseItem extends Component {
 						},
 					}
 				);
+			}
+
+			if ( productType ) {
+				return translate( '%(purchaseType)s for {{button}}%(siteDomain)s{{/button}}', {
+					args: {
+						purchaseType: productType,
+						siteDomain: site.domain,
+					},
+					components: {
+						button: (
+							<button
+								className="purchase-item__link"
+								onClick={ ( event ) => {
+									event.stopPropagation();
+									event.preventDefault();
+									page( getPurchaseListUrlFor( slug ) );
+								} }
+								title={ translate( 'View subscriptions for %(siteDomain)s', {
+									args: {
+										siteName: site.name,
+									},
+								} ) }
+							/>
+						),
+					},
+				} );
 			}
 
 			return translate( 'for {{button}}%(siteName)s{{/button}} ({{link}}%(siteDomain)s{{/link}})', {

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -445,6 +445,40 @@ class PurchaseItem extends Component {
 		return productType;
 	}
 
+	getSiteTitle() {
+		const { purchase, site, translate, slug, showSite } = this.props;
+		if ( isTemporarySitePurchase( purchase ) ) {
+			return null;
+		}
+
+		if ( showSite && site ) {
+			return translate( 'Subscription for {{button}}%(siteName)s{{/button}}', {
+				args: {
+					siteName: site.name,
+				},
+				components: {
+					button: (
+						<button
+							className="purchase-item__link"
+							onClick={ ( event ) => {
+								event.stopPropagation();
+								event.preventDefault();
+								page( getPurchaseListUrlFor( slug ) );
+							} }
+							title={ translate( 'View subscriptions for %(siteName)s', {
+								args: {
+									siteName: site.name,
+								},
+							} ) }
+						/>
+					),
+				},
+			} );
+		}
+
+		return;
+	}
+
 	getPaymentMethod() {
 		const { purchase, translate } = this.props;
 
@@ -577,6 +611,7 @@ class PurchaseItem extends Component {
 					</div>
 
 					<div className="purchase-item__purchase-type">{ this.getPurchaseType() }</div>
+					<div className="purchase-item__purchase-type">{ this.getSiteTitle() }</div>
 				</div>
 
 				<div className="purchase-item__status purchases-layout__status">{ this.getStatus() }</div>

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -384,33 +384,51 @@ class PurchaseItem extends Component {
 		const productType = purchaseType( purchase );
 		if ( showSite && site ) {
 			if ( productType ) {
-				return translate( '%(purchaseType)s for {{button}}%(site)s{{/button}}', {
-					args: {
-						purchaseType: productType,
-						site: site.domain,
-					},
-					components: {
-						button: (
-							<button
-								className="purchase-item__link"
-								onClick={ ( event ) => {
-									event.stopPropagation();
-									event.preventDefault();
-									page( getPurchaseListUrlFor( slug ) );
-								} }
-								title={ translate( 'View subscriptions for %(siteName)s', {
-									args: {
-										siteName: site.name,
-									},
-								} ) }
-							/>
-						),
-					},
-				} );
+				return translate(
+					'%(purchaseType)s for {{button}}%(siteName)s{{/button}} ({{link}}%(siteDomain)s{{/link}})',
+					{
+						args: {
+							purchaseType: productType,
+							siteName: site.name,
+							siteDomain: site.domain,
+						},
+						components: {
+							button: (
+								<button
+									className="purchase-item__link"
+									onClick={ ( event ) => {
+										event.stopPropagation();
+										event.preventDefault();
+										page( getPurchaseListUrlFor( slug ) );
+									} }
+									title={ translate( 'View subscriptions for %(siteName)s', {
+										args: {
+											siteName: site.name,
+										},
+									} ) }
+								/>
+							),
+							link: (
+								<a
+									className="purchase-item__link"
+									href={ 'https://' + site.domain }
+									target="_blank"
+									rel="noreferrer"
+									title={ translate( 'View %(siteName)s', {
+										args: {
+											siteName: site.name,
+										},
+									} ) }
+								/>
+							),
+						},
+					}
+				);
 			}
 
-			return translate( 'for {{button}}%(site)s{{/button}}', {
+			return translate( 'for {{button}}%(siteName)s{{/button}} ({{link}}%(siteDomain)s{{/link}})', {
 				args: {
+					siteName: site.name,
 					site: site.domain,
 				},
 				components: {
@@ -423,6 +441,19 @@ class PurchaseItem extends Component {
 								page( getPurchaseListUrlFor( slug ) );
 							} }
 							title={ translate( 'View subscriptions for %(siteName)s', {
+								args: {
+									siteName: site.name,
+								},
+							} ) }
+						/>
+					),
+					link: (
+						<a
+							className="purchase-item__link"
+							href={ 'https://' + site.domain }
+							target="_blank"
+							rel="noreferrer"
+							title={ translate( 'View %(siteName)s', {
 								args: {
 									siteName: site.name,
 								},

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -476,40 +476,6 @@ class PurchaseItem extends Component {
 		return productType;
 	}
 
-	getSiteTitle() {
-		const { purchase, site, translate, slug, showSite } = this.props;
-		if ( isTemporarySitePurchase( purchase ) ) {
-			return null;
-		}
-
-		if ( showSite && site ) {
-			return translate( 'Subscription for {{button}}%(siteName)s{{/button}}', {
-				args: {
-					siteName: site.name,
-				},
-				components: {
-					button: (
-						<button
-							className="purchase-item__link"
-							onClick={ ( event ) => {
-								event.stopPropagation();
-								event.preventDefault();
-								page( getPurchaseListUrlFor( slug ) );
-							} }
-							title={ translate( 'View subscriptions for %(siteName)s', {
-								args: {
-									siteName: site.name,
-								},
-							} ) }
-						/>
-					),
-				},
-			} );
-		}
-
-		return;
-	}
-
 	getPaymentMethod() {
 		const { purchase, translate } = this.props;
 
@@ -642,7 +608,6 @@ class PurchaseItem extends Component {
 					</div>
 
 					<div className="purchase-item__purchase-type">{ this.getPurchaseType() }</div>
-					<div className="purchase-item__purchase-type">{ this.getSiteTitle() }</div>
 				</div>
 
 				<div className="purchase-item__status purchases-layout__status">{ this.getStatus() }</div>

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -445,7 +445,7 @@ class PurchaseItem extends Component {
 								} }
 								title={ translate( 'View subscriptions for %(siteDomain)s', {
 									args: {
-										siteName: site.name,
+										siteDomain: site.domain,
 									},
 								} ) }
 							/>
@@ -458,7 +458,7 @@ class PurchaseItem extends Component {
 			return translate( 'for {{button}}%(siteName)s{{/button}} ({{link}}%(siteDomain)s{{/link}})', {
 				args: {
 					siteName: site.name,
-					site: site.domain,
+					siteDomain: site.domain,
 				},
 				components: {
 					button: (

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -384,6 +384,7 @@ class PurchaseItem extends Component {
 		const productType = purchaseType( purchase );
 		if ( showSite && site ) {
 			if ( productType && site.name ) {
+				// translators: The string contains the product name, the name of the site, and the URL for the site e.g. Premium plan for Block Store (blockstore.com)
 				return translate(
 					'%(purchaseType)s for {{button}}%(siteName)s{{/button}} ({{link}}%(siteDomain)s{{/link}})',
 					{
@@ -427,6 +428,7 @@ class PurchaseItem extends Component {
 			}
 
 			if ( productType ) {
+				// translators: The string contains the product name, and the URL of the site e.g. Premium plan for blockstore.com
 				return translate( '%(purchaseType)s for {{button}}%(siteDomain)s{{/button}}', {
 					args: {
 						purchaseType: productType,
@@ -452,6 +454,7 @@ class PurchaseItem extends Component {
 				} );
 			}
 
+			// translators: The string contains the name of the site, and the URL of the site e.g. for Block Store (blockstore.com)
 			return translate( 'for {{button}}%(siteName)s{{/button}} ({{link}}%(siteDomain)s{{/link}})', {
 				args: {
 					siteName: site.name,

--- a/client/me/purchases/style.scss
+++ b/client/me/purchases/style.scss
@@ -160,7 +160,8 @@
 	}
 }
 
-.purchase-item__purchase-type {
+.purchase-item__purchase-type,
+.purchase-item__site-title {
 	font-size: $font-body-small;
 	color: var(--color-neutral-50);
 	line-height: 1.4;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

A possible implementation of the change suggested in #94679

## Proposed Changes

* Add the site title to the information given for each purchase in the purchase list
* The default string should be in `{product-name} for {site-name} ({site-url})` format

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To help a customer identify which site the purchase is related to when the site's domain is ambiguous. For instance, if the default domain is automatically generated from the user's username.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the display is not broken for any of the various different subscription types that can appear in the subscription list.

Before:

<img width="483" alt="Screenshot 2025-02-13 at 14 00 21" src="https://github.com/user-attachments/assets/c6a0c8d5-fc37-4f4b-9fc4-a0ae201bbafa" />

After:

<img width="492" alt="Screenshot 2025-02-13 at 13 47 40" src="https://github.com/user-attachments/assets/946a0f32-aa5f-4f33-a4bd-f599ae1a4fbd" />

* Check that any empty site names do not get rendered as an extra blank space

Incorrect blank site name:
![image](https://github.com/user-attachments/assets/27e586ed-4d7b-4a37-9df3-2be76010c662)

Correct blank site name:
![image](https://github.com/user-attachments/assets/07aa0a0b-e95b-4a05-b4f2-4dbf82c8f938)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
