### PR TITLE
Logged-in Performance Profiler: A4A Dev Sites that are un-launched redirects to the correct page

### DIFF
--- a/client/hosting/performance/components/ReportUnavailable.tsx
+++ b/client/hosting/performance/components/ReportUnavailable.tsx
@@ -5,9 +5,11 @@ import { useTranslate } from 'i18n-calypso';
 export const ReportUnavailable = ( {
 	isLaunching,
 	onLaunchSiteClick,
+	ctaText,
 }: {
 	isLaunching: boolean;
 	onLaunchSiteClick(): void;
+	ctaText: string;
 } ) => {
 	const translate = useTranslate();
 
@@ -24,7 +26,7 @@ export const ReportUnavailable = ( {
 					variant="primary"
 					onClick={ onLaunchSiteClick }
 				>
-					{ translate( 'Launch your site' ) }
+					{ ctaText }
 				</Button>,
 			] }
 		>

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -189,6 +189,10 @@ export const SitePerformance = () => {
 	);
 
 	const onLaunchSiteClick = () => {
+		if ( site?.is_a4a_dev_site ) {
+			page( `/settings/general/${ site.slug }` );
+			return;
+		}
 		dispatch( launchSite( siteId! ) );
 	};
 
@@ -278,6 +282,11 @@ export const SitePerformance = () => {
 						<ReportUnavailable
 							isLaunching={ siteIsLaunching }
 							onLaunchSiteClick={ onLaunchSiteClick }
+							ctaText={
+								site?.is_a4a_dev_site
+									? translate( 'Prepare for launch' )
+									: translate( 'Launch Site' )
+							}
 						/>
 					) : (
 						currentPage && (

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -203,6 +203,7 @@ export const SitePerformance = () => {
 			onFilterValueChange={ setQuery }
 			allowReset={ false }
 			options={ pageOptions }
+			disabled={ isInitialLoading || performanceReport.isLoading }
 			onChange={ ( page_id ) => {
 				const url = new URL( window.location.href );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes
We show a launch site UI for unlaunched sites on the performance tab with the ability to launch the site. However a4a dev site should not be launched immediately but redirected to settings page for more information.
* Show `Prepare for launch` CTA and redirects to settings page. 
*
![image](https://github.com/user-attachments/assets/2ebcf9cc-6407-43cb-a227-ada25aab7f8e)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have an a4a dev site that is unlaunched (can use blog sticker `is_a4a_dev_site`)
* Go to `sites/performance/site` and verify the CTA redirects to `settings/general/site`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
