### PR TITLE
Enable reactfied lost password form on the core profiler connection page

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -129,7 +129,7 @@ class SignupForm extends Component {
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 		disableTosText: PropTypes.bool,
-		currentQuery: PropTypes.object,
+
 		// Connected props
 		oauth2Client: PropTypes.object,
 		sectionName: PropTypes.string,
@@ -625,7 +625,6 @@ class SignupForm extends Component {
 										),
 										pwdResetLink: isReactLostPasswordScreenEnabled() ? (
 											<a
-												className="login__form-forgot-password"
 												href="/"
 												onClick={ ( event ) => {
 													event.preventDefault();
@@ -638,13 +637,11 @@ class SignupForm extends Component {
 																? 'jetpack/lostpassword'
 																: 'lostpassword',
 															oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
-															from: get( this.props.currentQuery, 'from' ),
+															from: this.props.from,
 														} )
 													);
 												} }
-											>
-												{ this.props.translate( 'Forgot password?' ) }
-											</a>
+											/>
 										) : (
 											<a href={ lostPassword( this.props.locale ) } />
 										),
@@ -1447,7 +1444,6 @@ export default connect(
 				isP2Flow( props.flowName ) || get( getCurrentQueryArguments( state ), 'from' ) === 'p2',
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
 			isBlazePro: getIsBlazePro( state ),
-			currentQuery: getCurrentQueryArguments( state ),
 		};
 	},
 	{

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -628,7 +628,7 @@ class SignupForm extends Component {
 												href="/"
 												onClick={ ( event ) => {
 													event.preventDefault();
-													recordTracksEvent( 'calypso_login_reset_password_link_click' );
+													recordTracksEvent( 'calypso_signup_reset_password_link_click' );
 													page(
 														login( {
 															redirectTo: this.props.redirectToAfterLoginUrl,

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -608,6 +608,8 @@ class SignupForm extends Component {
 			if ( error_code === 'taken' ) {
 				const fieldValue = formState.getFieldValue( this.state.form, fieldName );
 				const link = addQueryArgs( { email_address: fieldValue }, this.getLoginLink() );
+				const lostPasswordLink = lostPassword( this.props.locale );
+
 				return (
 					<span key={ error_code }>
 						<p>
@@ -625,7 +627,7 @@ class SignupForm extends Component {
 										),
 										pwdResetLink: isReactLostPasswordScreenEnabled() ? (
 											<a
-												href="/"
+												href={ lostPasswordLink }
 												onClick={ ( event ) => {
 													event.preventDefault();
 													recordTracksEvent( 'calypso_signup_reset_password_link_click' );
@@ -643,7 +645,7 @@ class SignupForm extends Component {
 												} }
 											/>
 										) : (
-											<a href={ lostPassword( this.props.locale ) } />
+											<a href={ lostPasswordLink } />
 										),
 									},
 								}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR enables reactfied lost password form on the core profiler connection page

## Proposed Changes

* Enabled reactfied lost password form.

## Testing Instructions

1. Checkout this branch locally.
2. Open `config/development.json` and enable `woocommerce/core-profiler-passwordless-auth` feature flag.
3. Run `yarn start`
4. Once the build is ready, open this [link](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=236381464&redirect_uri=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D32ab4c9508%26redirect%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A2ca8ea2582da1c066074563a12cc8b22&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=13.7&secret=QFoaAXaOIPZTr9p6Z5Hqf6RWkCboPylJ&blogname=Noisily%20Fortunate%20Toucan&site_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&home_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&site_icon=&site_lang=en_US&site_created=2024-08-26%2019%3A40%3A51&allow_site_connection=1&calypso_env=production&source=&_as=search-term&_ak=jetpack&from=woocommerce-core-profiler&_ui=254662545&_ut=wpcom%3Auser_id&purchase_nonce=lbtPaOlO&_wp_nonce=69744335dc&redirect_after_auth=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja) in an incognito window
5. Enter your already existing account email and press tab.
6. You should see "An account with this email already exists. Log in or reset your password" message.
7. Click on `reset your password` link.
8. You should see the reactfied lost password form.
![Screenshot 2024-09-27 at 10 53 22 AM](https://github.com/user-attachments/assets/428ec162-71d4-4762-8b8b-6ef89cba5360)

![Screenshot 2024-09-27 at 10 54 07 AM](https://github.com/user-attachments/assets/25ebbf2a-2aa8-4dcf-b8cc-37d6852b5b08)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
