### PR TITLE
Stepper: Ensure clean timers on `calypso_signup_start`

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -26,6 +26,7 @@ export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT = 'calypso_signup_step_nav_ne
 export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO = 'calypso_signup_step_nav_go_to';
 export const STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW = 'calypso_signup_step_nav_exit_flow';
 export const STEPPER_TRACKS_EVENT_STEP_COMPLETE = 'calypso_signup_actions_complete_step';
+export const STEPPER_TRACKS_EVENT_SIGNUP_START = 'calypso_signup_start';
 
 export const STEPPER_TRACKS_EVENTS_STEP_NAV = < const >[
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
@@ -38,4 +39,5 @@ export const STEPPER_TRACKS_EVENTS_STEP_NAV = < const >[
 export const STEPPER_TRACKS_EVENTS = < const >[
 	...STEPPER_TRACKS_EVENTS_STEP_NAV,
 	STEPPER_TRACKS_EVENT_STEP_COMPLETE,
+	STEPPER_TRACKS_EVENT_SIGNUP_START,
 ];

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-signup-start.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-signup-start.ts
@@ -1,0 +1,20 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
+import { STEPPER_TRACKS_EVENT_SIGNUP_START } from 'calypso/landing/stepper/constants';
+
+export interface RecordStepCompleteProps {
+	flow: string;
+	step: string;
+	optionalProps?: Record< string, string | number | null >;
+}
+
+const recordSignupStart = ( { flow, step, optionalProps }: RecordStepCompleteProps ) => {
+	recordTracksEvent( STEPPER_TRACKS_EVENT_SIGNUP_START, {
+		flow,
+		step,
+		device: resolveDeviceTypeByViewPort(),
+		...optionalProps,
+	} );
+};
+
+export default recordSignupStart;

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-signup-start.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-signup-start.ts
@@ -2,16 +2,16 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { STEPPER_TRACKS_EVENT_SIGNUP_START } from 'calypso/landing/stepper/constants';
 
-export interface RecordStepCompleteProps {
+export interface RecordSignupStartProps {
 	flow: string;
-	step: string;
+	ref: string;
 	optionalProps?: Record< string, string | number | null >;
 }
 
-const recordSignupStart = ( { flow, step, optionalProps }: RecordStepCompleteProps ) => {
+const recordSignupStart = ( { flow, ref, optionalProps }: RecordSignupStartProps ) => {
 	recordTracksEvent( STEPPER_TRACKS_EVENT_SIGNUP_START, {
 		flow,
-		step,
+		ref,
 		device: resolveDeviceTypeByViewPort(),
 		...optionalProps,
 	} );

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -117,17 +117,25 @@ describe( 'useSignUpTracking', () => {
 			} );
 		} );
 
-		it( 'set the signup-start timer, records Google-Analytics and AD tracking only on initial mount', () => {
+		it( 'sets the signup-start timer only on initial mount (assuming static flowName and isSignupFlow)', () => {
 			const { rerender } = render( {
 				flow: {
 					...signUpFlow,
-					variantSlug: 'variant-slug',
 				} satisfies Flow,
 			} );
 
 			rerender();
-
 			expect( setSignupStartTime ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'records Google-Analytics and AD tracking only on initial mount (assuming static flowName and isSignupFlow)', () => {
+			const { rerender } = render( {
+				flow: {
+					...signUpFlow,
+				} satisfies Flow,
+			} );
+
+			rerender();
 			expect( gaRecordEvent ).toHaveBeenCalledTimes( 1 );
 			expect( adTrackSignupStart ).toHaveBeenCalledTimes( 1 );
 		} );

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -5,6 +5,9 @@ import { addQueryArgs } from '@wordpress/url';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import recordSignupStart from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-signup-start';
+import { adTrackSignupStart } from 'calypso/lib/analytics/ad-tracking';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import { setSignupStartTime } from 'calypso/signup/storageUtils';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
 import { useSignUpStartTracking } from '../';
 import type { Flow, StepperStep } from '../../../types';
@@ -28,6 +31,9 @@ const signUpFlow: Flow = {
 
 jest.mock( '@automattic/calypso-analytics' );
 jest.mock( 'calypso/landing/stepper/declarative-flow/internals/analytics/record-signup-start' );
+jest.mock( 'calypso/lib/analytics/ad-tracking' );
+jest.mock( 'calypso/lib/analytics/ga' );
+jest.mock( 'calypso/signup/storageUtils' );
 
 const render = ( { flow, queryParams = {} } ) => {
 	return renderHookWithProvider(
@@ -109,6 +115,21 @@ describe( 'useSignUpTracking', () => {
 				},
 				ref: '',
 			} );
+		} );
+
+		it( 'set the signup-start timer, records Google-Analytics and AD tracking only on initial mount', () => {
+			const { rerender } = render( {
+				flow: {
+					...signUpFlow,
+					variantSlug: 'variant-slug',
+				} satisfies Flow,
+			} );
+
+			rerender();
+
+			expect( setSignupStartTime ).toHaveBeenCalledTimes( 1 );
+			expect( gaRecordEvent ).toHaveBeenCalledTimes( 1 );
+			expect( adTrackSignupStart ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -1,12 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-
-import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import recordSignupStart from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-signup-start';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
 import { useSignUpStartTracking } from '../';
 import type { Flow, StepperStep } from '../../../types';
@@ -29,6 +27,7 @@ const signUpFlow: Flow = {
 };
 
 jest.mock( '@automattic/calypso-analytics' );
+jest.mock( 'calypso/landing/stepper/declarative-flow/internals/analytics/record-signup-start' );
 
 const render = ( { flow, queryParams = {} } ) => {
 	return renderHookWithProvider(
@@ -54,13 +53,13 @@ describe( 'useSignUpTracking', () => {
 	it( 'does not track event when the flow is not a isSignupFlow', () => {
 		render( { flow: regularFlow } );
 
-		expect( recordTracksEvent ).not.toHaveBeenCalled();
+		expect( recordSignupStart ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does not track event when the flow is not a isSignupFlow and the signup flag is set', () => {
 		render( { flow: regularFlow, queryParams: { start: 1 } } );
 
-		expect( recordTracksEvent ).not.toHaveBeenCalled();
+		expect( recordSignupStart ).not.toHaveBeenCalled();
 	} );
 
 	describe( 'sign-up-flow', () => {
@@ -70,10 +69,10 @@ describe( 'useSignUpTracking', () => {
 				queryParams: { ref: 'another-flow-or-cta' },
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
+			expect( recordSignupStart ).toHaveBeenCalledWith( {
 				flow: 'sign-up-flow',
 				ref: 'another-flow-or-cta',
-				device: resolveDeviceTypeByViewPort(),
+				optionalProps: {},
 			} );
 		} );
 
@@ -86,11 +85,12 @@ describe( 'useSignUpTracking', () => {
 				queryParams: { ref: 'another-flow-or-cta' },
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
+			expect( recordSignupStart ).toHaveBeenCalledWith( {
 				flow: 'sign-up-flow',
 				ref: 'another-flow-or-cta',
-				extra: 'props',
-				device: resolveDeviceTypeByViewPort(),
+				optionalProps: {
+					extra: 'props',
+				},
 			} );
 		} );
 
@@ -102,11 +102,12 @@ describe( 'useSignUpTracking', () => {
 				} satisfies Flow,
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
+			expect( recordSignupStart ).toHaveBeenCalledWith( {
 				flow: 'sign-up-flow',
-				flow_variant: 'variant-slug',
+				optionalProps: {
+					flow_variant: 'variant-slug',
+				},
 				ref: '',
-				device: resolveDeviceTypeByViewPort(),
 			} );
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -3,6 +3,7 @@
  */
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -72,6 +73,7 @@ describe( 'useSignUpTracking', () => {
 			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
 				flow: 'sign-up-flow',
 				ref: 'another-flow-or-cta',
+				device: resolveDeviceTypeByViewPort(),
 			} );
 		} );
 
@@ -88,6 +90,7 @@ describe( 'useSignUpTracking', () => {
 				flow: 'sign-up-flow',
 				ref: 'another-flow-or-cta',
 				extra: 'props',
+				device: resolveDeviceTypeByViewPort(),
 			} );
 		} );
 
@@ -103,6 +106,7 @@ describe( 'useSignUpTracking', () => {
 				flow: 'sign-up-flow',
 				flow_variant: 'variant-slug',
 				ref: '',
+				device: resolveDeviceTypeByViewPort(),
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94767

## Proposed Changes

This PR ensures that the timer for computing `elapsed_time_since_start` is properly started at the beginning of each signup session.
- Rerenders will not reset the timer
- Page reloads will reset the timer

The above also holds for Google Analytics and Marketing ad tracking we have around `calypso_signup_start` event

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94767

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

EDIT: See more thorough testing instructions added in comment below: https://github.com/Automattic/wp-calypso/pull/94841#issuecomment-2376765013

* Go to `/setup/ecommerce`
* After logging in, go through the steps with a delay of 10 secs at any step
  * Once on checkout, confirm `calypso_signup_complete` event recorded the right `elapsed_time_since_start`
* Same as above, but reload the page after the 10 secs delay. 
  * Confirm the time lapsed is correct (shorter)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
