### PR TITLE
A4A: Add overage pricing text on the Pressable section.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/style.scss
@@ -17,10 +17,6 @@
 		}
 	}
 
-	.pressable-overview-plan-selection__details {
-		flex-direction: column;
-	}
-
 	.pressable-overview-plan-selection__details-card {
 		border: none;
 		padding: 0;
@@ -37,11 +33,6 @@
 	@include break-large {
 		max-width: 1000px;
 		width: 100%;
-
-
-		.pressable-overview-plan-selection__details {
-			flex-direction: row;
-		}
 
 		.pressable-overview-plan-selection__details-card {
 			border: 1px solid var(--color-neutral-5);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -77,43 +77,174 @@ export default function PlanSelectionDetails( {
 	const isRegularOwnership = pressableOwnership === 'regular';
 
 	return (
-		<section className="pressable-overview-plan-selection__details">
-			<div className="pressable-overview-plan-selection__details-card">
-				<div className="pressable-overview-plan-selection__details-card-header">
-					<h3 className="pressable-overview-plan-selection__details-card-header-title plan-name">
-						{ isNewHostingPage
-							? translate( 'Pressable' )
-							: translate( '%(planName)s plan', {
-									args: {
-										planName: selectedPlan
-											? getPressableShortName( selectedPlan.name )
-											: customString,
-									},
-									comment: '%(planName)s is the name of the selected plan.',
-							  } ) }
-					</h3>
+		<>
+			<section className="pressable-overview-plan-selection__details">
+				<div className="pressable-overview-plan-selection__details-card">
+					<div className="pressable-overview-plan-selection__details-card-header">
+						<h3 className="pressable-overview-plan-selection__details-card-header-title plan-name">
+							{ isNewHostingPage
+								? translate( 'Pressable' )
+								: translate( '%(planName)s plan', {
+										args: {
+											planName: selectedPlan
+												? getPressableShortName( selectedPlan.name )
+												: customString,
+										},
+										comment: '%(planName)s is the name of the selected plan.',
+								  } ) }
+						</h3>
 
-					{ ! isReferMode && selectedPlan && (
-						<div className="pressable-overview-plan-selection__details-card-header-price">
-							<strong className="pressable-overview-plan-selection__details-card-header-price-value">
-								{ formatCurrency( discountedCost, selectedPlan.currency ) }
-							</strong>
-							<span className="pressable-overview-plan-selection__details-card-header-price-interval">
-								{ selectedPlan.price_interval === 'day' && translate( 'per plan per day' ) }
-								{ selectedPlan.price_interval === 'month' && translate( 'per plan per month' ) }
-							</span>
-						</div>
+						{ ! isReferMode && selectedPlan && (
+							<div className="pressable-overview-plan-selection__details-card-header-price">
+								<strong className="pressable-overview-plan-selection__details-card-header-price-value">
+									{ formatCurrency( discountedCost, selectedPlan.currency ) }
+								</strong>
+								<span className="pressable-overview-plan-selection__details-card-header-price-interval">
+									{ selectedPlan.price_interval === 'day' && translate( 'per plan per day' ) }
+									{ selectedPlan.price_interval === 'month' && translate( 'per plan per month' ) }
+								</span>
+							</div>
+						) }
+
+						{ isRegularOwnership && ! isReferMode && (
+							<div className="pressable-overview-plan-selection__details-card-header-subtitle is-regular-ownership">
+								{ translate(
+									'{{b}}You own this plan.{{/b}} Manage your hosting seamlessly by accessing the Pressable dashboard',
+									{
+										components: { b: <b /> },
+									}
+								) }
+							</div>
+						) }
+					</div>
+
+					{ ! isRegularOwnership && ! isReferMode && (
+						<SimpleList
+							items={ [
+								info?.install
+									? translate(
+											'{{b}}%(count)d{{/b}} WordPress install',
+											'{{b}}%(count)d{{/b}} WordPress installs',
+											{
+												args: {
+													count: info.install,
+												},
+												count: info.install,
+												components: { b: <b /> },
+												comment: '%(count)s is the number of WordPress installs.',
+											}
+									  )
+									: translate( 'Custom WordPress installs' ),
+								translate( '{{b}}%(count)s{{/b}} visits per month', {
+									args: {
+										count: info ? formatNumber( info.visits ) : customString,
+									},
+									components: { b: <b /> },
+									comment: '%(count)s is the number of visits per month.',
+								} ),
+								translate( '{{b}}%(size)s{{/b}} storage per month', {
+									args: {
+										size: info ? `${ info.storage }GB` : customString,
+									},
+									components: { b: <b /> },
+									comment: '%(size)s is the amount of storage in gigabytes.',
+								} ),
+								...( isNewHostingPage
+									? [
+											translate( '{{b}}Unmetered{{/b}} bandwidth', {
+												components: { b: <b /> },
+											} ),
+									  ]
+									: [] ),
+							] }
+						/>
 					) }
 
-					{ isRegularOwnership && ! isReferMode && (
-						<div className="pressable-overview-plan-selection__details-card-header-subtitle is-regular-ownership">
-							{ translate(
-								'{{b}}You own this plan.{{/b}} Manage your hosting seamlessly by accessing the Pressable dashboard',
-								{
-									components: { b: <b /> },
-								}
-							) }
+					{ isReferMode ? (
+						<div>
+							<div className="pressable-overview-plan-selection__details-card-header-subtitle is-refer-mode">
+								{ translate(
+									'Pressable hosting will be included in the referral program in the future.'
+								) }
+							</div>
+							<Button
+								className="pressable-overview-plan-selection__details-card-cta-button"
+								href={ CONTACT_URL_HASH_FRAGMENT }
+								primary
+							>
+								{ translate( 'Contact support' ) } <Icon icon={ external } size={ 16 } />
+							</Button>
 						</div>
+					) : (
+						<>
+							{ selectedPlan && (
+								<>
+									{ isRegularOwnership ? (
+										<div
+											className="pressable-overview-plan-selection__manage-account-button-container"
+											ref={ managedButtonRef }
+											role="button"
+											tabIndex={ 0 }
+											onMouseEnter={ () => setShowManagedTooltip( true ) }
+											onMouseLeave={ () => setShowManagedTooltip( false ) }
+											onMouseDown={ () => setShowManagedTooltip( false ) }
+										>
+											<Button
+												target="_blank"
+												rel="norefferer nooppener"
+												href="https://my.pressable.com/agency/auth"
+												disabled={ ! isOwner }
+											>
+												{ isOwner
+													? translate( 'Manage in Pressable' )
+													: translate( 'Managed by agency owner' ) }
+												{ isOwner && <Icon icon={ external } size={ 18 } /> }
+											</Button>
+										</div>
+									) : (
+										<Button
+											className="pressable-overview-plan-selection__details-card-cta-button"
+											onClick={ onSelectPlan }
+											primary
+										>
+											{ isNewHostingPage
+												? translate( 'Select this plan' )
+												: translate( 'Select %(planName)s plan', {
+														args: {
+															planName: selectedPlan
+																? getPressableShortName( selectedPlan.name )
+																: customString,
+														},
+														comment: '%(planName)s is the name of the selected plan.',
+												  } ) }
+										</Button>
+									) }
+
+									<Tooltip
+										context={ managedButtonRef.current }
+										isVisible={ ! isOwner && showManagedTooltip }
+										position="bottom"
+										className="pressable-overview-plan-selection__tooltip"
+									>
+										{ translate(
+											"This Pressable account is managed by the Agency Owner user on your account. If you'd like access to this Pressable account, request that they add you as a user in Pressable."
+										) }
+									</Tooltip>
+								</>
+							) }
+
+							{ ! selectedPlan && (
+								<Button
+									className="pressable-overview-plan-selection__details-card-cta-button"
+									onClick={ onContactUs }
+									href={ PRESSABLE_CONTACT_LINK }
+									target="_blank"
+									primary
+								>
+									{ translate( 'Contact us' ) } <Icon icon={ external } size={ 16 } />
+								</Button>
+							) }
+						</>
 					) }
 					{ isReferMode && (
 						<div className="pressable-overview-plan-selection__details-card-header-price">
@@ -124,180 +255,62 @@ export default function PlanSelectionDetails( {
 					) }
 				</div>
 
-				{ ! isRegularOwnership && ! isReferMode && (
-					<SimpleList
-						items={ [
-							info?.install
-								? translate(
-										'{{b}}%(count)d{{/b}} WordPress install',
-										'{{b}}%(count)d{{/b}} WordPress installs',
-										{
-											args: {
-												count: info.install,
-											},
-											count: info.install,
-											components: { b: <b /> },
-											comment: '%(count)s is the number of WordPress installs.',
-										}
-								  )
-								: translate( 'Custom WordPress installs' ),
-							translate( '{{b}}%(count)s{{/b}} visits per month', {
-								args: {
-									count: info ? formatNumber( info.visits ) : customString,
-								},
-								components: { b: <b /> },
-								comment: '%(count)s is the number of visits per month.',
-							} ),
-							translate( '{{b}}%(size)s{{/b}} storage per month', {
-								args: {
-									size: info ? `${ info.storage }GB` : customString,
-								},
-								components: { b: <b /> },
-								comment: '%(size)s is the amount of storage in gigabytes.',
-							} ),
-							...( isNewHostingPage
-								? [
-										translate( '{{b}}Unmetered{{/b}} bandwidth', {
-											components: { b: <b /> },
-										} ),
-								  ]
-								: [] ),
-						] }
-					/>
-				) }
-
-				{ isReferMode ? (
-					<div>
-						<div className="pressable-overview-plan-selection__details-card-header-subtitle is-refer-mode">
+				{ isNewHostingPage ? (
+					<div className="pressable-overview-plan-selection__details-card is-aside">
+						<h3 className="pressable-overview-plan-selection__details-card-header-title">
+							{ translate( 'Schedule a demo and personal consultation' ) }
+						</h3>
+						<div className="pressable-overview-plan-selection__details-card-header-subtitle">
 							{ translate(
-								'Pressable hosting will be included in the referral program in the future.'
+								'One of our friendly experts would be happy to give you a one-on-one tour of our platform and discuss:'
 							) }
 						</div>
+
+						<SimpleList
+							items={ [
+								translate( 'Our support, service, and pricing flexibility' ),
+								translate( 'The best hosting plan for your needs' ),
+								translate( 'How to launch and manage WordPress sites' ),
+								translate( 'The free perks that come with Pressable' ),
+							] }
+						/>
 						<Button
 							className="pressable-overview-plan-selection__details-card-cta-button"
-							href={ CONTACT_URL_HASH_FRAGMENT }
-							primary
+							onClick={ onScheduleDemo }
+							href={ PRESSABLE_CONTACT_LINK }
+							target="_blank"
 						>
-							{ translate( 'Contact support' ) } <Icon icon={ external } size={ 16 } />
+							{ translate( 'Schedule a Demo' ) } <Icon icon={ external } size={ 18 } />
 						</Button>
 					</div>
 				) : (
-					<>
-						{ selectedPlan && (
-							<>
-								{ isRegularOwnership ? (
-									<div
-										className="pressable-overview-plan-selection__manage-account-button-container"
-										ref={ managedButtonRef }
-										role="button"
-										tabIndex={ 0 }
-										onMouseEnter={ () => setShowManagedTooltip( true ) }
-										onMouseLeave={ () => setShowManagedTooltip( false ) }
-										onMouseDown={ () => setShowManagedTooltip( false ) }
-									>
-										<Button
-											target="_blank"
-											rel="norefferer nooppener"
-											href="https://my.pressable.com/agency/auth"
-											disabled={ ! isOwner }
-										>
-											{ isOwner
-												? translate( 'Manage in Pressable' )
-												: translate( 'Managed by agency owner' ) }
-											{ isOwner && <Icon icon={ external } size={ 18 } /> }
-										</Button>
-									</div>
-								) : (
-									<Button
-										className="pressable-overview-plan-selection__details-card-cta-button"
-										onClick={ onSelectPlan }
-										primary
-									>
-										{ isNewHostingPage
-											? translate( 'Select this plan' )
-											: translate( 'Select %(planName)s plan', {
-													args: {
-														planName: selectedPlan
-															? getPressableShortName( selectedPlan.name )
-															: customString,
-													},
-													comment: '%(planName)s is the name of the selected plan.',
-											  } ) }
-									</Button>
-								) }
+					<div className="pressable-overview-plan-selection__details-card is-aside">
+						<h3 className="pressable-overview-plan-selection__details-card-header-title">
+							{ translate( 'All plans include:' ) }
+						</h3>
 
-								<Tooltip
-									context={ managedButtonRef.current }
-									isVisible={ ! isOwner && showManagedTooltip }
-									position="bottom"
-									className="pressable-overview-plan-selection__tooltip"
-								>
-									{ translate(
-										"This Pressable account is managed by the Agency Owner user on your account. If you'd like access to this Pressable account, request that they add you as a user in Pressable."
-									) }
-								</Tooltip>
-							</>
-						) }
+						<SimpleList
+							items={ [
+								translate( '24/7 WordPress hosting support' ),
+								translate( 'WP Cloud platform' ),
+								translate( 'Jetpack Security (optional)' ),
+								translate( 'Free site migrations' ),
+							] }
+						/>
+					</div>
+				) }
+			</section>
 
-						{ ! selectedPlan && (
-							<Button
-								className="pressable-overview-plan-selection__details-card-cta-button"
-								onClick={ onContactUs }
-								href={ PRESSABLE_CONTACT_LINK }
-								target="_blank"
-								primary
-							>
-								{ translate( 'Contact us' ) } <Icon icon={ external } size={ 16 } />
-							</Button>
-						) }
-					</>
+			<div className="pressable-overview-plan-selection__hint">
+				{ translate(
+					'*We charge {{b}}$0.5{{/b}} per month per GB over their Storage limit, and {{b}}$8{{/b}} per 10k Visits per month over their Traffic limit.',
+					{
+						components: {
+							b: <b />,
+						},
+					}
 				) }
 			</div>
-
-			{ isNewHostingPage ? (
-				<div className="pressable-overview-plan-selection__details-card is-aside">
-					<h3 className="pressable-overview-plan-selection__details-card-header-title">
-						{ translate( 'Schedule a demo and personal consultation' ) }
-					</h3>
-					<div className="pressable-overview-plan-selection__details-card-header-subtitle">
-						{ translate(
-							'One of our friendly experts would be happy to give you a one-on-one tour of our platform and discuss:'
-						) }
-					</div>
-
-					<SimpleList
-						items={ [
-							translate( 'Our support, service, and pricing flexibility' ),
-							translate( 'The best hosting plan for your needs' ),
-							translate( 'How to launch and manage WordPress sites' ),
-							translate( 'The free perks that come with Pressable' ),
-						] }
-					/>
-					<Button
-						className="pressable-overview-plan-selection__details-card-cta-button"
-						onClick={ onScheduleDemo }
-						href={ PRESSABLE_CONTACT_LINK }
-						target="_blank"
-					>
-						{ translate( 'Schedule a Demo' ) } <Icon icon={ external } size={ 18 } />
-					</Button>
-				</div>
-			) : (
-				<div className="pressable-overview-plan-selection__details-card is-aside">
-					<h3 className="pressable-overview-plan-selection__details-card-header-title">
-						{ translate( 'All plans include:' ) }
-					</h3>
-
-					<SimpleList
-						items={ [
-							translate( '24/7 WordPress hosting support' ),
-							translate( 'WP Cloud platform' ),
-							translate( 'Jetpack Security (optional)' ),
-							translate( 'Free site migrations' ),
-						] }
-					/>
-				</div>
-			) }
-		</section>
+		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -77,231 +77,229 @@ export default function PlanSelectionDetails( {
 	const isRegularOwnership = pressableOwnership === 'regular';
 
 	return (
-		<>
-			<section className="pressable-overview-plan-selection__details">
-				<div className="pressable-overview-plan-selection__details-card">
-					<div className="pressable-overview-plan-selection__details-card-header">
-						<h3 className="pressable-overview-plan-selection__details-card-header-title plan-name">
-							{ isNewHostingPage
-								? translate( 'Pressable' )
-								: translate( '%(planName)s plan', {
-										args: {
-											planName: selectedPlan
-												? getPressableShortName( selectedPlan.name )
-												: customString,
-										},
-										comment: '%(planName)s is the name of the selected plan.',
-								  } ) }
-						</h3>
-
-						{ ! isReferMode && selectedPlan && (
-							<div className="pressable-overview-plan-selection__details-card-header-price">
-								<strong className="pressable-overview-plan-selection__details-card-header-price-value">
-									{ formatCurrency( discountedCost, selectedPlan.currency ) }
-								</strong>
-								<span className="pressable-overview-plan-selection__details-card-header-price-interval">
-									{ selectedPlan.price_interval === 'day' && translate( 'per plan per day' ) }
-									{ selectedPlan.price_interval === 'month' && translate( 'per plan per month' ) }
-								</span>
-							</div>
-						) }
-
-						{ isRegularOwnership && ! isReferMode && (
-							<div className="pressable-overview-plan-selection__details-card-header-subtitle is-regular-ownership">
-								{ translate(
-									'{{b}}You own this plan.{{/b}} Manage your hosting seamlessly by accessing the Pressable dashboard',
-									{
-										components: { b: <b /> },
-									}
-								) }
-							</div>
-						) }
-						{ isReferMode && (
-							<div className="pressable-overview-plan-selection__details-card-header-price">
-								<strong className="pressable-overview-plan-selection__details-card-header-coming-soon">
-									{ translate( 'Coming soon' ) }
-								</strong>
-							</div>
-						) }
-					</div>
-
-					{ ! isRegularOwnership && ! isReferMode && (
-						<SimpleList
-							items={ [
-								info?.install
-									? translate(
-											'{{b}}%(count)d{{/b}} WordPress install',
-											'{{b}}%(count)d{{/b}} WordPress installs',
-											{
-												args: {
-													count: info.install,
-												},
-												count: info.install,
-												components: { b: <b /> },
-												comment: '%(count)s is the number of WordPress installs.',
-											}
-									  )
-									: translate( 'Custom WordPress installs' ),
-								translate( '{{b}}%(count)s{{/b}} visits per month*', {
+		<section className="pressable-overview-plan-selection__details">
+			<div className="pressable-overview-plan-selection__details-card">
+				<div className="pressable-overview-plan-selection__details-card-header">
+					<h3 className="pressable-overview-plan-selection__details-card-header-title plan-name">
+						{ isNewHostingPage
+							? translate( 'Pressable' )
+							: translate( '%(planName)s plan', {
 									args: {
-										count: info ? formatNumber( info.visits ) : customString,
+										planName: selectedPlan
+											? getPressableShortName( selectedPlan.name )
+											: customString,
 									},
-									components: { b: <b /> },
-									comment: '%(count)s is the number of visits per month.',
-								} ),
-								translate( '{{b}}%(size)s{{/b}} storage per month*', {
-									args: {
-										size: info ? `${ info.storage }GB` : customString,
-									},
-									components: { b: <b /> },
-									comment: '%(size)s is the amount of storage in gigabytes.',
-								} ),
-								...( isNewHostingPage
-									? [
-											translate( '{{b}}Unmetered{{/b}} bandwidth', {
-												components: { b: <b /> },
-											} ),
-									  ]
-									: [] ),
-							] }
-						/>
+									comment: '%(planName)s is the name of the selected plan.',
+							  } ) }
+					</h3>
+
+					{ ! isReferMode && selectedPlan && (
+						<div className="pressable-overview-plan-selection__details-card-header-price">
+							<strong className="pressable-overview-plan-selection__details-card-header-price-value">
+								{ formatCurrency( discountedCost, selectedPlan.currency ) }
+							</strong>
+							<span className="pressable-overview-plan-selection__details-card-header-price-interval">
+								{ selectedPlan.price_interval === 'day' && translate( 'per plan per day' ) }
+								{ selectedPlan.price_interval === 'month' && translate( 'per plan per month' ) }
+							</span>
+						</div>
 					) }
 
-					{ isReferMode ? (
-						<div>
-							<div className="pressable-overview-plan-selection__details-card-header-subtitle is-refer-mode">
-								{ translate(
-									'Pressable hosting will be included in the referral program in the future.'
-								) }
-							</div>
-							<Button
-								className="pressable-overview-plan-selection__details-card-cta-button"
-								href={ CONTACT_URL_HASH_FRAGMENT }
-								primary
-							>
-								{ translate( 'Contact support' ) } <Icon icon={ external } size={ 16 } />
-							</Button>
+					{ isRegularOwnership && ! isReferMode && (
+						<div className="pressable-overview-plan-selection__details-card-header-subtitle is-regular-ownership">
+							{ translate(
+								'{{b}}You own this plan.{{/b}} Manage your hosting seamlessly by accessing the Pressable dashboard',
+								{
+									components: { b: <b /> },
+								}
+							) }
 						</div>
-					) : (
-						<>
-							{ selectedPlan && (
-								<>
-									{ isRegularOwnership ? (
-										<div
-											className="pressable-overview-plan-selection__manage-account-button-container"
-											ref={ managedButtonRef }
-											role="button"
-											tabIndex={ 0 }
-											onMouseEnter={ () => setShowManagedTooltip( true ) }
-											onMouseLeave={ () => setShowManagedTooltip( false ) }
-											onMouseDown={ () => setShowManagedTooltip( false ) }
-										>
-											<Button
-												target="_blank"
-												rel="norefferer nooppener"
-												href="https://my.pressable.com/agency/auth"
-												disabled={ ! isOwner }
-											>
-												{ isOwner
-													? translate( 'Manage in Pressable' )
-													: translate( 'Managed by agency owner' ) }
-												{ isOwner && <Icon icon={ external } size={ 18 } /> }
-											</Button>
-										</div>
-									) : (
-										<Button
-											className="pressable-overview-plan-selection__details-card-cta-button"
-											onClick={ onSelectPlan }
-											primary
-										>
-											{ isNewHostingPage
-												? translate( 'Select this plan' )
-												: translate( 'Select %(planName)s plan', {
-														args: {
-															planName: selectedPlan
-																? getPressableShortName( selectedPlan.name )
-																: customString,
-														},
-														comment: '%(planName)s is the name of the selected plan.',
-												  } ) }
-										</Button>
-									) }
-
-									<Tooltip
-										context={ managedButtonRef.current }
-										isVisible={ ! isOwner && showManagedTooltip }
-										position="bottom"
-										className="pressable-overview-plan-selection__tooltip"
-									>
-										{ translate(
-											"This Pressable account is managed by the Agency Owner user on your account. If you'd like access to this Pressable account, request that they add you as a user in Pressable."
-										) }
-									</Tooltip>
-								</>
-							) }
-
-							{ ! selectedPlan && (
-								<Button
-									className="pressable-overview-plan-selection__details-card-cta-button"
-									onClick={ onContactUs }
-									href={ PRESSABLE_CONTACT_LINK }
-									target="_blank"
-									primary
-								>
-									{ translate( 'Contact us' ) } <Icon icon={ external } size={ 16 } />
-								</Button>
-							) }
-						</>
+					) }
+					{ isReferMode && (
+						<div className="pressable-overview-plan-selection__details-card-header-price">
+							<strong className="pressable-overview-plan-selection__details-card-header-coming-soon">
+								{ translate( 'Coming soon' ) }
+							</strong>
+						</div>
 					) }
 				</div>
 
-				{ isNewHostingPage ? (
-					<div className="pressable-overview-plan-selection__details-card is-aside">
-						<h3 className="pressable-overview-plan-selection__details-card-header-title">
-							{ translate( 'Schedule a demo and personal consultation' ) }
-						</h3>
-						<div className="pressable-overview-plan-selection__details-card-header-subtitle">
+				{ ! isRegularOwnership && ! isReferMode && (
+					<SimpleList
+						items={ [
+							info?.install
+								? translate(
+										'{{b}}%(count)d{{/b}} WordPress install',
+										'{{b}}%(count)d{{/b}} WordPress installs',
+										{
+											args: {
+												count: info.install,
+											},
+											count: info.install,
+											components: { b: <b /> },
+											comment: '%(count)s is the number of WordPress installs.',
+										}
+								  )
+								: translate( 'Custom WordPress installs' ),
+							translate( '{{b}}%(count)s{{/b}} visits per month*', {
+								args: {
+									count: info ? formatNumber( info.visits ) : customString,
+								},
+								components: { b: <b /> },
+								comment: '%(count)s is the number of visits per month.',
+							} ),
+							translate( '{{b}}%(size)s{{/b}} storage per month*', {
+								args: {
+									size: info ? `${ info.storage }GB` : customString,
+								},
+								components: { b: <b /> },
+								comment: '%(size)s is the amount of storage in gigabytes.',
+							} ),
+							...( isNewHostingPage
+								? [
+										translate( '{{b}}Unmetered{{/b}} bandwidth', {
+											components: { b: <b /> },
+										} ),
+								  ]
+								: [] ),
+						] }
+					/>
+				) }
+
+				{ isReferMode ? (
+					<div>
+						<div className="pressable-overview-plan-selection__details-card-header-subtitle is-refer-mode">
 							{ translate(
-								'One of our friendly experts would be happy to give you a one-on-one tour of our platform and discuss:'
+								'Pressable hosting will be included in the referral program in the future.'
 							) }
 						</div>
-
-						<SimpleList
-							items={ [
-								translate( 'Our support, service, and pricing flexibility' ),
-								translate( 'The best hosting plan for your needs' ),
-								translate( 'How to launch and manage WordPress sites' ),
-								translate( 'The free perks that come with Pressable' ),
-							] }
-						/>
 						<Button
 							className="pressable-overview-plan-selection__details-card-cta-button"
-							onClick={ onScheduleDemo }
-							href={ PRESSABLE_CONTACT_LINK }
-							target="_blank"
+							href={ CONTACT_URL_HASH_FRAGMENT }
+							primary
 						>
-							{ translate( 'Schedule a Demo' ) } <Icon icon={ external } size={ 18 } />
+							{ translate( 'Contact support' ) } <Icon icon={ external } size={ 16 } />
 						</Button>
 					</div>
 				) : (
-					<div className="pressable-overview-plan-selection__details-card is-aside">
-						<h3 className="pressable-overview-plan-selection__details-card-header-title">
-							{ translate( 'All plans include:' ) }
-						</h3>
+					<>
+						{ selectedPlan && (
+							<>
+								{ isRegularOwnership ? (
+									<div
+										className="pressable-overview-plan-selection__manage-account-button-container"
+										ref={ managedButtonRef }
+										role="button"
+										tabIndex={ 0 }
+										onMouseEnter={ () => setShowManagedTooltip( true ) }
+										onMouseLeave={ () => setShowManagedTooltip( false ) }
+										onMouseDown={ () => setShowManagedTooltip( false ) }
+									>
+										<Button
+											target="_blank"
+											rel="norefferer nooppener"
+											href="https://my.pressable.com/agency/auth"
+											disabled={ ! isOwner }
+										>
+											{ isOwner
+												? translate( 'Manage in Pressable' )
+												: translate( 'Managed by agency owner' ) }
+											{ isOwner && <Icon icon={ external } size={ 18 } /> }
+										</Button>
+									</div>
+								) : (
+									<Button
+										className="pressable-overview-plan-selection__details-card-cta-button"
+										onClick={ onSelectPlan }
+										primary
+									>
+										{ isNewHostingPage
+											? translate( 'Select this plan' )
+											: translate( 'Select %(planName)s plan', {
+													args: {
+														planName: selectedPlan
+															? getPressableShortName( selectedPlan.name )
+															: customString,
+													},
+													comment: '%(planName)s is the name of the selected plan.',
+											  } ) }
+									</Button>
+								) }
 
-						<SimpleList
-							items={ [
-								translate( '24/7 WordPress hosting support' ),
-								translate( 'WP Cloud platform' ),
-								translate( 'Jetpack Security (optional)' ),
-								translate( 'Free site migrations' ),
-							] }
-						/>
-					</div>
+								<Tooltip
+									context={ managedButtonRef.current }
+									isVisible={ ! isOwner && showManagedTooltip }
+									position="bottom"
+									className="pressable-overview-plan-selection__tooltip"
+								>
+									{ translate(
+										"This Pressable account is managed by the Agency Owner user on your account. If you'd like access to this Pressable account, request that they add you as a user in Pressable."
+									) }
+								</Tooltip>
+							</>
+						) }
+
+						{ ! selectedPlan && (
+							<Button
+								className="pressable-overview-plan-selection__details-card-cta-button"
+								onClick={ onContactUs }
+								href={ PRESSABLE_CONTACT_LINK }
+								target="_blank"
+								primary
+							>
+								{ translate( 'Contact us' ) } <Icon icon={ external } size={ 16 } />
+							</Button>
+						) }
+					</>
 				) }
-			</section>
+			</div>
 
-			<div className="pressable-overview-plan-selection__hint">
+			{ isNewHostingPage ? (
+				<div className="pressable-overview-plan-selection__details-card is-aside">
+					<h3 className="pressable-overview-plan-selection__details-card-header-title">
+						{ translate( 'Schedule a demo and personal consultation' ) }
+					</h3>
+					<div className="pressable-overview-plan-selection__details-card-header-subtitle">
+						{ translate(
+							'One of our friendly experts would be happy to give you a one-on-one tour of our platform and discuss:'
+						) }
+					</div>
+
+					<SimpleList
+						items={ [
+							translate( 'Our support, service, and pricing flexibility' ),
+							translate( 'The best hosting plan for your needs' ),
+							translate( 'How to launch and manage WordPress sites' ),
+							translate( 'The free perks that come with Pressable' ),
+						] }
+					/>
+					<Button
+						className="pressable-overview-plan-selection__details-card-cta-button"
+						onClick={ onScheduleDemo }
+						href={ PRESSABLE_CONTACT_LINK }
+						target="_blank"
+					>
+						{ translate( 'Schedule a Demo' ) } <Icon icon={ external } size={ 18 } />
+					</Button>
+				</div>
+			) : (
+				<div className="pressable-overview-plan-selection__details-card is-aside">
+					<h3 className="pressable-overview-plan-selection__details-card-header-title">
+						{ translate( 'All plans include:' ) }
+					</h3>
+
+					<SimpleList
+						items={ [
+							translate( '24/7 WordPress hosting support' ),
+							translate( 'WP Cloud platform' ),
+							translate( 'Jetpack Security (optional)' ),
+							translate( 'Free site migrations' ),
+						] }
+					/>
+				</div>
+			) }
+
+			<div className="pressable-overview-plan-selection__details-hint">
 				{ translate(
 					"*If you exceed your plan's storage or traffic limits, you will be charged {{b}}$0.50{{/b}} per GB and {{b}}$8{{/b}} per 10K visits per month.",
 					{
@@ -311,6 +309,6 @@ export default function PlanSelectionDetails( {
 					}
 				) }
 			</div>
-		</>
+		</section>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -142,14 +142,14 @@ export default function PlanSelectionDetails( {
 											}
 									  )
 									: translate( 'Custom WordPress installs' ),
-								translate( '{{b}}%(count)s{{/b}} visits per month', {
+								translate( '{{b}}%(count)s{{/b}} visits per month*', {
 									args: {
 										count: info ? formatNumber( info.visits ) : customString,
 									},
 									components: { b: <b /> },
 									comment: '%(count)s is the number of visits per month.',
 								} ),
-								translate( '{{b}}%(size)s{{/b}} storage per month', {
+								translate( '{{b}}%(size)s{{/b}} storage per month*', {
 									args: {
 										size: info ? `${ info.storage }GB` : customString,
 									},

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -116,6 +116,13 @@ export default function PlanSelectionDetails( {
 								) }
 							</div>
 						) }
+						{ isReferMode && (
+							<div className="pressable-overview-plan-selection__details-card-header-price">
+								<strong className="pressable-overview-plan-selection__details-card-header-coming-soon">
+									{ translate( 'Coming soon' ) }
+								</strong>
+							</div>
+						) }
 					</div>
 
 					{ ! isRegularOwnership && ! isReferMode && (
@@ -246,13 +253,6 @@ export default function PlanSelectionDetails( {
 							) }
 						</>
 					) }
-					{ isReferMode && (
-						<div className="pressable-overview-plan-selection__details-card-header-price">
-							<strong className="pressable-overview-plan-selection__details-card-header-coming-soon">
-								{ translate( 'Coming soon' ) }
-							</strong>
-						</div>
-					) }
 				</div>
 
 				{ isNewHostingPage ? (
@@ -303,7 +303,7 @@ export default function PlanSelectionDetails( {
 
 			<div className="pressable-overview-plan-selection__hint">
 				{ translate(
-					'*We charge {{b}}$0.5{{/b}} per month per GB over their Storage limit, and {{b}}$8{{/b}} per 10k Visits per month over their Traffic limit.',
+					"If you exceed your plan's storage or traffic limits, you will be charged {{b}}$0.50{{/b}} per GB and {{b}}$8{{/b}} per 10K visits per month.",
 					{
 						components: {
 							b: <b />,

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -303,7 +303,7 @@ export default function PlanSelectionDetails( {
 
 			<div className="pressable-overview-plan-selection__hint">
 				{ translate(
-					"If you exceed your plan's storage or traffic limits, you will be charged {{b}}$0.50{{/b}} per GB and {{b}}$8{{/b}} per 10K visits per month.",
+					"*If you exceed your plan's storage or traffic limits, you will be charged {{b}}$0.50{{/b}} per GB and {{b}}$8{{/b}} per 10K visits per month.",
 					{
 						components: {
 							b: <b />,

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -11,46 +11,49 @@
 }
 
 .pressable-overview-plan-selection__details {
-	margin-block-start: 32px;
-	margin-block-end: 8px;
-	display: flex;
-	flex-direction: column;
-	gap: 32px;
-
-	> * {
-		padding: 24px;
-		display: flex;
-		flex-direction: column;
-		gap: 32px;
-	}
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-auto-rows: auto;
+	margin-block-end: 64px;
+	row-gap: 32px;
 
 	@include break-large {
-		flex-direction: row;
+		grid-template-columns: repeat(2, 1fr);
+		column-gap: 32px;
+		row-gap: 8px;
+
+		> * {
+			// Make items span full width if they're the only child
+			grid-column: auto / span 2;
+		}
+
+		// If there are 2 or more children, reset the grid span
+		> *:nth-child(1):nth-last-child(n+2),
+		> *:nth-child(2):nth-last-child(n+2) {
+			grid-column: auto / span 1;
+		}
+
 	}
 }
 
-.pressable-overview-plan-selection__hint {
+.pressable-overview-plan-selection__details-hint {
 	@include a4a-font-body-md;
-	margin-block-end: 64px;
 }
 
 .pressable-overview-plan-selection__details-card {
 	border-radius: 4px;
+	padding: 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
 }
 
 .pressable-overview-plan-selection__details-card:not(.is-aside) {
-	flex-grow: 1;
 	background: var(--color-light-backdrop);
 }
 
 .pressable-overview-plan-selection__details-card.is-aside {
 	border: 1px solid var(--color-neutral-5);
-	flex-grow: 1;
-
-	@include break-large {
-		width: 300px;
-		flex-grow: 0;
-	}
 }
 
 .pressable-overview-plan-selection__details-card-header-title {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -12,7 +12,7 @@
 
 .pressable-overview-plan-selection__details {
 	margin-block-start: 32px;
-	margin-block-end: 64px;
+	margin-block-end: 8px;
 	display: flex;
 	flex-direction: column;
 	gap: 32px;
@@ -27,6 +27,11 @@
 	@include break-large {
 		flex-direction: row;
 	}
+}
+
+.pressable-overview-plan-selection__hint {
+	@include a4a-font-body-md;
+	margin-block-end: 64px;
 }
 
 .pressable-overview-plan-selection__details-card {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -14,7 +14,7 @@
 	display: grid;
 	grid-template-columns: 1fr;
 	grid-auto-rows: auto;
-	margin-block-end: 64px;
+	margin-block: 32px 64px;
 	row-gap: 32px;
 
 	@include break-large {


### PR DESCRIPTION
This pull request includes overage pricing information for Pressable plans in the Marketplace.

<img width="1051" alt="Screenshot 2024-09-27 at 3 37 22 PM" src="https://github.com/user-attachments/assets/9113d52e-2980-47fa-b200-263d15e28112">

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1038


## Proposed Changes

* Add text about the overage pricing below the plan selection card.

## Why are these changes being made?

* If an A4A user with a Pressable plan exceeds their allocated traffic or storage, we will charge them more for this on their invoice. We must be upfront about that on the Pressable plan picker page.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting/pressable` page.
* Confirm that you see the overage pricing text same as the screenshot above.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
