### PR TITLE
A4A: Don't fire signup page view event when redirecting

### DIFF
--- a/client/a8c-for-agencies/sections/signup/controller.tsx
+++ b/client/a8c-for-agencies/sections/signup/controller.tsx
@@ -6,15 +6,35 @@ import {
 	A4A_SIGNUP_FINISH_LINK,
 	A4A_SIGNUP_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useSelector } from 'calypso/state';
+import {
+	getActiveAgency,
+	hasFetchedAgency,
+	isFetchingAgency,
+} from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { hideMasterbar } from 'calypso/state/ui/actions';
 import AgencySignUp from './primary/agency-signup';
 import AgencySignupFinish from './primary/agency-signup-finish';
+
+const PageViewTrackerWrapper = ( { path }: { path: string } ) => {
+	const agency = useSelector( getActiveAgency );
+	const hasFetched = useSelector( hasFetchedAgency );
+	const isFetching = useSelector( isFetchingAgency );
+
+	const shouldRenderTracker = hasFetched && ! isFetching && ! agency;
+
+	if ( ! shouldRenderTracker ) {
+		return null;
+	}
+
+	return <PageViewTracker title="A4A Signup" path={ path } />;
+};
 
 export const signUpContext: Callback = ( context, next ) => {
 	context.store.dispatch( hideMasterbar() );
 	context.primary = (
 		<>
-			<PageViewTracker title="A4A Signup" path={ context.path } />
+			<PageViewTrackerWrapper path={ context.path } />
 			<AgencySignUp />
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1176

## Proposed Changes

* Don't fire the `calypso_page_view` Tracks event on the A4A signup page when the user will get redirected to the overview page and never see the signup page.
* This uses useEffect and a zero timeout. The timeout ensures state updates have finished. Otherwise there's a slight delay between hasFetched being set to true and agency being set when an agency exists, which would otherwise be enough to know whether to fire the event or not.
* This approach feels a little more complex than I'd like, but it's the only way I've been able to get it to work. I'm very open to feedback.
* In any case, the majority of users hitting the signup page won't be logged in and so won't be affected by the timeout.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When a user visits /signup and they already have an agency account, we [redirect them](https://github.com/Automattic/wp-calypso/blob/trunk/client/a8c-for-agencies/sections/signup/primary/agency-signup/index.tsx#L27) to the overview page. We're still firing the `calypso_page_view` event even though the user didn't actually see the page. This will inflate the events to some extend and we probably shouldn't fire it in this case.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You'll need two different wpcom users: one that's an agency and one that isn't.
* In your browser, open the network tab of the dev console and filter for `t.gif` to monitor Tracks events.

##### A (event is not fired)
* While logged in as an agency user, visit /signup
* In the list of Tracks events, ensure you **do not** see `calypso_page_view` with the `path: /signup` property.
  * You should however see one with `path: /overview` when you're redirected to /overview.

<img width="1676" alt="Screenshot 2024-10-01 at 5 01 21 PM" src="https://github.com/user-attachments/assets/17696ac3-6a81-41ca-b0ae-434e7fab7c6c">

##### B (event is fired)
* While logged in as a user that's not an active agency, visit /signup.
* In the list of Tracks events, ensure you **do** see `calypso_page_view` with the `path: /signup` property.

<img width="1646" alt="Screenshot 2024-10-01 at 5 02 01 PM" src="https://github.com/user-attachments/assets/2d81f7d0-76fb-405b-a6b1-246e09d8912b">


##### C (event is fired)
* While logged out, visit /signup.
* In the list of Tracks events, ensure you **do** see `calypso_page_view` with the `path: /signup` property.

<img width="1646" alt="Screenshot 2024-10-01 at 5 02 01 PM" src="https://github.com/user-attachments/assets/2d81f7d0-76fb-405b-a6b1-246e09d8912b">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
