### PR TITLE
Launchpad experiment: Remove dev/testing code

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -74,13 +74,7 @@ export function shouldShowCustomerHome(
 	isLoadingExperiment: boolean,
 	experimentAssignment: ExperimentAssignment | null
 ): boolean {
-	return (
-		! isLoadingExperiment &&
-		( 'treatment' === experimentAssignment?.variationName ||
-			// for testing/development purposes we can use sessionStorage to force the treatment
-			'treatment' ===
-				window.sessionStorage.getItem( 'launchpad_removal_2024_experiment_variation' ) )
-	);
+	return ! isLoadingExperiment && 'treatment' === experimentAssignment?.variationName;
 }
 
 /**

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -72,11 +72,7 @@ export async function maybeRedirect( context, next ) {
 			'calypso_onboarding_launchpad_removal_test_2024_08'
 		);
 
-		const shouldShowLaunchpad =
-			'treatment' !== experimentAssignment?.variationName &&
-			// for testing/development purposes we can use sessionStorage to force the treatment
-			'treatment' !==
-				window.sessionStorage.getItem( 'launchpad_removal_2024_experiment_variation' );
+		const shouldShowLaunchpad = 'treatment' !== experimentAssignment?.variationName;
 
 		if (
 			shouldShowLaunchpad &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/93205

## Proposed Changes

Remove dev/testing piece of code

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Since the experiment is running, we no longer need the testing piece of code.

## Testing Instructions

* No need any special testing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
