### PR TITLE
Stepper: Only call `calypso_stepper_flow_start`  when the user lands to a valid step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-analytics/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-analytics/index.tsx
@@ -7,7 +7,10 @@ export const DURATION = 20 * 60 * 1000; // 20 min
 interface Params {
 	flow: string | null;
 	variant?: string;
-	step: string;
+	step: string | null;
+}
+interface Options {
+	enabled: boolean;
 }
 
 interface SessionKeys {
@@ -56,7 +59,7 @@ const startSession = ( keys: SessionKeys, extra: Record< string, any > ) => {
  * Same flow with same parameters will be tracked only once whitin the DURATION time
  * returns void
  */
-export const useFlowAnalytics = ( params: Params ) => {
+export const useFlowAnalytics = ( params: Params, options: Options = { enabled: true } ) => {
 	const [ search ] = useSearchParams();
 	const { flow, step, variant } = params;
 	const ref = search.get( 'ref' );
@@ -85,8 +88,8 @@ export const useFlowAnalytics = ( params: Params ) => {
 	);
 
 	useEffect( () => {
-		if ( ! flowStarted && flow ) {
+		if ( ! flowStarted && flow && step && options.enabled ) {
 			startSession( sessionKeys, extraTrackingParams );
 		}
-	}, [ extraTrackingParams, flow, flowStarted, sessionKeys ] );
+	}, [ extraTrackingParams, flow, flowStarted, sessionKeys, step, options.enabled ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-analytics/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-analytics/test/index.tsx
@@ -14,10 +14,13 @@ describe( 'useFlowAnalytics', () => {
 		( { initialEntries } ) =>
 		( { children } ) => <MemoryRouter initialEntries={ initialEntries }>{ children }</MemoryRouter>;
 
-	const render = ( options = { initialEntries: [ '/setup/flow' ] } ) => {
-		const Wrapper = buildWrapper( options );
+	const render = (
+		renderOptions = { initialEntries: [ '/setup/flow' ] },
+		hookOptions: Parameters< typeof useFlowAnalytics >[ 1 ] = { enabled: true }
+	) => {
+		const Wrapper = buildWrapper( renderOptions );
 		return renderHook(
-			() => useFlowAnalytics( { flow: 'flow', step: 'step', variant: 'variant' } ),
+			() => useFlowAnalytics( { flow: 'flow', step: 'step', variant: 'variant' }, hookOptions ),
 			{ wrapper: Wrapper }
 		);
 	};
@@ -73,6 +76,12 @@ describe( 'useFlowAnalytics', () => {
 		render();
 
 		expect( recordFlowStart ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'doesn`t track the flow when the hook is disabled', () => {
+		render( { initialEntries: [ '/setup/flow' ] }, { enabled: false } );
+
+		expect( recordFlowStart ).not.toHaveBeenCalled();
 	} );
 
 	it( 'tracks the same flow after 20 min', () => {

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -75,10 +75,14 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const currentStepRoute = params.step || '';
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const { lang = null } = useParams();
+	const isValidStep = params.step != null && stepPaths.includes( params.step );
 
 	// Start tracking performance for this step.
 	useStartStepperPerformanceTracking( params.flow || '', currentStepRoute );
-	useFlowAnalytics( { flow: params.flow, step: currentStepRoute, variant: flow.variantSlug } );
+	useFlowAnalytics(
+		{ flow: params.flow, step: params.step, variant: flow.variantSlug },
+		{ enabled: isValidStep }
+	);
 
 	const { __ } = useI18n();
 	useSaveQueryParams();


### PR DESCRIPTION
Closes  #95035


## Proposed Changes
* Disable the calypso_stepper_flow_start event trigger when the flow is started with an invalid step.

## Why are these changes being made?
Nowadays, we can start a flow using different ways:
1. `/setup/:flow`  -  Redirects user to the first flow step
2. `/setup/:flow/:step/` 
4. `/setup/:flow/:step/:lang`
5. `/setup/:flow/:lang`  --> Redirect the user to the first flow step using the correct language. * 

* If a flow starts with a locale code on the user, but the user is logged in, we respect the user preference instead of the URL.

Scenarios 2 and 4 are conflicting because we need to differentiate if the value after the flow name is a step or a locale.

This PR updates it only to trigger the `calypso_stepper_flow_start` when the user lands on a valid step. 


## Testing Instructions
* Clean up your sessionStorage  `sessionStorage.clear()`
* Access `/setup/migration/es` 
*  Check if you have a call to the calypso_stepper_flow_start event with the correct step name.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?