### PR TITLE
Fediverse: deprecate Discussion settings section

### DIFF
--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -134,10 +134,10 @@ const SharingServicesGroup = ( {
 							/* Injecting the Fediverse above Twitter */
 							if ( service.ID === 'twitter' && type === 'publicize' ) {
 								return (
-									<>
-										<Components.fediverse key="fediverse" />
+									<Fragment key="fediverse">
+										<Components.fediverse />
 										<Component key={ service.ID } service={ service } />
-									</>
+									</Fragment>
 								);
 							}
 						}

--- a/client/my-sites/marketing/connections/services/fediverse.jsx
+++ b/client/my-sites/marketing/connections/services/fediverse.jsx
@@ -15,7 +15,7 @@ function FediverseHeader() {
 	return (
 		<div>
 			<SocialLogo icon="fediverse" size={ 48 } className="sharing-service__logo" />
-			<div class="sharing-service__name">
+			<div className="sharing-service__name">
 				<h2>
 					{ translate( 'Fediverse' ) }
 					<Badge className="service__new-badge">{ translate( 'New' ) }</Badge>

--- a/client/my-sites/marketing/connections/services/fediverse.jsx
+++ b/client/my-sites/marketing/connections/services/fediverse.jsx
@@ -20,7 +20,7 @@ function FediverseHeader() {
 					{ translate( 'Fediverse' ) }
 					<Badge className="service__new-badge">{ translate( 'New' ) }</Badge>
 				</h2>
-				<p class="sharing-service__description">
+				<p className="sharing-service__description">
 					{ translate( 'Mastodon today, Threads tomorrow. Enter the Fediverse with ActivityPub.' ) }
 				</p>
 			</div>

--- a/client/my-sites/site-settings/fediverse-settings/index.jsx
+++ b/client/my-sites/site-settings/fediverse-settings/index.jsx
@@ -1,6 +1,8 @@
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { JetpackFediverseSettingsSection } from './JetpackFediverseSettingsSection';
@@ -28,6 +30,27 @@ export const FediverseSettingsSection = () => {
 		<>
 			<SettingsSectionHeader title={ translate( 'Fediverse settings' ) } />
 			<FediverseServiceSection />
+		</>
+	);
+};
+
+export const FediverseDeprecatedDiscussionSection = () => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+
+	return (
+		<>
+			<SettingsSectionHeader title={ translate( 'Fediverse settings' ) } />
+			<Card className="site-settings__card">
+				<p>
+					{ translate( 'Fediverse settings now live in {{link}}Marketing Connections{{/link}}.', {
+						components: {
+							link: <a href={ `/marketing/connections/${ domain }` } />,
+						},
+					} ) }
+				</p>
+			</Card>
 		</>
 	);
 };

--- a/client/my-sites/site-settings/settings-discussion/main.jsx
+++ b/client/my-sites/site-settings/settings-discussion/main.jsx
@@ -4,7 +4,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { FediverseSettingsSection } from 'calypso/my-sites/site-settings/fediverse-settings';
+import { FediverseDeprecatedDiscussionSection } from 'calypso/my-sites/site-settings/fediverse-settings';
 import DiscussionForm from 'calypso/my-sites/site-settings/form-discussion';
 import JetpackDevModeNotice from 'calypso/my-sites/site-settings/jetpack-dev-mode-notice';
 import SiteSettingsNavigation from 'calypso/my-sites/site-settings/navigation';
@@ -29,7 +29,7 @@ const SiteSettingsDiscussion = ( { site, translate } ) => (
 		/>
 
 		<SiteSettingsNavigation site={ site } section="discussion" />
-		<FediverseSettingsSection />
+		<FediverseDeprecatedDiscussionSection />
 		<DiscussionForm />
 	</Main>
 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6104

## Proposed Changes

* Add a deprecation notice to the former location of Fediverse settings atop Settings -> Discussion

<img width="779" alt="Screenshot 2024-09-18 at 14 33 04" src="https://github.com/user-attachments/assets/e80e808e-9aa9-4e19-b325-55035ca741de">


## Why are these changes being made?

In #90339 we added a Fediverse section to the Tools -> Marketing -> Connections page. We are now ready to deprecate the original home in Settings -> Discussion and link over to it.

In another ~few months we can just remove the deprecation notice entirely from Settings -> Discussion

## Testing Instructions

1. Navigate to Settings -> Discussion
2. You should see a notice like the above image, with the link properly taking you to the Marketing -> Connections page.
3. That's it!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
