### PR TITLE
A4A > Signup: Add user type dropdown to the signup form

### DIFF
--- a/client/a8c-for-agencies/components/layout/banner.tsx
+++ b/client/a8c-for-agencies/components/layout/banner.tsx
@@ -13,6 +13,7 @@ type Props = {
 	onClose?: () => void;
 	title?: string;
 	preferenceName?: string;
+	hideCloseButton?: boolean;
 };
 
 export default function LayoutBanner( {
@@ -23,6 +24,7 @@ export default function LayoutBanner( {
 	actions,
 	level = 'success',
 	preferenceName,
+	hideCloseButton = false,
 }: Props ) {
 	const dispatch = useDispatch();
 
@@ -45,7 +47,13 @@ export default function LayoutBanner( {
 
 	return (
 		<div className={ wrapperClass }>
-			<NoticeBanner level={ level } onClose={ handleClose } title={ title } actions={ actions }>
+			<NoticeBanner
+				level={ level }
+				onClose={ handleClose }
+				title={ title }
+				actions={ actions }
+				hideCloseButton={ hideCloseButton }
+			>
 				{ children }
 			</NoticeBanner>
 		</div>

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -13,6 +13,7 @@ function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 			agency_name: details.agencyName,
 			agency_url: details.agencyUrl,
 			number_sites: details.managedSites,
+			user_type: details.userType,
 			services_offered: details.servicesOffered,
 			products_offered: details.productsOffered,
 			address_line1: details.line1,

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
@@ -4,6 +4,7 @@ export interface AgencyDetailsPayload {
 	agencyName: string;
 	agencyUrl: string;
 	managedSites?: string;
+	userType: string;
 	servicesOffered: string[];
 	productsOffered: string[];
 	city: string;

--- a/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
@@ -60,6 +60,7 @@ export default function SignupForm() {
 					name: payload.agencyName,
 					business_url: payload.agencyUrl,
 					managed_sites: payload.managedSites,
+					user_type: payload.userType,
 					services_offered: ( payload.servicesOffered || [] ).join( ',' ),
 					products_offered: ( payload.productsOffered || [] ).join( ',' ),
 					city: payload.city,


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1110

## Proposed Changes

- This PR adds a user type selection to the signup form with the label: ` How would you describe yourself?`
- Shows a warning banner if the user chooses the `I do not work at an agency. I'm a site owner.` option.
- Track when the user chooses the `I do not work at an agency. I'm a site owner.` option.
- Saves the user selection into HubSpot.

## Why are these changes being made?

*  If the user is a site owner, we should prevent them from going further into the signup process.

## Testing Instructions

* Since we don't support signup/login using the A4A live links, we should be using the local server to test this completely.
* Switch to this branch and start the server.
* Patch D162299-code and follow the rest of the instructions here after submitting the form.
* Visit http://agencies.localhost:3000 > Create a new WPCOM account > Once you are redirected to the Signup page > Verify you can now see a new dropdown that says `How would you describe yourself?` and verify you can see the options shown below

<img width="1728" alt="Screenshot 2024-09-25 at 10 27 25 AM" src="https://github.com/user-attachments/assets/af8a2cd5-60e1-44ce-907b-35950386a965">

- Selecting the `I do not work at an agency. I'm a site owner.` option should show the below warning and user shouldn't allowed to proceed further. Verify that a track event is recorded when this options is chosen. 

<img width="1728" alt="Screenshot 2024-09-24 at 10 52 17 AM" src="https://github.com/user-attachments/assets/7855a2ad-fb8e-4a25-a143-31685e7b28b7">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?