### PR TITLE
Logged-in Performance Profiler: Do not wrap page and device selectors on tablet and beyond

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
 import { useDebouncedInput } from '@wordpress/compose';
 import { translate } from 'i18n-calypso';
@@ -200,7 +200,7 @@ export const SitePerformance = () => {
 		dispatch( launchSite( siteId! ) );
 	};
 
-	const isMobile = ! useDesktopBreakpoint();
+	const isMobile = useMobileBreakpoint();
 	const disableControls = performanceReport.isLoading || isInitialLoading || ! isSitePublic;
 
 	const pageSelector = (

--- a/client/hosting/performance/style.scss
+++ b/client/hosting/performance/style.scss
@@ -81,10 +81,13 @@ $section-max-width: 1224px;
 .site-performance-device-tab-controls__container {
 	display: flex;
 	gap: 24px;
-	flex-wrap: wrap;
 	align-items: center;
 	justify-content: space-between;
 	margin-bottom: 16px;
+
+	@media (max-width: $break-medium) {
+		flex-wrap: wrap;
+	}
 
 	.site-performance__page-selector {
 		display: flex;
@@ -142,7 +145,6 @@ $section-max-width: 1224px;
 	}
 
 	@media (max-width: $break-medium) {
-		margin-bottom: 8px;
 		width: 100%;
 
 		.formatted-header__subtitle {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/9291.

## Proposed Changes


https://github.com/user-attachments/assets/a0cda6f1-9b4f-467b-9195-eb6f8f18f16d

