### PR TITLE
Performance Profiler: Handle the lang parameter in the URL

### DIFF
--- a/client/performance-profiler/index.web.ts
+++ b/client/performance-profiler/index.web.ts
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { getAnyLanguageRouteParam } from '@automattic/i18n-utils/';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
 import {
 	PerformanceProfilerDashboardContext,
@@ -8,6 +9,23 @@ import {
 } from './controller';
 
 export default function () {
+	const lang = getAnyLanguageRouteParam();
+
+	page(
+		`/${ lang }/speed-test-tool/`,
+		PerformanceProfilerDashboardContext,
+		makeLayout,
+		clientRender
+	);
+	page( `/${ lang }/speed-test-tool/weekly-report`, WeeklyReportContext, makeLayout, clientRender );
+	page(
+		`/${ lang }/speed-test-tool/weekly-report/unsubscribe`,
+		WeeklyReportUnsubscribeContext,
+		makeLayout,
+		clientRender
+	);
+	page( `/${ lang }/speed-test-tool*`, notFound, makeLayout, clientRender );
+
 	page( '/speed-test-tool/', PerformanceProfilerDashboardContext, makeLayout, clientRender );
 	page( '/speed-test-tool/weekly-report', WeeklyReportContext, makeLayout, clientRender );
 	page(

--- a/client/performance-profiler/index.web.ts
+++ b/client/performance-profiler/index.web.ts
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { getAnyLanguageRouteParam } from '@automattic/i18n-utils/';
+import { getLanguageRouteParam } from '@automattic/i18n-utils/';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
 import {
 	PerformanceProfilerDashboardContext,
@@ -9,7 +9,7 @@ import {
 } from './controller';
 
 export default function () {
-	const lang = getAnyLanguageRouteParam();
+	const lang = getLanguageRouteParam();
 
 	page(
 		`/${ lang }/speed-test-tool/`,
@@ -25,14 +25,4 @@ export default function () {
 		clientRender
 	);
 	page( `/${ lang }/speed-test-tool*`, notFound, makeLayout, clientRender );
-
-	page( '/speed-test-tool/', PerformanceProfilerDashboardContext, makeLayout, clientRender );
-	page( '/speed-test-tool/weekly-report', WeeklyReportContext, makeLayout, clientRender );
-	page(
-		'/speed-test-tool/weekly-report/unsubscribe',
-		WeeklyReportUnsubscribeContext,
-		makeLayout,
-		clientRender
-	);
-	page( '/speed-test-tool*', notFound, makeLayout, clientRender );
 }


### PR DESCRIPTION


## Proposed Changes

Accept a lang parameter in all `speed-test-tool` urls.

## Why are these changes being made?

To allow users to see the page in their specified language.
The backend automatically adds the language param on links when its not English, so this is needed for the unsubscribe flow to work

## Testing Instructions

* Go to `/nl/speed-test-tool/weekly-report/unsubscribe?url=https://wordpress.com/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ODM3Mn0.k0fvpAjk7cX9hOKMIC5M3jOyYzeqUc7-VHX4DdLk86c` check if the page handles properly and in the correct language

![CleanShot 2024-09-27 at 14 11 00@2x](https://github.com/user-attachments/assets/b2cb1521-ef53-429a-b0cb-0d1146088543)

* Change the `nl` part to a different language (ex: `pt-br`) and see if this works properly
* Check if the path without the language still works
* Check if the same behavior can be seen on the other URLS starting with `speed-test-tool`
