### PR TITLE
Remove database confirmation checkbox when syncing Woo staging sites.

### DIFF
--- a/client/hosting/staging-site/components/staging-site-card/sync-options-panel.tsx
+++ b/client/hosting/staging-site/components/staging-site-card/sync-options-panel.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { ToggleControl, CheckboxControl } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { useState, useEffect, useMemo } from 'react';
 
@@ -19,11 +19,6 @@ const DangerousItemsTitle = styled.p( {
 	fontWeight: 500,
 	marginBottom: '8px',
 	color: '#D63638',
-} );
-
-const WooCommerceOverwriteWarning = styled.p( {
-	color: '#D63638',
-	marginTop: '1.5em',
 } );
 
 const ToggleControlWithHelpMargin = styled( ToggleControl )( {
@@ -69,20 +64,12 @@ export default function SyncOptionsPanel( {
 	disabled,
 	onChange,
 	isSqlsOptionDisabled,
-	isSiteWooStore,
-	databaseSyncConfirmed,
-	setdatabaseSyncConfirmed,
-	isSqlSyncOptionChecked,
 }: {
 	items: CheckboxOptionItem[];
 	reset: boolean;
 	disabled: boolean;
 	onChange: ( items: CheckboxOptionItem[] ) => void;
 	isSqlsOptionDisabled: boolean;
-	isSiteWooStore: boolean;
-	databaseSyncConfirmed: boolean;
-	isSqlSyncOptionChecked: boolean;
-	setdatabaseSyncConfirmed: ( value: boolean ) => void;
 } ) {
 	const initialItemsMap = useMemo(
 		() =>
@@ -198,22 +185,6 @@ export default function SyncOptionsPanel( {
 						</div>
 					);
 				} ) }
-				{ isSiteWooStore && (
-					<div>
-						<WooCommerceOverwriteWarning>
-							{ translate(
-								'This site has WooCommerce installed. All orders in the production database will be overwritten.'
-							) }
-						</WooCommerceOverwriteWarning>
-						<CheckboxControl
-							key="checkbox"
-							label={ translate( 'Confirm I want to proceed with database synchronization ' ) }
-							checked={ databaseSyncConfirmed }
-							disabled={ ! isSqlSyncOptionChecked }
-							onChange={ setdatabaseSyncConfirmed }
-						/>
-					</div>
-				) }
 			</DangerousItemsContainer>
 		</>
 	);


### PR DESCRIPTION
Related to pdKhl6-4az-p2#comment-7479

## Proposed Changes

Addressing some feedback we got on Staging Site Syncing for WooCommerce project, we are removing the confirmation checkbox when syncing Woo staging sites. We came to the conclusion that the warning on the final confirmation modal should be enough.

| Before |   After | 
|----------|:-------------:|
| ![image](https://github.com/user-attachments/assets/64cefd0f-2e17-4130-8c01-d48a42aa09a9) | ![image](https://github.com/user-attachments/assets/a061be22-af17-4eaa-ae04-d874eb807ea0) |

To the final confirmation modal warning we are updating its copy, by prepending `This site has WooCommerce installed.` in red color.

![image](https://github.com/user-attachments/assets/179ea248-fac3-45af-a719-ad8b326f1ef5)


## Testing Instructions

Have a Woo site with WooCommerce plugin active and the staging site set up.
Go to Staging Site setting `http://calypso.localhost:3000/staging-site/{site-url}`.
Choose `Staging into production`.
The `Confirm I want to proceed with database synchronization` should not existi anymore.
Toggle `Site database (SQL)` on.
The Synchronize button should be enabled, click it.
It should open the final confirmation modal. The warning text should have the red `This site has WooCommerce installed.`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?