### PR TITLE
Foldable FAQ: Fix chevron SVG shrinking

### DIFF
--- a/client/components/foldable-faq/style.scss
+++ b/client/components/foldable-faq/style.scss
@@ -22,6 +22,7 @@ button.foldable-faq__question {
 	cursor: pointer;
 
 	.gridicon {
+		flex-shrink: 0;
 		fill: var(--color-gray-50);
 
 		transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;


### PR DESCRIPTION
## Proposed Changes

* This PR updates the foldable FAQ styling to make sure the icon remains the same size independent of the header length.

Before:
![image](https://github.com/user-attachments/assets/7bd99e9d-8b4f-4da5-b27c-07a808b42d65)
After:
![image](https://github.com/user-attachments/assets/3a123104-e6cf-4e25-a8e8-d691d0fa0fc8)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `setup/new-hosted-site/plans` 
* Confirm that the FAQ chevrons are displayed correctly on small screens / with longer text. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
