### PR TITLE
A4A: Remove thousand separator before running parseFloat

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -35,6 +35,7 @@ export default function PricingSummary( {
 
 	// Agency checkout is when the user is not purchasing automated referrals and not a client
 	const isAgencyCheckout = ! isAutomatedReferrals && ! isClient;
+
 	const showOriginalPrice = isAgencyCheckout && totalCost !== actualCost;
 
 	return (

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/hooks/use-total-invoice-value.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/hooks/use-total-invoice-value.ts
@@ -49,7 +49,7 @@ export const useGetProductPricingInfo = () => {
 
 		const productBundleCost = bundle
 			? parseFloat( bundleAmount )
-			: parseFloat( product?.amount ) || 0;
+			: parseFloat( product?.amount.replace( ',', '' ) ) || 0;
 		const isDailyPricing = product.price_interval === 'day';
 
 		const discountInfo: {
@@ -84,7 +84,7 @@ export const useGetProductPricingInfo = () => {
 
 			// If a monthly product is found, calculate the actual cost and discount percentage
 			if ( monthlyProduct ) {
-				const monthlyProductBundleCost = parseFloat( product.amount ) * quantity;
+				const monthlyProductBundleCost = parseFloat( product.amount.replace( ',', '' ) ) * quantity;
 				const actualCost = isDailyPricing
 					? monthlyProductBundleCost / 365
 					: monthlyProductBundleCost;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1143

## Proposed Changes

* Fix how we convert string prices with a thousand separators to float.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If we don't remove the thousand separator before running `parseFloat`, the function returns an incorrect result. For example, `parseFloat("1,000.00")` returns `1` rather than `1000`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR from the Live branch.
* Visit `/marketplace/hosting/pressable`.
* Change your agency billing scheme from 876 to 877 so you can see the new Business 120 and 150 plans.
* Select the 150 plan.
* Verify the plan's price is $1,000.00 and not $1.00.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="486" alt="Google Chrome 2024-09-25 13 11 41" src="https://github.com/user-attachments/assets/d3f320dd-d8a4-4c8c-a8f2-16a0bd5ed43c">
</td>
<td>
<img width="486" alt="Google Chrome 2024-09-25 13 11 34" src="https://github.com/user-attachments/assets/d4c68ca4-ac8a-4e45-b8e5-76a39b5d8388">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
