### PR TITLE
A4A: Fix inconsistency with header spacing.

### DIFF
--- a/client/a8c-for-agencies/components/content-sidebar/style.scss
+++ b/client/a8c-for-agencies/components/content-sidebar/style.scss
@@ -2,6 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .content-sidebar {
+	margin-block-start: 16px;
 	grid-row: 4 / span 1;
 
 	@include break-xlarge {

--- a/client/a8c-for-agencies/components/layout/index.tsx
+++ b/client/a8c-for-agencies/components/layout/index.tsx
@@ -22,15 +22,7 @@ type Props = {
 	compact?: boolean;
 };
 
-function MainLayout( {
-	children,
-	className,
-	title,
-	wide,
-	withBorder,
-	compact,
-	sidebarNavigation,
-}: Props ) {
+function MainLayout( { children, className, title, wide, withBorder, sidebarNavigation }: Props ) {
 	const hasLayoutColumns = React.Children.toArray( children ).some(
 		( child ) => React.isValidElement( child ) && child.type === LayoutColumn
 	);
@@ -42,7 +34,6 @@ function MainLayout( {
 		<Main
 			className={ clsx( 'a4a-layout', className, {
 				'is-with-border': withBorder,
-				'is-compact': compact,
 			} ) }
 			fullWidthLayout={ wide }
 			wideLayout={ ! wide } // When we set to full width, we want to set this to false.

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -75,7 +75,7 @@ html,
 }
 
 .a4a-layout__top-wrapper {
-	padding-block-start: 48px;
+	padding-block-start: 24px;
 	border-bottom: #f1f1f1 1px solid;
 
 	@include breakpoint-deprecated( "<660px" ) {
@@ -94,12 +94,10 @@ html,
 			}
 		}
 	}
-}
 
-.main.a4a-layout.is-compact .a4a-layout__top-wrapper {
-	padding-block-start: 28px;
-	@include breakpoint-deprecated( "<660px" ) {
-		padding: 0;
+	// If we don't have a navigation, we will require some spacing on the borders.
+	&:not(.has-navigation) {
+		padding-block-end: 24px;
 	}
 }
 
@@ -107,32 +105,17 @@ html,
 	@include breakpoint-deprecated( ">660px" ) {
 		.a4a-layout__top-wrapper {
 			border-block-end: 1px solid var(--color-neutral-5);
-			// If we don't have a navigation, we will require some spacing on the borders.
-			&:not(.has-navigation) {
-				padding-block-end: 48px;
-			}
 		}
 	}
 }
-
-.main.a4a-layout.is-with-border.is-compact {
-	@include breakpoint-deprecated( ">660px" ) {
-		.a4a-layout__top-wrapper {
-
-			&:not(.has-navigation) {
-				padding-block-end: 28px;
-			}
-		}
-	}
-}
-
 
 .a4a-layout__header {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	margin: 0 auto 24px auto;
+	margin: 0 auto;
 	height: 100%;
+	min-height: 40px;
 
 	> * + * {
 		margin-inline-start: 24px;
@@ -279,6 +262,11 @@ html,
 		}
 	}
 
+	.section-nav-tab {
+		box-sizing: border-box;
+		max-height: 48px;
+	}
+
 	.section-nav-tabs.is-dropdown {
 		width: 100%;
 		margin: 0 0 1px 0;
@@ -304,7 +292,6 @@ html,
 	}
 
 	@include breakpoint-deprecated( ">1040px" ) {
-		margin-block-start: 32px;
 		margin-inline: -16px;
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -219,7 +219,6 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 			title={ title }
 			wide
 			withBorder={ ! isClient }
-			compact
 			sidebarNavigation={ ! isClient && <MobileSidebarNavigation /> }
 		>
 			{ isClient ? null : (

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -78,7 +78,6 @@ function Hosting( { section }: Props ) {
 			title={ isNarrowView ? translate( 'Hosting' ) : translate( 'Hosting Marketplace' ) }
 			wide
 			withBorder
-			compact
 		>
 			<LayoutTop>
 				<PendingPaymentNotification />

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -75,7 +75,6 @@ function PressableOverview() {
 			title={ translate( 'Pressable hosting' ) }
 			wide
 			withBorder
-			compact
 		>
 			<LayoutTop>
 				<LayoutHeader>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -84,7 +84,6 @@ function ProductsOverview( { siteId, suggestedProduct, productBrand, searchQuery
 			title={ translate( 'Product Marketplace' ) }
 			wide
 			withBorder
-			compact
 		>
 			<LayoutTop withNavigation>
 				<PendingPaymentNotification />

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -105,13 +105,7 @@ function WpcomOverview() {
 	const WPCOM_PRICING_PAGE_LINK = 'https://wordpress.com/pricing/';
 
 	return (
-		<Layout
-			className="wpcom-overview"
-			title={ translate( 'WordPress.com hosting' ) }
-			wide
-			withBorder
-			compact
-		>
+		<Layout className="wpcom-overview" title={ translate( 'WordPress.com hosting' ) } wide compact>
 			<LayoutTop>
 				<LayoutHeader>
 					<Breadcrumb

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -105,7 +105,7 @@ function WpcomOverview() {
 	const WPCOM_PRICING_PAGE_LINK = 'https://wordpress.com/pricing/';
 
 	return (
-		<Layout className="wpcom-overview" title={ translate( 'WordPress.com hosting' ) } wide compact>
+		<Layout className="wpcom-overview" title={ translate( 'WordPress.com hosting' ) } wide>
 			<LayoutTop>
 				<LayoutHeader>
 					<Breadcrumb

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -20,7 +20,7 @@ export default function Overview() {
 	const title = translate( 'Agency Overview' );
 
 	return (
-		<Layout title={ title } wide>
+		<Layout title={ title } compact wide>
 			<LayoutTop>
 				<LayoutHeader className="a4a-overview-header">
 					<Title>{ title }</Title>

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -20,7 +20,7 @@ export default function Overview() {
 	const title = translate( 'Agency Overview' );
 
 	return (
-		<Layout title={ title } compact wide>
+		<Layout title={ title } wide>
 			<LayoutTop>
 				<LayoutHeader className="a4a-overview-header">
 					<Title>{ title }</Title>

--- a/client/a8c-for-agencies/sections/overview/style.scss
+++ b/client/a8c-for-agencies/sections/overview/style.scss
@@ -6,8 +6,6 @@
 }
 
 .a4a-overview-header {
-	padding-block-end: 32px;
-
 	@include breakpoint-deprecated( "<660px" ) {
 		padding-block-end: 0;
 	}

--- a/client/a8c-for-agencies/sections/purchases/billing/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/billing/style.scss
@@ -1,3 +1,7 @@
+.billing-dashboard .a4a-layout__body {
+	padding-block-start: 32px;
+}
+
 .a4a-billing__header-actions {
 	@include breakpoint-deprecated( "<660px" ) {
 		display: block;

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-overview/index.tsx
@@ -8,13 +8,20 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import InvoicesList from '../invoices-list';
 
+import './style.scss';
+
 export default function InvoicesOverview() {
 	const translate = useTranslate();
 
 	const title = translate( 'Invoices' );
 
 	return (
-		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+		<Layout
+			className="invoices-overview"
+			title={ title }
+			wide
+			sidebarNavigation={ <MobileSidebarNavigation /> }
+		>
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title } </Title>

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-overview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-overview/style.scss
@@ -1,0 +1,3 @@
+.invoices-overview .a4a-layout__body {
+	padding-block-start: 32px;
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/style.scss
@@ -1,8 +1,14 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.licenses-overview .search {
-	box-shadow: 0 0 0 1px var(--color-neutral-5);
+.licenses-overview {
+	.a4a-layout__body {
+		padding-block-start: 32px;
+	}
+
+	.search {
+		box-shadow: 0 0 0 1px var(--color-neutral-5);
+	}
 }
 
 .licenses-overview__empty-message {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -130,11 +130,6 @@ $data-view-border-color: #f1f1f1;
 		margin-block-start: 32px;
 	}
 
-	&.main.a4a-layout.is-with-border .a4a-layout__top-wrapper:not(.has-navigation) {
-		padding-block-start: 24px;
-		padding-block-end: 0;
-	}
-
 	&.main.a4a-layout {
 		@include break-large {
 			background: inherit;
@@ -226,7 +221,9 @@ $data-view-border-color: #f1f1f1;
 	}
 }
 
-// FIXME: This is a temporary fix to make the referral layout columns the same height
+/* FIXME: This is a temporary fix to make the referral
+ * layout columns the same height
+ */
 .main.a4a-layout-column.referrals-layout__column {
 	height: auto;
 	overflow-y: scroll;

--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -31,7 +31,7 @@ export default function GetStarted() {
 	};
 
 	return (
-		<Layout className="team-list-get-started" title={ title } wide compact>
+		<Layout className="team-list-get-started" title={ title } wide>
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title }</Title>

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/index.tsx
@@ -104,12 +104,7 @@ export default function TeamAcceptInvite( { agencyId, inviteId, secret }: Props 
 	}
 
 	return (
-		<Layout
-			className="team-accept-invite"
-			title={ translate( 'Accepting team invite' ) }
-			wide
-			compact
-		>
+		<Layout className="team-accept-invite" title={ translate( 'Accepting team invite' ) } wide>
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title }</Title>

--- a/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
@@ -82,7 +82,7 @@ export default function TeamInvite() {
 	}, [] );
 
 	return (
-		<Layout className="team-invite" title={ title } wide compact>
+		<Layout className="team-invite" title={ title } wide>
 			<LayoutTop>
 				<LayoutHeader>
 					<Breadcrumb

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -97,7 +97,7 @@ export default function TeamList( { currentTab }: Props ) {
 	}
 
 	return (
-		<Layout className="team-list full-width-layout-with-table" title={ title } wide compact>
+		<Layout className="team-list full-width-layout-with-table" title={ title } wide>
 			<LayoutTop withNavigation>
 				<LayoutHeader>
 					<Title>{ title }</Title>


### PR DESCRIPTION
This pull request standardizes the spacing in the A4A header layout. We have a couple of pages with different spacing, causing our page content to shift a lot. Example is the Overview page.

| Before | After |
|--------|--------|
| <img width="1720" alt="Screenshot 2024-09-27 at 9 57 10 PM" src="https://github.com/user-attachments/assets/fa7f4b4a-02c6-434c-9730-6dec0afc4821"> | <img width="1724" alt="Screenshot 2024-09-27 at 9 57 16 PM" src="https://github.com/user-attachments/assets/c3e30b1c-ed9b-45db-a1fb-a3642a0328c7"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/805

## Proposed Changes

* Remove the 'compact' layout variant, which has different spacing, and force all layout consumers to use the same spacing. We follow a 24px spacing for both the top and bottom.
* Remove some ad-hoc on some of the pages to force some consistency. We no longer need it as we are standardizing it from the core layout.

## Why are these changes being made?

* Make our UI more polished, which results in a better user experience.

## Testing Instructions

* Use the A4A live link and verify all headers have consistent spacing. 

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
