### PR TITLE
Stepper: Add flow title when no pagetitle

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,11 +1,6 @@
-import {
-	isNewsletterOrLinkInBioFlow,
-	isSenseiFlow,
-	isWooExpressFlow,
-} from '@automattic/onboarding';
+import { isWooExpressFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, lazy } from 'react';
 import Modal from 'react-modal';
 import { generatePath, useParams } from 'react-router';
@@ -76,7 +71,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const currentStepRoute = params.step || '';
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const { lang = null } = useParams();
-	const translate = useTranslate();
 
 	// Start tracking performance for this step.
 	useStartStepperPerformanceTracking( params.flow || '', currentStepRoute );
@@ -191,13 +185,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	};
 
 	const getDocumentHeadTitle = () => {
-		if ( isNewsletterOrLinkInBioFlow( flow.name ) ) {
-			return flow.title;
-		} else if ( isSenseiFlow( flow.name ) ) {
-			return __( 'Course Creator' );
-		}
-
-		return flow.title ?? translate( 'Create a site' );
+		return flow.title ?? __( 'Create a site' );
 	};
 
 	useSignUpStartTracking( { flow } );

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -5,6 +5,7 @@ import {
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, lazy } from 'react';
 import Modal from 'react-modal';
 import { generatePath, useParams } from 'react-router';
@@ -75,6 +76,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const currentStepRoute = params.step || '';
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const { lang = null } = useParams();
+	const translate = useTranslate();
 
 	// Start tracking performance for this step.
 	useStartStepperPerformanceTracking( params.flow || '', currentStepRoute );
@@ -194,6 +196,8 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		} else if ( isSenseiFlow( flow.name ) ) {
 			return __( 'Course Creator' );
 		}
+
+		return flow.title ?? translate( 'Create a site' );
 	};
 
 	useSignUpStartTracking( { flow } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Add a default `Create a site` page title, similar to what's done in Start [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/utils.js#L92)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To add a page title to the page

![image](https://github.com/user-attachments/assets/101ea45e-ca6c-4158-8879-85a25fa6f381)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live link
* Visit `/setup/onboarding`
* Check that the Page title is `Create a site`
* Visit `/setup/sensei` and check that it is `Course Creator`
* Visit `/setup/newsletter` and check that it is `Newsletter`

