### PR TITLE
Me: Open "Manage Blogs" in same tab and add external icon to Gravatar

### DIFF
--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -1,4 +1,5 @@
 import { Card, FormLabel } from '@automattic/components';
+import { ExternalLink } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
@@ -144,7 +145,7 @@ class Profile extends Component {
 									{
 										components: {
 											strong: <strong />,
-											a: <a href="https://gravatar.com/profile" target="_blank" rel="noreferrer" />,
+											a: <ExternalLink href="https://gravatar.com/profile" />,
 										},
 										args: {
 											email: this.props.getSetting( 'user_email' ),

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -175,6 +175,7 @@ class MeSidebar extends Component {
 						link="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs"
 						label={ translate( 'Manage Blogs' ) }
 						materialIcon="apps"
+						forceInternalLink
 						onNavigate={ ( event, urlPath ) => {
 							this.handleGlobalSidebarMenuItemClick( urlPath );
 						} }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9087

## Proposed Changes

* This PR opens "Manage Blogs" in the same tab and removes the external link icon. It also adds an external link icon to the Gravatar link.



Before | After
--|--
 <img width="1449" alt="Screenshot 2024-09-24 at 4 30 57 PM" src="https://github.com/user-attachments/assets/8c3557e6-beb4-4380-9cd0-cc56258e1330"> | <img width="1446" alt="Screenshot 2024-09-24 at 4 31 19 PM" src="https://github.com/user-attachments/assets/6666f273-d80b-400d-a7c6-6aeb7724d077">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Creating consistency around external links and their icons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /me
* View that the changes above have been made and the links open as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
