### PR TITLE
Stats: Date control update: shortcuts and current month adjustments

### DIFF
--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -397,7 +397,7 @@ export class DateRange extends Component {
 	}
 
 	getNumberOfMonths() {
-		return window.matchMedia( '(min-width: 480px)' ).matches ? 2 : 1;
+		return window.matchMedia( '(min-width: 520px)' ).matches ? 2 : 1;
 	}
 
 	handleDateRangeChange = ( startDate, endDate, shortcutId = '' ) => {
@@ -470,6 +470,8 @@ export class DateRange extends Component {
 								currentShortcut={ this.state.currentShortcut }
 								onClick={ this.handleDateRangeChange }
 								locked={ !! this.props.overlay }
+								startDate={ this.state.startDate }
+								endDate={ this.state.endDate }
 							/>
 						</div>
 					) }

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -2,7 +2,7 @@ import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
+import moment, { Moment } from 'moment';
 import PropTypes from 'prop-types';
 
 const DATERANGE_PERIOD = {
@@ -15,14 +15,18 @@ const DateRangePickerShortcuts = ( {
 	currentShortcut,
 	onClick,
 	locked = false,
+	startDate,
+	endDate,
 }: {
 	currentShortcut?: string;
 	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment, shortcutId: string ) => void;
 	locked?: boolean;
+	startDate?: Moment;
+	endDate?: Moment;
 } ) => {
 	const translate = useTranslate();
 
-	const getShortcutList = () => [
+	const shortcutList = [
 		{
 			id: 'last_7_days',
 			label: translate( 'Last 7 Days' ),
@@ -65,7 +69,20 @@ const DateRangePickerShortcuts = ( {
 		},
 	];
 
-	const shortcutList = getShortcutList();
+	const getShortcutForRange = ( startDate: Moment, endDate: Moment ) => {
+		// Search the shortcut array for something matching the current date range.
+		// Returns shortcut or null;
+		const today = moment().startOf( 'day' );
+		const daysInRange = Math.abs( endDate.diff( startDate, 'days' ) );
+
+		const shortcut = shortcutList.find( ( element ) => {
+			if ( endDate.isSame( today ) && daysInRange === element.range ) {
+				return element;
+			}
+			return null;
+		} );
+		return shortcut;
+	};
 
 	const handleClick = ( { id, offset, range }: { id?: string; offset: number; range: number } ) => {
 		const newToDate = moment().subtract( offset, 'days' );
@@ -73,6 +90,11 @@ const DateRangePickerShortcuts = ( {
 
 		onClick( newFromDate, newToDate, id || '' );
 	};
+
+	currentShortcut =
+		currentShortcut ||
+		( startDate && endDate && getShortcutForRange( startDate, endDate )?.id ) ||
+		'custom_date_range';
 
 	return (
 		<div className="date-range-picker-shortcuts__inner">
@@ -98,6 +120,9 @@ const DateRangePickerShortcuts = ( {
 DateRangePickerShortcuts.propTypes = {
 	currentShortcut: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
+	locked: PropTypes.bool,
+	startDate: PropTypes.instanceOf( Date ),
+	endDate: PropTypes.instanceOf( Date ),
 };
 
 export default DateRangePickerShortcuts;

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -321,7 +321,7 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 
 	@media (max-width: $date-range-mobile-layout-switch) {
-		flex-direction: column; // Stack items vertically on small screens
+		flex-direction: column-reverse; // Stack items vertically on small screens
 	}
 }
 
@@ -332,9 +332,8 @@ $date-range-mobile-layout-switch: $break-small;
 
 	@media (max-width: $date-range-mobile-layout-switch) {
 		border-left: 0 none;
-		border-top: 1px solid var(--gray-gray-5, #dcdcde);
+		border-bottom: 1px solid var(--gray-gray-5, #dcdcde);
 		display: block; // Ensure it takes full width on mobile
-		margin-bottom: 16px; // Space between shortcuts and calendar
 	}
 
 	@media (min-width: $date-range-mobile-layout-switch) {

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -112,6 +112,16 @@ $date-range-mobile-layout-switch: $break-small;
 		margin-right: 0;
 	}
 	margin-top: 10px;
+
+	@media (max-width: $date-range-mobile-layout-switch) {
+		flex-direction: column-reverse;
+		align-items: stretch;
+
+		.button {
+			height: 40px;
+			border: 0;
+		}
+	}
 }
 
 .date-range__info {

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -149,7 +149,8 @@ const StatsDateControl = ( {
 					overlay={ overlay }
 					displayShortcuts
 					useArrowNavigation
-					customTitle="testing custom title prop"
+					customTitle="Date Range"
+					focusedMonth={ moment( dateRange.chartEnd ).toDate() }
 				/>
 			) : (
 				<DateControlPicker


### PR DESCRIPTION


## Proposed Changes

* Set current shortcut even no short cut ID is passed in
* Show two calendar when width>=520px
* Focus calendar with ending date when there's only one calendar
* Ensure the month of the calendar reflect the month of the ending date
* Move shortcuts above calendar for mobile view
* Full width buttons for mobile view

## Why are these changes being made?

* Minor changes to match the design

## Testing Instructions

* Open Calypso Live Branch `/stats/day/jetpack.com?flags=stats%2Fdate-picker-calendar`
* Change width to < 520px
* Ensure you see one calendar
* Ensure 'Apply' and 'Cancel' buttons are full width
* Ensure the current month aligns with the ending date

<img width="345" alt="image" src="https://github.com/user-attachments/assets/69240e91-2d6b-431c-91e3-29b563ffe8d1">



* Change with to >520px
* Ensure you see two calendars

<img width="761" alt="image" src="https://github.com/user-attachments/assets/7683c27c-8e9a-47e0-9a8b-bef102c3e129">


* Click a shortcut and apply; then refresh the page
* Open date range picker
* Ensure the shortcut is still selected

![image](https://github.com/user-attachments/assets/64b39aa6-1aa8-4bc7-a3bb-34c29ae2363e)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
