### PR TITLE
Show that PHP 8.2 is the preferred version, instead of 8.1

### DIFF
--- a/client/data/php-versions/use-php-versions.jsx
+++ b/client/data/php-versions/use-php-versions.jsx
@@ -8,7 +8,6 @@ export const usePhpVersions = () => {
 	// 10% of sites will have a recommended PHP version of 8.2.
 	const is10Percent = siteId % 10 === 0;
 	const recommendedValue = is10Percent ? '8.2' : '8.1';
-	console.log( siteId, recommendedValue );
 	const label = translate( '%s (recommended)', {
 		args: recommendedValue,
 		comment: 'PHP Version for a version switcher',

--- a/client/data/php-versions/use-php-versions.jsx
+++ b/client/data/php-versions/use-php-versions.jsx
@@ -1,8 +1,18 @@
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export const usePhpVersions = () => {
-	const recommendedValue = '8.1';
 	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	// 10% of sites will have a recommended PHP version of 8.2.
+	const is10Percent = siteId % 10 === 0;
+	const recommendedValue = is10Percent ? '8.2' : '8.1';
+	console.log( siteId, recommendedValue );
+	const label = translate( '%s (recommended)', {
+		args: recommendedValue,
+		comment: 'PHP Version for a version switcher',
+	} );
 
 	const phpVersions = [
 		{
@@ -24,11 +34,8 @@ export const usePhpVersions = () => {
 			disabled: true, // EOL 26th November, 2023
 		},
 		{
-			label: translate( '%s (recommended)', {
-				args: '8.1',
-				comment: 'PHP Version for a version switcher',
-			} ),
-			value: recommendedValue,
+			label: '8.1',
+			value: '8.1',
 		},
 		{
 			label: '8.2',
@@ -39,6 +46,12 @@ export const usePhpVersions = () => {
 			value: '8.3',
 		},
 	];
+
+	if ( is10Percent ) {
+		phpVersions[ 4 ].label = label;
+	} else {
+		phpVersions[ 3 ].label = label;
+	}
 
 	return { recommendedValue, phpVersions };
 };

--- a/client/data/php-versions/use-php-versions.jsx
+++ b/client/data/php-versions/use-php-versions.jsx
@@ -6,7 +6,8 @@ export const usePhpVersions = () => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	// 10% of sites will have a recommended PHP version of 8.2.
-	const is10Percent = siteId % 10 === 0;
+	// 237292101 is the first site of the list.
+	const is10Percent = siteId % 10 === 0 && siteId >= 237292101;
 	const recommendedValue = is10Percent ? '8.2' : '8.1';
 	const label = translate( '%s (recommended)', {
 		args: recommendedValue,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94578 

## Proposed Changes

* Set 8.2 as the default version for 10% of sites

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See p9o2xV-3ZL-p2#comment-9969

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Select a (simple) blog:
1. Created after 2024-09-23 13:06:21
2. With an ID that ends with zero. If you don't have one change `siteId % 10 === 0` to `siteId % 10 === __LAST_NUMBER__` in https://github.com/Automattic/wp-calypso/blob/add/php-8-2-provisioning/client/data/php-versions/use-php-versions.jsx#L10

Test:
1. Add a plan to the site, buying it or adding it using the Store Admin.
2. Visit `http://calypso.localhost:3000/hosting-config/__BLOG__`.
3. Start the transfer to WoA.
4. Ensure that in "Server Settings" the PHP version is 8.2 and the recommended version is 8.2.
5. Check if other sites have the 8.1 as previously.

<img width="228" alt="image" src="https://github.com/user-attachments/assets/a414fe56-2c91-4a3c-8220-94f226cd27ca">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?