### PR TITLE
Show new domains notice and skip the contrats page for domain purchases

### DIFF
--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -630,6 +630,9 @@ function getFallbackDestination( {
 	const domainItems = cart?.products?.filter( ( product ) => isDomainProduct( product ) );
 	if ( domainItems && domainItems.length > 0 && domainItems.length === cart?.products?.length ) {
 		debug( 'site with domain product' );
+		if ( siteSlug === 'no-site' ) {
+			return `/domains/manage/?new-domains=${ domainItems.length }`;
+		}
 		return `/domains/manage/${ siteSlug }?new-domains=${ domainItems.length }`;
 	}
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -19,6 +19,7 @@ import {
 	isWpComPremiumPlan,
 	isTitanMail,
 	is100Year,
+	isDomainProduct,
 	isValidFeatureKey,
 } from '@automattic/calypso-products';
 import {
@@ -624,6 +625,12 @@ function getFallbackDestination( {
 			},
 			`/marketplace/thank-you/${ siteSlug }`
 		);
+	}
+
+	const domainItems = cart?.products?.filter( ( product ) => isDomainProduct( product ) );
+	if ( domainItems && domainItems.length > 0 && domainItems.length === cart?.products?.length ) {
+		debug( 'site with domain product' );
+		return `/domains/manage/${ siteSlug }?new-domains=${ domainItems.length }`;
 	}
 
 	debug( 'simple thank-you page' );

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -627,8 +627,16 @@ function getFallbackDestination( {
 		);
 	}
 
+	// If the cart contains a product with the signup context, we want to fallback to the normal thank-you page (for now).
+	const signupContext = cart?.products?.some( ( product ) => product?.extra?.context === 'signup' );
+	// If the cart contains only domain items, redirect to the domains management page.
 	const domainItems = cart?.products?.filter( ( product ) => isDomainProduct( product ) );
-	if ( domainItems && domainItems.length > 0 && domainItems.length === cart?.products?.length ) {
+	if (
+		! signupContext &&
+		domainItems &&
+		domainItems.length > 0 &&
+		domainItems.length === cart?.products?.length
+	) {
 		debug( 'site with domain product' );
 		if ( siteSlug === 'no-site' ) {
 			return `/domains/manage/?new-domains=${ domainItems.length }`;

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1307,7 +1307,7 @@ describe( 'getThankYouPageUrl', () => {
 				receiptId: samplePurchaseId,
 			} );
 
-			expect( url ).toBe( `/checkout/thank-you/no-site/${ samplePurchaseId }` );
+			expect( url ).toBe( `/domains/manage/?new-domains=1` );
 		} );
 
 		it( 'Is not displayed if cart is missing', () => {
@@ -1969,6 +1969,41 @@ describe( 'getThankYouPageUrl', () => {
 					'test@example.com'
 				) }`
 			);
+		} );
+
+		/*
+		Code under test:
+
+			const domainItems = cart?.products?.filter( ( product ) => isDomainProduct( product ) );
+			if ( domainItems && domainItems.length > 0 && domainItems.length === cart?.products?.length ) {
+				debug( 'site with domain product' );
+				if ( siteSlug === 'no-site' ) {
+					return `/domains/manage/?new-domains=${ domainItems.length }`;
+				}
+				return `/domains/manage/${ siteSlug }?new-domains=${ domainItems.length }`;
+			}
+
+		*/
+		it( 'redirects to /domains/:domain/manage/:site when purchasing only domain', () => {
+			const cart = {
+				...getMockCart(),
+				products: [
+					{
+						...getEmptyResponseCartProduct(),
+						meta: 'domain-from-cart.com',
+						is_domain_registration: true,
+					},
+				],
+			};
+
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				cart,
+				receiptId: samplePurchaseId,
+				siteSlug: 'foo.bar',
+			} );
+
+			expect( url ).toBe( `/domains/manage/foo.bar?new-domains=1` );
 		} );
 	} );
 } );

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -328,11 +328,9 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 		if ( newDomains ) {
 			dispatch(
 				successNotice(
-					translate(
-						'Your domain is being setup. We’ll notify you when it’s ready.',
-						'Your domains are being set up. We’ll notify you when they are ready.',
-						{ count: parseInt( newDomains ) }
-					),
+					translate( 'Your domain is being setup.', 'Your domains are being set up.', {
+						count: parseInt( newDomains ),
+					} ),
 					{
 						duration: 10000,
 					}

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -1,14 +1,12 @@
 import { DomainsTable, useDomainsTable } from '@automattic/domains-table';
 import { Global, css } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { useSelector, useDispatch } from 'calypso/state';
-import { successNotice } from 'calypso/state/notices/actions';
+import { useSelector } from 'calypso/state';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import DomainHeader from '../components/domain-header';
 import {
@@ -22,6 +20,7 @@ import {
 import EmptyState from './empty-state';
 import GoogleDomainOwnerBanner from './google-domain-owner-banner';
 import OptionsDomainButton from './options-domain-button';
+import { useNewDomainsNotification } from './use-new-domains-notification';
 import { usePurchaseActions } from './use-purchase-actions';
 
 import './style.scss';
@@ -34,7 +33,6 @@ interface BulkAllDomainsProps {
 export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 	const { domains = [], isFetched, isLoading } = useDomainsTable( fetchAllDomains );
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 	const isInSupportSession = Boolean( useSelector( isSupportSession ) );
 	const sitesDashboardGlobalStyles = css`
 		html {
@@ -320,25 +318,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 		: [];
 	const purchaseActions = usePurchaseActions();
 
-	// Domain purhcases provide a new domain flag on checkout completion
-	// e.g. /domains/manage/example.wordpress.com?new-domains=2
-	const queryParams = new URLSearchParams( window.location.search );
-	const newDomains = queryParams.get( 'new-domains' );
-	useEffect( () => {
-		if ( newDomains ) {
-			dispatch(
-				successNotice(
-					translate( 'Your domain is being setup.', 'Your domains are being set up.', {
-						count: parseInt( newDomains ),
-					} ),
-					{
-						duration: 10000,
-					}
-				)
-			);
-		}
-	}, [ newDomains, dispatch, translate ] );
-
+	useNewDomainsNotification();
 	return (
 		<>
 			<Global styles={ sitesDashboardGlobalStyles } />

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -1,12 +1,14 @@
 import { DomainsTable, useDomainsTable } from '@automattic/domains-table';
 import { Global, css } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import DomainHeader from '../components/domain-header';
 import {
@@ -32,6 +34,7 @@ interface BulkAllDomainsProps {
 export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 	const { domains = [], isFetched, isLoading } = useDomainsTable( fetchAllDomains );
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const isInSupportSession = Boolean( useSelector( isSupportSession ) );
 	const sitesDashboardGlobalStyles = css`
 		html {
@@ -316,6 +319,27 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 		? [ <OptionsDomainButton key="breadcrumb_button_1" allDomainsList /> ]
 		: [];
 	const purchaseActions = usePurchaseActions();
+
+	// Domain purhcases provide a new domain flag on checkout completion
+	// e.g. /domains/manage/example.wordpress.com?new-domains=2
+	const queryParams = new URLSearchParams( window.location.search );
+	const newDomains = queryParams.get( 'new-domains' );
+	useEffect( () => {
+		if ( newDomains ) {
+			dispatch(
+				successNotice(
+					translate(
+						'Your domain is being setup. We’ll notify you when it’s ready.',
+						'Your domains are being set up. We’ll notify you when they are ready.',
+						{ count: parseInt( newDomains ) }
+					),
+					{
+						duration: 10000,
+					}
+				)
+			);
+		}
+	}, [ newDomains, dispatch, translate ] );
 
 	return (
 		<>

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable, ResponseDomain } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import SiteAddressChanger from 'calypso/blocks/site-address-changer';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -17,7 +17,6 @@ import {
 	showUpdatePrimaryDomainErrorNotice,
 	showUpdatePrimaryDomainSuccessNotice,
 } from 'calypso/state/domains/management/actions';
-import { successNotice } from 'calypso/state/notices/actions';
 import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
 import { hasDomainCredit as hasDomainCreditSelector } from 'calypso/state/sites/plans/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -37,6 +36,7 @@ import EmptyDomainsListCard from './empty-domains-list-card';
 import GoogleDomainOwnerBanner from './google-domain-owner-banner';
 import ManageAllDomainsButton from './manage-all-domains-button';
 import OptionsDomainButton from './options-domain-button';
+import { useNewDomainsNotification } from './use-new-domains-notification';
 import { usePurchaseActions } from './use-purchase-actions';
 import { filterOutWpcomDomains } from './utils';
 import './style.scss';
@@ -118,24 +118,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 		}
 	};
 
-	// Domain purhcases provide a new domain flag on checkout completion
-	// e.g. /domains/manage/example.wordpress.com?new-domains=2
-	const queryParams = new URLSearchParams( window.location.search );
-	const newDomains = queryParams.get( 'new-domains' );
-	useEffect( () => {
-		if ( newDomains ) {
-			dispatch(
-				successNotice(
-					translate( 'Your domain is being setup.', 'Your domains are being set up.', {
-						count: parseInt( newDomains ),
-					} ),
-					{
-						duration: 10000,
-					}
-				)
-			);
-		}
-	}, [ newDomains, dispatch, translate ] );
+	useNewDomainsNotification();
 
 	return (
 		<>

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -126,11 +126,9 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 		if ( newDomains ) {
 			dispatch(
 				successNotice(
-					translate(
-						'Your domain is being setup. We’ll notify you when it’s ready.',
-						'Your domains are being set up. We’ll notify you when they are ready.',
-						{ count: parseInt( newDomains ) }
-					),
+					translate( 'Your domain is being setup.', 'Your domains are being set up.', {
+						count: parseInt( newDomains ),
+					} ),
 					{
 						duration: 10000,
 					}

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable, ResponseDomain } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import SiteAddressChanger from 'calypso/blocks/site-address-changer';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -17,6 +17,7 @@ import {
 	showUpdatePrimaryDomainErrorNotice,
 	showUpdatePrimaryDomainSuccessNotice,
 } from 'calypso/state/domains/management/actions';
+import { successNotice } from 'calypso/state/notices/actions';
 import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
 import { hasDomainCredit as hasDomainCreditSelector } from 'calypso/state/sites/plans/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -116,6 +117,27 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 			}
 		}
 	};
+
+	// Domain purhcases provide a new domain flag on checkout completion
+	// e.g. /domains/manage/example.wordpress.com?new-domains=2
+	const queryParams = new URLSearchParams( window.location.search );
+	const newDomains = queryParams.get( 'new-domains' );
+	useEffect( () => {
+		if ( newDomains ) {
+			dispatch(
+				successNotice(
+					translate(
+						'Your domain is being setup. We’ll notify you when it’s ready.',
+						'Your domains are being set up. We’ll notify you when they are ready.',
+						{ count: parseInt( newDomains ) }
+					),
+					{
+						duration: 5000,
+					}
+				)
+			);
+		}
+	}, [ newDomains, dispatch, translate ] );
 
 	return (
 		<>

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -132,7 +132,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 						{ count: parseInt( newDomains ) }
 					),
 					{
-						duration: 5000,
+						duration: 10000,
 					}
 				)
 			);

--- a/client/my-sites/domains/domain-management/list/use-new-domains-notification.tsx
+++ b/client/my-sites/domains/domain-management/list/use-new-domains-notification.tsx
@@ -1,0 +1,27 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
+
+export function useNewDomainsNotification() {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	useEffect( () => {
+		const queryParams = new URLSearchParams( window.location.search );
+		const newDomains = queryParams.get( 'new-domains' );
+
+		if ( newDomains ) {
+			dispatch(
+				successNotice(
+					translate( 'Your domain is being setup.', 'Your domains are being set up.', {
+						count: parseInt( newDomains ),
+					} ),
+					{
+						duration: 10000,
+					}
+				)
+			);
+		}
+	}, [ dispatch, translate ] );
+}

--- a/client/my-sites/domains/domain-management/list/use-new-domains-notification.tsx
+++ b/client/my-sites/domains/domain-management/list/use-new-domains-notification.tsx
@@ -14,7 +14,7 @@ export function useNewDomainsNotification() {
 		if ( newDomains ) {
 			dispatch(
 				successNotice(
-					translate( 'Your domain is being setup.', 'Your domains are being set up.', {
+					translate( 'Your domain is being set up.', 'Your domains are being set up.', {
 						count: parseInt( newDomains ),
 					} ),
 					{


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9182

## Proposed Changes

* Following similar pattern as in https://github.com/Automattic/wp-calypso/pull/94766
* When only domain purchases are present in the cart, take the user directly to the domain management screen

## Testing Instructions

Site domains:

- [ ] Purchase one or more domains for a site via /domains/manage/:site
- [ ] You should no longer see the thank you page, instead going directly to the management screen for that site.
- [ ] You should see a toast notification temporarily.

No site domains:
- [ ] Purchase one ore more domains via /domains/manage or wordpress.com/domains
- [ ] You should land on /domains/manage with a notification

No changes:
- [ ] Purchases including a plan, email, or other product should continue to show a thank you page
- [ ] Domain purchases with a free plan during sign up should continue to show a thank you page
- [ ] Domain purchases with other failed purchases should continue to show a thank you page 
- [ ] Domain only purchase that adds a free site during the process should not land on the domains page

Before

![Screenshot 2024-09-26 at 16-52-07 Thank You — WordPress com](https://github.com/user-attachments/assets/9ce4cfca-1fa1-45bd-8e24-0b8539305701)

After

![Screenshot 2024-09-26 at 16-54-16 Domains ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/f16dc2fa-bb7a-428f-96d6-b26ba7b8c3cf)
