### PR TITLE
Add feature flags for VIP Onboarding for 100 Year plan

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -29,6 +29,7 @@
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
 	"features": {
+		"100-year-plan/vip": true,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"a4a-dev-sites-referral": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -10,6 +10,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"features": {
+		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"a4a-dev-sites-referral": false,

--- a/config/production.json
+++ b/config/production.json
@@ -20,6 +20,7 @@
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
+		"100-year-plan/vip": false,
 		"ad-tracking": true,
 		"a4a-dev-sites": true,
 		"a4a-dev-sites-referral": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -18,6 +18,7 @@
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
+		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"a4a-dev-sites-referral": false,

--- a/config/test.json
+++ b/config/test.json
@@ -21,6 +21,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"features": {
+		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"a4a-dev-sites-referral": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -17,6 +17,7 @@
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
+		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"a4a-dev-sites-referral": false,


### PR DESCRIPTION
Closes [#9268](https://github.com/Automattic/dotcom-forge/issues/9268)

## Proposed Changes

* Introduce the `100-year/vip` feature flag

## Why are these changes being made?

The feature flag is needed for feature gate the feature.

## Testing Instructions

- Code review should be fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
