### PR TITLE
Reader: Return React elements within `<ReaderListManage />`

### DIFF
--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -190,5 +190,5 @@ function ReaderListEdit( props ) {
 }
 
 export default function ReaderListManage( props ) {
-	return props.isCreateForm ? ReaderListCreate() : ReaderListEdit( props );
+	return props.isCreateForm ? <ReaderListCreate /> : <ReaderListEdit { ...props } />;
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/94769.

## Proposed Changes

Reader was giving the user a blank (error) page after creating a list. The fix was to return actual React elements (`createElement`) instead of calling the component functions. See this SO answer for more details: https://stackoverflow.com/a/63025883

It was "fine" before but I'm guessing that the problem arrived with the [React upgrade that happened recently](https://github.com/Automattic/wp-calypso/pull/90436). The dates match. cc @tyxla 

## Testing Instructions

Go to `/read` and verify you can create a list. Right after creating, you should be managing it.
