### PR TITLE
Site management panel - Keep "WP Admin" and "Home" button primary across all tabs

### DIFF
--- a/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -34,7 +34,6 @@ interface Props {
 	selectedSiteFeaturePreview: React.ReactNode;
 	closeSitePreviewPane: () => void;
 	changeSitePreviewPane: ( siteId: number ) => void;
-	sectionName?: string;
 }
 
 const OVERLAY_MODAL_SELECTORS = [
@@ -42,12 +41,6 @@ const OVERLAY_MODAL_SELECTORS = [
 	'#wpnc-panel.wpnt-open',
 	'div.help-center__container:not(.is-minimized)',
 ];
-
-type HeaderButtonsProps = {
-	focusRef: React.RefObject< HTMLButtonElement >;
-	itemData: ItemData;
-	closeSitePreviewPane: () => void;
-};
 
 const DotcomPreviewPane = ( {
 	site,
@@ -200,9 +193,7 @@ const DotcomPreviewPane = ( {
 			itemPreviewPaneHeaderExtraProps={ {
 				externalIconSize: 16,
 				siteIconFallback: 'first-grapheme',
-				headerButtons: ( props: HeaderButtonsProps ) => (
-					<PreviewPaneHeaderButtons { ...props } sectionName={ selectedSiteFeature } />
-				),
+				headerButtons: PreviewPaneHeaderButtons,
 				subtitleExtra: () =>
 					( site.is_wpcom_staging_site || isStagingStatusFinished ) && (
 						<SiteEnvironmentSwitcher onChange={ changeSitePreviewPane } site={ site } />

--- a/client/hosting/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/hosting/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -14,16 +14,10 @@ type Props = {
 	sectionName?: string;
 };
 
-const PreviewPaneHeaderButtons = ( {
-	focusRef,
-	closeSitePreviewPane,
-	itemData,
-	sectionName,
-}: Props ) => {
+const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane, itemData }: Props ) => {
 	const adminButtonRef = useRef< HTMLButtonElement | null >( null );
 	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( itemData.blogId );
 	const { __ } = useI18n();
-	const isHostingOverview = sectionName === 'dotcom-hosting';
 
 	return (
 		<>
@@ -31,7 +25,7 @@ const PreviewPaneHeaderButtons = ( {
 				{ __( 'Close' ) }
 			</Button>
 			<Button
-				primary={ isHostingOverview }
+				primary
 				className="item-preview__admin-button"
 				href={ `${ adminUrl }` }
 				ref={ useMergeRefs( [ adminButtonRef, focusRef ] ) }

--- a/client/hosting/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/hosting/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -11,7 +11,6 @@ type Props = {
 	focusRef: React.RefObject< HTMLButtonElement >;
 	itemData: ItemData;
 	closeSitePreviewPane?: () => void;
-	sectionName?: string;
 };
 
 const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane, itemData }: Props ) => {

--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -93,7 +93,6 @@ const SitesDashboard = ( {
 	selectedSite,
 	initialSiteFeature = DOTCOM_OVERVIEW,
 	selectedSiteFeaturePreview = undefined,
-	sectionName,
 }: SitesDashboardProps ) => {
 	const [ initialSortApplied, setInitialSortApplied ] = useState( false );
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
@@ -442,7 +441,6 @@ const SitesDashboard = ( {
 							setSelectedSiteFeature={ setSelectedSiteFeature }
 							closeSitePreviewPane={ closeSitePreviewPane }
 							changeSitePreviewPane={ changeSitePreviewPane }
-							sectionName={ sectionName }
 						/>
 					</LayoutColumn>
 					<GuidedTour defaultTourId="siteManagementTour" />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/94770

## Proposed Changes

* This PR makes the "Home" and "WP Admin" buttons in the upper right on the /sites screens always a primary CTA button.
* To do this, we revert some of the changes made in https://github.com/Automattic/wp-calypso/pull/94192 that allowed the button to be primary only on specific tabs.
* This PR doesn't change any other button colors.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Design and user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /sites and open all the Hosting tabs for a simple and Atomic site and confirm the Home and WP Admin buttons are blue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
