### PR TITLE
Calypso UI Components: DateRange: Align days to the start of day

### DIFF
--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -13,6 +13,7 @@ interface DateRangePickerProps {
 	selectedEndDate: MomentOrNull;
 	moment: typeof moment;
 	onDateRangeChange?: ( startDate: MomentOrNull, endDate: MomentOrNull ) => void;
+	onDateClick?: ( date: Moment ) => void;
 	focusedMonth?: Date;
 	numberOfMonths?: number;
 	useArrowNavigation?: boolean;
@@ -32,6 +33,7 @@ const DateRangePicker = ( {
 	moment,
 	focusedMonth,
 	onDateRangeChange = noop,
+	onDateClick = noop,
 	numberOfMonths = 2,
 	useArrowNavigation = false,
 }: DateRangePickerProps ) => {
@@ -87,6 +89,7 @@ const DateRangePicker = ( {
 	 * @param  {import('moment').Moment} date the newly selected date object
 	 */
 	const selectDate = ( date: Moment ) => {
+		date = date.startOf( 'day' );
 		if ( ! isValidDate( date ) ) {
 			return;
 		}
@@ -99,6 +102,7 @@ const DateRangePicker = ( {
 		const newEndDate = ! newRange.to ? NO_DATE_SELECTED_VALUE : newRange.to;
 
 		onDateRangeChange( newStartDate, newEndDate );
+		onDateClick( date );
 	};
 
 	/**
@@ -131,6 +135,10 @@ const DateRangePicker = ( {
 			onDateRangeChange?.( selectedEndDate, selectedStartDate );
 		}
 	}, [ selectedStartDate?.format(), selectedEndDate?.format() ] );
+
+	// Normalize dates to start of day
+	selectedStartDate = ! selectedStartDate ? selectedStartDate : selectedStartDate.startOf( 'day' );
+	selectedEndDate = ! selectedEndDate ? selectedEndDate : selectedEndDate.startOf( 'day' );
 
 	const fromDate = momentDateToJsDate( selectedStartDate );
 	const toDate = momentDateToJsDate( selectedEndDate );

--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -12,8 +12,11 @@ interface DateRangePickerProps {
 	selectedStartDate: MomentOrNull;
 	selectedEndDate: MomentOrNull;
 	moment: typeof moment;
-	onDateRangeChange?: ( startDate: MomentOrNull, endDate: MomentOrNull ) => void;
-	onDateClick?: ( date: Moment ) => void;
+	onDateRangeChange?: (
+		startDate: MomentOrNull,
+		endDate: MomentOrNull,
+		dateClicked?: Moment
+	) => void;
 	focusedMonth?: Date;
 	numberOfMonths?: number;
 	useArrowNavigation?: boolean;
@@ -33,7 +36,6 @@ const DateRangePicker = ( {
 	moment,
 	focusedMonth,
 	onDateRangeChange = noop,
-	onDateClick = noop,
 	numberOfMonths = 2,
 	useArrowNavigation = false,
 }: DateRangePickerProps ) => {
@@ -89,10 +91,11 @@ const DateRangePicker = ( {
 	 * @param  {import('moment').Moment} date the newly selected date object
 	 */
 	const selectDate = ( date: Moment ) => {
-		date = date.startOf( 'day' );
 		if ( ! isValidDate( date ) ) {
 			return;
 		}
+
+		date = date.startOf( 'day' );
 
 		// Calculate the new Date range
 		const newRange = addDayToRange( date, { from: selectedStartDate, to: selectedEndDate } );
@@ -101,8 +104,7 @@ const DateRangePicker = ( {
 		const newStartDate = ! newRange.from ? NO_DATE_SELECTED_VALUE : newRange.from;
 		const newEndDate = ! newRange.to ? NO_DATE_SELECTED_VALUE : newRange.to;
 
-		onDateRangeChange( newStartDate, newEndDate );
-		onDateClick( date );
+		onDateRangeChange( newStartDate, newEndDate, date );
 	};
 
 	/**

--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -12,11 +12,7 @@ interface DateRangePickerProps {
 	selectedStartDate: MomentOrNull;
 	selectedEndDate: MomentOrNull;
 	moment: typeof moment;
-	onDateRangeChange?: (
-		startDate: MomentOrNull,
-		endDate: MomentOrNull,
-		dateClicked?: Moment
-	) => void;
+	onDateRangeChange?: ( startDate: MomentOrNull, endDate: MomentOrNull ) => void;
 	focusedMonth?: Date;
 	numberOfMonths?: number;
 	useArrowNavigation?: boolean;
@@ -104,7 +100,7 @@ const DateRangePicker = ( {
 		const newStartDate = ! newRange.from ? NO_DATE_SELECTED_VALUE : newRange.from;
 		const newEndDate = ! newRange.to ? NO_DATE_SELECTED_VALUE : newRange.to;
 
-		onDateRangeChange( newStartDate, newEndDate, date );
+		onDateRangeChange( newStartDate, newEndDate );
 	};
 
 	/**

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -118,7 +118,6 @@ export class DateRange extends Component {
 			initialStartDate: startDate, // cache values in case we need to reset to them
 			initialEndDate: endDate, // cache values in case we need to reset to them
 			focusedMonth: this.props.focusedMonth,
-			currentShortcut: '',
 		};
 
 		// Ref to the Trigger <button> used to position the Popover component
@@ -400,14 +399,14 @@ export class DateRange extends Component {
 		return window.matchMedia( '(min-width: 520px)' ).matches ? 2 : 1;
 	}
 
-	handleDateRangeChange = ( startDate, endDate, shortcutId = '' ) => {
+	handleDateRangeChange = ( startDate, endDate, dateClicked ) => {
 		this.setState( {
 			startDate,
 			endDate,
 			textInputStartDate: this.toDateString( startDate ),
 			textInputEndDate: this.toDateString( endDate ),
-			currentShortcut: shortcutId,
 		} );
+		this.props.onDateSelect && this.props.onDateSelect( dateClicked );
 	};
 
 	/**
@@ -461,7 +460,6 @@ export class DateRange extends Component {
 					{ this.props.displayShortcuts && (
 						<div className="date-range-picker-shortcuts">
 							<Shortcuts
-								currentShortcut={ this.state.currentShortcut }
 								onClick={ this.handleDateRangeChange }
 								locked={ !! this.props.overlay }
 								startDate={ this.state.startDate }
@@ -486,7 +484,6 @@ export class DateRange extends Component {
 				selectedStartDate={ this.state.startDate }
 				selectedEndDate={ this.state.endDate }
 				onDateRangeChange={ this.handleDateRangeChange }
-				onDateSelect={ this.props.onDateSelect }
 				focusedMonth={ this.state.focusedMonth }
 				numberOfMonths={ this.getNumberOfMonths() }
 				useArrowNavigation={ this.props.useArrowNavigation }

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -408,12 +408,6 @@ export class DateRange extends Component {
 			textInputEndDate: this.toDateString( endDate ),
 			currentShortcut: shortcutId,
 		} );
-		this.props.onDateSelect && this.props.onDateSelect( startDate, endDate );
-	};
-
-	handleCalendarChange = ( startDate, endDate ) => {
-		// When the calendar or inputs change directly, set to custom range
-		this.handleDateRangeChange( startDate, endDate, 'custom_date_range' );
 	};
 
 	/**
@@ -491,7 +485,8 @@ export class DateRange extends Component {
 				lastSelectableDate={ this.props.lastSelectableDate }
 				selectedStartDate={ this.state.startDate }
 				selectedEndDate={ this.state.endDate }
-				onDateRangeChange={ this.handleCalendarChange }
+				onDateRangeChange={ this.handleDateRangeChange }
+				onDateSelect={ this.props.onDateSelect }
 				focusedMonth={ this.state.focusedMonth }
 				numberOfMonths={ this.getNumberOfMonths() }
 				useArrowNavigation={ this.props.useArrowNavigation }

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -399,14 +399,14 @@ export class DateRange extends Component {
 		return window.matchMedia( '(min-width: 520px)' ).matches ? 2 : 1;
 	}
 
-	handleDateRangeChange = ( startDate, endDate, dateClicked ) => {
+	handleDateRangeChange = ( startDate, endDate ) => {
 		this.setState( {
 			startDate,
 			endDate,
 			textInputStartDate: this.toDateString( startDate ),
 			textInputEndDate: this.toDateString( endDate ),
 		} );
-		this.props.onDateSelect && this.props.onDateSelect( dateClicked );
+		this.props.onDateSelect && this.props.onDateSelect( startDate, endDate );
 	};
 
 	/**

--- a/client/components/date-range/test/add-date-to-range.js
+++ b/client/components/date-range/test/add-date-to-range.js
@@ -66,7 +66,7 @@ describe( 'addDayToRange', () => {
 
 	test( 'should ignore time fractions', () => {
 		const range = { from: moment( '2023-01-01 11:10' ), to: moment( '2023-01-17 12:00' ) };
-		const result = addDayToRange( moment( '2023-01-17 :13:00' ), range );
+		const result = addDayToRange( moment( '2023-01-17 13:00' ), range );
 		expect( result.from ).toEqual( range.from );
 		expect( result.to ).toBeNull();
 	} );

--- a/client/components/date-range/test/add-date-to-range.js
+++ b/client/components/date-range/test/add-date-to-range.js
@@ -63,4 +63,11 @@ describe( 'addDayToRange', () => {
 		expect( result.from ).toEqual( range.from );
 		expect( result.to ).toEqual( moment( '2023-01-07' ) );
 	} );
+
+	test( 'should ignore time fractions', () => {
+		const range = { from: moment( '2023-01-01 11:10' ), to: moment( '2023-01-17 12:00' ) };
+		const result = addDayToRange( moment( '2023-01-17 :13:00' ), range );
+		expect( result.from ).toEqual( range.from );
+		expect( result.to ).toBeNull();
+	} );
 } );

--- a/client/components/date-range/utils.ts
+++ b/client/components/date-range/utils.ts
@@ -10,12 +10,16 @@ function addDayToRange( day: Moment, range: DateRange ): DateRange {
 		return range;
 	}
 
-	const { from, to } = range;
+	let { from, to } = range;
 
-	if ( from?.isSame( day, 'day' ) ) {
+	from = from?.startOf( 'day' ) ?? null;
+	to = to?.startOf( 'day' ) ?? null;
+	day = day.startOf( 'day' );
+
+	if ( from?.isSame( day ) ) {
 		return { ...range, from: null };
 	}
-	if ( to?.isSame( day, 'day' ) ) {
+	if ( to?.isSame( day ) ) {
 		return { ...range, to: null };
 	}
 

--- a/client/components/date-range/utils.ts
+++ b/client/components/date-range/utils.ts
@@ -12,10 +12,10 @@ function addDayToRange( day: Moment, range: DateRange ): DateRange {
 
 	const { from, to } = range;
 
-	if ( from?.isSame( day ) ) {
+	if ( from?.isSame( day, 'day' ) ) {
 		return { ...range, from: null };
 	}
-	if ( to?.isSame( day ) ) {
+	if ( to?.isSame( day, 'day' ) ) {
 		return { ...range, to: null };
 	}
 

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -125,7 +125,8 @@ const StatsDateControl = ( {
 				<DateRange
 					selectedStartDate={ moment( dateRange.chartStart ) }
 					selectedEndDate={ moment( dateRange.chartEnd ) }
-					lastSelectableDate={ moment().toDate() }
+					lastSelectableDate={ moment() }
+					firstSelectableDate={ moment( '2010-01-01' ) }
 					onDateCommit={ ( startDate: Moment, endDate: Moment ) =>
 						startDate &&
 						endDate &&


### PR DESCRIPTION
Slack: p1726787260195209-slack-C04UE0ANHDY

## Proposed Changes

* Align all days to the start of day to eliminate the issue for date comparing when there is time fraction

## Why are these changes being made?


* Bugfix

## Testing Instructions

* Open Calypso Live
* Ensure 'today' is selectable and de-selectable while choosing a new range
* Ensure shortcuts work as expected
* Ensure what happens in the video below doesn't happen anymore


https://github.com/user-attachments/assets/6aedf914-c7e7-4caf-b0f5-2ff2e497c0c4



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?