### PR TITLE
Logged-in Performance Profiler: Fix mobile header alignment

### DIFF
--- a/client/hosting/performance/components/MobileHeader.tsx
+++ b/client/hosting/performance/components/MobileHeader.tsx
@@ -20,21 +20,18 @@ export const MobileHeader = ( { pageTitle, pageSelector }: MobileHeaderProps ) =
 		<>
 			<NavigationHeader
 				className="site-performance__navigation-header"
-				title={
-					<div className="navigation-header-title">
-						{ translate( 'Performance' ) }
-						<Button
-							variant="tertiary"
-							onClick={ togglePageSelector }
-							aria-expanded={ isPageSelectorVisible }
-						>
-							<ScreenReaderText>{ translate( 'toggle page selector' ) }</ScreenReaderText>
-							<Gridicon icon="cog" />
-						</Button>
-					</div>
-				}
+				title={ <div className="navigation-header-title">{ translate( 'Performance' ) }</div> }
 				subtitle={ pageTitle }
-			/>
+			>
+				<Button
+					variant="tertiary"
+					onClick={ togglePageSelector }
+					aria-expanded={ isPageSelectorVisible }
+				>
+					<ScreenReaderText>{ translate( 'toggle page selector' ) }</ScreenReaderText>
+					<Gridicon icon="cog" />
+				</Button>
+			</NavigationHeader>
 
 			{ isPageSelectorVisible && (
 				<div

--- a/client/hosting/performance/components/PerformanceReportLoading.tsx
+++ b/client/hosting/performance/components/PerformanceReportLoading.tsx
@@ -13,7 +13,7 @@ export const PerformanceReportLoading = ( {
 	const { __ } = useI18n();
 
 	return (
-		<div css={ { display: 'flex', flexDirection: 'column', gap: '64px' } }>
+		<div className="site-performance__loader">
 			<PerformanceReportLoadingProgress
 				css={ {
 					span: {

--- a/client/hosting/performance/style.scss
+++ b/client/hosting/performance/style.scss
@@ -25,6 +25,16 @@ $section-max-width: 1224px;
 			padding-top: 24px;
 		}
 	}
+
+	.site-performance__loader {
+		display: flex;
+		flex-direction: column;
+		gap: 64px;
+
+		@media (max-width: $break-medium) {
+			margin-top: 24px;
+		}
+	}
 }
 
 .site-performance-device-tab-controls__container {
@@ -77,6 +87,10 @@ $section-max-width: 1224px;
 
 		.formatted-header__subtitle {
 			display: block;
+		}
+
+		.navigation-header__main {
+			align-items: center;
 		}
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -133,7 +133,7 @@
 		"p2-enabled": false,
 		"pattern-assembler/v2": true,
 		"performance-profiler/llm": true,
-		"performance-profiler/logged-in": false,
+		"performance-profiler/logged-in": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Fix mobile header alignment 
![image](https://github.com/user-attachments/assets/94f043f5-18f9-4786-90e3-da2308454b7a)

* Make feature available on wpcalypso

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `sites/performance/site`
* Verify the cog matches the design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
