### PR TITLE
A4A > Overview: Update the WooPayments line in WooCommerce section

### DIFF
--- a/client/a8c-for-agencies/components/offering/types.ts
+++ b/client/a8c-for-agencies/components/offering/types.ts
@@ -9,7 +9,7 @@ export type OfferingItemProps = {
 	title: string;
 	titleIcon: JSX.Element;
 	description: string;
-	highlights: string[];
+	highlights: React.ReactNode[];
 	expanded?: boolean;
 	clickableHeader?: boolean;
 	buttonTitle: string;

--- a/client/a8c-for-agencies/components/offering/types.ts
+++ b/client/a8c-for-agencies/components/offering/types.ts
@@ -9,7 +9,7 @@ export type OfferingItemProps = {
 	title: string;
 	titleIcon: JSX.Element;
 	description: string;
-	highlights: React.ReactNode[];
+	highlights: string[];
 	expanded?: boolean;
 	clickableHeader?: boolean;
 	buttonTitle: string;

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -74,17 +74,21 @@ const OverviewBodyProducts = () => {
 				'Product Bundles: Offer personalized bundles, bulk discounts, and assembled products.'
 			),
 			translate( 'Subscriptions: Enable weekly, monthly, or annual subscriptions.' ),
-			translate( 'WooPayments Referrals. {{a}}Learn more ↗{{/a}}', {
-				components: {
-					a: (
-						<a
-							href="https://automattic.com/for-agencies/program-incentives/"
-							target="_blank"
-							rel="noreferrer noopener"
-						/>
-					),
-				},
-			} ),
+			translate(
+				'WooPayments: Earn a recurring 5bps commission on Total Payment Volume (TPV) for any new clients referred. {{a}}Learn{{nbsp/}}more ↗{{/a}}',
+				{
+					components: {
+						a: (
+							<a
+								href="https://automattic.com/for-agencies/program-incentives/"
+								target="_blank"
+								rel="noreferrer noopener"
+							/>
+						),
+						nbsp: <>&nbsp;</>,
+					},
+				}
+			),
 		],
 		// translators: Button navigating to A4A Marketplace
 		buttonTitle: translate( 'View all WooCommerce products' ),

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -88,7 +88,7 @@ const OverviewBodyProducts = () => {
 						nbsp: <>&nbsp;</>,
 					},
 				}
-			),
+			) as string,
 		],
 		// translators: Button navigating to A4A Marketplace
 		buttonTitle: translate( 'View all WooCommerce products' ),

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -74,7 +74,17 @@ const OverviewBodyProducts = () => {
 				'Product Bundles: Offer personalized bundles, bulk discounts, and assembled products.'
 			),
 			translate( 'Subscriptions: Enable weekly, monthly, or annual subscriptions.' ),
-			translate( 'WooPayments Referrals: Coming soon.' ),
+			translate( 'WooPayments Referrals. {{a}}Learn more.{{/a}}', {
+				components: {
+					a: (
+						<a
+							href="https://automattic.com/for-agencies/program-incentives/"
+							target="_blank"
+							rel="noreferrer noopener"
+						/>
+					),
+				},
+			} ),
 		],
 		// translators: Button navigating to A4A Marketplace
 		buttonTitle: translate( 'View all WooCommerce products' ),

--- a/client/a8c-for-agencies/sections/overview/body/products/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/products/index.tsx
@@ -74,7 +74,7 @@ const OverviewBodyProducts = () => {
 				'Product Bundles: Offer personalized bundles, bulk discounts, and assembled products.'
 			),
 			translate( 'Subscriptions: Enable weekly, monthly, or annual subscriptions.' ),
-			translate( 'WooPayments Referrals. {{a}}Learn more.{{/a}}', {
+			translate( 'WooPayments Referrals. {{a}}Learn more ↗{{/a}}', {
 				components: {
 					a: (
 						<a


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1146

## Proposed Changes

* This PR updates the WooPayments line in the WooCommerce section on the overview page with the learn more link.

## Why are these changes being made?

* To update the WooPayments line in the WooCommerce section

## Testing Instructions

* Open the A4A live link
* Go to the Overview page > Scroll down to the WooCommerce section under Products > Verify that the line for WooPayments is updated as shown below and the link works as expected.



| Before | After |
|--------|--------|
| <img width="882" alt="Screenshot 2024-09-23 at 1 28 13 PM" src="https://github.com/user-attachments/assets/5691f224-c0d6-42d3-9106-8c4581c79231"> | <img width="913" alt="Screenshot 2024-09-24 at 8 18 44 AM" src="https://github.com/user-attachments/assets/24607bec-a66a-4611-b224-73ee55198bd5"> |




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
