### PR TITLE
Remove Card component from migration credentials screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/backup-file-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/backup-file-field.tsx
@@ -15,33 +15,31 @@ export const BackupFileField: React.FC< CredentialsFormFieldProps > = ( { contro
 
 	return (
 		<div className="site-migration-credentials">
-			<div className="site-migration-credentials__form">
-				<div className="site-migration-credentials__form-field">
-					<FormLabel htmlFor="backup-file">{ translate( 'Backup file location' ) }</FormLabel>
-					<Controller
-						control={ control }
-						name="backupFileLocation"
-						rules={ {
-							required: translate( 'Please enter a valid URL.' ),
-							validate: isBackupFileLocationValid,
-						} }
-						render={ ( { field } ) => (
-							<FormTextInput
-								id="backup-file"
-								type="text"
-								isError={ !! errors?.backupFileLocation }
-								placeholder={ translate( 'Enter your backup file location' ) }
-								{ ...field }
-							/>
-						) }
-					/>
-				</div>
-				<ErrorMessage error={ errors?.backupFileLocation } />
-				<div className="site-migration-credentials__form-note site-migration-credentials__backup-note">
-					{ translate(
-						"Upload your file to a service like Dropbox or Google Drive to get a link. Don't forget to make sure that anyone with the link can access it."
+			<div className="site-migration-credentials__form-field">
+				<FormLabel htmlFor="backup-file">{ translate( 'Backup file location' ) }</FormLabel>
+				<Controller
+					control={ control }
+					name="backupFileLocation"
+					rules={ {
+						required: translate( 'Please enter a valid URL.' ),
+						validate: isBackupFileLocationValid,
+					} }
+					render={ ( { field } ) => (
+						<FormTextInput
+							id="backup-file"
+							type="text"
+							isError={ !! errors?.backupFileLocation }
+							placeholder={ translate( 'Enter your backup file location' ) }
+							{ ...field }
+						/>
 					) }
-				</div>
+				/>
+			</div>
+			<ErrorMessage error={ errors?.backupFileLocation } />
+			<div className="site-migration-credentials__form-note site-migration-credentials__backup-note">
+				{ translate(
+					"Upload your file to a service like Dropbox or Google Drive to get a link. Don't forget to make sure that anyone with the link can access it."
+				) }
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -34,7 +34,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 	const queryError = useQuery().get( 'error' ) || null;
 
 	return (
-		<form onSubmit={ handleSubmit( submitHandler ) }>
+		<form className="site-migration-credentials__form" onSubmit={ handleSubmit( submitHandler ) }>
 			{ queryError === 'ticket-creation' && (
 				<Banner
 					className="site-migration-credentials__error-banner"
@@ -52,15 +52,13 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 				{ accessMethod === 'credentials' && (
 					<div className="site-migration-credentials">
-						<div className="site-migration-credentials__form">
-							<SiteAddressField
-								control={ control }
-								errors={ errors }
-								importSiteQueryParam={ importSiteQueryParam }
-							/>
-							<UsernameField control={ control } errors={ errors } />
-							<PasswordField control={ control } errors={ errors } />
-						</div>
+						<SiteAddressField
+							control={ control }
+							errors={ errors }
+							importSiteQueryParam={ importSiteQueryParam }
+						/>
+						<UsernameField control={ control } errors={ errors } />
+						<PasswordField control={ control } errors={ errors } />
 					</div>
 				) }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -1,4 +1,3 @@
-import { Card } from '@automattic/components';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -46,7 +45,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 					) }
 				></Banner>
 			) }
-			<Card>
+			<div className="site-migration-credentials__content">
 				<AccessMethodPicker control={ control } />
 
 				<hr />
@@ -76,7 +75,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 						{ translate( 'Continue' ) }
 					</NextButton>
 				</div>
-			</Card>
+			</div>
 
 			<div className="site-migration-credentials__skip">
 				<button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -7,13 +7,15 @@
 		}
 	}
 
-	.card {
+	.site-migration-credentials__content,
+	.site-migration-credentials__error-banner {
+		margin: 0 auto 16px;
 		max-width: 500px;
-		padding: 2em;
 
-		@media (max-width: $break-mobile) {
-			padding: 1.25em;
+		@media (min-width: $break-mobile) {
+			margin-bottom: 16px;
 		}
+
 		hr {
 			margin-top: 1em;
 			background: var(--color-border-subtle);
@@ -120,7 +122,8 @@
 	}
 	.site-migration-credentials__error-banner {
 		border-left-color: var(--color-error);
-		&.card {
+
+		&.site-migration-credentials__content {
 			padding: 1rem;
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -7,6 +7,10 @@
 		}
 	}
 
+	&__form {
+		margin-bottom: 60px;
+	}
+
 	.site-migration-credentials__content,
 	.site-migration-credentials__error-banner {
 		margin: 0 auto 16px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94709.

## Proposed Changes

* Removes the `Card` component from the migration credentials screen.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To bring the migration flow UI closer to the onboarding flow UI as per p9Jlb4-ee4-p2#comment-13481.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Proceed through the migration flow.
* On the "How do you want to migrate?" step, choose "Do it for me".
* Verify that there is no border around the form and that the background of the page is all the same color.
* Remove the conditional [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx#L39) to see the error.
* Ensure the error message spacing looks good.

![Screenshot 2024-09-19 at 3 10 08 PM](https://github.com/user-attachments/assets/49dbc14a-d29e-4a07-a5a6-b57e3f6ee6b6)

![Screenshot 2024-09-19 at 3 10 54 PM](https://github.com/user-attachments/assets/44efa1fe-70e7-41f5-884d-b134940b3c2c)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?