### PR TITLE
Atomic: Render eligibility warnings as HTML

### DIFF
--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,4 +1,5 @@
 import { Card, Badge } from '@automattic/components';
+import DOMPurify from 'dompurify';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
@@ -40,7 +41,9 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 							</Fragment>
 						) }
 						<span className="eligibility-warnings__message-description">
-							<span>{ description } </span>
+							<span
+								dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( description ) } } // eslint-disable-line react/no-danger
+							/>
 							{ domainNames && displayDomainNames( domainNames ) }
 							{ supportUrl && (
 								<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/9211
Required by D162549-code

## Proposed Changes

Renders the Atomic eligibility warnings as HTML since the endpoint can return messages with HTML tags.

Before | After
--- | ---
<img width="697" alt="Screenshot 2024-09-27 at 15 13 36" src="https://github.com/user-attachments/assets/9f204be3-8708-4f5f-8895-9ab4db4d687e"> | <img width="694" alt="Screenshot 2024-09-27 at 15 22 17" src="https://github.com/user-attachments/assets/f21a596f-2cbb-44b8-a7bd-617bf03e03f6">


## Why are these changes being made?

Because we want to highlight in bold format a part of the Atomic warnings.

## Testing Instructions

- Apply D162549-code to your sandbox
- Sandbox the API
- Use the Calypso live link below
- Go to `/hosting-config`
- Pick a Simple site with a Business plan
- Click on the "Activate now" button
- Check the Atomic warning modal
- Make sure the "your domain will change" text is bold

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?