### PR TITLE
Stepper: Track step-route unconditionally - logged-out/empty

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-complete.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-complete.ts
@@ -5,7 +5,7 @@ import { STEPPER_TRACKS_EVENT_STEP_COMPLETE } from 'calypso/landing/stepper/cons
 export interface RecordStepCompleteProps {
 	flow: string;
 	step: string;
-	optionalProps?: Record< string, string | number | null >;
+	optionalProps?: Record< string, string | number | null | boolean >;
 }
 
 const recordStepComplete = ( { flow, step, optionalProps }: RecordStepCompleteProps ) => {

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -38,12 +38,18 @@ interface Props {
 	flowName: string;
 	stepSlug: string;
 	flowVariantSlug?: string;
+	skipStepRender?: boolean;
 }
 
 /**
  * Hook to track the step route in the declarative flow.
  */
-export const useStepRouteTracking = ( { flowName, stepSlug, flowVariantSlug }: Props ) => {
+export const useStepRouteTracking = ( {
+	flowName,
+	stepSlug,
+	flowVariantSlug,
+	skipStepRender,
+}: Props ) => {
 	const intent = useIntent();
 	const design = useSelectedDesign();
 	const hasRequestedSelectedSite = useHasRequestedSelectedSite();
@@ -81,13 +87,14 @@ export const useStepRouteTracking = ( { flowName, stepSlug, flowVariantSlug }: P
 				is_in_hosting_flow: isAnyHostingFlow( flowName ),
 				...( design && { assembler_source: getAssemblerSource( design ) } ),
 				...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
+				skip_step_render: Boolean( skipStepRender ),
 			} );
 
 			// Apply the props to record in the exit/step-complete event. We only record this if start event gets recorded.
 			stepCompleteEventPropsRef.current = {
 				flow: flowName,
 				step: stepSlug,
-				optionalProps: { intent },
+				optionalProps: { intent, skip_step_render: Boolean( skipStepRender ) },
 			};
 
 			const stepOldSlug = getStepOldSlug( stepSlug );
@@ -98,6 +105,7 @@ export const useStepRouteTracking = ( { flowName, stepSlug, flowVariantSlug }: P
 					is_in_hosting_flow: isAnyHostingFlow( flowName ),
 					...( design && { assembler_source: getAssemblerSource( design ) } ),
 					...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
+					skip_step_render: Boolean( skipStepRender ),
 				} );
 			}
 		}
@@ -107,6 +115,7 @@ export const useStepRouteTracking = ( { flowName, stepSlug, flowVariantSlug }: P
 		const pageTitle = `Setup > ${ flowName } > ${ stepSlug }`;
 		const params = {
 			flow: flowName,
+			skip_step_render: Boolean( skipStepRender ),
 		};
 		recordPageView( pathname, pageTitle, params );
 

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -37,20 +37,13 @@ const useHasRequestedSelectedSite = () => {
 interface Props {
 	flowName: string;
 	stepSlug: string;
-	// If true, the tracking event will not be recorded
-	skipTracking: boolean;
 	flowVariantSlug?: string;
 }
 
 /**
  * Hook to track the step route in the declarative flow.
  */
-export const useStepRouteTracking = ( {
-	flowName,
-	stepSlug,
-	skipTracking,
-	flowVariantSlug,
-}: Props ) => {
+export const useStepRouteTracking = ( { flowName, stepSlug, flowVariantSlug }: Props ) => {
 	const intent = useIntent();
 	const design = useSelectedDesign();
 	const hasRequestedSelectedSite = useHasRequestedSelectedSite();
@@ -73,7 +66,7 @@ export const useStepRouteTracking = ( {
 	useEffect( () => {
 		// We record the event only when the step is not empty.
 		// Additionally, we wait for the site to be fetched before tracking the step route.
-		if ( ! hasRequestedSelectedSite || skipTracking ) {
+		if ( ! hasRequestedSelectedSite ) {
 			return;
 		}
 
@@ -121,5 +114,5 @@ export const useStepRouteTracking = ( {
 		// We leave out intent and design from the dependency list, due to the ONBOARD_STORE being reset in the exit flow.
 		// The store reset causes these values to become empty, and may trigger this event again.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ flowName, hasRequestedSelectedSite, stepSlug, skipTracking ] );
+	}, [ flowName, hasRequestedSelectedSite, stepSlug ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -87,14 +87,14 @@ export const useStepRouteTracking = ( {
 				is_in_hosting_flow: isAnyHostingFlow( flowName ),
 				...( design && { assembler_source: getAssemblerSource( design ) } ),
 				...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
-				skip_step_render: Boolean( skipStepRender ),
+				...( skipStepRender && { skip_step_render: skipStepRender } ),
 			} );
 
 			// Apply the props to record in the exit/step-complete event. We only record this if start event gets recorded.
 			stepCompleteEventPropsRef.current = {
 				flow: flowName,
 				step: stepSlug,
-				optionalProps: { intent, skip_step_render: Boolean( skipStepRender ) },
+				optionalProps: { intent, ...( skipStepRender && { skip_step_render: skipStepRender } ) },
 			};
 
 			const stepOldSlug = getStepOldSlug( stepSlug );
@@ -105,7 +105,7 @@ export const useStepRouteTracking = ( {
 					is_in_hosting_flow: isAnyHostingFlow( flowName ),
 					...( design && { assembler_source: getAssemblerSource( design ) } ),
 					...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
-					skip_step_render: Boolean( skipStepRender ),
+					...( skipStepRender && { skip_step_render: skipStepRender } ),
 				} );
 			}
 		}
@@ -115,7 +115,7 @@ export const useStepRouteTracking = ( {
 		const pageTitle = `Setup > ${ flowName } > ${ stepSlug }`;
 		const params = {
 			flow: flowName,
-			skip_step_render: Boolean( skipStepRender ),
+			...( skipStepRender && { skip_step_render: skipStepRender } ),
 		};
 		recordPageView( pathname, pageTitle, params );
 

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -37,7 +37,6 @@ const useHasRequestedSelectedSite = () => {
 interface Props {
 	flowName: string;
 	stepSlug: string;
-	pathname: string;
 	flowVariantSlug?: string;
 	skipStepRender?: boolean;
 }
@@ -48,7 +47,6 @@ interface Props {
 export const useStepRouteTracking = ( {
 	flowName,
 	stepSlug,
-	pathname,
 	flowVariantSlug,
 	skipStepRender,
 }: Props ) => {
@@ -56,6 +54,7 @@ export const useStepRouteTracking = ( {
 	const design = useSelectedDesign();
 	const hasRequestedSelectedSite = useHasRequestedSelectedSite();
 	const stepCompleteEventPropsRef = useRef< RecordStepCompleteProps | null >( null );
+	const pathname = window.location.pathname;
 
 	/**
 	 * Cleanup effect to record step-complete event when `StepRoute` unmounts.
@@ -122,6 +121,8 @@ export const useStepRouteTracking = ( {
 
 		// We leave out intent and design from the dependency list, due to the ONBOARD_STORE being reset in the exit flow.
 		// The store reset causes these values to become empty, and may trigger this event again.
+		// We also leave out pathname. The respective event (calypso_page_view) is recorded behind a timeout and we don't want to trigger it again.
+		//     - window.location.pathname called inside the effect keeps referring to the previous path on a redirect. So we moved it outside.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ flowName, hasRequestedSelectedSite, stepSlug, skipStepRender, pathname ] );
+	}, [ flowName, hasRequestedSelectedSite, stepSlug, skipStepRender ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -64,8 +64,7 @@ export const useStepRouteTracking = ( { flowName, stepSlug, flowVariantSlug }: P
 	}, [] );
 
 	useEffect( () => {
-		// We record the event only when the step is not empty.
-		// Additionally, we wait for the site to be fetched before tracking the step route.
+		// We wait for the site to be fetched before tracking the step route.
 		if ( ! hasRequestedSelectedSite ) {
 			return;
 		}

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -122,5 +122,5 @@ export const useStepRouteTracking = ( {
 		// We leave out intent and design from the dependency list, due to the ONBOARD_STORE being reset in the exit flow.
 		// The store reset causes these values to become empty, and may trigger this event again.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ flowName, hasRequestedSelectedSite, stepSlug ] );
+	}, [ flowName, hasRequestedSelectedSite, stepSlug, skipStepRender ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -37,6 +37,7 @@ const useHasRequestedSelectedSite = () => {
 interface Props {
 	flowName: string;
 	stepSlug: string;
+	pathname: string;
 	flowVariantSlug?: string;
 	skipStepRender?: boolean;
 }
@@ -47,6 +48,7 @@ interface Props {
 export const useStepRouteTracking = ( {
 	flowName,
 	stepSlug,
+	pathname,
 	flowVariantSlug,
 	skipStepRender,
 }: Props ) => {
@@ -111,7 +113,6 @@ export const useStepRouteTracking = ( {
 		}
 
 		// Also record page view for data and analytics
-		const pathname = window.location.pathname;
 		const pageTitle = `Setup > ${ flowName } > ${ stepSlug }`;
 		const params = {
 			flow: flowName,
@@ -122,5 +123,5 @@ export const useStepRouteTracking = ( {
 		// We leave out intent and design from the dependency list, due to the ONBOARD_STORE being reset in the exit flow.
 		// The store reset causes these values to become empty, and may trigger this event again.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ flowName, hasRequestedSelectedSite, stepSlug, skipStepRender ] );
+	}, [ flowName, hasRequestedSelectedSite, stepSlug, skipStepRender, pathname ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -31,7 +31,6 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep, navigate }: StepRoute
 	useStepRouteTracking( {
 		flowName: flow.name,
 		stepSlug: step.slug,
-		skipTracking: ! stepContent,
 		flowVariantSlug: flow.variantSlug,
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -33,7 +33,6 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep, navigate }: StepRoute
 		stepSlug: step.slug,
 		flowVariantSlug: flow.variantSlug,
 		skipStepRender: shouldSkipRender,
-		pathname: window.location.pathname,
 	} );
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -25,14 +25,13 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep, navigate }: StepRoute
 	const loginUrl = useLoginUrlForFlow( { flow } );
 	const shouldAuthUser = step.requiresLoggedInUser && ! userIsLoggedIn;
 	const shouldSkipRender = shouldAuthUser || ! stepContent;
-	const skipTracking = shouldAuthUser || ! stepContent;
 
 	const useBuiltItInAuth = flow.__experimentalUseBuiltinAuth;
 
 	useStepRouteTracking( {
 		flowName: flow.name,
 		stepSlug: step.slug,
-		skipTracking,
+		skipTracking: ! stepContent,
 		flowVariantSlug: flow.variantSlug,
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -33,6 +33,7 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep, navigate }: StepRoute
 		stepSlug: step.slug,
 		flowVariantSlug: flow.variantSlug,
 		skipStepRender: shouldSkipRender,
+		pathname: window.location.pathname,
 	} );
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -32,6 +32,7 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep, navigate }: StepRoute
 		flowName: flow.name,
 		stepSlug: step.slug,
 		flowVariantSlug: flow.variantSlug,
+		skipStepRender: shouldSkipRender,
 	} );
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
@@ -179,13 +179,6 @@ describe( 'StepRoute', () => {
 			expect( recordStepStart ).not.toHaveBeenCalled();
 		} );
 
-		it( 'skips trackings when the renderStep returns null', () => {
-			render( { step: regularStep, renderStep: () => null } );
-
-			expect( recordStepStart ).not.toHaveBeenCalled();
-			expect( recordPageView ).not.toHaveBeenCalled();
-		} );
-
 		it( 'tracks step-complete when the step is unmounted and step-start was previously recorded', () => {
 			( getSignupCompleteFlowNameAndClear as jest.Mock ).mockReturnValue( 'some-other-flow' );
 			( getSignupCompleteStepNameAndClear as jest.Mock ).mockReturnValue( 'some-other-step-slug' );

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
@@ -170,14 +170,6 @@ describe( 'StepRoute', () => {
 			} );
 		} );
 
-		it( 'does not record start and page view when the login is required and the user is not logged in', async () => {
-			( isUserLoggedIn as jest.Mock ).mockReturnValue( false );
-			render( { step: requiresLoginStep } );
-
-			expect( recordStepStart ).not.toHaveBeenCalled();
-			expect( recordPageView ).not.toHaveBeenCalled();
-		} );
-
 		it( 'skips tracking when the step is re-entered', () => {
 			( getSignupCompleteFlowNameAndClear as jest.Mock ).mockReturnValue( 'some-flow' );
 			( getSignupCompleteStepNameAndClear as jest.Mock ).mockReturnValue( 'some-step-slug' );
@@ -195,7 +187,6 @@ describe( 'StepRoute', () => {
 		} );
 
 		it( 'tracks step-complete when the step is unmounted and step-start was previously recorded', () => {
-			( isUserLoggedIn as jest.Mock ).mockReturnValue( true );
 			( getSignupCompleteFlowNameAndClear as jest.Mock ).mockReturnValue( 'some-other-flow' );
 			( getSignupCompleteStepNameAndClear as jest.Mock ).mockReturnValue( 'some-other-step-slug' );
 			const { unmount } = render( { step: regularStep } );

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
@@ -157,7 +157,6 @@ describe( 'StepRoute', () => {
 
 			expect( recordPageView ).toHaveBeenCalledWith( '/', 'Setup > some-flow > some-step-slug', {
 				flow: 'some-flow',
-				skip_step_render: false,
 			} );
 		} );
 
@@ -168,7 +167,6 @@ describe( 'StepRoute', () => {
 				intent: 'build',
 				assembler_source: 'premium',
 				is_in_hosting_flow: false,
-				skip_step_render: false,
 			} );
 		} );
 
@@ -193,7 +191,6 @@ describe( 'StepRoute', () => {
 				flow: 'some-flow',
 				optionalProps: {
 					intent: 'build',
-					skip_step_render: false,
 				},
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94715

## Proposed Changes

We basically now always track a step route access irrespective of any conditions that may or may not render the step content. The conditions were so far:
- a step requires logging in. The user is redirected to `/setup/:flow/user` in that case
- a step does not render any content and a redirection happens
  - this usually results from either the step not having loaded yet or having `AssertConditionState.FAILURE === true` - the latter happens when requirements aren't met / such as requiring login, or missing parameters)

This PR essentially reverts a lot of the underlying logic in https://github.com/Automattic/wp-calypso/pull/91241. The motivation for doing so is in https://github.com/Automattic/wp-calypso/issues/94715 (i.e. just accessing a given step is a data point worth tracking). There was a bit of discussion in https://github.com/Automattic/wp-calypso/pull/91241 (cc @daledupreez) - so let's doubly confirm we are onboard with this direction :-)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Addresses https://github.com/Automattic/wp-calypso/issues/94715

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding/plans` logged-out
* Confirm `calypso_signup_step_start`, `calypso_signup_actions_complete_step`, and `calypso_page_view` get recorded before navigated to `/setup/onboarding/user` for logging in
* Log in and progress through to `/setup/onboarding/plans` again. Confirm the same events being tracked

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
