### PR TITLE
A4A Dev Sites: Fix an issues with redirecting to creating A4A dev site, after entering credit card info

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg } from '@wordpress/url';
@@ -12,7 +11,6 @@ import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-co
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
 import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-
 import './style.scss';
 
 type Props = {
@@ -34,15 +32,16 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 
 	const onCreateSiteSuccess = useSiteCreatedCallback( refetchRandomSiteName );
 
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
-
-	const addNewDevSite = getQueryArg( window.location.href, 'add_new_dev_site' );
-
+	const shouldAutoOpenDevSiteConfigModal = getQueryArg( window.location.href, 'add_new_dev_site' );
 	useEffect( () => {
-		if ( devSitesEnabled && addNewDevSite ) {
+		if ( shouldAutoOpenDevSiteConfigModal && ! showConfigurationModal ) {
 			toggleDevSiteConfigurationsModal?.();
 		}
-	}, [ addNewDevSite, devSitesEnabled, toggleDevSiteConfigurationsModal ] );
+	}, [
+		shouldAutoOpenDevSiteConfigModal,
+		showConfigurationModal,
+		toggleDevSiteConfigurationsModal,
+	] );
 
 	return (
 		<div className="sites-header__actions">

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
@@ -24,24 +24,19 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 	const { randomSiteName, isRandomSiteNameLoading, refetchRandomSiteName } = useRandomSiteName();
 
 	const [ tourStepRef, setTourStepRef ] = useState< HTMLElement | null >( null );
-	const [ showConfigurationModal, setShowConfigurationModal ] = useState( false );
+
+	const shouldAutoOpenDevSiteConfigModal = Boolean(
+		getQueryArg( window.location.href, 'add_new_dev_site' )
+	);
+	const [ showConfigurationModal, setShowConfigurationModal ] = useState(
+		shouldAutoOpenDevSiteConfigModal
+	);
 
 	const toggleDevSiteConfigurationsModal = useCallback( () => {
 		setShowConfigurationModal( ! showConfigurationModal );
 	}, [ showConfigurationModal ] );
 
 	const onCreateSiteSuccess = useSiteCreatedCallback( refetchRandomSiteName );
-
-	const shouldAutoOpenDevSiteConfigModal = getQueryArg( window.location.href, 'add_new_dev_site' );
-	useEffect( () => {
-		if ( shouldAutoOpenDevSiteConfigModal && ! showConfigurationModal ) {
-			toggleDevSiteConfigurationsModal?.();
-		}
-	}, [
-		shouldAutoOpenDevSiteConfigModal,
-		showConfigurationModal,
-		toggleDevSiteConfigurationsModal,
-	] );
 
 	return (
 		<div className="sites-header__actions">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9252

## Proposed Changes

* When expecting to auto-open the development site confiugration modal on component load (based on a URL arg), we need to first check that the `showConfigurationModal` state is not already `true`, before we toggle the state. Otherwise we end up with an inifinite state update loop, resulting in `Maximum update depth exceeded` error.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow the testing instructions from the following PR: https://github.com/Automattic/wp-calypso/pull/93354.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
