### PR TITLE
e2e: Fix random Form AI placeholders

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -37,9 +37,24 @@ export class FormAiFlow implements BlockFlow {
 	 */
 	async configure( context: EditorContext ): Promise< void > {
 		const aiInputParentLocator = await context.editorPage.getEditorCanvas();
-		const aiInputReadyLocator =
-			await aiInputParentLocator.getByPlaceholder( 'Ask Jetpack AI to edit…' );
-		const aiInputBusyLocator = await aiInputParentLocator.getByRole( 'button', {
+
+		const possiblePlaceholders = [
+			// New random placeholders.
+			'Example: a contact form with name, email, and message fields',
+			'Example: a pizza ordering form with name, address, phone number and toppings',
+			'Example: a survey form with multiple choice questions',
+			// Old placeholder. Can remove once new code is deployed everywhere.
+			'Ask Jetpack AI to edit…',
+		];
+		const aiInputReadyLocator = await Promise.any(
+			possiblePlaceholders.map( async ( placeholder ) => {
+				const locator = aiInputParentLocator.getByPlaceholder( placeholder );
+				await locator.waitFor();
+				return locator;
+			} )
+		);
+
+		const aiInputBusyLocator = aiInputParentLocator.getByRole( 'button', {
 			name: 'Stop request',
 		} );
 		const sendButtonLocator = aiInputParentLocator.getByRole( 'button', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Update the test to match the different possible placeholders.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Automattic/jetpack#39482 changed the placeholder for the form AI assistant. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run tests, e.g. `VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
