### PR TITLE
A4A Dev Sites: Clean up feature flag checks

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -238,8 +238,7 @@ export default function LicensePreview( {
 		? translate( 'WordPress.com Site' )
 		: product;
 
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
-	const isDevelopmentSite = devSitesEnabled && Boolean( meta?.isDevSite );
+	const isDevelopmentSite = Boolean( meta?.isDevSite );
 
 	return (
 		<div

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -190,9 +190,6 @@ export const JetpackSitesDataViews = ( {
 						);
 					}
 
-					const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
-					const isDevSite = ( item.isDevSite && devSitesEnabled ) || false;
-
 					return (
 						<div
 							className={ clsx( {
@@ -203,7 +200,7 @@ export const JetpackSitesDataViews = ( {
 							<SiteDataField
 								site={ site }
 								isLoading={ isLoading }
-								isDevSite={ isDevSite }
+								isDevSite={ item.isDevSite }
 								onSiteTitleClick={ openSitePreviewPane }
 							/>
 						</div>

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg } from '@wordpress/url';
@@ -34,15 +33,13 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 
 	const onCreateSiteSuccess = useSiteCreatedCallback( refetchRandomSiteName );
 
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
-
 	const addNewDevSite = getQueryArg( window.location.href, 'add_new_dev_site' );
 
 	useEffect( () => {
-		if ( devSitesEnabled && addNewDevSite ) {
+		if ( addNewDevSite ) {
 			toggleDevSiteConfigurationsModal?.();
 		}
-	}, [ addNewDevSite, devSitesEnabled, toggleDevSiteConfigurationsModal ] );
+	}, [ addNewDevSite, toggleDevSiteConfigurationsModal ] );
 
 	return (
 		<div className="sites-header__actions">

--- a/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
+++ b/client/my-sites/site-settings/a4a-fully-managed-site-setting.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
@@ -24,13 +23,12 @@ export function A4AFullyManagedSiteSetting( {
 	onSaveSetting,
 	disabled,
 }: Props ) {
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 	const isDevSite = site.is_a4a_dev_site;
 	const isAtomicSite = site.is_wpcom_atomic;
 
 	const { data: agencySite } = useFetchAgencyFromBlog( site?.ID, { enabled: !! site?.ID } );
 
-	const shouldShowToggle = devSitesEnabled && agencySite && isAtomicSite;
+	const shouldShowToggle = agencySite && isAtomicSite;
 
 	if ( ! shouldShowToggle ) {
 		return null;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/9103

## Proposed Changes

* The PR ensures the feature flag is only used to hide the necessary UI items, i.e.:
  * The add new development site widget found within the "Add New Site" dropdown
  * The "Development" tab under in the Sites section of the dashboard
* The feature flag needs not to be used to hide the following:
  - "Development" site entry labels in Site Overview in Calypso, and in the Purchases -> Licenses and Sites A4A dashboard
  -  The "Agency Settings" within "Site Settings"
## Why are these changes being made?

<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To simplify testing, and the release to production process.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
#### Test 1
* Use the generated A4A dashboard link from the PR comments below.
* Ensure that when you open up the "Add sites" popup, the create a development site widget does not show up.

#### Test 2
* Use the generated A4A dashboard link from the PR comments below.
* Go to "Sites".
* Ensure the "Development" tab is not displayed in the dashboard's sidebar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
