### PR TITLE
Logged-in Performance Profiler: Fix borders

### DIFF
--- a/client/hosting/performance/style.scss
+++ b/client/hosting/performance/style.scss
@@ -20,6 +20,7 @@ $section-max-width: 1224px;
 
 	.performance-profiler-content .container {
 		padding-top: 0;
+		gap: 16px;
 
 		@media (max-width: $break-medium) {
 			padding-top: 24px;

--- a/client/performance-profiler/components/core-web-vitals-accordion/styles-v2.scss
+++ b/client/performance-profiler/components/core-web-vitals-accordion/styles-v2.scss
@@ -46,6 +46,7 @@ $blueberry-color: #3858e9;
 
 			&:not(.is-expanded) {
 				border-bottom: 1px solid var(--studio-gray-5);
+
 				&:not(:nth-child(-n+2)) {
 					border-top: none;
 				}
@@ -59,6 +60,10 @@ $blueberry-color: #3858e9;
 					font-size: 1rem;
 					font-weight: 500;
 				}
+			}
+
+			&.is-expanded:not(:nth-child(-n+2)) {
+				border-top: none;
 			}
 		}
 		.core-web-vitals-display__details {

--- a/client/performance-profiler/components/core-web-vitals-accordion/styles-v2.scss
+++ b/client/performance-profiler/components/core-web-vitals-accordion/styles-v2.scss
@@ -107,6 +107,10 @@ $blueberry-color: #3858e9;
 	flex-basis: 100%;
 }
 
+.core-web-vitals-accordion-v2__header-text-name {
+	font-weight: 500;
+}
+
 .core-web-vitals-accordion-v2__header-text-value {
 
 	font-family: $font-sf-pro-display;

--- a/client/performance-profiler/components/core-web-vitals-display/style.scss
+++ b/client/performance-profiler/components/core-web-vitals-display/style.scss
@@ -41,7 +41,7 @@ $blueberry-color: #3858e9;
 }
 
 .core-web-vitals-display__details {
-	border: 1.5px solid var(--studio-gray-5);
+	border: 1px solid var(--studio-gray-5);
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 0 0 6px 6px;
 	padding: 24px;
@@ -50,7 +50,7 @@ $blueberry-color: #3858e9;
 	column-gap: 48px;
 	min-height: 360px;
 	flex-wrap: wrap;
-	margin-top: -1.5px;
+	margin-top: -1px;
 
 	& > div {
 		flex-grow: 1;

--- a/client/performance-profiler/components/core-web-vitals-display/style.scss
+++ b/client/performance-profiler/components/core-web-vitals-display/style.scss
@@ -167,7 +167,7 @@ $blueberry-color: #3858e9;
 		min-height: 80px;
 	}
 
-	@media (max-width: $break-mobile) {
+	@media (max-width: $break-large) {
 		border: 0;
 		padding-top: 0;
 	}

--- a/client/performance-profiler/components/core-web-vitals-display/style.scss
+++ b/client/performance-profiler/components/core-web-vitals-display/style.scss
@@ -146,7 +146,7 @@ $blueberry-color: #3858e9;
 }
 
 .core-web-vitals-display__details-v2 {
-	border: 1.5px solid var(--studio-gray-5);
+	border: 1px solid var(--studio-gray-5);
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 6px;
 	padding: 24px;
@@ -155,7 +155,6 @@ $blueberry-color: #3858e9;
 	column-gap: 32px;
 	min-height: 360px;
 	flex-wrap: wrap;
-	margin-top: -1.5px;
 	flex-grow: 1;
 
 	& > div {

--- a/client/performance-profiler/components/dashboard-content/style.scss
+++ b/client/performance-profiler/components/dashboard-content/style.scss
@@ -7,6 +7,6 @@
 		padding-top: 40px;
 		flex-direction: column;
 		align-items: flex-start;
-		gap: 48px;
+		gap: 16px;
 	}
 }

--- a/client/performance-profiler/components/dashboard-content/style.scss
+++ b/client/performance-profiler/components/dashboard-content/style.scss
@@ -7,6 +7,6 @@
 		padding-top: 40px;
 		flex-direction: column;
 		align-items: flex-start;
-		gap: 16px;
+		gap: 32px;
 	}
 }

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -1,10 +1,13 @@
+@import "@automattic/color-studio/dist/color-variables";
 @import "@wordpress/base-styles/breakpoints";
-
-$blueberry-color: #3858e9;
 
 .performance-profiler-insights-section {
 	width: 100%;
+	box-sizing: border-box;
 	scroll-margin-top: 80px;
+	border: 1px solid var(--studio-gray-5);
+	padding: 24px;
+	border-radius: 4px;
 
 	.header {
 		display: flex;
@@ -16,7 +19,7 @@ $blueberry-color: #3858e9;
 	}
 
 	.title {
-		font-size: $font-title-small;
+		font-size: 1rem;
 		font-weight: 500;
 		margin-bottom: 8px;
 	}
@@ -236,15 +239,15 @@ $blueberry-color: #3858e9;
 
 					button.is-primary {
 						color: #fff;
-						background-color: $blueberry-color;
+						background-color: $studio-wordpress-blue-50;
 						border-radius: 4px;
 
 						&:hover:not(:disabled) {
-							background-color: darken($blueberry-color, 10%);
+							background-color: darken($studio-wordpress-blue-50, 10%);
 						}
 
 						&:focus:not(:disabled) {
-							background-color: darken($blueberry-color, 10%);
+							background-color: darken($studio-wordpress-blue-50, 10%);
 							box-shadow: none;
 						}
 					}
@@ -255,8 +258,8 @@ $blueberry-color: #3858e9;
 
 					textarea:focus,
 					textarea:focus-visible {
-						border-color: $blueberry-color;
-						box-shadow: 0 0 0 calc(1.5px - 1px)  $blueberry-color;
+						border-color: $studio-wordpress-blue-50;
+						box-shadow: 0 0 0 calc(1.5px - 1px)  $studio-wordpress-blue-50;
 					}
 				}
 
@@ -350,7 +353,7 @@ $blueberry-color: #3858e9;
 					}
 
 					code {
-						color: $blueberry-color;
+						color: $studio-wordpress-blue-50;
 					}
 
 					.score {

--- a/client/performance-profiler/components/metric-tab-bar/style.scss
+++ b/client/performance-profiler/components/metric-tab-bar/style.scss
@@ -18,14 +18,14 @@ $blueberry-color: #3858e9;
 	gap: 6px;
 	padding: 12px 16px;
 	background: var(--studio-white);
-	border: 1.5px solid var(--studio-white);
+	border: 1px solid var(--studio-white);
 	text-align: initial;
 	flex-grow: 1;
 
 	&.active {
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 6px 6px 0 0;
-		border: 1.5px solid var(--studio-gray-5);
+		border: 1px solid var(--studio-gray-5);
 		border-bottom: none;
 		position: relative;
 

--- a/client/performance-profiler/components/metric-tab-bar/style_v2.scss
+++ b/client/performance-profiler/components/metric-tab-bar/style_v2.scss
@@ -19,7 +19,7 @@ $blueberry-color: #3858e9;
 	display: flex;
 	gap: 6px;
 	background: var(--studio-white);
-	border: 1.5px solid var(--studio-gray-5);
+	border: 1px solid var(--studio-gray-5);
 	text-align: initial;
 	flex-grow: 1;
 	padding: 16px 22px 16px 22px;

--- a/client/performance-profiler/components/metric-tab-bar/style_v2.scss
+++ b/client/performance-profiler/components/metric-tab-bar/style_v2.scss
@@ -27,14 +27,15 @@ $blueberry-color: #3858e9;
 	&:not(.active) {
 		border-bottom: 1px solid var(--studio-gray-5);
 		&:not(:nth-child(-n+2)) {
-			border-top: none;
+			border-top-color: transparent;
 		}
 	}
 
 	&.active {
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 6px;
-		border: 1.5px solid $blueberry-color;
+		border-color: transparent;
+		outline: 1.5px solid $blueberry-color;
 		position: relative;
 
 		&::before {

--- a/client/performance-profiler/components/screenshot-timeline.tsx
+++ b/client/performance-profiler/components/screenshot-timeline.tsx
@@ -4,6 +4,9 @@ import { ScreenShotsTimeLine } from 'calypso/data/site-profiler/types';
 
 const Container = styled.div`
 	max-width: 100%;
+	border: 1px solid var( --studio-gray-5 );
+	padding: 24px;
+	border-radius: 4px;
 `;
 
 const Timeline = styled.div`
@@ -17,7 +20,8 @@ const Timeline = styled.div`
 
 const H2 = styled.h2`
 	font-weight: 500;
-	font-size: 1.25rem;
+	font-size: 1rem;
+	margin-bottom: 8px;
 `;
 
 const Thumbnail = styled.img`

--- a/client/performance-profiler/components/screenshot-timeline.tsx
+++ b/client/performance-profiler/components/screenshot-timeline.tsx
@@ -3,13 +3,16 @@ import { translate } from 'i18n-calypso';
 import { ScreenShotsTimeLine } from 'calypso/data/site-profiler/types';
 
 const Container = styled.div`
-	max-width: 100%;
+	width: 100%;
+	box-sizing: border-box;
 	border: 1px solid var( --studio-gray-5 );
 	padding: 24px;
 	border-radius: 4px;
+	overflow: hidden;
 `;
 
 const Timeline = styled.div`
+	width: 100%;
 	display: flex;
 	flex-direction: row;
 	gap: 1.5rem;
@@ -31,6 +34,12 @@ const Thumbnail = styled.img`
 	min-width: 60px;
 `;
 
+const Tick = styled.p`
+	margin: 6px 0 0;
+	color: var( --studio-gray-80 );
+	font-size: 0.875rem;
+`;
+
 type Props = { screenshots: ScreenShotsTimeLine[] };
 
 export const ScreenshotTimeline = ( { screenshots }: Props ) => {
@@ -48,7 +57,7 @@ export const ScreenshotTimeline = ( { screenshots }: Props ) => {
 					return (
 						<div key={ index }>
 							<Thumbnail alt={ timing } src={ screenshot.data } />
-							<p>{ timing }</p>
+							<Tick>{ timing }</Tick>
 						</div>
 					);
 				} ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9246

## Proposed Changes

* Fixed border width on metrics container.
* Fixed border issues causing the UI to jump when switching tabs.
* Removed duplicate border from showing when the layout switches to an accordion for mobile.
* Added borders to Timeline and Recommendations sections. (This applies to both logged-in and logged-out versions.)
* [Drive-by fix] Adjusted sizing on labels in the Timeline section.

| Logged-in | Logged-out |
|--------|--------|
| <img width="1195" alt="Screenshot 2024-09-25 at 11 37 55" src="https://github.com/user-attachments/assets/55ab964f-ecd7-4f60-a1d1-19c132399fb9"><img width="1205" alt="Screenshot 2024-09-25 at 11 38 09" src="https://github.com/user-attachments/assets/4894270a-45a4-42a8-ae50-9def75049d3f"> | ![Screenshot 2024-09-25 at 11 39 48](https://github.com/user-attachments/assets/372cdd0e-8325-422c-baed-79eb132f2737) | 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that the end product matches the designs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Logged-in version**

* Go to `/site`
* Select a public site
* Switch to the Performance tab
* Check that the container borders look correct on both desktop and mobile

**Logged-out version**

* Go to `/speed-test-tool?url=https%3A%2F%2Fmattwest.design%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ODE1NX0.hOTsWgFpLNf13HBWXhkrT5J90bqPuyfdshF9dLmpILA&filter=all`
* Check that the spacing between the sections are even
* Check that the contains have borders on mobile and desktop