### PR TITLE
Fix misaligned chat button

### DIFF
--- a/client/components/marketing-survey/cancel-auto-renewal-form/style.scss
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/style.scss
@@ -5,3 +5,10 @@
 .cancel-auto-renewal-form__form-fieldset {
 	margin-bottom: 0;
 }
+
+.cancel-auto-renewal-form__chat-button {
+	float: left;
+	font-size: 0.875rem;
+	position: initial;
+	transform: none;
+}

--- a/packages/help-center/src/components/help-center-third-party-cookies-notice.scss
+++ b/packages/help-center/src/components/help-center-third-party-cookies-notice.scss
@@ -6,4 +6,8 @@
 		font-weight: 500;
 		margin: 1em 0;
 	}
+
+	.help-center-third-party-cookies-notice__content {
+		padding: 0 30px 20px;
+	}
 }

--- a/packages/help-center/src/components/help-center-third-party-cookies-notice.tsx
+++ b/packages/help-center/src/components/help-center-third-party-cookies-notice.tsx
@@ -5,7 +5,7 @@ import { useEffect } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
-import { BackButton } from './back-button';
+import { BackButtonHeader } from './back-button';
 
 import './help-center-third-party-cookies-notice.scss';
 
@@ -23,8 +23,9 @@ const ThirdPartyCookiesNotice: React.FC = () => {
 
 	return (
 		<div className="help-center-third-party-cookies-notice">
-			<BackButton />
-			<div>
+			<BackButtonHeader />
+
+			<div className="help-center-third-party-cookies-notice__content">
 				<h1>{ __( 'Action needed', __i18n_text_domain__ ) }</h1>
 				<p>
 					{ __(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

When disabling auto-renew for professional email, the chat button text was misaligned.

| Before  | After |
| ------------- | ------------- |
| <img width="1182" alt="Screenshot 2024-09-19 at 14 42 11" src="https://github.com/user-attachments/assets/68f7e6cc-d951-40c1-8ec0-8d977df23f7f">  |  <img width="1183" alt="Screenshot 2024-09-19 at 14 41 49" src="https://github.com/user-attachments/assets/49a2d19c-1f18-4eb8-abc9-176235f7418e"> |

Fixes https://github.com/Automattic/wp-calypso/issues/94698

## Proposed Changes

* Add missing styles to component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Add professional email to a site
* /email/:site_slug/manage/:site_slug
* Disable Auto-renew
* The button "Need help? Contact us" should be correctly aligned to the left

