### PR TITLE
Allow woocommerce-payments to be included in the WooCommerce Core Profiler

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -456,8 +456,9 @@ export class JetpackAuthorize extends Component {
 		return 'woocommerce-onboarding' === from;
 	}
 
-	isWooCoreProfiler() {
-		return this.props.isWooCoreProfiler;
+	isWooCoreProfiler( props = this.props ) {
+		const { from } = props.authQuery;
+		return 'woocommerce-core-profiler' === from || this.props.isWooCoreProfiler;
 	}
 
 	getWooDnaConfig( props = this.props ) {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -54,6 +54,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getPartnerIdFromQuery from 'calypso/state/selectors/get-partner-id-from-query';
 import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSite, isRequestingSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import AuthFormHeader from './auth-form-header';
@@ -124,6 +125,7 @@ export class JetpackAuthorize extends Component {
 		isFetchingSites: PropTypes.bool,
 		isSiteBlocked: PropTypes.bool,
 		isRequestingSitePurchases: PropTypes.bool,
+		isWooCoreProfiler: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
 		siteHasJetpackPaidProduct: PropTypes.bool,
 		retryAuth: PropTypes.func.isRequired,
@@ -454,9 +456,8 @@ export class JetpackAuthorize extends Component {
 		return 'woocommerce-onboarding' === from;
 	}
 
-	isWooCoreProfiler( props = this.props ) {
-		const { from } = props.authQuery;
-		return 'woocommerce-core-profiler' === from;
+	isWooCoreProfiler() {
+		return this.props.isWooCoreProfiler;
 	}
 
 	getWooDnaConfig( props = this.props ) {
@@ -1322,6 +1323,7 @@ const connectComponent = connect(
 			isRequestingSitePurchases: isFetchingSitePurchases( state ),
 			isSiteBlocked: isSiteBlockedSelector( state ),
 			isVip: isVipSite( state, authQuery.clientId ),
+			isWooCoreProfiler: isWooCommerceCoreProfilerFlow( state ),
 			mobileAppRedirect,
 			partnerID: getPartnerIdFromQuery( state ),
 			partnerSlug: getPartnerSlugFromQuery( state ),

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -129,8 +129,9 @@ export class JetpackSignup extends Component {
 		return 'woocommerce-onboarding' === authQuery.from;
 	}
 
-	isWooCoreProfiler() {
-		return this.props.isWooCoreProfiler;
+	isWooCoreProfiler( props = this.props ) {
+		const { from } = props.authQuery;
+		return 'woocommerce-core-profiler' === from || this.props.isWooCoreProfiler;
 	}
 
 	getWooDnaConfig() {

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -43,6 +43,7 @@ import {
 	errorNotice as errorNoticeAction,
 	warningNotice as warningNoticeAction,
 } from 'calypso/state/notices/actions';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import AuthFormHeader from './auth-form-header';
 import HelpButton from './help-button';
 import MainWrapper from './main-wrapper';
@@ -65,6 +66,7 @@ export class JetpackSignup extends Component {
 		createAccount: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
+		isWooCoreProfiler: PropTypes.bool,
 	};
 
 	state = {
@@ -127,9 +129,8 @@ export class JetpackSignup extends Component {
 		return 'woocommerce-onboarding' === authQuery.from;
 	}
 
-	isWooCoreProfiler( props = this.props ) {
-		const { from } = props.authQuery;
-		return 'woocommerce-core-profiler' === from;
+	isWooCoreProfiler() {
+		return this.props.isWooCoreProfiler;
 	}
 
 	getWooDnaConfig() {
@@ -568,6 +569,7 @@ const connectComponent = connect(
 		usernameOrEmail: getLastCheckedUsernameOrEmail( state ),
 		isFullLoginFormVisible: !! getAuthAccountType( state ),
 		redirectTo: getRedirectToOriginal( state ),
+		isWooCoreProfiler: isWooCommerceCoreProfilerFlow( state ),
 	} ),
 	{
 		createAccount: createAccountAction,

--- a/client/state/selectors/is-woocommerce-core-profiler-flow.ts
+++ b/client/state/selectors/is-woocommerce-core-profiler-flow.ts
@@ -11,10 +11,10 @@ import type { AppState } from 'calypso/types';
  * @returns {?boolean}        Whether the user reached Calypso via the WooCommerce Core Profiler flow
  */
 export const isWooCommerceCoreProfilerFlow = ( state: AppState ): boolean => {
-	const allowed_from = [ 'woocommerce-core-profiler', 'woocommerce-payments' ];
+	const allowedFrom = [ 'woocommerce-core-profiler', 'woocommerce-payments' ];
 	return (
-		allowed_from.includes( get( getInitialQueryArguments( state ), 'from' ) as string ) ||
-		allowed_from.includes( get( getCurrentQueryArguments( state ), 'from' ) as string ) ||
+		allowedFrom.includes( get( getInitialQueryArguments( state ), 'from' ) as string ) ||
+		allowedFrom.includes( get( getCurrentQueryArguments( state ), 'from' ) as string ) ||
 		( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) &&
 			new URLSearchParams( state.login?.redirectTo?.original ).get( 'from' ) ===
 				'woocommerce-core-profiler' )

--- a/client/state/selectors/is-woocommerce-core-profiler-flow.ts
+++ b/client/state/selectors/is-woocommerce-core-profiler-flow.ts
@@ -11,9 +11,10 @@ import type { AppState } from 'calypso/types';
  * @returns {?boolean}        Whether the user reached Calypso via the WooCommerce Core Profiler flow
  */
 export const isWooCommerceCoreProfilerFlow = ( state: AppState ): boolean => {
+	const allowed_from = [ 'woocommerce-core-profiler', 'woocommerce-payments' ];
 	return (
-		'woocommerce-core-profiler' === get( getCurrentQueryArguments( state ), 'from' ) ||
-		'woocommerce-core-profiler' === get( getInitialQueryArguments( state ), 'from' ) ||
+		allowed_from.includes( get( getInitialQueryArguments( state ), 'from' ) as string ) ||
+		allowed_from.includes( get( getCurrentQueryArguments( state ), 'from' ) as string ) ||
 		( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) &&
 			new URLSearchParams( state.login?.redirectTo?.original ).get( 'from' ) ===
 				'woocommerce-core-profiler' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR allows WooCommerce Payments to be included in the WooCommerce Core Profiler flow.

I believe we should abstract/rename `isWooCommerceCoreProfilerFlow` function so that other plugins can take advantage of the new Jetpack connection. We can work on that later as we find more use cases.

## Proposed Changes

* Allow `woocommerce-payments` to be included in the WooCommerce Core Profiler.


## Testing Instructions

1. Create a new JN site with this branch and `use-wp-horizon` feature flag selected.
2. Go through the core profiler and select `Jetpack` on the extensions page.
3. Continue and you should be redirected to the Jetpack connection page.
4. Copy the URL and change `from` param to `woocommerce-payments`
5. You should still see the new Jetpack connection page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
