### PR TITLE
fix: unintended inclusion of woocommerce-payments production flow in passwordless feature

### DIFF
--- a/client/state/selectors/is-woocommerce-core-profiler-flow.ts
+++ b/client/state/selectors/is-woocommerce-core-profiler-flow.ts
@@ -11,7 +11,7 @@ import type { AppState } from 'calypso/types';
  * @returns {?boolean}        Whether the user reached Calypso via the WooCommerce Core Profiler flow
  */
 export const isWooCommerceCoreProfilerFlow = ( state: AppState ): boolean => {
-	const allowedFrom = [ 'woocommerce-core-profiler', 'woocommerce-payments' ];
+	const allowedFrom = [ 'woocommerce-core-profiler' ];
 	return (
 		allowedFrom.includes( get( getInitialQueryArguments( state ), 'from' ) as string ) ||
 		allowedFrom.includes( get( getCurrentQueryArguments( state ), 'from' ) as string ) ||


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/94911

## Proposed Changes

Remove `woocommerce-payments` from the `isWooCommerceCoreProfilerFlow` condition to fix the production WooCommerce Payments onboarding flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In #94911 we included `&from=woocommerce-payments` as a truthy condition for the `isWooCommerceCoreProfilerFlow` check. 

This was intended as a pre-production feature flag gated screen, but unfortunately we were not aware that the production WooCommerce Payments onboarding flow sets the `&from=woocommerce-payments` parameter as well. This resulted in a partially activated set of styling changes, causing a broken flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up a Jurassic Ninja site with WooCommerce, without Jetpack or WooCommerce Payments
2. Skip the WooCommerce Core Profiler onboarding flow, and in the skip flow set your country to United States
3. **important** Log in to this same JN site in an incognito browser as we want to see the logged out flow
4. Go to the payments screen just below WooCommerce, and Products in the nav bar on the left
5. Click on the "Install WooPayments for free" button
6. You should be seeing the broken screen if you have wordpress.com pointed to the production site before this PR is merged
7. Change it to the Calypso Live URL domain without changing the query parameters
8. You should see the fixed screen

Payments screen

<img width="729" alt="image" src="https://github.com/user-attachments/assets/c5a0cfdc-a3b4-4a0d-89c4-4a30b211c28d">

Broken screen

![image](https://github.com/user-attachments/assets/58d73914-c96f-4d4b-a70e-c619ba8922fc)

Fixed screen

![image](https://github.com/user-attachments/assets/3dbcd61d-15e3-469f-91c7-a2b012e67e05)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
