### PR TITLE
Themes: Include delisted when searching

### DIFF
--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -57,11 +57,19 @@ export function requestThemes( siteId, query = {}, locale ) {
 							// https://github.com/Automattic/wp-calypso/issues/71911#issuecomment-1381284172
 							// User can be redirected to PatternAssembler flow using the PatternAssemblerCTA on theme-list
 							include_blankcanvas_theme: null,
-							// Include retired themes when searching. This is useful when a theme exists in both wpcom and wporg.
-							// The theme will show up in the theme listing as wporg, but it cannot be activated
-							// since it's a retired wpcom theme (take precedence).
-							// See: https://github.com/Automattic/wp-calypso/pull/78231
-							...( query.search && !! query.search.length ? { retired: true } : null ),
+							...( query.search && !! query.search.length
+								? {
+										// Include retired themes when searching. This is useful when a theme exists in both wpcom and wporg.
+										// The theme will show up in the theme listing as wporg, but it cannot be activated
+										// since it's a retired wpcom theme (take precedence).
+										// See: https://github.com/Automattic/wp-calypso/pull/78231
+										retired: true,
+										// Include delisted themes when searching. This solves an issue where some themes
+										// are mistakenly displayed as 3rd-party themes requiring an upgrade.
+										// See: https://github.com/Automattic/wp-calypso/issues/94310#issuecomment-2370899172
+										delisted: true,
+								  }
+								: null ),
 						},
 						locale ? { locale } : null
 					)


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/94310.

| Before | After |
| ------- | ----- |
| ![image](https://github.com/user-attachments/assets/5e7d20ee-cb09-46ef-852c-5fedd0d191d8) | ![image](https://github.com/user-attachments/assets/3a9b73c8-5129-44ae-90c2-969635bddf5d) |

## Why are these changes being made?

Delisted themes were not being included in search, causing a mismatch with the Dotorg API and categorizing some free themes as 3rd-party that requires a paid site.

## Testing Instructions

1. Apply D162217-code and proxy your sandbox
2. Search for `2011` and `eleven` and make sure it shows up as a free theme instead of requiring an Upgrade