### PR TITLE
Signup: Submit the domains step on checkout back button click

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -316,8 +316,6 @@ export default {
 			}
 		}
 
-		// ... existing code ...
-
 		// If the flow has siteId or siteSlug as query dependencies, we should not clear selected site id
 		if (
 			! providesDependenciesInQuery?.includes( 'siteId' ) &&

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -308,7 +308,7 @@ export default {
 
 		// Hydrate the store with domains dependencies from session storage.
 		const signupDependencies = getSignupDependencies();
-		if ( signupDependencies && isManageSiteFlow ) {
+		if ( signupDependencies && isManageSiteFlow && flowName === 'onboarding' ) {
 			const parsedDependenciesJSON = JSON.parse( signupDependencies );
 			const parsedStep = { ...parsedDependenciesJSON.step };
 			const parsedDependencies = { ...parsedDependenciesJSON.dependencies };

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -24,6 +24,7 @@ import { isReskinnedFlow } from './is-flow';
 import SignupComponent from './main';
 import {
 	retrieveSignupDestination,
+	retrieveSignupDependencies,
 	clearSignupDestinationCookie,
 	getSignupCompleteFlowName,
 	wasSignupCheckoutPageUnloaded,
@@ -305,16 +306,13 @@ export default {
 		const isManageSiteFlow =
 			! excludeFromManageSiteFlows && ! isAddNewSiteFlow && isReEnteringSignupViaBrowserBack;
 
-		// If the user entered the signup flow from the checkout page, submit the domains step
-		// to allow the user to return to the plans page.
-		if ( isManageSiteFlow ) {
-			const stepData = {
-				stepName: 'domains',
-				suggestion: undefined,
-				domainCart: {},
-			};
-			context.store.dispatch( submitSignupStep( stepData, { domainCart: {} } ) );
+		// Hydrate the store with signup dependencies from cookie.
+		const signupDependencies = retrieveSignupDependencies();
+		if ( signupDependencies && isManageSiteFlow ) {
+			const parsedDependencies = JSON.parse( signupDependencies );
+			context.store.dispatch( submitSignupStep( { stepName: 'domains', ...parsedDependencies } ) );
 		}
+
 		// If the flow has siteId or siteSlug as query dependencies, we should not clear selected site id
 		if (
 			! providesDependenciesInQuery?.includes( 'siteId' ) &&

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -306,14 +306,17 @@ export default {
 		const isManageSiteFlow =
 			! excludeFromManageSiteFlows && ! isAddNewSiteFlow && isReEnteringSignupViaBrowserBack;
 
-		// Hydrate the store with domains dependencies from session storage.
+		// Hydrate the store with domains dependencies from session storage,
+		// only in the onboarding flow.
 		const signupDependencies = getSignupDependencies();
 		if ( signupDependencies && isManageSiteFlow && flowName === 'onboarding' ) {
-			const parsedDependenciesJSON = JSON.parse( signupDependencies );
-			const parsedStep = { ...parsedDependenciesJSON.step };
-			const parsedDependencies = { ...parsedDependenciesJSON.dependencies };
-			context.store.dispatch( submitSignupStep( parsedStep, parsedDependencies ) );
+			const { step, dependencies } = JSON.parse( signupDependencies );
+			if ( step && dependencies ) {
+				context.store.dispatch( submitSignupStep( step, dependencies ) );
+			}
 		}
+
+		// ... existing code ...
 
 		// If the flow has siteId or siteSlug as query dependencies, we should not clear selected site id
 		if (

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -24,7 +24,7 @@ import { isReskinnedFlow } from './is-flow';
 import SignupComponent from './main';
 import {
 	retrieveSignupDestination,
-	getSignupDependencies,
+	getDomainsDependencies,
 	clearSignupDestinationCookie,
 	getSignupCompleteFlowName,
 	wasSignupCheckoutPageUnloaded,
@@ -308,9 +308,14 @@ export default {
 
 		// Hydrate the store with domains dependencies from session storage,
 		// only in the onboarding flow.
-		const signupDependencies = getSignupDependencies();
-		if ( signupDependencies && isManageSiteFlow && flowName === 'onboarding' ) {
-			const { step, dependencies } = JSON.parse( signupDependencies );
+		const domainsDependencies = getDomainsDependencies();
+		if (
+			domainsDependencies &&
+			isManageSiteFlow &&
+			flowName === 'onboarding' &&
+			stepName !== 'domains'
+		) {
+			const { step, dependencies } = JSON.parse( domainsDependencies );
 			if ( step && dependencies ) {
 				context.store.dispatch( submitSignupStep( step, dependencies ) );
 			}

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -24,7 +24,7 @@ import { isReskinnedFlow } from './is-flow';
 import SignupComponent from './main';
 import {
 	retrieveSignupDestination,
-	retrieveSignupDependencies,
+	getSignupDependencies,
 	clearSignupDestinationCookie,
 	getSignupCompleteFlowName,
 	wasSignupCheckoutPageUnloaded,
@@ -306,11 +306,13 @@ export default {
 		const isManageSiteFlow =
 			! excludeFromManageSiteFlows && ! isAddNewSiteFlow && isReEnteringSignupViaBrowserBack;
 
-		// Hydrate the store with signup dependencies from cookie.
-		const signupDependencies = retrieveSignupDependencies();
+		// Hydrate the store with domains dependencies from session storage.
+		const signupDependencies = getSignupDependencies();
 		if ( signupDependencies && isManageSiteFlow ) {
-			const parsedDependencies = JSON.parse( signupDependencies );
-			context.store.dispatch( submitSignupStep( { stepName: 'domains', ...parsedDependencies } ) );
+			const parsedDependenciesJSON = JSON.parse( signupDependencies );
+			const parsedStep = { ...parsedDependenciesJSON.step };
+			const parsedDependencies = { ...parsedDependenciesJSON.dependencies };
+			context.store.dispatch( submitSignupStep( parsedStep, parsedDependencies ) );
 		}
 
 		// If the flow has siteId or siteSlug as query dependencies, we should not clear selected site id

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -13,6 +13,7 @@ import { updateDependencies } from 'calypso/state/signup/actions';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { setCurrentFlowName, setPreviousFlowName } from 'calypso/state/signup/flow/actions';
 import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
+import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSiteId } from 'calypso/state/sites/selectors';
@@ -37,7 +38,6 @@ import {
 	getFlowPageTitle,
 	shouldForceLogin,
 } from './utils';
-
 /**
  * Constants
  */
@@ -305,6 +305,16 @@ export default {
 		const isManageSiteFlow =
 			! excludeFromManageSiteFlows && ! isAddNewSiteFlow && isReEnteringSignupViaBrowserBack;
 
+		// If the user entered the signup flow from the checkout page, submit the domains step
+		// to allow the user to return to the plans page.
+		if ( isManageSiteFlow ) {
+			const stepData = {
+				stepName: 'domains',
+				suggestion: undefined,
+				domainCart: {},
+			};
+			context.store.dispatch( submitSignupStep( stepData, { domainCart: {} } ) );
+		}
 		// If the flow has siteId or siteSlug as query dependencies, we should not clear selected site id
 		if (
 			! providesDependenciesInQuery?.includes( 'siteId' ) &&

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -83,8 +83,8 @@ import { addP2SignupClassName } from './controller';
 import { isReskinnedFlow, isP2Flow } from './is-flow';
 import {
 	persistSignupDestination,
-	setSignupDependencies,
-	clearSignupDependencies,
+	setDomainsDependencies,
+	clearDomainsDependencies,
 	setSignupCompleteSlug,
 	getSignupCompleteSlug,
 	setSignupCompleteFlowName,
@@ -320,12 +320,9 @@ class Signup extends Component {
 
 		const { domainItem: prevDomainItem } = prevProps.signupDependencies;
 
-		if (
-			flowName === 'onboarding' &&
-			stepName === 'domains' &&
-			signupDependencies.domainItem !== prevDomainItem
-		) {
-			clearSignupDependencies();
+		// Clear domains dependencies when the domains data is updated.
+		if ( stepName === 'domains' && signupDependencies.domainItem !== prevDomainItem ) {
+			clearDomainsDependencies();
 		}
 	}
 
@@ -423,7 +420,7 @@ class Signup extends Component {
 			const { domainItem, siteUrl, domainCart } = dependencies;
 			const { stepSectionName } = this.props;
 
-			setSignupDependencies( {
+			setDomainsDependencies( {
 				step: {
 					stepName: 'domains',
 					domainItem,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -407,22 +407,23 @@ class Signup extends Component {
 			setSignupCompleteFlowName( this.props.flowName );
 		}
 
-		// Persist current domains data.
-		setSignupDependencies( {
-			step: {
-				stepName: 'domains',
-				domainItem: dependencies.domainItem,
-				siteUrl: dependencies.siteUrl,
-				isPurchasingItem: true,
-				stepSectionName: this.props.stepSectionName,
-				domainCart: dependencies.domainCart,
-			},
-			dependencies: {
-				domainItem: dependencies.domainItem,
-				siteUrl: dependencies.siteUrl,
-				domainCart: dependencies.domainCart,
-			},
-		} );
+		// Persist current domains data in the onboarding flow.
+		if ( this.props.flowName === 'onboarding' ) {
+			const { domainItem, siteUrl, domainCart } = dependencies;
+			const { stepSectionName } = this.props;
+
+			setSignupDependencies( {
+				step: {
+					stepName: 'domains',
+					domainItem,
+					siteUrl,
+					isPurchasingItem: true,
+					stepSectionName,
+					domainCart,
+				},
+				dependencies: { domainItem, siteUrl, domainCart },
+			} );
+		}
 
 		this.handleFlowComplete( dependencies, filteredDestination );
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -51,7 +51,6 @@ import P2SignupProcessingScreen from 'calypso/signup/p2-processing-screen';
 import SignupProcessingScreen from 'calypso/signup/processing-screen';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
 import SignupHeader from 'calypso/signup/signup-header';
-import { setSignupDependencies } from 'calypso/signup/storageUtils';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import {
 	isUserLoggedIn,
@@ -84,6 +83,8 @@ import { addP2SignupClassName } from './controller';
 import { isReskinnedFlow, isP2Flow } from './is-flow';
 import {
 	persistSignupDestination,
+	setSignupDependencies,
+	clearSignupDependencies,
 	setSignupCompleteSlug,
 	getSignupCompleteSlug,
 	setSignupCompleteFlowName,
@@ -269,7 +270,7 @@ class Signup extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { flowName, stepName, sitePlanName, sitePlanSlug } = this.props;
+		const { flowName, stepName, sitePlanName, sitePlanSlug, signupDependencies } = this.props;
 
 		if (
 			( flowName !== prevProps.flowName || stepName !== prevProps.stepName ) &&
@@ -315,6 +316,16 @@ class Signup extends Component {
 			);
 			this.handleLogin( this.props.signupDependencies, stepUrl, false );
 			this.handleDestination( this.props.signupDependencies, stepUrl, this.props.flowName );
+		}
+
+		const { domainItem: prevDomainItem } = prevProps.signupDependencies;
+
+		if (
+			flowName === 'onboarding' &&
+			stepName === 'domains' &&
+			signupDependencies.domainItem !== prevDomainItem
+		) {
+			clearSignupDependencies();
 		}
 	}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -83,6 +83,7 @@ import { addP2SignupClassName } from './controller';
 import { isReskinnedFlow, isP2Flow } from './is-flow';
 import {
 	persistSignupDestination,
+	persistSignupDependencies,
 	setSignupCompleteSlug,
 	getSignupCompleteSlug,
 	setSignupCompleteFlowName,
@@ -404,6 +405,9 @@ class Signup extends Component {
 			persistSignupDestination( destination );
 			setSignupCompleteSlug( dependencies.siteSlug );
 			setSignupCompleteFlowName( this.props.flowName );
+
+			// Persist dependencyStore data.
+			persistSignupDependencies( dependencies );
 		}
 
 		this.handleFlowComplete( dependencies, filteredDestination );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -51,6 +51,7 @@ import P2SignupProcessingScreen from 'calypso/signup/p2-processing-screen';
 import SignupProcessingScreen from 'calypso/signup/processing-screen';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
 import SignupHeader from 'calypso/signup/signup-header';
+import { setSignupDependencies } from 'calypso/signup/storageUtils';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import {
 	isUserLoggedIn,
@@ -83,7 +84,6 @@ import { addP2SignupClassName } from './controller';
 import { isReskinnedFlow, isP2Flow } from './is-flow';
 import {
 	persistSignupDestination,
-	persistSignupDependencies,
 	setSignupCompleteSlug,
 	getSignupCompleteSlug,
 	setSignupCompleteFlowName,
@@ -405,10 +405,24 @@ class Signup extends Component {
 			persistSignupDestination( destination );
 			setSignupCompleteSlug( dependencies.siteSlug );
 			setSignupCompleteFlowName( this.props.flowName );
-
-			// Persist dependencyStore data.
-			persistSignupDependencies( dependencies );
 		}
+
+		// Persist current domains data.
+		setSignupDependencies( {
+			step: {
+				stepName: 'domains',
+				domainItem: dependencies.domainItem,
+				siteUrl: dependencies.siteUrl,
+				isPurchasingItem: true,
+				stepSectionName: this.props.stepSectionName,
+				domainCart: dependencies.domainCart,
+			},
+			dependencies: {
+				domainItem: dependencies.domainItem,
+				siteUrl: dependencies.siteUrl,
+				domainCart: dependencies.domainCart,
+			},
+		} );
 
 		this.handleFlowComplete( dependencies, filteredDestination );
 

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -41,15 +41,15 @@ export const setSignupCompleteSlug = ( value ) =>
 	ignoreFatalsForSessionStorage( () =>
 		sessionStorage?.setItem( 'wpcom_signup_complete_site_slug', value )
 	);
-export const setSignupDependencies = ( dependencies ) => {
+export const setDomainsDependencies = ( dependencies ) => {
 	ignoreFatalsForSessionStorage( () =>
-		sessionStorage.setItem( 'wpcom_signup_dependencies', JSON.stringify( dependencies ) )
+		sessionStorage.setItem( 'wpcom_domains_dependencies', JSON.stringify( dependencies ) )
 	);
 };
-export const getSignupDependencies = () =>
-	ignoreFatalsForSessionStorage( () => sessionStorage?.getItem( 'wpcom_signup_dependencies' ) );
-export const clearSignupDependencies = () =>
-	ignoreFatalsForSessionStorage( () => sessionStorage?.removeItem( 'wpcom_signup_dependencies' ) );
+export const getDomainsDependencies = () =>
+	ignoreFatalsForSessionStorage( () => sessionStorage?.getItem( 'wpcom_domains_dependencies' ) );
+export const clearDomainsDependencies = () =>
+	ignoreFatalsForSessionStorage( () => sessionStorage?.removeItem( 'wpcom_domains_dependencies' ) );
 export const wasSignupCheckoutPageUnloaded = () =>
 	ignoreFatalsForSessionStorage( () =>
 		sessionStorage?.getItem( 'was_signup_checkout_page_unloaded' )

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -48,6 +48,8 @@ export const setSignupDependencies = ( dependencies ) => {
 };
 export const getSignupDependencies = () =>
 	ignoreFatalsForSessionStorage( () => sessionStorage?.getItem( 'wpcom_signup_dependencies' ) );
+export const clearSignupDependencies = () =>
+	ignoreFatalsForSessionStorage( () => sessionStorage?.removeItem( 'wpcom_signup_dependencies' ) );
 export const wasSignupCheckoutPageUnloaded = () =>
 	ignoreFatalsForSessionStorage( () =>
 		sessionStorage?.getItem( 'was_signup_checkout_page_unloaded' )

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -20,25 +20,6 @@ export const clearSignupDestinationCookie = () => {
 	document.cookie = cookie.serialize( 'wpcom_signup_complete_destination', '', options );
 };
 
-export const persistSignupDependencies = ( dependencies ) => {
-	const DAY_IN_SECONDS = 3600 * 24;
-	const expirationDate = new Date( new Date().getTime() + DAY_IN_SECONDS * 1000 );
-	const options = {
-		expires: expirationDate,
-		path: '/',
-	};
-	document.cookie = cookie.serialize(
-		'wpcom_signup_dependencies',
-		JSON.stringify( dependencies ),
-		options
-	);
-};
-
-export const retrieveSignupDependencies = () => {
-	const cookies = cookie.parse( document.cookie );
-	return cookies.wpcom_signup_dependencies;
-};
-
 /**
  * Ignore fatals when trying to access window.sessionStorage so that we do not
  * see them logged in Sentry. Please don't use this for anything else.
@@ -60,6 +41,13 @@ export const setSignupCompleteSlug = ( value ) =>
 	ignoreFatalsForSessionStorage( () =>
 		sessionStorage?.setItem( 'wpcom_signup_complete_site_slug', value )
 	);
+export const setSignupDependencies = ( dependencies ) => {
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage.setItem( 'wpcom_signup_dependencies', JSON.stringify( dependencies ) )
+	);
+};
+export const getSignupDependencies = () =>
+	ignoreFatalsForSessionStorage( () => sessionStorage?.getItem( 'wpcom_signup_dependencies' ) );
 export const wasSignupCheckoutPageUnloaded = () =>
 	ignoreFatalsForSessionStorage( () =>
 		sessionStorage?.getItem( 'was_signup_checkout_page_unloaded' )

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -20,6 +20,25 @@ export const clearSignupDestinationCookie = () => {
 	document.cookie = cookie.serialize( 'wpcom_signup_complete_destination', '', options );
 };
 
+export const persistSignupDependencies = ( dependencies ) => {
+	const DAY_IN_SECONDS = 3600 * 24;
+	const expirationDate = new Date( new Date().getTime() + DAY_IN_SECONDS * 1000 );
+	const options = {
+		expires: expirationDate,
+		path: '/',
+	};
+	document.cookie = cookie.serialize(
+		'wpcom_signup_dependencies',
+		JSON.stringify( dependencies ),
+		options
+	);
+};
+
+export const retrieveSignupDependencies = () => {
+	const cookies = cookie.parse( document.cookie );
+	return cookies.wpcom_signup_dependencies;
+};
+
 /**
  * Ignore fatals when trying to access window.sessionStorage so that we do not
  * see them logged in Sentry. Please don't use this for anything else.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/94080

https://github.com/user-attachments/assets/e2863e18-927c-44c2-9f4e-b57fe4631b2e


## Proposed Changes

* When the browser back button is clicked on checkout, submit the domains data so that the plans page can load. I'm using session storage to save the user's submitted domains data.
* You can see the stored data in Application > Session Storage > `wpcom_domains_dependencies`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the signup experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Test the happy path
* Go to /start/domains
* Follow the flow to checkout
* At checkout, hit the browser back button
* You should end up back on /plans.
* Check that no duplicate sites were created (e.g. you're not creating more sites every time you go back).
* Check that you can navigate back to domains.

#### Test with a paid domain
* Add a paid domain to the cart and go through the flow again. Check that you can go back to /plans and that you don't see the Free plan there.
* Test removing the paid domain from your cart. It shouldn't show up again when you go through the flow and back.

#### Test as a new user
* Start the flow as a logged-out user and check that you can't access /start/plans without going through the domain step first.

#### Regression test other flows
* Start a different flow like /start/plans-first and check that there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
