### PR TITLE
Plans Page: add additional properties to page view event

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -447,7 +447,13 @@ class Plans extends Component {
 				<PageViewTracker path="/plans/:site" title="Plans" />
 				{ /** QueryProducts added to ensure currency-code state gets populated for usages of getCurrentUserCurrencyCode */ }
 				<QueryProducts />
-				<TrackComponentView eventName="calypso_plans_view" />
+				<TrackComponentView
+					eventName="calypso_plans_view"
+					eventProperties={ {
+						current_plan_slug: currentPlanSlug || null,
+						is_site_on_paid_plan: !! ( currentPlanSlug && ! isFreePlan ),
+					} }
+				/>
 				{ ( isDomainUpsell || domainFromHomeUpsellFlow ) && (
 					<DomainUpsellDialog domain={ selectedSite.slug } />
 				) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR adds two additional properties to the `calypso_plans_view` Tracks event:
  * `current_plan_slug`: The current plan slug or `null` if not available.
  * `is_site_on_paid_plan`: true if the site is on a paid plan, false otherwise.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These changes are required for an upcoming event that utilizes this event.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Open the browser network inspector.
* Go to `/plans/<site slug>` for a site on a free plan.
* In the network inspector, search for `calypso_plans_view`. Select the network request.
* Confirm that the `current_plan_slug` prop value is `free_plan` and `is_site_on_paid_plan` is `false`.
* <img width="360" alt="image" src="https://github.com/user-attachments/assets/4da62569-a62a-4ec3-8e17-5dae6d4424f4">
* Go to `/plans/<site slug>` for a site on a paid plan.
* In the network inspector, search for `calypso_plans_view`. Select the network request.
* Confirm that the `current_plan_slug` prop value is the plan slug and `is_site_on_paid_plan` is `true`.
* <img width="316" alt="image" src="https://github.com/user-attachments/assets/5c3ed2f0-d5f6-4e3d-9c19-98a7cfa6961c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
