### PR TITLE
Post-migration Experience: Adds the Launchpad

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -62,5 +62,6 @@ export const LAUNCHPAD_INTENT_FREE_NEWSLETTER = 'home-launchpad-intent-free-news
 export const LAUNCHPAD_INTENT_PAID_NEWSLETTER = 'home-launchpad-intent-paid-newsletter';
 export const LAUNCHPAD_PRE_LAUNCH = 'home-launchpad-pre-launch';
 export const LAUNCHPAD_LEGACY_SITE_SETUP = 'home-launchpad-legacy-site-setup';
+export const LAUNCHPAD_POST_MIGRATION = 'home-launchpad-post-migration';
 export const NOTICE_HOME_LIMITED_TIME_OFFER_COUPON = 'home-limited-time-coupon';
 export const FEATURE_READER = 'home-feature-reader';

--- a/client/my-sites/customer-home/cards/launchpad/post-migration.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/post-migration.tsx
@@ -3,7 +3,7 @@ import LaunchpadPreLaunch from './pre-launch';
 export const LaunchpadPostMigration = (): JSX.Element => {
 	const checklistSlug = 'post-migration';
 
-	return (
+	return <LaunchpadPreLaunch checklistSlug={ checklistSlug } />
 		<>
 			<LaunchpadPreLaunch checklistSlug={ checklistSlug } />
 		</>

--- a/client/my-sites/customer-home/cards/launchpad/post-migration.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/post-migration.tsx
@@ -3,9 +3,5 @@ import LaunchpadPreLaunch from './pre-launch';
 export const LaunchpadPostMigration = (): JSX.Element => {
 	const checklistSlug = 'post-migration';
 
-	return <LaunchpadPreLaunch checklistSlug={ checklistSlug } />
-		<>
-			<LaunchpadPreLaunch checklistSlug={ checklistSlug } />
-		</>
-	);
+	return <LaunchpadPreLaunch checklistSlug={ checklistSlug } />;
 };

--- a/client/my-sites/customer-home/cards/launchpad/post-migration.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/post-migration.tsx
@@ -1,0 +1,11 @@
+import LaunchpadPreLaunch from './pre-launch';
+
+export const LaunchpadPostMigration = (): JSX.Element => {
+	const checklistSlug = 'post-migration';
+
+	return (
+		<>
+			<LaunchpadPreLaunch checklistSlug={ checklistSlug } />
+		</>
+	);
+};

--- a/client/my-sites/customer-home/locations/card-components.ts
+++ b/client/my-sites/customer-home/locations/card-components.ts
@@ -12,6 +12,7 @@ import {
 	LAUNCHPAD_INTENT_WRITE,
 	LAUNCHPAD_PRE_LAUNCH,
 	LAUNCHPAD_LEGACY_SITE_SETUP,
+	LAUNCHPAD_POST_MIGRATION,
 	NOTICE_CELEBRATE_SITE_CREATION,
 	NOTICE_CELEBRATE_SITE_LAUNCH,
 	NOTICE_CELEBRATE_SITE_MIGRATION,
@@ -59,6 +60,7 @@ import {
 	LaunchpadIntentPaidNewsletter,
 } from 'calypso/my-sites/customer-home/cards/launchpad/intent-newsletter';
 import LaunchpadIntentWrite from 'calypso/my-sites/customer-home/cards/launchpad/intent-write';
+import { LaunchpadPostMigration } from 'calypso/my-sites/customer-home/cards/launchpad/post-migration';
 import LaunchpadPreLaunch from 'calypso/my-sites/customer-home/cards/launchpad/pre-launch';
 import { LaunchpadSiteSetup } from 'calypso/my-sites/customer-home/cards/launchpad/site-setup';
 import CelebrateSiteCopy from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-copy';
@@ -145,6 +147,7 @@ const CARD_COMPONENTS: CardComponentMap = {
 	[ LAUNCHPAD_INTENT_WRITE ]: LaunchpadIntentWrite,
 	[ LAUNCHPAD_PRE_LAUNCH ]: LaunchpadPreLaunch,
 	[ LAUNCHPAD_LEGACY_SITE_SETUP ]: LaunchpadSiteSetup,
+	[ LAUNCHPAD_POST_MIGRATION ]: LaunchpadPostMigration,
 	[ NOTICE_READER_FIRST_POSTS ]: ReaderFirstPosts,
 	[ SECTION_BLOGGING_PROMPT ]: BloggingPrompt,
 	[ SECTION_BLOGANUARY_BLOGGING_PROMPT ]: BloggingPrompt,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pfuQfP-IF-p2

## Proposed Changes

* Adds the Launchpad component and registers it to allow us to display the Migration task list.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As we move forward to work on the post-migration experience, we want to create a new task list to add a clear step to sites recently migrated.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection should be enough.
* If you want to test it visually, please follow the testing instructions on D162739-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?