### PR TITLE
Performance Profiler: Update Notice component to match the design

### DIFF
--- a/client/hosting/performance/components/ReportError.tsx
+++ b/client/hosting/performance/components/ReportError.tsx
@@ -7,7 +7,7 @@ export const ReportError = ( { onRetestClick }: { onRetestClick(): void } ) => {
 
 	return (
 		<NoticeBanner
-			level="error"
+			level="warning"
 			title={ translate( 'Results not available' ) }
 			hideCloseButton
 			actions={ [

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -288,7 +288,7 @@ export const SitePerformance = () => {
 							ctaText={
 								site?.is_a4a_dev_site
 									? translate( 'Prepare for launch' )
-									: translate( 'Launch Site' )
+									: translate( 'Launch your site' )
 							}
 						/>
 					) : (

--- a/client/hosting/performance/style.scss
+++ b/client/hosting/performance/style.scss
@@ -1,4 +1,5 @@
 @use "sass:math";
+@import "@automattic/color-studio/dist/color-variables";
 @import "@wordpress/base-styles/breakpoints";
 
 $section-max-width: 1224px;
@@ -34,6 +35,26 @@ $section-max-width: 1224px;
 
 		@media (max-width: $break-medium) {
 			margin-top: 24px;
+		}
+	}
+
+	.notice-banner.is-info {
+		border: none;
+		background-color: $studio-wordpress-blue-5;
+		color: $studio-wordpress-blue-80;
+
+		.notice-banner__icon {
+			fill: $studio-wordpress-blue-80;
+		}
+	}
+
+	.notice-banner.is-warning {
+		border: none;
+		background-color: $studio-red-0;
+		color: $studio-red-80;
+
+		.notice-banner__icon {
+			fill: $studio-red-80;
 		}
 	}
 }

--- a/client/hosting/performance/style.scss
+++ b/client/hosting/performance/style.scss
@@ -13,6 +13,7 @@ $section-max-width: 1224px;
 	.notice-banner,
 	.notice-banner__title {
 		font-size: $font-body-small;
+		margin-bottom: 4px;
 	}
 
 	@media (max-width: $break-medium) {
@@ -32,6 +33,24 @@ $section-max-width: 1224px;
 		display: flex;
 		flex-direction: column;
 		gap: 64px;
+
+		@media (max-width: $break-medium) {
+			margin-top: 24px;
+		}
+	}
+
+	.notice-banner {
+		box-shadow: none;
+		padding: 16px;
+
+		.notice-banner__icon-wrapper {
+			margin-right: 8px;
+			position: unset;
+		}
+
+		.notice-banner__action-bar {
+			margin-top: 12px;
+		}
 
 		@media (max-width: $break-medium) {
 			margin-top: 24px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9246

## Proposed Changes

* Update Notices to match design
![image](https://github.com/user-attachments/assets/46102668-bebe-4fa5-8123-a2c13c4b7ab7)
![image](https://github.com/user-attachments/assets/ed90631f-4eff-4cd6-975e-5bcc2606f25c)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites/performance/site` with an unlaunched site`
* Verfiy notice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
