### PR TITLE
Domains Step: Improve domains step styling

### DIFF
--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -5,6 +5,10 @@
 	display: flex;
 	flex-direction: column;
 	flex-wrap: wrap;
+	border-top: 1px solid rgba(220, 220, 222, 0.64);
+	@include break-mobile {
+		border-top: none;
+	}
 
 	&.featured-domain-suggestions--has-match-reasons .featured-domain-suggestion {
 		.domain-registration-suggestion__match-reasons {
@@ -129,6 +133,11 @@
 		&.is-free-domain {
 			padding-left: 0;
 			margin-top: 12px;
+			display: flex;
+			flex-direction: column-reverse;
+			@include break-mobile {
+				flex-direction: column;
+			}
 		}
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -128,6 +128,7 @@
 		}
 		&.is-free-domain {
 			padding-left: 0;
+			margin-top: 12px;
 		}
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -6,8 +6,13 @@
 	flex-direction: column;
 	flex-wrap: wrap;
 	border-top: 1px solid rgba(220, 220, 222, 0.64);
+
 	@include break-mobile {
 		border-top: none;
+		margin: 0 20px;
+	}
+	@include break-xlarge {
+		margin: 0;
 	}
 
 	&.featured-domain-suggestions--has-match-reasons .featured-domain-suggestion {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -11,7 +11,7 @@
 		border-top: none;
 		margin: 0 20px;
 	}
-	@include break-xlarge {
+	@include break-large {
 		margin: 0;
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -7,7 +7,7 @@
 	flex-wrap: wrap;
 	border-top: 1px solid rgba(220, 220, 222, 0.64);
 
-	@include break-mobile {
+	@include break-small {
 		border-top: none;
 		margin: 0 20px;
 	}

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -215,13 +215,6 @@ button {
 
 }
 
-.domains {
-	&.step-route {
-		padding: 48px 0 0;
-	}
-
-}
-
 .import-focused .step-container.site-picker,
 .import-hosted-site .step-container.site-picker {
 	max-width: 1280px;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -215,6 +215,13 @@ button {
 
 }
 
+.domains {
+	&.step-route {
+		padding: 48px 0 0;
+	}
+
+}
+
 .import-focused .step-container.site-picker,
 .import-hosted-site .step-container.site-picker {
 	max-width: 1280px;

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -457,10 +457,6 @@ body.is-section-signup.is-white-signup {
 	.signup__step.is-mailbox-domain {
 		padding: 0 12px;
 	}
-
-	.step-container__content .domains__step-content-domain-step {
-		padding: 0 12px;
-	}
 }
 
 // blue signup flow-specific styles

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -465,6 +465,13 @@ body.is-section-signup.is-white-signup {
 	.signup__step.is-mailbox-domain {
 		padding: 0 12px;
 	}
+	.step-container__content .domains__step-content-domain-step {
+		padding: 0 12px;
+		@include break-mobile {
+			padding: 0;
+		}
+
+	}
 }
 
 // blue signup flow-specific styles

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -236,10 +236,16 @@ body.is-section-stepper .domains__step-content,
 	&.domains {
 		&.step-route {
 			padding: 48px 0 0;
+			@include break-mobile {
+				padding: 48px 12px 0 12px;
+			}
 			.step-container {
 				.step-container__header {
 					margin: 36px 0 24px 0;
 					@include break-mobile {
+						margin: 24px 20px;
+					}
+					@include break-xlarge {
 						margin: 48px 0 40px;
 					}
 				}
@@ -247,6 +253,9 @@ body.is-section-stepper .domains__step-content,
 			.formatted-header__title {
 				font-size: 2rem;
 				@include break-mobile {
+					font-size: 2.25rem;
+				}
+				@include break-xlarge {
 					font-size: 2.75rem;
 				}
 			}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -245,7 +245,7 @@ body.is-section-stepper .domains__step-content,
 					@include break-mobile {
 						margin: 24px 20px;
 					}
-					@include break-xlarge {
+					@include break-large {
 						margin: 48px 0 40px;
 					}
 				}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -236,6 +236,26 @@ body.is-section-stepper .domains__step-content,
 	&.domains {
 		&.step-route {
 			padding: 48px 0 0;
+			.step-container {
+				.step-container__header {
+					margin: 36px 0 24px 0;
+					@include break-mobile {
+						margin: 48px 0 40px;
+					}
+				}
+			}
+			.formatted-header__title {
+				font-size: 2rem;
+				@include break-mobile {
+					font-size: 2.75rem;
+				}
+			}
+			.formatted-header__subtitle {
+				margin-top: 8px;
+			}
+			.register-domain-step__search-domain-step {
+				padding-bottom: 16px;
+			}
 		}
 	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -232,6 +232,14 @@ body.is-section-stepper .domains__step-content,
 	}
 }
 
+.onboarding {
+	&.domains {
+		&.step-route {
+			padding: 48px 0 0;
+		}
+	}
+}
+
 /**
  * Styles for design reskin
  * The `is-white-signup` class is attached to the body when the user is assigned the `reskinned` group of the `reskinSignupFlow` a/b test


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Makes the domain step in stepper visually close to `/start`.

**Side by side before this fix**

https://github.com/user-attachments/assets/5bbf0e86-8cbb-4906-bdf7-ad38ff2d8fa0

**Side by side after this fix**

https://github.com/user-attachments/assets/c526739c-de36-4f50-9bc5-e241924f3506


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve domains step layout to match the same as we have in `/start`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using live link
* Compare `/setup/onboarding/domains` with `/setup/domains`
* They should look almost the same, besides the subtitles. Like the second video above
* The subtitle in /start uses a different font, which in this case I believe is outdated since all the flows in setup use the same font-family.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?