### PR TITLE
White-labeled plugin: Ensure we're retrying the query 

### DIFF
--- a/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
+++ b/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
@@ -292,7 +292,7 @@ describe( 'usePrepareSiteForMigrationWithMoveToWPCOM', () => {
 			.get( `/wpcom/v2/sites/${ siteId }/atomic-migration-status/migrate-guru-key?http_envelope=1` )
 			.reply( errorCaptureMigrationKey );
 
-		const { result } = renderHook( () => useSiteMigrationKey( siteId ), {
+		const { result } = renderHook( () => useSiteMigrationKey( siteId, { retry: 0 } ), {
 			wrapper: Wrapper( new QueryClient() ),
 		} );
 

--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -156,6 +156,7 @@ export const usePrepareSiteForMigrationWithMigrateGuru = ( siteId?: number ) => 
 		fetchStatus: migrationKeyFetchStatus,
 	} = useSiteMigrationKey( siteId, {
 		enabled: Boolean( pluginInstallationState.completed ),
+		retry: false,
 	} );
 
 	const { siteTransferStart, siteTransferEnd, pluginInstallationStart, pluginInstallationEnd } =
@@ -211,7 +212,7 @@ export const usePrepareSiteForMigrationWithMigrateToWPCOM = ( siteId?: number ) 
 		data: { migrationKey } = {},
 		error: migrationKeyError,
 		fetchStatus: migrationKeyFetchStatus,
-	} = useSiteMigrationKey( siteId );
+	} = useSiteMigrationKey( siteId, { enabled: true, retry: 20 } );
 
 	const { siteTransferStart, siteTransferEnd } = useTransferTimeTracking( siteTransferState );
 

--- a/client/landing/stepper/hooks/use-site-migration-key.ts
+++ b/client/landing/stepper/hooks/use-site-migration-key.ts
@@ -28,23 +28,16 @@ const getMigrationKey = async ( siteId: number ): Promise< ApiResponse > => {
 	);
 };
 
-type Options = Pick< UseQueryOptions, 'enabled' >;
+type Options = {
+	enabled?: UseQueryOptions[ 'enabled' ];
+	retry?: UseQueryOptions[ 'retry' ];
+};
 
 export const useSiteMigrationKey = ( siteId?: number, options?: Options ) => {
 	return useQuery( {
 		queryKey: [ 'site-migration-key', siteId ],
 		queryFn: () => getMigrationKey( siteId! ),
-		retry: ( failureCount: number, error: Error ) => {
-			if ( isWhiteLabeledPluginEnabled() && failureCount >= 20 ) {
-				throw error;
-			}
-
-			if ( isWhiteLabeledPluginEnabled() ) {
-				return true;
-			}
-
-			return false;
-		},
+		retry: options?.retry ?? false,
 		retryDelay: 5000,
 		enabled: !! siteId && ( options?.enabled ?? true ),
 		select: ( data ) => ( { migrationKey: data?.migration_key } ),

--- a/client/landing/stepper/hooks/use-site-migration-key.ts
+++ b/client/landing/stepper/hooks/use-site-migration-key.ts
@@ -39,8 +39,13 @@ export const useSiteMigrationKey = ( siteId?: number, options?: Options ) => {
 				throw error;
 			}
 
+			if ( isWhiteLabeledPluginEnabled() ) {
+				return true;
+			}
+
 			return false;
 		},
+		retryDelay: 5000,
 		enabled: !! siteId && ( options?.enabled ?? true ),
 		select: ( data ) => ( { migrationKey: data?.migration_key } ),
 		refetchOnWindowFocus: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Update retry callback to return `true` for the white-labeled plugin flag so we're actually incrementing the counter and retrying.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Update retry callback to return `true` for the white-labeled plugin flag so we're actually incrementing the counter and retrying.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to PR, navigate to `/setup/migration-signup?siteSlug=testsite.wordpress.com` where `testsite.wordpress.com` is one of the gated test blog URLs found in the Atomic software installation logic gate.
* Alternatively, don't use an existing `siteSlug` and you can install the software yourself once the site is provisioned.
* Ensure the feature flag is enabled by either adding the query param `&flags=migration-flow/enable-white-labeled-plugin` to the URL at the site instructions step OR in your session storage by running the following in your console, hitting enter, and reloading: `window.sessionStorage.setItem('flags', 'migration-flow/enable-white-labeled-plugin');`
* Go through the flow; check out. You should land on the site instructions page.
* You should see the correct migration key in the last step:

<img width="1454" alt="Screenshot 2024-09-24 at 3 07 47 PM" src="https://github.com/user-attachments/assets/4d296362-3bfd-409f-8bbb-54903e63297a">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
