### PR TITLE
Stepper: calypso_signup_complete as in Start

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -169,10 +169,6 @@ class PasswordlessSignupForm extends Component {
 		const { flowName, queryArgs = {} } = this.props;
 		const { redirect_to, oauth2_client_id, oauth2_redirect } = queryArgs;
 
-		if ( this.props.onCreateAccountSuccess ) {
-			return this.props.onCreateAccountSuccess( userData );
-		}
-
 		recordRegistration( {
 			userData,
 			flow: flowName,
@@ -187,6 +183,10 @@ class PasswordlessSignupForm extends Component {
 				? { oauth2_client_id, oauth2_redirect }
 				: { redirect: redirect_to } ),
 		} );
+
+		if ( this.props.onCreateAccountSuccess ) {
+			return this.props.onCreateAccountSuccess( userData );
+		}
 	};
 
 	submitStep = ( data ) => {

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -35,6 +35,7 @@ interface SignupFormSocialFirst {
 			extra: { first_name: string; last_name: string; username_hint: string };
 		} | null
 	) => void;
+	onCreateAccountSuccess?: ( data: AccountCreateReturn ) => void;
 	queryArgs: QueryArgs;
 	userEmail: string;
 	notice: JSX.Element | false;
@@ -69,6 +70,7 @@ const SignupFormSocialFirst = ( {
 	logInUrl,
 	socialServiceResponse,
 	handleSocialResponse,
+	onCreateAccountSuccess,
 	queryArgs,
 	userEmail,
 	notice,
@@ -175,6 +177,7 @@ const SignupFormSocialFirst = ( {
 								);
 							}
 						} }
+						onCreateAccountSuccess={ onCreateAccountSuccess }
 						{ ...gravatarProps }
 					/>
 					<Button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -1,5 +1,6 @@
 import { StepContainer } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -7,6 +8,7 @@ import { AnyAction } from 'redux';
 import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import SignupFormSocialFirst from 'calypso/blocks/signup-form/signup-form-social-first';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { login } from 'calypso/lib/paths';
 import { AccountCreateReturn } from 'calypso/lib/signup/api/type';
@@ -30,6 +32,7 @@ const UserStepComponent: Step = function UserStep( {
 	const translate = useTranslate();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const dispatch = useDispatch();
+	const { setIsNewUser } = useDataStoreDispatch( USER_STORE );
 	const { handleSocialResponse, notice, accountCreateResponse } = useHandleSocialResponse( flow );
 
 	const [ wpAccountCreateResponse, setWpAccountCreateResponse ] = useState< AccountCreateReturn >();
@@ -82,6 +85,7 @@ const UserStepComponent: Step = function UserStep( {
 						userEmail=""
 						notice={ notice }
 						isSocialFirst
+						onCreateAccountSuccess={ () => setIsNewUser( true ) }
 					/>
 					{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (
 						<WpcomLoginForm

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
@@ -24,7 +24,7 @@ export function useCreateAccountMutation() {
 			} );
 		},
 		onSuccess: ( data ) => {
-			if ( 'created_account' in data && !! data?.created_account ) {
+			if ( 'isNewAccountCreated' in data && data.isNewAccountCreated ) {
 				setIsNewUser( true );
 			}
 			dispatch( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
@@ -1,6 +1,8 @@
 // import config from '@automattic/calypso-config';
 // import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 import { useMutation } from '@tanstack/react-query';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { createAccount } from 'calypso/lib/signup/api/account';
 import { useDispatch } from 'calypso/state';
 import {
@@ -11,6 +13,7 @@ import {
 
 export function useCreateAccountMutation() {
 	const dispatch = useDispatch();
+	const { setIsNewUser } = useDataStoreDispatch( USER_STORE );
 
 	return useMutation( {
 		mutationKey: [ 'create' ],
@@ -21,6 +24,9 @@ export function useCreateAccountMutation() {
 			} );
 		},
 		onSuccess: ( data ) => {
+			if ( 'created_account' in data && !! data?.created_account ) {
+				setIsNewUser( true );
+			}
 			dispatch( {
 				type: SOCIAL_LOGIN_REQUEST_SUCCESS,
 				data: data,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -104,7 +104,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 			if ( availableFlows[ flow ] ) {
 				availableFlows[ flow ]().then( ( flowExport ) => {
 					if ( flowExport.default.isSignupFlow ) {
-						recordSignupComplete();
+						recordSignupComplete( { ...destinationState } );
 					}
 				} );
 			}

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -12,14 +12,14 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 	const site = useSite();
 	const siteId = site?.ID || null;
 	const theme = site?.options?.theme_slug || '';
-	const { domainCartItem, planCartItem, siteCount, selectedDomain, currentUser } = useSelect(
+	const { domainCartItem, planCartItem, siteCount, selectedDomain, isNewUser } = useSelect(
 		( select ) => {
 			return {
 				siteCount: ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.site_count,
 				domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
 				planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 				selectedDomain: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
-				currentUser: ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+				isNewUser: ( select( USER_STORE ) as UserSelect ).isNewUser(),
 			};
 		},
 		[]
@@ -32,8 +32,6 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 	return useCallback(
 		( signupCompletionState: Record< string, unknown > ) => {
 			const siteSlug = site?.slug ?? signupCompletionState?.siteSlug;
-
-			const isNewUser = !! currentUser?.username;
 
 			const isNew7DUserSite = !! (
 				isNewUser ||

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -12,14 +12,18 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 	const site = useSite();
 	const siteId = site?.ID || null;
 	const theme = site?.options?.theme_slug || '';
-	const { domainCartItem, planCartItem, siteCount, selectedDomain } = useSelect( ( select ) => {
-		return {
-			siteCount: ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.site_count,
-			domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
-			planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
-			selectedDomain: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
-		};
-	}, [] );
+	const { domainCartItem, planCartItem, siteCount, selectedDomain, currentUser } = useSelect(
+		( select ) => {
+			return {
+				siteCount: ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.site_count,
+				domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
+				planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
+				selectedDomain: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
+				currentUser: ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+			};
+		},
+		[]
+	);
 
 	const isNewishUser = useSelector( ( state ) =>
 		isUserRegistrationDaysWithinRange( state, null, 0, 7 )
@@ -29,7 +33,7 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 		( signupCompletionState: Record< string, unknown > ) => {
 			const siteSlug = site?.slug ?? signupCompletionState?.siteSlug;
 
-			const isNewUser = ! siteCount;
+			const isNewUser = !! currentUser?.username;
 
 			const isNew7DUserSite = !! (
 				isNewUser ||

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -3,16 +3,13 @@ import { useSelect } from '@wordpress/data';
 import { useCallback } from 'react';
 import { USER_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { SIGNUP_DOMAIN_ORIGIN, recordSignupComplete } from 'calypso/lib/analytics/signup';
-import { useStore } from 'calypso/state';
+import { useSelector } from 'calypso/state';
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
-import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { useSite } from './use-site';
 import type { UserSelect, OnboardSelect } from '@automattic/data-stores';
 
 export const useRecordSignupComplete = ( flow: string | null ) => {
 	const site = useSite();
-	const store = useStore();
-	const state = store.getState();
 	const siteId = site?.ID || null;
 	const theme = site?.options?.theme_slug || '';
 	const { domainCartItem, planCartItem, siteCount, selectedDomain } = useSelect( ( select ) => {
@@ -23,53 +20,60 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 			selectedDomain: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
 		};
 	}, [] );
-	const isNewishUser = isUserRegistrationDaysWithinRange( state, null, 0, 7 );
-	const dependencies = getSignupDependencyStore( state );
 
-	return useCallback( () => {
-		const isNewUser = !! ( dependencies && dependencies.username );
+	const isNewishUser = useSelector( ( state ) =>
+		isUserRegistrationDaysWithinRange( state, null, 0, 7 )
+	);
 
-		const isNew7DUserSite = !! (
-			isNewUser ||
-			( isNewishUser && dependencies && dependencies?.siteSlug && siteCount && siteCount <= 1 )
-		);
+	return useCallback(
+		( signupCompletionState: Record< string, unknown > ) => {
+			const siteSlug = site?.slug ?? signupCompletionState?.siteSlug;
 
-		// Domain product slugs can be a domain purchases like dotcom_domain or dotblog_domain or a mapping like domain_mapping
-		// When purchasing free subdomains the product_slugs is empty (since there is no actual produce being purchased)
-		// so we avoid capturing the product slug in these instances.
-		const domainProductSlug = domainCartItem?.product_slug ?? undefined;
+			const isNewUser = ! siteCount;
 
-		// Domain cart items can sometimes be included when free. So the selected domain is explicitly checked to see if it's free.
-		// For mappings and transfers this attribute should be empty but it needs to be checked.
-		const hasCartItems = !! ( domainProductSlug || planCartItem ); // see the function `dependenciesContainCartItem()
+			const isNew7DUserSite = !! (
+				isNewUser ||
+				( isNewishUser && siteSlug && siteCount && siteCount <= 1 )
+			);
 
-		// When there is no plan put in the cart, `planCartItem` is `null` instead of `undefined` like domainCartItem.
-		// It worths a investigation of whether the both should behave the same.
-		const planProductSlug = planCartItem?.product_slug ?? undefined;
-		// To have a paid domain item it has to either be a paid domain or a different domain product like mapping or transfer.
-		const hasPaidDomainItem =
-			( selectedDomain && ! selectedDomain.is_free ) || !! domainProductSlug;
+			// Domain product slugs can be a domain purchases like dotcom_domain or dotblog_domain or a mapping like domain_mapping
+			// When purchasing free subdomains the product_slugs is empty (since there is no actual produce being purchased)
+			// so we avoid capturing the product slug in these instances.
+			const domainProductSlug = domainCartItem?.product_slug ?? undefined;
 
-		recordSignupComplete(
-			{
-				flow,
-				siteId,
-				isNewUser,
-				hasCartItems,
-				isNew7DUserSite,
-				theme,
-				intent: flow,
-				startingPoint: flow,
-				isBlankCanvas: theme?.includes( 'blank-canvas' ),
-				planProductSlug,
-				domainProductSlug,
-				isMapping:
-					hasPaidDomainItem && domainCartItem ? isDomainMapping( domainCartItem ) : undefined,
-				isTransfer:
-					hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
-				signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.NOT_SET,
-			},
-			true
-		);
-	}, [ domainCartItem, flow, planCartItem, selectedDomain, siteCount, siteId, theme ] );
+			// Domain cart items can sometimes be included when free. So the selected domain is explicitly checked to see if it's free.
+			// For mappings and transfers this attribute should be empty but it needs to be checked.
+			const hasCartItems = !! ( domainProductSlug || planCartItem ); // see the function `dependenciesContainCartItem()
+
+			// When there is no plan put in the cart, `planCartItem` is `null` instead of `undefined` like domainCartItem.
+			// It worths a investigation of whether the both should behave the same.
+			const planProductSlug = planCartItem?.product_slug ?? undefined;
+			// To have a paid domain item it has to either be a paid domain or a different domain product like mapping or transfer.
+			const hasPaidDomainItem =
+				( selectedDomain && ! selectedDomain.is_free ) || !! domainProductSlug;
+
+			recordSignupComplete(
+				{
+					flow,
+					siteId: siteId ?? signupCompletionState?.siteId,
+					isNewUser,
+					hasCartItems,
+					isNew7DUserSite,
+					theme,
+					intent: flow,
+					startingPoint: flow,
+					isBlankCanvas: theme?.includes( 'blank-canvas' ),
+					planProductSlug,
+					domainProductSlug,
+					isMapping:
+						hasPaidDomainItem && domainCartItem ? isDomainMapping( domainCartItem ) : undefined,
+					isTransfer:
+						hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
+					signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.NOT_SET,
+				},
+				true
+			);
+		},
+		[ domainCartItem, flow, planCartItem, selectedDomain, siteCount, siteId, theme ]
+	);
 };

--- a/client/lib/signup/api/account.tsx
+++ b/client/lib/signup/api/account.tsx
@@ -130,9 +130,7 @@ export async function createAccount( {
 			username,
 			signupType: service ? 'social' : 'default',
 		} );
-
-		return response;
 	}
 
-	return response;
+	return { ...response, isNewAccountCreated };
 }

--- a/client/lib/signup/api/type.ts
+++ b/client/lib/signup/api/type.ts
@@ -9,6 +9,7 @@ export type AccountCreationAPIResponse =
 			oauth2_redirect?: string;
 			marketing_price_group?: string;
 			created_account?: boolean;
+			isNewAccountCreated?: boolean;
 	  }
 	| {
 			error: 'user_exists';

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -10,9 +10,15 @@ export function createActions() {
 		type: 'RECEIVE_CURRENT_USER_FAILED' as const,
 	} );
 
+	const setIsNewUser = ( isNewUser: boolean ) => ( {
+		type: 'SET_IS_NEW_USER' as const,
+		isNewUser,
+	} );
+
 	return {
 		receiveCurrentUser,
 		receiveCurrentUserFailed,
+		setIsNewUser,
 	};
 }
 
@@ -20,7 +26,9 @@ export type ActionCreators = ReturnType< typeof createActions >;
 
 export type Action =
 	| ReturnType<
-			ActionCreators[ 'receiveCurrentUser' ] | ActionCreators[ 'receiveCurrentUserFailed' ]
+			| ActionCreators[ 'receiveCurrentUser' ]
+			| ActionCreators[ 'receiveCurrentUserFailed' ]
+			| ActionCreators[ 'setIsNewUser' ]
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost
 	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/user/reducer.ts
+++ b/packages/data-stores/src/user/reducer.ts
@@ -13,7 +13,15 @@ export const currentUser: Reducer< CurrentUser | null | undefined, Action > = ( 
 	return state;
 };
 
-const reducer = combineReducers( { currentUser } );
+const isNewUser: Reducer< boolean, Action > = ( state = false, action ) => {
+	switch ( action.type ) {
+		case 'SET_IS_NEW_USER':
+			return action.isNewUser;
+	}
+	return state;
+};
+
+const reducer = combineReducers( { currentUser, isNewUser } );
 export type State = ReturnType< typeof reducer >;
 
 export default reducer;

--- a/packages/data-stores/src/user/selectors.ts
+++ b/packages/data-stores/src/user/selectors.ts
@@ -4,3 +4,4 @@ export const getState = ( state: State ) => state;
 
 export const getCurrentUser = ( state: State ) => state.currentUser;
 export const isCurrentUserLoggedIn = ( state: State ) => !! state.currentUser?.ID;
+export const isNewUser = ( state: State ) => state.isNewUser;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94688

## Proposed Changes

* Use the same logic as in [start](https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/main.jsx#L503-L508) for `isNewUser` and `isNew7DUserSite` values, these values are used to [properly log](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/analytics/signup.js#L92) the `calypso_signup_complete` tracking event.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* With the new domains step, this was not yet fully implemented. This PR adds it by mimicking the `/start` logic.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Mock wordpress
* Signup with social account and with an email
* Go after the the plans step and make sure that `calypso_signup_complete` gets triggered correctly, with the blog_id
* Make sure that [isNewUser](https://github.com/Automattic/wp-calypso/pull/94706/files#diff-5038e9e5336354287a5b121225f8b724daf5563cc47d8b4d29ce0fe6de9147f3R22) is set to true
* Make sure that isNewUser is not true if you signup with an existing user


