### PR TITLE
Performance Profiler: add feedback form to negative feedback

### DIFF
--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -246,8 +246,9 @@ $blueberry-color: #3858e9;
 						}
 					}
 
-					textarea {
-						width: 380px;
+					.feedback-textarea {
+						width: 100%;
+						max-width: 400px;
 					}
 
 					textarea:focus,

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -240,9 +240,9 @@ $blueberry-color: #3858e9;
 							background-color: darken($blueberry-color, 10%);
 						}
 
-						&:hover {
-							color: darken($blueberry-color, 10%);
-							text-decoration: underline;
+						&:focus:not(:disabled) {
+							background-color: darken($blueberry-color, 10%);
+							box-shadow: none;
 						}
 					}
 

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -222,10 +222,13 @@ $blueberry-color: #3858e9;
 					align-items: center;
 					gap: 16px;
 					flex-wrap: wrap;
+
+					&.wrapped {
+						flex-basis: 100%;
+					}
 				}
 
 				.survey-form {
-					flex-basis: 100%;
 					display: flex;
 					flex-direction: column;
 					align-items: flex-start;
@@ -248,7 +251,6 @@ $blueberry-color: #3858e9;
 
 					.feedback-textarea {
 						width: 100%;
-						max-width: 400px;
 					}
 
 					textarea:focus,

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -224,6 +224,39 @@ $blueberry-color: #3858e9;
 					flex-wrap: wrap;
 				}
 
+				.survey-form {
+					flex-basis: 100%;
+					display: flex;
+					flex-direction: column;
+					align-items: flex-start;
+					gap: 16px;
+
+					button.is-primary {
+						color: #fff;
+						background-color: $blueberry-color;
+						border-radius: 4px;
+
+						&:hover:not(:disabled) {
+							background-color: darken($blueberry-color, 10%);
+						}
+
+						&:hover {
+							color: darken($blueberry-color, 10%);
+							text-decoration: underline;
+						}
+					}
+
+					textarea {
+						width: 380px;
+					}
+
+					textarea:focus,
+					textarea:focus-visible {
+						border-color: $blueberry-color;
+						box-shadow: 0 0 0 calc(1.5px - 1px)  $blueberry-color;
+					}
+				}
+
 				.options {
 					display: flex;
 					align-items: center;

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -1,3 +1,4 @@
+import { Button, TextareaControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import Markdown from 'react-markdown';
@@ -23,13 +24,66 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 	const { data, fullPageScreenshot, isLoading, AIGenerated } = props;
 	const { description = '' } = data ?? {};
 	const [ feedbackSent, setFeedbackSent ] = useState( false );
+	const [ feedbackOpen, setFeedbackOpen ] = useState( false );
+	const [ userFeedback, setUserFeedback ] = useState( '' );
 	const onSurveyClick = ( rating: string ) => {
 		recordTracksEvent( 'calypso_performance_profiler_llm_survey_click', {
 			rating,
 			description,
+			...( userFeedback && { user_feedback: userFeedback } ),
 		} );
 
 		setFeedbackSent( true );
+	};
+
+	const renderFeedbackForm = () => {
+		if ( feedbackSent ) {
+			return <div className="survey">{ translate( 'Thanks for the feedback!' ) }</div>;
+		}
+
+		if ( feedbackOpen ) {
+			return (
+				<div className="survey-form">
+					<div>{ translate( 'Thanks for the feedback! Tell us more about your experience' ) }</div>
+					<TextareaControl
+						__nextHasNoMarginBottom
+						rows={ 4 }
+						onChange={ ( value ) => setUserFeedback( value ) }
+						value={ userFeedback }
+					/>
+					<Button variant="primary" onClick={ () => onSurveyClick( 'bad' ) }>
+						{ translate( 'Send' ) }
+					</Button>
+				</div>
+			);
+		}
+
+		return (
+			<div className="survey">
+				<span>{ translate( 'How did we do?' ) }</span>
+				<div
+					className="options good"
+					onClick={ () => onSurveyClick( 'good' ) }
+					onKeyUp={ () => onSurveyClick( 'good' ) }
+					role="button"
+					tabIndex={ 0 }
+				>
+					<ThumbsUpIcon />
+
+					{ translate( 'Good, it‘s helpful' ) }
+				</div>
+				<div
+					className="options bad"
+					onClick={ () => setFeedbackOpen( true ) }
+					onKeyUp={ () => setFeedbackOpen( true ) }
+					role="button"
+					tabIndex={ 0 }
+				>
+					<ThumbsDownIcon />
+					{ translate( 'Not helpful' ) }
+				</div>
+			</div>
+		);
 	};
 
 	return (
@@ -58,38 +112,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 							message={
 								<span className="generated-with-ai">{ translate( 'Generated with AI' ) }</span>
 							}
-							secondaryArea={
-								<div className="survey">
-									{ feedbackSent ? (
-										translate( 'Thanks for the feedback!' )
-									) : (
-										<>
-											<span>{ translate( 'How did we do?' ) }</span>
-											<div
-												className="options good"
-												onClick={ () => onSurveyClick( 'good' ) }
-												onKeyUp={ () => onSurveyClick( 'good' ) }
-												role="button"
-												tabIndex={ 0 }
-											>
-												<ThumbsUpIcon />
-
-												{ translate( 'Good, it‘s helpful' ) }
-											</div>
-											<div
-												className="options bad"
-												onClick={ () => onSurveyClick( 'bad' ) }
-												onKeyUp={ () => onSurveyClick( 'bad' ) }
-												role="button"
-												tabIndex={ 0 }
-											>
-												<ThumbsDownIcon />
-												{ translate( 'Not helpful' ) }
-											</div>
-										</>
-									) }
-								</div>
-							}
+							secondaryArea={ renderFeedbackForm() }
 						/>
 					) }
 

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -43,18 +43,22 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 
 		if ( feedbackOpen ) {
 			return (
-				<div className="survey-form">
-					<div>{ translate( 'Thanks for the feedback! Tell us more about your experience' ) }</div>
-					<TextareaControl
-						className="feedback-textarea"
-						__nextHasNoMarginBottom
-						rows={ 4 }
-						onChange={ ( value ) => setUserFeedback( value ) }
-						value={ userFeedback }
-					/>
-					<Button variant="primary" onClick={ () => onSurveyClick( 'bad' ) }>
-						{ translate( 'Send feedback' ) }
-					</Button>
+				<div className="survey wrapped">
+					<div className="survey-form">
+						<div>
+							{ translate( 'Thanks for the feedback! Tell us more about your experience' ) }
+						</div>
+						<TextareaControl
+							className="feedback-textarea"
+							__nextHasNoMarginBottom
+							rows={ 4 }
+							onChange={ ( value ) => setUserFeedback( value ) }
+							value={ userFeedback }
+						/>
+						<Button variant="primary" onClick={ () => onSurveyClick( 'bad' ) }>
+							{ translate( 'Send feedback' ) }
+						</Button>
+					</div>
 				</div>
 			);
 		}

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -46,13 +46,14 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 				<div className="survey-form">
 					<div>{ translate( 'Thanks for the feedback! Tell us more about your experience' ) }</div>
 					<TextareaControl
+						className="feedback-textarea"
 						__nextHasNoMarginBottom
 						rows={ 4 }
 						onChange={ ( value ) => setUserFeedback( value ) }
 						value={ userFeedback }
 					/>
 					<Button variant="primary" onClick={ () => onSurveyClick( 'bad' ) }>
-						{ translate( 'Send' ) }
+						{ translate( 'Send feedback' ) }
 					</Button>
 				</div>
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9164

## Proposed Changes

* add feedback form to negative feedback
* store feedback in tracks event

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/dotcom-forge/issues/9164

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/speed-test` and start a new test, or go to a results page eg. `/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzA1N30.7KXaBL1qcm0y0GqvM8ymJ0pbST9ls6P09_hri8EaKSI`
* Go to the insights, open one, and click the `Not Helpful` button
* Check that the feedback form opens, fill it out, and click the `Send feedback` button
* Check that the tracks event is sent
![CleanShot 2024-09-20 at 11 53 52@2x](https://github.com/user-attachments/assets/6303c08e-9291-42d8-9de2-e13e4abad3f3)

https://github.com/user-attachments/assets/cb348002-c01d-4c3e-9f96-517466acd0cd

