### PR TITLE
Me Developers: Links in me/developers open in Help Center or current tab

### DIFF
--- a/client/me/developer/features/github-deployment-card.tsx
+++ b/client/me/developer/features/github-deployment-card.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useHandleClickLink } from './use-handle-click-link';
 
 import './style.scss';
@@ -21,17 +22,14 @@ export const GitHubDeploymentCard = () => {
 				) }
 			</div>
 			<div className="developer-features-list__item-learn-more">
-				<a
-					id="github-deployments"
-					href={ localizeUrl(
+				<InlineSupportLink
+					supportPostId={ 170164 }
+					showIcon={ false }
+					supportLink={ localizeUrl(
 						'https://developer.wordpress.com/docs/developer-tools/github-deployments/'
 					) }
-					target="_blank"
-					rel="noopener noreferrer"
 					onClick={ handleClickLink }
-				>
-					{ translate( 'Learn more' ) }
-				</a>
+				/>
 			</div>
 		</Card>
 	);

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -20,7 +20,14 @@ export const DeveloperFeatures = () => {
 		const featureItemId = event?.currentTarget?.id;
 		// Opens the following feature articles in Help Center:
 		// "Custom code" and "Free SSL certificate"
-		const featureArticlesToOpenInHelpCenter = [ 'code', 'https-ssl' ];
+		const featureArticlesToOpenInHelpCenter = [
+			'connect-to-ssh-on-wordpress-com',
+			'how-to-create-a-staging-site',
+			'code',
+			'https-ssl',
+			'restore',
+			'support-options',
+		];
 
 		if (
 			openArticleInHelpCenter &&
@@ -41,7 +48,7 @@ export const DeveloperFeatures = () => {
 
 			<h2 className="developer-features-sub-title">{ translate( 'Popular features' ) }</h2>
 			<div className="developer-features-list">
-				{ features.map( ( { id, title, description, linkLearnMore } ) => (
+				{ features.map( ( { id, title, description, linkLearnMore, linkTarget = '_blank' } ) => (
 					<Card className="developer-features-list__item" key={ id }>
 						<div className="developer-features-list__item-title">{ title }</div>
 						<div className="developer-features-list__item-description">{ description }</div>
@@ -50,7 +57,7 @@ export const DeveloperFeatures = () => {
 								<a
 									id={ id }
 									href={ linkLearnMore }
-									target="_blank"
+									target={ linkTarget }
 									rel="noopener noreferrer"
 									onClick={ handleFeatureClickLink }
 								>

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -25,8 +25,7 @@ export const DeveloperFeatures = () => {
 			'how-to-create-a-staging-site',
 			'code',
 			'https-ssl',
-			'restore',
-			'support-options',
+			'help-support-options',
 		];
 
 		if (

--- a/client/me/developer/features/studio-card.tsx
+++ b/client/me/developer/features/studio-card.tsx
@@ -24,7 +24,6 @@ export const StudioCard = () => {
 				<a
 					id="studio"
 					href={ localizeUrl( 'https://developer.wordpress.com/studio/' ) }
-					target="_blank"
 					rel="noopener noreferrer"
 					onClick={ handleClickLink }
 				>

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -91,7 +91,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( 'https://wordpress.com/support/domains/https-ssl' ),
 		},
 		{
-			id: 'support-options',
+			id: 'help-support-options',
 			title: translate( '24/7 expert support', {
 				comment: 'Feature title',
 			} ),

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -1,5 +1,6 @@
 import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useHandleClickLink } from './use-handle-click-link';
 
 export const useFeaturesList = () => {
@@ -61,6 +62,7 @@ export const useFeaturesList = () => {
 						}
 				  ),
 			linkLearnMore: localizeUrl( 'https://wordpress.com/for-agencies?ref=wpcom-dev-dashboard' ),
+			linkTarget: '_self',
 		},
 		{
 			id: 'code',
@@ -89,7 +91,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( 'https://wordpress.com/support/domains/https-ssl' ),
 		},
 		{
-			id: 'help-support-options',
+			id: 'support-options',
 			title: translate( '24/7 expert support', {
 				comment: 'Feature title',
 			} ),
@@ -99,7 +101,9 @@ export const useFeaturesList = () => {
 					comment: 'Feature description',
 				}
 			),
-			linkLearnMore: localizeUrl( 'https://developer.wordpress.com/docs/support/' ),
+			linkLearnMore: localizeUrl(
+				'https://developer.wordpress.com/?post_type=documentation&p=99417'
+			),
 		},
 		{
 			id: 'malware-scanning-removal',
@@ -112,35 +116,26 @@ export const useFeaturesList = () => {
 					comment: 'Feature description',
 					components: {
 						backupsLink: (
-							<a
-								id="restore"
-								href={ localizeUrl(
-									'https://developer.wordpress.com/docs/platform-features/real-time-backup-restore/'
-								) }
-								target="_blank"
-								rel="noopener noreferrer"
+							<InlineSupportLink
+								supportPostId={ 99415 }
+								supportLink="https://developer.wordpress.com/docs/platform-features/real-time-backup-restore/"
+								showIcon={ false }
 								onClick={ handleClickLink }
 							/>
 						),
 						malwareScanningLink: (
-							<a
-								id="malware-and-site-security"
-								href={ localizeUrl(
-									'https://developer.wordpress.com/docs/platform-features/jetpack-scan/'
-								) }
-								target="_blank"
-								rel="noopener noreferrer"
+							<InlineSupportLink
+								supportPostId={ 99380 }
+								supportLink="https://developer.wordpress.com/docs/platform-features/jetpack-scan/"
+								showIcon={ false }
 								onClick={ handleClickLink }
 							/>
 						),
 						siteMonitoringLink: (
-							<a
-								id="site-monitoring"
-								href={ localizeUrl(
-									'https://developer.wordpress.com/docs/troubleshooting/site-monitoring/'
-								) }
-								target="_blank"
-								rel="noopener noreferrer"
+							<InlineSupportLink
+								supportPostId={ 99421 }
+								supportLink="https://developer.wordpress.com/docs/troubleshooting/site-monitoring/"
+								showIcon={ false }
 								onClick={ handleClickLink }
 							/>
 						),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9087

## Proposed Changes

* This PR updates the link in /me/developers so they open in the Help Center or the current tab.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Creating consistency in external links.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /me/developers
* Click on all the links. They should either open in the Help Center or in the current tab.
* Make sure the link destinations are the same as those in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
