### PR TITLE
Fix back url for domain flows started from site settings page

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -88,6 +88,7 @@ const domainSearch = ( context, next ) => {
 };
 
 const siteRedirect = ( context, next ) => {
+	const backUrl = context.query?.redirect_to;
 	context.primary = (
 		<Main>
 			<PageViewTracker
@@ -96,7 +97,7 @@ const siteRedirect = ( context, next ) => {
 			/>
 			<DocumentHead title={ translate( 'Redirect a Site' ) } />
 			<CalypsoShoppingCartProvider>
-				<SiteRedirect />
+				<SiteRedirect backUrl={ backUrl } />
 			</CalypsoShoppingCartProvider>
 		</Main>
 	);
@@ -104,12 +105,13 @@ const siteRedirect = ( context, next ) => {
 };
 
 const mapDomain = ( context, next ) => {
+	const backUrl = context.query?.redirect_tosdfsd;
 	context.primary = (
 		<Main wideLayout>
 			<PageViewTracker path={ domainMapping( ':site' ) } title="Domain Search > Domain Mapping" />
 			<DocumentHead title={ translate( 'Map a Domain' ) } />
 			<CalypsoShoppingCartProvider>
-				<MapDomain initialQuery={ context.query.initialQuery } />
+				<MapDomain backUrl={ backUrl } initialQuery={ context.query.initialQuery } />
 			</CalypsoShoppingCartProvider>
 		</Main>
 	);

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -105,7 +105,7 @@ const siteRedirect = ( context, next ) => {
 };
 
 const mapDomain = ( context, next ) => {
-	const backUrl = context.query?.redirect_tosdfsd;
+	const backUrl = context.query?.redirect_to;
 	context.primary = (
 		<Main wideLayout>
 			<PageViewTracker path={ domainMapping( ':site' ) } title="Domain Search > Domain Mapping" />

--- a/client/my-sites/domains/domain-search/site-redirect.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect.jsx
@@ -26,9 +26,14 @@ class SiteRedirect extends Component {
 		isSiteUpgradeable: PropTypes.bool.isRequired,
 		productsList: PropTypes.object.isRequired,
 		translate: PropTypes.func.isRequired,
+		backUrl: PropTypes.string,
 	};
 
 	handleBackToDomainSearch = () => {
+		if ( this.props.backUrl ) {
+			page( this.props.backUrl );
+			return;
+		}
 		page( '/domains/add/' + this.props.selectedSiteSlug );
 	};
 

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -39,6 +39,7 @@ export class MapDomain extends Component {
 		selectedSiteId: PropTypes.number,
 		selectedSiteSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
+		backUrl: PropTypes.string,
 	};
 
 	isMounted = false;
@@ -51,7 +52,12 @@ export class MapDomain extends Component {
 	};
 
 	goBack = () => {
-		const { currentRoute, selectedSite, selectedSiteSlug } = this.props;
+		const { currentRoute, selectedSite, selectedSiteSlug, backUrl } = this.props;
+
+		if ( backUrl ) {
+			page( backUrl );
+			return;
+		}
 
 		if ( ! selectedSite ) {
 			page( '/domains/add' );

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -249,13 +249,23 @@ export class SiteSettingsFormGeneral extends Component {
 								),
 								mapDomainLink: (
 									<a
-										href={ '/domains/add/mapping/' + siteSlug }
+										href={
+											'/domains/add/mapping/' +
+											siteSlug +
+											'?redirect_to=/settings/general/' +
+											siteSlug
+										}
 										onClick={ this.trackUpgradeClick }
 									/>
 								),
 								redirectLink: (
 									<a
-										href={ '/domains/add/site-redirect/' + siteSlug }
+										href={
+											'/domains/add/site-redirect/' +
+											siteSlug +
+											'?redirect_to=/settings/general/' +
+											siteSlug
+										}
 										onClick={ this.trackUpgradeClick }
 									/>
 								),

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -224,7 +224,10 @@ export class SiteSettingsFormGeneral extends Component {
 						value={ site.domain }
 						disabled="disabled"
 					/>
-					<Button href={ '/domains/add/' + siteSlug } onClick={ this.trackUpgradeClick }>
+					<Button
+						href={ '/domains/add/' + siteSlug + '?redirect_to=/settings/general/' + siteSlug }
+						onClick={ this.trackUpgradeClick }
+					>
 						<Gridicon icon="plus" />{ ' ' }
 						{ translate( 'Add custom address', { context: 'Site address, domain' } ) }
 					</Button>
@@ -237,7 +240,12 @@ export class SiteSettingsFormGeneral extends Component {
 						{
 							components: {
 								domainSearchLink: (
-									<a href={ '/domains/add/' + siteSlug } onClick={ this.trackUpgradeClick } />
+									<a
+										href={
+											'/domains/add/' + siteSlug + '?redirect_to=/settings/general/' + siteSlug
+										}
+										onClick={ this.trackUpgradeClick }
+									/>
 								),
 								mapDomainLink: (
 									<a


### PR DESCRIPTION
## Proposed Changes

This PR fixes the `Back` url for domain flows (`add`, `add/site-redirect`, `add/map`) when they are started from **Site Settings** page.

## Why are these changes being made?

When `domains/add/*` flows are started from general **Site Settings** page, the back button url goes to domain management page instead of going back to **Site Settings**.

## Testing Instructions

Apply this PR locally or use the Calypso live link below, visit site setting page (`/settings/general/{YOUR_SITE_SLUG}`) and go to `Site Address` section. Click on `custom domain` link and, once you are in the search domain flow, click on the `Back` button (top left). Verify that the link goes back to settings page.

Do the same for all the links highlighted in the image below:

![Markup on 2024-09-30 at 18:49:34](https://github.com/user-attachments/assets/8f4dc0d7-2958-45fd-8fd0-814b7449c10d)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
