### PR TITLE
Stats: Date Range Picker: make sure dates are moment object

### DIFF
--- a/client/components/date-range/date-range-picker.tsx
+++ b/client/components/date-range/date-range-picker.tsx
@@ -128,7 +128,7 @@ const DateRangePicker = ( {
 	};
 
 	const normlizeDate = ( date: MomentOrNull ) => {
-		return date ? date.startOf( 'day' ) : date;
+		return date ? moment( date ).startOf( 'day' ) : date;
 	};
 
 	useEffect( () => {


### PR DESCRIPTION

Related to https://github.com/Automattic/wp-calypso/pull/94805

## Proposed Changes

* Make sure dates are instances of Moment

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* bugfix

## Testing Instructions

* Open Calypso Live for Calypso Green
* Open Activities log
* Click open the calendar
* Ensure the calendar works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
