### PR TITLE
A4A: fix URL localization issue

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/index.tsx
@@ -131,6 +131,7 @@ export default function SiteActions( {
 						<PopoverMenuItem
 							key={ action.name }
 							isExternalLink={ action.isExternalLink }
+							localizeUrl={ false }
 							onClick={ action.onClick }
 							href={ action.href }
 							className={ clsx( 'site-actions__menu-item', action.className ) }

--- a/packages/components/src/external-link/README.md
+++ b/packages/components/src/external-link/README.md
@@ -22,9 +22,10 @@ function MyComponent() {
 
 The following props can be passed to the External Link component:
 
-| property | type    | required | comment                                                                        |
-| -------- | ------- | -------- | ------------------------------------------------------------------------------ |
-| `icon`   | Boolean | no       | Set to true if you want to render a nice external Gridicon at the end of link. |
+| property      | type    | required | comment                                                                        |
+| ------------- | ------- | -------- | ------------------------------------------------------------------------------ |
+| `icon`        | Boolean | no       | Set to true if you want to render a nice external Gridicon at the end of link. |
+| `localizeUrl` | Boolean | no       | Set to false if you want to render a link that is not localized.               |
 
 ### Other Props
 

--- a/packages/components/src/external-link/index.jsx
+++ b/packages/components/src/external-link/index.jsx
@@ -13,6 +13,7 @@ class ExternalLink extends Component {
 		iconSize: 18,
 		showIconFirst: false,
 		iconComponent: null,
+		localizeUrl: true,
 	};
 
 	static propTypes = {
@@ -25,6 +26,7 @@ class ExternalLink extends Component {
 		showIconFirst: PropTypes.bool,
 		iconClassName: PropTypes.string,
 		iconComponent: PropTypes.object,
+		localizeUrl: PropTypes.bool,
 	};
 
 	render() {
@@ -47,7 +49,7 @@ class ExternalLink extends Component {
 			props.rel = props.rel.concat( ' noopener noreferrer' );
 		}
 
-		if ( props.href ) {
+		if ( props.href && props.localizeUrl ) {
 			props.href = localizeUrl( props.href );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1148

## Proposed Changes

Currently, links under sites actions are broken for non eng locales
<img width="838" alt="Screenshot 2024-09-24 at 8 56 54 AM" src="https://github.com/user-attachments/assets/3eb62f5a-bc43-4eff-9f45-279bae64f042">

This happens due to a localizeURL function happening under the hood in one of core components.
This PR adds additional prop that allow to disable URL localization in the core component and disables it for components in A4A.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- In your wpcom account `https://wordpress.com/me/account` change the language to any non english
- Use live link below and visit /sites
- Verify action links and confirm they work as expected.
- You could also try to check external links within `wordpress.com` and `cloud.jetpack`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
