### PR TITLE
Add verification & continue anyway path In site migration credentials form, change error message area on top

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -34,16 +34,14 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 	const queryError = useQuery().get( 'error' ) || null;
 
-	let errorMessage =
-		queryError === 'ticket-creation'
-			? translate( 'We ran into a problem submitting your details. Please try again shortly.' )
-			: null;
-
-	errorMessage =
-		isEnglishLocale && errors.root && errors.root.type !== 'manual' && errors.root.message
-			? errors.root.message
-			: errorMessage;
-
+	let errorMessage;
+	if ( isEnglishLocale && errors.root && errors.root.type !== 'manual' && errors.root.message ) {
+		errorMessage = errors.root.message;
+	} else if ( queryError === 'ticket-creation' ) {
+		errorMessage = translate(
+			'We ran into a problem submitting your details. Please try again shortly.'
+		);
+	}
 	return (
 		<form className="site-migration-credentials__form" onSubmit={ handleSubmit( submitHandler ) }>
 			{ errorMessage && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -2,9 +2,9 @@ import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
-import Banner from 'calypso/components/banner';
+import Notice from 'calypso/components/notice';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { useCredentialsForm } from '../use-credentials-form';
+import { useCredentialsForm } from '../hooks/use-credentials-form';
 import { AccessMethodPicker } from './access-method-picker';
 import { BackupFileField } from './backup-file-field';
 import { ErrorMessage } from './error-message';
@@ -29,21 +29,31 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 		isPending,
 		submitHandler,
 		importSiteQueryParam,
+		getContinueButtonText,
 	} = useCredentialsForm( onSubmit );
 
 	const queryError = useQuery().get( 'error' ) || null;
 
+	let errorMessage =
+		queryError === 'ticket-creation'
+			? translate( 'We ran into a problem submitting your details. Please try again shortly.' )
+			: null;
+
+	errorMessage =
+		isEnglishLocale && errors.root && errors.root.type !== 'manual' && errors.root.message
+			? errors.root.message
+			: errorMessage;
+
 	return (
 		<form className="site-migration-credentials__form" onSubmit={ handleSubmit( submitHandler ) }>
-			{ queryError === 'ticket-creation' && (
-				<Banner
-					className="site-migration-credentials__error-banner"
-					showIcon={ false }
-					title=""
-					description={ translate(
-						'We ran into a problem submitting your details. Please try again shortly.'
-					) }
-				></Banner>
+			{ errorMessage && (
+				<Notice
+					className="site-migration-credentials__error-notice"
+					status="is-warning"
+					showDismiss={ false }
+				>
+					{ errorMessage }
+				</Notice>
 			) }
 			<div className="site-migration-credentials__content">
 				<AccessMethodPicker control={ control } />
@@ -66,11 +76,13 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 				<SpecialInstructions control={ control } errors={ errors } />
 
-				<ErrorMessage error={ errors.root } />
+				<ErrorMessage
+					error={ errors.root && errors.root.type === 'manual' ? errors.root : undefined }
+				/>
 
 				<div className="site-migration-credentials__submit">
 					<NextButton disabled={ isPending } type="submit">
-						{ translate( 'Continue' ) }
+						{ getContinueButtonText() }
 					</NextButton>
 				</div>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -1,13 +1,19 @@
-import { useEffect } from 'react';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useFormErrorMapping } from './hooks/use-form-error-mapping';
-import { CredentialsFormData } from './types';
+import { CredentialsFormData } from '../types';
+import { useFormErrorMapping } from './use-form-error-mapping';
 import { useSiteMigrationCredentialsMutation } from './use-site-migration-credentials-mutation';
 
 export const useCredentialsForm = ( onSubmit: () => void ) => {
 	const importSiteQueryParam = useQuery().get( 'from' ) || '';
+	const [ requestInAnywayMode, setRequestInAnywayMode ] = useState( false );
+	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
+
 	const {
 		isPending,
 		mutate: requestAutomatedMigration,
@@ -49,21 +55,47 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 	}, [ isSuccess, onSubmit ] );
 
 	useEffect( () => {
-		if ( error ) {
-			recordTracksEvent( 'calypso_site_migration_automated_request_error' );
+		if ( ! error ) {
+			return;
+		}
+
+		recordTracksEvent( 'calypso_site_migration_automated_request_error' );
+
+		const { code } = error;
+
+		const anywayModeErrors = [ 'automated_migration_tools_login_and_get_cookies_test_failed' ];
+
+		if ( anywayModeErrors.includes( code ) ) {
+			setRequestInAnywayMode( true );
 		}
 	}, [ error ] );
 
 	useEffect( () => {
 		const { unsubscribe } = watch( () => {
 			clearErrors( 'root' );
+			setRequestInAnywayMode( false );
 		} );
 		return () => unsubscribe();
 	}, [ watch, clearErrors ] );
 
 	const submitHandler = ( data: CredentialsFormData ) => {
-		requestAutomatedMigration( data );
+		requestAutomatedMigration( {
+			...data,
+			bypassVerification: requestInAnywayMode || ! isEnglishLocale,
+		} );
 	};
+
+	const getContinueButtonText = useCallback( () => {
+		if ( isEnglishLocale && isPending ) {
+			return translate( 'Verifying credentials' );
+		}
+
+		if ( isEnglishLocale && requestInAnywayMode ) {
+			return translate( 'Continue anyways' );
+		}
+
+		return translate( 'Continue' );
+	}, [ isPending, requestInAnywayMode, isEnglishLocale, translate ] );
 
 	return {
 		formState: { errors },
@@ -74,5 +106,6 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 		isPending,
 		submitHandler,
 		importSiteQueryParam,
+		getContinueButtonText,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -86,7 +86,7 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 	};
 
 	const getContinueButtonText = useCallback( () => {
-		if ( isEnglishLocale && isPending ) {
+		if ( isEnglishLocale && isPending && ! requestInAnywayMode ) {
 			return translate( 'Verifying credentials' );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -10,7 +10,7 @@ import { useSiteMigrationCredentialsMutation } from './use-site-migration-creden
 
 export const useCredentialsForm = ( onSubmit: () => void ) => {
 	const importSiteQueryParam = useQuery().get( 'from' ) || '';
-	const [ requestInAnywayMode, setRequestInAnywayMode ] = useState( false );
+	const [ canBypassVerification, setCanBypassVerification ] = useState( false );
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
 
@@ -66,14 +66,14 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 		const anywayModeErrors = [ 'automated_migration_tools_login_and_get_cookies_test_failed' ];
 
 		if ( anywayModeErrors.includes( code ) ) {
-			setRequestInAnywayMode( true );
+			setCanBypassVerification( true );
 		}
 	}, [ error ] );
 
 	useEffect( () => {
 		const { unsubscribe } = watch( () => {
 			clearErrors( 'root' );
-			setRequestInAnywayMode( false );
+			setCanBypassVerification( false );
 		} );
 		return () => unsubscribe();
 	}, [ watch, clearErrors ] );
@@ -81,21 +81,21 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 	const submitHandler = ( data: CredentialsFormData ) => {
 		requestAutomatedMigration( {
 			...data,
-			bypassVerification: requestInAnywayMode || ! isEnglishLocale,
+			bypassVerification: canBypassVerification || ! isEnglishLocale,
 		} );
 	};
 
 	const getContinueButtonText = useCallback( () => {
-		if ( isEnglishLocale && isPending && ! requestInAnywayMode ) {
+		if ( isEnglishLocale && isPending && ! canBypassVerification ) {
 			return translate( 'Verifying credentials' );
 		}
 
-		if ( isEnglishLocale && requestInAnywayMode ) {
+		if ( isEnglishLocale && canBypassVerification ) {
 			return translate( 'Continue anyways' );
 		}
 
 		return translate( 'Continue' );
-	}, [ isPending, requestInAnywayMode, isEnglishLocale, translate ] );
+	}, [ isPending, canBypassVerification, isEnglishLocale, translate ] );
 
 	return {
 		formState: { errors },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-form-error-mapping.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-form-error-mapping.ts
@@ -36,18 +36,18 @@ export const useFormErrorMapping = (
 					return {
 						from_url: {
 							type: 'manual',
-							message: translate( 'Check your site address' ),
+							message: translate( 'Check your site address.' ),
 						},
 					};
 				default:
 					return {
 						username: {
 							type: 'manual',
-							message: translate( 'Check your username' ),
+							message: translate( 'Check your username.' ),
 						},
 						password: {
 							type: 'manual',
-							message: translate( 'Check your password' ),
+							message: translate( 'Check your password.' ),
 						},
 					};
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-site-migration-credentials-mutation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-site-migration-credentials-mutation.tsx
@@ -1,7 +1,7 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
-import { ApiError, CredentialsFormData } from './types';
+import { ApiError, CredentialsFormData } from '../types';
 
 interface AutomatedMigrationAPIResponse {
 	success: boolean;
@@ -15,6 +15,7 @@ interface AutomatedMigrationBody {
 	password?: string;
 	backup_file_location?: string;
 	notes?: string;
+	bypass_verification?: boolean;
 }
 
 export const useSiteMigrationCredentialsMutation = <
@@ -33,6 +34,7 @@ export const useSiteMigrationCredentialsMutation = <
 			notes,
 			migrationType,
 			backupFileLocation,
+			bypassVerification,
 		}: CredentialsFormData ) => {
 			let body: AutomatedMigrationBody = {
 				migration_type: migrationType,
@@ -46,6 +48,7 @@ export const useSiteMigrationCredentialsMutation = <
 					from_url,
 					username,
 					password,
+					bypass_verification: bypassVerification,
 				};
 			} else {
 				// In case of backup, we need to send the backup file location.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -11,11 +11,19 @@
 		margin-bottom: 60px;
 	}
 
-	.site-migration-credentials__content,
-	.site-migration-credentials__error-banner {
+	&__error-notice.notice .notice__icon-wrapper svg.notice__icon {
+		fill: var(--color-text-inverted);
+	}
+
+	&__error-notice,
+	&__content,
+	&__error-banner {
 		margin: 0 auto 16px;
 		max-width: 500px;
+	}
 
+	.site-migration-credentials__content,
+	.site-migration-credentials__error-banner {
 		@media (min-width: $break-mobile) {
 			margin-bottom: 16px;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -286,32 +286,101 @@ describe( 'SiteMigrationCredentials', () => {
 		} );
 	} );
 
-	it( 'shows "Continue anyways" on the Continue button for verification error and shows error message', async () => {
+	it.each( [
+		{
+			response_code: 404,
+			errorMessage: 'Check your site address.',
+		},
+		{
+			response_code: 401,
+			errorMessage: 'Check your username.',
+		},
+		{
+			response_code: 401,
+			errorMessage: 'Check your password.',
+		},
+	] )(
+		'shows error message for %p verification error',
+		async ( { response_code, errorMessage } ) => {
+			const submit = jest.fn();
+			render( { navigation: { submit } } );
+
+			( wpcomRequest as jest.Mock ).mockRejectedValue( {
+				code: 'automated_migration_tools_login_and_get_cookies_test_failed',
+				data: {
+					response_code,
+				},
+			} );
+
+			await fillAllFields();
+			userEvent.click( continueButton() );
+
+			await waitFor( () => {
+				expect( continueButton( /Continue anyways/ ) ).toBeVisible();
+			} );
+
+			await waitFor( () => {
+				expect( continueButton( /Continue anyways/ ) ).toBeVisible();
+				expect(
+					getByText(
+						'We could not verify your credentials. Can you double check your account information and try again?'
+					)
+				).toBeVisible();
+				expect( getByText( errorMessage ) ).toBeVisible();
+			} );
+		}
+	);
+
+	it( 'creates a credentials ticket by Continue anyways button', async () => {
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
+
+		await userEvent.click( credentialsOption() );
+		await userEvent.type( siteAddressInput(), 'site-url.com' );
+		await userEvent.type( usernameInput(), 'username' );
+		await userEvent.type( passwordInput(), 'password' );
+
+		await userEvent.click( specialInstructionsButton() );
+		await userEvent.type( specialInstructionsInput(), 'notes' );
 
 		( wpcomRequest as jest.Mock ).mockRejectedValue( {
 			code: 'automated_migration_tools_login_and_get_cookies_test_failed',
 			data: {
-				response_code: 404,
+				response_code: 401,
 			},
 		} );
 
-		await fillAllFields();
-		userEvent.click( continueButton() );
+		await userEvent.click( continueButton() );
 
 		await waitFor( () => {
 			expect( continueButton( /Continue anyways/ ) ).toBeVisible();
 		} );
 
+		( wpcomRequest as jest.Mock ).mockResolvedValue( {
+			status: 200,
+			body: {},
+		} );
+
+		await userEvent.click( continueButton( /Continue anyways/ ) );
+
+		expect( wpcomRequest ).toHaveBeenCalledWith( {
+			path: 'sites/site-url.wordpress.com/automated-migration',
+			apiNamespace: 'wpcom/v2/',
+			apiVersion: '2',
+			method: 'POST',
+			body: {
+				migration_type: 'credentials',
+				blog_url: 'site-url.wordpress.com',
+				bypass_verification: true,
+				notes: 'notes',
+				from_url: 'site-url.com',
+				username: 'username',
+				password: 'password',
+			},
+		} );
+
 		await waitFor( () => {
-			expect( continueButton( /Continue anyways/ ) ).toBeVisible();
-			expect(
-				getByText(
-					'We could not verify your credentials. Can you double check your account information and try again?'
-				)
-			).toBeVisible();
-			expect( getByText( 'Check your site address.' ) ).toBeVisible();
+			expect( submit ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/types.ts
@@ -7,6 +7,7 @@ export interface CredentialsFormData {
 	backupFileLocation: string;
 	migrationType: 'credentials' | 'backup';
 	notes: string;
+	bypassVerification?: boolean;
 }
 
 export interface ApiFormData {
@@ -23,6 +24,7 @@ export interface ApiError {
 	message: string;
 	data: {
 		params?: Record< string, string >;
+		response_code?: number;
 	};
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/94714

## Proposed Changes

- Add verification of credentials
- Show error message in URL and credentials when applicable
- Add an option to "Continue anyways" if verification fails
- Change button text to "Verifying credentials" when submitting the form

Till translation is available, we're only making these changes apply only for users in EN locale.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To reduce the number of wrong credentials submission.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this patch in your sandbox - D162290-code
- Make sure WPCOM requests are pointed to your sandbox
- Proceed through the migration flow.
- On the "How do you want to migrate?" step, choose "Do it for me".
- In the credentials form, test the following scenarios -

#### Site is a random non-Wordpress site (i.e. google.com, facebook.com etc)

- You see an error on top
- See an error message below URL field
- Button changes to "Continue anyways"

#### Site can be Wordpress, but login.php/wp-admin etc are not accessible through the usual paths (i.e. minlovecat.sg)

- You see an error on top
- See an error message below URL field
- Button changes to "Continue anyways"

#### Site is wordpress, login.php/wp-admin etc are accessible, but credentials are wrong (You can try with a JN site)

- You see an error on top
- See an error message below the credential fields
- Button changes to "Continue anyways"

#### Site is wordpress, login.php/wp-admin etc are accessible, but credentials are wrong (You can try with a JN site and username "^^^&&&**")

- You DO NOT see an error on top
- See an error message below the username field
- Button DOES NOT change to "Continue anyways"

You should check that-
- When you click on "Continue", the button text should change to "Verifying credentials", but when you click on "Continue anyways", it won't show "Verifying credentials", because the "Continue anyways" button should bypass verification. That's why not showing "Verifying credentials" is more correct.
- Continue button should change to "Continue anyways" only when there is a verification error, not a validation error.
- "Continue anyway" button changes to "Continue" button if you make changes in the form again.

https://github.com/user-attachments/assets/4e33fda5-7254-4be2-88e8-edcea328ac1f

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?