### PR TITLE
Hosted Site flow: add query params to the login URL

### DIFF
--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -141,14 +141,14 @@ const hosting: Flow = {
 			[]
 		);
 
+		const queryParams = Object.fromEntries( query );
+
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
-			redirectTo: `/setup/${ flowName }`,
+			redirectTo: addQueryArgs( `/setup/${ flowName }`, { ...queryParams } ),
 		} );
 
 		useLayoutEffect( () => {
-			const queryParams = Object.fromEntries( query );
-
 			const urlWithQueryParams = addQueryArgs( '/setup/new-hosted-site', queryParams );
 
 			if ( ! userIsLoggedIn ) {
@@ -163,7 +163,7 @@ const hosting: Flow = {
 			if ( currentStepSlug === 'trialAcknowledge' && ! isEligible ) {
 				window.location.assign( urlWithQueryParams );
 			}
-		}, [ userIsLoggedIn, isEligible, currentStepSlug, query ] );
+		}, [ userIsLoggedIn, isEligible, currentStepSlug, queryParams, logInUrl ] );
 
 		useEffect(
 			() => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1726707421541109/1726695728.531049-slack-CV2TX2PAN

## Proposed Changes

* When visiting the `new-hosted-site` flow as a new user, query parameters are not carried over after account creation or login has been completed. This PR adds query parameters to the redirect URL.

Note: The proper fix is to use the newer methods, such as adding the `requiresLoggedInUser` param to the step definition or maybe the `__experimentalUseBuiltinAuth` param to the flow definition. Both these methods correctly carry the query parameters to the flow after login. However, due to its experimental nature, I opted to manually pass the query parameters to the login URL. Similar changes will have to be done in other places where the `redirectTo` param is passed to the `useLoginUrl` hook. [Example](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/blog.ts)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an incognito window, go to `/setup/new-hosted-site?utm_source=wordcamp&utm_medium=automattic_referred`.
* After creating the account or logging in, confirm that the Commerce plan is hidden on the plans step. This functionality was added in https://github.com/Automattic/wp-calypso/pull/94655.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?