### PR TITLE
Update Jetpack Scan link for Atomic sites in A4A

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
@@ -220,7 +220,7 @@ describe( 'useRowMetadata', () => {
 		const expected = {
 			eventName: 'calypso_jetpack_agency_dashboard_scan_threats_click_large_screen',
 			isExternalLink: true,
-			link: `https://wordpress.com/scan/history/${ FAKE_SITE.url }`,
+			link: `https://wordpress.com/scan/${ FAKE_SITE.url }`,
 			isSupported: true,
 			row: rows.scan,
 			siteDown: false,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
@@ -48,7 +48,7 @@ const getLinks = (
 		case 'scan': {
 			if ( status !== 'inactive' ) {
 				link = isAtomicSite
-					? `https://wordpress.com/scan/history/${ siteUrlWithMultiSiteSupport }`
+					? `https://wordpress.com/scan/${ siteUrlWithMultiSiteSupport }`
 					: `/scan/${ siteUrlWithMultiSiteSupport }`;
 				isExternalLink = isAtomicSite;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7891

## Proposed Changes

Before: Links to `/scan/history/:site`

After: Links to `/scan/:site`

* Link to the /scan page instead of the /history page since we've enabled Jetpack Scan for atomic sites in https://github.com/Automattic/wp-calypso/pull/94529 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/dotcom-forge/issues/7891#issuecomment-2368113218

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to A4A dashboard
* Click in the Scan cell and check that it goes to /scan/:site
![scan](https://github.com/user-attachments/assets/edab2db9-1db0-4de6-a5d6-72c6bfddb6e4)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
