### PR TITLE
Paid Newsletter: only reset the query if requesting the root url

### DIFF
--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -1,7 +1,7 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
-export type StepId = 'content' | 'subscribers' | 'summary';
+export type StepId = 'reset' | 'content' | 'subscribers' | 'summary';
 export type StepStatus = 'initial' | 'skipped' | 'importing' | 'done';
 
 interface ContentStepContentProgress {

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -19,7 +19,7 @@ import SelectNewsletterForm from './select-newsletter-form';
 import Subscribers from './subscribers';
 import Summary from './summary';
 import { EngineTypes } from './types';
-import { getSetpProgressSteps, getImporterStatus } from './utils';
+import { getStepsProgress, getImporterStatus } from './utils';
 
 import './importer.scss';
 
@@ -128,9 +128,18 @@ export default function NewsletterImporter( {
 
 			setValidFromSite( true );
 		}
-	}, [ urlData, fromSite, engine, selectedSite, resetPaidNewsletter, step, validFromSite ] );
+	}, [
+		urlData,
+		fromSite,
+		engine,
+		selectedSite,
+		resetPaidNewsletter,
+		step,
+		validFromSite,
+		shouldResetImport,
+	] );
 
-	const stepsProgress = getSetpProgressSteps(
+	const stepsProgress = getStepsProgress(
 		engine,
 		selectedSite?.slug || '',
 		fromSite,

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -44,17 +44,28 @@ function getTitle( engine: EngineTypes, urlData?: UrlData ) {
 	return 'Import your newsletter';
 }
 
+function updatePathToContent( path: string ) {
+	if ( path.endsWith( '/content' ) ) {
+		return path;
+	}
+	return path + '/content';
+}
+
 export default function NewsletterImporter( {
 	siteSlug,
 	engine,
-	step = 'content',
+	step = 'reset',
 }: NewsletterImporterProps ) {
 	const fromSite = getQueryArg( window.location.href, 'from' ) as string;
 	const selectedSite = useSelector( getSelectedSite ) ?? undefined;
 
 	const [ validFromSite, setValidFromSite ] = useState( false );
 	const [ autoFetchData, setAutoFetchData ] = useState( false );
+	const [ shouldResetImport, setShouldResetImport ] = useState( step === 'reset' );
 
+	if ( step === 'reset' ) {
+		step = 'content';
+	}
 	const { data: paidNewsletterData } = usePaidNewsletterQuery(
 		engine,
 		step,
@@ -105,8 +116,14 @@ export default function NewsletterImporter( {
 
 	useEffect( () => {
 		if ( urlData?.platform === engine ) {
-			if ( selectedSite && step === stepSlugs[ 0 ] && validFromSite === false ) {
+			if ( selectedSite && shouldResetImport && validFromSite === false ) {
 				resetPaidNewsletter( selectedSite.ID, engine, stepSlugs[ 0 ] );
+				setShouldResetImport( false );
+				window.history.replaceState(
+					null,
+					'',
+					updatePathToContent( window.location.pathname ) + window.location.search
+				);
 			}
 
 			setValidFromSite( true );

--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -21,7 +21,7 @@ function getStepProgressIndicator( stepStatus?: StepStatus ): ReactNode {
 	}
 }
 
-export function getSetpProgressSteps(
+export function getStepsProgress(
 	engine: string,
 	selectedSiteSlug: string,
 	fromSite: string,


### PR DESCRIPTION
Currently we make a reset endpoint request when a user reloads the the root of the importer or the content path. 

This make it so that a page refresh triggers a reset of the flow which in some case might be unintended and results in the user having to start the process from the beginning. 

This PR intends to fix this by only resetting the flow if the request is coming is though the root url. 

## Proposed Changes

* Only make the reset request when necessary and update the URL so that the if the user refreshes the page that we don't reset the flow again but preserve the state. 

## Why are these changes being made?
So that the user doesn't accidently end up in a situation where they have reset their flow. 

## Testing Instructions
* Open up the web/network inspector in your browser of choice and filter it to the paid-importer endpoint. 
* Navigate to the substack importer and start the content import process or skip it. 
* Now refresh the page. 
* Notice that you did not reset this process. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
