### PR TITLE
Domains: Include unsupported TLD message for different flows

### DIFF
--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -384,6 +384,17 @@ function getAvailabilityNotice(
 				message = translate( 'Sorry, WordPress.com does not support the %(tld)s TLD.', {
 					args: { tld },
 				} );
+			} else {
+				/* translators: %s: TLD (eg .com, .pl) */
+				message = translate(
+					'{{strong}}.%(tld)s{{/strong}} domains are not available for registration on WordPress.com.',
+					{
+						args: { tld },
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
 			}
 			break;
 		case domainAvailability.UNKNOWN:

--- a/client/lib/domains/registration/test/availability-messages.js
+++ b/client/lib/domains/registration/test/availability-messages.js
@@ -54,13 +54,18 @@ describe( 'getAvailabilityNotice()', () => {
 		} );
 	} );
 
+	test( 'Should return default message if TLD is unsupported', () => {
+		expect(
+			getAvailabilityNotice( 'test-domain.se', domainAvailability.TLD_NOT_SUPPORTED, null )
+		).toEqual( { message: 'default', severity: 'error' } );
+	} );
+
 	test( 'Should return no message when domain unavailable, unmappable, unknown, tld not supported, or search results are empty', () => {
 		// These are special cases where the error notice should not be handled by client/components/domains/register-domain-step/index.jsx
 		// but in client/components/domains/domain-search-results/index.jsx
 		[
 			domainAvailability.MAPPABLE,
 			domainAvailability.AVAILABLE,
-			domainAvailability.TLD_NOT_SUPPORTED,
 			domainAvailability.UNKNOWN,
 		].forEach( ( error ) => {
 			expect( getAvailabilityNotice( null, error, null ) ).toEqual( {


### PR DESCRIPTION
## Proposed Changes
Updates the `getAvailabilityNotice()` function to handle error messages for unsupported TLDs.

## Why are these changes being made?
There's a discrepancy between the domain search on the management page (`/domains/add/:site`) and other domain flows (`/start/domains`) - the error message for unsupported TLDs is displayed in the former but not in the latter. This PR fixes it.

## Testing Instructions
Try to search for a domain with an unsupported TLD and ensure you get the proper error message - same as in the screenshot.

## Preview

| Before | After  |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0f1eb732-0c3f-4767-ba0f-e49baa57ec64) | ![image](https://github.com/user-attachments/assets/0567d671-e3d2-42b1-9dc9-84ce9298b469) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
