### PR TITLE
Hide status/checklist in /sites when a site is in DIFM process

### DIFF
--- a/client/hosting/sites/components/sites-dataviews/sites-site-status.tsx
+++ b/client/hosting/sites/components/sites-dataviews/sites-site-status.tsx
@@ -127,12 +127,14 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 					<TransferNoticeWrapper { ...result } />
 				) : (
 					<>
-						<div>
-							{ translatedStatus }
-							<SiteLaunchNag site={ site } />
-						</div>
-						{ isDIFMInProgress && (
+						{ /* Hide status/checklist during DIFM for cleaner UI, as the user cannot access their site */ }
+						{ isDIFMInProgress ? (
 							<BadgeDIFM className="site__badge">{ __( 'Express Service' ) }</BadgeDIFM>
+						) : (
+							<div>
+								{ translatedStatus }
+								<SiteLaunchNag site={ site } />
+							</div>
 						) }
 					</>
 				)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/94981

## Proposed Changes

See https://github.com/Automattic/wp-calypso/pull/94981 for details as this is a logic fix of that PR.