### PR TITLE
NPS v2: Scaffold the NPS package

### DIFF
--- a/packages/nps/CHANGELOG.md
+++ b/packages/nps/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+The initial version.

--- a/packages/nps/README.md
+++ b/packages/nps/README.md
@@ -1,0 +1,3 @@
+# Nps
+
+The UI components implementing the net promoter score survey form. 

--- a/packages/nps/jest.config.js
+++ b/packages/nps/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
+	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
+};

--- a/packages/nps/package.json
+++ b/packages/nps/package.json
@@ -33,12 +33,12 @@
 		"postcss": "^8.4.5",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"tslib": "^2.3.0"
+		"tslib": "^2.3.0",
+		"webpack": "^5.94.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.7.4",
-		"webpack": "^5.94.0"
+		"typescript": "^4.7.4"
 	}
 }

--- a/packages/nps/package.json
+++ b/packages/nps/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "@automattic/nps",
+	"version": "1.0.0",
+	"description": "The UI components implementing the Net Promoter Score survey form.",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.tsx",
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/nps"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"prepare": "yarn run build",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"peerDependencies": {
+		"postcss": "^8.4.5",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"tslib": "^2.3.0"
+	},
+	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"typescript": "^4.7.4"
+	}
+}

--- a/packages/nps/package.json
+++ b/packages/nps/package.json
@@ -38,6 +38,7 @@
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.7.4"
+		"typescript": "^4.7.4",
+		"webpack": "^5.94.0"
 	}
 }

--- a/packages/nps/src/index.tsx
+++ b/packages/nps/src/index.tsx
@@ -1,0 +1,5 @@
+const Nps = () => {
+	return null;
+};
+
+export default Nps;

--- a/packages/nps/tsconfig-cjs.json
+++ b/packages/nps/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/nps/tsconfig.json
+++ b/packages/nps/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src",
+		"types": []
+	},
+	"include": [ "src", "src/*.json" ],
+	"exclude": [ "**/__tests__/*", "**/__mocks__/*" ]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -41,6 +41,7 @@
 		{ "path": "./launchpad" },
 		{ "path": "./launchpad-navigator" },
 		{ "path": "./mini-cart" },
+		{ "path": "./nps" },
 		{ "path": "./odie-client" },
 		{ "path": "./onboarding" },
 		{ "path": "./page-pattern-modal" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,6 +1444,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/nps@workspace:packages/nps":
+  version: 0.0.0-use.local
+  resolution: "@automattic/nps@workspace:packages/nps"
+  dependencies:
+    "@automattic/calypso-build": "workspace:^"
+    "@automattic/calypso-typescript-config": "workspace:^"
+    typescript: "npm:^4.7.4"
+  peerDependencies:
+    postcss: ^8.4.5
+    react: ^18.3.1
+    react-dom: ^18.3.1
+    tslib: ^2.3.0
+  languageName: unknown
+  linkType: soft
+
 "@automattic/o2-blocks@workspace:apps/o2-blocks":
   version: 0.0.0-use.local
   resolution: "@automattic/o2-blocks@workspace:apps/o2-blocks"
@@ -33068,6 +33083,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^4.7.4":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 5f6cad2e728a8a063521328e612d7876e12f0d8a8390d3b3aaa452a6a65e24e9ac8ea22beb72a924fd96ea0a49ea63bb4e251fb922b12eedfb7f7a26475e5c56
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.3.3":
   version: 5.3.3
   resolution: "typescript@npm:5.3.3"
@@ -33075,6 +33100,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: e33cef99d82573624fc0f854a2980322714986bc35b9cb4d1ce736ed182aeab78e2cb32b385efa493b2a976ef52c53e20d6c6918312353a91850e2b76f1ea44f
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^4.7.4#optional!builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: e3333f887c6829dfe0ab6c1dbe0dd1e3e2aeb56c66460cb85c5440c566f900c833d370ca34eb47558c0c69e78ced4bfe09b8f4f98b6de7afed9b84b8d1dd06a1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,6 +1456,7 @@ __metadata:
     react: ^18.3.1
     react-dom: ^18.3.1
     tslib: ^2.3.0
+    webpack: ^5.94.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR scaffolds the fundament package structure of the NPS v2 component package. 

* The package outline was generated by `yarn run generate`
* Added the placeholder CHANGELOG.md
* Moved the modules enlisted as dependencies in the generated template to the peer dependencies since those should be managed by the parent project in my opinion.
* Added `calypso-build` as a peer dependency so `copy-assets` is available.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

(TODO)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that the package structure should make sense.
* `yarn install`, `yarn build-packages` and `yarn workspace @automattic/nps run prepare` should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
