### PR TITLE
Logged-in Performance Profiler: Fix UI issues with status badges and performance score ring

### DIFF
--- a/client/hosting/performance/components/circular-performance-score/circular-performance-score.tsx
+++ b/client/hosting/performance/components/circular-performance-score/circular-performance-score.tsx
@@ -29,7 +29,13 @@ export const CircularPerformanceScore = ( {
 				numberOfSteps={ steps }
 				showProgressText={ false }
 			/>
-			<div className="circular-performance-score">{ score }</div>
+			<div
+				className={ `circular-performance-score ${
+					size > 48 && 'circular-performance-score--large'
+				} ` }
+			>
+				{ score }
+			</div>
 		</div>
 	);
 };

--- a/client/hosting/performance/components/circular-performance-score/style.scss
+++ b/client/hosting/performance/components/circular-performance-score/style.scss
@@ -1,27 +1,26 @@
+@import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/components/src/styles/typography";
 
 .circular-performance-bar {
 	position: relative;
 	display: inline-block;
+	color: $studio-black;
 
 	&.good {
-		color: #00ba37;
 		.circular__progress-bar .circular__progress-bar-fill-circle {
-			stroke: #00ba37;
+			stroke: $studio-green-30;
 		}
 	}
 
 	&.needs-improvement {
-		color: #d67709;
 		.circular__progress-bar .circular__progress-bar-fill-circle {
-			stroke: #d67709;
+			stroke: $studio-orange-40;
 		}
 	}
 
 	&.poor {
-		color: #d63638;
 		.circular__progress-bar .circular__progress-bar-fill-circle {
-			stroke: #d63638;
+			stroke: $studio-red-50;
 		}
 	}
 }

--- a/client/hosting/performance/components/circular-performance-score/style.scss
+++ b/client/hosting/performance/components/circular-performance-score/style.scss
@@ -33,5 +33,9 @@
 	font-family: $font-sf-pro-display;
 	font-size: $font-size-header-small;
 	font-weight: 400;
+
+	&--large {
+		font-size: 1.75rem;
+	}
 }
 

--- a/client/performance-profiler/components/core-web-vitals-accordion/core-web-vitals-accordion-v2.tsx
+++ b/client/performance-profiler/components/core-web-vitals-accordion/core-web-vitals-accordion-v2.tsx
@@ -20,10 +20,11 @@ type HeaderProps = {
 	displayName: string;
 	metricKey: Metrics;
 	metricValue: number;
+	isActive?: boolean;
 };
 
 const CardHeader = ( props: HeaderProps ) => {
-	const { displayName, metricKey, metricValue } = props;
+	const { displayName, metricKey, metricValue, isActive } = props;
 	const status = mapThresholdsToStatus( metricKey, metricValue );
 	const isPerformanceScoreSelected = metricKey === 'overall';
 
@@ -35,7 +36,7 @@ const CardHeader = ( props: HeaderProps ) => {
 
 				{ isPerformanceScoreSelected ? (
 					<div className="metric-tab-bar-v2__tab-metric" style={ { marginTop: '6px' } }>
-						<CircularPerformanceScore score={ metricValue } size={ 48 } />
+						<CircularPerformanceScore score={ metricValue } size={ isActive ? 72 : 48 } />
 					</div>
 				) : (
 					<span
@@ -91,6 +92,7 @@ export const CoreWebVitalsAccordionV2 = ( props: Props ) => {
 								displayName={ displayName }
 								metricKey={ key as Metrics }
 								metricValue={ props[ key as Metrics ] }
+								isActive={ key === activeTab }
 							/>
 						}
 						hideSummary

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
@@ -129,7 +129,7 @@ export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
 											marginTop: '16px',
 										} }
 									>
-										<CircularPerformanceScore score={ value } size={ 76 } />
+										<CircularPerformanceScore score={ value } size={ 72 } />
 									</div>
 								) : (
 									displayValue( activeTab as Metrics, value )

--- a/client/performance-profiler/components/core-web-vitals-display/style.scss
+++ b/client/performance-profiler/components/core-web-vitals-display/style.scss
@@ -179,7 +179,7 @@ $blueberry-color: #3858e9;
 	display: flex;
 	gap: 24px;
 
-	@media (max-width: $break-mobile) {
+	@media (max-width: $break-large) {
 		flex-direction: column;
 		gap: 0;
 	}

--- a/client/performance-profiler/components/status-section/style.scss
+++ b/client/performance-profiler/components/status-section/style.scss
@@ -6,9 +6,8 @@
 	color: #000;
 	display: flex;
 	flex-direction: column;
-	align-items: center;
+	align-items: flex-end;
 	gap: 12px;
-
 
 	.status-badge {
 		display: flex;
@@ -19,11 +18,6 @@
 		border-radius: 4px;
 		font-weight: 500;
 		flex-shrink: 0;
-		width: 100%;
-
-		@media (max-width: $break-mobile) {
-			width: unset;
-		}
 
 		&.poor {
 			background: var(--studio-red-5);
@@ -47,8 +41,10 @@
 		}
 	}
 
-	@media (max-width: $break-mobile) {
+	@media (max-width: $break-large) {
 		flex-direction: row;
+		width: 100%;
+		align-items: center;
 		margin-bottom: 24px;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9246

## Proposed Changes

Fix alignment and positioning of status badge on both desktop and mobile.

| Desktop | Mobile |
|--------|--------|
| <img width="202" alt="Screenshot 2024-09-25 at 09 49 09" src="https://github.com/user-attachments/assets/41a3cb1d-0416-4a86-85bc-36e80acb51e5"> | <img width="337" alt="Screenshot 2024-09-25 at 10 22 12" src="https://github.com/user-attachments/assets/37a35b22-cc4e-430b-ab22-947b28bbb951">  | 

Fix styling of performance score ring.

| Desktop | Mobile |
|--------|--------|
| <img width="405" alt="Screenshot 2024-09-25 at 10 22 57" src="https://github.com/user-attachments/assets/88827f7a-fcdd-4e39-8868-08c0f220d780"> | <img width="324" alt="Screenshot 2024-09-25 at 10 23 07" src="https://github.com/user-attachments/assets/a5e74598-b386-4a3b-811d-ff30be504cf0"> | 

Expand the performance score ring when the tab is selected in the accordion.

| Closed | Open |
|--------|--------|
| <img width="331" alt="Screenshot 2024-09-25 at 10 22 09" src="https://github.com/user-attachments/assets/e9fa0c40-2043-45f8-834c-37d102786cdf"> | <img width="337" alt="Screenshot 2024-09-25 at 10 22 12" src="https://github.com/user-attachments/assets/472bdea9-24f3-490c-951a-55e5bf0df9d5"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that the end product matches the designs.