### PR TITLE
Allow custom sandbox hostnames when using calypso apps builder

### DIFF
--- a/packages/calypso-apps-builder/index.js
+++ b/packages/calypso-apps-builder/index.js
@@ -103,6 +103,8 @@ async function runBuilder( args ) {
  * mode after a full sync. Is otherwise pending until the user kills the process.
  */
 function setupRemoteSync( localPath, remotePath, shouldWatch = false ) {
+	const remoteHost = process.env.WPCOM_SANDBOX || 'wpcom-sandbox';
+
 	return new Promise( ( resolve, reject ) => {
 		let rsync = null;
 		const debouncedSync = debouncer( () => {
@@ -114,7 +116,7 @@ function setupRemoteSync( localPath, remotePath, shouldWatch = false ) {
 				rsync.kill( 'SIGINT' );
 			}
 			rsync = exec(
-				`rsync -ahz --exclude=".*" ${ localPath } wpcom-sandbox:${ remotePath }`,
+				`rsync -ahz --exclude=".*" ${ localPath } ${ remoteHost }:${ remotePath }`,
 				( err ) => {
 					rsync = null;
 					// err.signal is null on macOS, so use error code 20 in that case.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR would allow a custom sandbox hostname to be set through a `WPCOM_SANDBOX=` environment variable. The current solution is hardcoded to `wpcom-sandbox` which can lead to conflicts depending on the users actual setup.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This change will allow the script to continue to function seamlessly for people who have their local dev environment set up in a different way.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Try dev builds for any of the `apps/`: `yarn dev --sync`.
- If you don't explicitly set `WPCOM_SANDBOX=`, it should still default to `wpcom-sandbox` and work as it did previously.
- If your sandbox is using a different hostname, try running the command with `WPCOM_SANDBOX=my-wpcom-sandbox` and verify it still works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
