### PR TITLE
A4A > Licenses: Allow agencies to assign referred products without a payment method

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -104,11 +104,13 @@ export default function LicensePreview( {
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl && ! isPressableLicense ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 
+	const isClientSite = isAutomatedReferralsEnabled && referral;
+
 	const assign = useCallback( () => {
 		const redirectUrl = isWPCOMLicense
 			? A4A_SITES_LINK_NEEDS_SETUP
 			: addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' );
-		if ( paymentMethodRequired ) {
+		if ( paymentMethodRequired && ! isClientSite ) {
 			const noticeLinkHref = addQueryArgs(
 				{
 					return: redirectUrl,
@@ -131,7 +133,7 @@ export default function LicensePreview( {
 		}
 
 		page.redirect( redirectUrl );
-	}, [ isWPCOMLicense, licenseKey, paymentMethodRequired, translate, dispatch ] );
+	}, [ isWPCOMLicense, licenseKey, paymentMethodRequired, isClientSite, translate, dispatch ] );
 
 	useEffect( () => {
 		if ( isHighlighted ) {
@@ -257,7 +259,7 @@ export default function LicensePreview( {
 				<div>
 					<span className="license-preview__product">
 						{ productTitle }
-						{ isAutomatedReferralsEnabled && referral && (
+						{ isClientSite && (
 							<div className="license-preview__client-email">
 								<ClientSite referral={ referral } />
 							</div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -104,13 +104,13 @@ export default function LicensePreview( {
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl && ! isPressableLicense ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 
-	const isClientSite = isAutomatedReferralsEnabled && referral;
+	const isClientLicense = isAutomatedReferralsEnabled && referral;
 
 	const assign = useCallback( () => {
 		const redirectUrl = isWPCOMLicense
 			? A4A_SITES_LINK_NEEDS_SETUP
 			: addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' );
-		if ( paymentMethodRequired && ! isClientSite ) {
+		if ( paymentMethodRequired && ! isClientLicense ) {
 			const noticeLinkHref = addQueryArgs(
 				{
 					return: redirectUrl,
@@ -133,7 +133,7 @@ export default function LicensePreview( {
 		}
 
 		page.redirect( redirectUrl );
-	}, [ isWPCOMLicense, licenseKey, paymentMethodRequired, isClientSite, translate, dispatch ] );
+	}, [ isWPCOMLicense, licenseKey, paymentMethodRequired, isClientLicense, translate, dispatch ] );
 
 	useEffect( () => {
 		if ( isHighlighted ) {
@@ -259,7 +259,7 @@ export default function LicensePreview( {
 				<div>
 					<span className="license-preview__product">
 						{ productTitle }
-						{ isClientSite && (
+						{ isClientLicense && (
 							<div className="license-preview__client-email">
 								<ClientSite referral={ referral } />
 							</div>


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1141

## Proposed Changes

This PR allows agencies to assign referred products without a payment method

## Why are these changes being made?

* To allow agencies to assign referred products without a payment method

## Testing Instructions

* Open the A4A live link
* Go to Marketplace > Toggle the Refer mode on > Add a WPCOM site and any product > Checkout
* Open the email > Login as a client and purchase the referred products.
* Now, as an agency, visit the Payment Methods page and remove all the payment methods. 
* Go to the Licenses page > Verify that clicking on Create site or Assign doesn't ask you to add a payment method for the referred products only and asks you to add it when it is a non-referred product. Go ahead and create a site and assign a license to any site and verify everything works as expected. 

<img width="1356" alt="Screenshot 2024-09-23 at 2 02 12 PM" src="https://github.com/user-attachments/assets/f7d6dd7a-1ad8-4ac4-86d1-270930f7b1b4">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
