### PR TITLE
Use launchpadOptions instead of Jetpack_LaunchpadSaveModal

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/use-launchpad-screen.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-launchpad-screen.js
@@ -1,7 +1,7 @@
 const useLaunchpadScreen = () => {
-	// We have this data populated, on window.Jetpack_LaunchpadSaveModal, so we should use it.
+	// We have this data populated, on window.launchpadOptions, so we should use it.
 	return {
-		launchpad_screen: window.Jetpack_LaunchpadSaveModal?.launchpadScreenOption,
+		launchpad_screen: window.launchpadOptions?.launchpadScreenOption,
 	};
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/use-site-intent.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-site-intent.js
@@ -6,7 +6,7 @@ const useSiteIntent = () => {
 	// permissions changes as it requires 'manage_options' to read
 	// https://github.com/Automattic/jetpack/blob/e135711f9a130946dae1bca6c9c0967350331067/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php#L121.
 	return {
-		siteIntent: window.Jetpack_LaunchpadSaveModal?.siteIntentOption,
+		siteIntent: window.launchpadOptions?.siteIntentOption,
 		siteIntentFetched: true,
 	};
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

The variable Jetpack_LaunchpadSaveModal has been deprecated in favor of launchpadOptions via https://github.com/Automattic/jetpack/pull/39429.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See p1726806709773699-slack-CRWCHQGUB

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?