### PR TITLE
Increase items per page on A4A Development sites page.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
@@ -50,13 +50,16 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 	}, [ dataViewsState.filters, showOnlyFavorites, showOnlyDevelopmentSites ] );
 	const search = dataViewsState.search;
 
+	// Temporarily set perPage to 100 on Development sites page due to unresolved ES issue (https://github.com/Automattic/dotcom-forge/issues/8806)
+	const sitesPerPage = showOnlyDevelopmentSites ? 100 : dataViewsState.perPage;
+
 	const queryKey = [
 		'jetpack-agency-dashboard-sites',
 		search,
 		currentPage,
 		filter,
 		dataViewsState.sort,
-		dataViewsState.perPage,
+		sitesPerPage,
 		...( agencyId ? [ agencyId ] : [] ),
 	];
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -118,13 +118,16 @@ export default function SitesDashboard() {
 		prevIsOnNeedsAttentionPageRef.current = isOnNeedsAttentionPage;
 	}, [ dataViewsState, setDataViewsState, showOnlyFavorites, showOnlyDevelopmentSites ] );
 
+	// Temporarily set perPage to 100 on developement sites page while having problems on its pagination
+	const sitesPerPage = showOnlyDevelopmentSites ? 100 : dataViewsState.perPage;
+
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites( {
 		isPartnerOAuthTokenLoaded: false,
 		searchQuery: dataViewsState?.search,
 		currentPage: dataViewsState.page ?? 1,
 		filter: agencyDashboardFilter,
 		sort: dataViewsState.sort,
-		perPage: dataViewsState.perPage,
+		perPage: sitesPerPage,
 		agencyId,
 	} );
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -118,7 +118,7 @@ export default function SitesDashboard() {
 		prevIsOnNeedsAttentionPageRef.current = isOnNeedsAttentionPage;
 	}, [ dataViewsState, setDataViewsState, showOnlyFavorites, showOnlyDevelopmentSites ] );
 
-	// Temporarily set perPage to 100 on developement sites page while having problems on its pagination
+	// Temporarily set perPage to 100 on Development sites page due to unresolved ES issue (https://github.com/Automattic/dotcom-forge/issues/8806)
 	const sitesPerPage = showOnlyDevelopmentSites ? 100 : dataViewsState.perPage;
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites( {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9193

## Proposed Changes

On A4A sites dashboard we list 50 sites per page, that are requested by the `/wpcom/v2/jetpack-agency/sites` API. It uses Elastic Search under the hood.

When filtering for Development sites, the server does not fetch the 50 development sites, but rather fetch the first 50 sites and within that array it filters the result to include only development sites.

If the agency has less than 50 sites, user will never miss any development site on the list.
But if the agency has 51 sites or more and created a new development site, the first page of `https://agencies.automattic.com/sites?is_development` will not include the new development site.

As a temporary fix, we are increasing the items per page for development sites to 100.
We are planning to work on a better fix on server side, but could not found a good solution yet.

## Testing Instructions

Pull this branch to your local environment.
If you agency already has 50 sites, you can easily test by creating a new development site and check that it appears on http://agencies.localhost:3000/sites?is_development

If you don't have so many sites, you can still test it by reducing the default per page constant for the overall dashboard.
- Have at least a couple development sites. If you have all 5 even better.
- On `client/a8c-for-agencies/components/items-dashboard/constants.ts` reduce the `perPage` from 50 to 1.
- Navigate on different dashboard, you should see only 1 site per page.
- When navigating, specifically on Development page, you should be able to see all development sites.
 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
