### PR TITLE
Fix two issues in devdocs

### DIFF
--- a/client/components/vertical-menu/README.md
+++ b/client/components/vertical-menu/README.md
@@ -19,7 +19,6 @@ const announceIt = ( service ) => console.log( `Clicked on ${ service }` );
 <VerticalMenu onClick={ announceIt }>
 	<SocialItem service="google" />
 	<SocialItem service="facebook" />
-	<SocialItem service="twitter" />
 </VerticalMenu>;
 ```
 
@@ -37,4 +36,3 @@ const announceIt = ( service ) => console.log( `Clicked on ${ service }` );
 - `"facebook"`
 - `"wordpress"`
 - `"linkedin"`
-- `"twitter"`

--- a/client/components/vertical-menu/docs/example.jsx
+++ b/client/components/vertical-menu/docs/example.jsx
@@ -11,7 +11,6 @@ export const VerticalMenuExample = () => (
 			<SocialItem service="facebook" />
 			<SocialItem service="wordpress" />
 			<SocialItem service="linkedin" />
-			<SocialItem service="twitter" />
 		</VerticalMenu>
 	</div>
 );

--- a/client/devdocs/docs-selectors/search.jsx
+++ b/client/devdocs/docs-selectors/search.jsx
@@ -62,7 +62,7 @@ export default class DocsSelectorsSearch extends Component {
 					<EmptyContent title="No selectors found" line="Try another search query" />
 				) }
 				<ul className="docs-selectors__results">
-					{ map( results, ( { name, description, tags } ) => (
+					{ map( results, ( { item: { name, description, tags } } ) => (
 						<li key={ name }>
 							<DocsSelectorsResult
 								{ ...{ name, description, tags } }

--- a/client/devdocs/docs-selectors/single.jsx
+++ b/client/devdocs/docs-selectors/single.jsx
@@ -32,7 +32,7 @@ export default class DocsSelectorsSingle extends Component {
 			const res = await fetch( `/devdocs/service/selectors?${ query }` );
 			if ( res.ok ) {
 				const results = await res.json();
-				const result = find( results, { name: selector } );
+				const result = find( results, { item: { name: selector } } );
 				this.setState( { result } );
 			}
 		} catch ( error ) {
@@ -53,7 +53,7 @@ export default class DocsSelectorsSingle extends Component {
 
 	render() {
 		const { selector } = this.props;
-		const { result: { name, description, tags } = {} } = this.state;
+		const { result: { item: { name, description, tags } = {} } = {} } = this.state;
 
 		return (
 			<div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/94711

## Overview

This PR fixes a couple of issues that were observed while testing [this PR](https://github.com/Automattic/wp-calypso/pull/92571)

The issues were:
- The VerticalMenu wasn't working, see linked issue
- The search state selectors wasn't working.

To reproduce the State Selectors issue:
1. Navigate to https://wpcalypso.wordpress.com/devdocs/selectors
2. Try a search
3. Observe that the results are broken:

![Screenshot 2024-09-19 at 14 45 33](https://github.com/user-attachments/assets/b2d8e53d-6090-4145-9fba-6d80fbad93e7)


## Proposed Changes

* Removes twitter which was deprecated from VerticalMenu
* The results returned from the search API now include an item attribute. Updated calling code to use the attribute.

## Testing Instructions

- Follow the steps described in #94711 and in the overview above and observe that the issues are solved.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
