### PR TITLE
Woo Express Plans: fix price display

### DIFF
--- a/client/my-sites/plans/woo-express-plans-page/index.tsx
+++ b/client/my-sites/plans/woo-express-plans-page/index.tsx
@@ -89,9 +89,11 @@ const WooExpressPlansPage = ( {
 					args: {
 						monthlyPrice: formatCurrency( annualPlanMonthlyPrice, currencyCode, {
 							stripZeros: true,
+							isSmallestUnit: true,
 						} ),
 						annualPrice: formatCurrency( annualPlanPrice, currencyCode, {
 							stripZeros: true,
+							isSmallestUnit: true,
 						} ),
 					},
 					components: {
@@ -106,6 +108,7 @@ const WooExpressPlansPage = ( {
 					args: {
 						monthlyPrice: formatCurrency( monthlyPlanPrice, currencyCode, {
 							stripZeros: true,
+							isSmallestUnit: true,
 						} ),
 					},
 					components: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1727372440804429-slack-C02BEP610

## Proposed Changes

* In #89653, we switched to the `usePricingMetaForGridPlans` hook, but the price display was not updated to reflect the fact that the hook returned prices in the smallest unit. For, e.g., if the price is $10.42, the hook returned a value of `1042`. This PR updates the price display to correctly handle integer price values.

| Before | After |
|--------|--------|
|<img width="1018" alt="image" src="https://github.com/user-attachments/assets/dd108f09-4346-430a-9394-ad0cb8b9ab05">| <img width="1003" alt="image" src="https://github.com/user-attachments/assets/c5885cb5-a8f3-41f1-b7b2-d3a818c85187"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/wooexpress` and create a trial site.
* Using the SA, add the WooExpress Essential plan to the site.
* Go to `/plans/<site slug>`.
* Confirm that the plan price is displayed correctly.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?