### PR TITLE
Logged in Performance Profiler: Adjust metric bar styling to match design

### DIFF
--- a/client/performance-profiler/components/charts/style.scss
+++ b/client/performance-profiler/components/charts/style.scss
@@ -11,8 +11,8 @@
 		}
 
 		text {
-			font-size: $font-body-small;
-			fill: var(--studio-gray-70);
+			font-size: $font-body-extra-small;
+			fill: var(--studio-gray-50);
 		}
 	}
 
@@ -41,6 +41,7 @@
 			border-radius: 4px;
 			background: #f6f7f7;
 			width: 70%;
+			max-width: 330px;
 			text-wrap: pretty;
 			font-family: $font-sf-pro-text;
 			line-height: $font-size-header-small;

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -54,10 +54,10 @@
 
 	.metrics-insight-item.foldable-card {
 		box-shadow: none;
-		border-top: 1px solid var(--studio-gray-5);
+		border-top: 1px solid var(--gutenberg-gray-100, #f0f0f0);
 
 		&:last-child {
-			border-bottom: 1px solid var(--studio-gray-5);
+			border-bottom: 1px solid var(--gutenberg-gray-100, #f0f0f0);
 		}
 
 		.foldable-card__header {

--- a/client/performance-profiler/components/metric-tab-bar/metric-tab-bar-v2.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/metric-tab-bar-v2.tsx
@@ -26,49 +26,58 @@ const MetricTabBarV2 = ( props: Props ) => {
 				onClick={ () => setActiveTab( 'overall' ) }
 			>
 				<div className="metric-tab-bar-v2__tab-text">
-					<div className="metric-tab-bar-v2__tab-header">Performance Score</div>
+					<div
+						className="metric-tab-bar-v2__tab-header"
+						css={ {
+							marginBottom: '6px',
+						} }
+					>
+						Performance Score
+					</div>
 					<div className="metric-tab-bar-v2__tab-metric">
 						<CircularPerformanceScore score={ props.overall } size={ 48 } />
 					</div>
 				</div>
 			</button>
-			{ Object.entries( metricsNames ).map( ( [ key, { name: displayName } ] ) => {
-				if ( props[ key as Metrics ] === undefined || props[ key as Metrics ] === null ) {
-					return null;
-				}
+			<div className="metric-tab-bar-v2__tab-container">
+				{ Object.entries( metricsNames ).map( ( [ key, { name: displayName } ] ) => {
+					if ( props[ key as Metrics ] === undefined || props[ key as Metrics ] === null ) {
+						return null;
+					}
 
-				// Only display TBT if INP is not available
-				if ( key === 'tbt' && props[ 'inp' ] !== undefined && props[ 'inp' ] !== null ) {
-					return null;
-				}
+					// Only display TBT if INP is not available
+					if ( key === 'tbt' && props[ 'inp' ] !== undefined && props[ 'inp' ] !== null ) {
+						return null;
+					}
 
-				if ( key === 'overall' ) {
-					return null;
-				}
+					if ( key === 'overall' ) {
+						return null;
+					}
 
-				const status = mapThresholdsToStatus( key as Metrics, props[ key as Metrics ] );
-				const statusClassName = status === 'needsImprovement' ? 'needs-improvement' : status;
+					const status = mapThresholdsToStatus( key as Metrics, props[ key as Metrics ] );
+					const statusClassName = status === 'needsImprovement' ? 'needs-improvement' : status;
 
-				return (
-					<button
-						key={ key }
-						className={ clsx( 'metric-tab-bar-v2__tab', { active: key === activeTab } ) }
-						onClick={ () => setActiveTab( key as Metrics ) }
-					>
-						<div className="metric-tab-bar-v2__tab-status">
-							<StatusIndicator
-								speed={ mapThresholdsToStatus( key as Metrics, props[ key as Metrics ] ) }
-							/>
-						</div>
-						<div className="metric-tab-bar-v2__tab-text">
-							<div className="metric-tab-bar-v2__tab-header">{ displayName }</div>
-							<div className={ `metric-tab-bar-v2__tab-metric ${ statusClassName }` }>
-								{ displayValue( key as Metrics, props[ key as Metrics ] ) }
+					return (
+						<button
+							key={ key }
+							className={ clsx( 'metric-tab-bar-v2__tab', { active: key === activeTab } ) }
+							onClick={ () => setActiveTab( key as Metrics ) }
+						>
+							<div className="metric-tab-bar-v2__tab-status">
+								<StatusIndicator
+									speed={ mapThresholdsToStatus( key as Metrics, props[ key as Metrics ] ) }
+								/>
 							</div>
-						</div>
-					</button>
-				);
-			} ) }
+							<div className="metric-tab-bar-v2__tab-text">
+								<div className="metric-tab-bar-v2__tab-header">{ displayName }</div>
+								<div className={ `metric-tab-bar-v2__tab-metric ${ statusClassName }` }>
+									{ displayValue( key as Metrics, props[ key as Metrics ] ) }
+								</div>
+							</div>
+						</button>
+					);
+				} ) }
+			</div>
 		</div>
 	);
 };

--- a/client/performance-profiler/components/metric-tab-bar/style_v2.scss
+++ b/client/performance-profiler/components/metric-tab-bar/style_v2.scss
@@ -18,50 +18,30 @@ $blueberry-color: #3858e9;
 .metric-tab-bar-v2__tab {
 	display: flex;
 	gap: 6px;
-	background: var(--studio-white);
-	border: 1px solid var(--studio-gray-5);
 	text-align: initial;
 	flex-grow: 1;
 	padding: 16px 22px 16px 22px;
+	width: 100%;
 
 	&:not(.active) {
-		border-bottom: 1px solid var(--studio-gray-5);
-		&:not(:nth-child(-n+2)) {
-			border-top-color: transparent;
+		border-bottom: 1px solid var(--gutenberg-gray-100, #f0f0f0);
+
+		&:last-child {
+			border-bottom: unset;
 		}
 	}
 
 	&.active {
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 6px;
-		border-color: transparent;
-		outline: 1.5px solid $blueberry-color;
+		border: 1.5px solid $blueberry-color;
 		position: relative;
+		margin-left: -1px;
+		width: 101%;
 
-		&::before {
-			left: -6px;
-			background-image: unset;
+		& + .metric-tab-bar-v2__tab {
+			border-top: none;
 		}
-
-		&::after {
-			right: -6px;
-			background-image: unset;
-		}
-
-	}
-
-	&:last-child {
-		/* stylelint-disable-next-line scales/radii */
-		border-bottom-right-radius: 6px;
-		/* stylelint-disable-next-line scales/radii */
-		border-bottom-left-radius: 6px;
-	}
-
-	&:nth-child(2) {
-		/* stylelint-disable-next-line scales/radii */
-		border-top-left-radius: 6px;
-		/* stylelint-disable-next-line scales/radii */
-		border-top-right-radius: 6px;
 	}
 
 	&:hover {
@@ -79,7 +59,6 @@ $blueberry-color: #3858e9;
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
-
 }
 
 .metric-tab-bar-v2__tab-header {
@@ -91,17 +70,16 @@ $blueberry-color: #3858e9;
 	font-family: $font-sf-pro-display;
 	font-size: $font-size-header-small;
 
-
 	&.good {
-		color: #00ba37;
+		color: $studio-green-30;
 	}
 
 	&.needs-improvement {
-		color: #d67709;
+		color: $studio-orange-40;
 	}
 
 	&.bad {
-		color: #d63638;
+		color: $studio-red-50;
 	}
 }
 
@@ -109,4 +87,22 @@ $blueberry-color: #3858e9;
 	margin-bottom: 16px;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 6px;
+	border: 1px solid var(--studio-gray-5);
+	&:not(.active) {
+		border-color: var(--studio-gray-5);
+	}
+	&.active {
+		width: 100%;
+		margin-left: unset;
+	}
+}
+
+.metric-tab-bar-v2__tab-container {
+	border: 1px solid var(--studio-gray-5);
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 6px;
+
+	.metric-tab-bar-v2__tab:has(+ .metric-tab-bar-v2__tab.active) {
+		border-bottom: none;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9246

## Proposed Changes

* Remove gaps that shows in the border when selecting a tab in the middle
* Adjust tab inner border colors to match design
* Adjust chart empty info to 330px 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `sites/performance/site`
* verify design of metric tabs

**Before**
![image](https://github.com/user-attachments/assets/7ac8c3e0-879d-4dc0-9f3b-903dd0f68b5c)

**After**
![image](https://github.com/user-attachments/assets/43403f86-9fe6-455c-978f-cf7777482a84)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
