### PR TITLE
A4A: Remove fallback admin access when role is unset

### DIFF
--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -98,14 +98,6 @@ export const isPathAllowed = ( pathname: string, agency: Agency | null ) => {
 		return false;
 	}
 
-	// Admins can access all paths
-	const role = agency?.user?.role;
-	// For some cases, the role isn't set, so we default to 'a4a_administrator'
-	// FIXME: This should be removed after the role is set for all users
-	if ( ! role || role === 'a4a_administrator' ) {
-		return true;
-	}
-
 	// Everyone can access the landing page and the overview page
 	if ( [ A4A_LANDING_LINK, A4A_OVERVIEW_LINK ].includes( pathname ) ) {
 		return true;


### PR DESCRIPTION
Removes the fallback behavior that granted admin-level access when a user's role wasn't set. 

With defined user roles and permissions now in place, this change enhances security by ensuring that only explicitly assigned admin roles have full access.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live link
* Navigate through the different pages in the portal and confirm the user still has access to the same pages as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
