### PR TITLE
Performance Profiler: Screenshot modals in the insights section uses the Gutenberg Modal component

### DIFF
--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -412,6 +412,8 @@
 		position: relative;
 		cursor: zoom-in;
 		overflow: hidden;
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 	.element-screenshot__mask {
@@ -432,18 +434,20 @@
 	}
 }
 
-.performance-profiler-insight-screenshot__overlay {
-	border-radius: 0;
-	max-height: initial;
+@media (min-width: $break-small) {
+	.performance-profiler-insight-screenshot__overlay {
+		border-radius: 0;
+		max-height: initial;
 
-	.components-modal__content {
-		padding: 0;
-		margin-top: 0;
-	}
+		.components-modal__content {
+			padding: 0;
+			margin-top: 0;
+		}
 
-	.components-modal__header {
-		button {
-			filter: invert(100%) contrast(130%);
+		.components-modal__header {
+			button {
+				filter: invert(100%) contrast(130%);
+			}
 		}
 	}
 }

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -286,46 +286,6 @@
 				width: 100%;
 				overflow-x: auto;
 
-				.element-screenshot__overlay {
-					position: fixed;
-					top: 0;
-					left: 0;
-					right: 0;
-					bottom: 0;
-					z-index: 2000;
-					background: rgba(0, 0, 0, 0.3);
-					display: flex;
-					align-items: center;
-					justify-content: center;
-					cursor: zoom-out;
-				}
-
-				.element-screenshot {
-
-					.element-screenshot__image {
-						position: relative;
-						cursor: zoom-in;
-						overflow: hidden;
-					}
-
-					.element-screenshot__mask {
-						position: absolute;
-						background-color: var(--studio-gray-60);
-						opacity: 0.8;
-
-						svg {
-							width: 0;
-							height: 0;
-						}
-					}
-
-					.element-screenshot__element-marker {
-						position: absolute;
-						border: 2px solid var(--studio-yellow-20);
-						box-sizing: border-box;
-					}
-				}
-
 				table {
 					table-layout: auto;
 					width: 100%;
@@ -445,3 +405,30 @@
 		}
 	}
 }
+
+.element-screenshot {
+
+	.element-screenshot__image {
+		position: relative;
+		cursor: zoom-in;
+		overflow: hidden;
+	}
+
+	.element-screenshot__mask {
+		position: absolute;
+		background-color: var(--studio-gray-60);
+		opacity: 0.8;
+
+		svg {
+			width: 0;
+			height: 0;
+		}
+	}
+
+	.element-screenshot__element-marker {
+		position: absolute;
+		border: 2px solid var(--studio-yellow-20);
+		box-sizing: border-box;
+	}
+}
+

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -432,3 +432,19 @@
 	}
 }
 
+.performance-profiler-insight-screenshot__overlay {
+	border-radius: 0;
+	max-height: initial;
+
+	.components-modal__content {
+		padding: 0;
+		margin-top: 0;
+	}
+
+	.components-modal__header {
+		button {
+			filter: invert(100%) contrast(130%);
+		}
+	}
+}
+

--- a/client/performance-profiler/components/metrics-insight/insight-screenshot.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-screenshot.tsx
@@ -7,6 +7,8 @@
  *   2. Display coords (DC suffix): that match the CSS pixel coordinate space of the LH report's page.
  */
 
+import { Modal } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 
 type Size = {
@@ -202,6 +204,7 @@ export const InsightScreenshotWithOverlay = ( {
 	elementRectSC,
 	maxRenderSizeDC,
 }: InsightScreenshotProps ) => {
+	const { __ } = useI18n();
 	const [ overlayOpen, setOverlayOpen ] = useState( false );
 
 	const maxLightboxSize = {
@@ -212,10 +215,9 @@ export const InsightScreenshotWithOverlay = ( {
 	return (
 		<>
 			{ overlayOpen && (
-				<div
-					className="element-screenshot__overlay"
-					onClick={ () => setOverlayOpen( false ) }
-					aria-hidden="true"
+				<Modal
+					onRequestClose={ () => setOverlayOpen( false ) }
+					contentLabel={ __( 'Image preview' ) }
 				>
 					<InsightScreenshot
 						nodeId={ nodeId + '-overlay' }
@@ -223,7 +225,7 @@ export const InsightScreenshotWithOverlay = ( {
 						elementRectSC={ elementRectSC }
 						maxRenderSizeDC={ maxLightboxSize }
 					/>
-				</div>
+				</Modal>
 			) }
 			<InsightScreenshot
 				onClick={ () => setOverlayOpen( true ) }

--- a/client/performance-profiler/components/metrics-insight/insight-screenshot.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-screenshot.tsx
@@ -218,6 +218,7 @@ export const InsightScreenshotWithOverlay = ( {
 				<Modal
 					onRequestClose={ () => setOverlayOpen( false ) }
 					contentLabel={ __( 'Image preview' ) }
+					className="performance-profiler-insight-screenshot__overlay"
 				>
 					<InsightScreenshot
 						nodeId={ nodeId + '-overlay' }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9245

## Proposed Changes

The screenshots in the insight section used a bespoke modal component which doesn't handle the escape key and z-ordering correctly. Especially when embedded in the sites dashboard.

Switching to the <Modal> component from Gutenberg addresses the a11y issues, although it also changes the visual style. It doesn't look like GB components are used very much in the Performance Profiler, and I don't know if that was an intentional design decision or not. Would be good to get input from @matt-west on that.

I've also adjusted the CSS so it no longer depends on the DOM being embedded deep within the performance profiler. This is how the GB modal gets around the z-index issues.

I think there's nothing wrong with having our modal look a little different from the UI that Google uses. It's good for the modal to be consistent with our other modals IMO. But if we're trying to match the existing styles then there's things we can do with the `__experimentalHideHeader` prop to match the old look.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When embedded in the sites dashboard the modal overlay doesn't fill the whole screen, and the menu bars open overtop of it.

![before](https://github.com/user-attachments/assets/a9a2b41a-75b5-4e4c-9f9e-76b3251d05d6)

There's also an issue with keyboard controls. I habitually pressed Escape during testing, and rather than closing the modal it took me right out of the performance tab and closed the sites dashboard flyout. Which is quite disorienting.

The fixed version looks like this.


https://github.com/user-attachments/assets/99c46f01-5d63-4581-9156-d44a70f7d23a





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test a site using the logged-in performance profiler
   * `http://calypso.localhost:3000/sites/performance/$siteSlug`
   * The site needs an insight like "Properly size images" that contains images that will open in a modal when clicked
   * Expand the insight and wait for AI to load
   * Click on one screenshot
   * The rectangle highlighting the problematic image should be positioned correctly.
   * Escape closes the modal
* Perform the same tests using the logged-out performance profiler
   * `http://calypso.localhost:3000/speed-test-tool?url=$siteUrl`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
