### PR TITLE
A4A: fix client contact support form submission

### DIFF
--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -45,7 +45,9 @@ export default function UserContactSupportModalForm( {
 	const [ message, setMessage ] = useState( defaultMessage );
 
 	const isPressableSelected = product === 'pressable';
-	const hasCompletedForm = !! message && !! name && !! email && !! product && !! agency;
+	const isClient = isClientView();
+	const hasCompletedForm =
+		!! message && !! name && !! email && !! product && ( !! agency || isClient );
 
 	const { isSubmitting, submit, isSubmissionSuccessful } = useSubmitContactSupport();
 
@@ -150,8 +152,6 @@ export default function UserContactSupportModalForm( {
 			dispatch( recordTracksEvent( 'calypso_a4a_user_contact_support_form_open' ) );
 		}
 	}, [ dispatch, show ] );
-
-	const isClient = isClientView();
 
 	if ( ! show ) {
 		return null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1726686282041829-slack-C07JCE3ETST

## Proposed Changes

Fix issue where clients can't send a support ticket, as they are not part of the agency.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?