### PR TITLE
Logged-in Performance Profiler: Trigger test re-run and store hash

### DIFF
--- a/client/hosting/performance/components/PerformanceReportLoading.tsx
+++ b/client/hosting/performance/components/PerformanceReportLoading.tsx
@@ -4,9 +4,11 @@ import { PerformanceReportLoadingProgress } from 'calypso/performance-profiler/p
 export const PerformanceReportLoading = ( {
 	isSavedReport,
 	pageTitle,
+	isLoadingPages,
 }: {
 	isSavedReport: boolean;
 	pageTitle: string;
+	isLoadingPages?: boolean;
 } ) => {
 	const { __ } = useI18n();
 
@@ -21,8 +23,9 @@ export const PerformanceReportLoading = ( {
 				} }
 				isSavedReport={ isSavedReport }
 				pageTitle={ pageTitle }
+				isLoadingPages={ isLoadingPages }
 			/>
-			<p>{ __( 'Testing your site may take around 30 seconds.' ) }</p>
+			{ ! isLoadingPages && <p>{ __( 'Testing your site may take around 30 seconds.' ) }</p> }
 		</div>
 	);
 };

--- a/client/hosting/performance/hooks/useSitePages.ts
+++ b/client/hosting/performance/hooks/useSitePages.ts
@@ -1,10 +1,11 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { saveSiteSettings } from 'calypso/state/site-settings/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 interface SitePage {
@@ -12,11 +13,9 @@ interface SitePage {
 	link: string;
 	title: { rendered: string };
 	wpcom_performance_report_url: string;
-	wpcom_performance_url?: {
-		url: string;
-		hash: string;
-	};
 }
+
+const FIELDS_TO_RETRIEVE = [ 'id', 'link', 'title', 'wpcom_performance_report_url' ];
 
 const getPages = ( siteId: number, query = '' ) => {
 	return wpcomRequest< SitePage[] >( {
@@ -25,29 +24,61 @@ const getPages = ( siteId: number, query = '' ) => {
 			search: query,
 			page: 1,
 			status: 'publish',
-			_fields: [ 'id', 'link', 'title', 'wpcom_performance_report_url' ],
+			_fields: FIELDS_TO_RETRIEVE,
 		} ),
 		method: 'GET',
 		apiNamespace: 'wp/v2',
 	} );
 };
 
-export const getSitePagesQueryKey = ( {
-	siteId,
-	query,
-}: {
-	siteId?: number | null;
-	query: string;
-} ) => [ 'useSitePages', siteId, query ];
+const savePageMeta = ( siteId: number, pageId: number, url: string ) => {
+	return wpcomRequest< SitePage >( {
+		path: addQueryArgs( `/sites/${ siteId }/pages/${ pageId }`, {
+			_fields: FIELDS_TO_RETRIEVE,
+		} ),
+		method: 'POST',
+		apiNamespace: 'wp/v2',
+		body: {
+			wpcom_performance_report_url: url,
+		},
+	} );
+};
 
-export const useSitePages = ( { query = '' } ) => {
+interface PerformanceReportUrl {
+	url: string;
+	hash: string;
+}
+
+const toPerformanceReportParts = (
+	pageUrl: string,
+	performanceReportUrl: string
+): PerformanceReportUrl => {
+	const [ url, hash ] = performanceReportUrl.split( '&hash=' );
+
+	if ( ! url || ! hash ) {
+		return { url: pageUrl, hash: '' };
+	}
+
+	return {
+		url,
+		hash,
+	};
+};
+
+const toPerformanceReportUrl = ( { url, hash }: PerformanceReportUrl ) => {
+	return `${ url }&hash=${ hash }`;
+};
+
+const HOME_PAGE_ID = '0';
+
+export const useSitePages = ( { query = '' } = {} ) => {
 	const { __ } = useI18n();
 
 	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID;
 
 	const { data } = useQuery( {
-		queryKey: getSitePagesQueryKey( { siteId, query } ),
+		queryKey: [ 'useSitePages', siteId, query ],
 		queryFn: () => getPages( siteId!, query ),
 		refetchOnWindowFocus: false,
 		enabled: !! siteId,
@@ -56,14 +87,16 @@ export const useSitePages = ( { query = '' } ) => {
 			return data.map( ( page ) => {
 				let path = page.link.replace( site?.URL ?? '', '' );
 				path = path.length > 1 ? path.replace( /\/$/, '' ) : path;
-				const [ url, hash ] = page.wpcom_performance_report_url?.split( '&hash=' ) ?? [];
 
 				return {
 					url: page.link,
 					path,
 					label: page.title.rendered,
 					value: page.id.toString(),
-					wpcom_performance_url: { url, hash },
+					wpcom_performance_report_url: toPerformanceReportParts(
+						page.link,
+						page.wpcom_performance_report_url
+					),
 				};
 			} );
 		},
@@ -73,27 +106,54 @@ export const useSitePages = ( { query = '' } ) => {
 	} );
 
 	const { getSiteSetting } = useSiteSettings( site?.slug );
-	const homePagePerformanceUrl: SitePage[ 'wpcom_performance_report_url' ] =
-		getSiteSetting( 'wpcom_performance_report_url' ) || undefined;
-
-	const [ url, hash ] = homePagePerformanceUrl?.split( '&hash=' ) ?? [];
+	const homePagePerformanceUrl: SitePage[ 'wpcom_performance_report_url' ] = getSiteSetting(
+		'wpcom_performance_report_url'
+	);
 
 	const pages = useMemo( () => {
+		if ( ! site?.URL ) {
+			return [];
+		}
+
 		if ( ! query ) {
 			return [
 				{
 					url: site?.URL,
 					path: '/',
 					label: __( 'Home' ),
-					value: '0',
-					wpcom_performance_url: { url, hash },
+					value: HOME_PAGE_ID,
+					wpcom_performance_report_url: toPerformanceReportParts(
+						site.URL,
+						homePagePerformanceUrl
+					),
 				},
 				...( data ?? [] ),
 			];
 		}
 
 		return data ?? [];
-	}, [ query, data, site?.URL, __, url, hash ] );
+	}, [ query, data, site?.URL, __, homePagePerformanceUrl ] );
 
-	return pages;
+	const dispatch = useDispatch();
+
+	const savePerformanceReportUrl = useCallback(
+		async ( pageId: string, performanceReport: PerformanceReportUrl ) => {
+			if ( ! siteId ) {
+				return;
+			}
+
+			const performanceReportUrl = toPerformanceReportUrl( performanceReport );
+
+			if ( pageId === HOME_PAGE_ID ) {
+				dispatch(
+					saveSiteSettings( siteId, { wpcom_performance_report_url: performanceReportUrl } )
+				);
+			} else {
+				savePageMeta( siteId, parseInt( pageId, 10 ), performanceReportUrl );
+			}
+		},
+		[ siteId, dispatch ]
+	);
+
+	return { pages, savePerformanceReportUrl };
 };

--- a/client/hosting/performance/hooks/useSitePerformancePageReports.ts
+++ b/client/hosting/performance/hooks/useSitePerformancePageReports.ts
@@ -71,14 +71,14 @@ const toPerformanceReportUrl = ( { url, hash }: PerformanceReportUrl ) => {
 
 const HOME_PAGE_ID = '0';
 
-export const useSitePages = ( { query = '' } = {} ) => {
+export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 	const { __ } = useI18n();
 
 	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID;
 
 	const { data } = useQuery( {
-		queryKey: [ 'useSitePages', siteId, query ],
+		queryKey: [ 'useSitePerformancePageReports', siteId, query ],
 		queryFn: () => getPages( siteId!, query ),
 		refetchOnWindowFocus: false,
 		enabled: !! siteId,

--- a/client/hosting/performance/hooks/useSitePerformancePageReports.ts
+++ b/client/hosting/performance/hooks/useSitePerformancePageReports.ts
@@ -77,7 +77,7 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID;
 
-	const { data } = useQuery( {
+	const { data, isLoading: isInitialLoading } = useQuery( {
 		queryKey: [ 'useSitePerformancePageReports', siteId, query ],
 		queryFn: () => getPages( siteId!, query ),
 		refetchOnWindowFocus: false,
@@ -155,5 +155,5 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 		[ siteId, dispatch ]
 	);
 
-	return { pages, savePerformanceReportUrl };
+	return { pages, isInitialLoading, savePerformanceReportUrl };
 };

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -17,6 +17,7 @@ import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors'
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PageSelector } from './components/PageSelector';
 import { PerformanceReport } from './components/PerformanceReport';
+import { PerformanceReportLoading } from './components/PerformanceReportLoading';
 import { ReportUnavailable } from './components/ReportUnavailable';
 import { DeviceTabControls, Tab } from './components/device-tab-control';
 import { useSitePerformancePageReports } from './hooks/useSitePerformancePageReports';
@@ -226,7 +227,7 @@ export const SitePerformance = () => {
 				<DeviceTabControls onDeviceTabChange={ setActiveTab } value={ activeTab } />
 			</div>
 			{ isInitialLoading ? (
-				<p>{ translate( 'Loading pages…' ) }</p>
+				<PerformanceReportLoading isLoadingPages isSavedReport={ false } pageTitle="" />
 			) : (
 				<>
 					{ ! isSitePublic ? (

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -128,7 +128,13 @@ export const SitePerformance = () => {
 		} );
 	};
 
-	const performanceReport = usePerformanceReport( wpcom_performance_report_url, activeTab );
+	const isSitePublic =
+		site && ! site.is_coming_soon && ! site.is_private && site.launch_status === 'launched';
+
+	const performanceReport = usePerformanceReport(
+		isSitePublic ? wpcom_performance_report_url : undefined,
+		activeTab
+	);
 
 	useEffect( () => {
 		if ( performanceReport.hash && performanceReport.hash !== wpcom_performance_report_url?.hash ) {
@@ -147,9 +153,6 @@ export const SitePerformance = () => {
 		savePerformanceReportUrl,
 		wpcom_performance_report_url?.hash,
 	] );
-
-	const isSitePublic =
-		site && ! site.is_coming_soon && ! site.is_private && site.launch_status === 'launched';
 
 	const siteIsLaunching = useSelector(
 		( state ) => getRequest( state, launchSite( siteId ) )?.isLoading ?? false

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -98,7 +98,9 @@ export const SitePerformance = () => {
 
 	const queryParams = useSelector( getCurrentQueryArguments );
 	const [ , setQuery, query ] = useDebouncedInput();
-	const { pages, savePerformanceReportUrl } = useSitePerformancePageReports( { query } );
+	const { pages, isInitialLoading, savePerformanceReportUrl } = useSitePerformancePageReports( {
+		query,
+	} );
 
 	const orderedPages = useMemo( () => {
 		return [ ...pages ].sort( ( a, b ) => {
@@ -223,19 +225,25 @@ export const SitePerformance = () => {
 				/>
 				<DeviceTabControls onDeviceTabChange={ setActiveTab } value={ activeTab } />
 			</div>
-			{ ! isSitePublic ? (
-				<ReportUnavailable
-					isLaunching={ siteIsLaunching }
-					onLaunchSiteClick={ onLaunchSiteClick }
-				/>
+			{ isInitialLoading ? (
+				<p>{ translate( 'Loading pages…' ) }</p>
 			) : (
-				currentPage && (
-					<PerformanceReport
-						{ ...performanceReport }
-						pageTitle={ currentPage.label }
-						onRetestClick={ retestPage }
-					/>
-				)
+				<>
+					{ ! isSitePublic ? (
+						<ReportUnavailable
+							isLaunching={ siteIsLaunching }
+							onLaunchSiteClick={ onLaunchSiteClick }
+						/>
+					) : (
+						currentPage && (
+							<PerformanceReport
+								{ ...performanceReport }
+								pageTitle={ currentPage.label }
+								onRetestClick={ retestPage }
+							/>
+						)
+					) }
+				</>
 			) }
 		</div>
 	);

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -19,7 +19,7 @@ import { PageSelector } from './components/PageSelector';
 import { PerformanceReport } from './components/PerformanceReport';
 import { ReportUnavailable } from './components/ReportUnavailable';
 import { DeviceTabControls, Tab } from './components/device-tab-control';
-import { useSitePages } from './hooks/useSitePages';
+import { useSitePerformancePageReports } from './hooks/useSitePerformancePageReports';
 
 import './style.scss';
 
@@ -98,7 +98,7 @@ export const SitePerformance = () => {
 
 	const queryParams = useSelector( getCurrentQueryArguments );
 	const [ , setQuery, query ] = useDebouncedInput();
-	const { pages, savePerformanceReportUrl } = useSitePages( { query } );
+	const { pages, savePerformanceReportUrl } = useSitePerformancePageReports( { query } );
 
 	const orderedPages = useMemo( () => {
 		return [ ...pages ].sort( ( a, b ) => {

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -1,10 +1,9 @@
 import page from '@automattic/calypso-router';
-import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { useDebouncedInput } from '@wordpress/compose';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
@@ -20,7 +19,7 @@ import { PageSelector } from './components/PageSelector';
 import { PerformanceReport } from './components/PerformanceReport';
 import { ReportUnavailable } from './components/ReportUnavailable';
 import { DeviceTabControls, Tab } from './components/device-tab-control';
-import { getSitePagesQueryKey, useSitePages } from './hooks/useSitePages';
+import { useSitePages } from './hooks/useSitePages';
 
 import './style.scss';
 
@@ -35,10 +34,10 @@ const statsQuery = {
 };
 
 const usePerformanceReport = (
-	wpcom_performance_url: { url: string; hash: string } | undefined,
+	wpcom_performance_report_url: { url: string; hash: string } | undefined,
 	activeTab: Tab
 ) => {
-	const { url = '', hash = '' } = wpcom_performance_url || {};
+	const { url = '', hash = '' } = wpcom_performance_report_url || {};
 
 	const { data: basicMetrics, isError } = useUrlBasicMetricsQuery( url, hash, true );
 	const { final_url: finalUrl, token } = basicMetrics || {};
@@ -99,7 +98,7 @@ export const SitePerformance = () => {
 
 	const queryParams = useSelector( getCurrentQueryArguments );
 	const [ , setQuery, query ] = useDebouncedInput();
-	const pages = useSitePages( { query } );
+	const { pages, savePerformanceReportUrl } = useSitePages( { query } );
 
 	const orderedPages = useMemo( () => {
 		return [ ...pages ].sort( ( a, b ) => {
@@ -114,24 +113,40 @@ export const SitePerformance = () => {
 		() => pages.find( ( page ) => page.value === currentPageId ),
 		[ pages, currentPageId ]
 	);
-	const [ wpcom_performance_url, setWpcom_performance_url ] = useState(
-		currentPage?.wpcom_performance_url
+	const [ wpcom_performance_report_url, setWpcom_performance_report_url ] = useState(
+		currentPage?.wpcom_performance_report_url
 	);
-	const queryClient = useQueryClient();
+
+	useLayoutEffect( () => {
+		setWpcom_performance_report_url( currentPage?.wpcom_performance_report_url );
+	}, [ currentPage?.wpcom_performance_report_url ] );
 
 	const retestPage = () => {
-		setWpcom_performance_url( {
+		setWpcom_performance_report_url( {
 			url: currentPage?.url ?? '',
 			hash: '',
 		} );
-
-		queryClient.invalidateQueries( {
-			queryKey: getSitePagesQueryKey( { siteId, query } ),
-			exact: true,
-		} );
 	};
 
-	const performanceReport = usePerformanceReport( wpcom_performance_url, activeTab );
+	const performanceReport = usePerformanceReport( wpcom_performance_report_url, activeTab );
+
+	useEffect( () => {
+		if ( performanceReport.hash && performanceReport.hash !== wpcom_performance_report_url?.hash ) {
+			const performanceReportUrl = {
+				url: performanceReport.url,
+				hash: performanceReport.hash,
+			};
+
+			setWpcom_performance_report_url( performanceReportUrl );
+			savePerformanceReportUrl( currentPageId, performanceReportUrl );
+		}
+	}, [
+		currentPageId,
+		performanceReport.url,
+		performanceReport.hash,
+		savePerformanceReportUrl,
+		wpcom_performance_report_url?.hash,
+	] );
 
 	const isSitePublic =
 		site && ! site.is_coming_soon && ! site.is_private && site.launch_status === 'launched';

--- a/client/performance-profiler/pages/loading-screen/progress.tsx
+++ b/client/performance-profiler/pages/loading-screen/progress.tsx
@@ -100,26 +100,34 @@ const LoadingProgressContainer = styled.div`
 const useLoadingSteps = ( {
 	isSavedReport,
 	pageTitle,
+	isLoadingPages,
 }: {
 	isSavedReport: boolean;
 	pageTitle?: string;
+	isLoadingPages?: boolean;
 } ) => {
 	const translate = useTranslate();
 
 	const [ step, setStep ] = useState( 0 );
 
-	const steps = isSavedReport
-		? [ translate( 'Getting your report…' ) ]
-		: [
-				pageTitle
-					? translate( 'Loading: %(pageTitle)s', { args: { pageTitle } } )
-					: translate( 'Loading your site' ),
-				translate( 'Measuring Core Web Vitals' ),
-				translate( 'Taking screenshots' ),
-				translate( 'Fetching historic data' ),
-				translate( 'Identifying performance improvements' ),
-				translate( 'Finalizing your results' ),
-		  ];
+	let steps = [];
+
+	if ( isLoadingPages ) {
+		steps = [ translate( 'Getting your site pages' ) ];
+	} else {
+		steps = isSavedReport
+			? [ translate( 'Getting your report…' ) ]
+			: [
+					pageTitle
+						? translate( 'Loading: %(pageTitle)s', { args: { pageTitle } } )
+						: translate( 'Loading your site' ),
+					translate( 'Measuring Core Web Vitals' ),
+					translate( 'Taking screenshots' ),
+					translate( 'Fetching historic data' ),
+					translate( 'Identifying performance improvements' ),
+					translate( 'Finalizing your results' ),
+			  ];
+	}
 
 	useEffect( () => {
 		const timeoutId = setTimeout( () => {
@@ -152,13 +160,19 @@ const useLoadingSteps = ( {
 export const PerformanceReportLoadingProgress = ( {
 	pageTitle,
 	isSavedReport,
+	isLoadingPages,
 	className,
 }: {
 	isSavedReport: boolean;
 	pageTitle?: string;
 	className?: string;
+	isLoadingPages?: boolean;
 } ) => {
-	const { step, steps, stepStatus } = useLoadingSteps( { isSavedReport, pageTitle } );
+	const { step, steps, stepStatus } = useLoadingSteps( {
+		isSavedReport,
+		pageTitle,
+		isLoadingPages,
+	} );
 
 	return (
 		<LoadingProgressContainer className={ className }>


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9176.

## Proposed Changes

Triggers a test if there is no `hash`, and saves the hash after it's been generated by the back-end.

Adds a loader to when fetching sites pages
![image](https://github.com/user-attachments/assets/bc5e80ff-fa9c-4ed1-82f2-3b87a36bd0cc)


## Testing Instructions

Visit `/site-performance/%s` and check that upon load the `Home` page gets tested. Verify you can re-trigger the test by clicking the "Test again" button. Reload the page and the existing test should be retrieved instead of triggering a new one.
