### PR TITLE
Logged in Performance Profiler: Show test again button on mobile layout. 

### DIFF
--- a/client/hosting/performance/components/MobileHeader.tsx
+++ b/client/hosting/performance/components/MobileHeader.tsx
@@ -1,15 +1,16 @@
 import { Gridicon, ScreenReaderText } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
-import React, { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
 
 type MobileHeaderProps = {
 	pageTitle: string;
 	pageSelector: JSX.Element;
+	subtitle?: ReactNode;
 };
 
-export const MobileHeader = ( { pageTitle, pageSelector }: MobileHeaderProps ) => {
+export const MobileHeader = ( { pageTitle, pageSelector, subtitle }: MobileHeaderProps ) => {
 	const [ isPageSelectorVisible, setIsPageSelectorVisible ] = useState( false );
 
 	const togglePageSelector = () => {
@@ -40,6 +41,15 @@ export const MobileHeader = ( { pageTitle, pageSelector }: MobileHeaderProps ) =
 					} }
 				>
 					{ pageSelector }
+					<div
+						css={ {
+							marginTop: '20px',
+							fontSize: '14px',
+							color: 'var(--color-neutral-50)',
+						} }
+					>
+						{ subtitle }
+					</div>
 				</div>
 			) }
 		</>

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -221,51 +221,53 @@ export const SitePerformance = () => {
 		/>
 	);
 
+	const subtitle = performanceReport.performanceReport
+		? translate( 'Tested on %(testedDate)s. {{button}}Test again{{/button}}', {
+				args: {
+					testedDate: moment( performanceReport.performanceReport.timestamp ).format(
+						'MMMM Do, YYYY h:mm:ss A'
+					),
+				},
+				components: {
+					button: (
+						<Button
+							css={ {
+								textDecoration: 'none !important',
+								':hover': {
+									textDecoration: 'underline !important',
+								},
+								fontSize: 'inherit',
+								whiteSpace: 'nowrap',
+							} }
+							variant="link"
+							onClick={ retestPage }
+						/>
+					),
+				},
+		  } )
+		: translate(
+				'Optimize your site for lightning-fast performance. {{link}}Learn more.{{/link}}',
+				{
+					components: {
+						link: <InlineSupportLink supportContext="site-monitoring" showIcon={ false } />,
+					},
+				}
+		  );
+
 	return (
 		<div className="site-performance">
 			<div className="site-performance-device-tab-controls__container">
 				{ isMobile ? (
-					<MobileHeader pageTitle={ currentPage?.label ?? '' } pageSelector={ pageSelector } />
+					<MobileHeader
+						pageTitle={ currentPage?.label ?? '' }
+						pageSelector={ pageSelector }
+						subtitle={ subtitle }
+					/>
 				) : (
 					<NavigationHeader
 						className="site-performance__navigation-header"
 						title={ translate( 'Performance' ) }
-						subtitle={
-							performanceReport.performanceReport
-								? translate( 'Tested on %(testedDate)s. {{button}}Test again{{/button}}', {
-										args: {
-											testedDate: moment( performanceReport.performanceReport.timestamp ).format(
-												'MMMM Do, YYYY h:mm:ss A'
-											),
-										},
-										components: {
-											button: (
-												<Button
-													css={ {
-														textDecoration: 'none !important',
-														':hover': {
-															textDecoration: 'underline !important',
-														},
-														fontSize: 'inherit',
-														whiteSpace: 'nowrap',
-													} }
-													variant="link"
-													onClick={ retestPage }
-												/>
-											),
-										},
-								  } )
-								: translate(
-										'Optimize your site for lightning-fast performance. {{link}}Learn more.{{/link}}',
-										{
-											components: {
-												link: (
-													<InlineSupportLink supportContext="site-monitoring" showIcon={ false } />
-												),
-											},
-										}
-								  )
-						}
+						subtitle={ subtitle }
 					/>
 				) }
 				{ ! isMobile && pageSelector }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9243

## Proposed Changes

* Add test gain button to mobile layout
![Screenshot 2024-09-25 at 12 52 47 PM](https://github.com/user-attachments/assets/6791aab6-3b75-4374-8ffa-8b9ff4d5de9a)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* User should have the ability to retest site performance on mobile.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `sites/performance/site`
* Change to mobile layout and you should see the cta to retest site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
