### PR TITLE
BackupScheduleSetting: add component scaffolding and load it on Jetpack Cloud settings under a feature flag

### DIFF
--- a/client/components/jetpack/backup-schedule-setting/index.tsx
+++ b/client/components/jetpack/backup-schedule-setting/index.tsx
@@ -2,6 +2,7 @@ import { Card } from '@automattic/components';
 import { SelectControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import type { FunctionComponent } from 'react';
+import './style.scss';
 
 // Helper function to generate all time slots
 const generateTimeSlots = (): { label: string; value: string }[] => {
@@ -22,14 +23,14 @@ const BackupScheduleSetting: FunctionComponent = () => {
 	const options = generateTimeSlots();
 
 	return (
-		<div className="backup-schedule-setting">
+		<div id="backup-schedule" className="backup-schedule-setting">
 			<Card compact className="setting-title">
 				<h3>{ translate( 'Backup schedule' ) }</h3>
 			</Card>
 			<Card className="setting-content">
 				<p>
 					{ translate(
-						'Pick a timeframe for your backup to run. Some site owners prefer scheduling backups at specific times for better control'
+						'Pick a timeframe for your backup to run. Some site owners prefer scheduling backups at specific times for better control.'
 					) }
 				</p>
 				<SelectControl options={ options } help={ translate( 'Default time' ) } />

--- a/client/components/jetpack/backup-schedule-setting/index.tsx
+++ b/client/components/jetpack/backup-schedule-setting/index.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@automattic/components';
 import { SelectControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import type { FunctionComponent } from 'react';
 
 // Helper function to generate all time slots
@@ -17,19 +18,21 @@ const generateTimeSlots = (): { label: string; value: string }[] => {
 };
 
 const BackupScheduleSetting: FunctionComponent = () => {
+	const translate = useTranslate();
 	const options = generateTimeSlots();
 
 	return (
 		<div className="backup-schedule-setting">
 			<Card compact className="setting-title">
-				<h3>Backup schedule</h3>
+				<h3>{ translate( 'Backup schedule' ) }</h3>
 			</Card>
 			<Card className="setting-content">
 				<p>
-					Pick a timeframe for your backup to run. Some site owners prefer scheduling backups at
-					specific times for better control.
+					{ translate(
+						'Pick a timeframe for your backup to run. Some site owners prefer scheduling backups at specific times for better control'
+					) }
 				</p>
-				<SelectControl options={ options } help="Default time" />
+				<SelectControl options={ options } help={ translate( 'Default time' ) } />
 			</Card>
 		</div>
 	);

--- a/client/components/jetpack/backup-schedule-setting/index.tsx
+++ b/client/components/jetpack/backup-schedule-setting/index.tsx
@@ -1,0 +1,38 @@
+import { Card } from '@automattic/components';
+import { SelectControl } from '@wordpress/components';
+import type { FunctionComponent } from 'react';
+
+// Helper function to generate all time slots
+const generateTimeSlots = (): { label: string; value: string }[] => {
+	const options = [];
+	for ( let hour = 0; hour < 24; hour++ ) {
+		const startTime = hour.toString().padStart( 2, '0' ) + ':00';
+		const endTime = hour.toString().padStart( 2, '0' ) + ':59';
+		options.push( {
+			label: `${ startTime } - ${ endTime }`,
+			value: hour.toString(),
+		} );
+	}
+	return options;
+};
+
+const BackupScheduleSetting: FunctionComponent = () => {
+	const options = generateTimeSlots();
+
+	return (
+		<div className="backup-schedule-setting">
+			<Card compact className="setting-title">
+				<h3>Backup schedule</h3>
+			</Card>
+			<Card className="setting-content">
+				<p>
+					Pick a timeframe for your backup to run. Some site owners prefer scheduling backups at
+					specific times for better control.
+				</p>
+				<SelectControl options={ options } help="Default time" />
+			</Card>
+		</div>
+	);
+};
+
+export default BackupScheduleSetting;

--- a/client/components/jetpack/backup-schedule-setting/style.scss
+++ b/client/components/jetpack/backup-schedule-setting/style.scss
@@ -1,0 +1,27 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.backup-schedule-setting {
+	box-sizing: border-box;
+	margin: auto;
+	max-width: 720px;
+	margin-left: -16px;
+	margin-right: -16px;
+
+	@include break-medium {
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	h3 {
+		font-size: $font-body;
+	}
+
+    p {
+        font-size: $font-body-small;
+    }
+
+	.components-select-control {
+		width: fit-content;
+	}
+}

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -4,6 +4,7 @@ import AdvancedCredentials from 'calypso/components/advanced-credentials';
 import BackupRetentionManagement from 'calypso/components/backup-retention-management';
 import DocumentHead from 'calypso/components/data/document-head';
 import HasSitePurchasesSwitch from 'calypso/components/has-site-purchases-switch';
+import BackupScheduleSetting from 'calypso/components/jetpack/backup-schedule-setting';
 import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
 import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
 import JetpackStagingSitesManagement from 'calypso/components/jetpack-staging-sites-management';
@@ -75,6 +76,7 @@ export const advancedCredentials: Callback = ( context, next ) => {
 				falseComponent={ null }
 				loadingComponent={ <AdvancedCredentialsLoadingPlaceholder /> }
 			/>
+			{ config.isEnabled( 'jetpack/backup-schedule-setting' ) ? <BackupScheduleSetting /> : null }
 		</Main>
 	);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/669

The idea of this PR is to add the foundation code to start iterating on the backup schedule feature on Jetpack Cloud. This component will be rendered under the `jetpack/backup-schedule-setting` feature flag, so it will not be visible to final users yet.

## Proposed Changes

* Add `BackupScheduleSetting` component scaffolding to render the backup schedule settings.
  * Load the component on Jetpack Setting under the `jetpack/backup-schedule-setting` feature flag

![CleanShot 2024-09-27 at 22 51 13@2x](https://github.com/user-attachments/assets/0459eb2c-756b-4b9e-97dc-005b20e437e2)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
peaFOp-2Lz-p2


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud live branch
* Append to the URL `?flags=jetpack/backup-schedule-setting` so it loads the feature flag
* Navigate to Jetpack Settings
* Ensure you see the `Backup schedule` setting at the end of the settings page, and it looks like the screenshot shared above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?