### PR TITLE
Logged-in Performance: Use updated url scheme

### DIFF
--- a/client/hosting/performance/controller.tsx
+++ b/client/hosting/performance/controller.tsx
@@ -12,7 +12,7 @@ export function sitePerformance( context: PageJSContext, next: () => void ) {
 
 	context.primary = (
 		<>
-			<PageViewTracker path="/site-performance/:site" title="Site Performance" />
+			<PageViewTracker path="/sites/performance/:site" title="Site Performance" />
 			<SitePerformance />
 		</>
 	);

--- a/client/hosting/performance/index.tsx
+++ b/client/hosting/performance/index.tsx
@@ -10,10 +10,10 @@ import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { sitePerformance } from './controller';
 
 export default function () {
-	page( '/site-performance', siteSelection, sites, makeLayout, clientRender );
+	page( '/sites/performance', siteSelection, sites, makeLayout, clientRender );
 
 	page(
-		'/site-performance/:site',
+		'/sites/performance/:site',
 		siteSelection,
 		redirectToHostingPromoIfNotAtomic,
 		navigation,

--- a/client/hosting/sites/components/site-preview-pane/constants.ts
+++ b/client/hosting/sites/components/site-preview-pane/constants.ts
@@ -17,5 +17,5 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOTCOM_HOSTING_CONFIG ]: 'hosting-config/:site',
 	[ DOTCOM_HOSTING_FEATURES ]: 'hosting-features/:site',
 	[ DOTCOM_STAGING_SITE ]: 'staging-site/:site',
-	[ DOTCOM_SITE_PERFORMANCE ]: 'site-performance/:site',
+	[ DOTCOM_SITE_PERFORMANCE ]: 'sites/performance/:site',
 };

--- a/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { SiteExcerptData } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
@@ -95,7 +96,7 @@ const DotcomPreviewPane = ( {
 			},
 			{
 				label: __( 'Performance' ),
-				enabled: false,
+				enabled: isActiveAtomicSite && config.isEnabled( 'performance-profiler/logged-in' ),
 				featureIds: [ DOTCOM_SITE_PERFORMANCE ],
 			},
 			{

--- a/client/sections.js
+++ b/client/sections.js
@@ -727,7 +727,7 @@ const sections = [
 	},
 	{
 		name: 'site-performance',
-		paths: [ '/site-performance' ],
+		paths: [ '/sites/performance' ],
 		module: 'calypso/hosting/performance',
 		group: 'sites',
 	},

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -13,7 +13,7 @@ const SITE_DASHBOARD_ROUTES = {
 	hosting: '/hosting-config/',
 	'github-deployments': '/github-deployments/',
 	'site-monitoring': '/site-monitoring/',
-	'site-performance': '/site-performance/',
+	'site-performance': '/sites/performance/',
 	'site-logs': '/site-logs/',
 	'hosting-features': '/hosting-features/',
 	'staging-site': '/staging-site/',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9195

## Proposed Changes

*  Update performance urls to `/sites/performance`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of updating hosting urls to be more coherent https://github.com/Automattic/dotcom-forge/issues/9152

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites/performance/ATSite`
* Verify performance feature is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
