### PR TITLE
remove the impressions and add spend in the campaign table

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -55,7 +55,6 @@ export default function CampaignItem( props: Props ) {
 
 	const clicks_total = campaign_stats?.clicks_total ?? 0;
 	const spent_budget_cents = campaign_stats?.spent_budget_cents ?? 0;
-	const impressions_total = campaign_stats?.impressions_total ?? 0;
 	const conversion_rate_percentage = campaign_stats?.conversion_rate
 		? campaign_stats.conversion_rate * 100
 		: 0;
@@ -68,32 +67,23 @@ export default function CampaignItem( props: Props ) {
 	const safeUrl = safeImageUrl( content_config.imageUrl );
 	const adCreativeUrl = safeUrl && resizeImageUrl( safeUrl, 108, 0 );
 
-	const { totalBudget, campaignDays } = useMemo(
+	const { totalBudgetUsed, campaignDays } = useMemo(
 		() =>
 			getCampaignBudgetData( budget_cents, start_date, end_date, spent_budget_cents, is_evergreen ),
 		[ budget_cents, end_date, spent_budget_cents, start_date, is_evergreen ]
 	);
 
-	let budgetString = '-';
-	let budgetStringMobile = '';
-	if ( is_evergreen && campaignDays && ui_status !== campaignStatus.REJECTED ) {
+	const formattedTotalSpend = `$${ formatCents( totalBudgetUsed || 0, 2 ) }`;
+
+	let spendString = '-';
+	let spendStringMobile = '';
+	if ( campaignDays && ui_status !== campaignStatus.REJECTED ) {
 		/* translators: Daily average spend. dailyAverageSpending is the budget */
-		budgetString = sprintf(
+		spendString = formattedTotalSpend;
+		spendStringMobile = sprintf(
 			/* translators: %s is a formatted amount */
-			translate( '$%s weekly' ),
-			formatCents( totalBudget )
-		);
-		budgetStringMobile = sprintf(
-			/* translators: %s is a formatted amount */
-			translate( '$%s weekly budget' ),
-			totalBudget
-		);
-	} else if ( campaignDays && ui_status !== campaignStatus.REJECTED ) {
-		budgetString = `$${ formatCents( totalBudget ) }`;
-		budgetStringMobile = sprintf(
-			/* translators: %s is a formatted amount */
-			translate( '$%s budget' ),
-			totalBudget
+			translate( '%s spend' ),
+			formattedTotalSpend
 		);
 	}
 
@@ -133,12 +123,9 @@ export default function CampaignItem( props: Props ) {
 
 	function getMobileStats() {
 		const statElements = [];
-		if ( impressions_total > 0 ) {
-			statElements[ statElements.length ] = sprintf(
-				// translators: %s is formatted number of views
-				_n( '%s impression', '%s impressions', impressions_total ),
-				formatNumber( impressions_total )
-			);
+
+		if ( spendStringMobile ) {
+			statElements[ statElements.length ] = spendStringMobile;
 		}
 
 		if ( clicks_total > 0 ) {
@@ -147,10 +134,6 @@ export default function CampaignItem( props: Props ) {
 				_n( '%s click', '%s clicks', clicks_total ),
 				formatNumber( clicks_total )
 			);
-		}
-
-		if ( budgetStringMobile ) {
-			statElements[ statElements.length ] = budgetStringMobile;
 		}
 
 		return statElements.map( ( value, index ) => {
@@ -179,9 +162,8 @@ export default function CampaignItem( props: Props ) {
 							></div>
 						) }
 						<div className="campaign-item__title-row">
-							<div className="campaign-item__post-type-mobile">{ getPostType( type ) }</div>
-							<div className="campaign-item__title">{ name }</div>
 							<div className="campaign-item__post-type">{ getPostType( type ) }</div>
+							<div className="campaign-item__title">{ name }</div>
 							<div className="campaign-item__status-mobile">{ statusBadge }</div>
 						</div>
 					</div>
@@ -228,11 +210,8 @@ export default function CampaignItem( props: Props ) {
 					{ getCampaignEndText( campaign.end_date, campaign.status, campaign?.is_evergreen ) }
 				</div>
 			</td>
-			<td className="campaign-item__budget">
-				<div>{ budgetString }</div>
-			</td>
-			<td className="campaign-item__impressions">
-				<div>{ formatNumber( impressions_total ) }</div>
+			<td className="campaign-item__spend">
+				<div>{ spendString }</div>
 			</td>
 			<td className="campaign-item__clicks">
 				<div>{ formatNumber( clicks_total ) }</div>

--- a/client/my-sites/promote-post-i2/components/campaign-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item/style.scss
@@ -14,10 +14,6 @@
 		line-height: 20px;
 	}
 
-	.campaign-item__title-row .campaign-item__post-type-mobile {
-		display: none;
-	}
-
 	.campaign-item__impressions,
 	.campaign-item__item__clicks,
 	.campaign-item__conversion {
@@ -64,14 +60,6 @@
 			.campaign-item__view-link:hover {
 				text-decoration: underline;
 			}
-		}
-
-		.campaign-item__title-row .campaign-item__post-type-mobile {
-			display: block;
-			font-size: 0.75rem;
-			font-weight: 400;
-			color: var(--studio-gray-40);
-			line-height: 20px;
 		}
 
 		.campaign-item__title {

--- a/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
@@ -43,6 +43,7 @@ export default function CampaignsList( props: Props ) {
 		hasMorePages,
 		campaigns,
 	} = props;
+
 	const isWooStore = config.isEnabled( 'is_running_in_woo_site' );
 
 	const translate = useTranslate();

--- a/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
@@ -64,12 +64,8 @@ export default function CampaignsTable( props: Props ) {
 				title: translate( 'Ends' ),
 			},
 			{
-				key: 'budget',
-				title: translate( 'Budget' ),
-			},
-			{
-				key: 'impressions',
-				title: translate( 'Impressions' ),
+				key: 'spend',
+				title: translate( 'Spend' ),
 			},
 			{
 				key: 'clicks',

--- a/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
@@ -48,10 +48,6 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 			padding-right: 16px;
 		}
 
-		&__post-type-mobile {
-			display: none;
-		}
-
 		&__data {
 			width: 28%;
 
@@ -76,7 +72,7 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 			width: 10%;
 		}
 
-		&__impressions {
+		&__spend {
 			width: 10%;
 		}
 
@@ -235,20 +231,15 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 		}
 
 		.campaign-item {
-			&__post-type,
 			&__user,
 			&__status,
 			&__ends,
 			&__budget,
-			&__impressions,
+			&__spend,
 			&__clicks,
 			&__conversion,
 			&__action {
 				display: none;
-			}
-
-			&__post-type-mobile {
-				display: block;
 			}
 
 			&__status-mobile {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2639-gh-tumblr/a8c-dsp

## Proposed Changes

please refer to the ticket. 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

we want to remove the impressions and add spend in the table view in the items for campaign

the new UI is attached below for reference
<img width="1111" alt="Screenshot 2024-09-25 at 18 16 46" src="https://github.com/user-attachments/assets/7c29b93e-dbb2-4a25-8bc7-8e4caf324d0e">

and in mobiles

<img width="711" alt="Screenshot 2024-09-25 at 18 16 33" src="https://github.com/user-attachments/assets/d9a9a20a-ea74-4247-be15-19bb29330e6f">

  

## Testing Instructions

checkout the branch.. check that everything looks good and it is according to the UI from the figma file
- please check the ready to promote page and make sure that nothing seems broken
- please check the campaign details page (for a few campaigns) and make sure that nothing seems broken
do a CR :)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?