### PR TITLE
Revert "Help Center E2E: Detect test user"

### DIFF
--- a/packages/help-center/src/components/help-center-odie.tsx
+++ b/packages/help-center/src/components/help-center-odie.tsx
@@ -11,11 +11,10 @@ import OdieAssistantProvider, {
 	isOdieAllowedBot,
 } from '@automattic/odie-client';
 import { useSelect } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
+import React, { useCallback } from 'react';
 import { useNavigate, Navigate } from 'react-router-dom';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { isE2ETest } from 'calypso/lib/e2e';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useShouldUseWapuu } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
@@ -140,7 +139,6 @@ export function HelpCenterOdie( {
 				navigateToContactOptions={ navigateToContactOptions }
 				navigateToSupportDocs={ navigateToSupportDocs }
 				isUserEligible={ isUserEligible }
-				isTest={ isE2ETest() }
 			>
 				<div className="help-center__container-content-odie">
 					<div className="help-center__container-odie-header">

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -33,7 +33,6 @@ type OdieAssistantContextInterface = {
 	isMinimized?: boolean;
 	isUserEligible: boolean;
 	isNudging: boolean;
-	isTest: boolean;
 	isVisible: boolean;
 	extraContactOptions?: ReactNode;
 	lastNudge: Nudge | null;
@@ -71,7 +70,6 @@ const defaultContextInterfaceValues = {
 	isNudging: false,
 	isVisible: false,
 	isUserEligible: false,
-	isTest: false,
 	lastNudge: null,
 	lastMessageRef: null,
 	navigateToContactOptions: noop,
@@ -111,7 +109,6 @@ type OdieAssistantProviderProps = {
 	isUserEligible?: boolean;
 	isMinimized?: boolean;
 	isLoadingEnvironment?: boolean;
-	isTest?: boolean;
 	currentUser: CurrentUser;
 	extraContactOptions?: ReactNode;
 	logger?: ( message: string, properties: Record< string, unknown > ) => void;
@@ -131,7 +128,6 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 	isMinimized = false,
 	isLoadingEnvironment = false,
 	isUserEligible = true,
-	isTest = false,
 	extraContactOptions,
 	enabled = true,
 	logger,
@@ -295,7 +291,6 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 				isLoadingEnvironment,
 				isLoadingExistingChat,
 				isUserEligible,
-				isTest,
 			} }
 		>
 			{ children }

--- a/packages/odie-client/src/query/index.ts
+++ b/packages/odie-client/src/query/index.ts
@@ -15,8 +15,7 @@ const buildSendChatMessage = async (
 	botNameSlug: OdieAllowedBots,
 	chat_id?: number | null,
 	version?: string | null,
-	selectedSiteId?: number | null,
-	isTest?: boolean
+	selectedSiteId?: number | null
 ) => {
 	const baseApiPath = '/help-center/odie/chat/';
 	const wpcomBaseApiPath = '/odie/chat/';
@@ -32,16 +31,11 @@ const buildSendChatMessage = async (
 			: `${ wpcomBaseApiPath }${ botNameSlug }`;
 
 	return canAccessWpcomApis()
-		? odieWpcomSendSupportMessage( message, wpcomApiPathWithIds, version, selectedSiteId, isTest )
+		? odieWpcomSendSupportMessage( message, wpcomApiPathWithIds, version, selectedSiteId )
 		: apiFetch( {
 				path: apiPathWithIds,
 				method: 'POST',
-				data: {
-					message: message.content,
-					version,
-					context: { selectedSiteId },
-					test: isTest,
-				},
+				data: { message: message.content, version, context: { selectedSiteId } },
 		  } );
 };
 
@@ -49,13 +43,12 @@ function odieWpcomSendSupportMessage(
 	message: Message,
 	path: string,
 	version?: string | null,
-	selectedSiteId?: number | null,
-	isTest?: boolean
+	selectedSiteId?: number | null
 ) {
 	return wpcom.req.post( {
 		path,
 		apiNamespace: 'wpcom/v2',
-		body: { message: message.content, version, context: { selectedSiteId }, test: isTest },
+		body: { message: message.content, version, context: { selectedSiteId } },
 	} );
 }
 
@@ -92,7 +85,6 @@ export const useOdieSendMessage = (): UseMutationResult<
 		odieClientId,
 		selectedSiteId,
 		version,
-		isTest,
 	} = useOdieAssistantContext();
 	const queryClient = useQueryClient();
 	const userMessage = useRef< Message | null >( null );
@@ -124,8 +116,7 @@ export const useOdieSendMessage = (): UseMutationResult<
 				botNameSlug,
 				chat.chat_id,
 				version,
-				selectedSiteId,
-				isTest
+				selectedSiteId
 			);
 		},
 		onMutate: ( { message } ) => {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#94908 because of failing tests p1727367142077729/1727364470.353109-slack-C01U2KGS2PQ