### PR TITLE
Logged-in Performance Profiler: Show jetpack boost upsell in recommendations

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
@@ -94,6 +94,7 @@ export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
 			style={ {
 				flexDirection: 'column',
 				borderRadius: '6px',
+				flex: 1,
 			} }
 		>
 			<div className="core-web-vitals-display__description">

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -3,13 +3,16 @@ import { FoldableCard } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
 	FullPageScreenshot,
 	PerformanceMetricsItemQueryResponse,
 } from 'calypso/data/site-profiler/types';
 import { Tip } from 'calypso/performance-profiler/components/tip';
 import { useSupportChatLLMQuery } from 'calypso/performance-profiler/hooks/use-support-chat-llm-query';
-import { tips } from 'calypso/performance-profiler/utils/tips';
+import { loggedInTips, tips } from 'calypso/performance-profiler/utils/tips';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { InsightContent } from './insight-content';
 import { InsightHeader } from './insight-header';
 
@@ -105,13 +108,16 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 		isWpcom,
 		isEnabled( 'performance-profiler/llm' ) && retrieveInsight
 	);
-	const tip = tips[ insight.id ];
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const site = useSelector( getSelectedSite );
 
-	if ( props.url && tip ) {
+	const tip = isLoggedIn && isWpcom ? loggedInTips[ insight.id ] : tips[ insight.id ];
+
+	if ( props.url && tip && ! isWpcom ) {
 		tip.link = `https://wordpress.com/setup/hosted-site-migration?from=${ props.url }&ref=performance-profiler-dashboard`;
 	}
 
-	if ( tip && isWpcom ) {
+	if ( tip && isWpcom && ! site?.is_wpcom_atomic ) {
 		tip.link = '';
 	}
 

--- a/client/performance-profiler/utils/tips.ts
+++ b/client/performance-profiler/utils/tips.ts
@@ -11,3 +11,20 @@ export const tips: Record< string, TipProps > = {
 		link: 'https://wordpress.com/setup/hosted-site-migration?ref=performance-profiler-dashboard',
 	},
 };
+
+const createLoggedInTip = (): TipProps => ( {
+	title: translate( 'Did you know?' ),
+	content: translate(
+		'Jetpack Boost automatically optimizes images and delivers them using a Global CDN to ensure they load lightning fast.'
+	),
+	linkText: translate( 'Get Jetpack Boost' ),
+	link: 'https://wordpress.com/plugins/jetpack-boost',
+} );
+
+export const loggedInTips: Record< string, TipProps > = {
+	'uses-responsive-images': createLoggedInTip(),
+	'uses-long-cache-ttl': createLoggedInTip(),
+	'server-response-time': createLoggedInTip(),
+	'render-blocking-resources': createLoggedInTip(),
+	'unminified-css': createLoggedInTip(),
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9060

## Proposed Changes

* Show the jetpack boost tip for logged-in user based on the type of page issue.
![image](https://github.com/user-attachments/assets/3115642d-1de0-409e-be9e-2d11ed2ad9af)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Provides a quick way for users to fix certain problems on their site using Jetpack Boost as an option.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As a logged in user
* Use speed test tool `/speed-test-tool` to run test on your Wordpress Atomic site
* Open the `Properly size images` improvement section and verify Jetpack Boost is recommended in the `Did you know` section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
