### PR TITLE
Sites: Fix Jetpack logo misalignment in the DataViews Properties list

### DIFF
--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -116,13 +116,6 @@
 			text-transform: uppercase;
 		}
 
-		svg {
-			&:not(:last-child) {
-				margin-right: 4px;
-				vertical-align: middle;
-			}
-		}
-
 		.dataviews-view-table-header-button {
 			color: inherit;
 		}

--- a/client/hosting/sites/components/sites-dataviews/index.tsx
+++ b/client/hosting/sites/components/sites-dataviews/index.tsx
@@ -161,10 +161,10 @@ const DotcomSitesDataViews = ( {
 				id: 'stats',
 				// @ts-expect-error -- Need to fix the label type upstream in @wordpress/dataviews to support React elements.
 				label: (
-					<>
+					<span className="sites-dataviews__stats-label">
 						<JetpackLogo size={ 16 } />
 						<span>{ __( 'Stats' ) }</span>
-					</>
+					</span>
 				),
 				render: ( { item }: { item: SiteExcerptData } ) => <SiteStats site={ item } />,
 				enableHiding: false,

--- a/client/hosting/sites/components/sites-dataviews/style.scss
+++ b/client/hosting/sites/components/sites-dataviews/style.scss
@@ -134,3 +134,10 @@
 .sites-overview__content .dataviews-wrapper .dataviews-filters__view-actions .components-h-stack button:nth-of-type(3) {
 	display: none;
 }
+
+// Style the Stats label that includes the Jetpack logo
+.sites-dataviews__stats-label {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}

--- a/client/hosting/sites/components/sites-dataviews/style.scss
+++ b/client/hosting/sites/components/sites-dataviews/style.scss
@@ -139,5 +139,5 @@
 .sites-dataviews__stats-label {
 	display: flex;
 	align-items: center;
-	gap: 4px;
+	gap: 6px;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94761

## Proposed Changes

* Add a span class for the Stats label that includes the Jetpack logo.
* Remove the previous style rule that didn't apply to all instances of the label.

Before | After
---- | -----
<img width="380" alt="Screen Shot 2024-09-20 at 10 36 03 AM" src="https://github.com/user-attachments/assets/bbca50d6-7e08-4e8b-8f2b-cd7fbaa52adb"> | <img width="384" alt="Screen Shot 2024-09-20 at 10 29 29 AM" src="https://github.com/user-attachments/assets/b42cd7ce-f10d-4296-a721-aef119bbe313">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix a bug resulting from updating the DataViews package to 14.3.0.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Click the gear icon.
* Verify that the Jetpack icon is aligned with "Stats".
* Regression test that the Jetpack icon is aligned in the table header.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
