### PR TITLE
Stepper: Add processing screen track event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -8,6 +8,7 @@ import {
 	isWooExpressFlow,
 	isTransferringHostedSiteCreationFlow,
 	HUNDRED_YEAR_PLAN_FLOW,
+	isAnyHostingFlow,
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -18,8 +19,10 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import availableFlows from 'calypso/landing/stepper/declarative-flow/registered-flows';
 import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { recordSignupProcessingScreen } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useInterval } from 'calypso/lib/interval';
+import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import useCaptureFlowException from '../../../../hooks/use-capture-flow-exception';
 import { ProcessingResult } from './constants';
 import { useProcessingLoadingMessages } from './hooks/use-processing-loading-messages';
@@ -113,6 +116,13 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 				submit?.( { ...destinationState, ...props.data }, ProcessingResult.SUCCESS );
 				return;
 			}
+
+			const { previousStep = '' } = props.data || {};
+
+			recordSignupProcessingScreen( flow, previousStep, {
+				is_in_hosting_flow: isAnyHostingFlow( flow ),
+				wccom_from: getWccomFrom( destinationState ),
+			} );
 
 			// Default processing handler.
 			submit?.( destinationState, ProcessingResult.SUCCESS );

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -176,7 +176,7 @@ export function recordRegistration( { userData, flow, type } ) {
  * Records loading of the processing screen
  * @param {string} flow Signup flow name
  * @param {string} previousStep The step before the processing screen
- * @param {string} optionalProps Extra properties to record
+ * @param {Object} optionalProps Extra properties to record
  */
 export function recordSignupProcessingScreen( flow, previousStep, optionalProps ) {
 	const device = resolveDeviceTypeByViewPort();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94422
Fixes #94422

## Proposed Changes

* Add track events on processing step to replicate the behavior in `/start`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to keep the same tracking structure in stepper.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link
* Navigate to /setup/onboarding
* Navigate through until after the processing screen
* Check on Tracks Vigilante if `calypso_signup_processing_screen_show` is recorded
* Compare the same flow on `/start` to help on testing

From Setup
<img width="498" alt="image" src="https://github.com/user-attachments/assets/2d814a23-9f8d-48a3-9256-26550c0cb36e">


From start
<img width="652" alt="image" src="https://github.com/user-attachments/assets/66f695d4-58ab-44df-9b2a-5a672089dc8a">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
