### PR TITLE
Update Jetpack Scan link in Jetpack Cloud sidebar

### DIFF
--- a/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
@@ -4,7 +4,7 @@ export const JETPACK_MANAGE_SITES_LINK_NEEDS_ATTENTION = '/sites?issue_types=all
 export const JETPACK_MANAGE_SITES_LINK_FAVORITES = '/sites/favorites';
 export const JETPACK_MANAGE_PLUGINS_LINK = '/plugins/manage';
 export const JETPACK_CLOUD_ACTIVITY_LOG_LINK = '/activity-log';
-export const JETPACK_CLOUD_SCAN_HISTORY_LINK = '/scan/history';
+export const JETPACK_CLOUD_SCAN_LINK = '/scan';
 export const JETPACK_CLOUD_SEARCH_LINK = '/jetpack-search';
 export const JETPACK_CLOUD_SOCIAL_LINK = '/jetpack-social';
 export const JETPACK_CLOUD_SUBSCRIBERS_LINK = '/subscribers';

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -42,7 +42,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import {
 	JETPACK_CLOUD_ACTIVITY_LOG_LINK,
 	JETPACK_CLOUD_MONETIZE_LINK,
-	JETPACK_CLOUD_SCAN_HISTORY_LINK,
+	JETPACK_CLOUD_SCAN_LINK,
 	JETPACK_CLOUD_SEARCH_LINK,
 	JETPACK_CLOUD_SOCIAL_LINK,
 	JETPACK_CLOUD_SUBSCRIBERS_LINK,
@@ -126,11 +126,11 @@ const useMenuItems = ( {
 				{
 					icon: shield,
 					path: '/',
-					link: `${ JETPACK_CLOUD_SCAN_HISTORY_LINK }/${ siteSlug }`,
+					link: `${ JETPACK_CLOUD_SCAN_LINK }/${ siteSlug }`,
 					title: translate( 'Scan' ),
-					trackEventName: 'calypso_jetpack_sidebar_scan_history_clicked',
+					trackEventName: 'calypso_jetpack_sidebar_scan_clicked',
 					enabled: isAdmin && showScanHistory && ! isWPForTeamsSite,
-					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_SCAN_HISTORY_LINK }/${ siteSlug }` ),
+					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_SCAN_LINK }/${ siteSlug }` ),
 				},
 				{
 					icon: search,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7891

## Proposed Changes

![scan](https://github.com/user-attachments/assets/7b56b78f-18a2-4648-a620-d01ee7476d43)

Before: Links to `/scan/history/:site`

After: Links to `/scan/:site`

* Link to the /scan page instead of the /history page since we've enabled Jetpack Scan for atomic sites in https://github.com/Automattic/wp-calypso/pull/94529 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/dotcom-forge/issues/7891#issuecomment-2368113218

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Jetpack Cloud
* Click Scan in the sidebar so it goes to /scan/:site

Atomic sites: See the scan
Jetpack sites: See an upsell
Simple classic sites: Scan doesn't exist in the sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
