### PR TITLE
Woo Core Profiler - Header and subtitle copy changes

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -633,17 +633,18 @@ class Login extends Component {
 					headerText = (
 						<h3>
 							{ config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
-								? translate( 'Log in to your account' )
+								? translate( 'Connect your account' )
 								: translate( 'One last step' ) }
 						</h3>
 					);
 					if ( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
 						subtitle = translate(
-							"In order to take advantage of the benefits offered by %(pluginName)s, please log in to your WordPress.com account below. {{br}}{{/br}}Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
+							'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. {{br}}{{/br}}For more information, please {{doc}}review our documentation{{/doc}}.',
 							{
 								components: {
 									signupLink,
 									br: <br />,
+									doc: <a href="https://woocommerce.com/documentation/woocommerce/" />,
 								},
 								args: { pluginName },
 							}

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -186,40 +186,45 @@ export class AuthFormHeader extends Component {
 					'Link displayed on the Jetpack Connect signup page for users to log in with a WordPress.com account',
 			};
 
-			switch ( currentState ) {
-				case 'logged-out':
-					return config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
-						? translate(
-								'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Please create one now, or {{a}}log in{{/a}}. {{br}}{{/br}}For more information, please {{doc}}review our documentation{{/doc}}.',
-								{
-									...translateParams,
-									components: {
-										...translateParams.components,
-										doc: reviewDocLink,
-									},
-								}
-						  )
-						: translate(
-								"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
-								translateParams
-						  );
-				default:
-					return config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
-						? translate(
-								'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. For more information, please {{doc}}review our documentation{{/doc}}.',
-								{
-									args: { pluginName },
-									components: {
-										doc: reviewDocLink,
-									},
-								}
-						  )
-						: translate(
-								"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account.",
-								{
-									args: { pluginName },
-								}
-						  );
+			if ( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
+				switch ( currentState ) {
+					case 'logged-out':
+						return translate(
+							'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Please create one now, or {{a}}log in{{/a}}. {{br}}{{/br}}For more information, please {{doc}}review our documentation{{/doc}}.',
+							{
+								...translateParams,
+								components: {
+									...translateParams.components,
+									doc: reviewDocLink,
+								},
+							}
+						);
+					default:
+						return translate(
+							'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. For more information, please {{doc}}review our documentation{{/doc}}.',
+							{
+								args: { pluginName },
+								components: {
+									doc: reviewDocLink,
+								},
+							}
+						);
+				}
+			} else {
+				switch ( currentState ) {
+					case 'logged-out':
+						return translate(
+							"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
+							translateParams
+						);
+					default:
+						return translate(
+							"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account.",
+							{
+								args: { pluginName },
+							}
+						);
+				}
 			}
 		}
 

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -107,7 +107,7 @@ export class AuthFormHeader extends Component {
 		}
 
 		if ( isWooCoreProfiler ) {
-			return translate( 'One last step!' );
+			return translate( 'Connect your account' );
 		}
 
 		if ( isWpcomMigration ) {
@@ -167,6 +167,7 @@ export class AuthFormHeader extends Component {
 
 		if ( isWooCoreProfiler ) {
 			const pluginName = getPluginTitle( this.props.authQuery?.plugin_name, translate );
+			const reviewDocLink = <a href="https://woocommerce.com/documentation/woocommerce/" />;
 			const translateParams = {
 				components: {
 					br: <br />,
@@ -189,20 +190,36 @@ export class AuthFormHeader extends Component {
 				case 'logged-out':
 					return config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
 						? translate(
-								"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to create a WordPress account. {{br/}} Already have one? {{a}}Log in{{/a}}",
-								translateParams
+								'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Please create one now, or {{a}}log in{{/a}}. {{br}}{{/br}}For more information, please {{doc}}review our documentation{{/doc}}.',
+								{
+									...translateParams,
+									components: {
+										...translateParams.components,
+										doc: reviewDocLink,
+									},
+								}
 						  )
 						: translate(
 								"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
 								translateParams
 						  );
 				default:
-					return translate(
-						"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account.",
-						{
-							args: { pluginName },
-						}
-					);
+					return config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
+						? translate(
+								'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. For more information, please {{doc}}review our documentation{{/doc}}.',
+								{
+									args: { pluginName },
+									components: {
+										doc: reviewDocLink,
+									},
+								}
+						  )
+						: translate(
+								"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account.",
+								{
+									args: { pluginName },
+								}
+						  );
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR updates the header and subtitle copies to reflect the latest design changes.

See Y5pUYSJPsGEud1vknUZhi8-fi-3163_27448 for the updated copy.

Note: The link to `review our documentation` is TBD. We'll need to update it once an approved link is provided.

## Proposed Changes

* Updated the header and subtitle.


## Testing Instructions


1. Setup [woocommerce-start-dev-env](https://github.com/woocommerce/woocommerce-start-dev-env) with this branch.
2. Go to your local wp-calypso and open `config/development.json` and enable `woocommerce/core-profiler-passwordless-auth` feature flag.
3. Run `yarn start`
4. Open an incognito window and navigate to [here](https://wordpress.com/jetpack/connect/authorize?client_id=236381464&redirect_uri=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D32ab4c9508%26redirect%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A2ca8ea2582da1c066074563a12cc8b22&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=13.7&secret=QFoaAXaOIPZTr9p6Z5Hqf6RWkCboPylJ&blogname=Noisily+Fortunate+Toucan&site_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&home_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&site_icon&site_lang=en_US&site_created=2024-08-26+19%3A40%3A51&allow_site_connection=1&calypso_env=production&source&_as=search-term&_ak=jetpack&from=woocommerce-core-profiler&installed_ext_success=1&_ui=254662545&_ut=wpcom%3Auser_id&purchase_nonce=lbtPaOlO&_wp_nonce=69744335dc&redirect_after_auth=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja)
5. Confirm the copy changes -- Y5pUYSJPsGEud1vknUZhi8-fi-3182_13819
6. Click on `log in` link
7. Confirm the copy changes -- Y5pUYSJPsGEud1vknUZhi8-fi-3182_14624
8. Sign-in to wordpress.com and navigate to [here](https://wordpress.com/jetpack/connect/authorize?client_id=236381464&redirect_uri=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D32ab4c9508%26redirect%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A2ca8ea2582da1c066074563a12cc8b22&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=13.7&secret=QFoaAXaOIPZTr9p6Z5Hqf6RWkCboPylJ&blogname=Noisily+Fortunate+Toucan&site_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&home_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&site_icon&site_lang=en_US&site_created=2024-08-26+19%3A40%3A51&allow_site_connection=1&calypso_env=production&source&_as=search-term&_ak=jetpack&from=woocommerce-core-profiler&installed_ext_success=1&_ui=254662545&_ut=wpcom%3Auser_id&purchase_nonce=lbtPaOlO&_wp_nonce=69744335dc&redirect_after_auth=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja) again as a logged-in user.
9. Confirm the copy changes -- Y5pUYSJPsGEud1vknUZhi8-fi-3182_10698

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?