### PR TITLE
Update text on site credentials page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
@@ -20,6 +21,7 @@ interface CredentialsFormProps {
 
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip } ) => {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 	const {
 		handleSubmit,
 		control,
@@ -83,7 +85,9 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 					onClick={ onSkip }
 					type="button"
 				>
-					{ translate( 'Skip, I need help providing access' ) }
+					{ isEnglishLocale
+						? translate( 'I need help, please contact me' )
+						: translate( 'Skip, I need help providing access' ) }
 				</button>
 			</div>
 		</form>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
@@ -1,5 +1,5 @@
 import { FormLabel } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
+import { useHasEnTranslation, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { Controller, Control } from 'react-hook-form';
 import getValidationMessage from 'calypso/blocks/import/capture/url-validation-message-helper';
@@ -20,6 +20,7 @@ export const SiteAddressField: React.FC< Props > = ( {
 	importSiteQueryParam,
 } ) => {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 	const hasEnTranslation = useHasEnTranslation();
 
 	const validateSiteAddress = ( siteAddress: string ) => {
@@ -35,7 +36,9 @@ export const SiteAddressField: React.FC< Props > = ( {
 
 	return (
 		<div className="site-migration-credentials__form-field">
-			<FormLabel htmlFor="site-address">{ translate( 'Site address' ) }</FormLabel>
+			<FormLabel htmlFor="site-address">
+				{ isEnglishLocale ? translate( 'Current site address' ) : translate( 'Site address' ) }
+			</FormLabel>
 			<Controller
 				control={ control }
 				name="siteAddress"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -1,3 +1,4 @@
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -9,6 +10,7 @@ import './style.scss';
 
 const SiteMigrationCredentials: Step = function ( { navigation } ) {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const handleSubmit = () => {
 		return navigation.submit?.();
@@ -22,7 +24,13 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 
 	return (
 		<>
-			<DocumentHead title={ translate( 'Tell us about your site' ) } />
+			<DocumentHead
+				title={
+					isEnglishLocale
+						? translate( 'Tell us about your WordPress site' )
+						: translate( 'Tell us about your site' )
+				}
+			/>
 			<StepContainer
 				stepName="site-migration-credentials"
 				flowName="site-migration"
@@ -33,10 +41,20 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 				formattedHeader={
 					<FormattedHeader
 						id="site-migration-credentials-header"
-						headerText={ translate( 'Tell us about your site' ) }
-						subHeaderText={ translate(
-							'Please share the following details to access your site and start your migration.'
-						) }
+						headerText={
+							isEnglishLocale
+								? translate( 'Tell us about your WordPress site' )
+								: translate( 'Tell us about your site' )
+						}
+						subHeaderText={
+							isEnglishLocale
+								? translate(
+										'Please share the following details to access your site and start your migration to WordPress.com.'
+								  )
+								: translate(
+										'Please share the following details to access your site and start your migration.'
+								  )
+						}
 						align="center"
 					/>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -41,7 +41,7 @@ const backupFileInput = () => getByLabelText( 'Backup file location' );
 //TODO: it requires a testid because there is no accessible name, it is an issue with the component
 const specialInstructionsInput = () => getByTestId( 'special-instructions-textarea' );
 const specialInstructionsButton = () => getByRole( 'button', { name: 'Special instructions' } );
-const skipButton = () => getByRole( 'button', { name: /Skip, I need help providing access/ } );
+const skipButton = () => getByRole( 'button', { name: /I need help, please contact me/ } );
 
 const fillAllFields = async () => {
 	await userEvent.click( credentialsOption() );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -32,7 +32,7 @@ const messages = {
 const { getByRole, getByLabelText, getByTestId, getByText, findByText } = screen;
 
 const continueButton = () => getByRole( 'button', { name: /Continue/ } );
-const siteAddressInput = () => getByLabelText( 'Site address' );
+const siteAddressInput = () => getByLabelText( 'Current site address' );
 const usernameInput = () => getByLabelText( 'WordPress admin username' );
 const passwordInput = () => getByLabelText( 'Password' );
 const backupOption = () => getByRole( 'radio', { name: 'Backup file' } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94705.

## Proposed Changes

* Updates the title to include WordPress.
* Updates the subtitle to include migrating to WordPress.com.
* Updates `Site address` to `Current site address`.
* Updates `Skip, I need help providing access` to `I need help, please contact me`.

![Screenshot 2024-09-19 at 10 56 39 AM](https://github.com/user-attachments/assets/a7d1f680-988e-461f-ba1b-3a26b5d74973)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To minimize the number of people who try to migrate WordPress.com and non-WordPress sites through the migration flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Proceed through the migration flow.
* On the "How do you want to migrate?" step, choose "Do it for me".
* Verify that the changes are as described in "Proposed Changes" above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?