### PR TITLE
Help Center E2E: Detect test user

### DIFF
--- a/packages/help-center/src/components/help-center-odie.tsx
+++ b/packages/help-center/src/components/help-center-odie.tsx
@@ -11,8 +11,8 @@ import OdieAssistantProvider, {
 	isOdieAllowedBot,
 } from '@automattic/odie-client';
 import { useSelect } from '@wordpress/data';
+import { useCallback, useMemo } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useCallback } from 'react';
 import { useNavigate, Navigate } from 'react-router-dom';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
@@ -122,6 +122,10 @@ export function HelpCenterOdie( {
 		[]
 	);
 
+	const isTestUser = useMemo( () => {
+		return currentUser?.username?.startsWith( 'e2eflowtesting' ) ?? false;
+	}, [ currentUser?.username ] );
+
 	return (
 		<ProtectedRoute condition={ preventOdieAccess }>
 			<OdieAssistantProvider
@@ -139,6 +143,7 @@ export function HelpCenterOdie( {
 				navigateToContactOptions={ navigateToContactOptions }
 				navigateToSupportDocs={ navigateToSupportDocs }
 				isUserEligible={ isUserEligible }
+				isTest={ isTestUser }
 			>
 				<div className="help-center__container-content-odie">
 					<div className="help-center__container-odie-header">

--- a/packages/help-center/src/components/help-center-odie.tsx
+++ b/packages/help-center/src/components/help-center-odie.tsx
@@ -11,10 +11,11 @@ import OdieAssistantProvider, {
 	isOdieAllowedBot,
 } from '@automattic/odie-client';
 import { useSelect } from '@wordpress/data';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { useNavigate, Navigate } from 'react-router-dom';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { isE2ETest } from 'calypso/lib/e2e';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useShouldUseWapuu } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
@@ -122,10 +123,6 @@ export function HelpCenterOdie( {
 		[]
 	);
 
-	const isTestUser = useMemo( () => {
-		return currentUser?.username?.startsWith( 'e2eflowtesting' ) ?? false;
-	}, [ currentUser?.username ] );
-
 	return (
 		<ProtectedRoute condition={ preventOdieAccess }>
 			<OdieAssistantProvider
@@ -143,7 +140,7 @@ export function HelpCenterOdie( {
 				navigateToContactOptions={ navigateToContactOptions }
 				navigateToSupportDocs={ navigateToSupportDocs }
 				isUserEligible={ isUserEligible }
-				isTest={ isTestUser }
+				isTest={ isE2ETest() }
 			>
 				<div className="help-center__container-content-odie">
 					<div className="help-center__container-odie-header">

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -33,6 +33,7 @@ type OdieAssistantContextInterface = {
 	isMinimized?: boolean;
 	isUserEligible: boolean;
 	isNudging: boolean;
+	isTest: boolean;
 	isVisible: boolean;
 	extraContactOptions?: ReactNode;
 	lastNudge: Nudge | null;
@@ -70,6 +71,7 @@ const defaultContextInterfaceValues = {
 	isNudging: false,
 	isVisible: false,
 	isUserEligible: false,
+	isTest: false,
 	lastNudge: null,
 	lastMessageRef: null,
 	navigateToContactOptions: noop,
@@ -109,6 +111,7 @@ type OdieAssistantProviderProps = {
 	isUserEligible?: boolean;
 	isMinimized?: boolean;
 	isLoadingEnvironment?: boolean;
+	isTest?: boolean;
 	currentUser: CurrentUser;
 	extraContactOptions?: ReactNode;
 	logger?: ( message: string, properties: Record< string, unknown > ) => void;
@@ -128,6 +131,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 	isMinimized = false,
 	isLoadingEnvironment = false,
 	isUserEligible = true,
+	isTest = false,
 	extraContactOptions,
 	enabled = true,
 	logger,
@@ -291,6 +295,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 				isLoadingEnvironment,
 				isLoadingExistingChat,
 				isUserEligible,
+				isTest,
 			} }
 		>
 			{ children }

--- a/packages/odie-client/src/query/index.ts
+++ b/packages/odie-client/src/query/index.ts
@@ -15,7 +15,8 @@ const buildSendChatMessage = async (
 	botNameSlug: OdieAllowedBots,
 	chat_id?: number | null,
 	version?: string | null,
-	selectedSiteId?: number | null
+	selectedSiteId?: number | null,
+	isTest?: boolean
 ) => {
 	const baseApiPath = '/help-center/odie/chat/';
 	const wpcomBaseApiPath = '/odie/chat/';
@@ -31,11 +32,16 @@ const buildSendChatMessage = async (
 			: `${ wpcomBaseApiPath }${ botNameSlug }`;
 
 	return canAccessWpcomApis()
-		? odieWpcomSendSupportMessage( message, wpcomApiPathWithIds, version, selectedSiteId )
+		? odieWpcomSendSupportMessage( message, wpcomApiPathWithIds, version, selectedSiteId, isTest )
 		: apiFetch( {
 				path: apiPathWithIds,
 				method: 'POST',
-				data: { message: message.content, version, context: { selectedSiteId } },
+				data: {
+					message: message.content,
+					version,
+					context: { selectedSiteId },
+					test: isTest,
+				},
 		  } );
 };
 
@@ -43,12 +49,13 @@ function odieWpcomSendSupportMessage(
 	message: Message,
 	path: string,
 	version?: string | null,
-	selectedSiteId?: number | null
+	selectedSiteId?: number | null,
+	isTest?: boolean
 ) {
 	return wpcom.req.post( {
 		path,
 		apiNamespace: 'wpcom/v2',
-		body: { message: message.content, version, context: { selectedSiteId } },
+		body: { message: message.content, version, context: { selectedSiteId }, test: isTest },
 	} );
 }
 
@@ -85,6 +92,7 @@ export const useOdieSendMessage = (): UseMutationResult<
 		odieClientId,
 		selectedSiteId,
 		version,
+		isTest,
 	} = useOdieAssistantContext();
 	const queryClient = useQueryClient();
 	const userMessage = useRef< Message | null >( null );
@@ -116,7 +124,8 @@ export const useOdieSendMessage = (): UseMutationResult<
 				botNameSlug,
 				chat.chat_id,
 				version,
-				selectedSiteId
+				selectedSiteId,
+				isTest
 			);
 		},
 		onMutate: ( { message } ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1727252948337079-slack-C069S5S3GP2

## Proposed Changes

Detect when we are using an E2E test user, to pass the `test` variable to Odie and do not pollute the AI measurements.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When triggering E2E tests in the Help Center, we send messages to Wapuu. We should be able to tell that these are not from real users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run E2E tests for the Help Center ( `yarn workspace wp-e2e-tests test -- help-center__calypso` ) and then check in `odie-chats` that the messages are tagged as test.