### PR TITLE
Remove the feature flag of the email subscription flow 

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -38,31 +38,6 @@ const getP2Flows = () => {
 		: [];
 };
 
-const getEmailSubscriptionFlow = () => {
-	return isEnabled( 'signup/email-subscription-flow' )
-		? [
-				{
-					name: 'email-subscription',
-					steps: [ 'subscribe' ],
-					destination: ( dependencies ) => `${ dependencies.redirect }`,
-					description:
-						'Signup flow that subscripes user to guides appointments for email campaigns',
-					lastModified: '2024-06-17',
-					showRecaptcha: true,
-					providesDependenciesInQuery: [
-						'user_email',
-						'redirect_to',
-						'mailing_list',
-						'from',
-						'first_name',
-					],
-					optionalDependenciesInQuery: [ 'last_name' ],
-					hideProgressIndicator: true,
-				},
-		  ]
-		: [];
-};
-
 export function generateFlows( {
 	getRedirectDestination = noop,
 	getSignupDestination = noop,
@@ -81,7 +56,6 @@ export function generateFlows( {
 } = {} ) {
 	const userSocialStep = getUserSocialStepOrFallback();
 	const p2Flows = getP2Flows();
-	const emailSubscriptionFlow = getEmailSubscriptionFlow();
 
 	const flows = [
 		{
@@ -646,7 +620,23 @@ export function generateFlows( {
 			hideProgressIndicator: true,
 			enableHotjar: true,
 		},
-		...emailSubscriptionFlow,
+		{
+			name: 'email-subscription',
+			steps: [ 'subscribe' ],
+			destination: ( dependencies ) => `${ dependencies.redirect }`,
+			description: 'Signup flow that subscripes user to guides appointments for email campaigns',
+			lastModified: '2024-06-17',
+			showRecaptcha: true,
+			providesDependenciesInQuery: [
+				'user_email',
+				'redirect_to',
+				'mailing_list',
+				'from',
+				'first_name',
+			],
+			optionalDependenciesInQuery: [ 'last_name' ],
+			hideProgressIndicator: true,
+		},
 	];
 
 	// convert the array to an object keyed by `name`

--- a/config/development.json
+++ b/config/development.json
@@ -209,7 +209,6 @@
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,
-		"signup/email-subscription-flow": true,
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -135,7 +135,6 @@
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,
-		"signup/email-subscription-flow": true,
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,

--- a/config/production.json
+++ b/config/production.json
@@ -178,7 +178,6 @@
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,
-		"signup/email-subscription-flow": true,
 		"site-indicator": true,
 		"site-profiler/metrics": false,
 		"ssr/log-prefetch-errors": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -173,7 +173,6 @@
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,
-		"signup/email-subscription-flow": true,
 		"site-indicator": true,
 		"site-profiler/metrics": false,
 		"ssr/prefetch-timebox": true,

--- a/config/test.json
+++ b/config/test.json
@@ -124,7 +124,6 @@
 		"settings/security/monitor": true,
 		"signup/social": true,
 		"signup/social-first": true,
-		"signup/email-subscription-flow": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/date-picker-calendar": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -173,7 +173,6 @@
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,
-		"signup/email-subscription-flow": true,
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The email subscription flow is now live, so we can remove the related feature flag gating now.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Since the functionality is now used in production without attempt of removal on horizon, we should clean up the code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This demonstrating-only URL should lead you through the flow and redirect you back to wordpress.com: http://calypso.localhost:3000/start/email-subscription/subscribe?user_email=southptest2@example.com&redirect_to=wordpress.com&mailing_list=test&first_name=Yo&from=wordpress.com . For other calypso instances, replacing the `calypso.localhost` part accordingly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
