### PR TITLE
Nomado 1046/allow registering connected same site

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1084,13 +1084,18 @@ class RegisterDomainStep extends Component {
 						MAPPED,
 						MAPPED_SAME_SITE_TRANSFERRABLE,
 						MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE,
+						MAPPED_SAME_SITE_REGISTRABLE,
 						TRANSFERRABLE,
 						TRANSFERRABLE_PREMIUM,
 						UNKNOWN,
 						REGISTERED_OTHER_SITE_SAME_USER,
 					} = domainAvailability;
 
-					const availableDomainStatuses = [ AVAILABLE, UNKNOWN ];
+					const availableDomainStatuses = [
+						AVAILABLE,
+						UNKNOWN,
+						MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE,
+					];
 
 					if ( error ) {
 						resolve( null );
@@ -1122,7 +1127,8 @@ class RegisterDomainStep extends Component {
 					if (
 						isDomainMapped &&
 						status !== REGISTERED_OTHER_SITE_SAME_USER &&
-						status !== MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE
+						status !== MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE &&
+						status !== MAPPED_SAME_SITE_REGISTRABLE
 					) {
 						availabilityStatus = mappable;
 					}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1091,11 +1091,7 @@ class RegisterDomainStep extends Component {
 						REGISTERED_OTHER_SITE_SAME_USER,
 					} = domainAvailability;
 
-					const availableDomainStatuses = [
-						AVAILABLE,
-						UNKNOWN,
-						MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE,
-					];
+					const availableDomainStatuses = [ AVAILABLE, UNKNOWN, MAPPED_SAME_SITE_REGISTRABLE ];
 
 					if ( error ) {
 						resolve( null );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1083,6 +1083,7 @@ class RegisterDomainStep extends Component {
 						AVAILABLE_PREMIUM,
 						MAPPED,
 						MAPPED_SAME_SITE_TRANSFERRABLE,
+						MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE,
 						TRANSFERRABLE,
 						TRANSFERRABLE_PREMIUM,
 						UNKNOWN,
@@ -1118,7 +1119,11 @@ class RegisterDomainStep extends Component {
 					let availabilityStatus = status;
 
 					// Mapped status always overrides other statuses, unless the domain is owned by the current user.
-					if ( isDomainMapped && status !== REGISTERED_OTHER_SITE_SAME_USER ) {
+					if (
+						isDomainMapped &&
+						status !== REGISTERED_OTHER_SITE_SAME_USER &&
+						status !== MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE
+					) {
 						availabilityStatus = mappable;
 					}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1493,7 +1493,11 @@ class RegisterDomainStep extends Component {
 		const domain = get( suggestion, 'domain_name' );
 		const { premiumDomains } = this.state;
 		const { includeOwnedDomainInSuggestions } = this.props;
-		const { DOMAIN_AVAILABILITY_THROTTLED, REGISTERED_OTHER_SITE_SAME_USER } = domainAvailability;
+		const {
+			DOMAIN_AVAILABILITY_THROTTLED,
+			REGISTERED_OTHER_SITE_SAME_USER,
+			MAPPED_SAME_SITE_REGISTRABLE,
+		} = domainAvailability;
 
 		// disable adding a domain to the cart while the premium price is still fetching
 		if ( premiumDomains?.[ domain ]?.pending ) {
@@ -1527,7 +1531,8 @@ class RegisterDomainStep extends Component {
 					const skipAvailabilityErrors =
 						! status ||
 						( status === REGISTERED_OTHER_SITE_SAME_USER && includeOwnedDomainInSuggestions ) ||
-						status === DOMAIN_AVAILABILITY_THROTTLED;
+						status === DOMAIN_AVAILABILITY_THROTTLED ||
+						status === MAPPED_SAME_SITE_REGISTRABLE;
 
 					if ( ! skipAvailabilityErrors ) {
 						this.setState( { unavailableDomains: [ ...this.state.unavailableDomains, domain ] } );

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -47,6 +47,7 @@ export const domainAvailability = {
 	MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE: 'mapped_to_other_site_same_user_registrable',
 	MAPPED_SAME_SITE_NOT_TRANSFERRABLE: 'mapped_to_same_site_not_transferrable',
 	MAPPED_SAME_SITE_TRANSFERRABLE: 'mapped_to_same_site_transferrable',
+	MAPPED_SAME_SITE_REGISTRABLE: 'mapped_to_same_site_registrable',
 	NOT_AVAILABLE: 'not_available',
 	NOT_REGISTRABLE: 'available_but_not_registrable',
 	PURCHASES_DISABLED: 'domain_registration_unavailable',

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -44,6 +44,7 @@ export const domainAvailability = {
 	MAPPABLE: 'mappable',
 	MAPPED: 'mapped_domain',
 	MAPPED_OTHER_SITE_SAME_USER: 'mapped_to_other_site_same_user',
+	MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE: 'mapped_to_other_site_same_user_registrable',
 	MAPPED_SAME_SITE_NOT_TRANSFERRABLE: 'mapped_to_same_site_not_transferrable',
 	MAPPED_SAME_SITE_TRANSFERRABLE: 'mapped_to_same_site_transferrable',
 	NOT_AVAILABLE: 'not_available',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -219,7 +219,7 @@ function getAvailabilityNotice(
 			break;
 		case domainAvailability.MAPPED_OTHER_SITE_SAME_USER:
 			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site). If you want to connect it to this site ' +
+				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s. If you want to connect it to this site ' +
 					'instead, we will be happy to help you do that. {{a}}Contact us.{{/a}}',
 				{
 					args: { domain, site },

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -15,6 +15,7 @@ import { getTld } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import SetAsPrimaryLink from 'calypso/my-sites/domains/domain-management/settings/set-as-primary/link';
 import {
+	domainAddNew,
 	domainManagementTransferToOtherSite,
 	domainManagementTransferIn,
 	domainMapping,
@@ -229,6 +230,24 @@ function getAvailabilityNotice(
 								target={ linksTarget }
 								rel="noopener noreferrer"
 								href={ CALYPSO_HELP_WITH_HELP_CENTER }
+							/>
+						),
+					},
+				}
+			);
+			break;
+		case domainAvailability.MAPPED_OTHER_SITES_SAME_USER_REGISTRABLE:
+			message = translate(
+				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s. {{a}}Register it via the connected site here.{{/a}}',
+				{
+					args: { domain, site },
+					components: {
+						strong: <strong />,
+						a: (
+							<a
+								target={ linksTarget }
+								rel="noopener noreferrer"
+								href={ domainAddNew( site, domain ) }
 							/>
 						),
 					},

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -219,7 +219,7 @@ function getAvailabilityNotice(
 			break;
 		case domainAvailability.MAPPED_OTHER_SITE_SAME_USER:
 			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s. If you want to connect it to this site ' +
+				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site). If you want to connect it to this site ' +
 					'instead, we will be happy to help you do that. {{a}}Contact us.{{/a}}',
 				{
 					args: { domain, site },
@@ -236,28 +236,22 @@ function getAvailabilityNotice(
 				}
 			);
 			break;
-		case domainAvailability.MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE:
+		case domainAvailability.MAPPED_SAME_SITE_REGISTRABLE:
 			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s.' +
-					' {{a}}Register it to the connected site.{{/a}}',
+				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s and also available for registration.',
 				{
 					args: { domain, site },
 					components: {
 						strong: <strong />,
-						a: (
-							<a
-								target={ linksTarget }
-								rel="noopener noreferrer"
-								href={ domainAddNew( site, domain ) }
-							/>
-						),
+						a: <a target={ linksTarget } rel="noopener noreferrer" href={ CALYPSO_CONTACT } />,
 					},
 				}
 			);
 			break;
-		case domainAvailability.MAPPED_OTHER_SITES_SAME_USER_REGISTRABLE:
+		case domainAvailability.MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE:
 			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s. {{a}}Register it via the connected site here.{{/a}}',
+				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site).' +
+					' {{a}}Register it to the connected site.{{/a}}',
 				{
 					args: { domain, site },
 					components: {
@@ -667,7 +661,7 @@ function getAvailabilityNotice(
 
 		default:
 			message = translate(
-				'HAHAHAHAHAH Sorry, there was a problem processing your request. Please try again in a few minutes.'
+				'Sorry, there was a problem processing your request. Please try again in a few minutes.'
 			);
 	}
 

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -236,21 +236,9 @@ function getAvailabilityNotice(
 				}
 			);
 			break;
-		case domainAvailability.MAPPED_SAME_SITE_REGISTRABLE:
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s and also available for registration.',
-				{
-					args: { domain, site },
-					components: {
-						strong: <strong />,
-						a: <a target={ linksTarget } rel="noopener noreferrer" href={ CALYPSO_CONTACT } />,
-					},
-				}
-			);
-			break;
 		case domainAvailability.MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE:
 			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site).' +
+				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s.' +
 					' {{a}}Register it to the connected site.{{/a}}',
 				{
 					args: { domain, site },

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -236,6 +236,25 @@ function getAvailabilityNotice(
 				}
 			);
 			break;
+		case domainAvailability.MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE:
+			message = translate(
+				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s.' +
+					' {{a}}Register it to the connected site.{{/a}}',
+				{
+					args: { domain, site },
+					components: {
+						strong: <strong />,
+						a: (
+							<a
+								target={ linksTarget }
+								rel="noopener noreferrer"
+								href={ domainAddNew( site, domain ) }
+							/>
+						),
+					},
+				}
+			);
+			break;
 		case domainAvailability.MAPPED_OTHER_SITES_SAME_USER_REGISTRABLE:
 			message = translate(
 				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s. {{a}}Register it via the connected site here.{{/a}}',
@@ -648,7 +667,7 @@ function getAvailabilityNotice(
 
 		default:
 			message = translate(
-				'Sorry, there was a problem processing your request. Please try again in a few minutes.'
+				'HAHAHAHAHAH Sorry, there was a problem processing your request. Please try again in a few minutes.'
 			);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 
- D162510-code
- This deploys first, as it relies on receiving newly introduced statuses that will come from the backend ^

Nomado-issues #1046 

As a user, I should be able to register a domain that is available to be registered, even if that domain is already mapped to one of my sites.

One catch: For simplicity sake, limiting the user to registering the domain via the Mapped-to site only. This keeps the backend much simpler for now. The user, as always, can simply delete the mapping and register that thang to whichever site they want. This just cuts back on users seeing the 'Contact Us!' slogan

## Proposed Changes

- Introduces 2 new messages:
  - When you are on a different site (this unregistered domain is mapped to another site you own) there is an error message with, "'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site). {{a}}Register it to the connected site.{{/a}}'" with a link to the Domain Management page of the correct/mapped-to site
  - The user is only allowed to register the domain on the site it is already mapped to
- Allows the user to register said domain

Mapped + Registrable domain on OTHER site:
![image](https://github.com/user-attachments/assets/01f472b3-85d1-4530-9b74-04bbdf3c94a7)

Mapped + Registrable domain on the mapped site (no error, nothing to see here folks):
![image](https://github.com/user-attachments/assets/6eb097c2-a7db-48af-826c-b8c1e5e56cd6)

See ticket & slack for before state error


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Cut down on support requests, was requested by HE
- Simplify and expand self-service capabilities for domain management

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Okay, here's the steps to test:
- See backend Diff for test setup instructions
- Check out both front-end and back-end code
  - Calypso `git checkout nomado-1046/allow-registering-connected-same-site`
  - wpcom `arc patch D162510`
- Now you should be able to search for and register that domain
  - When you are on a different site (this unregistered domain is mapped to another site you own) there is an error message with, "'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site). {{a}}Register it to the connected site.{{/a}}'" with a link to the Domain Management page of the correct site
  - When you are on the same site the Unregistered Domain is Mapped to, this message shows: "'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s and also available for registration.'"
  - The user is only allowed to register the domain on the site it is already mapped to



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?