### PR TITLE
Home: Make "view site" links open in current window

### DIFF
--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import { ReactNode } from 'react';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { SiteUrl, Truncated } from 'calypso/sites-dashboard/components/sites-site-url';
+import { Truncated } from 'calypso/sites-dashboard/components/sites-site-url';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -112,9 +112,13 @@ const SitePreview = ( {
 				<div className="home-site-preview__action-bar">
 					<div className="home-site-preview__site-info">
 						<h2 className="home-site-preview__info-title">{ selectedSiteName }</h2>
-						<SiteUrl href={ selectedSiteURL } title={ selectedSiteURL }>
+						<a
+							href={ selectedSiteURL }
+							title={ selectedSiteURL }
+							className="home-site-preview__info-domain"
+						>
 							<Truncated>{ selectedSiteSlug }</Truncated>
-						</SiteUrl>
+						</a>
 					</div>
 					<SitePreviewEllipsisMenu />
 				</div>

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -81,6 +81,17 @@
 				font-weight: 500;
 				line-height: 24px;
 			}
+
+			.home-site-preview__info-domain {
+				text-overflow: ellipsis;
+				overflow: hidden;
+				font-size: rem(14px);
+				color: var(--studio-gray-60);
+
+				&:hover {
+					text-decoration: underline;
+				}
+			}
 		}
 	}
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -2,7 +2,6 @@ import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN } from '@automattic/urls';
 import { useQueryClient } from '@tanstack/react-query';
-import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
@@ -153,7 +152,7 @@ const Home = ( {
 
 	const headerActions = (
 		<>
-			<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
+			<Button href={ site.URL } onClick={ trackViewSiteAction }>
 				{ translate( 'View site' ) }
 			</Button>
 			{ isAdmin && ! isP2 && (
@@ -179,13 +178,13 @@ const Home = ( {
 				<SiteIcon site={ site } size={ 58 } />
 				<div className="customer-home__site-info">
 					<div className="customer-home__site-title">{ site.name }</div>
-					<ExternalLink
+					<a
 						href={ site.URL }
 						className="customer-home__site-domain"
 						onClick={ trackViewSiteAction }
 					>
 						<span className="customer-home__site-domain-text">{ site.domain }</span>
-					</ExternalLink>
+					</a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9091

## Proposed Changes

* The "View site" button at the top right no longer opens in a new tab.
* The domain link under "Site Title" no longer opens in a new tab, and the external link icon should is removed.

<img width="1205" alt="Screenshot 2024-09-23 at 4 41 42 PM" src="https://github.com/user-attachments/assets/8bba83a3-8fd4-4b5a-96aa-afb456804390">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To create consistency around external links and links that open in new tabs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Open a site /home
* View the links above do not have external link icons and that they open in the current window when clicked
* The "View Site" button should continue to fire its Tracks event.
  * You can view the Tracks event by entering `localStorage.setItem( 'debug,' 'calypso:analytics*' );` in your browser's web tools console and refresh the page. After the page reloads, clear the console log and click the "View Site" button. You should see the Tracks event in the console.
  * Note that the other link does not have a Tracks event.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
