### PR TITLE
A4A: Implement agency tier features permissions

### DIFF
--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -66,14 +66,17 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_REFERRALS_DASHBOARD ]: [ 'a4a_read_referrals' ],
 	[ A4A_REFERRALS_PAYMENT_SETTINGS ]: [ 'a4a_read_referrals' ],
 	[ A4A_REFERRALS_FAQ ]: [ 'a4a_read_referrals' ],
-	[ A4A_PARTNER_DIRECTORY_LINK ]: [ 'partner_directory', 'a4a_read_partner_directory' ],
-	[ A4A_PARTNER_DIRECTORY_DASHBOARD_LINK ]: [ 'partner_directory', 'a4a_read_partner_directory' ],
+	[ A4A_PARTNER_DIRECTORY_LINK ]: [ 'a4a_feature_partner_directory', 'a4a_read_partner_directory' ],
+	[ A4A_PARTNER_DIRECTORY_DASHBOARD_LINK ]: [
+		'a4a_feature_partner_directory',
+		'a4a_read_partner_directory',
+	],
 	[ A4A_PARTNER_DIRECTORY_AGENCY_DETAILS_LINK ]: [
 		'partner_directory',
 		'a4a_read_partner_directory',
 	],
 	[ A4A_PARTNER_DIRECTORY_AGENCY_EXPERTISE_LINK ]: [
-		'partner_directory',
+		'a4a_feature_partner_directory',
 		'a4a_read_partner_directory',
 	],
 	[ A4A_PURCHASES_LINK ]: [ 'a4a_jetpack_licensing' ],

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -72,7 +72,7 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 		'a4a_read_partner_directory',
 	],
 	[ A4A_PARTNER_DIRECTORY_AGENCY_DETAILS_LINK ]: [
-		'partner_directory',
+		'a4a_feature_partner_directory',
 		'a4a_read_partner_directory',
 	],
 	[ A4A_PARTNER_DIRECTORY_AGENCY_EXPERTISE_LINK ]: [

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -98,14 +98,6 @@ export const isPathAllowed = ( pathname: string, agency: Agency | null ) => {
 		return false;
 	}
 
-	// Admins can access all paths
-	const role = agency?.user?.role;
-	// For some cases, the role isn't set, so we default to 'a4a_administrator'
-	// FIXME: This should be removed after the role is set for all users
-	if ( ! role || role === 'a4a_administrator' ) {
-		return true;
-	}
-
 	// Everyone can access the landing page and the overview page
 	if ( [ A4A_LANDING_LINK, A4A_OVERVIEW_LINK ].includes( pathname ) ) {
 		return true;

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -67,6 +67,11 @@ export interface Agency {
 		capabilities: string[];
 	};
 	can_issue_licenses: boolean;
+	tier: {
+		id?: string;
+		label?: string;
+		features?: string[];
+	};
 }
 
 export interface AgencyStore {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1169

## Proposed Changes

* Implement agency level permissions.
* To access the Partner Directory, the permissions list would need to include both the user capability `a4a_read_partner_directory` and the agency tier feature `a4a_feature_partner_directory`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch if not merged yet: D162677-code
* Go to https://mc-url-here/agencies, enter your agency ID or search by your username
* Assign a tier to your test agency. "Agency Partner" or "Pro Agency Partner".
* Open the live link and confirm you've access to the Partner Directory.
* Change the Tier to "Emerging Partner"
* Confirm that you no longer have access to the Partner Directory

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?