### PR TITLE
Odyssey: Fix moment locale for en-us

### DIFF
--- a/apps/odyssey-stats/src/app.tsx
+++ b/apps/odyssey-stats/src/app.tsx
@@ -16,6 +16,7 @@ import currentUser from 'calypso/state/current-user/reducer';
 import wpcomApiMiddleware from 'calypso/state/data-layer/wpcom-api-middleware';
 import { setStore } from 'calypso/state/redux-store';
 import sites from 'calypso/state/sites/reducer';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
 import config from './lib/config-api';
 import initSentry from './lib/init-sentry';
@@ -46,6 +47,8 @@ async function AppBoot() {
 		},
 	};
 
+	const isSmiple = isSimpleSite( initialState, siteId );
+
 	const queryClient = new QueryClient();
 
 	const middlewares = [ thunkMiddleware, analyticsMiddleware, wpcomApiMiddleware as Middleware ];
@@ -70,7 +73,7 @@ async function AppBoot() {
 	}
 
 	// Ensure locale files are loaded before rendering.
-	setLocale( localeSlug ).then( () => {
+	setLocale( localeSlug, isSmiple ).then( () => {
 		registerStatsPages( window.location.pathname + window.location.search );
 
 		// HACK: getPathWithUpdatedQueryString filters duplicate query parameters added by `page.js`.

--- a/apps/odyssey-stats/src/app.tsx
+++ b/apps/odyssey-stats/src/app.tsx
@@ -47,7 +47,7 @@ async function AppBoot() {
 		},
 	};
 
-	const isSmiple = isSimpleSite( initialState, siteId );
+	const isSimple = isSimpleSite( initialState, siteId );
 
 	const queryClient = new QueryClient();
 
@@ -73,7 +73,7 @@ async function AppBoot() {
 	}
 
 	// Ensure locale files are loaded before rendering.
-	setLocale( localeSlug, isSmiple ).then( () => {
+	setLocale( localeSlug, isSimple ).then( () => {
 		registerStatsPages( window.location.pathname + window.location.search );
 
 		// HACK: getPathWithUpdatedQueryString filters duplicate query parameters added by `page.js`.

--- a/apps/odyssey-stats/src/lib/set-locale.ts
+++ b/apps/odyssey-stats/src/lib/set-locale.ts
@@ -119,7 +119,7 @@ const fixLongDateFormatForEn = ( localeSlug: string ) => {
 	}
 };
 
-const loadMomentLocale = async ( localeSlug: string, languageCode: string ) => {
+const loadMomentLocale = async ( localeSlug: string, languageCode: string, isSimple: boolean ) => {
 	return import( `moment/locale/${ localeSlug }` )
 		.catch( ( error: Error ) => {
 			debug(
@@ -141,7 +141,7 @@ const loadMomentLocale = async ( localeSlug: string, languageCode: string ) => {
 			);
 			// Fallback 2 to the default US date time format.
 			// Interestingly `en` here represents `en-us` locale.
-			fixLongDateFormatForEn( localeSlug );
+			isSimple && fixLongDateFormatForEn( localeSlug );
 			localeSlug = DEFAULT_MOMENT_LOCALE;
 		} )
 		.then( () => moment.locale( localeSlug ) );
@@ -162,7 +162,7 @@ const loadLanguageFile = ( languageFileName: string ) => {
 	} );
 };
 
-export default ( localeSlug: string ) => {
+export default ( localeSlug: string, isSimple = false ) => {
 	const languageCode = getLanguageCodeFromLocale( localeSlug );
 
 	// Load tranlation file if it's not English.
@@ -183,5 +183,5 @@ export default ( localeSlug: string ) => {
 
 	// We have to wait for moment locale to load before rendering the page, because otherwise the rendered date time wouldn't get re-rendered.
 	// This could be improved in the future with hooks.
-	return loadMomentLocale( localeSlug, languageCode );
+	return loadMomentLocale( localeSlug, languageCode, isSimple );
 };


### PR DESCRIPTION
Slack: p1726784616274179-slack-C04UE0ANHDY

## Proposed Changes

* Only replace php date format for simple sites

## Why are these changes being made?

* Fix date format for self hosted sites

## Testing Instructions

* Build Odyssey Stats locally
* Open `/wp-admin/admin.php?page=stats#!/stats/day/jasper1.au.ngrok.io?page=stats&flags=stats%2Fdate-picker-calendar`
* Open date range picker
* Ensure the inputs look good

|Before:|After:|
|-------|------|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/5d08fd3c-83c6-467e-9094-b8c6266ada8b">|<img width="300" alt="image" src="https://github.com/user-attachments/assets/01f08dac-5954-4976-9ccb-df9c0b721e53">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?