### PR TITLE
Logged-in Performance Profiler: Modify core web vitals to match mobile layout.

### DIFF
--- a/client/hosting/performance/style.scss
+++ b/client/hosting/performance/style.scss
@@ -13,6 +13,18 @@ $section-max-width: 1224px;
 	.notice-banner__title {
 		font-size: $font-body-small;
 	}
+
+	@media (max-width: $break-medium) {
+		gap: 0;
+	}
+
+	.performance-profiler-content .container {
+		padding-top: 0;
+
+		@media (max-width: $break-medium) {
+			padding-top: 24px;
+		}
+	}
 }
 
 .site-performance-device-tab-controls__container {

--- a/client/performance-profiler/components/core-web-vitals-accordion/core-web-vitals-accordion-v2.tsx
+++ b/client/performance-profiler/components/core-web-vitals-accordion/core-web-vitals-accordion-v2.tsx
@@ -1,0 +1,111 @@
+import { FoldableCard } from '@automattic/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { Metrics } from 'calypso/data/site-profiler/types';
+import { CircularPerformanceScore } from 'calypso/hosting/performance/components/circular-performance-score/circular-performance-score';
+import {
+	metricsNames,
+	mapThresholdsToStatus,
+	displayValue,
+} from 'calypso/performance-profiler/utils/metrics';
+
+import './styles-v2.scss';
+
+type Props = Record< Metrics, number > & {
+	activeTab: Metrics | null;
+	setActiveTab: ( tab: Metrics | null ) => void;
+	children: React.ReactNode;
+};
+type HeaderProps = {
+	displayName: string;
+	metricKey: Metrics;
+	metricValue: number;
+};
+
+const CardHeader = ( props: HeaderProps ) => {
+	const { displayName, metricKey, metricValue } = props;
+	const status = mapThresholdsToStatus( metricKey, metricValue );
+	const isPerformanceScoreSelected = metricKey === 'overall';
+
+	const statusClassName = status === 'needsImprovement' ? 'needs-improvement' : status;
+	return (
+		<div className="core-web-vitals-accordion-v2__header">
+			<div className="core-web-vitals-accordion-v2__header-text">
+				<span className="core-web-vitals-accordion-v2__header-text-name">{ displayName }</span>
+
+				{ isPerformanceScoreSelected ? (
+					<div className="metric-tab-bar-v2__tab-metric" style={ { marginTop: '6px' } }>
+						<CircularPerformanceScore score={ metricValue } size={ 48 } />
+					</div>
+				) : (
+					<span
+						className={ `core-web-vitals-accordion-v2__header-text-value ${ statusClassName } ` }
+					>
+						{ displayValue( metricKey, metricValue ) }
+					</span>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export const CoreWebVitalsAccordionV2 = ( props: Props ) => {
+	const { activeTab, setActiveTab, children } = props;
+	const translate = useTranslate();
+
+	const onClick = ( key: Metrics ) => {
+		// If the user clicks the current tab, close it.
+		if ( key === activeTab ) {
+			setActiveTab( null );
+		} else {
+			setActiveTab( key as Metrics );
+		}
+	};
+
+	const entries = Object.entries( metricsNames );
+	const overallEntry = entries.find( ( [ key ] ) => key === 'overall' );
+	const otherEntries = entries.filter( ( [ key ] ) => key !== 'overall' );
+
+	const reorderedEntries = overallEntry ? [ overallEntry, ...otherEntries ] : otherEntries;
+
+	return (
+		<div className="core-web-vitals-accordion-v2">
+			{ reorderedEntries.map( ( [ key, { name: displayName } ] ) => {
+				if ( props[ key as Metrics ] === undefined || props[ key as Metrics ] === null ) {
+					return null;
+				}
+
+				// Only display TBT if INP is not available
+				if ( key === 'tbt' && props[ 'inp' ] !== undefined && props[ 'inp' ] !== null ) {
+					return null;
+				}
+
+				return (
+					<FoldableCard
+						className={ clsx( 'core-web-vitals-accordion-v2__card', {
+							[ 'core-web-vitals-accordion-v2__card--overall' ]: key === 'overall',
+						} ) }
+						key={ key }
+						header={
+							<CardHeader
+								displayName={ displayName }
+								metricKey={ key as Metrics }
+								metricValue={ props[ key as Metrics ] }
+							/>
+						}
+						hideSummary
+						screenReaderText={ translate( 'More' ) }
+						compact
+						clickableHeader
+						smooth
+						iconSize={ 18 }
+						onClick={ () => onClick( key as Metrics ) }
+						expanded={ key === activeTab }
+					>
+						{ children }
+					</FoldableCard>
+				);
+			} ) }
+		</div>
+	);
+};

--- a/client/performance-profiler/components/core-web-vitals-accordion/styles-v2.scss
+++ b/client/performance-profiler/components/core-web-vitals-accordion/styles-v2.scss
@@ -1,0 +1,124 @@
+@import "@automattic/components/src/styles/typography";
+
+$blueberry-color: #3858e9;
+
+.core-web-vitals-accordion-v2 {
+	.core-web-vitals-accordion-v2__card {
+		margin: 0;
+		border-top: 0;
+		.foldable-card__content {
+			border-top: 0;
+		}
+
+		&.foldable-card {
+			box-shadow: none;
+			border: 1px solid var(--studio-gray-5);
+
+			.foldable-card__header {
+				padding: 16px 22px;
+
+				button.foldable-card__action {
+					display: flex;
+					align-items: start;
+					margin-top: 20px;
+				}
+			}
+
+			&:last-child {
+				/* stylelint-disable-next-line scales/radii */
+				border-bottom-right-radius: 6px;
+				/* stylelint-disable-next-line scales/radii */
+				border-bottom-left-radius: 6px;
+			}
+
+			&:nth-child(2) {
+				/* stylelint-disable-next-line scales/radii */
+				border-top-left-radius: 6px;
+				/* stylelint-disable-next-line scales/radii */
+				border-top-right-radius: 6px;
+			}
+
+			&.is-expanded .foldable-card__content {
+				border-top: 0;
+				max-height: fit-content;
+				margin: 0;
+			}
+
+			&:not(.is-expanded) {
+				border-bottom: 1px solid var(--studio-gray-5);
+				&:not(:nth-child(-n+2)) {
+					border-top: none;
+				}
+			}
+
+			&.is-expanded {
+				margin: 0;
+
+				.core-web-vitals-accordion-v2__header-text {
+					font-family: $font-sf-pro-display;
+					font-size: 1rem;
+					font-weight: 500;
+				}
+			}
+		}
+		.core-web-vitals-display__details {
+			border: 0;
+		}
+
+
+	}
+
+	.core-web-vitals-accordion-v2__card--overall {
+		margin-bottom: 24px;
+
+		.card.is-compact {
+			margin-bottom: 24px;
+		}
+
+		&.foldable-card {
+			/* stylelint-disable-next-line scales/radii */
+			border-radius: 6px;
+			&.is-expanded {
+				margin-bottom: 24px;
+			}
+		}
+	}
+
+
+}
+
+.core-web-vitals-accordion-v2__header {
+	display: flex;
+	flex-direction: column;
+	align-items: start;
+	gap: 6px;
+	width: 100%;
+}
+
+.core-web-vitals-accordion-v2__header-text {
+	display: flex;
+	justify-content: space-between;
+	flex-direction: column;
+	flex-basis: 100%;
+}
+
+.core-web-vitals-accordion-v2__header-text-value {
+
+	font-family: $font-sf-pro-display;
+	font-size: $font-size-header-small;
+	margin-top: 6px;
+
+
+	&.good {
+		color: #00ba37;
+	}
+
+	&.needs-improvement {
+		color: #d67709;
+	}
+
+	&.bad {
+		color: #d63638;
+	}
+}
+

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
@@ -1,3 +1,4 @@
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import {
 	Metrics,
@@ -34,6 +35,7 @@ export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
 	...metrics
 } ) => {
 	const translate = useTranslate();
+	const isMobile = ! useDesktopBreakpoint();
 
 	if ( ! activeTab ) {
 		return null;
@@ -74,9 +76,9 @@ export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
 	let metricsData: number[] = history?.metrics[ activeTab ] ?? [];
 	let dates = history?.collection_period ?? [];
 
-	// last 8 weeks only
-	metricsData = metricsData.slice( -8 );
-	dates = dates.slice( -8 );
+	const weeksToShow = isMobile ? 6 : 8;
+	metricsData = metricsData.slice( -weeksToShow );
+	dates = dates.slice( -weeksToShow );
 
 	const dataAvailable = metricsData.length > 0 && metricsData.some( ( item ) => item !== null );
 	const historicalData = metricsData.map( ( item, index ) => {
@@ -104,32 +106,24 @@ export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
 	const isPerformanceScoreSelected = activeTab === 'overall';
 
 	return (
-		<div
-			className="core-web-vitals-display__details"
-			style={ {
-				flexDirection: 'column',
-				borderRadius: '6px',
-				flex: 1,
-			} }
-		>
+		<div className="core-web-vitals-display__details-v2">
 			<div className="core-web-vitals-display__description">
-				<div
-					css={ {
-						display: 'flex',
-						gap: '24px',
-					} }
-				>
+				<div className="core-web-vitals-display__description-container">
 					<div
 						css={ {
 							flex: 1,
 						} }
 					>
-						<span className="core-web-vitals-display__description-subheading">{ displayName }</span>
+						{ ! isMobile && (
+							<span className="core-web-vitals-display__description-subheading">
+								{ displayName }
+							</span>
+						) }
 
 						<div className={ `core-web-vitals-display__metric ${ statusClass }` }>
 							{ isPerformanceScoreSelected ? (
 								<div
-									className="metric-tab-bar__tab-metric"
+									className="metric-tab-bar-v2__tab-metric"
 									css={ {
 										marginTop: '16px',
 									} }
@@ -140,23 +134,6 @@ export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
 								displayValue( activeTab as Metrics, value )
 							) }
 						</div>
-						<p>
-							{ metricValuations[ activeTab ].explanation }
-							&nbsp;
-							{ isPerformanceScoreSelected ? (
-								<a
-									href="https://developer.chrome.com/docs/lighthouse/performance/performance-scoring"
-									target="_blank"
-									rel="noreferrer"
-								>
-									{ translate( 'See calculator ↗' ) }
-								</a>
-							) : (
-								<a href={ `https://web.dev/articles/${ activeTab }` }>
-									{ translate( 'Learn more ↗' ) }
-								</a>
-							) }
-						</p>
 					</div>
 					<StatusSection
 						activeTab={ activeTab }
@@ -166,7 +143,30 @@ export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
 						recommendationsQuantity={ numberOfAuditsForMetric }
 					/>
 				</div>
-				<div className="core-web-vitals-display__ranges">
+				<p
+					style={ {
+						marginTop: 0,
+						marginBottom: '24px',
+						maxWidth: '496px',
+					} }
+				>
+					{ metricValuations[ activeTab ].explanation }
+					&nbsp;
+					{ isPerformanceScoreSelected ? (
+						<a
+							href="https://developer.chrome.com/docs/lighthouse/performance/performance-scoring"
+							target="_blank"
+							rel="noreferrer"
+						>
+							{ translate( 'See calculator ↗' ) }
+						</a>
+					) : (
+						<a href={ `https://web.dev/articles/${ activeTab }` }>
+							{ translate( 'Learn more ↗' ) }
+						</a>
+					) }
+				</p>
+				<div className="core-web-vitals-display-v2__ranges">
 					<div className="range">
 						<StatusIndicator speed="good" />
 						<div className="range-heading">{ translate( 'Excellent' ) }</div>
@@ -238,7 +238,7 @@ export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
 					] }
 					height={ 300 }
 					d3Format="%b %d"
-					isMobile={ false }
+					isMobile={ isMobile }
 				/>
 			</div>
 		</div>

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
@@ -120,20 +120,22 @@ export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
 							</span>
 						) }
 
-						<div className={ `core-web-vitals-display__metric ${ statusClass }` }>
-							{ isPerformanceScoreSelected ? (
-								<div
-									className="metric-tab-bar-v2__tab-metric"
-									css={ {
-										marginTop: '16px',
-									} }
-								>
-									<CircularPerformanceScore score={ value } size={ 76 } />
-								</div>
-							) : (
-								displayValue( activeTab as Metrics, value )
-							) }
-						</div>
+						{ ! isMobile && (
+							<div className={ `core-web-vitals-display__metric ${ statusClass }` }>
+								{ isPerformanceScoreSelected ? (
+									<div
+										className="metric-tab-bar-v2__tab-metric"
+										css={ {
+											marginTop: '16px',
+										} }
+									>
+										<CircularPerformanceScore score={ value } size={ 76 } />
+									</div>
+								) : (
+									displayValue( activeTab as Metrics, value )
+								) }
+							</div>
+						) }
 					</div>
 					<StatusSection
 						activeTab={ activeTab }

--- a/client/performance-profiler/components/core-web-vitals-display/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/index.tsx
@@ -7,6 +7,7 @@ import {
 	PerformanceMetricsItemQueryResponse,
 } from 'calypso/data/site-profiler/types';
 import { CoreWebVitalsAccordion } from '../core-web-vitals-accordion';
+import { CoreWebVitalsAccordionV2 } from '../core-web-vitals-accordion/core-web-vitals-accordion-v2';
 import { MetricTabBar } from '../metric-tab-bar';
 import MetricTabBarV2 from '../metric-tab-bar/metric-tab-bar-v2';
 import { CoreWebVitalsDetails } from './core-web-vitals-details';
@@ -26,25 +27,10 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 	const [ activeTab, setActiveTab ] = useState< Metrics | null >( defaultTab );
 	const isDesktop = useDesktopBreakpoint();
 
-	const details = props.showV2 ? (
-		<CoreWebVitalsDetailsV2 activeTab={ activeTab } { ...props } />
-	) : (
-		<CoreWebVitalsDetails activeTab={ activeTab } { ...props } />
-	);
+	const MetricBar = props.showV2 ? MetricTabBarV2 : MetricTabBar;
+	const CoreWebVitalsDetail = props.showV2 ? CoreWebVitalsDetailsV2 : CoreWebVitalsDetails;
 
-	const metricTabBar = props.showV2 ? (
-		<MetricTabBarV2
-			activeTab={ activeTab ?? defaultTab }
-			setActiveTab={ setActiveTab }
-			{ ...props }
-		/>
-	) : (
-		<MetricTabBar
-			activeTab={ activeTab ?? defaultTab }
-			setActiveTab={ setActiveTab }
-			{ ...props }
-		/>
-	);
+	const Accordion = props.showV2 ? CoreWebVitalsAccordionV2 : CoreWebVitalsAccordion;
 
 	return (
 		<>
@@ -54,19 +40,19 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 						[ 'core-web-vitals-display-v2' ]: props.showV2,
 					} ) }
 				>
-					{ metricTabBar }
-					{ details }
+					<MetricBar
+						activeTab={ activeTab ?? defaultTab }
+						setActiveTab={ setActiveTab }
+						{ ...props }
+					/>
+					<CoreWebVitalsDetail activeTab={ activeTab } { ...props } />
 				</div>
 			) }
 			{ ! isDesktop && (
 				<div className="core-web-vitals-display">
-					<CoreWebVitalsAccordion
-						activeTab={ activeTab }
-						setActiveTab={ setActiveTab }
-						{ ...props }
-					>
-						<CoreWebVitalsDetails activeTab={ activeTab } { ...props } />
-					</CoreWebVitalsAccordion>
+					<Accordion activeTab={ activeTab } setActiveTab={ setActiveTab } { ...props }>
+						<CoreWebVitalsDetail activeTab={ activeTab } { ...props } />
+					</Accordion>
 				</div>
 			) }
 		</>

--- a/client/performance-profiler/components/core-web-vitals-display/style.scss
+++ b/client/performance-profiler/components/core-web-vitals-display/style.scss
@@ -1,5 +1,6 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/components/src/styles/typography";
+@import "@wordpress/base-styles/breakpoints";
 
 $blueberry-color: #3858e9;
 
@@ -38,7 +39,6 @@ $blueberry-color: #3858e9;
 		}
 	}
 }
-
 
 .core-web-vitals-display__details {
 	border: 1.5px solid var(--studio-gray-5);
@@ -125,7 +125,6 @@ $blueberry-color: #3858e9;
 	font-size: $font-size-header;
 	margin-bottom: 24px;
 
-
 	&.good {
 		color: #00ba37;
 	}
@@ -140,9 +139,83 @@ $blueberry-color: #3858e9;
 }
 
 .core-web-vitals-display__history-graph-container {
-
 	.chart-container {
 		width: 100%;
 		max-width: 100%;
+	}
+}
+
+.core-web-vitals-display__details-v2 {
+	border: 1.5px solid var(--studio-gray-5);
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 6px;
+	padding: 24px;
+	display: flex;
+	flex-direction: column;
+	column-gap: 32px;
+	min-height: 360px;
+	flex-wrap: wrap;
+	margin-top: -1.5px;
+	flex-grow: 1;
+
+	& > div {
+		flex-grow: 1;
+		flex-basis: 0;
+		min-width: 300px;
+	}
+
+	& > p {
+		min-height: 80px;
+	}
+
+	@media (max-width: $break-mobile) {
+		border: 0;
+	}
+
+}
+
+.core-web-vitals-display__description-container {
+	display: flex;
+	gap: 24px;
+
+	@media (max-width: $break-mobile) {
+		flex-direction: column;
+		gap: 0;
+	}
+}
+
+
+.core-web-vitals-display-v2__ranges {
+	display: flex;
+	flex-direction: row;
+	justify-content: start;
+	margin-bottom: 24px;
+	column-gap: 24px;
+
+	.range {
+		display: flex;
+		flex-direction: row;
+		column-gap: 6px;
+		font-family: $font-sf-pro-display;
+
+		& > svg {
+			padding-top: 4px;
+		}
+
+		.range-heading {
+			font-size: $font-body-small;
+			font-weight: 500;
+			line-height: 20px;
+		}
+
+		.range-subheading {
+			font-size: $font-body-extra-small;
+			line-height: 20px;
+		}
+	}
+
+	@media (max-width: $break-mobile) {
+		flex-direction: column;
+		gap: 8px;
 	}
 }

--- a/client/performance-profiler/components/core-web-vitals-display/style.scss
+++ b/client/performance-profiler/components/core-web-vitals-display/style.scss
@@ -170,6 +170,7 @@ $blueberry-color: #3858e9;
 
 	@media (max-width: $break-mobile) {
 		border: 0;
+		padding-top: 0;
 	}
 
 }

--- a/client/performance-profiler/components/status-section/style.scss
+++ b/client/performance-profiler/components/status-section/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+
+
 .status-section {
 	font-size: $font-body-small;
 	color: #000;
@@ -17,6 +20,10 @@
 		font-weight: 500;
 		flex-shrink: 0;
 		width: 100%;
+
+		@media (max-width: $break-mobile) {
+			width: unset;
+		}
 
 		&.poor {
 			background: var(--studio-red-5);
@@ -38,5 +45,10 @@
 		a {
 			cursor: pointer;
 		}
+	}
+
+	@media (max-width: $break-mobile) {
+		flex-direction: row;
+		margin-bottom: 24px;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9198

## Proposed Changes

* Add a new accordion component that matches the new design for mobile layout

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `sites/performance/{site}` change to mobile layout and verify design

![image](https://github.com/user-attachments/assets/03e66f7f-4395-4ef8-b96d-c910cfa46f32)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
