### PR TITLE
Stats: Remove subscriber counts from insights page

### DIFF
--- a/client/my-sites/stats/annual-highlights-section/index.tsx
+++ b/client/my-sites/stats/annual-highlights-section/index.tsx
@@ -25,15 +25,6 @@ type Insights = {
 	} >;
 };
 
-type Followers = {
-	subscribers: Array< object >;
-	total_email: number;
-	total_wpcom: number;
-	total: number;
-};
-
-const FOLLOWERS_QUERY = { type: 'all', max: 0 };
-
 // Meant to replace annual-site-stats section
 export default function AnnualHighlightsSection( { siteId }: { siteId: number } ) {
 	// In January show the previous year.
@@ -44,9 +35,6 @@ export default function AnnualHighlightsSection( { siteId }: { siteId: number } 
 	const insights = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, 'statsInsights' )
 	) as Insights;
-	const followers = useSelector( ( state ) =>
-		getSiteStatsNormalizedData( state, siteId, 'statsFollowers', FOLLOWERS_QUERY )
-	) as Followers;
 	const counts = useMemo( () => {
 		const hasYearsData = Array.isArray( insights?.years );
 		const currentYearData = insights?.years?.find( ( y ) => y.year === year.toString() );
@@ -57,9 +45,8 @@ export default function AnnualHighlightsSection( { siteId }: { siteId: number } 
 			likes: currentYearData?.total_likes ?? ( hasYearsData ? 0 : null ),
 			posts: currentYearData?.total_posts ?? ( hasYearsData ? 0 : null ),
 			words: currentYearData?.total_words ?? ( hasYearsData ? 0 : null ),
-			followers: year === currentYear ? followers?.total ?? null : null,
 		};
-	}, [ year, followers, insights, currentYear ] );
+	}, [ year, insights ] );
 
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const viewMoreHref = siteSlug ? `/stats/annualstats/${ siteSlug }` : null;
@@ -98,7 +85,6 @@ export default function AnnualHighlightsSection( { siteId }: { siteId: number } 
 			{ siteId && (
 				<>
 					<QuerySiteStats siteId={ siteId } statType="statsInsights" />
-					<QuerySiteStats siteId={ siteId } statType="statsFollowers" query={ FOLLOWERS_QUERY } />
 				</>
 			) }
 			<AnnualHighlightCards

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -1,4 +1,4 @@
-import { comment, Icon, paragraph, people, postContent, starEmpty } from '@wordpress/icons';
+import { comment, Icon, paragraph, postContent, starEmpty } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate, useTranslate } from 'i18n-calypso';
 import ComponentSwapper from '../component-swapper';
@@ -13,7 +13,6 @@ type AnnualHighlightCounts = {
 	likes: number | null;
 	posts: number | null;
 	words: number | null;
-	followers: number | null;
 };
 
 type AnnualHighlightsProps = {
@@ -34,7 +33,6 @@ function getCardProps( counts: AnnualHighlightCounts ) {
 		{ heading: translate( 'Words' ), count: counts?.words, icon: paragraph },
 		{ heading: translate( 'Likes' ), count: counts?.likes, icon: starEmpty },
 		{ heading: translate( 'Comments' ), count: counts?.comments, icon: comment },
-		{ heading: translate( 'Subscribers' ), count: counts?.followers, icon: people },
 	];
 }
 


### PR DESCRIPTION
## Proposed Changes

Before|After
-|-
![image](https://github.com/user-attachments/assets/e533485d-9b63-408d-9544-7a921bed02d1)|![image](https://github.com/user-attachments/assets/bc657b82-e219-416e-a87d-6554e5685ed4)
![image](https://github.com/user-attachments/assets/c3829f27-a0cc-4e8e-b5d9-9841a93bc6d3)|![image](https://github.com/user-attachments/assets/32deb9bc-0466-472b-8caf-5c2e4dd93464)



* Removes the "Subscribers" card from the Year in Review section of the insights dashboard.

## Why are these changes being made?

* This was the easiest, practical solution for this issue: p1HpG7-uml-p2#comment-73903. Historical subscriber count data is better visualized on the subscriber stats dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open this PR's live branch and navigate to the insights dashboard (`/stats/insights/example.com`).
* Ensure that the subscriber count highlight card has been removed from the year in review section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?