### PR TITLE
Domains: Display Email Forwards as a List

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -58,7 +58,13 @@ const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ) =>
 					<Count count={ emailAddresses.length }></Count>
 				</>
 			}
-			description={ emailAddresses.join( '\n' ) }
+			description={
+				<ul className="domain-email-info-card__email-list">
+					{ emailAddresses.map( ( email, index ) => (
+						<li key={ index }>{ email }</li>
+					) ) }
+				</ul>
+			}
 			ctaText={ translate( 'View emails' ) }
 			buttonDisabled={ domain.isMoveToNewSitePending }
 		/>

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
@@ -65,5 +65,10 @@
 				display: none;
 			}
 		}
+
+		.domain-email-info-card__email-list {
+			list-style-type: none;
+			margin: 0;
+		}
 	}
 }


### PR DESCRIPTION
# edit: this needs a fix to ensure the HTML layout is acceptable! 
 
## Proposed Changes

Ensures that the Email Forwarding list is displayed as a list. 

## Why are these changes being made?

At the moment, the items aren't visible when there's more than a few. It also doesn't seem appropriate to use a paragraph tag here, which is what currently happens.

## Testing Instructions

* Navigate to My Sites > Upgrades > Domains 
* Add some email forwards
* Confirm that the list now appears properly 

| Before | After |
|--------|--------|
| <img width="704" alt="Screenshot 2024-09-21 at 15 53 37" src="https://github.com/user-attachments/assets/777be9f9-bfaa-4f2c-9116-babd76e685c8"> | <img width="303" alt="Screenshot 2024-09-21 at 15 53 01" src="https://github.com/user-attachments/assets/2eb427a4-8c42-411c-bc56-a00714deef9f"> | 

cc @rafaelgallani, @gius80, @leonardost 
