### PR TITLE
Stats: Fix more dates to start of day

### DIFF
--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -87,11 +87,10 @@ const DateRangePicker = ( {
 	 * @param  {import('moment').Moment} date the newly selected date object
 	 */
 	const selectDate = ( date: Moment ) => {
+		date = date.startOf( 'day' );
 		if ( ! isValidDate( date ) ) {
 			return;
 		}
-
-		date = date.startOf( 'day' );
 
 		// Calculate the new Date range
 		const newRange = addDayToRange( date, { from: selectedStartDate, to: selectedEndDate } );
@@ -128,6 +127,10 @@ const DateRangePicker = ( {
 		return [ config ];
 	};
 
+	const normlizeDate = ( date: MomentOrNull ) => {
+		return date ? date.startOf( 'day' ) : date;
+	};
+
 	useEffect( () => {
 		if ( selectedStartDate && selectedEndDate && selectedStartDate.isAfter( selectedEndDate ) ) {
 			onDateRangeChange?.( selectedEndDate, selectedStartDate );
@@ -135,8 +138,10 @@ const DateRangePicker = ( {
 	}, [ selectedStartDate?.format(), selectedEndDate?.format() ] );
 
 	// Normalize dates to start of day
-	selectedStartDate = ! selectedStartDate ? selectedStartDate : selectedStartDate.startOf( 'day' );
-	selectedEndDate = ! selectedEndDate ? selectedEndDate : selectedEndDate.startOf( 'day' );
+	selectedStartDate = normlizeDate( selectedStartDate );
+	selectedEndDate = normlizeDate( selectedEndDate );
+	firstSelectableDate = normlizeDate( firstSelectableDate );
+	lastSelectableDate = normlizeDate( lastSelectableDate );
 
 	const fromDate = momentDateToJsDate( selectedStartDate );
 	const toDate = momentDateToJsDate( selectedEndDate );

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -121,8 +121,8 @@ DateRangePickerShortcuts.propTypes = {
 	currentShortcut: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
 	locked: PropTypes.bool,
-	startDate: PropTypes.instanceOf( Date ),
-	endDate: PropTypes.instanceOf( Date ),
+	startDate: PropTypes.object,
+	endDate: PropTypes.object,
 };
 
 export default DateRangePickerShortcuts;


### PR DESCRIPTION
Follow up for: https://github.com/Automattic/wp-calypso/pull/94739

## Proposed Changes

* Set moment to the start of the day for comparison

## Why are these changes being made?

* Bugfixes

## Testing Instructions


* Follow instructions at https://github.com/Automattic/wp-calypso/pull/94739

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
