### PR TITLE
Change sort order of email stats summary to post_date

### DIFF
--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -93,7 +93,7 @@ export function requestSiteStats( siteId, statType, query ) {
 					return {
 						period: PERIOD_ALL_TIME,
 						quantity: query.quantity ?? 10,
-						sort_field: query.sort_field ?? 'post_id',
+						sort_field: query.sort_field ?? 'post_date',
 						sort_order: query.sort_order ?? 'desc',
 					};
 				default:


### PR DESCRIPTION
Context: p1726603888439889/1724340558.866919-slack-C052XEUUBL4

## Proposed Changes

* Change the sort order of the email stats summary page to post_date

## Why are these changes being made?

Currently, we're sorting on post_id for performance reasons; sorting & slicing happen before enriching the data. We've had questions about the summary page and decided to change it.

## Testing Instructions

- Test together with: D162137-code 
- Visit `http://calypso.localhost:3000/stats/day/emails/<yoursite.wordpress.com>`
- Ensure a XHR goes out to `https://public-api.wordpress.com/rest/v1.1/sites/xxxx/stats/emails/summary?http_envelope=1&period=alltime&quantity=30&sort_field=post_date&sort_order=desc`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?