### PR TITLE
Hosting features transfer modal: Bold your domain will change text in warning

### DIFF
--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -40,7 +40,7 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 							</Fragment>
 						) }
 						<span className="eligibility-warnings__message-description">
-							<span>{ description } </span>
+							<span>{ boldDomainText( description, translate ) }</span>
 							{ domainNames && displayDomainNames( domainNames ) }
 							{ supportUrl && (
 								<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
@@ -135,6 +135,22 @@ function getWarningDescription(
 		default:
 			return defaultCopy;
 	}
+}
+
+// Bold the text "your domain will change" in the description.
+function boldDomainText( text: string, translate: LocalizeProps[ 'translate' ] ) {
+	const match = translate( 'your domain will change' );
+	const parts = text.split( match );
+	return (
+		<>
+			{ parts.map( ( part, index ) => (
+				<Fragment key={ index }>
+					{ part }
+					{ index < parts.length - 1 && <strong>{ match }</strong> }
+				</Fragment>
+			) ) }
+		</>
+	);
 }
 
 export default localize( WarningList );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7727

## Proposed Changes

* Bold "your domain will change" text.

<img width="726" alt="Screen Shot 2024-09-18 at 5 09 46 PM" src="https://github.com/user-attachments/assets/e6171e92-ed59-4007-896a-b80ca4aca71a">

To do:
- [ ] Check if translation will work.
- [ ] Memoize?

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
