### PR TITLE
A4A: Add description to the Company Name field in the PD details form.

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -118,6 +118,9 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			<FormSection title={ translate( 'Agency information' ) }>
 				<FormField
 					label={ translate( 'Company name' ) }
+					description={ translate(
+						'Include only your company name; save any descriptors for the Company bio section.'
+					) }
 					error={ validationError.name }
 					field={ formData.name }
 					checks={ [ validateNonEmpty() ] }


### PR DESCRIPTION
This pull request includes a description below the Company Name field to provide guidance for users.

<img width="699" alt="Screenshot 2024-09-24 at 2 55 14 PM" src="https://github.com/user-attachments/assets/c9e51852-d0eb-4f24-beca-a8feba444895">

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1149

## Proposed Changes

* Add description text on the 'Company name' field.

## Why are these changes being made?

* Users will be likely to fill in the Company name correctly.

## Testing Instructions

* To test this, you need an approved directory, but PD is live now, so you need to be careful. Another safe option is you will need to modify the code to bypass the UI logic that hides the agency details page.

Look for these lines of code and make sure hasDirectoryApproval is always true to bypass the logic.
```
const hasDirectoryApproval = agency?.profile?.partner_directory_application?.directories.some(
		( { status } ) => status === 'approved'
	);
```
* Spin up this branch and go to http://agencies.localhost:3000/partner-directory/agency-details
* Check that the company name has the correct description.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
