### PR TITLE
Paid Newsletter Importer: Only show the confetti once.

### DIFF
--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -1,6 +1,6 @@
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import FormattedHeader from 'calypso/components/formatted-header';
 import StepProgress from 'calypso/components/step-progress';
@@ -19,7 +19,7 @@ import SelectNewsletterForm from './select-newsletter-form';
 import Subscribers from './subscribers';
 import Summary from './summary';
 import { EngineTypes } from './types';
-import { getSetpProgressSteps } from './utils';
+import { getSetpProgressSteps, getImporterStatus } from './utils';
 
 import './importer.scss';
 
@@ -127,6 +127,21 @@ export default function NewsletterImporter( {
 		}
 	);
 
+	// Helps only show the confetti once even if you navigate between the different steps.
+	const shouldShowConfettiRef = useRef( false );
+	const [ showConfetti, setShowConfetti ] = useState( false );
+	const importerStatus = getImporterStatus(
+		paidNewsletterData?.steps.content.status,
+		paidNewsletterData?.steps.subscribers.status
+	);
+
+	useEffect( () => {
+		if ( importerStatus === 'done' && ! shouldShowConfettiRef.current ) {
+			shouldShowConfettiRef.current = true;
+			setShowConfetti( true );
+		}
+	}, [ importerStatus, showConfetti ] );
+
 	return (
 		<div className={ clsx( 'newsletter-importer', 'newsletter-importer__step-' + step ) }>
 			<LogoChain logos={ logoChainLogos } />
@@ -180,6 +195,8 @@ export default function NewsletterImporter( {
 							steps={ paidNewsletterData.steps }
 							engine={ engine }
 							fromSite={ fromSite }
+							showConfetti={ showConfetti }
+							shouldShownConfetti={ setShowConfetti }
 						/>
 					) }
 				</>

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -1,6 +1,7 @@
 import { Card, ConfettiAnimation } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { Notice } from '@wordpress/components';
+import { Dispatch, SetStateAction, useEffect } from 'react';
 import { Steps, StepStatus } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import { useResetMutation } from 'calypso/data/paid-newsletter/use-reset-mutation';
 import ImporterActionButton from '../importer-action-buttons/action-button';
@@ -27,12 +28,20 @@ interface SummaryProps {
 	steps: Steps;
 	engine: EngineTypes;
 	fromSite: string;
+	showConfetti: boolean;
+	shouldShownConfetti: Dispatch< SetStateAction< boolean > >;
 }
 
-export default function Summary( { steps, selectedSite, engine, fromSite }: SummaryProps ) {
+export default function Summary( {
+	steps,
+	selectedSite,
+	engine,
+	fromSite,
+	showConfetti,
+	shouldShownConfetti,
+}: SummaryProps ) {
 	const { resetPaidNewsletter } = useResetMutation();
 	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
-	const importerStatus = getImporterStatus( steps.content.status, steps.subscribers.status );
 
 	const onButtonClick = () => resetPaidNewsletter( selectedSite.ID, engine, 'content' );
 	const paidSubscribersCount = parseInt(
@@ -40,10 +49,17 @@ export default function Summary( { steps, selectedSite, engine, fromSite }: Summ
 	);
 	const showPauseSubstackBillingWarning = paidSubscribersCount > 0;
 
+	useEffect( () => {
+		if ( showConfetti ) {
+			shouldShownConfetti( false );
+		}
+	}, [ showConfetti, shouldShownConfetti ] );
+
+	const importerStatus = getImporterStatus( steps.content.status, steps.subscribers.status );
+
 	return (
 		<Card>
-			{ importerStatus === 'done' && <ConfettiAnimation trigger={ ! prefersReducedMotion } /> }
-
+			{ showConfetti && <ConfettiAnimation trigger={ ! prefersReducedMotion } /> }
 			<h2>{ getStepTitle( importerStatus ) }</h2>
 
 			{ steps.content.content && (


### PR DESCRIPTION
## Proposed Changes

* This PR make it so that if you navigate around you will only ever see the confetti once on the summary page. 
* It used the useRef for persistence and resets the flag once after it has been shown and the animation has fired. 

## Why are these changes being made?

* To improve the UX. The repeat confetti animation is nice but can also be annoying. 

## Testing Instructions

* Bring up the summary page with one of the importers completed. (the other once needs to be skipped)
notice the that now when you navigate between the different steps. Using the stepper or the back button that the confetti animation get triggered only once. 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
