### PR TITLE
Add Thank You (Booking Confirmation) step to 100 Year Flow

### DIFF
--- a/client/landing/stepper/declarative-flow/hundred-year-plan.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-plan.ts
@@ -44,6 +44,11 @@ const HundredYearPlanFlow: Flow = {
 							asyncComponent: () =>
 								import( './internals/steps-repository/hundred-year-plan-schedule-appointment' ),
 						},
+						{
+							slug: 'thank-you',
+							asyncComponent: () =>
+								import( './internals/steps-repository/hundred-year-plan-thank-you' ),
+						},
 				  ]
 				: [] ),
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import type { Step } from '../../types';
@@ -8,7 +7,6 @@ import './styles.scss';
 
 const HundredYearPlanDIYOrDIFM: Step = function HundredYearPlanDIYOrDIFM( { navigation, flow } ) {
 	const { submit } = navigation;
-	const translate = useTranslate();
 
 	return (
 		<HundredYearPlanStepWrapper
@@ -21,8 +19,8 @@ const HundredYearPlanDIYOrDIFM: Step = function HundredYearPlanDIYOrDIFM( { navi
 			formattedHeader={
 				<FormattedHeader
 					brandFont
-					headerText={ translate( 'TODO: title' ) }
-					subHeaderText={ translate( 'TODO: header' ) }
+					headerText="TODO: title"
+					subHeaderText="TODO: header"
 					subHeaderAlign="center"
 				/>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-schedule-appointment/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-schedule-appointment/index.tsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { UserSelect } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
-import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { USER_STORE } from '../../../../stores';
 import CalendlyWidget from '../components/calendy-widget';
@@ -16,7 +15,6 @@ const HundredYearPlanScheduleAppointment: Step = function HundredYearPlanSchedul
 } ) {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const { submit } = navigation;
-	const translate = useTranslate();
 
 	const currentUser = useSelect(
 		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
@@ -48,8 +46,8 @@ const HundredYearPlanScheduleAppointment: Step = function HundredYearPlanSchedul
 			formattedHeader={
 				<FormattedHeader
 					brandFont
-					headerText={ translate( 'TODO: title' ) }
-					subHeaderText={ translate( 'TODO: header' ) }
+					headerText="TODO: title"
+					subHeaderText="TODO: header"
 					subHeaderAlign="center"
 				/>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-thank-you/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-thank-you/index.tsx
@@ -1,4 +1,3 @@
-import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import type { Step } from '../../types';
@@ -6,8 +5,6 @@ import type { Step } from '../../types';
 import './styles.scss';
 
 const HundredYearPlanThankYou: Step = function HundredYearPlanThankYou( { flow } ) {
-	const translate = useTranslate();
-
 	return (
 		<HundredYearPlanStepWrapper
 			stepContent={
@@ -18,8 +15,8 @@ const HundredYearPlanThankYou: Step = function HundredYearPlanThankYou( { flow }
 			formattedHeader={
 				<FormattedHeader
 					brandFont
-					headerText={ translate( 'TODO: Thank You title' ) }
-					subHeaderText={ translate( 'TODO: Thank You header' ) }
+					headerText="TODO: Thank You title"
+					subHeaderText="TODO: Thank You header"
 					subHeaderAlign="center"
 				/>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-thank-you/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-thank-you/index.tsx
@@ -1,0 +1,32 @@
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
+import type { Step } from '../../types';
+
+import './styles.scss';
+
+const HundredYearPlanThankYou: Step = function HundredYearPlanThankYou( { flow } ) {
+	const translate = useTranslate();
+
+	return (
+		<HundredYearPlanStepWrapper
+			stepContent={
+				<div>
+					<p>TODO: Thank You content</p>
+				</div>
+			}
+			formattedHeader={
+				<FormattedHeader
+					brandFont
+					headerText={ translate( 'TODO: Thank You title' ) }
+					subHeaderText={ translate( 'TODO: Thank You header' ) }
+					subHeaderAlign="center"
+				/>
+			}
+			stepName="hundred-year-plan-setup"
+			flowName={ flow }
+		/>
+	);
+};
+
+export default HundredYearPlanThankYou;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-thank-you/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-thank-you/styles.scss
@@ -1,0 +1,1 @@
+/* Comment because we cannot have empty files */


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9272

## Proposed Changes

* Adds the final step (Thank you) to the 100 Year Flow

## Testing Instructions

- Apply this PR
- Visit http://calypso.localhost:3000/setup/hundred-year-plan/?flags=100year%2Fvip
- Choose DIFM
- Book a meeting
- You will be thanked

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
