### PR TITLE
A4A: Update the A4A migration incentive banner copy

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
@@ -38,7 +38,7 @@ const MigrationOfferV2 = () => {
 					<div className="a4a-migration-offer-v2__body">
 						<p className="a4a-migration-offer-v2__description">
 							{ translate(
-								'From now until the end of 2024, you’ll receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000*. If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
+								'From now until the end of 2024, you’ll receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000.* If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
 								{
 									components: {
 										a: (

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
@@ -38,7 +38,7 @@ const MigrationOfferV2 = () => {
 					<div className="a4a-migration-offer-v2__body">
 						<p className="a4a-migration-offer-v2__description">
 							{ translate(
-								'From now until the end of 2024, you’ll receive $100 for each migrated site, up to $10,000*. If you’re a WP\u00A0Engine customer, we’ll also cover any costs of breaking your contract. {{a}}Full Terms ↗{{/a}}',
+								'From now until the end of 2024, you’ll receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000*. If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
 								{
 									components: {
 										a: (

--- a/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
@@ -27,7 +27,7 @@ const MigrationOfferHeader = ( { withIcon }: { withIcon?: boolean } ) => {
 const MigrationOfferBody = () => {
 	const translate = useTranslate();
 	const description = translate(
-		'From now until the end of 2024, you’ll receive $100 for each migrated site, up to $10,000*. If you’re a WP\u00A0Engine customer, we’ll also cover any costs of breaking your contract. {{a}}Full Terms ↗{{/a}}',
+		'From now until the end of 2024, you’ll receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000*. If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
 		{
 			components: {
 				a: (

--- a/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
@@ -27,7 +27,7 @@ const MigrationOfferHeader = ( { withIcon }: { withIcon?: boolean } ) => {
 const MigrationOfferBody = () => {
 	const translate = useTranslate();
 	const description = translate(
-		'From now until the end of 2024, you’ll receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000*. If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
+		'From now until the end of 2024, you’ll receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000.* If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
 		{
 			components: {
 				a: (

--- a/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
@@ -66,7 +66,7 @@ export default function MigrationsOverview() {
 				</div>
 				<div className="migrations-overview__section-intro">
 					{ translate(
-						'From now until the end of 2024, you’ll receive $100 for each migrated site to Pressable or WordPress.com, up to $10,000. If you’re a WP\u00A0Engine customer, we’ll also cover any costs associated with breaking your contract. {{a}}Full Terms ↗{{/a}}',
+						'From now until the end of 2024, you’ll receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000*. If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
 						{
 							components: {
 								a: (

--- a/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
@@ -82,7 +82,7 @@ export default function MigrationsOverview() {
 				</div>
 				<p className="migrations-overview__asterisk">
 					{ translate(
-						'* The migration limit is $10,000 for WP\u00A0Engine and $3,000 for other hosts.g'
+						'* The migration limit is $10,000 for WP\u00A0Engine and $3,000 for other hosts.'
 					) }
 				</p>
 				<div className="migrations-overview__section-subtitle">

--- a/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
@@ -66,7 +66,7 @@ export default function MigrationsOverview() {
 				</div>
 				<div className="migrations-overview__section-intro">
 					{ translate(
-						'From now until the end of 2024, you’ll receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000*. If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
+						'From now until the end of 2024, you’ll receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000.* If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
 						{
 							components: {
 								a: (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1171

## Proposed Changes

* Simplify the terms of the migration incentive.

<img width="724" alt="image" src="https://github.com/user-attachments/assets/4cd9e572-0067-4702-8962-685a4ec4a35f">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Simplify the terms of the migration incentive.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live branch.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
