### PR TITLE
Theme tooltips: sets specific messaging for ecommerce trial plans.

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -43,7 +43,7 @@ export default function ThemeTierCommunityBadge() {
 		if ( isEcommerceTrialMonthly ) {
 			return createInterpolateElement(
 				translate(
-					'This community theme cannot be installed in a trial plan site. Please upgrade your <Link>%(ecommercePlanName)s plan</Link> on your site.',
+					"This theme can't be installed on a trial site. Please upgrade to the <Link>%(ecommercePlanName)s plan</Link> to install this theme.",
 					{ args: { ecommercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '' } }
 				),
 				{

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -27,24 +27,36 @@ export default function ThemeTierCommunityBadge() {
 	const planSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) ?? '' );
 	const isEcommerceTrialMonthly = planSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 	const planTooltipName = isEcommerceTrialMonthly ? 'ecommerce' : 'business';
-	const planTooltipTitle = isEcommerceTrialMonthly
-		? getPlan( PLAN_ECOMMERCE )?.getTitle()
-		: getPlan( PLAN_BUSINESS )?.getTitle();
+
+	const getTooltipMessage = () => {
+		if ( ! isEcommerceTrialMonthly ) {
+			return createInterpolateElement(
+				translate(
+					'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.',
+					{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+				),
+				{
+					Link: <ThemeTierBadgeCheckoutLink plan={ planTooltipName } />,
+				}
+			);
+		}
+		if ( isEcommerceTrialMonthly ) {
+			return createInterpolateElement(
+				translate(
+					'This community theme cannot be installed in a trial plan site. Please upgrade your <Link>%(ecommercePlanName)s plan</Link> on your site.',
+					{ args: { ecommercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '' } }
+				),
+				{
+					Link: <ThemeTierBadgeCheckoutLink plan={ planTooltipName } />,
+				}
+			);
+		}
+	};
 
 	const tooltipContent = (
 		<>
 			<ThemeTierTooltipTracker />
-			<div data-testid="upsell-message">
-				{ createInterpolateElement(
-					translate(
-						'This community theme can only be installed if you have the <Link>%(planName)s plan</Link> or higher on your site.',
-						{ args: { planName: planTooltipTitle ?? '' } }
-					),
-					{
-						Link: <ThemeTierBadgeCheckoutLink plan={ planTooltipName } />,
-					}
-				) }
-			</div>
+			<div data-testid="upsell-message">{ getTooltipMessage() }</div>
 		</>
 	);
 

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -27,9 +27,6 @@ export default function ThemeTierPartnerBadge() {
 
 	const isEcommerceTrialMonthly = planSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 	const planTooltipName = isEcommerceTrialMonthly ? 'ecommerce' : 'business';
-	const planTooltipTitle = isEcommerceTrialMonthly
-		? getPlan( PLAN_ECOMMERCE )?.getTitle()
-		: getPlan( PLAN_BUSINESS )?.getTitle();
 
 	const { showUpgradeBadge, themeId } = useThemeTierBadgeContext();
 	const isPartnerThemePurchased = useSelector( ( state ) =>
@@ -45,11 +42,22 @@ export default function ThemeTierPartnerBadge() {
 		: translate( 'Upgrade and Subscribe' );
 
 	const getTooltipMessage = () => {
-		if ( isPartnerThemePurchased && ! isThemeAllowed ) {
+		if ( isPartnerThemePurchased && ! isThemeAllowed && ! isEcommerceTrialMonthly ) {
 			return createInterpolateElement(
 				translate(
-					'You have a subscription for this theme, but it will only be usable if you have the <link>%(planName)s plan</link> on your site.',
-					{ args: { planName: planTooltipTitle ?? '' } }
+					'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> or higher on your site.',
+					{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+				),
+				{
+					Link: <ThemeTierBadgeCheckoutLink plan={ planTooltipName } />,
+				}
+			);
+		}
+		if ( isPartnerThemePurchased && ! isThemeAllowed && isEcommerceTrialMonthly ) {
+			return createInterpolateElement(
+				translate(
+					"You have a subscription for this theme, but it's not usable on a trial plan site. Please upgrade your <link>%(ecommercePlanName)s plan</link> on your site.",
+					{ args: { ecommercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '' } }
 				),
 				{
 					Link: <ThemeTierBadgeCheckoutLink plan={ planTooltipName } />,
@@ -68,16 +76,34 @@ export default function ThemeTierPartnerBadge() {
 				}
 			);
 		}
-		if ( ! isPartnerThemePurchased && ! isThemeAllowed ) {
+		if ( ! isPartnerThemePurchased && ! isThemeAllowed && ! isEcommerceTrialMonthly ) {
 			return createInterpolateElement(
 				/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
 				translate(
-					'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(planName)s plan</Link> on your site.',
+					'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.',
 					{
 						args: {
 							annualPrice: subscriptionPrices.year ?? '',
 							monthlyPrice: subscriptionPrices.month ?? '',
-							planName: planTooltipTitle ?? '',
+							businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+						},
+					}
+				),
+				{
+					Link: <ThemeTierBadgeCheckoutLink plan={ planTooltipName } />,
+				}
+			);
+		}
+		if ( ! isPartnerThemePurchased && ! isThemeAllowed && isEcommerceTrialMonthly ) {
+			return createInterpolateElement(
+				/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
+				translate(
+					'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and cannot be purchased in a trial plan site. Please upgraed your <Link>%(ecommercePlanName)s plan</Link> on your site.',
+					{
+						args: {
+							annualPrice: subscriptionPrices.year ?? '',
+							monthlyPrice: subscriptionPrices.month ?? '',
+							businessPlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
 						},
 					}
 				),

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -103,7 +103,7 @@ export default function ThemeTierPartnerBadge() {
 						args: {
 							annualPrice: subscriptionPrices.year ?? '',
 							monthlyPrice: subscriptionPrices.month ?? '',
-							businessPlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+							ecommercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
 						},
 					}
 				),

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -98,7 +98,7 @@ export default function ThemeTierPartnerBadge() {
 			return createInterpolateElement(
 				/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
 				translate(
-					'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and cannot be purchased in a trial plan site. Please upgraed your <Link>%(ecommercePlanName)s plan</Link> on your site.',
+					'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and cannot be purchased in a trial plan site. Please upgrade your <Link>%(ecommercePlanName)s plan</Link> on your site.',
 					{
 						args: {
 							annualPrice: subscriptionPrices.year ?? '',

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -53,10 +53,11 @@ export default function ThemeTierPartnerBadge() {
 				}
 			);
 		}
+
 		if ( isPartnerThemePurchased && ! isThemeAllowed && isEcommerceTrialMonthly ) {
 			return createInterpolateElement(
 				translate(
-					"You have a subscription for this theme, but it's not usable on a trial plan site. Please upgrade your <link>%(ecommercePlanName)s plan</link> on your site.",
+					"You have a subscription for this theme, but it isn't usable on a trial plan site. Please upgrade to the <link>%(ecommercePlanName)s plan</link> to install this theme.",
 					{ args: { ecommercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '' } }
 				),
 				{
@@ -98,7 +99,7 @@ export default function ThemeTierPartnerBadge() {
 			return createInterpolateElement(
 				/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
 				translate(
-					'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and cannot be purchased in a trial plan site. Please upgrade your <Link>%(ecommercePlanName)s plan</Link> on your site.',
+					"This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can't be purchased on a trial site. Please upgrade to the <Link>%(ecommercePlanName)s plan</Link> to install this theme.",
 					{
 						args: {
 							annualPrice: subscriptionPrices.year ?? '',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94748

## Proposed Changes

* Sets specific messaging for trial plan sites when hovering a community or partner theme

**Community**
`This community theme cannot be installed in a trial plan site. Please upgrade your Commerce plan on your site.`

**Partner**
`This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and cannot be purchased in a trial plan site. Please upgrade your Commerce plan on your site.`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Commerce Trial Plan**
- Go to [wordpress.com/ecommerce](https://wordpress.com/ecommerce/)
- Press Get Started and proceed all the way through the flow
- Go to wordpress.com/themes/:siteSlug
- Look for themes that require update and hover on "Upgrade and Subscribe". The tooltip should show ecommerce link leading to the checkout page with the ecommerce plan in the cart.
- Search for "Construction Firm" in the theme filter field.
- Check the "Upgrade" badge on community themes. The tooltip should show ecommerce link leading to the checkout page with the ecommerce plan in the cart.
- Both tooltips should denote that the theme isn't available to trial plans.

**On a plan lower than business**
- Look for themes that require update and hover on "Upgrade and Subscribe". The tooltip should show business link leading to the checkout page with the business plan in the cart.
- Search for "Construction Firm" in the theme filter field.
- Check the "Upgrade" badge on community themes. The tooltip should show business link leading to the checkout page with the business plan in the cart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
