### PR TITLE
A4A Dev Sites: Temporarily hide Refer To Client button behind feature flag.

### DIFF
--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -81,7 +81,8 @@ const LaunchSite = () => {
 		isDevelopmentSite &&
 		! siteReferralActive &&
 		! agencyLoading;
-	const shouldShowAgencyBillingMessage = isDevelopmentSite && ! agencyLoading;
+	const shouldShowAgencyBillingMessage =
+		isDevelopmentSite && ! siteReferralActive && ! agencyLoading;
 
 	const handleLaunchSiteClick = () => {
 		if ( isDevelopmentSite && ! siteReferralActive ) {

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -81,6 +81,7 @@ const LaunchSite = () => {
 		isDevelopmentSite &&
 		! siteReferralActive &&
 		! agencyLoading;
+	const shouldShowAgencyBillingMessage = isDevelopmentSite && ! agencyLoading;
 
 	const handleLaunchSiteClick = () => {
 		if ( isDevelopmentSite && ! siteReferralActive ) {
@@ -187,7 +188,7 @@ const LaunchSite = () => {
 										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
 								  ) }
 						</p>
-						{ shouldShowReferToClientButton && <i>{ agencyBillingMessage }</i> }
+						{ shouldShowAgencyBillingMessage && <i>{ agencyBillingMessage }</i> }
 					</div>
 					<div className={ launchSiteClasses }>{ btnComponent }</div>
 					{ shouldShowReferToClientButton && (

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products';
 import { Card, CompactCard, Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
@@ -76,7 +77,10 @@ const LaunchSite = () => {
 	const price = formatCurrency( agency?.prices?.actual_price, agency?.prices?.currency );
 	const siteReferralActive = agency?.referral_status === 'active';
 	const shouldShowReferToClientButton =
-		isDevelopmentSite && ! siteReferralActive && ! agencyLoading;
+		config.isEnabled( 'a4a-dev-sites-referral' ) &&
+		isDevelopmentSite &&
+		! siteReferralActive &&
+		! agencyLoading;
 
 	const handleLaunchSiteClick = () => {
 		if ( isDevelopmentSite && ! siteReferralActive ) {

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -191,7 +191,7 @@ const LaunchSite = () => {
 					</div>
 					<div className={ launchSiteClasses }>{ btnComponent }</div>
 					{ shouldShowReferToClientButton && (
-						<div className={ launchSiteClasses }>
+						<div className="site-settings__general-settings-refer-to-client-button">
 							<Button onClick={ handleReferToClient } disabled={ isLaunchInProgress }>
 								{ translate( 'Refer to client' ) }
 							</Button>

--- a/client/my-sites/site-settings/site-visibility/styles.scss
+++ b/client/my-sites/site-settings/site-visibility/styles.scss
@@ -14,6 +14,13 @@
 	white-space: nowrap;
 }
 
+.site-settings__general-settings-refer-to-client-button {
+	margin-top: auto;
+	margin-bottom: auto;
+	margin-left: 20px;
+	white-space: nowrap;
+}
+
 .site-settings__launch-confirmation-modal {
 	max-width: 60%;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -30,6 +30,7 @@
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
 	"features": {
 		"ad-tracking": false,
+		"a4a-dev-sites-referral": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -11,6 +11,7 @@
 	"facebook_api_key": "249643311490",
 	"features": {
 		"ad-tracking": false,
+		"a4a-dev-sites-referral": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -11,7 +11,7 @@
 	"facebook_api_key": "249643311490",
 	"features": {
 		"ad-tracking": false,
-		"a4a-dev-sites-referral": true,
+		"a4a-dev-sites-referral": false,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": true,

--- a/config/production.json
+++ b/config/production.json
@@ -21,6 +21,7 @@
 	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
 		"ad-tracking": true,
+		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,6 +19,7 @@
 	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
 		"ad-tracking": false,
+		"a4a-dev-sites-referral": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,7 +19,7 @@
 	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
 		"ad-tracking": false,
-		"a4a-dev-sites-referral": true,
+		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/test.json
+++ b/config/test.json
@@ -22,6 +22,7 @@
 	"facebook_api_key": "249643311490",
 	"features": {
 		"ad-tracking": false,
+		"a4a-dev-sites-referral": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypsoify/plugins": true,

--- a/config/test.json
+++ b/config/test.json
@@ -22,7 +22,7 @@
 	"facebook_api_key": "249643311490",
 	"features": {
 		"ad-tracking": false,
-		"a4a-dev-sites-referral": true,
+		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypsoify/plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -18,7 +18,7 @@
 	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
 		"ad-tracking": false,
-		"a4a-dev-sites-referral": true,
+		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -18,6 +18,7 @@
 	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
 		"ad-tracking": false,
+		"a4a-dev-sites-referral": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": true,
@@ -160,7 +161,6 @@
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
-
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9249

## Proposed Changes

* Temporarily hide Refer To Client button behind feature flag.
* This only applies to production environment, so use `flags=-a4a-dev-sites-referral` to disable it.
* Some minor classname separation and logic changes to ensure agency billing message is shown.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Needs further polishing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
1. Go to `http://calypso.localhost:3000/settings/general/YOUR_DEV_SITE?flags=-a4a-dev-sites-referral`
2. You should not see the Refer To Client button.

<img width="760" alt="image" src="https://github.com/user-attachments/assets/978684eb-2df2-48c2-b70e-9de6f076be4e">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
