### PR TITLE
Paid newsletter importer updates

### DIFF
--- a/client/data/paid-newsletter/use-reset-mutation.ts
+++ b/client/data/paid-newsletter/use-reset-mutation.ts
@@ -6,11 +6,12 @@ import {
 } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
+import { StepId } from './use-paid-newsletter-query';
 
 interface MutationVariables {
 	siteId: number;
 	engine: string;
-	currentStep: string;
+	currentStep: StepId;
 }
 
 export const useResetMutation = (
@@ -48,7 +49,7 @@ export const useResetMutation = (
 	const { mutate } = mutation;
 
 	const resetPaidNewsletter = useCallback(
-		( siteId: number, engine: string, currentStep: string ) =>
+		( siteId: number, engine: string, currentStep: StepId ) =>
 			mutate( { siteId, engine, currentStep } ),
 		[ mutate ]
 	);

--- a/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
@@ -115,7 +115,7 @@ export class UploadingPane extends PureComponent {
 				return (
 					<div className="content-upload-form__in-progress">
 						<p>{ uploaderPrompt }</p>
-						<ProgressBar className="content-upload-form__in-progress-bar" />
+						<ProgressBar className="content-upload-form__in-progress-bar is-larger-progress-bar" />
 					</div>
 				);
 			}

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -11,11 +11,12 @@ import { fetchImporterState, startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import { getImporterStatusForSiteId } from 'calypso/state/imports/selectors';
 import FileImporter from './content-upload/file-importer';
+import { EngineTypes } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 interface ContentProps {
 	nextStepUrl: string;
-	engine: string;
+	engine: EngineTypes;
 	selectedSite: SiteDetails;
 	siteSlug: string;
 	fromSite: string;

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -81,9 +81,7 @@
 		display: block;
 		margin: 24px 0;
 	}
-
-	.subscriber-upload-form__progress-bar,
-	.content-upload-form__in-progress-bar {
+	.is-larger-progress-bar {
 		height: 5px;
 		border-radius: 3px;
 	}

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -44,12 +44,23 @@
 		clear: both;
 		margin-bottom: 12px;
 
+		p {
+			position: relative;
+			overflow: hidden;
+			margin-bottom: 0;
+		}
+
 		svg {
 			float: left;
 			margin-right: 6px;
 			margin-top: -1px;
 			fill: var(--studio-gray-50);
 		}
+	}
+
+	.summary__content-indent {
+		margin-top: -20;
+		margin-left: 20px;
 	}
 
 	.stripe-logo {

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -176,7 +176,11 @@ export default function NewsletterImporter( {
 						/>
 					) }
 					{ step === 'summary' && (
-						<Summary selectedSite={ selectedSite } steps={ paidNewsletterData.steps } />
+						<Summary
+							selectedSite={ selectedSite }
+							steps={ paidNewsletterData.steps }
+							engine={ engine }
+						/>
 					) }
 				</>
 			) }

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -55,7 +55,7 @@ export default function NewsletterImporter( {
 	const [ validFromSite, setValidFromSite ] = useState( false );
 	const [ autoFetchData, setAutoFetchData ] = useState( false );
 
-	const { data: paidNewsletterData, isFetching: isFetchingPaidNewsletter } = usePaidNewsletterQuery(
+	const { data: paidNewsletterData } = usePaidNewsletterQuery(
 		engine,
 		step,
 		selectedSite?.ID,
@@ -171,7 +171,6 @@ export default function NewsletterImporter( {
 							cardData={ paidNewsletterData.steps[ step ]?.content }
 							engine={ engine }
 							status={ paidNewsletterData.steps[ step ]?.status || 'initial' }
-							isFetchingContent={ isFetchingPaidNewsletter }
 							setAutoFetchData={ setAutoFetchData }
 						/>
 					) }

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -9,7 +9,6 @@ export default function Subscribers( {
 	selectedSite,
 	fromSite,
 	status,
-	isFetchingContent,
 	siteSlug,
 	skipNextStep,
 	cardData,
@@ -35,7 +34,6 @@ export default function Subscribers( {
 			cardData={ cardData }
 			engine={ engine }
 			fromSite={ fromSite }
-			isFetchingContent={ isFetchingContent }
 			nextStepUrl={ nextStepUrl }
 			selectedSite={ selectedSite }
 			setAutoFetchData={ setAutoFetchData }

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers.tsx
@@ -10,7 +10,6 @@ export default function PaidSubscribers( {
 	nextStepUrl,
 	selectedSite,
 	fromSite,
-	isFetchingContent,
 	siteSlug,
 	skipNextStep,
 	cardData,
@@ -39,7 +38,6 @@ export default function PaidSubscribers( {
 					cardData={ cardData }
 					engine={ engine }
 					fromSite={ fromSite }
-					isFetchingContent={ isFetchingContent }
 					nextStepUrl={ nextStepUrl }
 					selectedSite={ selectedSite }
 					setAutoFetchData={ setAutoFetchData }
@@ -53,7 +51,6 @@ export default function PaidSubscribers( {
 					cardData={ cardData }
 					engine={ engine }
 					fromSite={ fromSite }
-					isFetchingContent={ isFetchingContent }
 					nextStepUrl={ nextStepUrl }
 					selectedSite={ selectedSite }
 					setAutoFetchData={ setAutoFetchData }

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -1,6 +1,7 @@
 import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
 import StripeLogo from 'calypso/assets/images/jetpack/stripe-logo-white.svg';
+import { navigate } from 'calypso/lib/navigate';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ImporterActionButton from '../../../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../../../importer-action-buttons/container';
@@ -30,6 +31,7 @@ export default function ConnectStripe( {
 	engine,
 	isFetchingContent,
 	selectedSite,
+	siteSlug,
 }: SubscribersStepProps ) {
 	if ( isFetchingContent || cardData?.connect_url === undefined ) {
 		return null;
@@ -57,8 +59,12 @@ export default function ConnectStripe( {
 				<StartImportButton
 					engine={ engine }
 					siteId={ selectedSite.ID }
-					step="summary"
+					step="subscribers"
 					primary={ false }
+					navigate={ () => {
+						navigate( `/import/newsletter/${ engine }/${ siteSlug }/summary?from=${ fromSite }` );
+					} }
+					label="Continue free subscriber import"
 				/>
 			</ImporterActionButtonContainer>
 		</>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -41,10 +41,10 @@ export default function ConnectStripe( {
 
 	return (
 		<>
-			<h2>Finish importing paid subscribers</h2>
+			<h2>Do you have paid subscribers?</h2>
 			<p>
-				To migrate your paid subscribers to WordPress.com, make sure you're connecting the{ ' ' }
-				<strong>same</strong> Stripe account you use with Substack.
+				To migrate your <strong>paid subscribers</strong> to WordPress.com, make sure you're
+				connecting the <strong>same</strong> Stripe account you use with Substack.
 			</p>
 			<ImporterActionButtonContainer noSpacing>
 				<ImporterActionButton

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -29,11 +29,10 @@ export default function ConnectStripe( {
 	cardData,
 	fromSite,
 	engine,
-	isFetchingContent,
 	selectedSite,
 	siteSlug,
 }: SubscribersStepProps ) {
-	if ( isFetchingContent || cardData?.connect_url === undefined ) {
+	if ( cardData?.connect_url === undefined ) {
 		return null;
 	}
 

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -5,6 +5,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ImporterActionButton from '../../../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../../../importer-action-buttons/container';
 import { SubscribersStepProps } from '../../types';
+import StartImportButton from '../start-import-button';
 
 /**
  * Update the connect URL with the from_site and engine parameters.
@@ -28,6 +29,7 @@ export default function ConnectStripe( {
 	fromSite,
 	engine,
 	isFetchingContent,
+	selectedSite,
 }: SubscribersStepProps ) {
 	if ( isFetchingContent || cardData?.connect_url === undefined ) {
 		return null;
@@ -37,10 +39,10 @@ export default function ConnectStripe( {
 
 	return (
 		<>
-			<h2>Do you have paid subscribers?</h2>
+			<h2>Finish importing paid subscribers</h2>
 			<p>
-				To your migrate your <strong>paid subscribers</strong> to WordPress.com, make sure you're
-				connecting <strong>the same Stripe account</strong> you use with Substack.
+				To migrate your paid subscribers to WordPress.com, make sure you're connecting the{ ' ' }
+				<strong>same</strong> Stripe account you use with Substack.
 			</p>
 			<ImporterActionButtonContainer noSpacing>
 				<ImporterActionButton
@@ -52,6 +54,12 @@ export default function ConnectStripe( {
 				>
 					Connect <img src={ StripeLogo } className="stripe-logo" width="48px" alt="Stripe logo" />
 				</ImporterActionButton>
+				<StartImportButton
+					engine={ engine }
+					siteId={ selectedSite.ID }
+					step="summary"
+					primary={ false }
+				/>
 			</ImporterActionButtonContainer>
 		</>
 	);

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
@@ -23,13 +23,13 @@ function formatCurrencyFloat( amount: number, currency: string ) {
 	return parseFloat( formattedCurrency );
 }
 
-function shouldShowButton( cardData: any ) {
-	// Show the button if
+function shouldEnableImporting( cardData: any ) {
+	// Enable the button if
 	if ( ! cardData?.is_connected_stripe ) {
 		return true;
 	}
 
-	// show the button if we have mapped all the
+	// Enable the button if we have mapped all the
 	const plans = cardData?.plans ?? [];
 	const map_plans = cardData?.map_plans ?? {};
 
@@ -137,7 +137,7 @@ export default function MapPlans( {
 		},
 	};
 
-	const showButton = shouldShowButton( cardData );
+	const isImportButtonDisabled = ! shouldEnableImporting( cardData ) || isSavingPlanMapping;
 
 	const onProductSelect = ( stripePlanId: string, productId: string ) => {
 		mapStripePlanToProduct( selectedSite.ID, engine, currentStep, stripePlanId, productId );
@@ -181,19 +181,15 @@ export default function MapPlans( {
 				} ) }
 			</div>
 
-			{ showButton && ! isSavingPlanMapping && (
-				<StartImportButton
-					engine={ engine }
-					siteId={ selectedSite.ID }
-					hasPaidSubscribers
-					step={ currentStep }
-					navigate={ () => {
-						navigate( `/import/newsletter/${ engine }/${ siteSlug }/summary?from=${ fromSite }` );
-					} }
-				/>
-			) }
-			{ showButton && isSavingPlanMapping && <p>Saving selection...</p> }
-			{ ! showButton && <p>Map plans on WordPress.com to continue...</p> }
+			<StartImportButton
+				engine={ engine }
+				siteId={ selectedSite.ID }
+				step={ currentStep }
+				navigate={ () => {
+					navigate( `/import/newsletter/${ engine }/${ siteSlug }/summary?from=${ fromSite }` );
+				} }
+				disabled={ isImportButtonDisabled }
+			/>
 
 			{ productToAdd && (
 				<RecurringPaymentsPlanAddEditModal

--- a/client/my-sites/importer/newsletter/subscribers/start-import-button.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/start-import-button.tsx
@@ -9,6 +9,7 @@ type Props = {
 	navigate?: () => void;
 	disabled?: boolean;
 	primary?: boolean;
+	label?: string;
 };
 
 export default function StartImportButton( {
@@ -18,6 +19,7 @@ export default function StartImportButton( {
 	navigate = () => {},
 	disabled,
 	primary = true,
+	label,
 }: Props ) {
 	const { enqueueSubscriberImport } = useSubscriberImportMutation();
 
@@ -28,7 +30,7 @@ export default function StartImportButton( {
 
 	return (
 		<ImporterActionButton primary={ primary } disabled={ disabled } onClick={ importSubscribers }>
-			Continue
+			{ label || 'Import subscribers' }
 		</ImporterActionButton>
 	);
 }

--- a/client/my-sites/importer/newsletter/subscribers/start-import-button.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/start-import-button.tsx
@@ -1,7 +1,3 @@
-import { FormLabel } from '@automattic/components';
-import { useState } from '@wordpress/element';
-import { ChangeEvent } from 'react';
-import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import { useSubscriberImportMutation } from 'calypso/data/paid-newsletter/use-subscriber-import-mutation';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 
@@ -9,19 +5,17 @@ type Props = {
 	step: string;
 	engine: string;
 	siteId: number;
-	hasPaidSubscribers: boolean;
 	navigate?: () => void;
+	disabled?: boolean;
 };
 
 export default function StartImportButton( {
 	siteId,
-	hasPaidSubscribers,
 	step,
 	engine,
 	navigate = () => {},
+	disabled,
 }: Props ) {
-	const [ isDisabled, setIsDisabled ] = useState( ! hasPaidSubscribers );
-
 	const { enqueueSubscriberImport } = useSubscriberImportMutation();
 
 	const importSubscribers = () => {
@@ -29,30 +23,9 @@ export default function StartImportButton( {
 		navigate();
 	};
 
-	const onChange = ( { target: { checked } }: ChangeEvent< HTMLInputElement > ) =>
-		setIsDisabled( checked );
-
 	return (
-		<>
-			{ hasPaidSubscribers && (
-				<>
-					<p>
-						<strong>To prevent any unexpected actions by your old provider</strong>, go to your
-						Stripe dashboard and click “Revoke access” for any service previously associated with
-						this subscription.
-					</p>
-
-					<p>
-						<FormLabel>
-							<FormCheckbox checked={ isDisabled } onChange={ onChange } />
-							I’ve disconnected other providers from the Stripe account
-						</FormLabel>
-					</p>
-				</>
-			) }
-			<ImporterActionButton primary disabled={ ! isDisabled } onClick={ importSubscribers }>
-				Import subscribers
-			</ImporterActionButton>
-		</>
+		<ImporterActionButton primary disabled={ disabled } onClick={ importSubscribers }>
+			Continue
+		</ImporterActionButton>
 	);
 }

--- a/client/my-sites/importer/newsletter/subscribers/start-import-button.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/start-import-button.tsx
@@ -1,12 +1,14 @@
+import { StepId } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import { useSubscriberImportMutation } from 'calypso/data/paid-newsletter/use-subscriber-import-mutation';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 
 type Props = {
-	step: string;
+	step: StepId;
 	engine: string;
 	siteId: number;
 	navigate?: () => void;
 	disabled?: boolean;
+	primary?: boolean;
 };
 
 export default function StartImportButton( {
@@ -15,6 +17,7 @@ export default function StartImportButton( {
 	engine,
 	navigate = () => {},
 	disabled,
+	primary = true,
 }: Props ) {
 	const { enqueueSubscriberImport } = useSubscriberImportMutation();
 
@@ -24,7 +27,7 @@ export default function StartImportButton( {
 	};
 
 	return (
-		<ImporterActionButton primary disabled={ disabled } onClick={ importSubscribers }>
+		<ImporterActionButton primary={ primary } disabled={ disabled } onClick={ importSubscribers }>
 			Continue
 		</ImporterActionButton>
 	);

--- a/client/my-sites/importer/newsletter/subscribers/step-done.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-done.tsx
@@ -1,5 +1,17 @@
 import { Card } from '@automattic/components';
+import { Notice } from '@wordpress/components';
+import ImporterActionButton from '../../importer-action-buttons/action-button';
+import { SubscribersStepProps } from '../types';
 
-export default function StepDone() {
-	return <Card>DONE!</Card>;
+export default function StepDone( { cardData, nextStepUrl }: SubscribersStepProps ) {
+	const subscribedCount = parseInt( cardData.meta?.subscribed_count || '0' );
+	return (
+		<Card>
+			<h2>Import your subscribers to WordPress.com</h2>
+			<Notice status="success" className="importer__notice" isDismissible={ false }>
+				Success! { subscribedCount } subscribers have been added!
+			</Notice>
+			<ImporterActionButton href={ nextStepUrl }>View Summary</ImporterActionButton>
+		</Card>
+	);
 }

--- a/client/my-sites/importer/newsletter/subscribers/step-importing.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-importing.tsx
@@ -1,5 +1,25 @@
 import { Card } from '@automattic/components';
+import { ProgressBar } from '@wordpress/components';
+import { Icon, atSymbol } from '@wordpress/icons';
+import ImporterActionButton from '../../importer-action-buttons/action-button';
+import { SubscribersStepProps } from '../types';
 
-export default function StepAwaiting() {
-	return <Card>Awaiting!!</Card>;
+export default function StepImporting( { nextStepUrl }: SubscribersStepProps ) {
+	return (
+		<Card>
+			<div className="summary__content">
+				<p>
+					<Icon icon={ atSymbol } /> <strong>We're importing your subscribers</strong>
+				</p>
+			</div>
+			<p>
+				This may take a few minutes. Feel free to leave this window – we'll let you know when it's
+				done.
+			</p>
+			<p>
+				<ProgressBar className="is-larger-progress-bar" />
+			</p>
+			<ImporterActionButton href={ nextStepUrl }>View Summary</ImporterActionButton>
+		</Card>
+	);
 }

--- a/client/my-sites/importer/newsletter/subscribers/step-pending.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-pending.tsx
@@ -12,7 +12,6 @@ export default function StepPending( {
 	skipNextStep,
 	cardData,
 	engine,
-	isFetchingContent,
 	setAutoFetchData,
 	status,
 }: SubscribersStepProps ) {
@@ -28,7 +27,6 @@ export default function StepPending( {
 				cardData={ cardData }
 				engine={ engine }
 				fromSite={ fromSite }
-				isFetchingContent={ isFetchingContent }
 				nextStepUrl={ nextStepUrl }
 				selectedSite={ selectedSite }
 				setAutoFetchData={ setAutoFetchData }

--- a/client/my-sites/importer/newsletter/subscribers/step-pending.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-pending.tsx
@@ -1,12 +1,8 @@
 import { Card } from '@automattic/components';
 import { Notice } from '@wordpress/components';
 import { toInteger } from 'lodash';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import ImporterActionButton from '../../importer-action-buttons/action-button';
-import ImporterActionButtonContainer from '../../importer-action-buttons/container';
 import { SubscribersStepProps } from '../types';
 import PaidSubscribers from './paid-subscribers';
-import StartImportButton from './start-import-button';
 
 export default function StepPending( {
 	nextStepUrl,
@@ -40,26 +36,6 @@ export default function StepPending( {
 				skipNextStep={ skipNextStep }
 				status={ status }
 			/>
-
-			{ ! cardData?.is_connected_stripe && (
-				<ImporterActionButtonContainer noSpacing>
-					<StartImportButton
-						engine={ engine }
-						siteId={ selectedSite.ID }
-						hasPaidSubscribers={ false }
-						step="subscribers"
-					/>
-					<ImporterActionButton
-						href={ nextStepUrl }
-						onClick={ () => {
-							skipNextStep();
-							recordTracksEvent( 'calypso_paid_importer_connect_stripe_skipped' );
-						} }
-					>
-						Skip for now
-					</ImporterActionButton>
-				</ImporterActionButtonContainer>
-			) }
 		</Card>
 	);
 }

--- a/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
@@ -74,7 +74,7 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 				<div className="subscriber-upload-form__in-progress">
 					<Icon icon={ cloudUpload } viewBox="4 4 16 16" size={ 16 } />
 					<p>Uploading...</p>
-					<ProgressBar className="subscriber-upload-form__progress-bar" />
+					<ProgressBar className="is-larger-progress-bar" />
 				</div>
 			</div>
 		);

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -1,10 +1,12 @@
 import { Card, ConfettiAnimation } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { Steps, StepStatus } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import { useResetMutation } from 'calypso/data/paid-newsletter/use-reset-mutation';
 import ImporterActionButton from '../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../importer-action-buttons/container';
 import ContentSummary from './summary/content';
 import SubscribersSummary from './summary/subscribers';
+import { EngineTypes } from './types';
 import { getImporterStatus } from './utils';
 
 function getStepTitle( importerStatus: StepStatus ) {
@@ -22,11 +24,15 @@ function getStepTitle( importerStatus: StepStatus ) {
 interface SummaryProps {
 	selectedSite: SiteDetails;
 	steps: Steps;
+	engine: EngineTypes;
 }
 
-export default function Summary( { steps, selectedSite }: SummaryProps ) {
+export default function Summary( { steps, selectedSite, engine }: SummaryProps ) {
+	const { resetPaidNewsletter } = useResetMutation();
 	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 	const importerStatus = getImporterStatus( steps.content.status, steps.subscribers.status );
+
+	const onButtonClick = () => resetPaidNewsletter( selectedSite.ID, engine, 'content' );
 
 	return (
 		<Card>
@@ -43,13 +49,20 @@ export default function Summary( { steps, selectedSite }: SummaryProps ) {
 			) }
 
 			<ImporterActionButtonContainer noSpacing>
-				<ImporterActionButton href={ '/settings/newsletter/' + selectedSite.slug } primary>
+				<ImporterActionButton
+					href={ '/settings/newsletter/' + selectedSite.slug }
+					onClick={ onButtonClick }
+					primary
+				>
 					Customize your newsletter
 				</ImporterActionButton>
-				<ImporterActionButton href={ '/posts/' + selectedSite.slug }>
+				<ImporterActionButton href={ '/posts/' + selectedSite.slug } onClick={ onButtonClick }>
 					View content
 				</ImporterActionButton>
-				<ImporterActionButton href={ '/subscribers/' + selectedSite.slug }>
+				<ImporterActionButton
+					href={ '/subscribers/' + selectedSite.slug }
+					onClick={ onButtonClick }
+				>
 					Check subscribers
 				</ImporterActionButton>
 			</ImporterActionButtonContainer>

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,4 +1,5 @@
-import { Icon, people, currencyDollar, atSymbol } from '@wordpress/icons';
+import { ProgressBar } from '@wordpress/components';
+import { Icon, people, atSymbol, payment } from '@wordpress/icons';
 import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
 interface SubscriberSummaryProps {
@@ -7,8 +8,8 @@ interface SubscriberSummaryProps {
 }
 
 export default function SubscriberSummary( { stepContent, status }: SubscriberSummaryProps ) {
-	const paidSubscribers = parseInt( stepContent?.meta?.paid_subscribers_count || '0' );
-	const hasPaidSubscribers = paidSubscribers > 0;
+	const paidSubscribersCount = parseInt( stepContent?.meta?.paid_subscribers_count || '0' );
+	const hasPaidSubscribers = paidSubscribersCount > 0;
 
 	if ( status === 'skipped' ) {
 		return (
@@ -20,38 +21,50 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 		);
 	}
 
-	if ( status === 'importing' || status === 'pending' ) {
+	if ( status === 'importing' ) {
 		return (
-			<div className="summary__content">
+			<>
+				<div className="summary__content">
+					<p>
+						<Icon icon={ atSymbol } /> <strong>We're importing your subscribers.</strong>
+						<br />
+					</p>
+				</div>
 				<p>
-					<Icon icon={ people } /> <strong>We're importing your subscribers.</strong>
-					<br />
 					This may take a few minutes. Feel free to leave this window – we'll let you know when it's
 					done.
 				</p>
-			</div>
+				<p>
+					<ProgressBar className="is-larger-progress-bar" />
+				</p>
+			</>
 		);
 	}
 
 	if ( status === 'done' ) {
-		const paidSubscribersCount = parseInt( stepContent.meta?.paid_subscribers_count || '0' );
 		const subscribedCount = parseInt( stepContent.meta?.subscribed_count || '0' );
 		const freeSubscribersCount = subscribedCount - paidSubscribersCount;
 
 		return (
-			<div className="summary__content">
-				<p>We migrated { subscribedCount } subscribers</p>
-				<p>
-					<Icon icon={ people } />
-					<strong>{ freeSubscribersCount }</strong> free subscribers
-				</p>
-				{ hasPaidSubscribers && (
+			<>
+				<div className="summary__content">
 					<p>
-						<Icon icon={ currencyDollar } />
-						<strong>{ paidSubscribersCount }</strong> paid subscribers
+						<Icon icon={ atSymbol } /> We imported { subscribedCount } subscribers, where:
 					</p>
-				) }
-			</div>
+				</div>
+				<div className="summary__content summary__content-indent">
+					<p>
+						<Icon icon={ people } />
+						<strong>{ freeSubscribersCount }</strong> free subscribers
+					</p>
+					{ hasPaidSubscribers && (
+						<p>
+							<Icon icon={ payment } />
+							<strong>{ paidSubscribersCount }</strong> paid subscribers
+						</p>
+					) }
+				</div>
+			</>
 		);
 	}
 }

--- a/client/my-sites/importer/newsletter/types.ts
+++ b/client/my-sites/importer/newsletter/types.ts
@@ -11,7 +11,6 @@ export interface SubscribersStepProps {
 	status: StatusType;
 	engine: 'substack';
 	fromSite: QueryArgParsed;
-	isFetchingContent: boolean;
 	nextStepUrl: string;
 	selectedSite: SiteDetails;
 	setAutoFetchData: Dispatch< SetStateAction< boolean > >;

--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -27,6 +27,10 @@ export function getSetpProgressSteps(
 	fromSite: string,
 	paidNewsletterData?: PaidNewsletterData
 ) {
+	const summaryStatus = getImporterStatus(
+		paidNewsletterData?.steps.content.status,
+		paidNewsletterData?.steps.subscribers.status
+	);
 	const result: ClickHandler[] = [
 		{
 			message: 'Content',
@@ -55,12 +59,7 @@ export function getSetpProgressSteps(
 		{
 			message: 'Summary',
 			onClick: noop,
-			indicator: getStepProgressIndicator(
-				getImporterStatus(
-					paidNewsletterData?.steps.content.status,
-					paidNewsletterData?.steps.subscribers.status
-				)
-			),
+			indicator: getStepProgressIndicator( summaryStatus === 'done' ? 'done' : 'initial' ),
 		},
 	];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

It:
- reset the importer state on summary step buttons click
- shows the subscribers import button but disables it when the import is not allowed
- removes the checkbox from importing subscribers step
- updates UI for the Stripe connection step

<img width="742" alt="Screenshot 2024-09-19 at 11 20 23" src="https://github.com/user-attachments/assets/b474b712-37c2-4bf3-b7d3-270484ce16fe">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
