### PR TITLE
Checkout: Add canEditStep prop to CheckoutStep to hide 'Edit' link

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -511,11 +511,11 @@ export default function CheckoutMainContent( {
 	}
 
 	const nextStepButtonText = translate( 'Continue to payment', { textOnly: true } );
-	const canEditStep = () => {
+	const canEditPaymentStep = () => {
 		if ( ! paymentMethods ) {
 			return false;
 		}
-		const containsFreeOrCreditMethod = paymentMethods.filter(
+		const containsFreeOrCreditMethod = paymentMethods.some(
 			( method ) => method.id === 'free-purchase'
 		);
 		if ( paymentMethods.length < 2 && containsFreeOrCreditMethod ) {
@@ -709,7 +709,7 @@ export default function CheckoutMainContent( {
 					) }
 					<PaymentMethodStep
 						activeStepHeader={ <GoogleDomainsCopy responseCart={ responseCart } /> }
-						canEditStep={ canEditStep() }
+						canEditStep={ canEditPaymentStep() }
 						editButtonText={ String( translate( 'Edit' ) ) }
 						editButtonAriaLabel={ String( translate( 'Edit the payment method' ) ) }
 						nextStepButtonText={ String( translate( 'Continue' ) ) }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -89,6 +89,7 @@ import type { OnChangeItemVariant } from './item-variation-picker';
 import type {
 	CheckoutPageErrorCallback,
 	StepChangedCallback,
+	PaymentMethod,
 } from '@automattic/composite-checkout';
 import type {
 	RemoveProductFromCart,
@@ -291,6 +292,7 @@ export default function CheckoutMainContent( {
 	infoMessage,
 	isLoggedOutCart,
 	onPageLoadError,
+	paymentMethods,
 	removeProductFromCart,
 	showErrorMessageBriefly,
 	siteId,
@@ -311,6 +313,7 @@ export default function CheckoutMainContent( {
 	infoMessage?: JSX.Element;
 	isLoggedOutCart: boolean;
 	onPageLoadError: CheckoutPageErrorCallback;
+	paymentMethods: PaymentMethod[];
 	removeProductFromCart: RemoveProductFromCart;
 	showErrorMessageBriefly: ( error: string ) => void;
 	siteId: number | undefined;
@@ -508,6 +511,18 @@ export default function CheckoutMainContent( {
 	}
 
 	const nextStepButtonText = translate( 'Continue to payment', { textOnly: true } );
+	const canEditStep = () => {
+		if ( ! paymentMethods ) {
+			return false;
+		}
+		const containsFreeOrCreditMethod = paymentMethods.filter(
+			( method ) => method.id === 'free-purchase'
+		);
+		if ( paymentMethods.length < 2 && containsFreeOrCreditMethod ) {
+			return false;
+		}
+		return true;
+	};
 
 	return (
 		<WPCheckoutWrapper>
@@ -694,6 +709,7 @@ export default function CheckoutMainContent( {
 					) }
 					<PaymentMethodStep
 						activeStepHeader={ <GoogleDomainsCopy responseCart={ responseCart } /> }
+						canEditStep={ canEditStep() }
 						editButtonText={ String( translate( 'Edit' ) ) }
 						editButtonAriaLabel={ String( translate( 'Edit the payment method' ) ) }
 						nextStepButtonText={ String( translate( 'Continue' ) ) }

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -790,6 +790,7 @@ export default function CheckoutMain( {
 					infoMessage={ <PrePurchaseNotices siteId={ updatedSiteId } isSiteless={ isSiteless } /> }
 					isLoggedOutCart={ !! isLoggedOutCart }
 					onPageLoadError={ onPageLoadError }
+					paymentMethods={ paymentMethods }
 					removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
 					showErrorMessageBriefly={ showErrorMessageBriefly }
 					siteId={ updatedSiteId }

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -425,6 +425,7 @@ export const CheckoutStep = ( {
 	stepId,
 	className,
 	isCompleteCallback,
+	canEditStep = true,
 	editButtonText,
 	editButtonAriaLabel,
 	nextStepButtonText,
@@ -487,6 +488,7 @@ export const CheckoutStep = ( {
 			validatingButtonAriaLabel={ validatingButtonAriaLabel || __( 'Please wait…' ) }
 			isStepActive={ isStepActive }
 			isStepComplete={ isStepComplete }
+			canEditStep={ canEditStep }
 			stepNumber={ stepNumber }
 			stepId={ stepId }
 			titleContent={ titleContent }
@@ -724,6 +726,7 @@ export function CheckoutStepBody( {
 	validatingButtonAriaLabel,
 	isStepActive,
 	isStepComplete,
+	canEditStep,
 	className,
 	stepNumber,
 	stepId,
@@ -756,6 +759,7 @@ export function CheckoutStepBody( {
 					title={ titleContent }
 					isActive={ isStepActive }
 					isComplete={ isStepComplete }
+					canEditStep={ canEditStep }
 					onEdit={
 						formStatus === FormStatus.READY && isStepComplete && goToThisStep && ! isStepActive
 							? goToThisStep
@@ -812,6 +816,7 @@ interface CheckoutStepBodyProps {
 	nextStepButtonAriaLabel?: string;
 	isStepActive: boolean;
 	isStepComplete: boolean;
+	canEditStep?: boolean;
 	className?: string;
 	stepNumber?: number;
 	stepId: string;
@@ -834,6 +839,7 @@ CheckoutStepBody.propTypes = {
 	nextStepButtonAriaLabel: PropTypes.string,
 	isStepActive: PropTypes.bool.isRequired,
 	isStepComplete: PropTypes.bool.isRequired,
+	canEditStep: PropTypes.bool,
 	className: PropTypes.string,
 	stepNumber: PropTypes.number,
 	stepId: PropTypes.string.isRequired,
@@ -911,6 +917,7 @@ function CheckoutStepHeader( {
 	title,
 	isActive,
 	isComplete,
+	canEditStep,
 	onEdit,
 	editButtonText,
 	editButtonAriaLabel,
@@ -921,12 +928,13 @@ function CheckoutStepHeader( {
 	title: ReactNode;
 	isActive?: boolean;
 	isComplete?: boolean;
+	canEditStep?: boolean;
 	onEdit?: () => void;
 	editButtonText?: string;
 	editButtonAriaLabel?: string;
 } ) {
 	const { __ } = useI18n();
-	const shouldShowEditButton = !! onEdit;
+	const shouldShowEditButton = canEditStep && !! onEdit;
 
 	return (
 		<StepHeader

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -17,6 +17,7 @@ export interface CheckoutStepProps {
 	activeStepHeader?: React.ReactNode;
 	completeStepContent?: React.ReactNode;
 	className?: string;
+	canEditStep?: boolean;
 	editButtonText?: string;
 	editButtonAriaLabel?: string;
 	nextStepButtonText?: string;


### PR DESCRIPTION
This is a follow up PR to #90240

In #90240 we added the credit amount to the `WordPressFreePurchaseSummary` component to make the amount more obvious.

In this PR we are hiding the edit button for the Payment Method step if the step only contains a credit/free payment method - because editing a list of one isn't really possible or serves any purpose in this scenario.

Related to #88863
| Before | After |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/e47e612e-ba0a-47e1-81db-4854cf929ef4) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/83bfe5d9-1d47-4cc4-9f44-7a6d6f06c0b5) |

## Proposed Changes

This change is a bit more robust than the [previous attempt](https://github.com/Automattic/wp-calypso/pull/90345). In this PR I added the `canEditStep` prop to the `CheckoutStep` component and pass this prop all the way down to `CheckoutStepHeader` where we can use it to conditionally show or hide the edit link.

This approach lets us calculate `canEditStep` however we like _outside_ of composite-checkout and helps separate the conditional logic from the headless structure of composite-checkout. 

In this case, I created a short function to check if there is only one payment method passed to checkout, and if that payment method's ID is `free-purchase`. Since we only show the free-purchase payment method by itself, it is then safe to hide the edit link, since we do not have any editable methods displaying.

Note: I am looking into exactly how we hide all available methods when credits are available to ensure there isn't a case where we accidentally hide the link for some fringe case, but from my tests this code seems to work as expected.

## Testing Instructions

**Regular purchases**

- Add a renewal to your shopping cart, ensure the cart has valid payment methods
- Go to the Payment Method step and ensure that you see an edit link to change your payment method
- Make sure you can change methods via the edit link

**Credit purchases**

- Next, add enough credit to your account to cover the purchase completely
- Refresh checkout and go to Payment method step, it should show WordPress.com Credits $x.xx
- At this point there should **not** be an edit link next to the payment method step, but, there **should** be an edit link next to Billing Information
- Try to find some combination that breaks this PR

@sirbrillig A [while back](https://github.com/Automattic/wp-calypso/pull/90345#pullrequestreview-2046148626) you had some concerns regarding my first approach to this issue - hopefully this approach addresses that.