### PR TITLE
A4A > Signup: Adding smoke tests

### DIFF
--- a/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
+++ b/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
@@ -1,0 +1,101 @@
+/**
+ * @group calypso-pr
+ */
+
+import {
+	TestAccount,
+	getTestAccountByFeature,
+	envToFeatureKey,
+	envVariables,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+const A4A_URL = 'https://agencies.automattic.com';
+
+/**
+ * Verifies the A4A > Signup page loads
+ */
+describe( 'A4A > Signup: Smoke Test', function () {
+	let page: Page;
+	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+	const testAccount = new TestAccount( accountName );
+
+	beforeAll( async function () {
+		page = await browser.newPage();
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Navigate to A4A > Signup', async function () {
+		await page.goto( `${ A4A_URL }/signup` );
+
+		// Enter first name
+		const firstName = 'John';
+		await page.fill( 'input[name="firstName"]', firstName );
+
+		// Enter last name
+		const lastName = 'Doe';
+		await page.fill( 'input[name="lastName"]', lastName );
+
+		// Enter the agency name
+		const agencyName = 'Agency Name';
+		await page.fill( 'input[name="agencyName"]', agencyName );
+
+		// Enter the business URL
+		const businessURL = 'https://example.com';
+		await page.fill( 'input[name="agencyUrl"]', businessURL );
+
+		// Select the number of managed sites
+		await page.selectOption( 'select[name="managed_sites"]', { value: '6-20' } );
+
+		// Select the services offered
+		await page.click( 'input[name="services_offered[]"][value="strategy_consulting"]' );
+
+		// Select the products offered
+		await page.click( 'input[name="products_offered[]"][value="WordPress.com"]' );
+
+		// Enter the address
+		await page.fill( 'input[name="line1"]', '123 Main St' );
+		await page.fill( 'input[name="line2"]', 'Suite 101' );
+		await page.fill( 'input[name="city"]', 'San Francisco' );
+		await page.fill( 'input[name="postalCode"]', '94105' );
+
+		// Select the country
+		await page.fill(
+			'input[id="components-form-token-input-combobox-control-0"]',
+			'United States'
+		);
+
+		// Verify the form values
+		const firstNameValue = await page.inputValue( 'input[name="firstName"]' );
+		expect( firstNameValue ).toBe( firstName );
+
+		const lastNameValue = await page.inputValue( 'input[name="lastName"]' );
+		expect( lastNameValue ).toBe( lastName );
+
+		const agencyNameValue = await page.inputValue( 'input[name="agencyName"]' );
+		expect( agencyNameValue ).toBe( agencyName );
+
+		const businessURLValue = await page.inputValue( 'input[name="agencyUrl"]' );
+		expect( businessURLValue ).toBe( businessURL );
+
+		const managedSitesValue = await page.inputValue( 'select[name="managed_sites"]' );
+		expect( managedSitesValue ).toBe( '6-20' );
+
+		const servicesOfferedValue = await page.inputValue(
+			'input[name="services_offered[]"][value="strategy_consulting"]'
+		);
+		expect( servicesOfferedValue ).toBe( 'strategy_consulting' );
+
+		const productsOfferedValue = await page.inputValue(
+			'input[name="products_offered[]"][value="WordPress.com"]'
+		);
+		expect( productsOfferedValue ).toBe( 'WordPress.com' );
+
+		const countryValue = await page.inputValue(
+			'input[id="components-form-token-input-combobox-control-0"]'
+		);
+		expect( countryValue ).toBe( 'United States' );
+	} );
+} );

--- a/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
+++ b/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
@@ -49,7 +49,7 @@ describe( 'A4A > Signup: Smoke Test', function () {
 		// Select the user type to site owner
 		await page
 			.getByRole( 'combobox', { name: 'How would you describe yourself?' } )
-			.selectOption( { value: 'site_owner' } );
+			.selectOption( { label: "I do not work at an agency. I'm a site owner." } );
 
 		// Verify the message is displayed
 		const message = await page.$(
@@ -60,7 +60,7 @@ describe( 'A4A > Signup: Smoke Test', function () {
 		// Select the user type to agency owner
 		await page
 			.getByRole( 'combobox', { name: 'How would you describe yourself?' } )
-			.selectOption( { value: 'agency_owner' } );
+			.selectOption( { label: "I'm an agency owner" } );
 
 		// Select the number of managed sites
 		await page

--- a/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
+++ b/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
@@ -65,7 +65,7 @@ describe( 'A4A > Signup: Smoke Test', function () {
 		// Select the number of managed sites
 		await page
 			.getByRole( 'combobox', { name: 'How many sites do you manage?' } )
-			.selectOption( { value: '6-20' } );
+			.selectOption( { label: '6-20' } );
 
 		// Select the services offered
 		await page.getByRole( 'checkbox', { name: 'Strategy Consulting' } ).check();
@@ -96,5 +96,13 @@ describe( 'A4A > Signup: Smoke Test', function () {
 		expect( await page.getByRole( 'checkbox', { name: 'WordPress.com' } ).isChecked() ).toBe(
 			true
 		);
+		expect( await page.getByPlaceholder( 'Street name and house number' ).inputValue() ).toBe(
+			'123 Main St'
+		);
+		expect(
+			await page.getByPlaceholder( 'Apartment, floor, suite or unit number' ).inputValue()
+		).toBe( 'Suite 101' );
+		expect( await page.getByLabel( 'City' ).inputValue() ).toBe( 'San Francisco' );
+		expect( await page.getByLabel( 'Postal code' ).inputValue() ).toBe( '94105' );
 	} );
 } );

--- a/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
+++ b/test/e2e/specs/a8c-for-agencies/signup__smoke.ts
@@ -32,70 +32,69 @@ describe( 'A4A > Signup: Smoke Test', function () {
 
 		// Enter first name
 		const firstName = 'John';
-		await page.fill( 'input[name="firstName"]', firstName );
+		await page.getByLabel( 'First name' ).fill( firstName );
 
 		// Enter last name
 		const lastName = 'Doe';
-		await page.fill( 'input[name="lastName"]', lastName );
+		await page.getByLabel( 'Last name' ).fill( lastName );
 
 		// Enter the agency name
 		const agencyName = 'Agency Name';
-		await page.fill( 'input[name="agencyName"]', agencyName );
+		await page.getByLabel( 'Agency name' ).fill( agencyName );
 
 		// Enter the business URL
 		const businessURL = 'https://example.com';
-		await page.fill( 'input[name="agencyUrl"]', businessURL );
+		await page.getByLabel( 'Business URL' ).fill( businessURL );
+
+		// Select the user type to site owner
+		await page
+			.getByRole( 'combobox', { name: 'How would you describe yourself?' } )
+			.selectOption( { value: 'site_owner' } );
+
+		// Verify the message is displayed
+		const message = await page.$(
+			'text=It seems like we might not be the perfect match right now.'
+		);
+		expect( message ).not.toBeNull();
+
+		// Select the user type to agency owner
+		await page
+			.getByRole( 'combobox', { name: 'How would you describe yourself?' } )
+			.selectOption( { value: 'agency_owner' } );
 
 		// Select the number of managed sites
-		await page.selectOption( 'select[name="managed_sites"]', { value: '6-20' } );
+		await page
+			.getByRole( 'combobox', { name: 'How many sites do you manage?' } )
+			.selectOption( { value: '6-20' } );
 
 		// Select the services offered
-		await page.click( 'input[name="services_offered[]"][value="strategy_consulting"]' );
+		await page.getByRole( 'checkbox', { name: 'Strategy Consulting' } ).check();
 
 		// Select the products offered
-		await page.click( 'input[name="products_offered[]"][value="WordPress.com"]' );
+		await page.getByRole( 'checkbox', { name: 'WordPress.com' } ).check();
 
 		// Enter the address
-		await page.fill( 'input[name="line1"]', '123 Main St' );
-		await page.fill( 'input[name="line2"]', 'Suite 101' );
-		await page.fill( 'input[name="city"]', 'San Francisco' );
-		await page.fill( 'input[name="postalCode"]', '94105' );
-
-		// Select the country
-		await page.fill(
-			'input[id="components-form-token-input-combobox-control-0"]',
-			'United States'
-		);
+		await page.getByPlaceholder( 'Street name and house number' ).fill( '123 Main St' );
+		await page.getByPlaceholder( 'Apartment, floor, suite or unit number' ).fill( 'Suite 101' );
+		await page.getByLabel( 'City' ).fill( 'San Francisco' );
+		await page.getByLabel( 'Postal code' ).fill( '94105' );
 
 		// Verify the form values
-		const firstNameValue = await page.inputValue( 'input[name="firstName"]' );
-		expect( firstNameValue ).toBe( firstName );
-
-		const lastNameValue = await page.inputValue( 'input[name="lastName"]' );
-		expect( lastNameValue ).toBe( lastName );
-
-		const agencyNameValue = await page.inputValue( 'input[name="agencyName"]' );
-		expect( agencyNameValue ).toBe( agencyName );
-
-		const businessURLValue = await page.inputValue( 'input[name="agencyUrl"]' );
-		expect( businessURLValue ).toBe( businessURL );
-
-		const managedSitesValue = await page.inputValue( 'select[name="managed_sites"]' );
-		expect( managedSitesValue ).toBe( '6-20' );
-
-		const servicesOfferedValue = await page.inputValue(
-			'input[name="services_offered[]"][value="strategy_consulting"]'
+		expect( await page.getByLabel( 'First name' ).inputValue() ).toBe( firstName );
+		expect( await page.getByLabel( 'Last name' ).inputValue() ).toBe( lastName );
+		expect( await page.getByLabel( 'Agency name' ).inputValue() ).toBe( agencyName );
+		expect( await page.getByLabel( 'Business URL' ).inputValue() ).toBe( businessURL );
+		expect(
+			await page.getByRole( 'combobox', { name: 'How would you describe yourself?' } ).inputValue()
+		).toBe( 'agency_owner' );
+		expect(
+			await page.getByRole( 'combobox', { name: 'How many sites do you manage?' } ).inputValue()
+		).toBe( '6-20' );
+		expect( await page.getByRole( 'checkbox', { name: 'Strategy Consulting' } ).isChecked() ).toBe(
+			true
 		);
-		expect( servicesOfferedValue ).toBe( 'strategy_consulting' );
-
-		const productsOfferedValue = await page.inputValue(
-			'input[name="products_offered[]"][value="WordPress.com"]'
+		expect( await page.getByRole( 'checkbox', { name: 'WordPress.com' } ).isChecked() ).toBe(
+			true
 		);
-		expect( productsOfferedValue ).toBe( 'WordPress.com' );
-
-		const countryValue = await page.inputValue(
-			'input[id="components-form-token-input-combobox-control-0"]'
-		);
-		expect( countryValue ).toBe( 'United States' );
 	} );
 } );


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1136

## Proposed Changes

* This PR adds basic smoke tests to the A4A signup page
* This only checks if some of the form fields are rendered correctly and the values can be entered.

## Testing Instructions

- Switch this branch locally
- Follow the setup instructions here: https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/README.md#quick-start.
- Run `yarn workspace wp-e2e-tests test -- specs/a8c-for-agencies/signup__smoke.ts` and verify the tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
