### PR TITLE
Auth: Update log in with Jetpack button

### DIFF
--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -232,7 +232,7 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 	];
 
 	const notice = translate(
-		"Login via the mobile app is {{strong}}not available{{/strong}} if you've enabled two-step authentication on your account.",
+		"Logging in with the Jetpack app is {{strong}}not available{{/strong}} if you've enabled two-step authentication on your account.",
 		{
 			components: {
 				strong: <strong />,

--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -232,7 +232,7 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 	];
 
 	const notice = translate(
-		"Logging in with the Jetpack app is {{strong}}not available{{/strong}} if you've enabled two-step authentication on your account.",
+		"Logging in via the Jetpack app is {{strong}}not available{{/strong}} if you've enabled two-step authentication on your account.",
 		{
 			components: {
 				strong: <strong />,

--- a/client/components/social-buttons/qr-code.tsx
+++ b/client/components/social-buttons/qr-code.tsx
@@ -58,7 +58,9 @@ const QrCodeLoginButton = ( { loginUrl }: QrCodeLoginButtonProps ) => {
 			key="lost-password-link"
 		>
 			<JetpackLogo monochrome={ isDisabled } size={ 20 } className="social-icons" />
-			<span className="social-buttons__service-name">{ translate( 'Login via app' ) }</span>
+			<span className="social-buttons__service-name">
+				{ translate( 'Log in with the Jetpack app' ) }
+			</span>
 		</Button>
 	);
 };

--- a/client/components/social-buttons/qr-code.tsx
+++ b/client/components/social-buttons/qr-code.tsx
@@ -59,7 +59,7 @@ const QrCodeLoginButton = ( { loginUrl }: QrCodeLoginButtonProps ) => {
 		>
 			<JetpackLogo monochrome={ isDisabled } size={ 20 } className="social-icons" />
 			<span className="social-buttons__service-name">
-				{ translate( 'Log in with the Jetpack app' ) }
+				{ translate( 'Log in via Jetpack app' ) }
 			</span>
 		</Button>
 	);

--- a/client/login/qr-code-login-page/index.jsx
+++ b/client/login/qr-code-login-page/index.jsx
@@ -17,7 +17,9 @@ function QrCodeLoginPage( { locale, redirectTo } ) {
 	return (
 		<Main className="qr-code-login-page">
 			<div className="qr-code-login-page__form">
-				<h1 className="qr-code-login-page__heading">{ translate( 'Login via the mobile app' ) }</h1>
+				<h1 className="qr-code-login-page__heading">
+					{ translate( 'Log in with the Jetpack app' ) }
+				</h1>
 				<AsyncLoad
 					require="calypso/blocks/qr-code-login"
 					placeholder={ <QrCodeLoginPlaceholder /> }

--- a/client/login/qr-code-login-page/index.jsx
+++ b/client/login/qr-code-login-page/index.jsx
@@ -17,9 +17,7 @@ function QrCodeLoginPage( { locale, redirectTo } ) {
 	return (
 		<Main className="qr-code-login-page">
 			<div className="qr-code-login-page__form">
-				<h1 className="qr-code-login-page__heading">
-					{ translate( 'Log in with the Jetpack app' ) }
-				</h1>
+				<h1 className="qr-code-login-page__heading">{ translate( 'Log in via Jetpack app' ) }</h1>
 				<AsyncLoad
 					require="calypso/blocks/qr-code-login"
 					placeholder={ <QrCodeLoginPlaceholder /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9282

## Proposed Changes

* Updated Jetpack button text to: `Log in via Jetpack app`
* Updated QR Code page header to: `Log in via Jetpack app`
* Updated the disabled copy to start: `Logging in via the Jetpack app is...`

| Desktop | Mobile |
|--------|--------|
| <img width="874" alt="Screenshot 2024-10-25 at 14 56 02" src="https://github.com/user-attachments/assets/11d81a5b-3a49-4b70-8d1f-2534f339c35a"> | <img width="372" alt="Screenshot 2024-10-25 at 14 56 23" src="https://github.com/user-attachments/assets/76c21bcd-4b97-4048-bd16-62637ef0881c"> |
| <img width="881" alt="Screenshot 2024-10-25 at 14 56 52" src="https://github.com/user-attachments/assets/23f98675-84ea-44ef-9ca6-67aa63b2bea8"> | <img width="384" alt="Screenshot 2024-10-25 at 14 56 35" src="https://github.com/user-attachments/assets/90dcfeb0-db47-4dc9-96cb-692aedec3693"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make it clearer to users that the Jetpack app is required to use this option.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/log-in`
* Check the button copy for the Jetpack option
* Click the Jetpack option
* Check the page header and banner copy