### PR TITLE
Code style: Fix markdown table alignment

### DIFF
--- a/client/components/masonry-grid/README.md
+++ b/client/components/masonry-grid/README.md
@@ -4,6 +4,7 @@
 It's not as full-featured as the real Masonry library, but it's considerably more lightweight and circumvents the browser bugs that [CSS multi-column layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_multicol_layout) is still plagued by. The approach is to use CSS Grid layout combined with negative top margins.
 
 ## Usage
+
 ```jsx
 import { MasonryGrid } from 'calypso/components/masonry-grid';
  
@@ -21,6 +22,7 @@ export default function MyComponent() {
 ```
 
 By default it renders 2 columns, but you can easily customize it with the help of CSS. e.g.
+
 ```
 .masonry-grid-example {
 	@include break-medium {
@@ -37,6 +39,6 @@ By default it renders 2 columns, but you can easily customize it with the help o
 
 The following props can be passed to the `<SpinnerLine />` component:
 
-| property    | type   | required | default | comment                                                                                              |
-| ----------- | ------ | -------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| property    | type   | required | default | comment                                                                                                       |
+| ----------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------- |
 | `className` | String | no       | `null`  | A custom class name to apply to the rendered element, in addition to the base `.masonry-grid__wrapper` class. |


### PR DESCRIPTION
## Proposed Changes
Many code-style checks have been failing recently (see recent `Web app` -> `Code style` checks) due to an `eslint` command failing. This PR fixes it.

## Testing Instructions
Just ensure the table still renders properly markdown-wise ;)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
