### PR TITLE
White-labeled plugin: Retry migration key endpoint when we're using the flag

### DIFF
--- a/client/landing/stepper/hooks/test/use-site-migration-key.tsx
+++ b/client/landing/stepper/hooks/test/use-site-migration-key.tsx
@@ -9,34 +9,48 @@ import React from 'react';
 import { useSiteMigrationKey } from '../use-site-migration-key';
 
 describe( 'useSiteMigrationKey', () => {
-	it( 'returns the site migration key', async () => {
-		const queryClient = new QueryClient();
-		const isWhiteLabeledPluginEnabled = config.isEnabled(
-			'migration-flow/enable-white-labeled-plugin'
-		);
-		const wrapper = ( { children } ) => (
-			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
-		);
+	const isWhiteLabeledPluginEnabled = config.isEnabled(
+		'migration-flow/enable-white-labeled-plugin'
+	);
+	if ( ! isWhiteLabeledPluginEnabled ) {
+		it( 'returns the migrateguru site migration key', async () => {
+			const queryClient = new QueryClient();
+			const wrapper = ( { children } ) => (
+				<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+			);
 
-		if ( isWhiteLabeledPluginEnabled ) {
-			nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/sites/123/atomic-migration-status/wpcom-migration-key' )
-				.query( { http_envelope: 1 } )
-				.once()
-				.reply( 200, { migration_key: 'some-migration-key' } );
-		} else {
 			nock( 'https://public-api.wordpress.com' )
 				.get( '/wpcom/v2/sites/123/atomic-migration-status/migrate-guru-key' )
 				.query( { http_envelope: 1 } )
 				.once()
 				.reply( 200, { migration_key: 'some-migration-key' } );
-		}
 
-		const { result } = renderHook( () => useSiteMigrationKey( 123 ), { wrapper } );
+			const { result } = renderHook( () => useSiteMigrationKey( 123 ), { wrapper } );
 
-		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
-		expect( result.current.data?.migrationKey ).toEqual( 'some-migration-key' );
-	} );
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+			expect( result.current.data?.migrationKey ).toEqual( 'some-migration-key' );
+		} );
+	}
+
+	if ( isWhiteLabeledPluginEnabled ) {
+		it( 'returns the migration to wp.com site migration key', async () => {
+			const queryClient = new QueryClient();
+			const wrapper = ( { children } ) => (
+				<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+			);
+
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/sites/123/atomic-migration-status/wpcom-migration-key' )
+				.query( { http_envelope: 1 } )
+				.once()
+				.reply( 200, { migration_key: 'some-migration-key' } );
+
+			const { result } = renderHook( () => useSiteMigrationKey( 123 ), { wrapper } );
+
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+			expect( result.current.data?.migrationKey ).toEqual( 'some-migration-key' );
+		} );
+	}
 
 	it( 'skip the request when the siteId is not available', async () => {
 		const queryClient = new QueryClient();

--- a/client/landing/stepper/hooks/test/use-site-migration-key.tsx
+++ b/client/landing/stepper/hooks/test/use-site-migration-key.tsx
@@ -30,7 +30,7 @@ describe( 'useSiteMigrationKey', () => {
 		jest.resetAllMocks();
 	} );
 
-	it( 'returns the migrateguru site migration key', async () => {
+	it( 'returns the migrateguru site migration key if the flag is disabled', async () => {
 		withFeatureDisabled();
 		const queryClient = new QueryClient();
 		const wrapper = ( { children } ) => (
@@ -49,7 +49,7 @@ describe( 'useSiteMigrationKey', () => {
 		expect( result.current.data?.migrationKey ).toEqual( 'some-migration-key' );
 	} );
 
-	it( 'returns the migration to wp.com site migration key', async () => {
+	it( 'returns the migrate to wp.com site migration key if the flag is enabled', async () => {
 		withFeatureEnabled();
 		const queryClient = new QueryClient();
 		const wrapper = ( { children } ) => (

--- a/client/landing/stepper/hooks/test/use-site-migration-key.tsx
+++ b/client/landing/stepper/hooks/test/use-site-migration-key.tsx
@@ -22,13 +22,11 @@ const withFeatureDisabled = () =>
 	);
 
 describe( 'useSiteMigrationKey', () => {
-	beforeEach( () => {
-		nock.cleanAll();
-	} );
+	beforeAll( () => nock.disableNetConnect() );
 
-	afterEach( () => {
-		jest.resetAllMocks();
-	} );
+	beforeEach( () => nock.cleanAll() );
+
+	afterEach( () => jest.resetAllMocks() );
 
 	it( 'returns the migrateguru site migration key if the flag is disabled', async () => {
 		withFeatureDisabled();

--- a/client/landing/stepper/hooks/test/use-site-migration-key.tsx
+++ b/client/landing/stepper/hooks/test/use-site-migration-key.tsx
@@ -14,11 +14,11 @@ jest.mock( '@automattic/calypso-config', () => ( {
 
 const withFeatureEnabled = () =>
 	( config.isEnabled as jest.Mock ).mockImplementation(
-		( key ) => key === 'migration-flow/enable-white-labeled-plugin'
+		( feature ) => feature === 'migration-flow/enable-white-labeled-plugin'
 	);
 const withFeatureDisabled = () =>
 	( config.isEnabled as jest.Mock ).mockImplementation(
-		( key ) => key !== 'migration-flow/enable-white-labeled-plugin'
+		( feature ) => feature !== 'migration-flow/enable-white-labeled-plugin'
 	);
 
 describe( 'useSiteMigrationKey', () => {

--- a/client/landing/stepper/hooks/test/use-site-migration-key.tsx
+++ b/client/landing/stepper/hooks/test/use-site-migration-key.tsx
@@ -28,7 +28,7 @@ describe( 'useSiteMigrationKey', () => {
 
 	afterEach( () => jest.resetAllMocks() );
 
-	it( 'returns the migrateguru site migration key if the flag is disabled', async () => {
+	it( 'returns the migrateguru site migration key from the old endpoint if the flag is disabled', async () => {
 		withFeatureDisabled();
 		const queryClient = new QueryClient();
 		const wrapper = ( { children } ) => (

--- a/client/landing/stepper/hooks/test/use-site-migration-key.tsx
+++ b/client/landing/stepper/hooks/test/use-site-migration-key.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import config from '@automattic/calypso-config';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
@@ -10,15 +11,26 @@ import { useSiteMigrationKey } from '../use-site-migration-key';
 describe( 'useSiteMigrationKey', () => {
 	it( 'returns the site migration key', async () => {
 		const queryClient = new QueryClient();
+		const isWhiteLabeledPluginEnabled = config.isEnabled(
+			'migration-flow/enable-white-labeled-plugin'
+		);
 		const wrapper = ( { children } ) => (
 			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 		);
 
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/sites/123/atomic-migration-status/migrate-guru-key' )
-			.query( { http_envelope: 1 } )
-			.once()
-			.reply( 200, { migration_key: 'some-migration-key' } );
+		if ( isWhiteLabeledPluginEnabled ) {
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/sites/123/atomic-migration-status/wpcom-migration-key' )
+				.query( { http_envelope: 1 } )
+				.once()
+				.reply( 200, { migration_key: 'some-migration-key' } );
+		} else {
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/wpcom/v2/sites/123/atomic-migration-status/migrate-guru-key' )
+				.query( { http_envelope: 1 } )
+				.once()
+				.reply( 200, { migration_key: 'some-migration-key' } );
+		}
 
 		const { result } = renderHook( () => useSiteMigrationKey( 123 ), { wrapper } );
 

--- a/client/landing/stepper/hooks/use-site-migration-key.ts
+++ b/client/landing/stepper/hooks/use-site-migration-key.ts
@@ -10,6 +10,16 @@ const isWhiteLabeledPluginEnabled = () => {
 	return config.isEnabled( 'migration-flow/enable-white-labeled-plugin' );
 };
 
+const migrationKeyRetry = ( failureCount, error ) => {
+	if ( ! isWhiteLabeledPluginEnabled() ) {
+		return false;
+	}
+
+	if ( failureCount >= 20 ) {
+		throw error;
+	}
+};
+
 const getMigrationKey = async ( siteId: number ): Promise< ApiResponse > => {
 	if ( isWhiteLabeledPluginEnabled() ) {
 		return wpcom.req.get(
@@ -34,7 +44,7 @@ export const useSiteMigrationKey = ( siteId?: number, options?: Options ) => {
 	return useQuery( {
 		queryKey: [ 'site-migration-key', siteId ],
 		queryFn: () => getMigrationKey( siteId! ),
-		retry: isWhiteLabeledPluginEnabled ? true : false,
+		retry: migrationKeyRetry,
 		enabled: !! siteId && ( options?.enabled ?? true ),
 		select: ( data ) => ( { migrationKey: data?.migration_key } ),
 		refetchOnWindowFocus: false,

--- a/client/landing/stepper/hooks/use-site-migration-key.ts
+++ b/client/landing/stepper/hooks/use-site-migration-key.ts
@@ -6,12 +6,12 @@ interface ApiResponse {
 	migration_key: string;
 }
 
-const isWhiteLabeledPluginEnabled = config.isEnabled(
-	'migration-flow/enable-white-labeled-plugin'
-);
+const isWhiteLabeledPluginEnabled = () => {
+	return config.isEnabled( 'migration-flow/enable-white-labeled-plugin' );
+};
 
 const getMigrationKey = async ( siteId: number ): Promise< ApiResponse > => {
-	if ( isWhiteLabeledPluginEnabled ) {
+	if ( isWhiteLabeledPluginEnabled() ) {
 		return wpcom.req.get(
 			`/sites/${ siteId }/atomic-migration-status/wpcom-migration-key?http_envelope=1`,
 			{

--- a/client/landing/stepper/hooks/use-site-migration-key.ts
+++ b/client/landing/stepper/hooks/use-site-migration-key.ts
@@ -35,15 +35,11 @@ export const useSiteMigrationKey = ( siteId?: number, options?: Options ) => {
 		queryKey: [ 'site-migration-key', siteId ],
 		queryFn: () => getMigrationKey( siteId! ),
 		retry: ( failureCount: number, error: Error ) => {
-			if ( ! isWhiteLabeledPluginEnabled() ) {
-				return false;
-			}
-
-			if ( failureCount >= 20 ) {
+			if ( isWhiteLabeledPluginEnabled() && failureCount >= 20 ) {
 				throw error;
 			}
 
-			return true;
+			return false;
 		},
 		enabled: !! siteId && ( options?.enabled ?? true ),
 		select: ( data ) => ( { migrationKey: data?.migration_key } ),

--- a/client/landing/stepper/hooks/use-site-migration-key.ts
+++ b/client/landing/stepper/hooks/use-site-migration-key.ts
@@ -10,7 +10,7 @@ const isWhiteLabeledPluginEnabled = () => {
 	return config.isEnabled( 'migration-flow/enable-white-labeled-plugin' );
 };
 
-const migrationKeyRetry = ( failureCount, error ) => {
+const migrationKeyRetry = ( failureCount: number, error: Error ): boolean | Error => {
 	if ( ! isWhiteLabeledPluginEnabled() ) {
 		return false;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94802

## Proposed Changes

* The new migration key may not be available immediately since the software is installed via an async job. Tell the query to retry if we're using the white-labeled plugin flag.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Before this, we installed the software on the site via a call from the front end, ensuring it was available to get the migration key.
* Now that we've moved the software installation logic to an async job, we aren't guaranteed to have the key available when we land on the site instructions page. This change allows us to recheck the API for the key until we get a successful response.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/setup/migration-signup`
* Ensure the feature flag is enabled by either adding the query param `&flags=migration-flow/enable-white-labeled-plugin` to the URL at the site instructions step OR in your session storage by running the following in your console, hitting enter, and reloading: `window.sessionStorage.setItem('flags', 'migration-flow/enable-white-labeled-plugin');`
* Go through the flow; check out. You should land on the site instructions page:

<img width="1389" alt="Screenshot 2024-09-23 at 9 48 31 AM" src="https://github.com/user-attachments/assets/855a4be5-7d6f-48d0-9e0b-f8fb0f5724ee">

* Wait for the new site to be transferred to Atomic
* Go to the site's `/wp-admin` and install and activate the Migrate to WordPress.com plugin (link available in Slack).
* Go back to the site instructions page and see the key displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
