### PR TITLE
Post-purchase migration experience: redirect to migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -376,6 +376,16 @@ const siteMigration: Flow = {
 						);
 
 						urlQueryParams.delete( 'showModal' );
+						const extraQueryParams: Record< string, string > = {
+							flow_name: FLOW_NAME,
+						};
+
+						if (
+							providedDependencies?.sendIntentWhenCreatingTrial &&
+							providedDependencies?.plan === PLAN_MIGRATION_TRIAL_MONTHLY
+						) {
+							extraQueryParams[ 'hosting_intent' ] = HOSTING_INTENT_MIGRATE;
+						}
 						goToCheckout( {
 							flowName: flowPath,
 							stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
@@ -385,11 +395,7 @@ const siteMigration: Flow = {
 							cancelDestination: `/setup/${ flowPath }/${
 								STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
 							}?${ urlQueryParams.toString() }`,
-							extraQueryParams:
-								providedDependencies?.sendIntentWhenCreatingTrial &&
-								providedDependencies?.plan === PLAN_MIGRATION_TRIAL_MONTHLY
-									? { hosting_intent: HOSTING_INTENT_MIGRATE }
-									: {},
+							extraQueryParams,
 						} );
 						return;
 					}

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -376,8 +376,16 @@ const siteMigration: Flow = {
 						);
 
 						urlQueryParams.delete( 'showModal' );
+
+						const how = urlQueryParams.get( 'how' );
+
+						let flow_name = FLOW_NAME;
+
+						if ( how ) {
+							flow_name = `${ FLOW_NAME }-${ how }`;
+						}
 						const extraQueryParams: Record< string, string > = {
-							flow_name: FLOW_NAME,
+							flow_name,
 						};
 
 						if (

--- a/client/my-sites/checkout/modal/index.tsx
+++ b/client/my-sites/checkout/modal/index.tsx
@@ -48,6 +48,7 @@ const CheckoutModal: FunctionComponent< Props > = ( {
 	const siteSlug = site?.slug;
 	const previousRoute = removeQueryArgs( previousRouteWithArgs, KEY_PRODUCTS );
 	const hostingIntent = getQueryArg( window.location.href, 'hosting_intent' ) as string;
+	const flowName = getQueryArg( window.location.href, 'flow_name' ) as string;
 
 	const redirectTo =
 		( getQueryArg( window.location.href, 'redirect_to' ) as string ) || previousRouteWithArgs;
@@ -117,6 +118,7 @@ const CheckoutModal: FunctionComponent< Props > = ( {
 							disabledThankYouPage
 							onAfterPaymentComplete={ handleAfterPaymentComplete }
 							hostingIntent={ hostingIntent }
+							flowName={ flowName }
 						/>
 					</RazorpayHookProvider>
 				</StripeHookProvider>

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -106,6 +106,7 @@ export interface CheckoutMainProps {
 	fromSiteSlug?: string;
 	adminUrl?: string;
 	hostingIntent?: string | undefined;
+	flowName?: string | undefined;
 }
 
 export default function CheckoutMain( {
@@ -136,6 +137,7 @@ export default function CheckoutMain( {
 	fromSiteSlug,
 	adminUrl,
 	hostingIntent,
+	flowName,
 }: CheckoutMainProps ) {
 	const translate = useTranslate();
 
@@ -216,6 +218,7 @@ export default function CheckoutMain( {
 		source: productSourceFromUrl,
 		isGiftPurchase,
 		hostingIntent,
+		flowName,
 	} );
 
 	const cartKey = useCartKey();

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -700,7 +700,7 @@ function createItemToAddToCart( {
 			context: 'calypstore',
 			source: source ?? undefined,
 			hosting_intent: hostingIntent,
-			flow_name: flowName,
+			signup_flow: flowName,
 		},
 		...( cartMeta ? { meta: cartMeta } : {} ),
 	} );

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -53,6 +53,7 @@ export default function usePrepareProductsForCart( {
 	source,
 	isGiftPurchase,
 	hostingIntent,
+	flowName,
 }: {
 	productAliasFromUrl: string | null | undefined;
 	purchaseId: string | number | null | undefined;
@@ -68,6 +69,7 @@ export default function usePrepareProductsForCart( {
 	source?: string;
 	isGiftPurchase?: boolean;
 	hostingIntent?: string | undefined;
+	flowName?: string | undefined;
 } ): PreparedProductsForCart {
 	const [ state, dispatch ] = useReducer( preparedProductsReducer, initialPreparedProductsState );
 
@@ -121,6 +123,7 @@ export default function usePrepareProductsForCart( {
 		jetpackPurchaseToken,
 		source,
 		hostingIntent,
+		flowName,
 	} );
 	useAddProductFromBillingIntent( {
 		intentId: productAliasFromUrl,
@@ -454,6 +457,7 @@ function useAddProductFromSlug( {
 	jetpackPurchaseToken,
 	source,
 	hostingIntent,
+	flowName,
 }: {
 	productAliasFromUrl: string | undefined | null;
 	dispatch: ( action: PreparedProductsAction ) => void;
@@ -465,6 +469,7 @@ function useAddProductFromSlug( {
 	jetpackPurchaseToken?: string;
 	source?: string;
 	hostingIntent?: string | undefined;
+	flowName?: string | undefined;
 } ) {
 	const translate = useTranslate();
 
@@ -500,6 +505,7 @@ function useAddProductFromSlug( {
 				jetpackPurchaseToken,
 				source,
 				hostingIntent,
+				flowName,
 			} )
 		);
 
@@ -654,6 +660,7 @@ function createItemToAddToCart( {
 	jetpackPurchaseToken,
 	source,
 	hostingIntent,
+	flowName,
 }: {
 	productSlug: string;
 	productAlias: string;
@@ -662,6 +669,7 @@ function createItemToAddToCart( {
 	jetpackPurchaseToken?: string;
 	source?: string;
 	hostingIntent?: string | undefined;
+	flowName?: string | undefined;
 } ): RequestCartProduct {
 	// Allow setting meta (theme name or domain name) from products in the URL by
 	// using a colon between the product slug and the meta.
@@ -692,6 +700,7 @@ function createItemToAddToCart( {
 			context: 'calypstore',
 			source: source ?? undefined,
 			hosting_intent: hostingIntent,
+			flow_name: flowName,
 		},
 		...( cartMeta ? { meta: cartMeta } : {} ),
 	} );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -67,7 +67,6 @@ import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
-import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -350,13 +349,6 @@ function onSelectedSiteAvailable( context ) {
 			return false;
 		}
 		context.hideLeftNavigation = true;
-	} else {
-		// If migration is in progress, only /migrate paths should be loaded for the site
-		const isMigrationInProgress = isSiteMigrationInProgress( state, selectedSite.ID );
-		if ( isMigrationInProgress && ! startsWith( context.pathname, '/migrate/' ) ) {
-			page.redirect( `/migrate/${ selectedSite.slug }` );
-			return false;
-		}
 	}
 
 	const primaryDomain = getPrimaryDomainBySiteId( state, selectedSite.ID );

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -6,6 +6,7 @@ import { getQueryArgs } from 'calypso/lib/query-args';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
+import getSiteMigrationStatus from 'calypso/state/selectors/get-site-migration-status';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { isSiteOnWooExpressEcommerceTrial } from 'calypso/state/sites/plans/selectors';
 import { canCurrentUserUseCustomerHome, getSiteUrl } from 'calypso/state/sites/selectors';
@@ -42,13 +43,32 @@ export async function maybeRedirect( context, next ) {
 
 	const { verified, courseSlug } = getQueryArgs() || {};
 
+	const siteId = getSelectedSiteId( state );
+	const status = getSiteMigrationStatus( state, siteId );
+
+	if ( status === 'pending' ) {
+		window.location.replace(
+			`/setup/site-migration/site-migration-how-to-migrate?siteSlug=${ slug }&siteId=${ siteId }`
+		);
+		return;
+	} else if ( status === 'pending-difm' ) {
+		window.location.replace(
+			`/setup/site-migration/site-migration-credentials?siteSlug=${ slug }&siteId=${ siteId }`
+		);
+		return;
+	} else if ( status === 'pending-diy' || status === 'inactive' ) {
+		window.location.replace(
+			`/setup/site-migration/site-migration-instructions?siteSlug=${ slug }&siteId=${ siteId }`
+		);
+		return;
+	}
+
 	// The courseSlug is to display pages with onboarding videos for learning,
 	// so we should not redirect the page to launchpad.
 	if ( courseSlug ) {
 		return next();
 	}
 
-	const siteId = getSelectedSiteId( state );
 	const site = getSelectedSite( state );
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	let fetchPromise;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -693,6 +693,7 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	 *
 	 */
 	hosting_intent?: string;
+	flow_name?: string;
 }
 
 export interface GSuiteProductUser {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -693,7 +693,6 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	 *
 	 */
 	hosting_intent?: string;
-	flow_name?: string;
 }
 
 export interface GSuiteProductUser {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9199

## Proposed Changes

* On the migration flow, pass an extra with the checkout purchase, `signup_flow`. This signals that a blog sticker should be added to the backend after checkout. See D161970-code  for the backend. 
* Intercept `/home/:site` and redirect to migration flow. 
* Disable the `/migrate/:site` redirect, which was causing issues with this PR. This redirect is related to Caribou's previous work.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's part of the pfuQfP-Hj-p2 project 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply patch D161970-code to your sandbox
* Using a migration flow, like `/setup/migration`
* Choose either DIFM or DIY and remember your choice
* Buy a plan on the flow and after checkout completes, confirm a sticker has been added to your blog:
   - `pending-migration-diy` if you chose DIY
   - `pending-migration-difm` if you chose DIFM
- TBC

<img width="517" alt="Screenshot 2567-09-25 at 10 54 43" src="https://github.com/user-attachments/assets/e3283b68-6a63-4431-bd45-eecb1602d8f6">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?