### PR TITLE
Me Privacy: Open privacy links in the current tab

### DIFF
--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -8,7 +8,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
-import ExternalLink from 'calypso/components/external-link';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import Main from 'calypso/components/main';
@@ -57,12 +56,8 @@ class Privacy extends Component {
 
 		const isSubmitButtonDisabled = ! hasUnsavedUserSettings || isUpdatingUserSettings;
 
-		const cookiePolicyLink = (
-			<ExternalLink href={ localizeUrl( 'https://automattic.com/cookies/' ) } target="_blank" />
-		);
-		const privacyPolicyLink = (
-			<ExternalLink href={ localizeUrl( 'https://automattic.com/privacy/' ) } target="_blank" />
-		);
+		const cookiePolicyLink = <a href={ localizeUrl( 'https://automattic.com/cookies/' ) } />;
+		const privacyPolicyLink = <a href={ localizeUrl( 'https://automattic.com/privacy/' ) } />;
 
 		return (
 			<Main wideLayout className="privacy">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9087

## Proposed Changes

* This PR opens the privacy links in me/privacy in the current tab.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There is precedence for these links to open in the same tab because that is the behavior of the "logged out homepage" wordpress.com. Additionally, these links are "in our system," so following [these rules](https://github.com/Automattic/dotcom-forge/issues/8076#issuecomment-2321439467), they do not need to open in a new tab.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso Live
* Go to /me/privacy
* Observe the links open in the current tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
