### PR TITLE
[WIP] Siteless Checkout: support `redirect_to`

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
@@ -16,13 +16,13 @@ import useGetJetpackActivationConfirmationInfo from './use-get-jetpack-activatio
 interface Props {
 	productSlug: string;
 	destinationSiteId: number;
-	redirectTo?: string;
+	postActivationUrl?: string;
 }
 
 const LicensingActivationThankYouCompleted: FC< Props > = ( {
 	productSlug = 'no_product',
 	destinationSiteId = 0,
-	redirectTo,
+	postActivationUrl,
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -102,7 +102,7 @@ const LicensingActivationThankYouCompleted: FC< Props > = ( {
 								)
 							}
 							// TODO: Need to ensure redirectTo is either wp.com or wp admin of the site.
-							href={ redirectTo ?? productConfirmationInfo.buttonUrl }
+							href={ postActivationUrl ?? productConfirmationInfo.buttonUrl }
 						>
 							{ translate( 'Go to Dashboard' ) }
 						</Button>

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
@@ -101,7 +101,7 @@ const LicensingActivationThankYouCompleted: FC< Props > = ( {
 									} )
 								)
 							}
-							// Need to ensure redirectTo is either wp.com or wp admin of the site.
+							// TODO: Need to ensure redirectTo is either wp.com or wp admin of the site.
 							href={ redirectTo ?? productConfirmationInfo.buttonUrl }
 						>
 							{ translate( 'Go to Dashboard' ) }

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
@@ -16,11 +16,13 @@ import useGetJetpackActivationConfirmationInfo from './use-get-jetpack-activatio
 interface Props {
 	productSlug: string;
 	destinationSiteId: number;
+	redirectTo?: string;
 }
 
 const LicensingActivationThankYouCompleted: FC< Props > = ( {
 	productSlug = 'no_product',
 	destinationSiteId = 0,
+	redirectTo,
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -99,7 +101,8 @@ const LicensingActivationThankYouCompleted: FC< Props > = ( {
 									} )
 								)
 							}
-							href={ productConfirmationInfo.buttonUrl }
+							// Need to ensure redirectTo is either wp.com or wp admin of the site.
+							href={ redirectTo ?? productConfirmationInfo.buttonUrl }
 						>
 							{ translate( 'Go to Dashboard' ) }
 						</Button>

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -28,6 +28,7 @@ interface Props {
 	source?: string;
 	jetpackTemporarySiteId?: number;
 	fromSiteSlug?: string;
+	redirectTo?: string;
 }
 
 type JetpackSite = {
@@ -55,6 +56,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 	source = 'onboarding-calypso-ui',
 	jetpackTemporarySiteId = 0,
 	fromSiteSlug,
+	redirectTo,
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -206,6 +208,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 			const thankYouCompletedUrl = addQueryArgs(
 				{
 					destinationSiteId,
+					redirect_to: redirectTo,
 				},
 				`/checkout/jetpack/thank-you/licensing-auto-activate-completed/${ productSlug }`
 			);

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -28,7 +28,7 @@ interface Props {
 	source?: string;
 	jetpackTemporarySiteId?: number;
 	fromSiteSlug?: string;
-	redirectTo?: string;
+	postActivationUrl?: string;
 }
 
 type JetpackSite = {
@@ -56,7 +56,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 	source = 'onboarding-calypso-ui',
 	jetpackTemporarySiteId = 0,
 	fromSiteSlug,
-	redirectTo,
+	postActivationUrl,
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -208,7 +208,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 			const thankYouCompletedUrl = addQueryArgs(
 				{
 					destinationSiteId,
-					redirect_to: redirectTo,
+					postActivationUrl,
 				},
 				`/checkout/jetpack/thank-you/licensing-auto-activate-completed/${ productSlug }`
 			);

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -480,7 +480,7 @@ export function licensingThankYouAutoActivation( context, next ) {
 	const userHasJetpackSites = currentUser && currentUser.jetpack_visible_site_count >= 1;
 
 	const { product } = context.params;
-	const { receiptId, source, siteId, fromSiteSlug, redirect_to } = context.query;
+	const { receiptId, source, siteId, fromSiteSlug, postActivationUrl } = context.query;
 
 	if ( ! userHasJetpackSites ) {
 		page.redirect(
@@ -498,7 +498,7 @@ export function licensingThankYouAutoActivation( context, next ) {
 				source={ source }
 				jetpackTemporarySiteId={ siteId }
 				fromSiteSlug={ fromSiteSlug }
-				redirectTo={ redirect_to }
+				postActivationUrl={ postActivationUrl }
 			/>
 		);
 	}
@@ -507,13 +507,13 @@ export function licensingThankYouAutoActivation( context, next ) {
 }
 
 export function licensingThankYouAutoActivationCompleted( context, next ) {
-	const { destinationSiteId, redirect_to } = context.query;
+	const { destinationSiteId, postActivationUrl } = context.query;
 
 	context.primary = (
 		<LicensingThankYouAutoActivationCompleted
 			productSlug={ context.params.product }
 			destinationSiteId={ destinationSiteId }
-			redirectTo={ redirect_to }
+			postActivationUrl={ postActivationUrl }
 		/>
 	);
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -480,7 +480,7 @@ export function licensingThankYouAutoActivation( context, next ) {
 	const userHasJetpackSites = currentUser && currentUser.jetpack_visible_site_count >= 1;
 
 	const { product } = context.params;
-	const { receiptId, source, siteId, fromSiteSlug } = context.query;
+	const { receiptId, source, siteId, fromSiteSlug, redirect_to } = context.query;
 
 	if ( ! userHasJetpackSites ) {
 		page.redirect(
@@ -498,6 +498,7 @@ export function licensingThankYouAutoActivation( context, next ) {
 				source={ source }
 				jetpackTemporarySiteId={ siteId }
 				fromSiteSlug={ fromSiteSlug }
+				redirectTo={ redirect_to }
 			/>
 		);
 	}
@@ -506,12 +507,13 @@ export function licensingThankYouAutoActivation( context, next ) {
 }
 
 export function licensingThankYouAutoActivationCompleted( context, next ) {
-	const { destinationSiteId } = context.query;
+	const { destinationSiteId, redirect_to } = context.query;
 
 	context.primary = (
 		<LicensingThankYouAutoActivationCompleted
 			productSlug={ context.params.product }
 			destinationSiteId={ destinationSiteId }
+			redirectTo={ redirect_to }
 		/>
 	);
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -259,6 +259,7 @@ export default function getThankYouPageUrl( {
 					siteId: jetpackTemporarySiteId && parseInt( jetpackTemporarySiteId ),
 					fromSiteSlug,
 					productSlug,
+					redirect_to: redirectTo,
 				},
 				`${ calypsoHost }/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }`
 			);
@@ -283,6 +284,7 @@ export default function getThankYouPageUrl( {
 			{
 				receiptId: receiptIdOrPlaceholder,
 				siteId: jetpackTemporarySiteId && parseInt( jetpackTemporarySiteId ),
+				redirect_to: redirectTo,
 			},
 			thankYouUrl
 		);

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -109,6 +109,7 @@ export interface PostCheckoutUrlArguments {
 	 * logged in).
 	 */
 	fromSiteSlug?: string;
+	postActivationUrl?: string;
 }
 
 /**
@@ -147,6 +148,7 @@ export default function getThankYouPageUrl( {
 	domains,
 	connectAfterCheckout,
 	fromSiteSlug,
+	postActivationUrl,
 }: PostCheckoutUrlArguments ): string {
 	debug( 'starting getThankYouPageUrl' );
 
@@ -259,7 +261,7 @@ export default function getThankYouPageUrl( {
 					siteId: jetpackTemporarySiteId && parseInt( jetpackTemporarySiteId ),
 					fromSiteSlug,
 					productSlug,
-					redirect_to: redirectTo,
+					postActivationUrl,
 				},
 				`${ calypsoHost }/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }`
 			);
@@ -284,7 +286,7 @@ export default function getThankYouPageUrl( {
 			{
 				receiptId: receiptIdOrPlaceholder,
 				siteId: jetpackTemporarySiteId && parseInt( jetpackTemporarySiteId ),
-				redirect_to: redirectTo,
+				postActivationUrl,
 			},
 			thankYouUrl
 		);

--- a/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
@@ -115,6 +115,7 @@ export default function useCreatePaymentCompleteCallback( {
 			// created site in the Thank You page URL.
 			// TODO: It does not seem like this would be needed for Akismet, but marking to follow up
 			let jetpackTemporarySiteId: string | undefined;
+			let postActivationUrl: string | undefined;
 			if (
 				sitelessCheckoutType === 'jetpack' &&
 				! siteSlug &&
@@ -123,6 +124,7 @@ export default function useCreatePaymentCompleteCallback( {
 				transactionResult.purchases
 			) {
 				jetpackTemporarySiteId = Object.keys( transactionResult.purchases ).pop();
+				postActivationUrl = redirectTo;
 			}
 
 			const getThankYouPageUrlArguments: PostCheckoutUrlArguments = {
@@ -143,6 +145,7 @@ export default function useCreatePaymentCompleteCallback( {
 				domains,
 				connectAfterCheckout,
 				fromSiteSlug,
+				postActivationUrl,
 			};
 
 			debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/56

## Proposed Changes

* Pass `redirect_to` around in the siteless flow to support proper redirection after license activation

## Why are these changes being made?

* Bugfix

## Testing Instructions

* 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
