### PR TITLE
Polish UI when site is being build during DIFM

### DIFF
--- a/client/hosting/sites/components/sites-dataviews/sites-site-status.tsx
+++ b/client/hosting/sites/components/sites-dataviews/sites-site-status.tsx
@@ -127,7 +127,7 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 					<TransferNoticeWrapper { ...result } />
 				) : (
 					<>
-						{ /* Hide status badge during DIFM for cleaner UI, as the user cannot access their site */ }
+						{ /* Hide status/checklist during DIFM for cleaner UI, as the user cannot access their site */ }
 						{ isDIFMInProgress ? (
 							<div>
 								{ translatedStatus }

--- a/client/hosting/sites/components/sites-dataviews/sites-site-status.tsx
+++ b/client/hosting/sites/components/sites-dataviews/sites-site-status.tsx
@@ -127,11 +127,13 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 					<TransferNoticeWrapper { ...result } />
 				) : (
 					<>
-						<div>
-							{ translatedStatus }
-							<SiteLaunchNag site={ site } />
-						</div>
-						{ isDIFMInProgress && (
+						{ /* Hide status badge during DIFM for cleaner UI, as the user cannot access their site */ }
+						{ isDIFMInProgress ? (
+							<div>
+								{ translatedStatus }
+								<SiteLaunchNag site={ site } />
+							</div>
+						) : (
 							<BadgeDIFM className="site__badge">{ __( 'Express Service' ) }</BadgeDIFM>
 						) }
 					</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1727275733089299/1727165645.063029-slack-C9EJ7KSGH

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/user-attachments/assets/b41c004e-9ed1-4871-93db-29bd088ca63b">  | <img src="https://github.com/user-attachments/assets/23042f70-04a9-4299-96d9-79af0f209bcf">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* More polished UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through DIFM flow https://wordpress.com/website-design-service/#pricing-grid
* Check /sites to see the badge

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?