### PR TITLE
Remove plan: Skip survey

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -19,7 +19,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { isAgencyPartnerType, isPartnerPurchase, isRefundable } from 'calypso/lib/purchases';
-import { cancelPurchaseSurveyTaken, submitSurvey } from 'calypso/lib/purchases/actions';
+import { cancelPurchaseSurveyCompleted, submitSurvey } from 'calypso/lib/purchases/actions';
 import wpcom from 'calypso/lib/wp';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -283,7 +283,7 @@ class CancelPurchaseForm extends Component {
 					} );
 				} );
 
-			this.props.cancelPurchaseSurveyTaken( purchase.id );
+			this.props.cancelPurchaseSurveyCompleted( purchase.id );
 		}
 
 		this.props.onClickFinalConfirm();
@@ -858,7 +858,7 @@ const ConnectedCancelPurchaseForm = connect(
 		hasBackupsFeature: siteHasFeature( state, purchase.siteId, WPCOM_FEATURES_BACKUPS ),
 	} ),
 	{
-		cancelPurchaseSurveyTaken,
+		cancelPurchaseSurveyCompleted,
 		fetchAtomicTransfer,
 		recordTracksEvent,
 		submitSurvey,

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -48,7 +48,13 @@ import EducationContentStep from './step-components/educational-content-step';
 import FeedbackStep from './step-components/feedback-step';
 import NextAdventureStep from './step-components/next-adventure-step';
 import UpsellStep from './step-components/upsell-step';
-import { ATOMIC_REVERT_STEP, FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP } from './steps';
+import {
+	ATOMIC_REVERT_STEP,
+	FEEDBACK_STEP,
+	UPSELL_STEP,
+	NEXT_ADVENTURE_STEP,
+	REMOVE_PLAN_STEP,
+} from './steps';
 
 import './style.scss';
 
@@ -96,6 +102,10 @@ class CancelPurchaseForm extends Component {
 
 		if ( willAtomicSiteRevert ) {
 			steps.push( ATOMIC_REVERT_STEP );
+		}
+
+		if ( skipSurvey && steps.length === 0 ) {
+			steps.push( REMOVE_PLAN_STEP );
 		}
 
 		return steps;
@@ -335,6 +345,7 @@ class CancelPurchaseForm extends Component {
 			flowType,
 		} = this.props;
 		const { atomicRevertCheckOne, atomicRevertCheckTwo, surveyStep, upsell } = this.state;
+		const { productName } = purchase;
 
 		if ( surveyStep === FEEDBACK_STEP ) {
 			return (
@@ -515,6 +526,48 @@ class CancelPurchaseForm extends Component {
 							</ExternalLink>
 						</div>
 					) }
+				</div>
+			);
+		}
+
+		if ( surveyStep === REMOVE_PLAN_STEP ) {
+			return (
+				<div className="cancel-purchase-form__remove-plan">
+					<FormattedHeader
+						brandFont
+						headerText={ translate( 'Sorry to see you go' ) }
+						subHeaderText={
+							<>
+								<span className="cancel-purchase-form__remove-plan-text">
+									{
+										// Translators: %(planName)s: name of the plan being canceled, eg: "WordPress.com Business"
+										translate(
+											'If you remove your subscription, you will lose access to the features of the %(planName)s plan.',
+											{
+												args: {
+													planName: productName,
+												},
+											}
+										)
+									}
+								</span>
+								<span className="cancel-purchase-form__remove-plan-text">
+									{
+										// Translators: %(planName)s: name of the plan being canceled, eg: "WordPress.com Business". %(purchaseRenewalDate)s: date when the plan will expire, eg: "January 1, 2022"
+										translate(
+											'If you keep your subscription, you will be able to continue using your %(planName)s plan features until %(purchaseRenewalDate)s.',
+											{
+												args: {
+													planName: productName,
+													purchaseRenewalDate: moment( purchase.expiryDate ).format( 'LL' ),
+												},
+											}
+										)
+									}
+								</span>
+							</>
+						}
+					/>
 				</div>
 			);
 		}

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -675,19 +675,41 @@ class CancelPurchaseForm extends Component {
 			);
 		}
 
+		if ( surveyStep === REMOVE_PLAN_STEP ) {
+			return (
+				<>
+					<GutenbergButton
+						className="cancel-purchase-form__remove-plan-button"
+						isPrimary
+						isBusy={ isCancelling }
+						disabled={ ! this.canGoNext() }
+						onClick={ this.onSubmit }
+					>
+						{ this.getFinalActionText() }
+					</GutenbergButton>
+					<GutenbergButton
+						isSecondary
+						isBusy={ isCancelling }
+						disabled={ ! this.canGoNext() }
+						onClick={ this.closeDialog }
+					>
+						{ translate( 'Keep plan' ) }
+					</GutenbergButton>
+				</>
+			);
+		}
+
 		return (
-			<>
-				<GutenbergButton
-					isPrimary={ surveyStep !== UPSELL_STEP }
-					isSecondary={ surveyStep === UPSELL_STEP }
-					isDefault={ surveyStep !== UPSELL_STEP }
-					isBusy={ isCancelling }
-					disabled={ ! this.canGoNext() }
-					onClick={ this.onSubmit }
-				>
-					{ this.getFinalActionText() }
-				</GutenbergButton>
-			</>
+			<GutenbergButton
+				isPrimary={ surveyStep !== UPSELL_STEP }
+				isSecondary={ surveyStep === UPSELL_STEP }
+				isDefault={ surveyStep !== UPSELL_STEP }
+				isBusy={ isCancelling }
+				disabled={ ! this.canGoNext() }
+				onClick={ this.onSubmit }
+			>
+				{ this.getFinalActionText() }
+			</GutenbergButton>
 		);
 	};
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -19,7 +19,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { isAgencyPartnerType, isPartnerPurchase, isRefundable } from 'calypso/lib/purchases';
-import { submitSurvey } from 'calypso/lib/purchases/actions';
+import { cancelPurchaseSurveyTaken, submitSurvey } from 'calypso/lib/purchases/actions';
 import wpcom from 'calypso/lib/wp';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -282,6 +282,8 @@ class CancelPurchaseForm extends Component {
 						isSubmitting: false,
 					} );
 				} );
+
+			this.props.cancelPurchaseSurveyTaken( purchase.id );
 		}
 
 		this.props.onClickFinalConfirm();
@@ -856,6 +858,7 @@ const ConnectedCancelPurchaseForm = connect(
 		hasBackupsFeature: siteHasFeature( state, purchase.siteId, WPCOM_FEATURES_BACKUPS ),
 	} ),
 	{
+		cancelPurchaseSurveyTaken,
 		fetchAtomicTransfer,
 		recordTracksEvent,
 		submitSurvey,

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -555,11 +555,14 @@ class CancelPurchaseForm extends Component {
 									{
 										// Translators: %(planName)s: name of the plan being canceled, eg: "WordPress.com Business". %(purchaseRenewalDate)s: date when the plan will expire, eg: "January 1, 2022"
 										translate(
-											'If you keep your subscription, you will be able to continue using your %(planName)s plan features until %(purchaseRenewalDate)s.',
+											'If you keep your subscription, you will be able to continue using your %(planName)s plan features until {{strong}}%(purchaseRenewalDate)s{{/strong}}.',
 											{
 												args: {
 													planName: productName,
 													purchaseRenewalDate: moment( purchase.expiryDate ).format( 'LL' ),
+												},
+												components: {
+													strong: <strong className="is-highlighted" />,
 												},
 											}
 										)

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -85,12 +85,6 @@ class CancelPurchaseForm extends Component {
 			skipSurvey ||
 			( isPartnerPurchase( purchase ) && isAgencyPartnerType( purchase.partnerType ) )
 		) {
-			/**
-			 * We don't want to display the cancellation survey for sites purchased
-			 * through partners (e.g., A4A.)
-			 *
-			 * Let's jump right to the confirmation step.
-			 */
 			steps = [];
 		} else if ( ! isPlan( purchase ) ) {
 			steps = [ NEXT_ADVENTURE_STEP ];

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -64,6 +64,7 @@ class CancelPurchaseForm extends Component {
 		cancelBundledDomain: PropTypes.bool,
 		includedDomainPurchase: PropTypes.object,
 		linkedPurchases: PropTypes.array,
+		skipSurvey: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -71,10 +72,13 @@ class CancelPurchaseForm extends Component {
 	};
 
 	getAllSurveySteps() {
-		const { willAtomicSiteRevert, purchase } = this.props;
+		const { purchase, skipSurvey, willAtomicSiteRevert } = this.props;
 		let steps = [ FEEDBACK_STEP ];
 
-		if ( isPartnerPurchase( purchase ) && isAgencyPartnerType( purchase.partnerType ) ) {
+		if (
+			skipSurvey ||
+			( isPartnerPurchase( purchase ) && isAgencyPartnerType( purchase.partnerType ) )
+		) {
 			/**
 			 * We don't want to display the cancellation survey for sites purchased
 			 * through partners (e.g., A4A.)

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -70,7 +70,7 @@ class CancelPurchaseForm extends Component {
 		cancelBundledDomain: PropTypes.bool,
 		includedDomainPurchase: PropTypes.object,
 		linkedPurchases: PropTypes.array,
-		skipSurvey: PropTypes.bool,
+		skipRemovePlanSurvey: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -78,11 +78,11 @@ class CancelPurchaseForm extends Component {
 	};
 
 	getAllSurveySteps() {
-		const { purchase, skipSurvey, willAtomicSiteRevert } = this.props;
+		const { purchase, skipRemovePlanSurvey, willAtomicSiteRevert } = this.props;
 		let steps = [ FEEDBACK_STEP ];
 
 		if (
-			skipSurvey ||
+			skipRemovePlanSurvey ||
 			( isPartnerPurchase( purchase ) && isAgencyPartnerType( purchase.partnerType ) )
 		) {
 			steps = [];
@@ -98,7 +98,7 @@ class CancelPurchaseForm extends Component {
 			steps.push( ATOMIC_REVERT_STEP );
 		}
 
-		if ( skipSurvey && steps.length === 0 ) {
+		if ( skipRemovePlanSurvey && steps.length === 0 ) {
 			steps.push( REMOVE_PLAN_STEP );
 		}
 

--- a/client/components/marketing-survey/cancel-purchase-form/steps.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps.js
@@ -4,3 +4,4 @@ export const FINAL_STEP = 'final_step';
 export const INITIAL_STEP = 'initial_step';
 export const UPSELL_STEP = 'upsell_step';
 export const NEXT_ADVENTURE_STEP = 'next_adventure_step';
+export const REMOVE_PLAN_STEP = 'remove_plan_step';

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -28,6 +28,11 @@
 	margin: 0 auto 2rem;
 }
 
+.cancel-purchase-form__remove-plan .formatted-header__subtitle {
+	max-width: 290px;
+	margin: 0 auto;
+}
+
 .cancel-purchase-form__feedback-questions {
 	max-width: 540px;
 	margin: 0 auto;
@@ -359,4 +364,8 @@
 	&:not(:last-child) {
 		margin-bottom: 1rem;
 	}
+}
+
+.cancel-purchase-form__remove-plan-button {
+	margin-right: 1rem;
 }

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -50,13 +50,6 @@
 		}
 	}
 
-	strong.is-highlighted {
-		background-color: var(--studio-yellow-5);
-		padding: 0.25rem 0.5rem;
-		border-radius: 5px; /* stylelint-disable-line scales/radii */
-		color: var(--stugio-gray-80);
-	}
-
 	.components-base-control__field {
 		background-color: var(--studio-white);
 		padding: 0.8125rem 1.25rem;
@@ -83,6 +76,16 @@
 			margin-top: auto;
 			margin-bottom: auto;
 		}
+	}
+}
+
+.cancel-purchase-form__atomic-revert,
+.cancel-purchase-form__remove-plan {
+	strong.is-highlighted {
+		background-color: var(--studio-yellow-5);
+		padding: 0.25rem 0.5rem;
+		border-radius: 5px; /* stylelint-disable-line scales/radii */
+		color: var(--stugio-gray-80);
 	}
 }
 

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -22,7 +22,8 @@
 }
 
 .cancel-purchase-form__feedback,
-.cancel-purchase-form__atomic-revert {
+.cancel-purchase-form__atomic-revert,
+.cancel-purchase-form__remove-plan {
 	max-width: 730px;
 	margin: 0 auto 2rem;
 }
@@ -346,5 +347,13 @@
 
 	li {
 		margin: 0.75rem 0;
+	}
+}
+
+.cancel-purchase-form__remove-plan-text {
+	display: block;
+
+	&:not(:last-child) {
+		margin-bottom: 1rem;
 	}
 }

--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -1,6 +1,8 @@
 import debugFactory from 'debug';
 import wpcom from 'calypso/lib/wp';
+import { getCancelPurchaseSurveyTakenPreferenceKey } from 'calypso/me/purchases/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
 
 const debug = debugFactory( 'calypso:purchases:actions' );
 
@@ -58,6 +60,10 @@ export const submitSurvey = ( surveyName, siteId, surveyData ) => ( dispatch ) =
 			}
 		} )
 		.catch( ( err ) => debug( err ) ); // shouldn't get here
+};
+
+export const cancelPurchaseSurveyTaken = ( purchaseId ) => ( dispatch ) => {
+	savePreference( getCancelPurchaseSurveyTakenPreferenceKey( purchaseId ), true )( dispatch );
 };
 
 export function disableAutoRenew( purchaseId, onComplete ) {

--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -1,6 +1,6 @@
 import debugFactory from 'debug';
 import wpcom from 'calypso/lib/wp';
-import { getCancelPurchaseSurveyTakenPreferenceKey } from 'calypso/me/purchases/utils';
+import { getCancelPurchaseSurveyCompletedPreferenceKey } from 'calypso/me/purchases/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 
@@ -62,8 +62,8 @@ export const submitSurvey = ( surveyName, siteId, surveyData ) => ( dispatch ) =
 		.catch( ( err ) => debug( err ) ); // shouldn't get here
 };
 
-export const cancelPurchaseSurveyTaken = ( purchaseId ) => ( dispatch ) => {
-	savePreference( getCancelPurchaseSurveyTakenPreferenceKey( purchaseId ), true )( dispatch );
+export const cancelPurchaseSurveyCompleted = ( purchaseId ) => ( dispatch ) => {
+	savePreference( getCancelPurchaseSurveyCompletedPreferenceKey( purchaseId ), true )( dispatch );
 };
 
 export function disableAutoRenew( purchaseId, onComplete ) {

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -146,7 +146,7 @@ import {
 	isJetpackTemporarySitePurchase,
 	isAkismetTemporarySitePurchase,
 	isMarketplaceTemporarySitePurchase,
-	getCancelPurchaseSurveyTakenPreferenceKey,
+	getCancelPurchaseSurveyCompletedPreferenceKey,
 } from '../utils';
 import PurchaseNotice from './notices';
 import PurchasePlanDetails from './plan-details';
@@ -187,7 +187,7 @@ export interface ManagePurchaseConnectedProps {
 	hasLoadedDomains?: boolean;
 	hasLoadedPurchasesFromServer: boolean;
 	hasLoadedSites: boolean;
-	hasTakenCancelPurchaseSurvey: boolean | null;
+	hasCompletedCancelPurchaseSurvey: boolean | null;
 	hasNonPrimaryDomainsFlag?: boolean;
 	hasSetupAds?: boolean;
 	isAtomicSite?: boolean | null;
@@ -646,7 +646,7 @@ class ManagePurchase extends Component<
 			hasLoadedSites,
 			hasNonPrimaryDomainsFlag,
 			hasCustomPrimaryDomain,
-			hasTakenCancelPurchaseSurvey,
+			hasCompletedCancelPurchaseSurvey,
 			site,
 			purchase,
 			purchaseListUrl,
@@ -681,7 +681,7 @@ class ManagePurchase extends Component<
 				purchase={ purchase }
 				purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
 				linkIcon="chevron-right"
-				skipRemovePlanSurvey={ isPlanPurchase && hasTakenCancelPurchaseSurvey }
+				skipRemovePlanSurvey={ isPlanPurchase && hasCompletedCancelPurchaseSurvey }
 			>
 				<MaterialIcon icon="delete" className="card__icon" />
 				{ text }
@@ -1631,9 +1631,9 @@ export default connect( ( state: IAppState, props: ManagePurchaseProps ) => {
 		hasSetupAds: Boolean(
 			site?.options?.wordads || isRequestingWordAdsApprovalForSite( state, site )
 		),
-		hasTakenCancelPurchaseSurvey: getPreference(
+		hasCompletedCancelPurchaseSurvey: getPreference(
 			state,
-			getCancelPurchaseSurveyTakenPreferenceKey( purchase?.id )
+			getCancelPurchaseSurveyCompletedPreferenceKey( purchase?.id )
 		),
 		isAtomicSite: isSiteAtomic( state, siteId ),
 		isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -676,6 +676,7 @@ class ManagePurchase extends Component<
 				purchase={ purchase }
 				purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
 				linkIcon="chevron-right"
+				skipSurvey
 			>
 				<MaterialIcon icon="delete" className="card__icon" />
 				{ text }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -116,6 +116,7 @@ import {
 	getCurrentUserId,
 } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import {
 	getSitePurchases,
@@ -145,6 +146,7 @@ import {
 	isJetpackTemporarySitePurchase,
 	isAkismetTemporarySitePurchase,
 	isMarketplaceTemporarySitePurchase,
+	getCancelPurchaseSurveyTakenPreferenceKey,
 } from '../utils';
 import PurchaseNotice from './notices';
 import PurchasePlanDetails from './plan-details';
@@ -185,6 +187,7 @@ export interface ManagePurchaseConnectedProps {
 	hasLoadedDomains?: boolean;
 	hasLoadedPurchasesFromServer: boolean;
 	hasLoadedSites: boolean;
+	hasTakenCancelPurchaseSurvey: boolean | null;
 	hasNonPrimaryDomainsFlag?: boolean;
 	hasSetupAds?: boolean;
 	isAtomicSite?: boolean | null;
@@ -643,6 +646,7 @@ class ManagePurchase extends Component<
 			hasLoadedSites,
 			hasNonPrimaryDomainsFlag,
 			hasCustomPrimaryDomain,
+			hasTakenCancelPurchaseSurvey,
 			site,
 			purchase,
 			purchaseListUrl,
@@ -677,7 +681,7 @@ class ManagePurchase extends Component<
 				purchase={ purchase }
 				purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
 				linkIcon="chevron-right"
-				skipRemovePlanSurvey={ isPlanPurchase }
+				skipRemovePlanSurvey={ isPlanPurchase && hasTakenCancelPurchaseSurvey }
 			>
 				<MaterialIcon icon="delete" className="card__icon" />
 				{ text }
@@ -1626,6 +1630,10 @@ export default connect( ( state: IAppState, props: ManagePurchaseProps ) => {
 			: false,
 		hasSetupAds: Boolean(
 			site?.options?.wordads || isRequestingWordAdsApprovalForSite( state, site )
+		),
+		hasTakenCancelPurchaseSurvey: getPreference(
+			state,
+			getCancelPurchaseSurveyTakenPreferenceKey( purchase?.id )
 		),
 		isAtomicSite: isSiteAtomic( state, siteId ),
 		isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -656,9 +656,10 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
+		const isPlanPurchase = isPlan( purchase );
 		let text = translate( 'Remove subscription' );
 
-		if ( isPlan( purchase ) ) {
+		if ( isPlanPurchase ) {
 			text = translate( 'Remove plan' );
 		} else if ( isDomainRegistration( purchase ) ) {
 			text = translate( 'Remove domain' );
@@ -676,7 +677,7 @@ class ManagePurchase extends Component<
 				purchase={ purchase }
 				purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
 				linkIcon="chevron-right"
-				skipSurvey
+				skipSurvey={ isPlanPurchase }
 			>
 				<MaterialIcon icon="delete" className="card__icon" />
 				{ text }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -677,7 +677,7 @@ class ManagePurchase extends Component<
 				purchase={ purchase }
 				purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
 				linkIcon="chevron-right"
-				skipSurvey={ isPlanPurchase }
+				skipRemovePlanSurvey={ isPlanPurchase }
 			>
 				<MaterialIcon icon="delete" className="card__icon" />
 				{ text }

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -286,7 +286,7 @@ class RemovePurchase extends Component {
 	}
 
 	renderPlanDialog() {
-		const { activeSubscriptions, purchase } = this.props;
+		const { activeSubscriptions, purchase, skipSurvey } = this.props;
 
 		return (
 			<CancelPurchaseForm
@@ -297,6 +297,7 @@ class RemovePurchase extends Component {
 				onClose={ this.closeDialog }
 				onClickFinalConfirm={ this.removePurchase }
 				flowType={ CANCEL_FLOW_TYPE.REMOVE }
+				skipSurvey={ skipSurvey }
 			/>
 		);
 	}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -64,7 +64,7 @@ class RemovePurchase extends Component {
 		activeSubscriptions: PropTypes.array,
 		linkIcon: PropTypes.string,
 		primaryDomain: PropTypes.object,
-		skipSurvey: PropTypes.bool,
+		skipRemovePlanSurvey: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -286,7 +286,7 @@ class RemovePurchase extends Component {
 	}
 
 	renderPlanDialog() {
-		const { activeSubscriptions, purchase, skipSurvey } = this.props;
+		const { activeSubscriptions, purchase, skipRemovePlanSurvey } = this.props;
 
 		return (
 			<CancelPurchaseForm
@@ -297,7 +297,7 @@ class RemovePurchase extends Component {
 				onClose={ this.closeDialog }
 				onClickFinalConfirm={ this.removePurchase }
 				flowType={ CANCEL_FLOW_TYPE.REMOVE }
-				skipSurvey={ skipSurvey }
+				skipRemovePlanSurvey={ skipRemovePlanSurvey }
 			/>
 		);
 	}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -64,6 +64,7 @@ class RemovePurchase extends Component {
 		activeSubscriptions: PropTypes.array,
 		linkIcon: PropTypes.string,
 		primaryDomain: PropTypes.object,
+		skipSurvey: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -285,7 +286,7 @@ class RemovePurchase extends Component {
 	}
 
 	renderPlanDialog() {
-		const { purchase, activeSubscriptions } = this.props;
+		const { activeSubscriptions, purchase } = this.props;
 
 		return (
 			<CancelPurchaseForm

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -66,12 +66,17 @@ function isJetpackTemporarySitePurchase( purchase ) {
 	return isTemporarySitePurchase( purchase ) && productType === 'jetpack';
 }
 
+function getCancelPurchaseSurveyTakenPreferenceKey( purchaseId ) {
+	return `cancel-purchase-survey-taken-${ purchaseId }`;
+}
+
 export {
 	canEditPaymentDetails,
 	getChangePaymentMethodPath,
 	getAddNewPaymentMethodPath,
 	isDataLoading,
 	isTemporarySitePurchase,
+	getCancelPurchaseSurveyTakenPreferenceKey,
 	getTemporarySiteType,
 	isJetpackTemporarySitePurchase,
 	isAkismetTemporarySitePurchase,

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -66,8 +66,8 @@ function isJetpackTemporarySitePurchase( purchase ) {
 	return isTemporarySitePurchase( purchase ) && productType === 'jetpack';
 }
 
-function getCancelPurchaseSurveyTakenPreferenceKey( purchaseId ) {
-	return `cancel-purchase-survey-taken-${ purchaseId }`;
+function getCancelPurchaseSurveyCompletedPreferenceKey( purchaseId ) {
+	return `cancel-purchase-survey-completed-${ purchaseId }`;
 }
 
 export {
@@ -76,7 +76,7 @@ export {
 	getAddNewPaymentMethodPath,
 	isDataLoading,
 	isTemporarySitePurchase,
-	getCancelPurchaseSurveyTakenPreferenceKey,
+	getCancelPurchaseSurveyCompletedPreferenceKey,
 	getTemporarySiteType,
 	isJetpackTemporarySitePurchase,
 	isAkismetTemporarySitePurchase,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8752

## Proposed Changes

* In order to remove a plan, the user needs to first cancel its subscription. That takes the user twice through the same offboarding survey. This PR removes the survey on the `Remove plan` flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/me/purchases`

Atomic site:
* From the list, click on an atomic site with an active plan:
![image](https://github.com/user-attachments/assets/e17772cb-e281-43e1-80e6-a83977bba59c)
* Click on `Cancel plan`
* Click on `Cancel Subscription`
* Go through the survey, check that it has the following steps: `Share your feedback`, `Sorry to see you go`, and `Proceed With Caution`
* Click on `Submit and cancel plan` on the final step
* Back on the list, click on the same atomic site, which now has an expiry date:
![image](https://github.com/user-attachments/assets/51bee433-36fb-47b0-aeaa-cf2826085d9c)
* Click on `Remove plan`
* Check that you go to the `Proceed With Caution` step
* Click on `Submit and remove plan` 
* Check that site has been removed from the list

Simple site:
* From the list, click on a simple site with an active plan:
![image](https://github.com/user-attachments/assets/87b08ac1-5acf-4377-87ed-b8e34055c34b)
* Click on `Cancel plan`
* Click on `Cancel Subscription`
* Go through the survey, check that it has the following steps: `Share your feedback`, and `Sorry to see you go`
* Click on `Submit and cancel plan` on the final step
* Back on the list, click on the same simple site, which now has an expiry date:
![image](https://github.com/user-attachments/assets/5be2a72a-0a38-4c18-993f-e2b194b05453)
* Click on `Remove plan`
* Check that you go to the new `Sorry to see you go` step:
![image](https://github.com/user-attachments/assets/78725c79-5e17-4ebc-b0d6-ae756e104d4e)
* Click on `Submit and remove plan` 
* Check that site has been removed from the list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
