### PR TITLE
Fix no purchases URL

### DIFF
--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -109,14 +109,14 @@ function NoPurchasesMessage() {
 	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );
 
 	let url;
-	if ( hasJetpackPartnerAccess ) {
+	if ( ! isJetpackCloud() ) {
+		url = selectedSite ? `/plans/${ selectedSite.slug }` : '/plans';
+	} else if ( hasJetpackPartnerAccess ) {
 		url = selectedSiteId
 			? `/partner-portal/issue-license?site_id=${ selectedSiteId }`
 			: '/partner-portal/issue-license';
-	} else if ( isJetpackCloud() ) {
-		url = selectedSite ? `/pricing/${ selectedSite.slug }` : '/pricing';
 	} else {
-		url = selectedSite ? `/plans/${ selectedSite.slug }` : '/plans';
+		url = selectedSite ? `/pricing/${ selectedSite.slug }` : '/pricing';
 	}
 
 	return isJetpackCloud() ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94723

Seems that this PR https://github.com/Automattic/wp-calypso/pull/86263 changed the url for the EmptyComponent.
For a free site the url should lead to the plans in calypso.

## Proposed Changes

* Apply partner link modifications only for `isJetpackCloud`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

- Choose free site.
- Go to Upgrades > Purchases
- Click on the "Upgrade Now" button
- It should lead to the correct page instead of 404

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


