### PR TITLE
Include calypso_env in the send-login-email payload

### DIFF
--- a/client/state/data-layer/wpcom/auth/send-login-email/index.js
+++ b/client/state/data-layer/wpcom/auth/send-login-email/index.js
@@ -72,7 +72,8 @@ export const sendLoginEmail = ( action ) => {
 					...( flow && { flow } ),
 					create_account: createAccount,
 					tos: getToSAcceptancePayload(),
-					calypso_env: config( 'env_id' ),
+					calypso_env:
+						window?.location?.host === 'wordpress.com' ? 'production' : config( 'env_id' ),
 				},
 			},
 			{ ...action, infoNoticeId: noticeAction ? noticeAction.notice.noticeId : null }

--- a/client/state/data-layer/wpcom/auth/send-login-email/index.js
+++ b/client/state/data-layer/wpcom/auth/send-login-email/index.js
@@ -72,6 +72,7 @@ export const sendLoginEmail = ( action ) => {
 					...( flow && { flow } ),
 					create_account: createAccount,
 					tos: getToSAcceptancePayload(),
+					calypso_env: config( 'env_id' ),
 				},
 			},
 			{ ...action, infoNoticeId: noticeAction ? noticeAction.notice.noticeId : null }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR adds `calypso_env` in the `send-login-email` request payload. This allow us to have a magic link in different calypso environments. For more information how the backend handles `calypso_env`, please see D161820-code

## Proposed Changes

* Added `calypso_env` in the `send-login-email` request payload



## Testing Instructions

1. Checkout this branch and open `config/development.json`
2. Enable `"woocommerce/core-profiler-passwordless-auth"` feature flag.
3. Run `yarn start`
4. Open http://calypso.localhost:3000/log-in/jetpack?from=woocommerce-core-profiler
5. Open your browser insepctor.
6. Enter your passwordless account email and click on `Continue`
7. Search for `send-login-email` request and confirm the payload contains `calypso_env`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?