### PR TITLE
Calypso UI Components: DateRange Component: fix overlay coverage

### DIFF
--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -60,7 +60,8 @@ $date-range-mobile-layout-switch: $break-small;
 		.date-range__controls,
 		.date-range__date-inputs,
 		.date-range__picker,
-		.date-range__popover-header {
+		.date-range__popover-header,
+		.date-range__popover-footer {
 			filter: blur(10px);
 			z-index: 0;
 		}
@@ -104,7 +105,7 @@ $date-range-mobile-layout-switch: $break-small;
 }
 
 .date-range__popover-footer {
-	order: 4;
+	order: 3;
 	display: flex;
 	justify-content: flex-end;
 	padding: 10px 0 0;

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -105,7 +105,7 @@ $date-range-mobile-layout-switch: $break-small;
 }
 
 .date-range__popover-footer {
-	order: 3;
+	order: 4;
 	display: flex;
 	justify-content: flex-end;
 	padding: 10px 0 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* fixes the overlay to cover the footer buttons

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* part of the date control update

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the calypso live branch
* navigate to `/devdocs/design/date-range`
* open the daterange picker `With Overlay Enabled`
* check that the buttons are covered by the blurred out overlay now

![image](https://github.com/user-attachments/assets/f0af99ee-4ce5-40d4-bf3d-7c1995107960)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
