### PR TITLE
Performance Profiler: Add some padding to the right of the Metrics range

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-display/style.scss
+++ b/client/performance-profiler/components/core-web-vitals-display/style.scss
@@ -47,7 +47,7 @@ $blueberry-color: #3858e9;
 	padding: 24px;
 	display: flex;
 	flex-direction: row;
-	column-gap: 32px;
+	column-gap: 48px;
 	min-height: 360px;
 	flex-wrap: wrap;
 	margin-top: -1.5px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9184

## Proposed Changes

* Add some extra padding to the line range metric

|Before | After|
|-------|------|
| ![CleanShot 2024-09-23 at 17 28 46@2x](https://github.com/user-attachments/assets/3dbd219e-6dc3-4e51-931c-9682cbd3a599)| ![CleanShot 2024-09-23 at 17 28 13@2x](https://github.com/user-attachments/assets/e6dc0493-1897-4d55-a6b9-e4796b4ede71) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid overlapping issues

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this changes, navigate to Performance Tool and test a site with a bad metric
* Alternatively, add this code to this line https://github.com/Automattic/wp-calypso/blob/6ed383ffabc478cdd9989a642cfa3c2fe3ab48cd/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx#L37
```
metrics = { ...metrics, inp: 1053.5 };
```
* Check there is enough space between the metric range and the chart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
