### PR TITLE
Calypso UI Components: DateRange: add spacing between weeks

### DIFF
--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -50,7 +50,6 @@ $date-range-mobile-layout-switch: $break-small;
 	flex-direction: column;
 	padding: 15px;
 	margin: 0 auto;
-	// max-width: 90%;
 
 	@include breakpoint-deprecated( "<480px" ) {
 		max-width: 300px;
@@ -75,6 +74,9 @@ $date-range-mobile-layout-switch: $break-small;
 			justify-content: center;
 			align-items: center;
 		}
+	}
+	.DayPicker-Week {
+		border-bottom: 4px solid var(--color-surface);
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

* Add spacing between weeks


## Why are these changes being made?

* From design `design/804HN2REV2iap2ytjRQ055/Core-System-Library?node-id=13066-3845&t=W7cRwbXYwGZLae68-4`

## Testing Instructions


* Open Calypso Live with `flags=stats%2Fdate-picker-calendar`
* Ensure there's a gap between weeks
* Ensure the start / end date styling looks okay

<img width="487" alt="image" src="https://github.com/user-attachments/assets/770182a2-e979-413d-a6fe-bc5a35282950">





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
