### PR TITLE
SSR: Enable Login Section SSR for Mag-16 Locales

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -376,7 +376,7 @@ export const setSelectedSiteIdByOrigin = ( context, next ) => {
 };
 
 /**
- * This function is only used to provide API compatibility with for the sections that use shared controllers.
+ * This function is only used to provide API compatibility for the sections that use shared controllers.
  */
 export const ssrSetupLocale = ( _context, next ) => {
 	next();

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -374,3 +374,10 @@ export const setSelectedSiteIdByOrigin = ( context, next ) => {
 	}
 	next();
 };
+
+/**
+ * This function is only used to provide API compatibility with for the sections that use shared controllers.
+ */
+export const ssrSetupLocale = ( _context, next ) => {
+	next();
+};

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { Provider as ReduxProvider } from 'react-redux';
+import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { RouteProvider } from 'calypso/components/route';
 import { setHrefLangLinks } from 'calypso/controller/localized-links';
 import {
@@ -18,7 +19,7 @@ import {
 	redirectDefaultLocale,
 } from './controller';
 import redirectLoggedIn from './redirect-logged-in';
-import { setShouldServerSideRenderLogin } from './ssr';
+import { setShouldServerSideRenderLogin, ssrSetupLocaleLogin } from './ssr';
 
 export const LOGIN_SECTION_DEFINITION = {
 	name: 'login',
@@ -37,22 +38,25 @@ const ReduxWrappedLayout = ( {
 	secondary,
 	redirectUri,
 	showGdprBanner,
+	i18n,
 } ) => {
 	return (
-		<RouteProvider
-			currentSection={ currentSection }
-			currentRoute={ currentRoute }
-			currentQuery={ currentQuery }
-		>
-			<ReduxProvider store={ store }>
-				<LayoutLoggedOut
-					primary={ primary }
-					secondary={ secondary }
-					redirectUri={ redirectUri }
-					showGdprBanner={ showGdprBanner }
-				/>
-			</ReduxProvider>
-		</RouteProvider>
+		<CalypsoI18nProvider i18n={ i18n }>
+			<RouteProvider
+				currentSection={ currentSection }
+				currentRoute={ currentRoute }
+				currentQuery={ currentQuery }
+			>
+				<ReduxProvider store={ store }>
+					<LayoutLoggedOut
+						primary={ primary }
+						secondary={ secondary }
+						redirectUri={ redirectUri }
+						showGdprBanner={ showGdprBanner }
+					/>
+				</ReduxProvider>
+			</RouteProvider>
+		</CalypsoI18nProvider>
 	);
 };
 
@@ -109,6 +113,7 @@ export default ( router ) => {
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		login,
 		setShouldServerSideRenderLogin,
+		ssrSetupLocaleLogin,
 		makeLoggedOutLayout
 	);
 };

--- a/client/login/ssr.js
+++ b/client/login/ssr.js
@@ -14,6 +14,12 @@ const VALID_QUERY_KEYS = [ 'client_id', 'signup_flow', 'redirect_to' ];
  * @param {Function} next     Next middleware in the running sequence
  */
 export function setShouldServerSideRenderLogin( context, next ) {
+	/**
+	 * To align with other localized sections, server-side rendering is restricted to the English and Mag-16 locales.
+	 * However, since the login section has good translation coverage for non-Mag-16 locales,
+	 * we'd prefer to maintain client-side rendering as a fallback,
+	 * rather than redirecting non-Mag-16 locales to English, as is done for other sections.
+	 */
 	const isLocaleValidForSSR =
 		isDefaultLocale( context.lang ) ||
 		config( 'magnificent_non_en_locales' ).includes( context.lang );

--- a/client/login/test/ssr.js
+++ b/client/login/test/ssr.js
@@ -8,9 +8,18 @@ function getSomeCleanLoginContext( queryValues, lang = 'en' ) {
 }
 
 describe( 'setShouldServerSideRenderLogin', () => {
-	test( 'when lang is non-default, then sets context.serverSideRender to FALSE - and calls next()', () => {
+	test( 'when lang is Mag-16, then sets context.serverSideRender to TRUE - and calls next()', () => {
 		const next = jest.fn();
 		const contextWithNonDefaultLang = getSomeCleanLoginContext( {}, 'ar' );
+
+		setShouldServerSideRenderLogin( contextWithNonDefaultLang, next );
+		expect( contextWithNonDefaultLang.serverSideRender ).toBe( true );
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'when lang is non-default and non-Mag-16, then sets context.serverSideRender to FALSE - and calls next()', () => {
+		const next = jest.fn();
+		const contextWithNonDefaultLang = getSomeCleanLoginContext( {}, 'bg' );
 
 		setShouldServerSideRenderLogin( contextWithNonDefaultLang, next );
 		expect( contextWithNonDefaultLang.serverSideRender ).toBe( false );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/94712

## Proposed Changes

* Enable SSR for the Login section for Mag-16 locales.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're looking to add localized meta description to the Login section. To achieve that, we need to enable SSR and load the locale data for Mag-16 locales.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Visit `/log-in/{mag-16-locale}`, for example `/log-in/de`, and verify the SSR page source is localized.
* Visit `/log-in` and verify the page is served in English and verify previous behavior remains unchanged.
* Visit the Login section for non-mag-16 locale, for example `/log-in/bg` and verify the page is rendered on the client side and localized, i.e. works as it did before the changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
