### PR TITLE
Add platform and hosting check, add hosting error message, continue anyway path for WPCOM sites

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -29,7 +29,6 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 		isPending,
 		isSiteInfoLoading,
 		submitHandler,
-		importSiteQueryParam,
 		getContinueButtonText,
 	} = useCredentialsForm( onSubmit );
 
@@ -61,11 +60,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 				{ accessMethod === 'credentials' && (
 					<div className="site-migration-credentials">
-						<SiteAddressField
-							control={ control }
-							errors={ errors }
-							importSiteQueryParam={ importSiteQueryParam }
-						/>
+						<SiteAddressField control={ control } errors={ errors } />
 						<UsernameField control={ control } errors={ errors } />
 						<PasswordField control={ control } errors={ errors } />
 					</div>
@@ -89,7 +84,6 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 			<div className="site-migration-credentials__skip">
 				<button
 					className="button navigation-link step-container__navigation-link has-underline is-borderless"
-					disabled={ isPending || isSiteInfoLoading }
 					onClick={ onSkip }
 					type="button"
 				>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -27,6 +27,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 		errors,
 		accessMethod,
 		isPending,
+		isSiteInfoLoading,
 		submitHandler,
 		importSiteQueryParam,
 		getContinueButtonText,
@@ -79,7 +80,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 				/>
 
 				<div className="site-migration-credentials__submit">
-					<NextButton disabled={ isPending } type="submit">
+					<NextButton disabled={ isPending || isSiteInfoLoading } type="submit">
 						{ getContinueButtonText() }
 					</NextButton>
 				</div>
@@ -88,7 +89,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 			<div className="site-migration-credentials__skip">
 				<button
 					className="button navigation-link step-container__navigation-link has-underline is-borderless"
-					disabled={ isPending }
+					disabled={ isPending || isSiteInfoLoading }
 					onClick={ onSkip }
 					type="button"
 				>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -60,7 +60,11 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 				{ accessMethod === 'credentials' && (
 					<div className="site-migration-credentials">
-						<SiteAddressField control={ control } errors={ errors } />
+						<SiteAddressField
+							control={ control }
+							errors={ errors }
+							isSiteInfoLoading={ isSiteInfoLoading }
+						/>
 						<UsernameField control={ control } errors={ errors } />
 						<PasswordField control={ control } errors={ errors } />
 					</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -59,11 +59,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 				{ accessMethod === 'credentials' && (
 					<div className="site-migration-credentials">
-						<SiteAddressField
-							control={ control }
-							errors={ errors }
-							isSiteInfoLoading={ isSiteInfoLoading }
-						/>
+						<SiteAddressField control={ control } errors={ errors } />
 						<UsernameField control={ control } errors={ errors } />
 						<PasswordField control={ control } errors={ errors } />
 					</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -59,7 +59,11 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 				{ accessMethod === 'credentials' && (
 					<div className="site-migration-credentials">
-						<SiteAddressField control={ control } errors={ errors } />
+						<SiteAddressField
+							control={ control }
+							errors={ errors }
+							isSiteInfoLoading={ isSiteInfoLoading }
+						/>
 						<UsernameField control={ control } errors={ errors } />
 						<PasswordField control={ control } errors={ errors } />
 					</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -26,8 +26,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 		control,
 		errors,
 		accessMethod,
-		isPending,
-		isSiteInfoLoading,
+		isBusy,
 		submitHandler,
 		getContinueButtonText,
 	} = useCredentialsForm( onSubmit );
@@ -60,11 +59,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 				{ accessMethod === 'credentials' && (
 					<div className="site-migration-credentials">
-						<SiteAddressField
-							control={ control }
-							errors={ errors }
-							isSiteInfoLoading={ isSiteInfoLoading }
-						/>
+						<SiteAddressField control={ control } errors={ errors } />
 						<UsernameField control={ control } errors={ errors } />
 						<PasswordField control={ control } errors={ errors } />
 					</div>
@@ -79,7 +74,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 				/>
 
 				<div className="site-migration-credentials__submit">
-					<NextButton disabled={ isPending || isSiteInfoLoading } type="submit">
+					<NextButton disabled={ isBusy } type="submit">
 						{ getContinueButtonText() }
 					</NextButton>
 				</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
@@ -8,15 +8,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import { CredentialsFormFieldProps } from '../types';
 import { ErrorMessage } from './error-message';
 
-interface Props extends CredentialsFormFieldProps {
-	importSiteQueryParam?: string | undefined | null;
-}
-
-export const SiteAddressField: React.FC< Props > = ( {
-	control,
-	errors,
-	importSiteQueryParam,
-} ) => {
+export const SiteAddressField: React.FC< CredentialsFormFieldProps > = ( { control, errors } ) => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
 	const hasEnTranslation = useHasEnTranslation();
@@ -49,8 +41,6 @@ export const SiteAddressField: React.FC< Props > = ( {
 						id="from_url"
 						isError={ !! errors?.from_url }
 						placeholder={ placeholder }
-						readOnly={ !! importSiteQueryParam }
-						disabled={ !! importSiteQueryParam }
 						type="text"
 						{ ...field }
 					/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
@@ -8,7 +8,11 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import { CredentialsFormFieldProps } from '../types';
 import { ErrorMessage } from './error-message';
 
-export const SiteAddressField: React.FC< CredentialsFormFieldProps > = ( { control, errors } ) => {
+interface Props extends CredentialsFormFieldProps {
+	isSiteInfoLoading: boolean;
+}
+
+export const SiteAddressField: React.FC< Props > = ( { control, errors, isSiteInfoLoading } ) => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
 	const hasEnTranslation = useHasEnTranslation();
@@ -42,6 +46,7 @@ export const SiteAddressField: React.FC< CredentialsFormFieldProps > = ( { contr
 						isError={ !! errors?.from_url }
 						placeholder={ placeholder }
 						type="text"
+						disabled={ isSiteInfoLoading }
 						{ ...field }
 					/>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
@@ -8,11 +8,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import { CredentialsFormFieldProps } from '../types';
 import { ErrorMessage } from './error-message';
 
-interface Props extends CredentialsFormFieldProps {
-	isSiteInfoLoading: boolean;
-}
-
-export const SiteAddressField: React.FC< Props > = ( { control, errors, isSiteInfoLoading } ) => {
+export const SiteAddressField: React.FC< CredentialsFormFieldProps > = ( { control, errors } ) => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
 	const hasEnTranslation = useHasEnTranslation();
@@ -46,7 +42,6 @@ export const SiteAddressField: React.FC< Props > = ( { control, errors, isSiteIn
 						isError={ !! errors?.from_url }
 						placeholder={ placeholder }
 						type="text"
-						disabled={ isSiteInfoLoading }
 						{ ...field }
 					/>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -39,6 +39,8 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 
 	const serverSideError = useFormErrorMapping( error, variables, siteInfo );
 
+	const serverSideError = useFormErrorMapping( error, variables, siteInfo );
+
 	const {
 		formState: { errors, isSubmitting },
 		control,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -45,7 +45,7 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 	} = useForm< CredentialsFormData >( {
 		mode: 'onSubmit',
 		reValidateMode: 'onSubmit',
-		disabled: isPending || isSiteInfoLoading,
+		disabled: isPending,
 		defaultValues: {
 			from_url: importSiteQueryParam,
 			username: '',
@@ -77,14 +77,14 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 	);
 
 	const getContinueButtonText = useCallback( () => {
-		if ( isEnglishLocale && ( isPending || isSiteInfoLoading ) && ! canBypassVerification ) {
+		if ( isEnglishLocale && isPending && ! canBypassVerification ) {
 			return translate( 'Verifying credentials' );
 		}
 		if ( isEnglishLocale && canBypassVerification ) {
 			return translate( 'Continue anyways' );
 		}
 		return translate( 'Continue' );
-	}, [ isPending, canBypassVerification, isEnglishLocale, translate, isSiteInfoLoading ] );
+	}, [ isPending, canBypassVerification, isEnglishLocale, translate ] );
 
 	useEffect( () => {
 		if ( isSuccess ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -1,20 +1,23 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useDebounce } from 'use-debounce';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { isValidUrl } from 'calypso/lib/importer/url-validation';
 import { CredentialsFormData } from '../types';
 import { useFormErrorMapping } from './use-form-error-mapping';
 import { useSiteMigrationCredentialsMutation } from './use-site-migration-credentials-mutation';
 
 export const useCredentialsForm = ( onSubmit: () => void ) => {
-	const importSiteQueryParam = useQuery().get( 'from' ) || '';
-	const [ canBypassVerification, setCanBypassVerification ] = useState( false );
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
-	const [ formData, setFormData ] = useState< CredentialsFormData | null >( null );
+	const importSiteQueryParam = useQuery().get( 'from' ) || '';
+	const [ sourceUrl, setSourceUrl ] = useState( importSiteQueryParam );
+	const [ debouncedSourceUrl ] = useDebounce( sourceUrl, 500 );
 
 	const {
 		isPending,
@@ -29,7 +32,7 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 		data: siteInfo,
 		isError: isPlatformVerificationError,
 		isLoading: isSiteInfoLoading,
-	} = useAnalyzeUrlQuery( formData?.from_url ?? '', !! formData && ! canBypassVerification );
+	} = useAnalyzeUrlQuery( debouncedSourceUrl, isEnglishLocale && isValidUrl( debouncedSourceUrl ) );
 
 	const serverSideError = useFormErrorMapping( error, variables, siteInfo );
 
@@ -54,97 +57,68 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 		errors: serverSideError,
 	} );
 
-	const accessMethod = watch( 'migrationType' );
+	const isWpcom = useMemo( () => !! siteInfo?.platform_data?.is_wpcom, [ siteInfo ] );
 
-	useEffect( () => {
-		if ( ! formData || isSiteInfoLoading || ( ! siteInfo && ! isPlatformVerificationError ) ) {
-			return;
-		}
+	const canBypassVerification = useMemo( () => {
+		const credentialsVerificationFailed =
+			error?.code === 'automated_migration_tools_login_and_get_cookies_test_failed';
+		return credentialsVerificationFailed || isWpcom;
+	}, [ error, isWpcom ] );
 
-		if ( ! canBypassVerification && siteInfo?.platform_data?.is_wpcom ) {
-			setFormData( null );
-			setCanBypassVerification( true );
-			return;
-		}
-
-		requestAutomatedMigration( {
-			...formData,
-			bypassVerification: canBypassVerification || ! isEnglishLocale,
-		} );
-	}, [
-		siteInfo,
-		formData,
-		canBypassVerification,
-		isPlatformVerificationError,
-		isSiteInfoLoading,
-		isEnglishLocale,
-		requestAutomatedMigration,
-	] );
-
-	useEffect( () => {
-		if ( isSuccess ) {
-			recordTracksEvent( 'calypso_site_migration_automated_request_success' );
-			onSubmit();
-		}
-	}, [ isSuccess, onSubmit ] );
-
-	useEffect( () => {
-		if ( ! error ) {
-			return;
-		}
-
-		setFormData( null );
-
-		recordTracksEvent( 'calypso_site_migration_automated_request_error' );
-
-		const { code } = error;
-
-		const anywayModeErrors = [ 'automated_migration_tools_login_and_get_cookies_test_failed' ];
-
-		if ( anywayModeErrors.includes( code ) ) {
-			setCanBypassVerification( true );
-		}
-	}, [ error ] );
-
-	useEffect( () => {
-		const { unsubscribe } = watch( () => {
-			clearErrors( 'root' );
-			setCanBypassVerification( false );
-			setFormData( null );
-		} );
-		return () => unsubscribe();
-	}, [ watch, clearErrors ] );
-
-	const submitHandler = ( data: CredentialsFormData ) => {
-		reset();
-		clearErrors();
-		setFormData( data );
-	};
+	const submitHandler = useCallback(
+		( data: CredentialsFormData ) => {
+			clearErrors();
+			requestAutomatedMigration( {
+				...data,
+				bypassVerification: canBypassVerification || ! isEnglishLocale,
+			} );
+		},
+		[ requestAutomatedMigration, canBypassVerification, isEnglishLocale, clearErrors ]
+	);
 
 	const getContinueButtonText = useCallback( () => {
 		if ( isEnglishLocale && ( isPending || isSiteInfoLoading ) && ! canBypassVerification ) {
 			return translate( 'Verifying credentials' );
 		}
-
 		if ( isEnglishLocale && canBypassVerification ) {
 			return translate( 'Continue anyways' );
 		}
-
 		return translate( 'Continue' );
 	}, [ isPending, canBypassVerification, isEnglishLocale, translate, isSiteInfoLoading ] );
 
+	useEffect( () => {
+		if ( isSuccess ) {
+			recordTracksEvent( 'calypso_site_migration_automated_request_success' );
+			onSubmit();
+		} else if ( error ) {
+			recordTracksEvent( 'calypso_site_migration_automated_request_error' );
+		}
+	}, [ isSuccess, error, onSubmit, clearErrors ] );
+
+	useEffect( () => {
+		const { unsubscribe } = watch( ( formData, changedField ) => {
+			if ( changedField?.name === 'from_url' && formData?.from_url ) {
+				setSourceUrl( formData?.from_url );
+				clearErrors( 'from_url' );
+			}
+
+			clearErrors( 'root' );
+			reset();
+		} );
+		return () => unsubscribe();
+	}, [ watch, clearErrors, reset ] );
+
 	return {
 		formState: { errors },
+		errors,
 		control,
 		handleSubmit,
-		errors,
-		accessMethod,
-		isPending,
 		submitHandler,
-		importSiteQueryParam,
+		accessMethod: watch( 'migrationType' ),
+		isPending,
 		getContinueButtonText,
-		siteInfo,
-		isPlatformVerificationError,
 		isSiteInfoLoading,
+		isPlatformVerificationError,
+		isWpcom,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -39,8 +39,6 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 
 	const serverSideError = useFormErrorMapping( error, variables, siteInfo );
 
-	const serverSideError = useFormErrorMapping( error, variables, siteInfo );
-
 	const {
 		formState: { errors, isSubmitting },
 		control,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -93,7 +93,7 @@ export const useCredentialsForm = ( onSubmit: () => void ) => {
 		} else if ( error ) {
 			recordTracksEvent( 'calypso_site_migration_automated_request_error' );
 		}
-	}, [ isSuccess, error, onSubmit, clearErrors ] );
+	}, [ isSuccess, error, onSubmit ] );
 
 	useEffect( () => {
 		const { unsubscribe } = watch( ( formData, changedField ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -186,14 +186,6 @@ describe( 'SiteMigrationCredentials', () => {
 		expect( getByText( messages.noTLDError ) ).toBeVisible();
 	} );
 
-	it( 'fills the site address and disable it when the user already informed the site address on previous step', async () => {
-		const initialEntry = '/site-migration-credentials?from=https://example.com';
-		render( {}, { initialEntry } );
-
-		expect( siteAddressInput() ).toHaveValue( 'https://example.com' );
-		expect( siteAddressInput() ).toBeDisabled();
-	} );
-
 	it( 'shows error messages by each field when the server returns "invalid param" by each field', async () => {
 		const submit = jest.fn();
 		render( { navigation: { submit } } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import React from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
+import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import wp from 'calypso/lib/wp';
 import SiteMigrationCredentials from '..';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -6,7 +6,6 @@ import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import React from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
-import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import wp from 'calypso/lib/wp';
 import SiteMigrationCredentials from '..';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -6,7 +6,6 @@ import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import React from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
-import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import wp from 'calypso/lib/wp';
 import SiteMigrationCredentials from '..';
@@ -19,7 +18,6 @@ jest.mock( 'calypso/lib/wp', () => ( {
 	},
 } ) );
 
-jest.mock( 'calypso/data/site-profiler/use-analyze-url-query' );
 jest.mock( 'wpcom-proxy-request', () => jest.fn() );
 jest.mock( 'calypso/landing/stepper/hooks/use-site-slug-param' );
 
@@ -448,14 +446,6 @@ describe( 'SiteMigrationCredentials', () => {
 		await fillAllFields();
 		await fillNoteField();
 
-		( useAnalyzeUrlQuery as jest.Mock ).mockReturnValue( {
-			data: {
-				url: 'site-url.wordpress.com',
-			},
-			isError: false,
-			isLoading: false,
-		} );
-
 		( wpcomRequest as jest.Mock ).mockResolvedValue( {
 			status: 200,
 			body: {},
@@ -543,36 +533,13 @@ describe( 'SiteMigrationCredentials', () => {
 		render( { navigation: { submit } } );
 
 		await fillAllFields();
+
 		( wpcomRequest as jest.Mock ).mockImplementation(
 			() =>
 				new Promise( ( resolve ) => {
 					setTimeout( resolve, 2000 );
 				} )
 		);
-		( useAnalyzeUrlQuery as jest.Mock ).mockImplementation( ( url: string ) => {
-			if ( url === 'site-url.com' ) {
-				return {
-					data: {
-						url: 'site-url.wordpress.com',
-						platform_data: {
-							is_wpcom: true,
-						},
-					},
-					isError: false,
-					isLoading: true,
-				};
-			}
-			return {
-				data: {
-					url: 'site-url1.wordpress.com',
-					platform_data: {
-						is_wpcom: false,
-					},
-				},
-				isError: false,
-				isLoading: false,
-			};
-		} );
 
 		userEvent.click( continueButton() );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/94915

## Proposed Changes

* Added functionality to fetch platform and hosting info for source site.
* Added error message for displaying if site's already on WordPress.com.
* Also, we won't need any further checks to implement to direct users to either the survey page or other platform importing pages. We'll just need to direct them when we have the pages ready.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To let the users know that they are already on WordPress.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Proceed through the migration flow. Make sure to give input to a site that's already on WordPress.com
- On the "How do you want to migrate?" step, choose "Do it for me".
- In the credentials form, fill the fields and click on Continue button. Check for the following cases-

#### Site already on WordPress.com
- Make sure you see an error below the source URL field to remind you that the site is already on WordPress.com
- Make sure the Continue button has changed to "Continue anyways". Click that button
- Make sure your request completes as expected and you are taken to the next page

#### WP site, but not on WordPress.com
- Now repeat the whole flow with a site that's not on wordpress.com, but is still a valid Wordpress site. Once you click on the Continue button, you shouldn't see any error (if your creds are valid) and your request should complete as expected.

#### Non-WP site
- Now repeat the whole process with a site that's not a WordPress site at all. Once you click on the Continue button, you shouldn't see similar validation and "Continue anyways" behavior of the button as before

https://github.com/user-attachments/assets/5d32eabb-8d60-4f52-8c9e-1c738508a9a5

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
