### PR TITLE
Logged-in Performance Profiler: Persist selection on query change

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -122,6 +122,12 @@ export const SitePerformance = () => {
 		}
 	}, [ pages, currentPage, currentPageId ] );
 
+	const pageOptions = useMemo( () => {
+		return currentPage
+			? [ currentPage, ...orderedPages.filter( ( p ) => p.value !== currentPage.value ) ]
+			: orderedPages;
+	}, [ currentPage, orderedPages ] );
+
 	const [ wpcom_performance_report_url, setWpcom_performance_report_url ] = useState(
 		currentPage?.wpcom_performance_report_url
 	);
@@ -229,7 +235,8 @@ export const SitePerformance = () => {
 				/>
 				<PageSelector
 					onFilterValueChange={ setQuery }
-					options={ orderedPages }
+					allowReset={ false }
+					options={ pageOptions }
 					onChange={ ( page_id ) => {
 						const url = new URL( window.location.href );
 

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -114,10 +114,14 @@ export const SitePerformance = () => {
 	const currentPageId = queryParams?.page_id?.toString() ?? '0';
 	const filter = queryParams?.filter?.toString();
 	const [ recommendationsFilter, setRecommendationsFilter ] = useState( filter );
-	const currentPage = useMemo(
-		() => pages.find( ( page ) => page.value === currentPageId ),
-		[ pages, currentPageId ]
-	);
+	const [ currentPage, setCurrentPage ] = useState< ( typeof pages )[ number ] >();
+
+	useEffect( () => {
+		if ( pages && ! currentPage ) {
+			setCurrentPage( pages.find( ( page ) => page.value === currentPageId ) );
+		}
+	}, [ pages, currentPage, currentPageId ] );
+
 	const [ wpcom_performance_report_url, setWpcom_performance_report_url ] = useState(
 		currentPage?.wpcom_performance_report_url
 	);
@@ -230,8 +234,10 @@ export const SitePerformance = () => {
 						const url = new URL( window.location.href );
 
 						if ( page_id ) {
+							setCurrentPage( pages.find( ( page ) => page.value === page_id ) );
 							url.searchParams.set( 'page_id', page_id );
 						} else {
+							setCurrentPage( undefined );
 							url.searchParams.delete( 'page_id' );
 						}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9196.

## Proposed Changes

Preserve the selected page as state so changing the query won't reset it. The previous behavior was happening because a new query means a new `pages` array, which might or might not have the selected page, despite the selection not changing.

## Testing Instructions

1. Verify that changing the query preserves the selected page
2. Verify that typing anything in the textbox and then blurring it preserves the selected page instead of displaying a blank box