### PR TITLE
A4A: fix pressable referral pricing

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -115,6 +115,13 @@ export default function PlanSelectionDetails( {
 							) }
 						</div>
 					) }
+					{ isReferMode && (
+						<div className="pressable-overview-plan-selection__details-card-header-price">
+							<strong className="pressable-overview-plan-selection__details-card-header-comming-soon">
+								{ translate( 'Coming soon' ) }
+							</strong>
+						</div>
+					) }
 				</div>
 
 				{ ! isRegularOwnership && ! isReferMode && (

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -117,7 +117,7 @@ export default function PlanSelectionDetails( {
 					) }
 					{ isReferMode && (
 						<div className="pressable-overview-plan-selection__details-card-header-price">
-							<strong className="pressable-overview-plan-selection__details-card-header-comming-soon">
+							<strong className="pressable-overview-plan-selection__details-card-header-coming-soon">
 								{ translate( 'Coming soon' ) }
 							</strong>
 						</div>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -65,7 +65,7 @@ export default function PlanSelectionDetails( {
 
 	const PRESSABLE_CONTACT_LINK = 'https://pressable.com/request-demo';
 
-	if ( isLoading ) {
+	if ( ! isReferMode && isLoading ) {
 		return (
 			<section className="pressable-overview-plan-selection__details is-loader">
 				<div className="pressable-overview-plan-selection__details-card"></div>
@@ -93,7 +93,7 @@ export default function PlanSelectionDetails( {
 							  } ) }
 					</h3>
 
-					{ selectedPlan && (
+					{ ! isReferMode && selectedPlan && (
 						<div className="pressable-overview-plan-selection__details-card-header-price">
 							<strong className="pressable-overview-plan-selection__details-card-header-price-value">
 								{ formatCurrency( discountedCost, selectedPlan.currency ) }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -54,10 +54,8 @@
 	font-weight: 600;
 }
 
-.pressable-overview-plan-selection__details-card-header-comming-soon {
-	font-size: 1rem;
-	line-height: 1.4;
-	font-weight: 400;
+.pressable-overview-plan-selection__details-card-header-coming-soon {
+	@include a4a-font-heading-md($font-weight: 400);
 }
 
 .pressable-overview-plan-selection__details-card-header-subtitle {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -54,6 +54,12 @@
 	font-weight: 600;
 }
 
+.pressable-overview-plan-selection__details-card-header-comming-soon {
+	font-size: 1rem;
+	line-height: 1.4;
+	font-weight: 400;
+}
+
 .pressable-overview-plan-selection__details-card-header-subtitle {
 	@include a4a-font-body-md;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1029

## Proposed Changes

In referral mode we shouldn't show pricing, as we are not able yet to refer Pressable product. Instead, we are adding 'Comming Soon' label

| Before | After |
| ---- | ---- |
| <img width="502" alt="Screenshot 2024-09-23 at 12 01 22 PM" src="https://github.com/user-attachments/assets/42f40480-44ed-4a37-90d4-11664877b852"> | <img width="516" alt="Screenshot 2024-09-23 at 11 57 33 AM" src="https://github.com/user-attachments/assets/09982eb0-96de-48bb-b016-37fa6a097327"> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link, navigate to `/marketplace/hosting/pressable` and switch to referall mode in the top right corner.
- Check the view of the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
