### PR TITLE
A4A > Signup: Update the site owner warning banner text

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -9,6 +9,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import MultiCheckbox, { ChangeList } from 'calypso/components/forms/multi-checkbox';
+import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { Option as CountryOption, useCountriesAndStates } from './hooks/use-countries-and-states';
@@ -498,12 +499,27 @@ export default function AgencyDetailsForm( {
 					<LayoutBanner
 						hideCloseButton
 						level="warning"
-						title={ translate( 'Unable to Proceed with Application' ) }
+						title={ preventWidows(
+							translate( 'It seems like we might not be the perfect match right now.' )
+						) }
 					>
 						<div>
-							{ translate(
-								'Automattic for Agencies is a program designed for agencies, developers, and freelancers who work with and provide services to their clients.' +
-									' Thank you for your interest, but we will not be progressing your application now. If you chose this option in error, please select the appropriate option from the list.'
+							{ preventWidows(
+								translate(
+									'Automattic for Agencies is a program designed for agencies, developers, and freelancers who work with and provide services to their clients.' +
+										" Depending on what you are looking for, you may want to check out one of our individual products, like {{wp}}WordPress.com{{/wp}}, {{pressable}}Pressable.com{{/pressable}}, {{woo}}Woo.com{{/woo}}, {{jetpack}}Jetpack.com{{/jetpack}}. If you really aren't sure where to go, feel free to contact us at {{email}}partnerships@automattic.com{{/email}} and we'll point you in the right direction.",
+									{
+										components: {
+											wp: <a href="https://wordpress.com" target="_blank" rel="noreferrer" />,
+											pressable: (
+												<a href="https://pressable.com" target="_blank" rel="noreferrer" />
+											),
+											woo: <a href="https://woocommerce.com" target="_blank" rel="noreferrer" />,
+											jetpack: <a href="https://jetpack.com" target="_blank" rel="noreferrer" />,
+											email: <a href="mailto:partnerships@automattic.com" />,
+										},
+									}
+								)
 							) }
 						</div>
 					</LayoutBanner>


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1181

## Proposed Changes

This PR updates the site owner warning banner text during A4A signup

## Why are these changes being made?

* To update the warning text when selecting the site owner user type.

## Testing Instructions

* Switch to this branch locally.
* Create a new WPCOM account > Go to the /signup page > Select the `I do not work at an agency. I'm a site owner` option > Verify the text on the warning banner is updated as shown below and matches the one on the ticket. 
* Verify all the links open the new tabs correctly, and clicking on the email opens up your default email client app.

<img width="1728" alt="Screenshot 2024-09-27 at 3 41 27 PM" src="https://github.com/user-attachments/assets/46ef19f0-4b09-4d0b-a0ec-d405b935f437">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
