### PR TITLE
Stats: Update panel animations

### DIFF
--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -209,13 +209,6 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		window.open( FEEDBACK_LEAVE_REVIEW_URL );
 	};
 
-	const dismissPanelWithDelay = () => {
-		// Allows the animation to run first.
-		setTimeout( () => {
-			setIsFloatingPanelOpen( false );
-		}, FEEDBACK_PANEL_ANIMATION_DELAY_EXIT );
-	};
-
 	const handleButtonClick = ( action: string ) => {
 		switch ( action ) {
 			case ACTION_SEND_FEEDBACK:
@@ -224,12 +217,10 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 				} );
 				break;
 			case ACTION_DISMISS_FLOATING_PANEL:
+				dismissFloatingPanel();
 				if ( ! debug ) {
-					dismissPanelWithDelay();
 					updateFeedbackPanelHibernationDelayWithDebug();
 					trackStatsAnalyticsEvent( `stats_feedback_${ ACTION_DISMISS_FLOATING_PANEL }` );
-				} else {
-					dismissFloatingPanel();
 				}
 				break;
 			case ACTION_LEAVE_REVIEW:

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -163,6 +163,10 @@ function FeedbackCard( { clickHandler }: FeedbackPropsInternal ) {
 	);
 }
 
+// TODO: Remove debug mode.
+// And toggle panel button/action support.
+const FEEDBACK_DEBUG_MODE = true;
+
 function StatsFeedbackController( { siteId }: FeedbackProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ isFloatingPanelOpen, setIsFloatingPanelOpen ] = useState( false );
@@ -172,15 +176,6 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 
 	const { isPending, isError, shouldShowFeedbackPanel, updateFeedbackPanelHibernationDelay } =
 		useNoticeVisibilityHooks( siteId );
-
-	// Wrap hibernation delay callback for debugging.
-	const debug = true;
-	const updateFeedbackPanelHibernationDelayWithDebug = () => {
-		if ( debug ) {
-			return;
-		}
-		updateFeedbackPanelHibernationDelay();
-	};
 
 	useEffect( () => {
 		if ( ! isPending && ! isError && shouldShowFeedbackPanel ) {
@@ -222,8 +217,8 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 				break;
 			case ACTION_DISMISS_FLOATING_PANEL:
 				dismissFloatingPanel();
-				if ( ! debug ) {
-					updateFeedbackPanelHibernationDelayWithDebug();
+				if ( ! FEEDBACK_DEBUG_MODE ) {
+					updateFeedbackPanelHibernationDelay();
 					trackStatsAnalyticsEvent( `stats_feedback_${ ACTION_DISMISS_FLOATING_PANEL }` );
 				}
 				break;

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -184,6 +184,11 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		}
 	}, [ isPending, isError, shouldShowFeedbackPanel ] );
 
+	const presentPlugInPage = () => {
+		setIsFloatingPanelOpen( false );
+		window.open( FEEDBACK_LEAVE_REVIEW_URL );
+	};
+
 	const dismissPanelWithDelay = () => {
 		// Allows the animation to run first.
 		setTimeout( () => {
@@ -203,8 +208,7 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 				trackStatsAnalyticsEvent( `stats_feedback_${ ACTION_DISMISS_FLOATING_PANEL }` );
 				break;
 			case ACTION_LEAVE_REVIEW:
-				setIsFloatingPanelOpen( false );
-				window.open( FEEDBACK_LEAVE_REVIEW_URL );
+				presentPlugInPage();
 				break;
 			// Ignore other cases.
 		}

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -167,6 +167,15 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 	const { isPending, isError, shouldShowFeedbackPanel, updateFeedbackPanelHibernationDelay } =
 		useNoticeVisibilityHooks( siteId );
 
+	// Wrap hibernation delay callback for debugging.
+	const debug = true;
+	const updateFeedbackPanelHibernationDelayWithDebug = () => {
+		if ( debug ) {
+			return;
+		}
+		updateFeedbackPanelHibernationDelay();
+	};
+
 	useEffect( () => {
 		if ( ! isPending && ! isError && shouldShowFeedbackPanel ) {
 			setTimeout( () => {
@@ -190,7 +199,7 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 				break;
 			case ACTION_DISMISS_FLOATING_PANEL:
 				dismissPanelWithDelay();
-				updateFeedbackPanelHibernationDelay();
+				updateFeedbackPanelHibernationDelayWithDebug();
 				trackStatsAnalyticsEvent( `stats_feedback_${ ACTION_DISMISS_FLOATING_PANEL }` );
 				break;
 			case ACTION_LEAVE_REVIEW:

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -184,6 +184,16 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		}
 	}, [ isPending, isError, shouldShowFeedbackPanel ] );
 
+	const toggleFloatingPanel = () => {
+		if ( isFloatingPanelOpen ) {
+			setTimeout( () => {
+				setIsFloatingPanelOpen( false );
+			}, FEEDBACK_PANEL_ANIMATION_DELAY_EXIT );
+		} else {
+			setIsFloatingPanelOpen( true );
+		}
+	};
+
 	const presentPlugInPage = () => {
 		setIsFloatingPanelOpen( false );
 		window.open( FEEDBACK_LEAVE_REVIEW_URL );
@@ -208,7 +218,11 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 				trackStatsAnalyticsEvent( `stats_feedback_${ ACTION_DISMISS_FLOATING_PANEL }` );
 				break;
 			case ACTION_LEAVE_REVIEW:
-				presentPlugInPage();
+				if ( debug ) {
+					toggleFloatingPanel();
+				} else {
+					presentPlugInPage();
+				}
 				break;
 			// Ignore other cases.
 		}

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -213,11 +213,6 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		} );
 	}
 
-	const presentPlugInPage = () => {
-		setIsFloatingPanelOpen( false );
-		window.open( FEEDBACK_LEAVE_REVIEW_URL );
-	};
-
 	const handleButtonClick = ( action: string ) => {
 		switch ( action ) {
 			case ACTION_SEND_FEEDBACK:
@@ -233,11 +228,9 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 				}
 				break;
 			case ACTION_LEAVE_REVIEW:
-				if ( debug ) {
-					toggleFloatingPanel();
-				} else {
-					presentPlugInPage();
-				}
+				dismissFloatingPanel().then( () => {
+					window.open( FEEDBACK_LEAVE_REVIEW_URL );
+				} );
 				break;
 			case 'present-panel':
 				toggleFloatingPanel();

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -95,6 +95,15 @@ function FeedbackContent( { clickHandler }: FeedbackPropsInternal ) {
 					<span className="stats-feedback-content__emoji">😠</span>
 					{ secondaryButtonText }
 				</Button>
+				<Button
+					variant="secondary"
+					onClick={ () => {
+						clickHandler( 'present-panel' );
+					} }
+				>
+					<span className="stats-feedback-content__emoji">🐞</span>
+					Show panel
+				</Button>
 			</div>
 		</div>
 	);
@@ -229,6 +238,9 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 				} else {
 					presentPlugInPage();
 				}
+				break;
+			case 'present-panel':
+				toggleFloatingPanel();
 				break;
 			// Ignore other cases.
 		}

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -63,6 +63,7 @@ interface FeedbackProps {
 }
 
 interface FeedbackPropsInternal {
+	animationClassName?: string;
 	clickHandler: ( action: string ) => void;
 	isOpen?: boolean;
 }
@@ -99,22 +100,17 @@ function FeedbackContent( { clickHandler }: FeedbackPropsInternal ) {
 	);
 }
 
-function FeedbackPanel( { isOpen, clickHandler }: FeedbackPropsInternal ) {
+function FeedbackPanel( { isOpen, animationClassName, clickHandler }: FeedbackPropsInternal ) {
 	const translate = useTranslate();
-	const [ animationClassName, setAnimationClassName ] = useState(
-		FEEDBACK_PANEL_ANIMATION_NAME_ENTRY
-	);
 
 	const handleCloseButtonClicked = () => {
 		clickHandler( ACTION_DISMISS_FLOATING_PANEL );
-		setAnimationClassName( FEEDBACK_PANEL_ANIMATION_NAME_EXIT );
 	};
 
 	const clickHandlerWithAnalytics = ( action: string ) => {
 		// stats_feedback_action_redirect_to_plugin_review_page_from_floating_panel
 		// stats_feedback_action_open_form_modal_from_floating_panel
 		trackStatsAnalyticsEvent( `stats_feedback_${ action }_from_floating_panel` );
-
 		clickHandler( action );
 	};
 
@@ -161,6 +157,7 @@ function FeedbackCard( { clickHandler }: FeedbackPropsInternal ) {
 function StatsFeedbackController( { siteId }: FeedbackProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ isFloatingPanelOpen, setIsFloatingPanelOpen ] = useState( false );
+	const [ animationName, setAnimationName ] = useState( FEEDBACK_PANEL_ANIMATION_NAME_ENTRY );
 
 	const { supportCommercialUse } = useStatsPurchases( siteId );
 
@@ -186,11 +183,13 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 
 	const toggleFloatingPanel = () => {
 		if ( isFloatingPanelOpen ) {
+			setAnimationName( FEEDBACK_PANEL_ANIMATION_NAME_EXIT );
 			setTimeout( () => {
 				setIsFloatingPanelOpen( false );
 			}, FEEDBACK_PANEL_ANIMATION_DELAY_EXIT );
 		} else {
 			setIsFloatingPanelOpen( true );
+			setAnimationName( FEEDBACK_PANEL_ANIMATION_NAME_ENTRY );
 		}
 	};
 
@@ -241,7 +240,11 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 	return (
 		<div className="stats-feedback-container">
 			<FeedbackCard clickHandler={ handleButtonClick } />
-			<FeedbackPanel isOpen={ isFloatingPanelOpen } clickHandler={ handleButtonClick } />
+			<FeedbackPanel
+				isOpen={ isFloatingPanelOpen }
+				animationClassName={ animationName }
+				clickHandler={ handleButtonClick }
+			/>
 			{ isOpen && <FeedbackModal siteId={ siteId } onClose={ onModalClose } /> }
 		</div>
 	);

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -95,15 +95,6 @@ function FeedbackContent( { clickHandler }: FeedbackPropsInternal ) {
 					<span className="stats-feedback-content__emoji">😠</span>
 					{ secondaryButtonText }
 				</Button>
-				<Button
-					variant="secondary"
-					onClick={ () => {
-						clickHandler( 'present-panel' );
-					} }
-				>
-					<span className="stats-feedback-content__emoji">🐞</span>
-					Show panel
-				</Button>
 			</div>
 		</div>
 	);
@@ -163,10 +154,6 @@ function FeedbackCard( { clickHandler }: FeedbackPropsInternal ) {
 	);
 }
 
-// TODO: Remove debug mode.
-// And toggle panel button/action support.
-const FEEDBACK_DEBUG_MODE = true;
-
 function StatsFeedbackController( { siteId }: FeedbackProps ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ isFloatingPanelOpen, setIsFloatingPanelOpen ] = useState( false );
@@ -184,18 +171,6 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 			}, FEEDBACK_PANEL_PRESENTATION_DELAY );
 		}
 	}, [ isPending, isError, shouldShowFeedbackPanel ] );
-
-	const toggleFloatingPanel = () => {
-		if ( isFloatingPanelOpen ) {
-			setAnimationName( FEEDBACK_PANEL_ANIMATION_NAME_EXIT );
-			setTimeout( () => {
-				setIsFloatingPanelOpen( false );
-			}, FEEDBACK_PANEL_ANIMATION_DELAY_EXIT );
-		} else {
-			setIsFloatingPanelOpen( true );
-			setAnimationName( FEEDBACK_PANEL_ANIMATION_NAME_ENTRY );
-		}
-	};
 
 	function dismissFloatingPanel() {
 		const delay = isFloatingPanelOpen ? FEEDBACK_PANEL_ANIMATION_DELAY_EXIT : 0;
@@ -217,18 +192,13 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 				break;
 			case ACTION_DISMISS_FLOATING_PANEL:
 				dismissFloatingPanel();
-				if ( ! FEEDBACK_DEBUG_MODE ) {
-					updateFeedbackPanelHibernationDelay();
-					trackStatsAnalyticsEvent( `stats_feedback_${ ACTION_DISMISS_FLOATING_PANEL }` );
-				}
+				updateFeedbackPanelHibernationDelay();
+				trackStatsAnalyticsEvent( `stats_feedback_${ ACTION_DISMISS_FLOATING_PANEL }` );
 				break;
 			case ACTION_LEAVE_REVIEW:
 				dismissFloatingPanel().then( () => {
 					window.open( FEEDBACK_LEAVE_REVIEW_URL );
 				} );
-				break;
-			case 'present-panel':
-				toggleFloatingPanel();
 				break;
 			// Ignore other cases.
 		}

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -193,6 +193,17 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		}
 	};
 
+	function dismissFloatingPanel() {
+		const delay = isFloatingPanelOpen ? FEEDBACK_PANEL_ANIMATION_DELAY_EXIT : 0;
+		setAnimationName( FEEDBACK_PANEL_ANIMATION_NAME_EXIT );
+		return new Promise( ( resolve ) => {
+			setTimeout( () => {
+				setIsFloatingPanelOpen( false );
+				resolve( '' );
+			}, delay );
+		} );
+	}
+
 	const presentPlugInPage = () => {
 		setIsFloatingPanelOpen( false );
 		window.open( FEEDBACK_LEAVE_REVIEW_URL );
@@ -208,13 +219,18 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 	const handleButtonClick = ( action: string ) => {
 		switch ( action ) {
 			case ACTION_SEND_FEEDBACK:
-				setIsFloatingPanelOpen( false );
-				setIsOpen( true );
+				dismissFloatingPanel().then( () => {
+					setIsOpen( true );
+				} );
 				break;
 			case ACTION_DISMISS_FLOATING_PANEL:
-				dismissPanelWithDelay();
-				updateFeedbackPanelHibernationDelayWithDebug();
-				trackStatsAnalyticsEvent( `stats_feedback_${ ACTION_DISMISS_FLOATING_PANEL }` );
+				if ( ! debug ) {
+					dismissPanelWithDelay();
+					updateFeedbackPanelHibernationDelayWithDebug();
+					trackStatsAnalyticsEvent( `stats_feedback_${ ACTION_DISMISS_FLOATING_PANEL }` );
+				} else {
+					dismissFloatingPanel();
+				}
 				break;
 			case ACTION_LEAVE_REVIEW:
 				if ( debug ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/173

## Proposed Changes

Controller manages animation via classnames. In this way the panel is always animated smoothly offscreen regardless of which button/action is triggered. Previously only the "x" and Dismiss actions would trigger an animation.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Keeps panel behaviour consistent.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on a site with a commercial Stats plan.
* Visit the Traffic page.
* Refresh the page and confirm the floating panel is presented with an animation (after a short delay).
* Scroll down to the inline card and click either of the buttons.
* Confirm the panel animation runs before the next action is taken. In practice, this means a slight delay before opening the review page or presenting the feedback modal.

Note: If you check out `d18c92a8` locally there's an extra button to show/hide the panel for easier testing without submitting or throttling.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
