### PR TITLE
Domains: hide renew/auto-renew option for 100 year domains

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -113,7 +113,7 @@ const RegisteredDomainDetails = ( {
 			domain.pendingRegistrationAtRegistry ||
 			domain.pendingRegistration ||
 			! domain.currentUserCanManage ||
-			( domain.expired && ! domain.isRenewable && ! domain.isRedeemable ) ||
+			( ! domain.isRenewable && ! domain.isRedeemable ) ||
 			( ! isLoadingPurchase && ! purchase ) ||
 			domain.aftermarketAuction
 		);

--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -52,6 +52,7 @@ const RegisteredDomainDetails = ( {
 		return (
 			! domain.currentUserIsOwner ||
 			( ! isLoadingPurchase && ! purchase ) ||
+			( ! domain.isRenewable && ! domain.isRedeemable ) ||
 			domain.aftermarketAuction
 		);
 	};

--- a/packages/domains-table/src/utils/is-renewable.ts
+++ b/packages/domains-table/src/utils/is-renewable.ts
@@ -12,7 +12,7 @@ export function isDomainRenewable( domain: ResponseDomain ) {
 		domain.pendingRegistrationAtRegistry ||
 		domain.pendingRegistration ||
 		! domain.currentUserCanManage ||
-		( domain.expired && ! domain.isRenewable && ! domain.isRedeemable ) ||
+		( ! domain.isRenewable && ! domain.isRedeemable ) ||
 		domain.aftermarketAuction;
 	return ! shouldNotAllowManualRenew;
 }


### PR DESCRIPTION
## Proposed Changes
Disables both renew and auto-renew options for 100-year domains.

## Testing Instructions
Visit the management page of a 100-year domain you own and ensure you get the same results as in the screenshot.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Preview

| Before | After  |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/67c54028-3b4f-44d0-9bc2-eb755972101c) | ![image](https://github.com/user-attachments/assets/c50b1fb7-887f-4658-9287-36091ecd8595) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
