### PR TITLE
Help: Update compact card link targets

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { CompactCard, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Icon, external } from '@wordpress/icons';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
 import { PureComponent } from 'react';
@@ -145,7 +146,12 @@ class Help extends PureComponent {
 					<Gridicon icon="video" size={ 36 } />
 					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">
-							{ this.props.translate( 'Video tutorials' ) }
+							{ this.props.translate( 'Video tutorials' ) }{ ' ' }
+							<Icon
+								icon={ external }
+								size={ 16 }
+								className="help__support-link-title__external-icon"
+							/>
 						</h2>
 						<p className="help__support-link-content">
 							{ this.props.translate(
@@ -157,7 +163,7 @@ class Help extends PureComponent {
 				<CompactCard
 					className="help__support-link"
 					href="https://wordpress.com/learn/courses?ref=wpcom-help-more-resources"
-					target="_blank"
+					showLinkIcon={ false }
 				>
 					<Gridicon icon="mail" size={ 36 } />
 					<div className="help__support-link-section">
@@ -170,7 +176,7 @@ class Help extends PureComponent {
 				<CompactCard
 					className="help__support-link"
 					href="https://learn.wordpress.com"
-					target="_blank"
+					showLinkIcon={ false }
 				>
 					<Gridicon icon="list-ordered" size={ 36 } />
 					<div className="help__support-link-section">
@@ -192,7 +198,7 @@ class Help extends PureComponent {
 				className="help__support-link"
 				href={ localizeUrl( 'https://wordpress.com/webinars/' ) }
 				onClick={ this.trackCoursesButtonClick }
-				target="_blank"
+				showLinkIcon={ false }
 			>
 				<Gridicon icon="chat" size={ 36 } />
 				<div className="help__support-link-section">

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -56,6 +56,11 @@
 	color: var(--color-neutral-70);
 	font-size: $font-body;
 	font-weight: 600;
+
+	.help__support-link-title__external-icon {
+		vertical-align: text-bottom;
+		fill: currentColor;
+	}
 }
 
 .help__support-link-content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9087

## Proposed Changes

* This PR opens the "compact cards" at the bottom of /help in the current tab, except for the YouTube card.
* It adds an "external link" icon to the YouTube card.


<img width="1416" alt="Screenshot 2024-09-27 at 5 32 32 PM" src="https://github.com/user-attachments/assets/1e076b2b-6bdd-4387-b5dc-660bf98a9eb2">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Creating consistency in external links.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /help
* Observe that the "More resources" card links open in the same tab, except for YouTube, which now has an external link icon.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
