### PR TITLE
A4A: Update Onboarding copies and walkthrough tasks.

### DIFF
--- a/client/a8c-for-agencies/components/guided-tour-step/style.scss
+++ b/client/a8c-for-agencies/components/guided-tour-step/style.scss
@@ -1,4 +1,6 @@
 .guided-tour__popover {
+	z-index: 9999999;
+
 	.popover__inner {
 		display: flex;
 		gap: 16px;

--- a/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
+++ b/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
@@ -9,8 +9,10 @@ import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
 import {
 	A4A_MARKETPLACE_LINK,
 	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
+	A4A_REFERRALS_DASHBOARD,
 	A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
 	A4A_SITES_LINK_WALKTHROUGH_TOUR,
+	A4A_TEAM_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import { A4A_ONBOARDING_TOURS_PREFERENCE_NAME } from '../sections/onboarding-tours/constants';
 import useNoActiveSite from './use-no-active-site';
@@ -52,23 +54,11 @@ export default function useOnboardingTours() {
 				resetTour( [ 'addSiteStep1', 'addSiteStep2' ] );
 			},
 			id: 'add_sites',
-			title: translate( 'Learn how to add sites' ),
+			title: translate( 'Add your first site' ),
 			useCalypsoPath: true,
 		};
 
 		const tasks: Task[] = [
-			{
-				calypso_path: A4A_SITES_LINK_WALKTHROUGH_TOUR,
-				completed: checkTourCompletion( preferences, 'sitesWalkthrough' ),
-				disabled: false,
-				actionDispatch: () => {
-					dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_get_familiar_click' ) );
-					resetTour( [ 'sitesWalkthrough' ] );
-				},
-				id: 'get_familiar',
-				title: translate( 'Get familiar with the sites management dashboard' ),
-				useCalypsoPath: true,
-			},
 			{
 				calypso_path: A4A_MARKETPLACE_LINK,
 				completed: checkTourCompletion( preferences, 'exploreMarketplace' ),
@@ -82,7 +72,21 @@ export default function useOnboardingTours() {
 					);
 				},
 				id: 'explore_marketplace',
-				title: translate( 'Explore the marketplace' ),
+				title: translate( 'Explore our best-in-class hosting and plugins' ),
+				useCalypsoPath: true,
+			},
+			{
+				calypso_path: A4A_REFERRALS_DASHBOARD,
+				completed: checkTourCompletion( preferences, 'startReferrals' ),
+				disabled: false,
+				actionDispatch: () => {
+					dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_start_referrals_click' ) );
+					dispatch(
+						savePreference( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'startReferrals' ], true )
+					);
+				},
+				id: 'start_referrals',
+				title: translate( 'Start earning commission on referrals' ),
 				useCalypsoPath: true,
 			},
 			...( config.isEnabled( 'a4a-partner-directory' )
@@ -105,11 +109,35 @@ export default function useOnboardingTours() {
 								);
 							},
 							id: 'boost_agency_visibility',
-							title: translate( 'Boost your agency’s visibility across Automattic platforms' ),
+							title: translate( "Boost your agency's visibilty across our partner directories" ),
 							useCalypsoPath: true,
 						},
 				  ]
 				: [] ),
+			{
+				calypso_path: A4A_TEAM_LINK,
+				completed: checkTourCompletion( preferences, 'inviteTeam' ),
+				disabled: false,
+				actionDispatch: () => {
+					dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_invite_team_click' ) );
+					dispatch( savePreference( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'inviteTeam' ], true ) );
+				},
+				id: 'invite_team',
+				title: translate( 'Invite your team' ),
+				useCalypsoPath: true,
+			},
+			{
+				calypso_path: A4A_SITES_LINK_WALKTHROUGH_TOUR,
+				completed: checkTourCompletion( preferences, 'sitesWalkthrough' ),
+				disabled: false,
+				actionDispatch: () => {
+					dispatch( recordTracksEvent( 'calypso_a4a_overview_next_steps_get_familiar_click' ) );
+					resetTour( [ 'sitesWalkthrough' ] );
+				},
+				id: 'get_familiar',
+				title: translate( 'Manage all of your client sites in a single place' ),
+				useCalypsoPath: true,
+			},
 		];
 
 		if ( noActiveSite ) {

--- a/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
+++ b/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
@@ -7,6 +7,8 @@ export const A4A_ONBOARDING_TOURS_PREFERENCE_NAME: Record< string, string > = {
 	sitesWalkthrough: 'a4a-sites-tour',
 	exploreMarketplace: 'a4a-marketplace-tour',
 	boostAgencyVisibility: 'a4a-boost-agency-visibility-tour',
+	startReferrals: 'a4a-start-referrals',
+	inviteTeam: 'a4a-invite-team',
 };
 
 export const A4A_ONBOARDING_TOURS_EVENT_NAMES: Record< string, string > = {

--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
@@ -1,5 +1,6 @@
 import { Card, DotPager } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import SimpleList from 'calypso/a8c-for-agencies/sections/marketplace/common/simple-list';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -12,12 +13,24 @@ const Card1 = () => {
 			<h1>{ translate( 'Welcome to Automattic for Agencies' ) }</h1>
 			<p>
 				{ translate(
-					'Automattic for Agencies is a new agency program that brings together all of Automattic’s brands under one roof, enabling you to get the best deals on our products and services. We’ll also provide you with tooling to help you be more efficient in your work and grow your business.'
+					"Automattic for Agencies is a new agency program that combines the best of Automattic's offerings all in one place. By partnering with us, you will have opportunities to grow your business with:"
 				) }
 			</p>
+
+			<SimpleList
+				items={ [
+					translate( 'Significant discounts on our products and services' ),
+					translate( 'Earn partner badges to align your agency with Automattic brands' ),
+					translate( 'Recurring commissions on product referrals – including WooPayments' ),
+					translate( 'Tooling to help you be more efficient' ),
+				] }
+			/>
+
+			<br />
+
 			<p>
 				{ translate(
-					'This is only just the beginning. Soon, we’ll add partner directory listings across our brands, multiple user support, WooPayments commissions, and much more.'
+					'This is just the beginning. We look forward to partnering with you and seeing what the next chapter brings.'
 				) }
 			</p>
 		</>
@@ -28,10 +41,15 @@ const Card2 = () => {
 	const translate = useTranslate();
 	return (
 		<>
-			<h1>{ translate( 'Get big discounts when purchasing in bulk' ) }</h1>
+			<h1>{ translate( 'Only pay for what you use' ) }</h1>
 			<p>
 				{ translate(
-					'You can save up to 80% on Woo, Jetpack, WordPress.com, and Pressable plans when purchasing in bulk. We also charge on a monthly basis, so you don’t have to pay for a year upfront to get the best prices.'
+					"We aim to ensure your business grows with as little upfront cost as possible. That's why we've adopted a pay-for-what-you-use model across all our products, including hosting. This allows you to add and remove products as needed without paying for a whole year upfront to get the best prices."
+				) }
+			</p>
+			<p>
+				{ translate(
+					'We will bill you at the start of each month for any hosting or products used in the previous month. These are charged on a per-day basis.'
 				) }
 			</p>
 		</>
@@ -42,10 +60,15 @@ const Card3 = () => {
 	const translate = useTranslate();
 	return (
 		<>
-			<h1>{ translate( 'Manage all of your sites in a single place, regardless of host' ) }</h1>
+			<h1>{ translate( 'Earn recurring commissions on referrals' ) }</h1>
 			<p>
 				{ translate(
-					'With our sites dashboard, you can get a birds-eye view of the security and performance across all your sites, regardless of host. You’ll be notified immediately if critical issues need your attention, ensuring your clients remain happy.'
+					'With our novel create-a-cart feature, you can add any product in our marketplace to a cart for your client to purchase in just a few clicks. Once your client makes the purchase, you will receive a quarterly recurring commission (up to 50%).'
+				) }
+			</p>
+			<p>
+				{ translate(
+					'You can also earn a five basis points commission on WooPayments TPV (Total Payments Volume) by referring new clients to WooPayments.'
 				) }
 			</p>
 		</>
@@ -56,15 +79,10 @@ const Card4 = () => {
 	const translate = useTranslate();
 	return (
 		<>
-			<h1>{ translate( 'And more to come' ) }</h1>
+			<h1>{ translate( 'Grow your business by getting listed on our partner directories' ) }</h1>
 			<p>
 				{ translate(
-					'We’re only just getting started. Our mission is to create an agency program that helps your business to grow with us. If you have any feedback or suggestions for us, we’d love to hear from you at {{mailto}}partnerships@automattic.com{{/mailto}}.',
-					{
-						components: {
-							mailto: <a href="mailto:partnerships@automattic.com" />,
-						},
-					}
+					'With our program, you can earn partner badges and align your agency with Woo, Jetpack, WordPress.com, and Pressable, enabling you to secure placement in multiple partner directory listings. All you need to do is demonstrate your expertise in supporting clients for each brand to get listed on their directory page.'
 				) }
 			</p>
 		</>

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -166,13 +166,16 @@
 
 	.components-button.is-primary,
 	.button.is-primary {
-		background-color: var(--color-primary-50);
-		border-color: var(--color-primary-50);
-		fill: var(--color-text-inverted);
-		color: var(--color-text-inverted);
+		&,
+		&:focus:not(:disabled) {
+			background-color: var(--color-primary-50);
+			border-color: var(--color-primary-50);
+			fill: var(--color-text-inverted);
+			color: var(--color-text-inverted);
+		}
 
-		&:hover,
-		&:focus-visible {
+		&:hover:not(:disabled),
+		&:focus-visible:not(:disabled) {
 			background-color: var(--color-primary-70);
 			border-color: var(--color-primary-70);
 			fill: var(--color-text-inverted);


### PR DESCRIPTION
This PR updates a few onboarding messages to showcase the new features in A4A.

| Header | Header |
|--------|--------|
| <img width="1021" alt="Screenshot 2024-09-25 at 2 41 54 PM" src="https://github.com/user-attachments/assets/9c516115-632b-4fa9-af3a-f791266dc468"> | <img width="1017" alt="Screenshot 2024-09-25 at 2 45 06 PM" src="https://github.com/user-attachments/assets/e526a39a-647b-45f7-ab91-3fb21df5195f"> |
| <img width="1014" alt="Screenshot 2024-09-25 at 2 42 05 PM" src="https://github.com/user-attachments/assets/e079b64c-4ece-49bb-8da1-aea6a0818035"> | <img width="1017" alt="Screenshot 2024-09-25 at 2 45 16 PM" src="https://github.com/user-attachments/assets/3709ba29-8fb5-4724-8bfd-2f8ca3f313bb"> |
| <img width="1015" alt="Screenshot 2024-09-25 at 2 42 12 PM" src="https://github.com/user-attachments/assets/67d61e58-c3a6-475b-8629-bad91a7be444"> | <img width="1014" alt="Screenshot 2024-09-25 at 2 45 23 PM" src="https://github.com/user-attachments/assets/c2a1a525-6f80-45b8-9c36-fb878cf0e790"> |
| <img width="1015" alt="Screenshot 2024-09-25 at 2 42 18 PM" src="https://github.com/user-attachments/assets/d90fecd7-8beb-4d19-a9ee-52433ddb03fb"> | <img width="1020" alt="Screenshot 2024-09-25 at 2 45 30 PM" src="https://github.com/user-attachments/assets/6d374eee-392d-4e49-bfc5-2cbd7026cec3"> | 
| <img width="1017" alt="Screenshot 2024-09-25 at 2 43 12 PM" src="https://github.com/user-attachments/assets/ec55eaf0-4793-4cd3-ae56-b8025b4e334a"> | <img width="1012" alt="Screenshot 2024-09-25 at 2 46 19 PM" src="https://github.com/user-attachments/assets/b87909ed-7b2b-41b2-ba46-7bbee1ea06f5"> | 

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1082

## Proposed Changes

* Update the Onboarding carousel on the Overview page to highlight new features.
* Update the onboarding task list which now adds more actions related to the new features.

## Why are these changes being made?

* Right now, our Onboarding page is outdated and does not reflect the current capabilities of A4A. This pull request updates it to reflect the current A4A.

## Testing Instructions

* Use the A4A live link and go to the `/overview` page.
* Verify all copies highlighted above are rendered.
* Verify the task list if it redirects to the correct pages and onboarding tours.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
