### PR TITLE
Add DIY/DIFM step to 100 year flow 

### DIFF
--- a/client/landing/stepper/declarative-flow/hundred-year-plan.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-plan.ts
@@ -116,10 +116,10 @@ const HundredYearPlanFlow: Flow = {
 			switch ( _currentStep ) {
 				case 'diy-or-difm':
 					if ( 'diy' === providedDependencies?.diyOrDifmChoice ) {
-						return navigate( hasSite ? 'site-picker' : 'setup' );
+						return navigate( hasSite ? 'new-or-existing-site' : 'setup' );
 					}
 					// TODO: add VIP flow
-					return navigate( hasSite ? 'site-picker' : 'setup' );
+					return navigate( hasSite ? 'new-or-existing-site' : 'setup' );
 				case 'new-or-existing-site':
 					if ( 'new-site' === providedDependencies?.newExistingSiteChoice ) {
 						return navigate( 'setup' );

--- a/client/landing/stepper/declarative-flow/hundred-year-plan.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-plan.ts
@@ -42,7 +42,7 @@ const HundredYearPlanFlow: Flow = {
 				  ]
 				: [] ),
 
-			// Has site steps (conditional)
+			// If the user has a site, we show them a different flow
 			...( hasSite
 				? [
 						{
@@ -56,8 +56,6 @@ const HundredYearPlanFlow: Flow = {
 						},
 				  ]
 				: [] ),
-
-			// Common steps (always included)
 			{
 				slug: 'setup',
 				asyncComponent: () => import( './internals/steps-repository/hundred-year-plan-setup' ),
@@ -120,7 +118,7 @@ const HundredYearPlanFlow: Flow = {
 					if ( 'diy' === providedDependencies?.diyOrDifmChoice ) {
 						return navigate( hasSite ? 'site-picker' : 'setup' );
 					}
-					// TODO: VIP flow
+					// TODO: add VIP flow
 					return navigate( hasSite ? 'site-picker' : 'setup' );
 				case 'new-or-existing-site':
 					if ( 'new-site' === providedDependencies?.newExistingSiteChoice ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
@@ -1,0 +1,35 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
+import type { Step } from '../../types';
+
+import './styles.scss';
+
+const HundredYearPlanDIYOrDIFM: Step = function HundredYearPlanDIYOrDIFM( { navigation, flow } ) {
+	const { submit } = navigation;
+	const translate = useTranslate();
+
+	return (
+		<HundredYearPlanStepWrapper
+			stepContent={
+				<div>
+					<Button onClick={ () => submit?.( { diyOrDifmChoice: 'difm' } ) }>Do it for me</Button>
+					<Button onClick={ () => submit?.( { diyOrDifmChoice: 'diy' } ) }>Do it myself</Button>
+				</div>
+			}
+			formattedHeader={
+				<FormattedHeader
+					brandFont
+					headerText={ translate( 'TODO: title' ) }
+					subHeaderText={ translate( 'TODO: header' ) }
+					subHeaderAlign="center"
+				/>
+			}
+			stepName="hundred-year-plan-setup"
+			flowName={ flow }
+		/>
+	);
+};
+
+export default HundredYearPlanDIYOrDIFM;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
@@ -1,0 +1,1 @@
+/* Comment because we cannot have empty files */


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9270

## Proposed Changes

* This change adds the DIFM / DIY step to the 100 year flow.
* This step is still unstyled.
* Copy is not there.

## Testing Instructions

- Apply this PR
- Visit: `https://calypso.localhost:3000/setup/hundred-year-plan/?flags=100year/vip`

You should get the DIY/DIFM option. Both will go to the next step for now.

- Confirm that you don't get this step when omitting the flag.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
