### PR TITLE
Adds a new parameter to the Blaze Dashboard app initialization

### DIFF
--- a/apps/blaze-dashboard/src/load-config.js
+++ b/apps/blaze-dashboard/src/load-config.js
@@ -37,7 +37,11 @@ productionConfig.features.blaze_setup_mode = !! needSetup;
 productionConfig.features[ 'use-translation-chunks' ] = false;
 
 // Sets the advertising path prefix for this app
-productionConfig.advertising_dashboard_path_prefix = isBlazePlugin ? '/wc-blaze' : '/advertising';
+const dashboardPathPrefix = isBlazePlugin
+	? window.configData?.dashboard_path_prefix || '/wc-blaze' // Compatibility with older versions of Blaze Ads plugin
+	: '/advertising';
+
+productionConfig.advertising_dashboard_path_prefix = dashboardPathPrefix;
 
 // Note: configData is hydrated in Jetpack: https://github.com/Automattic/jetpack/blob/60b0dac0dc5ad7edec2b86edb57b65a3a98ec42d/projects/packages/blaze/src/class-dashboard-config-data.php#L31
 window.configData = {

--- a/apps/blaze-dashboard/src/pages/setup/components/disconnected-site.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/components/disconnected-site.jsx
@@ -42,7 +42,7 @@ export default function DisconnectedSite() {
 							</svg>
 						</div>
 						<div>
-							<h4>{ translate( 'Connect your store' ) }</h4>
+							<h4>{ translate( 'Connect your site' ) }</h4>
 							<p>
 								{ translate(
 									"You'll need to connect your WordPress.com account to integrate Blaze Ads with your site. Don’t have an account? Not to worry - we’ll help you create one!"

--- a/apps/blaze-dashboard/src/pages/setup/components/disconnected-site.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/components/disconnected-site.jsx
@@ -17,7 +17,7 @@ export default function DisconnectedSite() {
 					{ translate( 'Welcome to Blaze Ads' ) }
 				</h3>
 				<p className="setup-pages__body">
-					{ translate( 'One-click advertising for your store and products.' ) }
+					{ translate( 'One-click advertising for your posts, pages and products.' ) }
 				</p>
 
 				<ul className="promote-post-i2__active-steps">
@@ -45,7 +45,7 @@ export default function DisconnectedSite() {
 							<h4>{ translate( 'Connect your store' ) }</h4>
 							<p>
 								{ translate(
-									"You'll need to connect your WordPress.com account to integrate Blaze Ads with your store. Don’t have an account? Not to worry - we’ll help you create one!"
+									"You'll need to connect your WordPress.com account to integrate Blaze Ads with your site. Don’t have an account? Not to worry - we’ll help you create one!"
 								) }
 							</p>
 							<Button className="is-primary" href={ connectUrl } target="_self">

--- a/apps/blaze-dashboard/src/pages/setup/components/ineligible-site.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/components/ineligible-site.jsx
@@ -9,11 +9,11 @@ export default function IneligibleSite() {
 			<div className="promote-post-i2__inner-container">
 				<div className="promote-post-i2__setup-icon"></div>
 				<h3 className="setup-pages__title wp-brand-font">
-					{ translate( 'Your store is not eligible to Advertise with Blaze' ) }
+					{ translate( 'Your site is not eligible to Advertise with Blaze' ) }
 				</h3>
 				<p className="setup-pages__body">
 					{ translate(
-						"Unfortunately, your store doesn't qualify for advertising using Blaze. If you have any questions or need assistance, please contact our {{a}}support team{{/a}}.",
+						"Unfortunately, your site doesn't qualify for advertising using Blaze. If you have any questions or need assistance, please contact our {{a}}support team{{/a}}.",
 						{
 							components: {
 								a: (


### PR DESCRIPTION
We are working on releasing the Blaze Ads plugin, and part of the changes for the plugin is a new route. We want to change the initialization of the Blaze Dashboard app to take the path prefix as a configurable parameter.

## Proposed Changes

* Adds a new initial parameter to the Blaze Dashboard app
* Also changed some texts to match the new generic plugin 

**Messages changed:**

![Screenshot 2024-09-25 at 1 09 52 PM](https://github.com/user-attachments/assets/d965986b-a35a-40a2-8e57-74c1d3b6c0df)

![Screenshot 2024-09-25 at 1 10 28 PM](https://github.com/user-attachments/assets/00bc4fe7-54b9-4f96-9979-0fccb8c67b97)

## Why are these changes being made?

* It is part of the work concerning the new Blaze Ads plugin

## Testing Instructions

You will need a sandbox to test this.

* Checout this branch
* Connect to your sandbox to activate the session
* Navigate to `wp-calypso/apps/blaze-dashboard`, and execute `yarn dev --sync`
* Move the traffic from `widgets.wp.com` to your sandbox (by editing the /etc/hosts file)
* On any site, install the [Blaze Ads plugin](https://woocommerce.com/products/blaze-ads/) (If you don't have it already)
* Verify that the Blaze dashboard works fine with these changes. 
* Now, load any jetpack site, and verify that Jetpack Blaze still works fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
