### PR TITLE
Stats: DateRange Picker adds shortcut and trigger click tracking

### DIFF
--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -53,6 +53,7 @@ export class DateRange extends Component {
 		useArrowNavigation: PropTypes.bool,
 		overlay: PropTypes.node,
 		customTitle: PropTypes.string,
+		onShortcutClick: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -479,6 +480,7 @@ export class DateRange extends Component {
 								locked={ !! this.props.overlay }
 								startDate={ this.state.startDate }
 								endDate={ this.state.endDate }
+								onShortcutClick={ this.props.onShortcutClick } // for tracking clicks
 							/>
 						</div>
 					) }

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -480,7 +480,7 @@ export class DateRange extends Component {
 								locked={ !! this.props.overlay }
 								startDate={ this.state.startDate }
 								endDate={ this.state.endDate }
-								onShortcutClick={ this.props.onShortcutClick } // for tracking clicks
+								onShortcutClick={ this.props.onShortcutClick } // for tracking shortcut clicks
 							/>
 						</div>
 					) }

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -14,14 +14,14 @@ const DATERANGE_PERIOD = {
 const DateRangePickerShortcuts = ( {
 	currentShortcut,
 	onClick,
-	onShortcutClick, // for tracking shortcut clicks
+	onShortcutClick, // Optional callback function for tracking shortcut clicks
 	locked = false,
 	startDate,
 	endDate,
 }: {
 	currentShortcut?: string;
 	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment, shortcutId: string ) => void;
-	onShortcutClick?: ( shortcutId: string ) => void; // Optional tracking function
+	onShortcutClick?: ( shortcutId: string ) => void;
 	locked?: boolean;
 	startDate?: Moment;
 	endDate?: Moment;

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -14,12 +14,14 @@ const DATERANGE_PERIOD = {
 const DateRangePickerShortcuts = ( {
 	currentShortcut,
 	onClick,
+	onShortcutClick, // for tracking shortcut clicks
 	locked = false,
 	startDate,
 	endDate,
 }: {
 	currentShortcut?: string;
 	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment, shortcutId: string ) => void;
+	onShortcutClick?: ( shortcutId: string ) => void; // Optional tracking function
 	locked?: boolean;
 	startDate?: Moment;
 	endDate?: Moment;
@@ -89,6 +91,11 @@ const DateRangePickerShortcuts = ( {
 		const newFromDate = moment().subtract( offset + range, 'days' );
 
 		onClick( newFromDate, newToDate, id || '' );
+
+		// Call the onShortcutClick if provided
+		if ( onShortcutClick && id ) {
+			onShortcutClick( id );
+		}
 	};
 
 	currentShortcut =
@@ -120,6 +127,7 @@ const DateRangePickerShortcuts = ( {
 DateRangePickerShortcuts.propTypes = {
 	currentShortcut: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
+	onShortcutClick: PropTypes.func,
 	locked: PropTypes.bool,
 	startDate: PropTypes.object,
 	endDate: PropTypes.object,

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -24,6 +24,7 @@ const eventNames = {
 		last_year: 'jetpack_odyssey_stats_date_picker_shortcut_last_year_click',
 		custom_date_range: 'jetpack_odyssey_stats_date_picker_shortcut_custom_date_range_click',
 		apply_button: 'jetpack_odyssey_stats_date_picker_apply_button_click',
+		trigger_button: 'jetpack_odyssey_stats_date_picker_trigger_click',
 	},
 	calypso: {
 		last_7_days: 'calypso_stats_date_picker_shortcut_last_7_days_click',
@@ -32,6 +33,7 @@ const eventNames = {
 		last_year: 'calypso_stats_date_picker_shortcut_last_year_click',
 		custom_date_range: 'calypso_stats_date_picker_shortcut_custom_date_range_click',
 		apply_button: 'calypso_stats_date_picker_apply_button_click',
+		trigger_button: 'calypso_stats_date_picker_trigger_click',
 	},
 };
 
@@ -169,7 +171,7 @@ const StatsDateControl = ( {
 							<Button
 								onClick={ () => {
 									const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-									recordTracksEvent( `${ event_from }_stats_date_picker_trigger_clicked` );
+									recordTracksEvent( eventNames[ event_from ][ 'trigger_button' ] );
 									onTriggerClick();
 								} }
 								ref={ buttonRef }

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -87,9 +87,9 @@ const StatsDateControl = ( {
 	};
 
 	// handler for shortcut clicks in new updated DateRange component
-	const onShortcutClickHandler = ( shortcut: DateControlPickerShortcut ) => {
+	const onShortcutClickHandler = ( shortcutId: string ) => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_stats_date_picker_shortcut_${ shortcut.id }_clicked` );
+		recordTracksEvent( `${ event_from }_stats_date_picker_shortcut_${ shortcutId }_clicked` );
 	};
 
 	const getShortcutForRange = () => {

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -15,12 +15,28 @@ import './style.scss';
 const COMPONENT_CLASS_NAME = 'stats-date-control';
 const isCalendarEnabled = config.isEnabled( 'stats/date-picker-calendar' );
 
-// Hardcoding event names ensures consistency, searchability, and prevents errors per Tracks naming conventions.
-const eventNames = {
+// Define the event name keys for tracking events
+type EventNameKey =
+	| 'last_7_days'
+	| 'last_30_days'
+	| 'last_90_days'
+	| 'last_year'
+	| 'custom_date_range'
+	| 'apply_button'
+	| 'trigger_button';
+
+// Define the structure for tracking event names
+interface EventNames {
+	jetpack_odyssey: Record< EventNameKey, string >;
+	calypso: Record< EventNameKey, string >;
+}
+
+// Define the tracking event names object. Hardcoding event names ensures consistency, searchability, and prevents errors per Tracks naming conventions.
+const eventNames: EventNames = {
 	jetpack_odyssey: {
 		last_7_days: 'jetpack_odyssey_stats_date_picker_shortcut_last_7_days_click',
 		last_30_days: 'jetpack_odyssey_stats_date_picker_shortcut_last_30_days_click',
-		last_3_months: 'jetpack_odyssey_stats_date_picker_shortcut_last_3_months_click',
+		last_90_days: 'jetpack_odyssey_stats_date_picker_shortcut_last_90_days_click',
 		last_year: 'jetpack_odyssey_stats_date_picker_shortcut_last_year_click',
 		custom_date_range: 'jetpack_odyssey_stats_date_picker_shortcut_custom_date_range_click',
 		apply_button: 'jetpack_odyssey_stats_date_picker_apply_button_click',
@@ -29,7 +45,7 @@ const eventNames = {
 	calypso: {
 		last_7_days: 'calypso_stats_date_picker_shortcut_last_7_days_click',
 		last_30_days: 'calypso_stats_date_picker_shortcut_last_30_days_click',
-		last_3_months: 'calypso_stats_date_picker_shortcut_last_3_months_click',
+		last_90_days: 'calypso_stats_date_picker_shortcut_last_90_days_click',
 		last_year: 'calypso_stats_date_picker_shortcut_last_year_click',
 		custom_date_range: 'calypso_stats_date_picker_shortcut_custom_date_range_click',
 		apply_button: 'calypso_stats_date_picker_apply_button_click',
@@ -102,14 +118,14 @@ const StatsDateControl = ( {
 		const endDate = anchor.format( 'YYYY-MM-DD' );
 		const startDate = anchor.subtract( shortcut.range, 'days' ).format( 'YYYY-MM-DD' );
 
-		recordTracksEvent( eventNames[ event_from ][ shortcut.id ] );
+		recordTracksEvent( eventNames[ event_from ][ shortcut.id as EventNameKey ] );
 
 		// Update chart via routing.
 		setTimeout( () => page( generateNewLink( shortcut.period, startDate, endDate ) ), 250 );
 	};
 
 	// handler for shortcut clicks in new updated DateRange component
-	const onShortcutClickHandler = ( shortcutId: string ) => {
+	const onShortcutClickHandler = ( shortcutId: EventNameKey ) => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( eventNames[ event_from ][ shortcutId ] );
 	};

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -146,7 +146,14 @@ const StatsDateControl = ( {
 						buttonRef: RefObject< typeof Button >;
 					} ) => {
 						return (
-							<Button onClick={ onTriggerClick } ref={ buttonRef }>
+							<Button
+								onClick={ () => {
+									const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+									recordTracksEvent( `${ event_from }_stats_date_picker_trigger_clicked` ); // Tracking event
+									onTriggerClick();
+								} }
+								ref={ buttonRef }
+							>
 								{ getButtonLabel() }
 								<Icon className="gridicon" icon={ calendar } />
 							</Button>

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -86,6 +86,12 @@ const StatsDateControl = ( {
 		setTimeout( () => page( generateNewLink( shortcut.period, startDate, endDate ) ), 250 );
 	};
 
+	// handler for shortcut clicks in new updated DateRange component
+	const onShortcutClickHandler = ( shortcut: DateControlPickerShortcut ) => {
+		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+		recordTracksEvent( `${ event_from }_stats_date_picker_shortcut_${ shortcut.id }_clicked` );
+	};
+
 	const getShortcutForRange = () => {
 		// Search the shortcut array for something matching the current date range.
 		// Returns shortcut or null;
@@ -152,6 +158,7 @@ const StatsDateControl = ( {
 					useArrowNavigation
 					customTitle="Date Range"
 					focusedMonth={ moment( dateRange.chartEnd ).toDate() }
+					onShortcutClick={ onShortcutClickHandler } // Pass the new handler
 				/>
 			) : (
 				<DateControlPicker

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -165,7 +165,7 @@ const StatsDateControl = ( {
 					useArrowNavigation
 					customTitle="Date Range"
 					focusedMonth={ moment( dateRange.chartEnd ).toDate() }
-					onShortcutClick={ onShortcutClickHandler } // Pass the new handler
+					onShortcutClick={ onShortcutClickHandler }
 				/>
 			) : (
 				<DateControlPicker

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -149,7 +149,7 @@ const StatsDateControl = ( {
 							<Button
 								onClick={ () => {
 									const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-									recordTracksEvent( `${ event_from }_stats_date_picker_trigger_clicked` ); // Tracking event
+									recordTracksEvent( `${ event_from }_stats_date_picker_trigger_clicked` );
 									onTriggerClick();
 								} }
 								ref={ buttonRef }

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -15,6 +15,26 @@ import './style.scss';
 const COMPONENT_CLASS_NAME = 'stats-date-control';
 const isCalendarEnabled = config.isEnabled( 'stats/date-picker-calendar' );
 
+// Hardcoding event names ensures consistency, searchability, and prevents errors per Tracks naming conventions.
+const eventNames = {
+	jetpack_odyssey: {
+		last_7_days: 'jetpack_odyssey_stats_date_picker_shortcut_last_7_days_click',
+		last_30_days: 'jetpack_odyssey_stats_date_picker_shortcut_last_30_days_click',
+		last_3_months: 'jetpack_odyssey_stats_date_picker_shortcut_last_3_months_click',
+		last_year: 'jetpack_odyssey_stats_date_picker_shortcut_last_year_click',
+		custom_date_range: 'jetpack_odyssey_stats_date_picker_shortcut_custom_date_range_click',
+		apply_button: 'jetpack_odyssey_stats_date_picker_apply_button_click',
+	},
+	calypso: {
+		last_7_days: 'calypso_stats_date_picker_shortcut_last_7_days_click',
+		last_30_days: 'calypso_stats_date_picker_shortcut_last_30_days_click',
+		last_3_months: 'calypso_stats_date_picker_shortcut_last_3_months_click',
+		last_year: 'calypso_stats_date_picker_shortcut_last_year_click',
+		custom_date_range: 'calypso_stats_date_picker_shortcut_custom_date_range_click',
+		apply_button: 'calypso_stats_date_picker_apply_button_click',
+	},
+};
+
 const StatsDateControl = ( {
 	slug,
 	queryParams,
@@ -66,7 +86,7 @@ const StatsDateControl = ( {
 		const period = bestPeriodForDays( rangeInDays );
 
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_stats_date_picker_apply_button_clicked` );
+		recordTracksEvent( eventNames[ event_from ][ 'apply_button' ] );
 
 		// Update chart via routing.
 		setTimeout( () => page( generateNewLink( period, startDate, endDate ) ), 250 );
@@ -80,7 +100,7 @@ const StatsDateControl = ( {
 		const endDate = anchor.format( 'YYYY-MM-DD' );
 		const startDate = anchor.subtract( shortcut.range, 'days' ).format( 'YYYY-MM-DD' );
 
-		recordTracksEvent( `${ event_from }_stats_date_picker_shortcut_${ shortcut.id }_clicked` );
+		recordTracksEvent( eventNames[ event_from ][ shortcut.id ] );
 
 		// Update chart via routing.
 		setTimeout( () => page( generateNewLink( shortcut.period, startDate, endDate ) ), 250 );
@@ -89,7 +109,7 @@ const StatsDateControl = ( {
 	// handler for shortcut clicks in new updated DateRange component
 	const onShortcutClickHandler = ( shortcutId: string ) => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_stats_date_picker_shortcut_${ shortcutId }_clicked` );
+		recordTracksEvent( eventNames[ event_from ][ shortcutId ] );
 	};
 
 	const getShortcutForRange = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR adds tracks events to the new DateRange picker used in Stats.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For use with the Stats Date Control update.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the live branch or locally
* turn on tracking debugging in the JS developer console using `localStorage.setItem('debug', 'calypso:analytics*');`
* open up the daterange picker, check for the analytics event for `calypso_stats_date_picker_trigger_clicked` 
* click on the different shortcuts, check for their events `calypso_stats_date_picker_shortcut_last_year_click` and that they match the correct shortcut
* click on the apply button, check for the event `calypso_stats_date_picker_apply_button_click`
* check again in Odyssey, and the events should be prefixed with `jetpack_odyssey` rather than `calypso`

![image](https://github.com/user-attachments/assets/dfb41ef1-1022-4522-bcff-be6b3b715a12)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
