### PR TITLE
Themes Marketplace: Add external icon to the "Preview demo site" button

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -600,9 +600,16 @@ class ThemeSheet extends Component {
 	}
 
 	renderScreenshot() {
-		const { isWpcomTheme, name: themeName, demoUrl, translate } = this.props;
+		const {
+			isWpcomTheme,
+			name: themeName,
+			demoUrl,
+			translate,
+			isExternallyManagedTheme,
+		} = this.props;
 		const screenshotFull = isWpcomTheme ? this.getFullLengthScreenshot() : this.props.screenshot;
 		const width = 735;
+		const isExternalLink = ! isWpcomTheme || isExternallyManagedTheme;
 		// Photon may return null, allow fallbacks
 		const photonSrc = screenshotFull && photon( screenshotFull, { width } );
 		const img = screenshotFull && (
@@ -632,6 +639,7 @@ class ThemeSheet extends Component {
 					{ this.shouldRenderPreviewButton() && (
 						<Button className="theme__sheet-preview-demo-site">
 							{ translate( 'Preview demo site' ) }
+							{ isExternalLink && <Icon icon={ external } size={ 16 } /> }
 						</Button>
 					) }
 					{ img }
@@ -649,6 +657,7 @@ class ThemeSheet extends Component {
 						} }
 					>
 						{ translate( 'Preview demo site' ) }
+						{ isExternalLink && <Icon icon={ external } size={ 16 } /> }
 					</Button>
 				) }
 				{ img }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -178,6 +178,15 @@ $button-border: 4px;
 			order: 1;
 		}
 	}
+
+	.theme__sheet-demo-button,
+	.heme__sheet-preview-demo-site {
+		svg {
+			vertical-align: text-bottom;
+			margin-left: 4px;
+			fill: currentColor;
+		}
+	}
 }
 
 .theme__sheet-columns.is-removed {
@@ -245,14 +254,6 @@ $button-border: 4px;
 			right: auto;
 			top: auto;
 			margin-right: 0 !important;
-		}
-
-		.theme__sheet-demo-button {
-			svg {
-				vertical-align: text-bottom;
-				margin-left: 4px;
-				fill: currentColor;
-			}
 		}
 	}
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -180,7 +180,7 @@ $button-border: 4px;
 	}
 
 	.theme__sheet-demo-button,
-	.heme__sheet-preview-demo-site {
+	.theme__sheet-preview-demo-site {
 		svg {
 			vertical-align: text-bottom;
 			margin-left: 4px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9090
Follow up to https://github.com/Automattic/wp-calypso/pull/94300

## Proposed Changes

* This PR adds an external link icon to the "Preview demo site" button that overlays on top of theme screenshots.
* It only adds the icon if the theme opens in a new tab.


<img width="1264" alt="Screenshot 2024-09-19 at 3 54 31 PM" src="https://github.com/user-attachments/assets/09f398a5-5ada-4f12-8c00-58d7387bee5d">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Inform the user of external links.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


- Use Calypso Live
- Go to /themes
- Select a non-wpcom theme, such as a "Subscribe and Upgrade" labeled theme.
- These themes should have an external link icon on the "Demo site" button.
- Hover over the theme screenshot and see a "Preview demo site" button with an external link icon. Click the image to open a new tab for the theme demo.
- Go back to /themes and select a wpcom theme (this will be most themes)
- The "Preview demo site" button should NOT have an external link icon. Clicking on the button should open a modal demo of the theme.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?