### PR TITLE
Add tracks event to site profiler

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -9,6 +9,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
 import { useUrlPerformanceInsightsQuery } from 'calypso/data/site-profiler/use-url-performance-insights';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch, useSelector } from 'calypso/state';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getRequest from 'calypso/state/selectors/get-request';
@@ -146,6 +147,7 @@ export const SitePerformance = () => {
 	}, [ currentPage?.wpcom_performance_report_url ] );
 
 	const retestPage = () => {
+		recordTracksEvent( 'calypso_performance_profiler_test_again_click' );
 		setWpcom_performance_report_url( {
 			url: currentPage?.url ?? '',
 			hash: '',
@@ -202,6 +204,13 @@ export const SitePerformance = () => {
 
 	const isMobile = ! useDesktopBreakpoint();
 	const disableControls = performanceReport.isLoading || isInitialLoading || ! isSitePublic;
+
+	const handleDeviceTabChange = ( tab: Tab ) => {
+		setActiveTab( tab );
+		recordTracksEvent( 'calypso_performance_profiler_device_tab_change', {
+			device: tab,
+		} );
+	};
 
 	const pageSelector = (
 		<PageSelector
@@ -278,7 +287,7 @@ export const SitePerformance = () => {
 				{ ! isMobile && pageSelector }
 				<DeviceTabControls
 					showTitle={ ! isMobile }
-					onDeviceTabChange={ setActiveTab }
+					onDeviceTabChange={ handleDeviceTabChange }
 					disabled={ disableControls }
 					value={ activeTab }
 				/>

--- a/client/performance-profiler/components/core-web-vitals-accordion/core-web-vitals-accordion-v2.tsx
+++ b/client/performance-profiler/components/core-web-vitals-accordion/core-web-vitals-accordion-v2.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { Metrics } from 'calypso/data/site-profiler/types';
 import { CircularPerformanceScore } from 'calypso/hosting/performance/components/circular-performance-score/circular-performance-score';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	metricsNames,
 	mapThresholdsToStatus,
@@ -59,6 +60,9 @@ export const CoreWebVitalsAccordionV2 = ( props: Props ) => {
 		if ( key === activeTab ) {
 			setActiveTab( null );
 		} else {
+			recordTracksEvent( 'calypso_performance_profiler_metric_tab_click', {
+				tab: key,
+			} );
 			setActiveTab( key as Metrics );
 		}
 	};

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -37,6 +37,9 @@ export const InsightsSection = forwardRef(
 			.filter( ( key ) => filterRecommendations( selectedFilter, audits[ key ] ) )
 			.sort( sortInsightKeys );
 		const onFilter = useCallback( ( option: { label: string; value: string } ) => {
+			recordTracksEvent( 'calypso_performance_profiler_recommendations_filter_change', {
+				filter: option.value,
+			} );
 			setSelectedFilter( option.value );
 			if ( props.onRecommendationsFilterChange ) {
 				props.onRecommendationsFilterChange( option.value );

--- a/client/performance-profiler/components/metric-tab-bar/metric-tab-bar-v2.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/metric-tab-bar-v2.tsx
@@ -1,6 +1,7 @@
 import { clsx } from 'clsx';
 import { Metrics } from 'calypso/data/site-profiler/types';
 import { CircularPerformanceScore } from 'calypso/hosting/performance/components/circular-performance-score/circular-performance-score';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	metricsNames,
 	mapThresholdsToStatus,
@@ -17,13 +18,18 @@ type Props = Record< Metrics, number > & {
 const MetricTabBarV2 = ( props: Props ) => {
 	const { activeTab, setActiveTab } = props;
 
+	const handleTabClick = ( tab: Metrics ) => {
+		setActiveTab( tab );
+		recordTracksEvent( 'calypso_performance_profiler_metric_tab_click', { tab } );
+	};
+
 	return (
 		<div className="metric-tab-bar-v2">
 			<button
 				className={ clsx( 'metric-tab-bar-v2__tab metric-tab-bar-v2__performance', {
 					active: activeTab === 'overall',
 				} ) }
-				onClick={ () => setActiveTab( 'overall' ) }
+				onClick={ () => handleTabClick( 'overall' ) }
 			>
 				<div className="metric-tab-bar-v2__tab-text">
 					<div
@@ -61,7 +67,7 @@ const MetricTabBarV2 = ( props: Props ) => {
 						<button
 							key={ key }
 							className={ clsx( 'metric-tab-bar-v2__tab', { active: key === activeTab } ) }
-							onClick={ () => setActiveTab( key as Metrics ) }
+							onClick={ () => handleTabClick( key as Metrics ) }
 						>
 							<div className="metric-tab-bar-v2__tab-status">
 								<StatusIndicator

--- a/client/performance-profiler/components/tip/index.tsx
+++ b/client/performance-profiler/components/tip/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 export type TipProps = {
 	title: string;
@@ -11,13 +12,19 @@ export type TipProps = {
 export const Tip = ( { title, content, link, linkText }: TipProps ) => {
 	const translate = useTranslate();
 
+	const handleLearnMoreClick = () => {
+		recordTracksEvent( 'calypso_performance_profiler_tip_learn_more_clicked', {
+			link: link,
+		} );
+	};
+
 	return (
 		<div className="performance-profiler-tip">
 			<h4>{ title }</h4>
 			<p>{ content }</p>
 			{ link && (
 				<p className="learn-more-link">
-					<a href={ link } target="_blank" rel="noreferrer">
+					<a href={ link } target="_blank" rel="noreferrer" onClick={ handleLearnMoreClick }>
 						{ linkText ?? translate( 'Learn more ↗' ) }
 					</a>
 				</p>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9065

## Proposed Changes

Added tracks event for the following parts

![tracks@2x](https://github.com/user-attachments/assets/74c7546b-2797-467f-bfe3-39c7f0e8b295)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To see how users are interacting with the site-profiler

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `calypso.localhost:3000/sites/performance/:site`
* See if the tracks events are being triggered
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
