### PR TITLE
Stepper: Log event on page load

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -1,5 +1,5 @@
 import { SENSEI_FLOW } from '@automattic/onboarding';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { recordSignupStart } from 'calypso/lib/analytics/signup';
 import { type Flow } from '../../types';
@@ -16,6 +16,7 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 	const steps = flow.useSteps();
 	const [ queryParams, setQuery ] = useSearchParams();
 	const ref = queryParams.get( 'ref' ) || '';
+	const [ isInitialMount, setIsInitialMount ] = useState( true );
 
 	// TODO: Using the new start flag we can remove reference to SENSEI_FLOW
 	const firstStepSlug = ( flow.name === SENSEI_FLOW ? steps[ 1 ] : steps[ 0 ] ).slug;
@@ -40,6 +41,16 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 			setQuery( queryParams );
 		}
 	}, [ queryParams, setQuery ] );
+
+	// recordSignupStart should always be logged on page load.
+	// this ensures it gets logged after a page refresh.
+	useEffect( () => {
+		if ( isInitialMount ) {
+			recordSignupStart( flowName, ref, extraProps || {} );
+			setIsInitialMount( false );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	useEffect( () => {
 		if ( ! shouldTrack ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94717
Fixes #94717

## Proposed Changes

* Make sure it calls `recordSignupStart` on page load, currently there's an issue that it is not called upon page refresh.
* Add useEffect hook together with initialState variable to handle page load

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix #94717 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and navigate to /setup/onboarding
* On domains or plans step, make sure the `calypso_signup_start ` is triggered only once upon page refresh.
* Navigate between steps and refresh the page, it should log only once.
* Use /start/onboarding as a reference


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
