### PR TITLE
Stats: Apply the newly introduced location views API to the Locations module

### DIFF
--- a/client/state/stats/lists/test/actions.js
+++ b/client/state/stats/lists/test/actions.js
@@ -54,7 +54,7 @@ describe( 'actions', () => {
 				.persist()
 				.get( `/rest/v1.1/sites/${ SITE_ID }/stats/streak?startDate=2015-06-01&endDate=2016-06-01` )
 				.reply( 200, STREAK_RESPONSE )
-				.get( `/rest/v1.1/sites/${ SITE_ID }/stats/country-views` )
+				.get( `/rest/v1.1/sites/${ SITE_ID }/stats/location-views/country` )
 				.reply( 404, {
 					error: 'not_found',
 				} )

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -403,7 +403,7 @@ export const normalizers = {
 	 * @returns {Object | null}        Normalized stats data
 	 */
 	statsCountryViews: ( data, query = {} ) => {
-		// parsing a country-views response requires a period and date
+		// parsing a location-views response requires a period and date
 		if ( ! data || ! query.period || ! query.date ) {
 			return null;
 		}

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -415,6 +415,19 @@ export const normalizers = {
 
 		// filter out country views that have no legitimate country data associated with them
 		const countryData = filter( get( data, dataPath, [] ), ( viewData ) => {
+			// Ignore the unknown location of sources from the legacy stats geoviews table.
+			if ( [ 'A1', 'A2', 'ZZ' ].includes( viewData.country_code ) ) {
+				return false;
+			}
+
+			// TODO: Investigate ignored countries that have `false` as the country_full data.
+			if (
+				countryInfo[ viewData.country_code ] &&
+				! countryInfo[ viewData.country_code ].country_full
+			) {
+				return false;
+			}
+
 			return countryInfo[ viewData.country_code ];
 		} );
 

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -397,7 +397,7 @@ export const normalizers = {
 	},
 
 	/**
-	 * Returns a normalized payload from `/sites/{ site }/stats/country-views`
+	 * Returns a normalized payload from `/sites/{ site }/stats/location-views/country`
 	 * @param   {Object} data    Stats data
 	 * @param   {Object} query   Stats query
 	 * @returns {Object | null}        Normalized stats data

--- a/packages/wpcom.js/docs/site.md
+++ b/packages/wpcom.js/docs/site.md
@@ -156,7 +156,7 @@ site.statsComments( function ( err, data ) {
 
 ### Site#statsCountryViews([query, ]fn)
 
-Returns stats [country views](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/country-views/) data.
+Returns stats [country views](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/location-views/country/) data.
 
 ```js
 site.statsCountryViews( function ( err, data ) {

--- a/packages/wpcom.js/docs/site.md
+++ b/packages/wpcom.js/docs/site.md
@@ -160,7 +160,7 @@ Returns stats [country views](https://developer.wordpress.com/docs/api/1.1/get/s
 
 ```js
 site.statsCountryViews( function ( err, data ) {
-	// data country-views response
+	// data location-views response
 } );
 ```
 

--- a/packages/wpcom.js/src/lib/runtime/site.get.js
+++ b/packages/wpcom.js/src/lib/runtime/site.get.js
@@ -14,7 +14,7 @@ export default [
 	{ name: 'statsClicks', subpath: 'stats/clicks' },
 	{ name: 'statsCommentFollowers', subpath: 'stats/comment-followers' },
 	{ name: 'statsComments', subpath: 'stats/comments' },
-	{ name: 'statsCountryViews', subpath: 'stats/country-views' },
+	{ name: 'statsCountryViews', subpath: 'stats/location-views/country' },
 	{ name: 'statsFollowers', subpath: 'stats/followers' },
 	{ name: 'statsInsights', subpath: 'stats/insights' },
 	{ name: 'statsPublicize', subpath: 'stats/publicize' },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1727106755052629-slack-C82FZ5T4G, panfyZ-41e-p2#comment-10163

## Proposed Changes

* Replace the legacy `stats/country-views` API endpoint with the newly introduced `stats/location-views/country` one, which would keep existing response data properties and eliminate **_unknown_** visit locations.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Some users reported unknown location sources, which do not correspond with our support guide. We have a newly introduced API endpoint compatible with legacy data tables, which ignores unknown locations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Scroll to the `Locations` module.
* Ensure the country map and list work well but do not have unknown sources.

> Note: The data between the two endpoints would differ because they use different mechanisms to check the source location. Google translated the screenshots above, so some words might be incorrect.

| Before | After |
|-|-|
|<img width="1265" alt="截圖 2024-10-01 上午12 58 05" src="https://github.com/user-attachments/assets/358a145b-b074-4b53-83af-851847585de9">|<img width="1275" alt="截圖 2024-10-01 上午1 02 13" src="https://github.com/user-attachments/assets/c7eb1de0-9c51-4934-aacd-6fdf1f3ffc53">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?