### PR TITLE
Logged-in Performance Profiler: Fix layout shift

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-accordion/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-accordion/index.tsx
@@ -51,40 +51,42 @@ export const CoreWebVitalsAccordion = ( props: Props ) => {
 
 	return (
 		<div className="core-web-vitals-accordion">
-			{ Object.entries( metricsNames ).map( ( [ key, { name: displayName } ] ) => {
-				if ( props[ key as Metrics ] === undefined || props[ key as Metrics ] === null ) {
-					return null;
-				}
+			{ Object.entries( metricsNames )
+				.filter( ( [ name ] ) => name !== 'overall' )
+				.map( ( [ key, { name: displayName } ] ) => {
+					if ( props[ key as Metrics ] === undefined || props[ key as Metrics ] === null ) {
+						return null;
+					}
 
-				// Only display TBT if INP is not available
-				if ( key === 'tbt' && props[ 'inp' ] !== undefined && props[ 'inp' ] !== null ) {
-					return null;
-				}
+					// Only display TBT if INP is not available
+					if ( key === 'tbt' && props[ 'inp' ] !== undefined && props[ 'inp' ] !== null ) {
+						return null;
+					}
 
-				return (
-					<FoldableCard
-						className="core-web-vitals-accordion__card"
-						key={ key }
-						header={
-							<CardHeader
-								displayName={ displayName }
-								metricKey={ key as Metrics }
-								metricValue={ props[ key as Metrics ] }
-							/>
-						}
-						hideSummary
-						screenReaderText={ translate( 'More' ) }
-						compact
-						clickableHeader
-						smooth
-						iconSize={ 18 }
-						onClick={ () => onClick( key as Metrics ) }
-						expanded={ key === activeTab }
-					>
-						{ children }
-					</FoldableCard>
-				);
-			} ) }
+					return (
+						<FoldableCard
+							className="core-web-vitals-accordion__card"
+							key={ key }
+							header={
+								<CardHeader
+									displayName={ displayName }
+									metricKey={ key as Metrics }
+									metricValue={ props[ key as Metrics ] }
+								/>
+							}
+							hideSummary
+							screenReaderText={ translate( 'More' ) }
+							compact
+							clickableHeader
+							smooth
+							iconSize={ 18 }
+							onClick={ () => onClick( key as Metrics ) }
+							expanded={ key === activeTab }
+						>
+							{ children }
+						</FoldableCard>
+					);
+				} ) }
 		</div>
 	);
 };

--- a/client/performance-profiler/components/core-web-vitals-display/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/index.tsx
@@ -1,6 +1,6 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
-import { lazy, Suspense, useState } from 'react';
+import { useState } from 'react';
 import {
 	Metrics,
 	PerformanceMetricsHistory,
@@ -8,6 +8,7 @@ import {
 } from 'calypso/data/site-profiler/types';
 import { CoreWebVitalsAccordion } from '../core-web-vitals-accordion';
 import { MetricTabBar } from '../metric-tab-bar';
+import MetricTabBarV2 from '../metric-tab-bar/metric-tab-bar-v2';
 import { CoreWebVitalsDetails } from './core-web-vitals-details';
 import { CoreWebVitalsDetailsV2 } from './core-web-vitals-details_v2';
 import './style.scss';
@@ -19,8 +20,6 @@ type CoreWebVitalsDisplayProps = Record< Metrics, number > & {
 	showV2?: boolean;
 	onRecommendationsFilterChange?: ( filter: string ) => void;
 };
-
-const MetricTabBarV2 = lazy( () => import( '../metric-tab-bar/metric-tab-bar-v2' ) );
 
 export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 	const defaultTab = props.showV2 ? 'overall' : 'fcp';
@@ -34,13 +33,11 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 	);
 
 	const metricTabBar = props.showV2 ? (
-		<Suspense fallback={ null }>
-			<MetricTabBarV2
-				activeTab={ activeTab ?? defaultTab }
-				setActiveTab={ setActiveTab }
-				{ ...props }
-			/>
-		</Suspense>
+		<MetricTabBarV2
+			activeTab={ activeTab ?? defaultTab }
+			setActiveTab={ setActiveTab }
+			{ ...props }
+		/>
 	) : (
 		<MetricTabBar
 			activeTab={ activeTab ?? defaultTab }

--- a/client/performance-profiler/components/metric-tab-bar/metric-tab-bar-v2.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/metric-tab-bar-v2.tsx
@@ -18,16 +18,16 @@ const MetricTabBarV2 = ( props: Props ) => {
 	const { activeTab, setActiveTab } = props;
 
 	return (
-		<div className="metric-tab-bar">
+		<div className="metric-tab-bar-v2">
 			<button
-				className={ clsx( 'metric-tab-bar__tab metric-tab-bar__performance', {
+				className={ clsx( 'metric-tab-bar-v2__tab metric-tab-bar-v2__performance', {
 					active: activeTab === 'overall',
 				} ) }
 				onClick={ () => setActiveTab( 'overall' ) }
 			>
-				<div className="metric-tab-bar__tab-text">
-					<div className="metric-tab-bar__tab-header">Performance Score</div>
-					<div className="metric-tab-bar__tab-metric">
+				<div className="metric-tab-bar-v2__tab-text">
+					<div className="metric-tab-bar-v2__tab-header">Performance Score</div>
+					<div className="metric-tab-bar-v2__tab-metric">
 						<CircularPerformanceScore score={ props.overall } size={ 48 } />
 					</div>
 				</div>
@@ -52,17 +52,17 @@ const MetricTabBarV2 = ( props: Props ) => {
 				return (
 					<button
 						key={ key }
-						className={ clsx( 'metric-tab-bar__tab', { active: key === activeTab } ) }
+						className={ clsx( 'metric-tab-bar-v2__tab', { active: key === activeTab } ) }
 						onClick={ () => setActiveTab( key as Metrics ) }
 					>
-						<div className="metric-tab-bar__tab-status">
+						<div className="metric-tab-bar-v2__tab-status">
 							<StatusIndicator
 								speed={ mapThresholdsToStatus( key as Metrics, props[ key as Metrics ] ) }
 							/>
 						</div>
-						<div className="metric-tab-bar__tab-text">
-							<div className="metric-tab-bar__tab-header">{ displayName }</div>
-							<div className={ `metric-tab-bar__tab-metric ${ statusClassName }` }>
+						<div className="metric-tab-bar-v2__tab-text">
+							<div className="metric-tab-bar-v2__tab-header">{ displayName }</div>
+							<div className={ `metric-tab-bar-v2__tab-metric ${ statusClassName }` }>
 								{ displayValue( key as Metrics, props[ key as Metrics ] ) }
 							</div>
 						</div>

--- a/client/performance-profiler/components/metric-tab-bar/style_v2.scss
+++ b/client/performance-profiler/components/metric-tab-bar/style_v2.scss
@@ -3,7 +3,7 @@
 
 $blueberry-color: #3858e9;
 
-.metric-tab-bar {
+.metric-tab-bar-v2 {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -15,7 +15,7 @@ $blueberry-color: #3858e9;
 	}
 }
 
-.metric-tab-bar__tab {
+.metric-tab-bar-v2__tab {
 	display: flex;
 	gap: 6px;
 	background: var(--studio-white);
@@ -69,24 +69,24 @@ $blueberry-color: #3858e9;
 	}
 }
 
-.metric-tab-bar__tab-status {
+.metric-tab-bar-v2__tab-status {
 	line-height: normal;
 	display: none;
 }
 
-.metric-tab-bar__tab-text {
+.metric-tab-bar-v2__tab-text {
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
 
 }
 
-.metric-tab-bar__tab-header {
+.metric-tab-bar-v2__tab-header {
 	font-family: $font-sf-pro-display;
 	font-size: $font-body-small;
 	font-weight: 500;
 }
-.metric-tab-bar__tab-metric {
+.metric-tab-bar-v2__tab-metric {
 	font-family: $font-sf-pro-display;
 	font-size: $font-size-header-small;
 
@@ -104,7 +104,7 @@ $blueberry-color: #3858e9;
 	}
 }
 
-.metric-tab-bar__performance {
+.metric-tab-bar-v2__performance {
 	margin-bottom: 16px;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 6px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
Version 2 of the metric components uses same classnames as v1 to make it easy to change when we switch fully to version 2, to prevent classname collisions we lazy loaded v2 to show when v2 is enabled however this lazy loading causes layout to shift when component is loaded which is not desirable.

* Append `v2` to the classnames of the v2 component and avoid lazy loading.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To prevent layout shifts due to lazy loading the component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `sites/performance/:siteSlug` 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
