### PR TITLE
Stepper: Ensure `calypso_signup_start` doesn't get recorded over and over / 50 times

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -46,9 +46,11 @@ export const useSignUpStartTracking = ( { flow }: Props ) => {
 		adTrackSignupStart( flowName );
 	}, [ isSignupFlow, flowName ] );
 
-	if ( ! isSignupFlow ) {
-		return;
-	}
+	useEffect( () => {
+		if ( ! isSignupFlow ) {
+			return;
+		}
 
-	recordSignupStart( { flow: flowName, ref, optionalProps: extraProps || {} } );
+		recordSignupStart( { flow: flowName, ref, optionalProps: extraProps || {} } );
+	}, [ isSignupFlow, flowName, ref, extraProps ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -117,6 +117,29 @@ describe( 'useSignUpTracking', () => {
 			} );
 		} );
 
+		it( 'records the calypso_signup_start event a single time if dependencies are stable', () => {
+			const { rerender } = render( {
+				flow: {
+					...signUpFlow,
+				} satisfies Flow,
+			} );
+
+			rerender();
+			expect( recordSignupStart ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'records the calypso_signup_start event multiple times when dependencies change', () => {
+			const { rerender } = render( {
+				flow: {
+					...signUpFlow,
+					useSignupStartEventProps: () => ( { extra: 'props' } ),
+				} satisfies Flow,
+			} );
+
+			rerender();
+			expect( recordSignupStart ).toHaveBeenCalledTimes( 2 );
+		} );
+
 		it( 'sets the signup-start timer only on initial mount (assuming static flowName and isSignupFlow)', () => {
 			const { rerender } = render( {
 				flow: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to discussion in Slack: p1727699892896309-slack-C073776NJ66

## Proposed Changes

Apparently, we notice the `calypso_signup_start` event being recorded many times (50 total) throughout a single pass of `/setup/onboarding`. Just visiting `/setup/onboarding/user` logs it 6 times just off the bat:

> I see `calypso_signup_start` being fired 6 times with apparently the same props and `flow: onboarding` (but slightly different timestamps) - It seems easy to replicate. 

Per https://github.com/Automattic/wp-calypso/issues/94175#issuecomment-2382538069, we are ok to log a given event multiple times, but within reason e.g. a flow implementing a dynamic `useTracksEventProps` hook with async props. Any other case should only lead to a single time within a single mount of Stepper without redirections, considering the related dependencies right now. So some bug exists here if we are seeing this 50 times, likely coming from recent refactors. Recent refactors happened in:

- https://github.com/Automattic/wp-calypso/pull/94743
- https://github.com/Automattic/wp-calypso/pull/94841

### How

This PR fixes the issue. The problem was moving `recordSignupStart` out of the `useEffect` hook. The result was recording the event of any rerender/call in the parent component, as long as `isSignupFlow` was true (always for `/setup/onboarding`). It looks like down to pure oversight in https://github.com/Automattic/wp-calypso/pull/94841 (I explain below why that happened: https://github.com/Automattic/wp-calypso/pull/95028#issuecomment-2383661551)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fix a bug

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through `/setup/onboarding` and ensure `calypso_signup_start` gets recorded once unless due to redirection (when logged out)
  * Also try starting from `/setup/onboarding/user`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?