### PR TITLE
Sites: Move react elements to headers instead of labels

### DIFF
--- a/client/hosting/sites/components/sites-dataviews/index.tsx
+++ b/client/hosting/sites/components/sites-dataviews/index.tsx
@@ -118,8 +118,8 @@ const DotcomSitesDataViews = ( {
 		() => [
 			{
 				id: 'site',
-				// @ts-expect-error -- Need to fix the label type upstream in @wordpress/dataviews to support React elements.
-				label: <span>{ __( 'Site' ) }</span>,
+				label: __( 'Site' ),
+				header: <span>{ __( 'Site' ) }</span>,
 				getValue: ( { item }: { item: SiteExcerptData } ) => item.URL,
 				render: ( { item }: { item: SiteExcerptData } ) => {
 					return <SiteField site={ item } openSitePreviewPane={ openSitePreviewPane } />;
@@ -129,8 +129,8 @@ const DotcomSitesDataViews = ( {
 			},
 			{
 				id: 'plan',
-				// @ts-expect-error -- Need to fix the label type upstream in @wordpress/dataviews to support React elements.
-				label: <span>{ __( 'Plan' ) }</span>,
+				label: __( 'Plan' ),
+				header: <span>{ __( 'Plan' ) }</span>,
 				render: ( { item }: { item: SiteExcerptData } ) => (
 					<SitePlan site={ item } userId={ userId } />
 				),
@@ -150,8 +150,8 @@ const DotcomSitesDataViews = ( {
 			},
 			{
 				id: 'last-publish',
-				// @ts-expect-error -- Need to fix the label type upstream in @wordpress/dataviews to support React elements.
-				label: <span>{ __( 'Last Published' ) }</span>,
+				label: __( 'Last Published' ),
+				header: <span>{ __( 'Last Published' ) }</span>,
 				render: ( { item }: { item: SiteExcerptData } ) =>
 					item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
 				enableHiding: false,
@@ -159,8 +159,8 @@ const DotcomSitesDataViews = ( {
 			},
 			{
 				id: 'stats',
-				// @ts-expect-error -- Need to fix the label type upstream in @wordpress/dataviews to support React elements.
-				label: (
+				label: __( 'Stats' ),
+				header: (
 					<span className="sites-dataviews__stats-label">
 						<JetpackLogo size={ 16 } />
 						<span>{ __( 'Stats' ) }</span>
@@ -172,8 +172,8 @@ const DotcomSitesDataViews = ( {
 			},
 			{
 				id: 'actions',
-				// @ts-expect-error -- Need to fix the label type upstream in @wordpress/dataviews to support React elements.
-				label: <span>{ __( 'Actions' ) }</span>,
+				label: __( 'Actions' ),
+				header: <span>{ __( 'Actions' ) }</span>,
 				render: ( { item }: { item: SiteExcerptData } ) => <ActionsField site={ item } />,
 				enableHiding: false,
 				enableSorting: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/94762

## Proposed Changes

* Move the column headers, which are React elements, to `header` instead of `label`, to fix tooltip issues and type errors in DataViews.

Before | After
---- | ----
<img width="415" alt="Screen Shot 2024-09-20 at 3 20 18 PM" src="https://github.com/user-attachments/assets/a19e263e-26ef-4824-97cf-fce56c03fbf3"> | <img width="411" alt="Screen Shot 2024-09-20 at 3 19 50 PM" src="https://github.com/user-attachments/assets/8a5f4bb6-864f-4929-b091-38c6b1b98c9c">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Align with core and fix the tooltips.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Verify that the column headers haven't changed from production.
* Verify that if you click the gear icon and hover over the headers in the Properties list, the tooltip for the hide icon doesn't say `[object Object]`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
