### PR TITLE
Stats: DateRange Component: fix custom date range always selected

### DIFF
--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -11,6 +11,8 @@ const DATERANGE_PERIOD = {
 	MONTH: 'month',
 };
 
+type MomentOrNull = Moment | null;
+
 const DateRangePickerShortcuts = ( {
 	currentShortcut,
 	onClick,
@@ -21,10 +23,18 @@ const DateRangePickerShortcuts = ( {
 	currentShortcut?: string;
 	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment, shortcutId: string ) => void;
 	locked?: boolean;
-	startDate?: Moment;
-	endDate?: Moment;
+	startDate?: MomentOrNull;
+	endDate?: MomentOrNull;
 } ) => {
 	const translate = useTranslate();
+
+	const normalizeDate = ( date: MomentOrNull ) => {
+		return date ? date.startOf( 'day' ) : date;
+	};
+
+	// Normalize dates to start of day
+	const normalizedStartDate = startDate ? normalizeDate( startDate ) : null;
+	const normalizedEndDate = endDate ? normalizeDate( endDate ) : null;
 
 	const shortcutList = [
 		{
@@ -69,12 +79,14 @@ const DateRangePickerShortcuts = ( {
 		},
 	];
 
-	const getShortcutForRange = ( startDate: Moment, endDate: Moment ) => {
+	const getShortcutForRange = ( startDate: MomentOrNull, endDate: MomentOrNull ) => {
+		if ( ! startDate || ! endDate ) {
+			return null;
+		}
 		// Search the shortcut array for something matching the current date range.
 		// Returns shortcut or null;
 		const today = moment().startOf( 'day' );
 		const daysInRange = Math.abs( endDate.diff( startDate, 'days' ) );
-
 		const shortcut = shortcutList.find( ( element ) => {
 			if ( endDate.isSame( today ) && daysInRange === element.range ) {
 				return element;
@@ -85,15 +97,16 @@ const DateRangePickerShortcuts = ( {
 	};
 
 	const handleClick = ( { id, offset, range }: { id?: string; offset: number; range: number } ) => {
-		const newToDate = moment().subtract( offset, 'days' );
-		const newFromDate = moment().subtract( offset + range, 'days' );
-
+		const newToDate = moment().startOf( 'day' ).subtract( offset, 'days' );
+		const newFromDate = moment()
+			.startOf( 'day' )
+			.subtract( offset + range, 'days' );
 		onClick( newFromDate, newToDate, id || '' );
 	};
 
 	currentShortcut =
 		currentShortcut ||
-		( startDate && endDate && getShortcutForRange( startDate, endDate )?.id ) ||
+		getShortcutForRange( normalizedStartDate, normalizedEndDate )?.id ||
 		'custom_date_range';
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* fixes custom date range always selected issue
* normalizes the dates to the start of day

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* part of the date control update

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the calypso live branch
* navigate to `/stats/day/{site URL}`
* open the daterange picker on the traffic page
* check that when you select a different shortcut item, that the custom range does not remain highlighted or look selected in any way. 

https://github.com/user-attachments/assets/f0e1e878-1805-4273-a7dd-1ba7a41eeea1


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
