### PR TITLE
A4A: Collect Phone details during signup.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -21,6 +21,7 @@ function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 			address_city: details.city,
 			address_country: details.country,
 			address_state: details.state,
+			address_postal_code: details.postalCode,
 			phone_number: details.phone?.phoneNumber ? details.phone?.phoneNumberFull : '',
 			referral_status: details.referer,
 		},

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -22,6 +22,9 @@ function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 			address_country: details.country,
 			address_state: details.state,
 			address_postal_code: details.postalCode,
+			phone_country_code: details.phoneCountryCode,
+			phone_country_numeric_code: details.phoneCountryNumericCode,
+			phone_number: details.phoneNumber,
 			referral_status: details.referer,
 		},
 	} );

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-create-agency-mutation.ts
@@ -21,10 +21,7 @@ function createAgency( details: AgencyDetailsPayload ): Promise< Agency > {
 			address_city: details.city,
 			address_country: details.country,
 			address_state: details.state,
-			address_postal_code: details.postalCode,
-			phone_country_code: details.phoneCountryCode,
-			phone_country_numeric_code: details.phoneCountryNumericCode,
-			phone_number: details.phoneNumber,
+			phone_number: details.phone?.phoneNumber ? details.phone?.phoneNumberFull : '',
 			referral_status: details.referer,
 		},
 	} );

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -499,10 +499,10 @@ export default function AgencyDetailsForm( {
 							</FormLabel>
 							<FormPhoneInput
 								countrySelectProps={ {
-									'data-testid': 'country-code-select',
+									'data-testid': 'a4a-signup-country-code-select',
 								} }
 								phoneInputProps={ {
-									'data-testid': 'phone-number-input',
+									'data-testid': 'a4a-signup-phone-number-input',
 								} }
 								isDisabled={ noCountryList }
 								countriesList={ countriesList }

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -69,13 +69,7 @@ export default function AgencyDetailsForm( {
 	const [ line2, setLine2 ] = useState( initialValues?.line2 ?? '' );
 	const [ postalCode, setPostalCode ] = useState( initialValues?.postalCode ?? '' );
 	const [ addressState, setAddressState ] = useState( initialValues?.state ?? '' );
-	const [ phoneCountryCode, setPhoneCountryCode ] = useState(
-		initialValues?.phoneCountryCode ?? ''
-	);
-	const [ phoneCountryNumericCode, setPhoneCountryNumericCode ] = useState(
-		initialValues?.phoneCountryNumericCode ?? ''
-	);
-	const [ phoneNumber, setPhoneNumber ] = useState( initialValues?.phoneNumber ?? '' );
+	const [ phone, setPhone ] = useState( initialValues?.phone ?? {} );
 	const [ agencyName, setAgencyName ] = useState( initialValues?.agencyName ?? '' );
 	const [ firstName, setFirstName ] = useState( initialValues?.firstName ?? '' );
 	const [ lastName, setLastName ] = useState( initialValues?.lastName ?? '' );
@@ -112,9 +106,7 @@ export default function AgencyDetailsForm( {
 			postalCode,
 			state: addressState,
 			referer,
-			phoneCountryCode,
-			phoneCountryNumericCode,
-			phoneNumber,
+			phone,
 			...( includeTermsOfService ? { tos: 'consented' } : {} ),
 		} ),
 		[
@@ -133,9 +125,7 @@ export default function AgencyDetailsForm( {
 			postalCode,
 			addressState,
 			referer,
-			phoneCountryCode,
-			phoneCountryNumericCode,
-			phoneNumber,
+			phone,
 			includeTermsOfService,
 		]
 	);
@@ -206,18 +196,26 @@ export default function AgencyDetailsForm( {
 	};
 
 	const handlePhoneInputChange = ( {
+		phoneNumberFull,
 		phoneNumber,
 		countryData,
 	}: {
+		phoneNumberFull: string;
 		phoneNumber: string;
 		countryData: {
 			code: string;
 			numeric_code: string;
 		};
+		isValid: boolean;
+		validation: {
+			message: string;
+		};
 	} ) => {
-		setPhoneNumber( phoneNumber );
-		setPhoneCountryCode( countryData.code );
-		setPhoneCountryNumericCode( countryData.numeric_code );
+		setPhone( {
+			phoneNumber,
+			countryCode: countryData.code,
+			phoneNumberFull,
+		} );
 	};
 
 	const isUserSiteOwner = userType === 'site_owner';
@@ -508,8 +506,8 @@ export default function AgencyDetailsForm( {
 								} }
 								isDisabled={ noCountryList }
 								countriesList={ countriesList }
-								initialCountryCode={ phoneCountryCode }
-								initialPhoneNumber={ phoneNumber }
+								initialCountryCode={ phone.countryCode }
+								initialPhoneNumber={ phone.phoneNumber }
 								onChange={ handlePhoneInputChange }
 								className="company-details-form__phone-input"
 							/>

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
@@ -59,4 +59,21 @@
 		font-size: 1rem;
 	}
 
+	.company-details-form__phone-input {
+		display: flex;
+		flex-direction: column;
+
+		> * {
+			flex-grow: 1;
+		}
+
+		@include break-small {
+			flex-direction: row;
+			gap: 16px;
+		}
+
+		.form-label {
+			display: none;
+		}
+	}
 }

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
@@ -12,6 +12,9 @@ export interface AgencyDetailsPayload {
 	line2: string;
 	country: string;
 	postalCode: string;
+	phoneCountryCode?: string;
+	phoneCountryNumericCode?: string;
+	phoneNumber?: string;
 	state: string;
 	referer?: string | null;
 	tos?: 'consented';

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/types.ts
@@ -12,9 +12,11 @@ export interface AgencyDetailsPayload {
 	line2: string;
 	country: string;
 	postalCode: string;
-	phoneCountryCode?: string;
-	phoneCountryNumericCode?: string;
-	phoneNumber?: string;
+	phone?: {
+		phoneNumberFull?: string;
+		phoneNumber?: string;
+		countryCode?: string;
+	};
 	state: string;
 	referer?: string | null;
 	tos?: 'consented';

--- a/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
@@ -70,6 +70,9 @@ export default function SignupForm() {
 					postal_code: payload.postalCode,
 					state: payload.state,
 					referer: payload.referer,
+					phone_country_code: payload.phoneCountryCode,
+					phone_country_numeric_code: payload.phoneCountryNumericCode,
+					phone_number: payload.phoneNumber,
 				} )
 			);
 		},

--- a/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
@@ -70,9 +70,7 @@ export default function SignupForm() {
 					postal_code: payload.postalCode,
 					state: payload.state,
 					referer: payload.referer,
-					phone_country_code: payload.phoneCountryCode,
-					phone_country_numeric_code: payload.phoneCountryNumericCode,
-					phone_number: payload.phoneNumber,
+					phone_number: payload.phone?.phoneNumberFull ?? '',
 				} )
 			);
 		},


### PR DESCRIPTION
This PR updates the signup form to include the Phone number field. 

<img width="635" alt="Screenshot 2024-09-26 at 8 12 09 PM" src="https://github.com/user-attachments/assets/d14704e7-368a-4680-8078-5ba47cf76467">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1127

## Proposed Changes

* Update the Signup form component to also collect and submit phone information.

## Why are these changes being made?

* To ensure quick engagement with our agency, we collect phone numbers during signup. This allows our marketing team to easily set up calls without having to email and request phone details for agency who would like to take the onboarding call.

## Testing Instructions
* Apply D162462-code to your sandbox.
* Point public-api.wordpress.com to your sandbox.
* Spin up this branch locally and go to http://agencies.localhost:3000/signup
* Complete the signup.
* Confirm the signup is completed.
* Check D162462-code for instructions to verify backend has correctly recorded the new field.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?