### PR TITLE
Home: Make Jetpack AI Logo Upsell Links Open in Current Window

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
@@ -43,7 +43,7 @@ export const UpgradeScreen: React.FC< {
 					{ reason === 'feature' ? upgradeMessageFeature : upgradeMessageRequests }
 				</span>
 				&nbsp;
-				<Button variant="link" href="https://jetpack.com/ai/" target="_blank">
+				<Button variant="link" href="https://jetpack.com/ai/">
 					{ __( 'Learn more', 'jetpack' ) }
 				</Button>
 			</div>
@@ -51,12 +51,7 @@ export const UpgradeScreen: React.FC< {
 				<Button variant="tertiary" onClick={ onCancel }>
 					{ __( 'Cancel', 'jetpack' ) }
 				</Button>
-				<Button
-					variant="primary"
-					href={ upgradeURL }
-					target="_blank"
-					onClick={ handleUpgradeClick }
-				>
+				<Button variant="primary" href={ upgradeURL } onClick={ handleUpgradeClick }>
 					{ __( 'Upgrade', 'jetpack' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9091

## Proposed Changes

* This PR opens the "Learn more" and "Upgrade" links in the Jetpack AI logo maker upsell in the same window.

<img width="1182" alt="Screenshot 2024-09-23 at 5 06 02 PM" src="https://github.com/user-attachments/assets/1a4bb915-9ec4-4d73-b131-5b6a4ad451a2">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Creating consistency in external links and opening them in a new tab.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* On a site with a free plan, go to /home and click the Jetpack AI Logo "Quick link"
* In the modal popup, the links mentioned above should open in the current window.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
