### PR TITLE
Checkout: Adjust label style to accommodate more cards

### DIFF
--- a/client/my-sites/checkout/src/components/payment-method-logos.js
+++ b/client/my-sites/checkout/src/components/payment-method-logos.js
@@ -9,7 +9,7 @@ export const PaymentMethodLogos = styled.span`
 	align-items: center;
 	justify-content: flex-start;
 
-	&.credit-card__logo svg {
+	&.credit-card__logos svg {
 		display: inline-block;
 		height: 26px;
 		width: 42px;

--- a/client/my-sites/checkout/src/components/payment-method-logos.js
+++ b/client/my-sites/checkout/src/components/payment-method-logos.js
@@ -5,12 +5,17 @@ export const PaymentMethodLogos = styled.span`
 	flex: 1;
 	flex-wrap: wrap;
 	gap: 5px;
+	text-align: end;
 	align-items: center;
-	justify-content: flex-end;
+	justify-content: flex-start;
 
-	svg {
+	&.credit-card__logo svg {
 		display: inline-block;
 		height: 26px;
 		width: 42px;
+	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
+		justify-content: flex-end;
 	}
 `;

--- a/client/my-sites/checkout/src/components/payment-method-logos.js
+++ b/client/my-sites/checkout/src/components/payment-method-logos.js
@@ -3,19 +3,14 @@ import styled from '@emotion/styled';
 export const PaymentMethodLogos = styled.span`
 	display: flex;
 	flex: 1;
-	text-align: right;
+	flex-wrap: wrap;
+	gap: 5px;
 	align-items: center;
 	justify-content: flex-end;
 
-	.rtl & {
-		text-align: left;
-	}
-
 	svg {
 		display: inline-block;
-
-		&.has-background {
-			padding-inline-end: 5px;
-		}
+		height: 26px;
+		width: 42px;
 	}
 `;

--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -62,7 +62,7 @@ const CreditCardLabel: React.FC< {
 
 function CreditCardLogos( { currency }: { currency: string | null } ) {
 	return (
-		<PaymentMethodLogos className="credit-card__logo">
+		<PaymentMethodLogos className="credit-card__logos">
 			{ currency === 'EUR' && <CBLogo className="has-background" /> }
 			<VisaLogo />
 			<MastercardLogo />

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -105,11 +105,13 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	box-sizing: border-box;
 	width: 100%;
 	display: flex;
+	column-gap: 10px;
 	justify-content: space-between;
 	align-items: center;
 	align-content: center;
 	font-size: 14px;
-	height: 72px;
+	height: fit-content;
+	min-height: 72px;
 
 	.rtl & {
 		padding: 16px 56px 16px 14px;
@@ -126,7 +128,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		content: '';
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
 		border-radius: 100%;
-		top: 28px;
+		top: 40%;
 		left: 24px;
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
@@ -145,7 +147,8 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		height: 8px;
 		content: '';
 		border-radius: 100%;
-		top: 32px;
+		margin-top: 4px;
+		top: 40%;
 		left: 28px;
 		position: absolute;
 		background: ${ getRadioColor };

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -105,9 +105,10 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	box-sizing: border-box;
 	width: 100%;
 	display: flex;
-	column-gap: 5px;
-	justify-content: space-between;
-	align-items: center;
+	flex-direction: column;
+	gap: 5px;
+	justify-content: center;
+	align-items: flex-start;
 	align-content: center;
 	font-size: 14px;
 	height: fit-content;
@@ -160,6 +161,13 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 			left: auto;
 		}
 	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+			gap: 7px:
+		}
 }
 
 	${ handleLabelDisabled };

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -52,6 +52,15 @@ const RadioButtonWrapper = styled.div<
 		}
 	}
 
+	.credit-card__logos {
+		${ ( props ) => ( props.checked ? `display:flex;` : `display:none;` ) }
+
+		@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
+			display: flex;
+			filter: grayscale( ${ getGrayscaleValue } );
+		}
+	}
+
 	svg {
 		filter: grayscale( ${ getGrayscaleValue } );
 	}
@@ -106,7 +115,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	width: 100%;
 	display: flex;
 	flex-direction: column;
-	gap: 5px;
+	gap: 10px;
 	justify-content: center;
 	align-items: flex-start;
 	align-content: center;

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -105,7 +105,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	box-sizing: border-box;
 	width: 100%;
 	display: flex;
-	column-gap: 10px;
+	column-gap: 5px;
 	justify-content: space-between;
 	align-items: center;
 	align-content: center;


### PR DESCRIPTION
The labels in Checkout were breaking out of their bounding box on small mobile viewports (< 375px), this PR adjusts how we handle the credit card logos across viewport sizes and tries to gracefully wrap them at different device sizes.

| Before | After |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/805ffddb-3b68-4238-af8f-d9712bf2c5e6) | ![image](https://github.com/user-attachments/assets/6b59f0c1-76e9-487d-9dfe-cc1a4d3082b5) |

A side benefit to this is that the changes also extend to the 'Add a payment method' and 'Change payment method' forms in the Purchases section.

## Proposed Changes
### Left to Right

**Viewport 1024px - Inactive payment method**
Not very different at this viewport

| Before | After |
| ----- | ----- |
|  ![image](https://github.com/user-attachments/assets/438ae224-7ee9-4c22-b098-05c6a3074c03) | ![image](https://github.com/user-attachments/assets/a44f619b-506a-4e7a-bea5-cc56d7ab947f) |

**View port 425px - Inactive payment method**
Small changes at this size, the logos begin to wrap now. The benefit becomes more obvious at certain sizes like 375px wide where the logos drop onto their own line.

| Before | After | 375 |
| ----- | ----- | ----- |
| ![image](https://github.com/user-attachments/assets/ccb9d401-6dcb-44a0-a0d8-b099ddc1c16e) | ![image](https://github.com/user-attachments/assets/d3830e59-b4e0-434e-9365-2f131cb2c752) | ![image](https://github.com/user-attachments/assets/47db4fbe-7aa2-4dc4-b2e3-23f0d809e717) |

**Viewport 320px - Inactive payment method**
Most visible at this size, fixes a bug where label items would overflow their bounding box by dropping cards to next line.

| Before | After |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/688a4740-f514-41fd-92ea-cd4b172981b4) | ![image](https://github.com/user-attachments/assets/9722e6ca-a312-4413-a618-e8ef9b10f791) |

**Viewport 1024px - Active payment method**

Not much change here other than standardizing the sizes of the svg logos for better alignment
| Before | After |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/78376142-0109-409d-b220-b5d6dcb9e73d) | ![image](https://github.com/user-attachments/assets/51ff2af8-2f33-4947-9294-3cd20f12a52c) |

**Viewport 320px - Active payment method**
Logos will stack at this viewport size
| Before | After |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/805ffddb-3b68-4238-af8f-d9712bf2c5e6) | ![image](https://github.com/user-attachments/assets/6b59f0c1-76e9-487d-9dfe-cc1a4d3082b5) |



## Testing Instructions

* Test the different viewports in checkout and purchases, use the examples above for guidance
* Try different languages to see if anything breaks
* Try right to left languages to ensure the styles correctly reverse themselves
