### PR TITLE
Marketing Tools: adds facebook placement.

### DIFF
--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -32,7 +32,7 @@ export const MarketingTools: FunctionComponent = () => {
 	const currentDate = new Date();
 	const shouldShowFacebook =
 		( currentDate.getFullYear() === 2024 && currentDate.getMonth() === 9 ) ||
-		config.isEnabled( 'marketing-force-facebook-display' ); // October 2024 only.
+		config.isEnabled( 'marketing-force-facebook-display' ); // October 2024 only OR if the feature flag is enabled ( dev, calypso, stage ).
 
 	const handleBusinessToolsClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_business_tools_button_click' );

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -117,7 +117,7 @@ export const MarketingTools: FunctionComponent = () => {
 					<MarketingToolsFeature
 						title={ translate( 'Want to connect with your audience on Facebook and Instagram?' ) }
 						description={ translate(
-							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and eCommerce plans{{/em}}.',
+							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and Commerce plans{{/em}}.',
 							{
 								components: {
 									em: <em />,

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -8,6 +8,7 @@ import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
 import rocket from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 import earnIllustration from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
 import wordPressLogo from 'calypso/assets/images/icons/wordpress-logo.svg';
+import facebookLogo from 'calypso/assets/images/illustrations/facebook-logo.png';
 import simpletextLogo from 'calypso/assets/images/illustrations/simpletext-logo.png';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -27,6 +28,11 @@ export const MarketingTools: FunctionComponent = () => {
 	const recordTracksEvent = ( event: string ) => dispatch( recordTracksEventAction( event ) );
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId ) || 0;
+	const isEnglish = ( config( 'english_locales' ) as string[] ).includes( getLocaleSlug() ?? '' );
+	const currentDate = new Date();
+	const shouldShowFacebook =
+		( currentDate.getFullYear() === 2024 && currentDate.getMonth() === 9 ) ||
+		config.isEnabled( 'marketing-force-facebook-display' ); // October 2024 only.
 
 	const handleBusinessToolsClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_business_tools_button_click' );
@@ -38,6 +44,12 @@ export const MarketingTools: FunctionComponent = () => {
 		recordTracksEvent( 'calypso_marketing_tools_earn_button_click' );
 
 		page( `/earn/${ selectedSiteSlug }` );
+	};
+
+	const handleFacebookClick = () => {
+		recordTracksEvent( 'calypso_marketing_tools_facebook_button_click' );
+
+		page( `/plugins/official-facebook-pixel/${ selectedSiteSlug }` );
 	};
 
 	const handleBuiltByWpClick = () => {
@@ -65,8 +77,6 @@ export const MarketingTools: FunctionComponent = () => {
 	const handleSEOCourseClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_seo_course_button_click' );
 	};
-
-	const isEnglish = ( config( 'english_locales' ) as string[] ).includes( getLocaleSlug() ?? '' );
 
 	return (
 		<Fragment>
@@ -102,6 +112,26 @@ export const MarketingTools: FunctionComponent = () => {
 				>
 					<Button onClick={ handleEarnClick }>{ translate( 'Start earning' ) }</Button>
 				</MarketingToolsFeature>
+
+				{ shouldShowFacebook && (
+					<MarketingToolsFeature
+						title={ translate( 'Want to connect with your audience on Facebook and Instagram?' ) }
+						description={ translate(
+							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and eCommerce plans{{/em}}.',
+							{
+								components: {
+									em: <em />,
+								},
+							}
+						) }
+						imagePath={ facebookLogo }
+						imageAlt={ translate( 'Facebook Logo' ) }
+					>
+						<Button onClick={ handleFacebookClick }>
+							{ translate( 'Add Facebook for WordPress.com' ) }
+						</Button>
+					</MarketingToolsFeature>
+				) }
 
 				<MarketingToolsFeature
 					title={ translate( 'Fiverr logo maker' ) }

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -1,7 +1,9 @@
 import config from '@automattic/calypso-config';
+import { PLAN_BUSINESS, getPlan, PLAN_ECOMMERCE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { Fragment, FunctionComponent } from 'react';
 import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
@@ -51,6 +53,16 @@ export const MarketingTools: FunctionComponent = () => {
 
 		page( `/plugins/official-facebook-pixel/${ selectedSiteSlug }` );
 	};
+
+	const facebookDescription = translate(
+		'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. <em>Available on %(businessPlanName)s and %(commercePlanName)s plans</em>.',
+		{
+			args: {
+				businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+				commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+			},
+		}
+	) as string;
 
 	const handleBuiltByWpClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_built_by_wp_button_click' );
@@ -116,14 +128,9 @@ export const MarketingTools: FunctionComponent = () => {
 				{ shouldShowFacebook && (
 					<MarketingToolsFeature
 						title={ translate( 'Want to connect with your audience on Facebook and Instagram?' ) }
-						description={ translate(
-							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and Commerce plans{{/em}}.',
-							{
-								components: {
-									em: <em />,
-								},
-							}
-						) }
+						description={ createInterpolateElement( facebookDescription, {
+							em: <em />,
+						} ) }
 						imagePath={ facebookLogo }
 						imageAlt={ translate( 'Facebook Logo' ) }
 					>

--- a/config/development.json
+++ b/config/development.json
@@ -136,6 +136,7 @@
 		"logmein": true,
 		"mailchimp": true,
 		"manage/import/site-importer-endpoints": true,
+		"marketing-force-facebook-display": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -106,6 +106,7 @@
 		"login/react-lost-password-screen": true,
 		"login/social-first": true,
 		"mailchimp": true,
+		"marketing-force-facebook-display": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -103,6 +103,7 @@
 		"login/social-first": true,
 		"logmein": true,
 		"mailchimp": true,
+		"marketing-force-facebook-display": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pfUMqg-1E-p2

## Proposed Changes

* Adds facebook placement.
* Link redirects to the facebook pixel plugin page.
* The placement will be shown only in October 2024, it's also shown in dev, wpcalypso, and staging environments for testing.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
![CleanShot 2024-09-24 at 09 14 40](https://github.com/user-attachments/assets/6021e8e3-7545-4e97-b9bb-b5b2811ff4ef)


* While proxied
* Go to `/marketing/tools/[domain]`
* Check that placement appears and that the links redirects to the plugin page
![CleanShot 2024-09-24 at 09 14 55](https://github.com/user-attachments/assets/d0269b29-24f6-4006-ae78-41325f33af67)


* While not proxied ( production ) and not in dev or wpcalypso and still in September
* Go to `/marketing/tools/[domain]`
* Check that placement doesn't appear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?