### PR TITLE
A4A > Referrals: Fix the cancel subscription confirmation message for the client

### DIFF
--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -74,7 +74,7 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 						<TextPlaceholder />
 					) : (
 						translate(
-							'{{b}}%(productName)s{{/b}} will stop recommending products to your customers. This action cannot be undone.',
+							'{{b}}%(productName)s{{/b}} will be canceled, and you will no longer have access to it. Are you sure you want to cancel?',
 							{
 								args: {
 									productName,


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/990

## Proposed Changes

This PR fixes the cancel subscription confirmation message for the client.

## Why are these changes being made?

* To fix the cancel subscription confirmation message for the client.

## Testing Instruction

* Switch to this branch and start the server locally.
* Login as a client 
* From the Subscriptions page -> Click on any `Cancel the subscription` button on the table row -> Verify that the message is updated as shown below. 

| Before | After |
|--------|--------|
| <img width="509" alt="Screenshot 2024-09-19 at 3 56 12 PM" src="https://github.com/user-attachments/assets/805dea2d-9f3e-4a09-b900-3f044cc6abb8">| <img width="910" alt="Screenshot 2024-09-19 at 3 51 47 PM" src="https://github.com/user-attachments/assets/ef5d812e-6d40-4da3-a300-6cf8f5240fd7"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
