### PR TITLE
Updating Portfolio toggle description text for WoA sites

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/portfolios.jsx
+++ b/client/my-sites/site-settings/custom-content-types/portfolios.jsx
@@ -17,6 +17,25 @@ function Portfolios( {
 } ) {
 	const name = 'jetpack_portfolio';
 	const numberFieldIdentifier = name + '_posts_per_page';
+	const portfolioDescription = isAtomic
+		? translate(
+				'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
+					'you can display them using the shortcode [portfolio]. If your theme does support portfolio projects, portfolio projects will remain active regardless of toggle state.',
+				{
+					components: {
+						link: <InlineSupportLink supportContext="portfolios" />,
+					},
+				}
+		  )
+		: translate(
+				'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
+					'you can display them using the shortcode [portfolio].',
+				{
+					components: {
+						link: <InlineSupportLink supportContext="portfolios" />,
+					},
+				}
+		  );
 	return (
 		<FormFieldset>
 			<SupportInfo
@@ -65,17 +84,7 @@ function Portfolios( {
 						},
 					} ) }
 				</div>
-				<FormSettingExplanation isIndented>
-					{ translate(
-						'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
-							'you can display them using the shortcode [portfolio].',
-						{
-							components: {
-								link: <InlineSupportLink supportContext="portfolios" />,
-							},
-						}
-					) }
-				</FormSettingExplanation>
+				<FormSettingExplanation isIndented>{ portfolioDescription }</FormSettingExplanation>
 			</div>
 		</FormFieldset>
 	);

--- a/client/my-sites/site-settings/custom-content-types/portfolios.jsx
+++ b/client/my-sites/site-settings/custom-content-types/portfolios.jsx
@@ -20,7 +20,7 @@ function Portfolios( {
 	const portfolioDescription = isAtomic
 		? translate(
 				'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
-					'you can display them using the shortcode [portfolio]. If your theme does support portfolio projects, portfolio projects will remain active regardless of toggle state.',
+					'you can display them using the shortcode [portfolio]. If your theme does support portfolio projects, these will remain active regardless of toggle state.',
 				{
 					components: {
 						link: <InlineSupportLink supportContext="portfolios" />,


### PR DESCRIPTION
Related to https://github.com/Automattic/vulcan/issues/532

## Proposed Changes

* This PR adds additional text to the Portfolio toggle description, on the `wordpress.com/settings/writing/` page. 

## Why are these changes being made?

* This is designed to explain why the toggle will not have an affect on WoA sites who use themes that support Jetpack Portfolios (as this will be active regardless, a change made in this PR to prevent toggle issues https://github.com/Automattic/jetpack/pull/39431).

## Testing Instructions


* The best way to test would be to use the Calypso Live link provided in the generated comment below. Using that, visit the following page, replacing the container-live URL if necessary, and replacing the URL at the end with that of a WoA test site: `https://container-mystifying-euler.calypso.live/settings/writing/example-woa-site.com`. You should see the additional text underneath the Portfolio toggle.
* Test by replacing the URL with a Simple site URL, and self-hosted site URL - there should be no additional text.

Screenshot showing additional text:
<img width="720" alt="Screenshot 2024-09-25 at 14 17 24" src="https://github.com/user-attachments/assets/caa77eb9-dd5d-42dd-9b6a-b45a79216f31">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
