### PR TITLE
Stats: Fix for blip when dismissing feedback modal

### DIFF
--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -55,13 +55,11 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 
 	const handleClose = useCallback(
 		( isDirectClose: boolean = false ) => {
-			setTimeout( () => {
-				onClose();
+			onClose();
 
-				if ( isDirectClose ) {
-					trackStatsAnalyticsEvent( 'stats_feedback_action_directly_close_form_modal' );
-				}
-			}, 200 );
+			if ( isDirectClose ) {
+				trackStatsAnalyticsEvent( 'stats_feedback_action_directly_close_form_modal' );
+			}
 		},
 		[ onClose ]
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/wp-calypso/pull/94983#issuecomment-2382196040

## Proposed Changes

Removes the timeout when dismissing the feedback modal. Changes to the underlying component's animation timing conflict with the timeout causing the modal to "blip" (disappear, reappear, then disappear again) when dismissed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See above.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Calypso Live site.
* Visit the Traffic page for a self-hosted site inside Calypso.
* Click the "Help us improve" button.
* Dismiss the modal dialog using the "x" button.
* Confirm it doesn't "blip".
* Click the "Help us improve" button again.
* Dismiss via Esc or clicking outside the modal.
* Confirm it doesn't "blip" here either. Note that it gets a nice subtle animation in this case which doesn't appear to be triggered when dismissing via the caller.

— `http://wordpress.com/stats/day/SITE_SLUG`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
