### PR TITLE
Logged-in Performance Profiler: Update header to fit mobile layout design

### DIFF
--- a/client/hosting/performance/components/MobileHeader.tsx
+++ b/client/hosting/performance/components/MobileHeader.tsx
@@ -1,0 +1,50 @@
+import { Gridicon, ScreenReaderText } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
+import React, { useState } from 'react';
+import NavigationHeader from 'calypso/components/navigation-header';
+
+type MobileHeaderProps = {
+	pageTitle: string;
+	pageSelector: JSX.Element;
+};
+
+export const MobileHeader = ( { pageTitle, pageSelector }: MobileHeaderProps ) => {
+	const [ isPageSelectorVisible, setIsPageSelectorVisible ] = useState( false );
+
+	const togglePageSelector = () => {
+		setIsPageSelectorVisible( ! isPageSelectorVisible );
+	};
+
+	return (
+		<>
+			<NavigationHeader
+				className="site-performance__navigation-header"
+				title={
+					<div className="navigation-header-title">
+						{ translate( 'Performance' ) }
+						<Button
+							variant="tertiary"
+							onClick={ togglePageSelector }
+							aria-expanded={ isPageSelectorVisible }
+						>
+							<ScreenReaderText>{ translate( 'toggle page selector' ) }</ScreenReaderText>
+							<Gridicon icon="cog" />
+						</Button>
+					</div>
+				}
+				subtitle={ pageTitle }
+			/>
+
+			{ isPageSelectorVisible && (
+				<div
+					css={ {
+						width: '100%',
+					} }
+				>
+					{ pageSelector }
+				</div>
+			) }
+		</>
+	);
+};

--- a/client/hosting/performance/components/PageSelector.tsx
+++ b/client/hosting/performance/components/PageSelector.tsx
@@ -6,32 +6,13 @@ export const PageSelector = ( props: ComponentProps< typeof SearchableDropdown >
 	const translate = useTranslate();
 
 	return (
-		<div
-			css={ {
-				display: 'flex',
-				alignItems: 'flex-start',
-				flexGrow: 1,
-				justifyContent: 'flex-end',
-				gap: '10px',
-				maxHeight: '40px',
-			} }
-		>
+		<div className="site-performance__page-selector">
 			<div css={ { alignSelf: 'stretch', display: 'flex', alignItems: 'center' } }>
 				{ translate( 'Page' ) }
 			</div>
 			<SearchableDropdown
 				{ ...props }
-				css={ {
-					maxWidth: '240px',
-					minWidth: '240px',
-					'.components-combobox-control__suggestions-container': {
-						position: 'relative',
-						zIndex: 1,
-						background: 'var(--color-surface)',
-					},
-					'.components-form-token-field__suggestions-list': { maxHeight: 'initial !important' },
-					'.components-form-token-field__suggestions-list li': { padding: '0 !important' },
-				} }
+				className="site-performance__page-selector-drowdown"
 				__experimentalRenderItem={ ( { item } ) => (
 					<div
 						aria-label={ item.label }

--- a/client/hosting/performance/components/device-tab-control/index.tsx
+++ b/client/hosting/performance/components/device-tab-control/index.tsx
@@ -8,9 +8,14 @@ export type Tab = 'mobile' | 'desktop';
 type DeviceTabControlsProps = {
 	onDeviceTabChange: ( tab: Tab ) => void;
 	value: Tab;
+	showTitle?: boolean;
 };
 
-export const DeviceTabControls = ( { onDeviceTabChange, value }: DeviceTabControlsProps ) => {
+export const DeviceTabControls = ( {
+	onDeviceTabChange,
+	value,
+	showTitle,
+}: DeviceTabControlsProps ) => {
 	const translate = useTranslate();
 
 	const options = [
@@ -26,7 +31,9 @@ export const DeviceTabControls = ( { onDeviceTabChange, value }: DeviceTabContro
 
 	return (
 		<div className="site-performance-device-tab__container">
-			<div className="site-performance-device-tab__heading">{ translate( 'Device' ) }</div>
+			{ showTitle && (
+				<div className="site-performance-device-tab__heading">{ translate( 'Device' ) }</div>
+			) }
 			<SegmentedControl className="site-performance-device-tab__controls">
 				{ options.map( ( option ) => {
 					return (

--- a/client/hosting/performance/style.scss
+++ b/client/hosting/performance/style.scss
@@ -21,6 +21,33 @@ $section-max-width: 1224px;
 	flex-wrap: wrap;
 	align-items: start;
 	justify-content: space-between;
+
+	.site-performance__page-selector {
+		display: flex;
+		align-items: flex-start;
+		flex-grow: 1;
+		justify-content: flex-end;
+		gap: 10px;
+		max-height: 40px;
+
+		@media (max-width: $break-medium) {
+			flex-direction: column;
+			align-items: start;
+			justify-content: center;
+			gap: 6px;
+			max-height: unset;
+
+			.searchable-dropdown {
+				width: 100%;
+			}
+		}
+	}
+
+	.navigation-header-title {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
 }
 
 .site-performance__navigation-header.navigation-header {
@@ -28,7 +55,39 @@ $section-max-width: 1224px;
 	padding-bottom: 0;
 	margin-bottom: 16px;
 
+	.gridicon {
+		fill: var(--color-neutral-100);
+	}
+
 	@media (max-width: $break-medium) {
 		margin-bottom: 8px;
+		width: 100%;
+
+		.formatted-header__subtitle {
+			display: block;
+		}
+	}
+}
+
+.site-performance__page-selector-drowdown {
+	max-width: 240px;
+	min-width: 240px;
+
+	.components-combobox-control__suggestions-container {
+		position: relative;
+		z-index: 1;
+		background: var(--color-surface);
+	}
+
+	.components-form-token-field__suggestions-list {
+		max-height: initial !important;
+	}
+
+	.components-form-token-field__suggestions-list li {
+		padding: 0 !important;
+	}
+
+	@media (max-width: $break-medium) {
+		max-width: unset;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9197

## Proposed Changes

* Add a mobile header component that matches the design on mobile layout
* 
![image](https://github.com/user-attachments/assets/7def5f00-4ec0-4ecc-bd00-18e615208670)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `sites/performance/site`
* Browse in mobile view and verify header matches the Iix1FFHIQdfECIXn5JKT5s-fi-5288_123831

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?