### PR TITLE
Stepper: Record `calypso_signup_start` unconditionally => multiple logs

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -3,7 +3,6 @@
  */
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { SENSEI_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -28,21 +27,13 @@ const signUpFlow: Flow = {
 	isSignupFlow: true,
 };
 
-const senseiFlow: Flow = {
-	...regularFlow,
-	name: SENSEI_FLOW,
-	// The original sensei flow is missing the isSignupFlow flag as true, it will be addressed by wp-calypso/pull/91593
-	isSignupFlow: true,
-};
-
 jest.mock( '@automattic/calypso-analytics' );
 
-const render = ( { flow, currentStepRoute, queryParams = {} } ) => {
+const render = ( { flow, queryParams = {} } ) => {
 	return renderHookWithProvider(
 		() =>
 			useSignUpStartTracking( {
 				flow,
-				currentStepRoute,
 			} ),
 		{
 			wrapper: ( { children } ) => (
@@ -60,22 +51,21 @@ describe( 'useSignUpTracking', () => {
 	} );
 
 	it( 'does not track event when the flow is not a isSignupFlow', () => {
-		render( { flow: regularFlow, currentStepRoute: 'step-1' } );
+		render( { flow: regularFlow } );
 
 		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does not track event when the flow is not a isSignupFlow and the signup flag is set', () => {
-		render( { flow: regularFlow, currentStepRoute: 'step-1', queryParams: { start: 1 } } );
+		render( { flow: regularFlow, queryParams: { start: 1 } } );
 
 		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
 	describe( 'sign-up-flow', () => {
-		it( 'tracks the event current step is first step', () => {
+		it( 'tracks the event current', () => {
 			render( {
 				flow: signUpFlow,
-				currentStepRoute: 'step-1',
 				queryParams: { ref: 'another-flow-or-cta' },
 			} );
 
@@ -85,26 +75,12 @@ describe( 'useSignUpTracking', () => {
 			} );
 		} );
 
-		it( 'tracks the event when the step is not the first but the start flag is set', () => {
-			render( {
-				flow: signUpFlow,
-				currentStepRoute: 'step-2',
-				queryParams: { start: 1 },
-			} );
-
-			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
-				flow: 'sign-up-flow',
-				ref: '',
-			} );
-		} );
-
 		it( 'tracks the event with extra props from useSighupStartEventProps', () => {
 			render( {
 				flow: {
 					...signUpFlow,
 					useSignupStartEventProps: () => ( { extra: 'props' } ),
 				} satisfies Flow,
-				currentStepRoute: 'step-1',
 				queryParams: { ref: 'another-flow-or-cta' },
 			} );
 
@@ -121,45 +97,12 @@ describe( 'useSignUpTracking', () => {
 					...signUpFlow,
 					variantSlug: 'variant-slug',
 				} satisfies Flow,
-				currentStepRoute: 'step-1',
 			} );
 
 			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
 				flow: 'sign-up-flow',
 				flow_variant: 'variant-slug',
 				ref: '',
-			} );
-		} );
-
-		it( 'does not track events current step is NOT the first step', () => {
-			render( { flow: signUpFlow, currentStepRoute: 'step-2' } );
-
-			expect( recordTracksEvent ).not.toHaveBeenCalled();
-		} );
-
-		// Check if sensei is a sign-up flow;
-		it( "tracks when the user is on the sensei's flow second step", () => {
-			render( { flow: senseiFlow, currentStepRoute: 'step-2' } );
-
-			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
-				flow: SENSEI_FLOW,
-				ref: '',
-			} );
-		} );
-
-		it( 'does not trigger the event on rerender', () => {
-			const { rerender } = render( {
-				flow: { ...signUpFlow, useSignupStartEventProps: () => ( { extra: 'props' } ) },
-				currentStepRoute: 'step-1',
-				queryParams: { ref: 'another-flow-or-cta' },
-			} );
-
-			rerender();
-
-			expect( recordTracksEvent ).toHaveBeenNthCalledWith( 1, 'calypso_signup_start', {
-				flow: 'sign-up-flow',
-				ref: 'another-flow-or-cta',
-				extra: 'props',
 			} );
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -196,7 +196,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		}
 	};
 
-	useSignUpStartTracking( { flow, currentStepRoute: currentStepRoute } );
+	useSignUpStartTracking( { flow } );
 
 	return (
 		<Boot fallback={ <StepperLoader /> }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/94175
Fixes https://github.com/Automattic/wp-calypso/issues/94717

## Proposed Changes

Records `calypso_signup_start` event unconditionally. This means it can get logged not only on the first step but on any of the dependencies changing. 

`extraProps` coming from `useSignupStartEventProps` are guaranteed now to be logged as they change through flow progression.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Addressed https://github.com/Automattic/wp-calypso/issues/94175#issuecomment-2362724556

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding`
* Ensure you see `calypso_signup_start` being recorded when logging in and on refreshing the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
