### PR TITLE
Jetpack Checkout: fix plan term label color

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -145,6 +145,7 @@ export const Label = styled.span`
 	display: flex;
 	white-space: nowrap;
 	font-size: 14px;
+	color: var( --studio-black );
 
 	// MOBILE_BREAKPOINT is <480px, used in useMobileBreakpoint
 	@media ( max-width: 480px ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to linked issue

## Proposed Changes

* Fix the plan term select color for the Jetpack Checkout (that defaults to blue in iOS)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So the color is standardized across different browsers and OSs

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can test this in your iPhone or in a tool like [Appetize](https://appetize.io/demo?device=iphone14pro&osVersion=16.2&record=true)
* Open https://wordpress.com/checkout/jetpack/jetpack_backup_t1_yearly and confirm that the term label is blue
* Now open the Calypso live link and visit `/checkout/jetpack/jetpack_backup_t1_yearly`
* Confirm that the label is now black

Before | After
--- | ---
<img width="331" alt="image" src="https://github.com/user-attachments/assets/68c6a507-0624-43ac-8a80-327a531364f2">|<img width="331" alt="image" src="https://github.com/user-attachments/assets/0083c4f4-c1cb-4c08-85c0-7d58963ee7cb">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
