### PR TITLE
A4A dev sites: Handle errors on site configuration modal.

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -6,12 +6,16 @@ import { check, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
-import useCreateWPCOMDevSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-dev-site';
+import useCreateWPCOMDevSiteMutation, {
+	APIError,
+} from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-dev-site';
 import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { useDataCenterOptions } from 'calypso/data/data-center/use-data-center-options';
 import { usePhpVersions } from 'calypso/data/php-versions/use-php-versions';
+import { useDispatch } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { useSiteName } from './use-site-name';
 
 import './style.scss';
@@ -42,6 +46,7 @@ export default function SiteConfigurationsModal( {
 	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading );
 	const { mutate: createWPCOMSite } = useCreateWPCOMSiteMutation();
 	const { mutate: createWPCOMDevSite } = useCreateWPCOMDevSiteMutation();
+	const dispatch = useDispatch();
 
 	const toggleAllowClientsToUseSiteHelpCenter = () =>
 		setAllowClientsToUseSiteHelpCenter( ! allowClientsToUseSiteHelpCenter );
@@ -93,18 +98,30 @@ export default function SiteConfigurationsModal( {
 
 		recordTracksEvent( 'calypso_a4a_create_site_config_submit', trackingParams );
 
+		const handleAPIError = async ( error: APIError ) => {
+			if ( error.status === 400 ) {
+				await siteName.revalidateCurrentSiteName();
+			} else if ( error.code === 'partner_key_disabled' ) {
+				dispatch(
+					errorNotice(
+						translate(
+							'Your account is blocked from creating new developer sites. Please get in touch with our support team for assistance.'
+						)
+					)
+				);
+			} else {
+				dispatch( errorNotice( translate( 'Something went wrong. Please try again.' ) ) );
+			}
+			setIsSubmitting( false );
+		};
+
 		if ( isDevSite ) {
 			createWPCOMDevSite( params, {
 				onSuccess: ( response ) => {
 					onCreateSiteSuccess( response.site.id, true );
 					closeModal();
 				},
-				onError: async ( error ) => {
-					if ( error.status === 400 ) {
-						await siteName.revalidateCurrentSiteName();
-						setIsSubmitting( false );
-					}
-				},
+				onError: handleAPIError,
 			} );
 		} else {
 			createWPCOMSite(
@@ -113,12 +130,7 @@ export default function SiteConfigurationsModal( {
 					onSuccess: () => {
 						onCreateSiteSuccess( siteId );
 					},
-					onError: async ( error ) => {
-						if ( error.status === 400 ) {
-							await siteName.revalidateCurrentSiteName();
-							setIsSubmitting( false );
-						}
-					},
+					onError: handleAPIError,
 				}
 			);
 		}

--- a/client/a8c-for-agencies/data/sites/use-create-wpcom-dev-site.ts
+++ b/client/a8c-for-agencies/data/sites/use-create-wpcom-dev-site.ts
@@ -11,6 +11,7 @@ import { getFetchDevLicensesQueryKey } from '../purchases/use-fetch-dev-licenses
 
 export interface APIError {
 	status: number;
+	code: string;
 }
 
 export interface CreateDevSiteParams {

--- a/client/a8c-for-agencies/data/sites/use-create-wpcom-site.ts
+++ b/client/a8c-for-agencies/data/sites/use-create-wpcom-site.ts
@@ -5,6 +5,7 @@ import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selecto
 
 export interface APIError {
 	status: number;
+	code: string;
 }
 
 export interface CreateSiteParams {

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -366,6 +366,10 @@
 		cursor: not-allowed;
 		pointer-events: none;
 	}
+
+	.global-notices {
+		z-index: 100001;
+	}
 }
 
 // New navigation will not include a masterbar


### PR DESCRIPTION
## Proposed Changes
![image](https://github.com/user-attachments/assets/d8707ec8-9b10-42b2-803c-7a4d4949b604)

On site configuration modal then only error currently handled when  the selected url is already in use.
At D161803-code we are introducing a new error `partner_key_disabled` for when the agency's **Partner Key ID** is deactivated. To notify the user on the error, we are using the existing notice component on the top right of the screen. We ara also canceling the submitting stage on the form, avoid it to look like an endless loop when untreated errors are returned from the API.


## Testing Instructions

- Apply this patch to you local env.
- Use the Add site button to start a new dev site with site configuration modal, but do not submit it.
- On another tab, deactivate your **Partner Key ID**:
  - Open Agencies portal on matticspace.
  - Click on `User Agencies`
  - Search for your username
  - Click on the `Partner Key ID`
  - Click on Deactivate red button. Don't worry you can activate it again any time.
- Return to the A4A client tab.
- Submit the form.
- The request should fail and you should see the notification: `Your account is blocked from creating new developer sites. Please get in touch with our support team for assistance.`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?