### PR TITLE
Admin Interface Style: Update support doc link

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -8,8 +8,8 @@ const contextLinks = {
 		post_id: 80368,
 	},
 	'admin-interface-style': {
-		link: 'https://wordpress.com/support/dashboard/#set-the-admin-interface-style',
-		post_id: 137,
+		link: 'https://wordpress.com/support/set-your-admin-interface-style/',
+		post_id: 386651,
 	},
 	advertising: {
 		link: 'https://wordpress.com/support/promote-a-post/',


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/94810.

## Why are these changes being made?

There's a new support document and we should point to it.

## Testing Instructions

1. Visit a site’s dashboard in the default (Calypso) admin.
2. Navigate to Settings → General.
3. Scroll down to the “Admin Interface Style” section.
4. Click the i (information) icon.
5. Click "Learn more".
6. Verify you're redirected to https://wordpress.com/support/set-your-admin-interface-style/
