### PR TITLE
Performance Profiler: Hide Migration banner for WPCOM sites

### DIFF
--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -115,7 +115,7 @@ export const PerformanceProfilerDashboardContent = ( {
 			</div>
 
 			<Disclaimer />
-			{ displayMigrationBanner && (
+			{ displayMigrationBanner && ! is_wpcom && (
 				<MigrationBanner
 					url={ url }
 					onClick={ () => {

--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -115,7 +115,7 @@ export const PerformanceProfilerDashboardContent = ( {
 			</div>
 
 			<Disclaimer />
-			{ displayMigrationBanner && ! is_wpcom && (
+			{ displayMigrationBanner && (
 				<MigrationBanner
 					url={ url }
 					onClick={ () => {

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -147,6 +147,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 							url={ finalUrl ?? url }
 							hash={ hash }
 							filter={ filter }
+							displayMigrationBanner={ ! performanceReport?.is_wpcom }
 						/>
 					) }
 				</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Further context p1727256618484139/1727255345.890389-slack-C02JPCHEKDY

## Proposed Changes

* Hide the Migration banner for WordPress.com hosted sites

|Before for WordPress.com sites | After for WordPress.com sites| Non WordPress.com sites |
|-------|------|------|
|![CleanShot 2024-09-25 at 10 58 55@2x](https://github.com/user-attachments/assets/0739c5b8-5819-4f7d-9688-7c90f7329d77) | ![CleanShot 2024-09-25 at 12 42 12@2x](https://github.com/user-attachments/assets/834bb0aa-694d-4e63-88d9-cedda5957761)| ![CleanShot 2024-09-25 at 12 44 20@2x](https://github.com/user-attachments/assets/8bd71416-5e8d-4c43-9818-09738b4aab93) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Migration banner does not make sense if the sites are already hosted in WP.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this changes and test with a site hosted in WordPress.com, e.g. `/speed-test-tool?hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzA3MX0.m3-63iGZmpJOpOfkZ4ww184EoKd8P3UHzTYwv1VLQUo&url=https%3A%2F%2Fwordpress.com%2F&tab=mobile`
* Check the migration banner is not displayed
* Repeat with a site not hosted on WP.com, e.g. `/speed-test-tool?url=https%3A%2F%2Felblogdeepeicher.godaddysites.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ODE2MX0.OklGE6SqBbc7_VlNMxBGJzVPaGr9UW61Au-BiQQheq4&tab=desktop`
* Confirm the migration banner is correctly displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?