### PR TITLE
Add Calendly Step to 100 Year Flow

### DIFF
--- a/client/landing/stepper/declarative-flow/hundred-year-plan.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-plan.ts
@@ -39,6 +39,11 @@ const HundredYearPlanFlow: Flow = {
 							asyncComponent: () =>
 								import( './internals/steps-repository/hundred-year-plan-diy-or-difm' ),
 						},
+						{
+							slug: 'schedule-appointment',
+							asyncComponent: () =>
+								import( './internals/steps-repository/hundred-year-plan-schedule-appointment' ),
+						},
 				  ]
 				: [] ),
 
@@ -119,7 +124,9 @@ const HundredYearPlanFlow: Flow = {
 						return navigate( hasSite ? 'new-or-existing-site' : 'setup' );
 					}
 					// TODO: add VIP flow
-					return navigate( hasSite ? 'new-or-existing-site' : 'setup' );
+					return navigate( 'schedule-appointment' );
+				case 'schedule-appointment':
+					return navigate( 'thank-you' );
 				case 'new-or-existing-site':
 					if ( 'new-site' === providedDependencies?.newExistingSiteChoice ) {
 						return navigate( 'setup' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/calendy-widget/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/calendy-widget/index.tsx
@@ -1,25 +1,25 @@
 import React, { useEffect, useMemo } from 'react';
 
+const CALENDLY_SCRIPT_URL = 'https://assets.calendly.com/assets/external/widget.js';
+
 declare global {
 	interface Window {
 		Calendly: any;
 	}
 }
 
-interface PrefillData {
+type CalendlyPrefillData = {
 	name?: string;
 	email?: string;
 	// Add other prefill fields as needed
-}
+};
 
-interface CalendlyWidgetProps {
+type CalendlyWidgetProps = {
 	url: string;
 	id?: string;
-	prefill?: PrefillData;
+	prefill?: CalendlyPrefillData;
 	onSchedule?: () => void;
-}
-
-const CALENDLY_SCRIPT_URL = 'https://assets.calendly.com/assets/external/widget.js';
+};
 
 function isCalendlyEvent( e: MessageEvent ): boolean {
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/calendy-widget/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/calendy-widget/index.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useMemo } from 'react';
+
+declare global {
+	interface Window {
+		Calendly: any;
+	}
+}
+
+interface PrefillData {
+	name?: string;
+	email?: string;
+	// Add other prefill fields as needed
+}
+
+interface CalendlyWidgetProps {
+	url: string;
+	id?: string;
+	prefill?: PrefillData;
+	onSchedule?: () => void;
+}
+
+const CALENDLY_SCRIPT_URL = 'https://assets.calendly.com/assets/external/widget.js';
+
+function isCalendlyEvent( e: MessageEvent ): boolean {
+	return (
+		e.origin === 'https://calendly.com' && e.data.event && e.data.event.indexOf( 'calendly.' ) === 0
+	);
+}
+
+const CalendlyWidget: React.FC< CalendlyWidgetProps > = ( { url, id, prefill, onSchedule } ) => {
+	const widgetId = useMemo(
+		() => id || `calendly-widget-${ Math.random().toString( 36 ).substr( 2, 9 ) }`,
+		[ id ]
+	);
+
+	useEffect( () => {
+		const handleMessage = ( e: MessageEvent ) => {
+			if ( isCalendlyEvent( e ) && e.data.event === 'calendly.event_scheduled' ) {
+				onSchedule?.();
+			}
+		};
+
+		window.addEventListener( 'message', handleMessage );
+		return () => window.removeEventListener( 'message', handleMessage );
+	}, [ onSchedule ] );
+
+	useEffect( () => {
+		// Check if the script is already loaded
+		if ( ! document.querySelector( `script[src="${ CALENDLY_SCRIPT_URL }"]` ) ) {
+			const script = document.createElement( 'script' );
+			script.src = CALENDLY_SCRIPT_URL;
+			script.async = true;
+			document.body.appendChild( script );
+		}
+
+		const loadCalendly = async () => {
+			while ( typeof window.Calendly === 'undefined' || ! url ) {
+				await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
+			}
+
+			const element = document.getElementById( widgetId );
+			if ( element ) {
+				// Clear out the container div when props change.
+				element.innerHTML = '';
+				window.Calendly.initInlineWidget( {
+					url: `https://calendly.com/${ url }`,
+					parentElement: document.getElementById( widgetId ),
+					prefill: prefill || {},
+					utm: {},
+				} );
+			}
+		};
+
+		loadCalendly();
+
+		// Cleanup function
+		return () => {
+			const existingScript = document.querySelector( `script[src="${ CALENDLY_SCRIPT_URL }"]` );
+			if ( existingScript ) {
+				existingScript.remove();
+			}
+		};
+	}, [ url, widgetId, prefill ] );
+
+	return <div id={ widgetId } className="calendly-widget" />;
+};
+
+export default CalendlyWidget;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/calendy-widget/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/calendy-widget/style.scss
@@ -1,0 +1,4 @@
+.calendly-widget {
+    min-width: 320px;
+    height: 630px;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-schedule-appointment/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-schedule-appointment/index.tsx
@@ -1,0 +1,69 @@
+import { UserSelect } from '@automattic/data-stores';
+import { useSelect } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { USER_STORE } from '../../../../stores';
+import CalendlyWidget from '../components/calendy-widget';
+import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
+import type { Step } from '../../types';
+
+import './styles.scss';
+
+declare global {
+	interface Window {
+		Calendly: any;
+	}
+}
+
+const CALENDLY_ID = 'tim-broddin-a8c/30min';
+
+const HundredYearPlanScheduleAppointment: Step = function HundredYearPlanScheduleAppointment( {
+	navigation,
+	flow,
+} ) {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { submit } = navigation;
+	const translate = useTranslate();
+
+	const currentUser = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+		[]
+	);
+
+	return (
+		<HundredYearPlanStepWrapper
+			stepContent={
+				<div className="hundred-year-plan-schedule-appointment-content">
+					<div className="hundred-year-plan-schedule-appointment-content__left-pane">
+						// TODO: content
+					</div>
+					<div className="hundred-year-plan-schedule-appointment-content__right-pane">
+						<CalendlyWidget
+							url={ CALENDLY_ID }
+							prefill={
+								currentUser
+									? { name: currentUser?.display_name, email: currentUser?.email }
+									: undefined
+							}
+							onSchedule={ () => {
+								submit?.();
+							} }
+						/>
+					</div>
+				</div>
+			}
+			formattedHeader={
+				<FormattedHeader
+					brandFont
+					headerText={ translate( 'TODO: title' ) }
+					subHeaderText={ translate( 'TODO: header' ) }
+					subHeaderAlign="center"
+				/>
+			}
+			stepName="hundred-year-plan-setup"
+			flowName={ flow }
+		/>
+	);
+};
+
+export default HundredYearPlanScheduleAppointment;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-schedule-appointment/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-schedule-appointment/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { UserSelect } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -8,14 +9,6 @@ import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import type { Step } from '../../types';
 
 import './styles.scss';
-
-declare global {
-	interface Window {
-		Calendly: any;
-	}
-}
-
-const CALENDLY_ID = 'tim-broddin-a8c/30min';
 
 const HundredYearPlanScheduleAppointment: Step = function HundredYearPlanScheduleAppointment( {
 	navigation,
@@ -34,12 +27,12 @@ const HundredYearPlanScheduleAppointment: Step = function HundredYearPlanSchedul
 		<HundredYearPlanStepWrapper
 			stepContent={
 				<div className="hundred-year-plan-schedule-appointment-content">
-					<div className="hundred-year-plan-schedule-appointment-content__left-pane">
+					<div className="hundred-year-plan-schedule-appointment-content__start-pane">
 						// TODO: content
 					</div>
-					<div className="hundred-year-plan-schedule-appointment-content__right-pane">
+					<div className="hundred-year-plan-schedule-appointment-content__end-pane">
 						<CalendlyWidget
-							url={ CALENDLY_ID }
+							url={ config( '100_year_plan_calendly_id' ) }
 							prefill={
 								currentUser
 									? { name: currentUser?.display_name, email: currentUser?.email }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-schedule-appointment/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-schedule-appointment/styles.scss
@@ -1,0 +1,18 @@
+.hundred-year-plan-schedule-appointment-content {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    &__left-pane {
+        width: 50%;
+    }
+
+    &__right-pane {
+        width: 50%;
+    }
+
+    .calendly-widget {
+        min-width: 320px;
+        height: 700px;
+    }
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-schedule-appointment/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-schedule-appointment/styles.scss
@@ -3,12 +3,12 @@
     flex-direction: row;
     justify-content: space-between;
 
-    &__left-pane {
-        width: 50%;
+    &__start-pane {
+       flex: 1;
     }
 
-    &__right-pane {
-        width: 50%;
+    &__end-pane {
+        flex: 1;
     }
 
     .calendly-widget {

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -260,5 +260,6 @@
 		"onboarding-affiliate",
 		"email-subscription"
 	],
+	"100_year_plan_calendly_id": "tim-broddin-a8c/30min",
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js"
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9271

## Proposed Changes

This PR adds the schedule appointment step to the VIP onboarding 100 year plan flow.

- It adds a `<CalendlyWidget />` component that supports prefilling the fields with the customer's data and also allows for a callback when a booking is made.
- It sets up the submit action to redirect to the welcome screen.

## Testing Instructions

- Apply this PR
- Visit http://calypso.localhost:3000/setup/hundred-year-plan/?flags=100year%2Fvip
- Choose DIFM
- Book a meeting
- You will be redirected to step 1 because the `thank-you` step does not exist yet 😅


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
