### PR TITLE
Me Security: Use the inline Help Center for support links

### DIFF
--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -3,6 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import SectionHeader from 'calypso/components/section-header';
 import useAppPasswordsQuery from 'calypso/data/application-passwords/use-app-passwords-query';
 import useCreateAppPasswordMutation from 'calypso/data/application-passwords/use-create-app-password-mutation';
@@ -98,15 +99,13 @@ function ApplicationPasswords() {
 								'each third-party application you authorize to use your WordPress.com account. ' +
 								'You can revoke access for an individual application here if you ever need to.'
 						) }{ ' ' }
-						<a
-							href={ localizeUrl(
+						<InlineSupportLink
+							supportPostId={ 263616 }
+							showIcon={ false }
+							supportLink={ localizeUrl(
 								'https://wordpress.com/support/security/two-step-authentication/application-specific-passwords'
 							) }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							{ translate( 'Learn more' ) }
-						</a>
+						/>
 					</>
 				</p>
 

--- a/client/me/security-2fa-disable/index.jsx
+++ b/client/me/security-2fa-disable/index.jsx
@@ -5,6 +5,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Security2faCodePrompt from 'calypso/me/security-2fa-code-prompt';
 import Security2faStatus from 'calypso/me/security-2fa-status';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -100,12 +101,12 @@ class Security2faDisable extends Component {
 						{
 							components: {
 								changephonelink: (
-									<a
-										href={ localizeUrl(
+									<InlineSupportLink
+										supportPostId={ 39178 } // This is the post ID for the two-step authentication support article
+										supportLink={ localizeUrl(
 											'https://wordpress.com/support/security/two-step-authentication/#moving-to-a-new-device'
 										) }
-										target="_blank"
-										rel="noopener noreferrer"
+										showIcon={ false }
 									/>
 								),
 							},

--- a/client/me/security-2fa-disable/index.jsx
+++ b/client/me/security-2fa-disable/index.jsx
@@ -102,7 +102,7 @@ class Security2faDisable extends Component {
 							components: {
 								changephonelink: (
 									<InlineSupportLink
-										supportPostId={ 39178 } // This is the post ID for the two-step authentication support article
+										supportPostId={ 39178 }
 										supportLink={ localizeUrl(
 											'https://wordpress.com/support/security/two-step-authentication/#moving-to-a-new-device'
 										) }

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -9,6 +9,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import HeaderCake from 'calypso/components/header-cake';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -208,12 +209,12 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 							{
 								br: <br />,
 								a: (
-									<a
-										href={ localizeUrl(
-											'https://wordpress.com/support/connect-to-ssh-on-wordpress-com/'
+									<InlineSupportLink
+										supportPostId={ 100385 }
+										supportLink={ localizeUrl(
+											'https://developer.wordpress.com/docs/developer-tools/ssh/'
 										) }
-										target="_blank"
-										rel="noreferrer"
+										showIcon={ false }
 									/>
 								),
 							}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9087

## Proposed Changes

* This PR uses the inline Help Center for support links under /me/security
  * https://wordpress.com/me/security/two-step - "Follow these steps" and "Learn more" should open in Help Center
  * https://wordpress.com/me/security/ssh-key - "Read more" should open in the Help Center.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Creating consistency in external links.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /me/security/two-step and confirm that "Follow these steps" and "Learn more" open in the inline Help Center and that they open to the same support docs as production. https://wordpress.com/me/security/two-step
* Go to /me/security/ssh-key and confirm that the "Read more" link opens in the Help Center and opens to the same support doc as production. https://wordpress.com/me/security/ssh-key

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
