### PR TITLE
Stats: Fix bar number not respecting date range selected

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -287,30 +287,23 @@ class StatsSite extends Component {
 			customChartRange.chartStart = moment().subtract( daysInRange, 'days' ).format( 'YYYY-MM-DD' );
 		}
 
-		//TODO: We need to align the start day of week from the backend.
+		customChartRange.daysInRange = daysInRange;
+
 		// Calculate diff between requested start and end in `priod` units.
 		// Move end point (most recent) to the end of period to account for partial periods
 		// (e.g. requesting period between June 2020 and Feb 2021 would require 2 `yearly` units but would return 1 unit without the shift to the end of period)
-		const adjustedChartStartDate =
-			period === 'day'
-				? moment( customChartRange.chartStart )
-				: moment( customChartRange.chartStart ).startOf( period === 'week' ? 'isoWeek' : period );
-
-		const adjustedChartEndDate =
-			period === 'day'
-				? moment( customChartRange.chartEnd )
-				: moment( customChartRange.chartEnd ).endOf( period === 'week' ? 'isoWeek' : period );
+		// TODO: We need to align the start day of week from the backend.
+		const adjustedChartStartDate = moment( customChartRange.chartStart ).startOf(
+			period === 'week' ? 'isoWeek' : period
+		);
+		// TODO: We need to align the start day of week from the backend.
+		const adjustedChartEndDate = moment( customChartRange.chartEnd ).endOf(
+			period === 'week' ? 'isoWeek' : period
+		);
 
 		let customChartQuantity = Math.ceil(
 			adjustedChartEndDate.diff( adjustedChartStartDate, period, true )
 		);
-
-		// The above calculation is not accurate for the day period which always needs a plus one.
-		if ( period === 'day' ) {
-			customChartQuantity += 1;
-		}
-
-		customChartRange.daysInRange = daysInRange;
 
 		// Force the default date range to be 7 days if the 30-day option is locked.
 		if ( shouldForceDefaultDateRange ) {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -287,17 +287,28 @@ class StatsSite extends Component {
 			customChartRange.chartStart = moment().subtract( daysInRange, 'days' ).format( 'YYYY-MM-DD' );
 		}
 
+		//TODO: We need to align the start day of week from the backend.
 		// Calculate diff between requested start and end in `priod` units.
 		// Move end point (most recent) to the end of period to account for partial periods
 		// (e.g. requesting period between June 2020 and Feb 2021 would require 2 `yearly` units but would return 1 unit without the shift to the end of period)
+		const adjustedChartStartDate =
+			period === 'day'
+				? moment( customChartRange.chartStart )
+				: moment( customChartRange.chartStart ).startOf( period === 'week' ? 'isoWeek' : period );
+
 		const adjustedChartEndDate =
 			period === 'day'
 				? moment( customChartRange.chartEnd )
-				: moment( customChartRange.chartEnd ).endOf( period );
+				: moment( customChartRange.chartEnd ).endOf( period === 'week' ? 'isoWeek' : period );
 
 		let customChartQuantity = Math.ceil(
-			adjustedChartEndDate.diff( moment( customChartRange.chartStart ), period, true )
+			adjustedChartEndDate.diff( adjustedChartStartDate, period, true )
 		);
+
+		// The above calculation is not accurate for the day period which always needs a plus one.
+		if ( period === 'day' ) {
+			customChartQuantity += 1;
+		}
 
 		customChartRange.daysInRange = daysInRange;
 


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/184

## Proposed Changes

* Quantity of days is of the same calculation as other periods if you think about it by adjusting them to the start and end of day respectively. For example, '2024-09-01' to '2024-09-02' becomes '2024-09-01 00:00:00' to '2024-09-02 23:59:59', which is exactly two days!!
* Align start of week to Monday, the same as the backend to be consistent. The next step should be supporting customize start day of week from both the front and backend

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistency + bugfix

## Testing Instructions


* Open Calypso Live Branch `/stats/week/jetpack.com`
* Choose 7 Days, 30 Days and 90 Days
* Ensure it shows the correct number of bars
* Choose a custom range
* Ensure the bars match the date selected

https://github.com/user-attachments/assets/5563fc9f-d10a-41fb-9ca6-e1d748fd0635



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
