### PR TITLE
Performance Profiler: Fix report rendering the wrong site

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -87,6 +87,9 @@ export const SitePerformance = () => {
 	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID;
 
+	const isSitePublic =
+		site && ! site.is_coming_soon && ! site.is_private && site.launch_status === 'launched';
+
 	const stats = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, statsQuery )
 	) as { id: number; value: number }[];
@@ -117,6 +120,10 @@ export const SitePerformance = () => {
 	const filter = queryParams?.filter?.toString();
 	const [ recommendationsFilter, setRecommendationsFilter ] = useState( filter );
 	const [ currentPage, setCurrentPage ] = useState< ( typeof pages )[ number ] >();
+
+	useEffect( () => {
+		setCurrentPage( undefined );
+	}, [ siteId ] );
 
 	useEffect( () => {
 		if ( pages && ! currentPage ) {
@@ -157,9 +164,6 @@ export const SitePerformance = () => {
 
 		window.history.replaceState( {}, '', url.toString() );
 	};
-
-	const isSitePublic =
-		site && ! site.is_coming_soon && ! site.is_private && site.launch_status === 'launched';
 
 	const performanceReport = usePerformanceReport(
 		isSitePublic ? wpcom_performance_report_url : undefined,
@@ -277,7 +281,7 @@ export const SitePerformance = () => {
 					value={ activeTab }
 				/>
 			</div>
-			{ isInitialLoading ? (
+			{ isInitialLoading && isSitePublic ? (
 				<PerformanceReportLoading isLoadingPages isSavedReport={ false } pageTitle="" />
 			) : (
 				<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9247
## Proposed Changes

This PR fixes situation where you browse a unlaunched site performance tab then switch to a site that was launch but it runs the report on the incorrect url of the unlaunched site. This happened because the current page which holds information about the site eg. the url , that page is not reset when the site change and so the incorrect url is used.

Image of what's happening
![image](https://github.com/user-attachments/assets/728cfe90-45ac-471f-86d2-0bf5de507023)


* Reset current page data when the site changes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of ensuring the product work as expected

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go `sites/performance/unlaunch_site` after seeing the notice
* Switch to a launched site so the performance report is executed.
* Verify the report is executed on the correct site by checking images in the timeline.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
