### PR TITLE
A4A Dev Sites: Add 'Learn more' links.

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -263,7 +263,20 @@ export default function SiteConfigurationsModal( {
 											),
 										},
 									}
-								) }
+								) }{ ' ' }
+								{ translate( '{{a}}Learn more.{{/a}}', {
+									components: {
+										a: (
+											<a
+												target="_blank"
+												href={ localizeUrl(
+													'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/'
+												) }
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								} ) }
 							</label>
 						) : (
 							<>

--- a/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
+++ b/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
@@ -75,7 +75,20 @@ export function A4AFullyManagedSiteSetting( {
 							{
 								components: translationComponents,
 							}
-						) }
+						) }{ ' ' }
+						{ translate( '{{a}}Learn more.{{/a}}', {
+							components: {
+								a: (
+									<a
+										target="_blank"
+										href={ localizeUrl(
+											'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/'
+										) }
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						} ) }
 					</p>
 				) : (
 					<ToggleControl

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -1,6 +1,7 @@
 import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products';
 import { Card, CompactCard, Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
+import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -141,7 +142,9 @@ const LaunchSite = () => {
 							a: (
 								<a
 									className="site-settings__general-settings-launch-site-agency-learn-more"
-									href="https://agencieshelp.automattic.com/knowledge-base/the-marketplace/"
+									href={ localizeUrl(
+										'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/'
+									) }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9194

## Proposed Changes

* Add "Learn more." anchor copy pointing to https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/.
  * In the A4A Site creation configuration modal.
  * WordPress.com: Site settings for development sites, in the "Agency settings" box.
* Also, in WordPress.com: Site settings for development sites, in the "Launch site" box, update the learn more link (currently pointing to marketplace article) to the dev license article instead. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To provide users with more context on the free A4A dev sites feature.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Test Links in Site Settings
* Go to "Site settings" of your A4A free development site: http://calypso.localhost:3000/settings/general/your-a4a-dev-site.wpcomstaging.com?flags=a4a-dev-sites.
* Ensure the "Learn more." link within the "Launch Site" section is clickable and points to https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/.
* Ensure the "Learn more." link within the Agency Settings section points is clickable and points to https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/.

#### Test Links in Site Configuration Modal
* Go to A4A dashboard: http://agencies.localhost:3002/overview?flags=a4a-dev-sites
* Click on "Add Sites".
* In the "Add Sites" dropdown, click on the "Start Building for Free" widget.
* Ensure that the "Learn more." link is present in the bottom of the site configuration modal. Ensure that it is clickable and that it opens up the expected URL.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
