### PR TITLE
VideoPress: Fix VideoPress signup flow styles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -149,13 +149,17 @@ $videopress-background: #010101;
 		background: none;
 		box-shadow: none;
 		border: none;
-		border-bottom: solid 1px rgba(255, 255, 255, 0.2);
+		cursor: pointer;
 
 		.domain-registration-suggestion__domain-title-name {
-			color: #c3c4c7;
+			color: #c3c4c7 !important;
 		}
 		.domain-registration-suggestion__domain-title-tld {
 			color: #fff;
+		}
+
+		.domain-product-price__price {
+			color: var(--color-text-subtle) !important;
 		}
 
 		.domain-registration-suggestion__badges {
@@ -175,13 +179,42 @@ $videopress-background: #010101;
 			color: #fff;
 			background: none;
 		}
+
+		&:not(.is-placeholder):not(.featured-domain-suggestion) {
+			border-bottom: solid 1px rgba(255, 255, 255, 0.2) !important;
+
+			&:hover + .domain-suggestion {
+				border-top: solid 1px #646970;
+			}
+		}
+	}
+
+	.featured-domain-suggestion.featured-domain-suggestion--is-placeholder {
+		background-color: rgba(255, 255, 255, 0.15) !important;
+		border: solid 1px rgba(255, 255, 255, 0.1) !important;
+
+		@media (min-width: $videopress-mobile-layout-width) {
+			.domain-product-price {
+				flex-basis: 40%;
+			}
+
+			.domain-registration-suggestion__badges {
+				align-self: center;
+			}
+		}
+
+		.domain-registration-suggestion__match-reasons {
+			display: none;
+		}
 	}
 
 	.domain-suggestion.is-placeholder,
 	.featured-domain-suggestion--is-placeholder {
 		background: none;
 		box-shadow: none;
-		border: solid 1px rgba(255, 255, 255, 0.2);
+		border-top: solid 1px rgba(255, 255, 255, 0.2);
+		border-bottom: solid 1px rgba(255, 255, 255, 0.2);
+		pointer-events: none;
 
 		.domain-registration-suggestion__badges,
 		.domain-registration-suggestion__match-reasons {
@@ -193,6 +226,11 @@ $videopress-background: #010101;
 	.domain-suggestion.is-placeholder {
 		.domain-suggestion__content {
 			background-color: rgba(255, 255, 255, 0.2);
+			margin-right: 0;
+		}
+
+		&:nth-of-type(2n + 1) .domain-suggestion__content {
+			margin-right: 2%;
 		}
 	}
 
@@ -258,6 +296,11 @@ $videopress-background: #010101;
 	.featured-domain-suggestion.card .domain-product-price {
 		align-items: flex-start;
 		margin-top: 12px;
+	}
+
+	.register-domain-step__filter-reset-notice {
+		background: none;
+		color: #fff;
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9162

## Proposed Changes

* Fix loading placeholder card, hover colors, and reset filters button style

<img width="400" alt="Screenshot 2024-09-26 at 17 39 56" src="https://github.com/user-attachments/assets/ac4a8bde-bbbd-4599-b8a5-7c8c62077a54">
<img width="400" alt="Screenshot 2024-09-26 at 17 40 24" src="https://github.com/user-attachments/assets/d81cf852-4df2-4379-a55c-ab3af85651ce">

## Why are these changes being made?

https://github.com/Automattic/dotcom-forge/issues/9162#issuecomment-2361439910

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/videopress/chooseADomain?from=vpcom
* Check if the loading placeholders are on a darker color
* Check if the hovers are consistent
* Apply filters and check "Show exact matches only"
* You should see the "Click here to disable filters for more results" button with a darker color
* Check for regressions, compare with the regular lighter color page http://calypso.localhost:3000/start/domains?source=sites-dashboard&ref=topbar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
