### PR TITLE
Performance Profiler: handle null values in history chart

### DIFF
--- a/client/performance-profiler/components/charts/history-chart.jsx
+++ b/client/performance-profiler/components/charts/history-chart.jsx
@@ -21,8 +21,10 @@ const createScales = ( data, range, margin, width, height ) => {
 		.domain( d3Extent( data, ( item ) => new Date( item.date ) ) )
 		.range( [ margin.left + 20, width - margin.right - 20 ] );
 
+	const maxItemValue = d3Max( data, ( item ) => item.value );
+
 	const yScale = d3ScaleLinear()
-		.domain( [ 0, d3Max( data, ( item ) => item.value ) * 1.5 ] )
+		.domain( [ 0, maxItemValue === 0 ? 1 : maxItemValue * 1.5 ] )
 		.nice()
 		.range( [ height - margin.bottom, margin.top ] );
 
@@ -83,8 +85,12 @@ const drawGrid = ( svg, yScale, width, margin ) => {
 // Draw line with gradient
 const drawLine = ( svg, data, xScale, yScale ) => {
 	const lineGenerator = d3Line()
+		.defined( ( d ) => ! isNaN( d.value ) )
 		.x( ( item ) => xScale( new Date( item.date ) ) )
-		.y( ( item ) => yScale( item.value ) )
+		.y( ( item ) => {
+			const value = item.value;
+			return isNaN( value ) ? null : yScale( item.value );
+		} )
 		.curve( d3MonotoneXCurve );
 
 	svg

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -45,11 +45,12 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 
 	const { good, needsImprovement } = metricsTresholds[ activeTab ];
 
-	const formatUnit = ( value: number ) => {
+	const formatUnit = ( value: number | string ) => {
+		const num = parseFloat( value as string );
 		if ( [ 'lcp', 'fcp', 'ttfb' ].includes( activeTab ) ) {
-			return +( value / 1000 ).toFixed( 2 );
+			return +( num / 1000 ).toFixed( 2 );
 		}
-		return value;
+		return num;
 	};
 
 	const displayUnit = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9188

## Proposed Changes

* don't render null values as 0 on the history chart
* add Y axis scales to the chart even when all values are 0

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/dotcom-forge/issues/9188

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/speed-test` and start a new test for a site that doesn't have historical data for all 8 weeks, or use this report:
```
/speed-test-tool?url=https://stitchandstyle.ie/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzgyOX0.3nU626e3YxQ7lpMXD6t_zXCwJpCAKUVXDVpNquLh0eM
```
* Check in the API response that not all dates have values in the report
* Check that the history chart renders only the existing data, and that it's rendered correctly
* Check that on the CLS chart, if all values are 0, the Y axis still has a maximum value of 1

| Issue | Before | After |
|--------|--------|--------|
| Null values | ![CleanShot 2024-09-20 at 15 28 35@2x](https://github.com/user-attachments/assets/404ab4bf-6a92-4b83-a190-c34d50f4ab69) | ![CleanShot 2024-09-20 at 15 28 21@2x](https://github.com/user-attachments/assets/7e921d47-d192-42e8-b0d5-83a6c3df24a4) |
| Graph scaling | ![CleanShot 2024-09-20 at 15 28 41@2x](https://github.com/user-attachments/assets/faaf55c4-5162-4516-85e0-be77ba983b10) | ![CleanShot 2024-09-20 at 15 28 27@2x](https://github.com/user-attachments/assets/7aa83599-6563-42e5-9402-bf017441cb0b) | 
