### PR TITLE
Add Help Center to the migration flow

### DIFF
--- a/client/components/help-center-loader/index.tsx
+++ b/client/components/help-center-loader/index.tsx
@@ -1,0 +1,63 @@
+import { HelpCenter } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
+import { useBreakpoint } from '@automattic/viewport-react';
+import { useDispatch } from '@wordpress/data';
+import { useCallback } from 'react';
+import AsyncLoad from 'calypso/components/async-load';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import { onboardingUrl } from 'calypso/lib/paths';
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { FC } from 'react';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+interface HelpCenterLoaderProps {
+	site: SiteDetails | null;
+	sectionName: string;
+	loadHelpCenter: boolean;
+	currentRoute?: string;
+}
+
+const HelpCenterLoader: FC< HelpCenterLoaderProps > = ( {
+	site,
+	sectionName,
+	loadHelpCenter,
+	currentRoute,
+} ) => {
+	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
+	const isDesktop = useBreakpoint( '>782px' );
+	const handleClose = useCallback( () => {
+		setShowHelpCenter( false );
+	}, [ setShowHelpCenter ] );
+
+	const locale = useLocale();
+	const hasPurchases = useSelector( hasCancelableUserPurchases );
+	const user = useSelector( getCurrentUser );
+
+	if ( ! loadHelpCenter ) {
+		return null;
+	}
+
+	return (
+		<AsyncLoad
+			require="@automattic/help-center"
+			placeholder={ null }
+			handleClose={ handleClose }
+			currentRoute={ currentRoute }
+			locale={ locale }
+			sectionName={ sectionName }
+			site={ site }
+			currentUser={ user }
+			hasPurchases={ hasPurchases }
+			// hide Calypso's version of the help-center on Desktop, because the Editor has its own help-center
+			hidden={ sectionName === 'gutenberg-editor' && isDesktop }
+			onboardingUrl={ onboardingUrl() }
+			googleMailServiceFamily={ getGoogleMailServiceFamily() }
+		/>
+	);
+};
+
+export default HelpCenterLoader;

--- a/client/landing/stepper/declarative-flow/internals/components/help-center/async.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/help-center/async.tsx
@@ -1,20 +1,17 @@
-import { HelpCenter } from '@automattic/data-stores';
-import { useDispatch } from '@wordpress/data';
-import { useCallback } from 'react';
-import AsyncLoad from 'calypso/components/async-load';
-
-const HELP_CENTER_STORE = HelpCenter.register();
+import HelpCenterLoader from 'calypso/components/help-center-loader';
+// import { useCurrentRoute } from 'calypso/landing/stepper/hooks/use-current-route';
+// import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 
 const AsyncHelpCenter = () => {
-	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
+	// TODO: The useSite uses the `useLocation`, but we are not adding it inside the router because HelpCenter also has its own router.
+	// const site = useSite();
 
-	const handleClose = useCallback( () => {
-		setShowHelpCenter( false );
-	}, [ setShowHelpCenter ] );
+	const site = null;
 
-	return (
-		<AsyncLoad require="@automattic/help-center" placeholder={ null } handleClose={ handleClose } />
-	);
+	// const currentRoute = useCurrentRoute();
+
+	// TODO: Should we set the currentRoute prop or allow the HelpCenter get the default value from `window.location`? It would probably cause issues not updating this value. Notice that the hook `useCurrentRoute` also depends on the router because it uses the `useLocation`.
+	return <HelpCenterLoader site={ site } sectionName="stepper" loadHelpCenter />;
 };
 
 export default AsyncHelpCenter;

--- a/client/landing/stepper/declarative-flow/internals/components/help-center/help-center-action-button.scss
+++ b/client/landing/stepper/declarative-flow/internals/components/help-center/help-center-action-button.scss
@@ -1,0 +1,8 @@
+.help-center-action-button {
+	margin-inline-start: auto;
+	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list -- Match the Button font-size. */
+}
+
+.help-center-action-button__label {
+	margin-right: 0.5rem;
+}

--- a/client/landing/stepper/declarative-flow/internals/components/help-center/help-center-action-button.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/help-center/help-center-action-button.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import type { HelpCenterSelect } from '@automattic/data-stores';
+
+import './help-center-action-button.scss';
+
+export const HelpCenterActionButton = () => {
+	const translate = useTranslate();
+	const { setShowHelpCenter } = useDispatch( 'automattic/help-center' );
+	const { show } = useSelect( ( select ) => {
+		const store: HelpCenterSelect = select( 'automattic/help-center' );
+		return {
+			show: store.isHelpCenterShown(),
+		};
+	}, [] );
+
+	return (
+		<div className="help-center-action-button">
+			<span className="help-center-action-button__label">{ translate( 'Need extra help?' ) }</span>
+			<Button
+				variant="link"
+				onClick={ () => {
+					setShowHelpCenter( ! show );
+				} }
+			>
+				{ translate( 'Visit Help Center' ) }
+			</Button>
+		</div>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-how-to-migrate/index.tsx
@@ -1,15 +1,18 @@
 import { useTranslate } from 'i18n-calypso';
+import { HelpCenterActionButton } from '../../components/help-center/help-center-action-button';
 import SiteMigrationHowToMigrate from '../site-migration-how-to-migrate';
 import type { Step } from '../../types';
 
 const MigratioHowToMigrate: Step = ( props ) => {
 	const translate = useTranslate();
+	const customizedActionButton = <HelpCenterActionButton />;
 
 	return (
 		<SiteMigrationHowToMigrate
 			{ ...props }
 			headerText={ translate( 'Need a hand?' ) }
 			subHeaderText={ translate( 'There are two ways to get your site migrated.' ) }
+			customizedActionButtons={ customizedActionButton }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -16,13 +16,16 @@ import type { StepProps } from '../../types';
 
 import './style.scss';
 
+type StepContainerProps = React.ComponentProps< typeof StepContainer >;
+
 interface Props extends StepProps {
 	headerText?: string;
 	subHeaderText?: string;
+	customizedActionButtons?: StepContainerProps[ 'customizedActionButtons' ];
 }
 
 const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
-	const { navigation, headerText } = props;
+	const { navigation, headerText, customizedActionButtons } = props;
 
 	const translate = useTranslate();
 	const site = useSite();
@@ -120,6 +123,7 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }
 				goBack={ navigation.goBack }
+				customizedActionButtons={ customizedActionButtons }
 			/>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94548

## Proposed Changes

* Prepares the `Stepper`, so we can use Help Center in the `setup` flows.
* It fixes the help center on the checkout when used in the steps, like cases of the migration flows.
  * The issue is noticed when we click on "Visit Help Center and then "Still need help?" (See Testing Instructions of this PR for an example).
* Add Help Center link to the migration flows post-checkout.

<img width="1269" alt="Screenshot 2024-09-19 at 19 15 50" src="https://github.com/user-attachments/assets/9e4f4430-608e-4953-9ac4-44ae09fb839d">

<img width="1271" alt="Screenshot 2024-09-19 at 19 16 13" src="https://github.com/user-attachments/assets/213a5ffd-1753-46cc-bfc2-730a7b42efc6">

https://github.com/user-attachments/assets/a3d82a25-3b80-490d-9aa8-3951f7411c03

## TODO

- [ ] Solve context issues to pass the `currentRoute` and `site` properly.
- [ ] Improve Help Center context for migrations (start displaying migration items).
- [ ] Add help center for all the steps post-checkout.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Help the user during the migration flows.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Check that Help Center is fixed in the checkout

* Navigate to `/setup/migration`.
* Select the "WordPress" option.
* Navigate until the checkout.
* Click on "Visit Help Center".
* Click on "Still need help?".
* Check that now the chat is properly displayed.

#### Check that Help Center is displayed post-checkout in the migration flows

* Continuing from the previous steps, complete the checkout.
* Check that you see the "Visit Help Center" link in the top right and it works properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
