### PR TITLE
SSR: Prevent Log-in sub-pages from indexing

### DIFF
--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -3,6 +3,7 @@ import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, setLocaleMiddleware } from 'calypso/controller';
 import webRouter from './index.web';
 import redirectLoggedIn from './redirect-logged-in';
+import { setMetaTags } from './ssr';
 
 /**
  * Re-exports
@@ -18,6 +19,7 @@ export default ( router ) => {
 			[ `/log-in/link/use/${ lang }`, `/log-in/link/jetpack/use/${ lang }` ],
 			setLocaleMiddleware(),
 			redirectLoggedIn,
+			setMetaTags,
 			makeLayout
 		);
 	}

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -19,7 +19,7 @@ import {
 	redirectDefaultLocale,
 } from './controller';
 import redirectLoggedIn from './redirect-logged-in';
-import { setShouldServerSideRenderLogin, ssrSetupLocaleLogin } from './ssr';
+import { setShouldServerSideRenderLogin, ssrSetupLocaleLogin, setMetaTags } from './ssr';
 
 export const LOGIN_SECTION_DEFINITION = {
 	name: 'login',
@@ -70,6 +70,7 @@ export default ( router ) => {
 			[ `/log-in/link/use/${ lang }`, `/log-in/jetpack/link/use/${ lang }` ],
 			redirectLoggedIn,
 			setLocaleMiddleware(),
+			setMetaTags,
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 			magicLoginUse,
 			makeLoggedOutLayout
@@ -78,6 +79,7 @@ export default ( router ) => {
 		router(
 			[ `/log-in/link/${ lang }`, `/log-in/jetpack/link/${ lang }`, `/log-in/new/link/${ lang }` ],
 			setLocaleMiddleware(),
+			setMetaTags,
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 			magicLogin,
 			makeLoggedOutLayout
@@ -88,6 +90,7 @@ export default ( router ) => {
 		[ `/log-in/qr/${ lang }` ],
 		redirectLoggedIn,
 		setLocaleMiddleware(),
+		setMetaTags,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		qrCodeLogin,
 		makeLoggedOutLayout
@@ -110,6 +113,7 @@ export default ( router ) => {
 		redirectDefaultLocale,
 		setLocaleMiddleware(),
 		setHrefLangLinks,
+		setMetaTags,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		login,
 		setShouldServerSideRenderLogin,

--- a/client/login/ssr.js
+++ b/client/login/ssr.js
@@ -76,29 +76,19 @@ export function setMetaTags( context, next ) {
 	);
 
 	/**
-	 * Only the main `/log-in` and `/log-in/[locale]` routes should be indexed.
+	 * Only the main `/log-in` and `/log-in/[mag-16-locale]` routes should be indexed.
 	 */
-	if (
-		hasQueryString ||
-		pathSegments.length > 2 ||
-		( pathSegments.length === 2 && ! hasMag16LocaleParam )
-	) {
-		const meta = getDocumentHeadMeta( context.store.getState() );
-		const noIndexMetaExists = meta.some(
-			( tag ) => tag.name === 'robots' && tag.content === 'noindex'
-		);
+	if ( hasQueryString || pathSegments.length > ( hasMag16LocaleParam ? 2 : 1 ) ) {
+		const meta = getDocumentHeadMeta( context.store.getState() )
+			// Remove existing robots meta tags to prevent duplication.
+			.filter( ( { name } ) => name !== 'robots' )
+			// Add the noindex meta tag.
+			.concat( {
+				name: 'robots',
+				content: 'noindex',
+			} );
 
-		// Set the noindex meta only if it's not already set.
-		if ( ! noIndexMetaExists ) {
-			context.store.dispatch(
-				setDocumentHeadMeta(
-					meta.concat( {
-						name: 'robots',
-						content: 'noindex',
-					} )
-				)
-			);
-		}
+		context.store.dispatch( setDocumentHeadMeta( meta ) );
 	}
 
 	next();

--- a/client/login/ssr.js
+++ b/client/login/ssr.js
@@ -1,5 +1,4 @@
-import config from '@automattic/calypso-config';
-import { isDefaultLocale } from '@automattic/i18n-utils';
+import { isDefaultLocale, isMagnificentLocale } from '@automattic/i18n-utils';
 import { ssrSetupLocale } from 'calypso/controller';
 import { setDocumentHeadMeta } from 'calypso/state/document-head/actions';
 import { getDocumentHeadMeta } from 'calypso/state/document-head/selectors';
@@ -23,8 +22,7 @@ export function setShouldServerSideRenderLogin( context, next ) {
 	 * rather than redirecting non-Mag-16 locales to English, as is done for other sections.
 	 */
 	const isLocaleValidForSSR =
-		isDefaultLocale( context.lang ) ||
-		config( 'magnificent_non_en_locales' ).includes( context.lang );
+		isDefaultLocale( context.lang ) || isMagnificentLocale( context.lang );
 
 	context.serverSideRender =
 		// if there are any parameters, they must be ONLY the ones in the list of valid query keys
@@ -71,9 +69,7 @@ export function ssrSetupLocaleLogin( context, next ) {
 export function setMetaTags( context, next ) {
 	const pathSegments = context.pathname.replace( /^[/]|[/]$/g, '' ).split( '/' );
 	const hasQueryString = Object.keys( context.query ).length > 0;
-	const hasMag16LocaleParam = config( 'magnificent_non_en_locales' ).includes(
-		context.params?.lang
-	);
+	const hasMag16LocaleParam = isMagnificentLocale( context.params?.lang );
 
 	/**
 	 * Only the main `/log-in` and `/log-in/[mag-16-locale]` routes should be indexed.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1439-gh-Automattic/martech

## Proposed Changes

* Prevent `/log-in/*` and `/log-in/[mag-16-locale]/*` sub-pages from indexing.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Adding `noindex` meta tag to the sub-pages should help search engine indexing only the main page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Navigate to a sub page, e.g. `/log-in/link` or `/log-in/link/de`, and confirm `<meta name="robots" content="noindex"/>` is added.
* Repeat the same for non-Mag-16 locales, e.g. `/log-in/bg` or `/log-in/link/bg`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
