### PR TITLE
Use plugin_name param to include woocommerce-payments in the woocommerce core profiler

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -176,6 +176,7 @@ export class AuthFormHeader extends Component {
 								isJetpack: true,
 								redirectTo: window.location.href,
 								from: this.props.authQuery.from,
+								plugin_name: this.props.authQuery.plugin_name,
 							} ) }
 						/>
 					),

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -42,6 +42,7 @@ export function login( {
 	usernameOnly = undefined,
 	gravatarFrom = undefined,
 	gravatarFlow = undefined,
+	plugin_name = undefined,
 } = {} ) {
 	let url = '/log-in';
 
@@ -119,6 +120,10 @@ export function login( {
 
 	if ( gravatarFlow ) {
 		url = addQueryArgs( { gravatar_flow: '1' }, url );
+	}
+
+	if ( plugin_name ) {
+		url = addQueryArgs( { plugin_name }, url );
 	}
 
 	return url;

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -122,8 +122,8 @@ export function login( {
 		url = addQueryArgs( { gravatar_flow: '1' }, url );
 	}
 
-	if ( plugin_name ) {
-		url = addQueryArgs( { plugin_name }, url );
+	if ( pluginName ) {
+		url = addQueryArgs( { pluginName }, url );
 	}
 
 	return url;

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -42,7 +42,7 @@ export function login( {
 	usernameOnly = undefined,
 	gravatarFrom = undefined,
 	gravatarFlow = undefined,
-	plugin_name = undefined,
+	pluginName = undefined,
 } = {} ) {
 	let url = '/log-in';
 

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -123,7 +123,7 @@ export function login( {
 	}
 
 	if ( pluginName ) {
-		url = addQueryArgs( { pluginName }, url );
+		url = addQueryArgs( { plugin_name: pluginName }, url );
 	}
 
 	return url;

--- a/client/state/selectors/is-woocommerce-core-profiler-flow.ts
+++ b/client/state/selectors/is-woocommerce-core-profiler-flow.ts
@@ -11,10 +11,22 @@ import type { AppState } from 'calypso/types';
  * @returns {?boolean}        Whether the user reached Calypso via the WooCommerce Core Profiler flow
  */
 export const isWooCommerceCoreProfilerFlow = ( state: AppState ): boolean => {
-	const allowedFrom = [ 'woocommerce-core-profiler' ];
+	const isCoreProfiler =
+		get( getInitialQueryArguments( state ), 'from' ) === 'woocommerce-core-profiler' ||
+		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-core-profiler';
+
+	const allowedPluginNames = [ 'woocommerce-payment' ];
+	const isPluginNameAllowed =
+		allowedPluginNames.includes(
+			get( getInitialQueryArguments( state ), 'plugin_name' ) as string
+		) ||
+		allowedPluginNames.includes(
+			get( getCurrentQueryArguments( state ), 'plugin_name' ) as string
+		);
+
 	return (
-		allowedFrom.includes( get( getInitialQueryArguments( state ), 'from' ) as string ) ||
-		allowedFrom.includes( get( getCurrentQueryArguments( state ), 'from' ) as string ) ||
+		isCoreProfiler ||
+		isPluginNameAllowed ||
 		( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) &&
 			new URLSearchParams( state.login?.redirectTo?.original ).get( 'from' ) ===
 				'woocommerce-core-profiler' )

--- a/client/state/selectors/is-woocommerce-core-profiler-flow.ts
+++ b/client/state/selectors/is-woocommerce-core-profiler-flow.ts
@@ -15,7 +15,7 @@ export const isWooCommerceCoreProfilerFlow = ( state: AppState ): boolean => {
 		get( getInitialQueryArguments( state ), 'from' ) === 'woocommerce-core-profiler' ||
 		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-core-profiler';
 
-	const allowedPluginNames = [ 'woocommerce-payment' ];
+	const allowedPluginNames = [ 'woocommerce-payments' ];
 	const isPluginNameAllowed =
 		allowedPluginNames.includes(
 			get( getInitialQueryArguments( state ), 'plugin_name' ) as string

--- a/client/state/selectors/is-woocommerce-core-profiler-flow.ts
+++ b/client/state/selectors/is-woocommerce-core-profiler-flow.ts
@@ -11,22 +11,22 @@ import type { AppState } from 'calypso/types';
  * @returns {?boolean}        Whether the user reached Calypso via the WooCommerce Core Profiler flow
  */
 export const isWooCommerceCoreProfilerFlow = ( state: AppState ): boolean => {
-	const isCoreProfiler =
-		get( getInitialQueryArguments( state ), 'from' ) === 'woocommerce-core-profiler' ||
-		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-core-profiler';
+	const initFrom = get( getInitialQueryArguments( state ), 'from' );
+	const currentFrom = get( getCurrentQueryArguments( state ), 'from' );
 
-	const allowedPluginNames = [ 'woocommerce-payments' ];
-	const isPluginNameAllowed =
-		allowedPluginNames.includes(
-			get( getInitialQueryArguments( state ), 'plugin_name' ) as string
-		) ||
-		allowedPluginNames.includes(
-			get( getCurrentQueryArguments( state ), 'plugin_name' ) as string
-		);
+	const initPluginName = get( getInitialQueryArguments( state ), 'plugin_name' );
+	const currentPluginName = get( getCurrentQueryArguments( state ), 'plugin_name' );
+
+	const isCoreProfiler =
+		initFrom === 'woocommerce-core-profiler' || currentFrom === 'woocommerce-core-profiler';
+
+	const isWooCommercePayments =
+		( initFrom === 'woocommerce-payments' || currentFrom === 'woocommerce-payments' ) &&
+		( initPluginName === 'woocommerce-payments' || currentPluginName === 'woocommerce-payments' );
 
 	return (
 		isCoreProfiler ||
-		isPluginNameAllowed ||
+		isWooCommercePayments ||
 		( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) &&
 			new URLSearchParams( state.login?.redirectTo?.original ).get( 'from' ) ===
 				'woocommerce-core-profiler' )


### PR DESCRIPTION
This PR uses `plugin_name` param instead of `from` to avoid conflict with WooCommerce Payment onboarding.

See https://github.com/Automattic/wp-calypso/pull/95023 for more details

## Proposed Changes

* Uses `plugin_name` param.



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Create a new JN site with this branch and `use-wp-horizon` feature flag selected.
2. Go through the core profiler and select `Jetpack` on the extensions page.
3. Continue and you should be redirected to the Jetpack connection page.
4. Change `from` to `woocommerce-payments` and add `plugin_name=woocommerce-payments`  param to the URL and hit the enter.
5. You should still see the new Jetpack connection page.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
