### PR TITLE
Calypso UI Components: DateRange: Set calendar number on window resize

### DIFF
--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -1,6 +1,7 @@
 import { Popover } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
+import { debounce } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -118,10 +119,24 @@ export class DateRange extends Component {
 			initialStartDate: startDate, // cache values in case we need to reset to them
 			initialEndDate: endDate, // cache values in case we need to reset to them
 			focusedMonth: this.props.focusedMonth,
+			numberOfMonths: this.getNumberOfMonths(),
 		};
 
 		// Ref to the Trigger <button> used to position the Popover component
 		this.triggerButtonRef = createRef();
+		this.throttledHandleResize = debounce( () => {
+			this.setState( {
+				numberOfMonths: this.getNumberOfMonths(),
+			} );
+		}, 250 );
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'resize', this.throttledHandleResize );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.throttledHandleResize );
 	}
 
 	/**

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -500,7 +500,7 @@ export class DateRange extends Component {
 				selectedEndDate={ this.state.endDate }
 				onDateRangeChange={ this.handleDateRangeChange }
 				focusedMonth={ this.state.focusedMonth }
-				numberOfMonths={ this.getNumberOfMonths() }
+				numberOfMonths={ this.state.numberOfMonths }
 				useArrowNavigation={ this.props.useArrowNavigation }
 			/>
 		);


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/94695#issuecomment-2360004860

## Proposed Changes

* Adjust month number on window resize

## Why are these changes being made?

* Responsiveness

## Testing Instructions

* Ensure number of calendars adjust well on resizing


https://github.com/user-attachments/assets/df8bbdc8-925e-4324-a0f7-a85251ea4a9a



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
