### PR TITLE
Fix: paid subscriber importer newsletter tier creation & no plans case

### DIFF
--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -24,6 +24,7 @@ export interface SubscribersStepContent {
 	connect_url?: string;
 	is_connected_stripe: boolean;
 	map_plans?: Record< string, string >;
+	account_display?: string;
 	plans?: Plan[];
 	meta?: {
 		email_count: string;

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -33,6 +33,11 @@ export interface SubscribersStepContent {
 		scheduled_at: string;
 		status: string;
 		subscribed_count: string | null;
+		already_subscribed_count: string | null;
+		failed_subscribed_count: string | null;
+		paid_subscribed_count: string | null;
+		paid_already_subscribed_count: string | null;
+		paid_failed_subscribed_count: string | null;
 		timestamp: string;
 	};
 }

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -139,7 +139,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	);
 	const [ editedProductName, setEditedProductName ] = useState( product?.title ?? '' );
 	const [ editedPostPaidNewsletter, setEditedPostPaidNewsletter ] = useState(
-		product?.subscribe_as_site_subscriber ?? false
+		product?.subscribe_as_site_subscriber ?? isOnlyTier
 	);
 
 	const [ editedPostIsTier, setEditedPostIsTier ] = useState(

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -76,7 +76,7 @@ export default function NewsletterImporter( {
 	useEffect( () => {
 		if (
 			paidNewsletterData?.steps?.content?.status === 'importing' ||
-			paidNewsletterData?.steps.subscribers?.status === 'importing'
+			paidNewsletterData?.steps?.subscribers?.status === 'importing'
 		) {
 			setAutoFetchData( true );
 		} else {
@@ -157,8 +157,8 @@ export default function NewsletterImporter( {
 	const shouldShowConfettiRef = useRef( false );
 	const [ showConfetti, setShowConfetti ] = useState( false );
 	const importerStatus = getImporterStatus(
-		paidNewsletterData?.steps.content.status,
-		paidNewsletterData?.steps.subscribers.status
+		paidNewsletterData?.steps?.content.status,
+		paidNewsletterData?.steps?.subscribers.status
 	);
 
 	useEffect( () => {

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -1,6 +1,5 @@
 import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
-import { toInteger } from 'lodash';
 import StripeLogo from 'calypso/assets/images/jetpack/stripe-logo-white.svg';
 import { navigate } from 'calypso/lib/navigate';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -39,7 +38,8 @@ export default function ConnectStripe( {
 	}
 
 	const connectUrl = updateConnectUrl( cardData?.connect_url ?? '', fromSite, engine );
-	const allEmailsCount = toInteger( cardData?.meta?.email_count ) || 0;
+	const allEmailsCount = parseInt( cardData?.meta?.email_count || '0' );
+
 	return (
 		<>
 			<SuccessNotice allEmailsCount={ allEmailsCount } />

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -1,5 +1,6 @@
 import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
+import { toInteger } from 'lodash';
 import StripeLogo from 'calypso/assets/images/jetpack/stripe-logo-white.svg';
 import { navigate } from 'calypso/lib/navigate';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -7,6 +8,7 @@ import ImporterActionButton from '../../../importer-action-buttons/action-button
 import ImporterActionButtonContainer from '../../../importer-action-buttons/container';
 import { SubscribersStepProps } from '../../types';
 import StartImportButton from '../start-import-button';
+import SuccessNotice from './success-notice';
 
 /**
  * Update the connect URL with the from_site and engine parameters.
@@ -37,9 +39,10 @@ export default function ConnectStripe( {
 	}
 
 	const connectUrl = updateConnectUrl( cardData?.connect_url ?? '', fromSite, engine );
-
+	const allEmailsCount = toInteger( cardData?.meta?.email_count ) || 0;
 	return (
 		<>
+			<SuccessNotice allEmailsCount={ allEmailsCount } />
 			<h2>Do you have paid subscribers?</h2>
 			<p>
 				To migrate your <strong>paid subscribers</strong> to WordPress.com, make sure you're

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -63,7 +63,7 @@ export default function ConnectStripe( {
 					navigate={ () => {
 						navigate( `/import/newsletter/${ engine }/${ siteSlug }/summary?from=${ fromSite }` );
 					} }
-					label="Continue free subscriber import"
+					label="I have only free subscribers"
 				/>
 			</ImporterActionButtonContainer>
 		</>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plan.scss
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plan.scss
@@ -52,3 +52,7 @@
 .newsletter-importer input[type="checkbox"] {
 	margin-right: 8px;
 }
+
+.no-plans__info {
+	margin-top: 24px;
+}

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
@@ -1,5 +1,6 @@
 import { formatCurrency } from '@automattic/format-currency';
 import { useQueryClient } from '@tanstack/react-query';
+import { toInteger } from 'lodash';
 import { useEffect, useState, useRef } from 'react';
 import { useMapStripePlanToProductMutation } from 'calypso/data/paid-newsletter/use-map-stripe-plan-to-product-mutation';
 import { navigate } from 'calypso/lib/navigate';
@@ -15,6 +16,8 @@ import { getProductsForSiteId } from 'calypso/state/memberships/product-list/sel
 import { SubscribersStepProps } from '../../types';
 import StartImportButton from './../start-import-button';
 import { MapPlan, TierToAdd } from './map-plan';
+import NoPlans from './no-plans';
+import SuccessNotice from './success-notice';
 
 function formatCurrencyFloat( amount: number, currency: string ) {
 	const formattedCurrency = formatCurrency( amount, currency, {
@@ -119,7 +122,15 @@ export default function MapPlans( {
 
 	// TODO what if those plans are undefined?
 	if ( ! monthyPlan || ! annualPlan ) {
-		return;
+		return (
+			<NoPlans
+				cardData={ cardData }
+				selectedSite={ selectedSite }
+				engine={ engine }
+				siteSlug={ siteSlug }
+				fromSite={ fromSite }
+			/>
+		);
 	}
 
 	const tierToAdd = {
@@ -148,8 +159,11 @@ export default function MapPlans( {
 		setProductToAdd( tierToAdd );
 	};
 
+	const allEmailsCount = toInteger( cardData?.meta?.email_count ) || 0;
+
 	return (
 		<>
+			<SuccessNotice allEmailsCount={ allEmailsCount } />
 			<h2>Paid subscribers</h2>
 			<p>
 				<strong>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
@@ -1,6 +1,5 @@
 import { formatCurrency } from '@automattic/format-currency';
 import { useQueryClient } from '@tanstack/react-query';
-import { toInteger } from 'lodash';
 import { useEffect, useState, useRef } from 'react';
 import { useMapStripePlanToProductMutation } from 'calypso/data/paid-newsletter/use-map-stripe-plan-to-product-mutation';
 import { navigate } from 'calypso/lib/navigate';
@@ -159,7 +158,7 @@ export default function MapPlans( {
 		setProductToAdd( tierToAdd );
 	};
 
-	const allEmailsCount = toInteger( cardData?.meta?.email_count ) || 0;
+	const allEmailsCount = parseInt( cardData?.meta?.email_count || '0' );
 
 	return (
 		<>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
@@ -1,0 +1,118 @@
+import { Dialog } from '@automattic/components';
+import { useQueryClient } from '@tanstack/react-query';
+import { Notice } from '@wordpress/components';
+import { useState, useEffect } from 'react';
+import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import { navigate } from 'calypso/lib/navigate';
+import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';
+import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
+import { useDispatch } from 'calypso/state';
+import { requestDisconnectSiteStripeAccount } from 'calypso/state/memberships/settings/actions';
+import StartImportButton from './../start-import-button';
+import type { SiteDetails } from '@automattic/data-stores';
+
+type NoPlansProps = {
+	cardData: SubscribersStepContent;
+	selectedSite: SiteDetails;
+	engine: string;
+	siteSlug: string;
+	fromSite: string;
+};
+
+export default function NoPlans( {
+	cardData,
+	selectedSite,
+	engine,
+	siteSlug,
+	fromSite,
+}: NoPlansProps ) {
+	const currentStep = 'subscribers';
+	const [ showDisconnectStripeDialog, setShowDisconnectStripeDialog ] = useState( false );
+	const [ shouldCheckConnection, setShouldCheckConnection ] = useState( false );
+
+	const dispatch = useDispatch();
+	const queryClient = useQueryClient();
+
+	const disconnectStripe = () => {
+		setShowDisconnectStripeDialog( true );
+		setShouldCheckConnection( false );
+	};
+
+	useEffect( () => {
+		if ( shouldCheckConnection ) {
+			// Invalidete the state so that we fetch it again.
+			queryClient.invalidateQueries( {
+				queryKey: [ 'paid-newsletter-importer', selectedSite.ID, engine ],
+			} );
+		}
+	}, [ engine, queryClient, selectedSite.ID, shouldCheckConnection ] );
+
+	function onCloseDisconnectStripeAccount( reason: string | undefined ) {
+		if ( reason === 'disconnect' ) {
+			dispatch(
+				requestDisconnectSiteStripeAccount(
+					selectedSite.ID,
+					'Please wait, disconnecting Stripe\u2026',
+					'Stripe account is disconnected.'
+				)
+			);
+			setTimeout( () => {
+				setShouldCheckConnection( true );
+			}, 1000 );
+		}
+		setShowDisconnectStripeDialog( false );
+	}
+
+	return (
+		<>
+			<Notice isDismissible={ false } status="warning">
+				We couldn't find any plans in your connected Stripe account.
+			</Notice>
+			<div className="no-plans__info">
+				<p>
+					It looks like the Stripe Account ( { cardData?.account_display } ) does not have any
+					active plans. Are you sure you connected the same Stipe account that you use on Substack?
+				</p>
+			</div>
+			<ImporterActionButtonContainer>
+				<ImporterActionButton onClick={ disconnectStripe } primary>
+					Try a different Stripe account
+				</ImporterActionButton>
+
+				<StartImportButton
+					engine={ engine }
+					siteId={ selectedSite.ID }
+					primary={ false }
+					step={ currentStep }
+					label="Only Import free subscrivers"
+					navigate={ () => {
+						navigate( `/import/newsletter/${ engine }/${ siteSlug }/summary?from=${ fromSite }` );
+					} }
+				/>
+			</ImporterActionButtonContainer>
+			<Dialog
+				className="memberships__stripe-disconnect-modal"
+				isVisible={ showDisconnectStripeDialog }
+				buttons={ [
+					{
+						label: 'Cancel',
+						action: 'cancel',
+					},
+					{
+						label: 'Disconnect Payments from Stripe',
+						isPrimary: true,
+						additionalClassNames: 'is-scary',
+						action: 'disconnect',
+					},
+				] }
+				onClose={ onCloseDisconnectStripeAccount }
+			>
+				<h1>Disconnect Stripe?</h1>
+				<p>
+					Once you disconnect Payments from Stripe, new subscribers won’t be able to sign up and
+					existing subscriptions will stop working.
+				</p>
+			</Dialog>
+		</>
+	);
+}

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/success-notice.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/success-notice.tsx
@@ -1,0 +1,9 @@
+import { Notice } from '@wordpress/components';
+
+export default function SuccessNotice( { allEmailsCount }: { allEmailsCount: number } ) {
+	return (
+		<Notice status="success" className="importer__notice" isDismissible={ false }>
+			All set! We’ve found <strong>{ allEmailsCount } subscribers</strong> to import.
+		</Notice>
+	);
+}

--- a/client/my-sites/importer/newsletter/subscribers/step-done.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-done.tsx
@@ -4,7 +4,8 @@ import ImporterActionButton from '../../importer-action-buttons/action-button';
 import { SubscribersStepProps } from '../types';
 
 export default function StepDone( { cardData, nextStepUrl }: SubscribersStepProps ) {
-	const subscribedCount = parseInt( cardData.meta?.subscribed_count || '0' );
+	const subscribedCount = parseInt( cardData?.meta?.email_count || '0' );
+
 	return (
 		<Card>
 			<h2>Import your subscribers to WordPress.com</h2>

--- a/client/my-sites/importer/newsletter/subscribers/step-pending.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-pending.tsx
@@ -1,6 +1,4 @@
 import { Card } from '@automattic/components';
-import { Notice } from '@wordpress/components';
-import { toInteger } from 'lodash';
 import { SubscribersStepProps } from '../types';
 import PaidSubscribers from './paid-subscribers';
 
@@ -15,14 +13,8 @@ export default function StepPending( {
 	setAutoFetchData,
 	status,
 }: SubscribersStepProps ) {
-	const allEmailsCount = toInteger( cardData?.meta?.email_count ) || 0;
-
 	return (
 		<Card>
-			<Notice status="success" className="importer__notice" isDismissible={ false }>
-				All set! We’ve found <strong>{ allEmailsCount } subscribers</strong> to import.
-			</Notice>
-
 			<PaidSubscribers
 				cardData={ cardData }
 				engine={ engine }

--- a/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
@@ -24,7 +24,7 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 
 	const [ hasImportError, setHasImportError ] = useState( false );
 
-	const { importCsvSubscribers } = useDispatch( Subscriber.store );
+	const { importCsvSubscribers, importCsvSubscribersUpdate } = useDispatch( Subscriber.store );
 	const { importSelector } = useSelect( ( select ) => {
 		const subscriber = select( Subscriber.store );
 
@@ -64,6 +64,11 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 
 		return validExtensions.includes( match?.groups?.extension.toLowerCase() as string );
 	}
+
+	// This fixes the issue of the form being the the upload state even if the user hasn't loaded the importer.
+	useEffect( () => {
+		importCsvSubscribersUpdate( undefined ); // reset the form.
+	}, [ importCsvSubscribersUpdate ] );
 
 	const importSubscribersUrl =
 		'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/';

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -45,7 +45,7 @@ export default function Summary( {
 
 	const onButtonClick = () => resetPaidNewsletter( selectedSite.ID, engine, 'content' );
 	const paidSubscribersCount = parseInt(
-		steps.subscribers.content?.meta?.paid_subscribers_count || '0'
+		steps.subscribers.content?.meta?.paid_subscribed_count || '0'
 	);
 	const showPauseSubstackBillingWarning = paidSubscribersCount > 0;
 
@@ -75,7 +75,7 @@ export default function Summary( {
 
 			{ showPauseSubstackBillingWarning && (
 				<Notice status="warning" className="importer__notice" isDismissible={ false }>
-					<h2>Heads up!</h2>
+					<h2>Action Required!</h2>
 					To prevent any charges from your old provider, go to your{ ' ' }
 					<a
 						href={ `https://${ normalizeFromSite( fromSite ) }/publish/settings#payments-settings` }

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -75,10 +75,12 @@ export default function Summary( {
 
 			{ showPauseSubstackBillingWarning && (
 				<Notice status="warning" className="importer__notice" isDismissible={ false }>
-					<h2>Action Required!</h2>
+					<h2>Action Required</h2>
 					To prevent any charges from your old provider, go to your{ ' ' }
 					<a
-						href={ `https://${ normalizeFromSite( fromSite ) }/publish/settings#payments-settings` }
+						href={ `https://${ normalizeFromSite(
+							fromSite
+						) }/publish/settings?search=Pause%20subscription` }
 						target="_blank"
 						rel="noreferrer"
 					>

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -59,32 +59,31 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 					{ !! addedFree && (
 						<p>
 							<Icon icon={ people } />
-							<strong>{ addedFree }</strong> free subscribers
+							<strong>{ addedFree }</strong> free subscribers.
 						</p>
 					) }
-					{ !! existingFree && (
-						<p>
-							<Icon icon={ info } />
-							<strong>{ existingFree }</strong> existing subscribers
-						</p>
-					) }
-					{ !! failedFree && (
-						<p>
-							<Icon icon={ warning } />
-							<strong>{ failedFree }</strong> error in the email format.
-						</p>
-					) }
-
 					{ !! addedPaid && (
 						<p>
 							<Icon icon={ payment } />
 							<strong>{ addedPaid }</strong> paid subscribers added.
 						</p>
 					) }
+					{ !! existingFree && (
+						<p>
+							<Icon icon={ info } />
+							<strong>{ existingFree }</strong> existing subscribers.
+						</p>
+					) }
 					{ !! existingPaid && (
 						<p>
 							<Icon icon={ info } />
 							<strong>{ existingPaid }</strong> existing paid subscribers.
+						</p>
+					) }
+					{ !! failedFree && (
+						<p>
+							<Icon icon={ warning } />
+							<strong>{ failedFree }</strong> error in the email format.
 						</p>
 					) }
 					{ !! failedPaid && (

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,5 +1,5 @@
 import { ProgressBar } from '@wordpress/components';
-import { Icon, people, atSymbol, payment } from '@wordpress/icons';
+import { Icon, people, atSymbol, payment, info, warning } from '@wordpress/icons';
 import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
 interface SubscriberSummaryProps {
@@ -8,9 +8,6 @@ interface SubscriberSummaryProps {
 }
 
 export default function SubscriberSummary( { stepContent, status }: SubscriberSummaryProps ) {
-	const paidSubscribersCount = parseInt( stepContent?.meta?.paid_subscribers_count || '0' );
-	const hasPaidSubscribers = paidSubscribersCount > 0;
-
 	if ( status === 'skipped' ) {
 		return (
 			<div className="summary__content">
@@ -42,8 +39,14 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 	}
 
 	if ( status === 'done' ) {
-		const subscribedCount = parseInt( stepContent.meta?.subscribed_count || '0' );
-		const freeSubscribersCount = subscribedCount - paidSubscribersCount;
+		const subscribedCount = parseInt( stepContent.meta?.email_count || '0' );
+		const addedFree = parseInt( stepContent.meta?.subscribed_count || '0' );
+		const existingFree = parseInt( stepContent.meta?.already_subscribed_count || '0' );
+		const failedFree = parseInt( stepContent.meta?.failed_subscribed_count || '0' );
+
+		const addedPaid = parseInt( stepContent.meta?.paid_subscribed_count || '0' );
+		const existingPaid = parseInt( stepContent.meta?.paid_already_subscribed_count || '0' );
+		const failedPaid = parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' );
 
 		return (
 			<>
@@ -53,14 +56,41 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 					</p>
 				</div>
 				<div className="summary__content summary__content-indent">
-					<p>
-						<Icon icon={ people } />
-						<strong>{ freeSubscribersCount }</strong> free subscribers
-					</p>
-					{ hasPaidSubscribers && (
+					{ !! addedFree && (
+						<p>
+							<Icon icon={ people } />
+							<strong>{ addedFree }</strong> free subscribers
+						</p>
+					) }
+					{ !! existingFree && (
+						<p>
+							<Icon icon={ info } />
+							<strong>{ existingFree }</strong> existing subscribers
+						</p>
+					) }
+					{ !! failedFree && (
+						<p>
+							<Icon icon={ warning } />
+							<strong>{ failedFree }</strong> error in the email format.
+						</p>
+					) }
+
+					{ !! addedPaid && (
 						<p>
 							<Icon icon={ payment } />
-							<strong>{ paidSubscribersCount }</strong> paid subscribers
+							<strong>{ addedPaid }</strong> paid subscribers added.
+						</p>
+					) }
+					{ !! existingPaid && (
+						<p>
+							<Icon icon={ info } />
+							<strong>{ existingPaid }</strong> existing paid subscribers.
+						</p>
+					) }
+					{ !! failedPaid && (
+						<p>
+							<Icon icon={ warning } />
+							<strong>{ failedPaid }</strong> error in the email format.
 						</p>
 					) }
 				</div>

--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -9,8 +9,6 @@ import {
 } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import { navigate } from 'calypso/lib/navigate';
 
-const noop = () => {};
-
 function getStepProgressIndicator( stepStatus?: StepStatus ): ReactNode {
 	if ( stepStatus === 'done' ) {
 		return <Icon icon={ check } />;
@@ -31,6 +29,7 @@ export function getStepsProgress(
 		paidNewsletterData?.steps.content.status,
 		paidNewsletterData?.steps.subscribers.status
 	);
+
 	const result: ClickHandler[] = [
 		{
 			message: 'Content',
@@ -58,7 +57,14 @@ export function getStepsProgress(
 		},
 		{
 			message: 'Summary',
-			onClick: noop,
+			onClick: () => {
+				navigate(
+					addQueryArgs( `/import/newsletter/${ engine }/${ selectedSiteSlug }/summary`, {
+						from: fromSite,
+					} )
+				);
+			},
+			show: summaryStatus === 'done' || summaryStatus === 'skipped' ? 'always' : 'onComplete',
 			indicator: getStepProgressIndicator( summaryStatus === 'done' ? 'done' : 'initial' ),
 		},
 	];

--- a/client/state/memberships/settings/actions.js
+++ b/client/state/memberships/settings/actions.js
@@ -20,7 +20,7 @@ const requestDisconnectStripeAccountByUrl = (
 	return ( dispatch ) => {
 		dispatch(
 			warningNotice( noticeTextOnProcessing, {
-				duration: 10000,
+				duration: 5000,
 			} )
 		);
 


### PR DESCRIPTION
Related to #

## Proposed Changes

* Fix Newsletter Tier Bug. Paid Subscribers now also get added in the correctly as paid subscribers under the subscribers.
* Add the No Plans case. If a user connects to Stripe plan that doesn't return any plans. Then allow them to continue or connect a different stripe plan. 
* Show better summary of subscriber import. 
* Fix the case where a user goes though the import process multiple times. 

## Why are these changes being made?

* To fix bugs with the paid importer flow. 

## Testing Instructions


* Navigate to Tools > Import select the substack importer and go though the paid subscriber process. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
