### PR TITLE
Theme: Remove Congrats screen for the DotOrg theme

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -59,7 +59,6 @@ import { connectOptions } from 'calypso/my-sites/themes/theme-options';
 import ThemePreview from 'calypso/my-sites/themes/theme-preview';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { isUserPaid } from 'calypso/state/purchases/selectors';
@@ -103,6 +102,7 @@ import {
 	getThemeType,
 	isThemeWooCommerce,
 	isActivatingTheme as getIsActivatingTheme,
+	isInstallingTheme as getIsInstallingTheme,
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
@@ -353,9 +353,13 @@ class ThemeSheet extends Component {
 	};
 
 	isRequestingActivatingTheme = () => {
-		const { isThemeActivationSyncStarted, isActivatingTheme } = this.props;
+		const { isThemeActivationSyncStarted, isActivatingTheme, isInstallingTheme } = this.props;
 		const { isAtomicTransferCompleted } = this.state;
-		return ( isThemeActivationSyncStarted && ! isAtomicTransferCompleted ) || isActivatingTheme;
+		return (
+			( isThemeActivationSyncStarted && ! isAtomicTransferCompleted ) ||
+			isActivatingTheme ||
+			isInstallingTheme
+		);
 	};
 
 	// If a theme has been removed by a theme shop, then the theme will still exist and a8c will take over any support responsibilities.
@@ -1666,6 +1670,7 @@ export default connect(
 			isLivePreviewSupported,
 			themeType: getThemeType( state, themeId ),
 			isActivatingTheme: getIsActivatingTheme( state, siteId ),
+			isInstallingTheme: getIsInstallingTheme( state, themeId, siteId ),
 		};
 	},
 	{
@@ -1674,6 +1679,5 @@ export default connect(
 		recordTracksEvent,
 		themeStartActivationSync: themeStartActivationSyncAction,
 		errorNotice,
-		setProductToBeInstalled: productToBeInstalled,
 	}
 )( withSiteGlobalStylesStatus( localize( ThemeSheetWithOptions ) ) );

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -223,9 +223,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 				typeof window !== 'undefined' ? window.location : {};
 			const slug = getSiteSlug( state, siteId );
 
-			const redirectTo = encodeURIComponent(
-				`${ origin }/marketplace/theme/${ themeId }/install/${ slug }`
-			);
+			const redirectTo = encodeURIComponent( `${ origin }/theme/${ themeId }/${ slug }` );
 
 			const currentPlanSlug = getSitePlanSlug( state, siteId );
 			const isEcommerceTrialMonthly = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { activateTheme } from 'calypso/state/themes/actions/activate-theme';
@@ -38,6 +37,7 @@ export function activate( themeId, siteId, options ) {
 		// The theme with the plugin bundle will be handled by the plugin bundle flow.
 		const shouldAtomicTransfer =
 			isExternallyManagedTheme( getState(), themeId ) ||
+			isDotOrgTheme ||
 			( isDotComTheme && hasThemeBundleSoftwareSet && ! isOnboardingFlow );
 
 		/**
@@ -73,11 +73,6 @@ export function activate( themeId, siteId, options ) {
 			return page(
 				`/marketplace/thank-you/${ siteSlug }?themes=${ themeId }&continueWithPluginBundle=true`
 			);
-		}
-
-		if ( isDotOrgTheme ) {
-			dispatch( productToBeInstalled( themeId, siteSlug ) );
-			return page( `/marketplace/theme/${ themeId }/install/${ siteSlug }` );
 		}
 
 		return activateOrInstallThenActivate( themeId, siteId, {

--- a/client/state/themes/actions/install-theme.js
+++ b/client/state/themes/actions/install-theme.js
@@ -30,11 +30,6 @@ export function installTheme( themeId, siteId ) {
 			.post( `/sites/${ siteId }/themes/${ themeId }/install` )
 			.then( ( theme ) => {
 				dispatch( receiveTheme( theme, siteId ) );
-				dispatch( {
-					type: THEME_INSTALL_SUCCESS,
-					siteId,
-					themeId,
-				} );
 
 				// Install parent theme if theme requires one
 				if ( themeId.endsWith( '-wpcom' ) ) {
@@ -48,6 +43,13 @@ export function installTheme( themeId, siteId ) {
 				}
 			} )
 			.then( () => dispatch( requestThemes( siteId, {} ) ) )
+			.then( () => {
+				dispatch( {
+					type: THEME_INSTALL_SUCCESS,
+					siteId,
+					themeId,
+				} );
+			} )
 			.catch( ( error ) => {
 				dispatch( {
 					type: THEME_INSTALL_FAILURE,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9179

## Proposed Changes

* Redirect back to the Theme Details page after checkout
* Don't redirect to the install page when activating the DotOrg theme. Instead, just activate the theme on the theme details page directly
* Fix the activating status between installation and activation because there is a small period for requesting themes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Remove Congrats screen the theme activation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Theme Showcase
* Search for the DotOrg themes, e.g.: astra
* Go to the Theme Details page
* Activate the theme/Upgrade to activate
* Make sure you can see the Checkout if the plan on your site is not business or above
* Make sure you can see the Atomic Transfer dialog if your site is not an AT site
  ![image](https://github.com/user-attachments/assets/ac3cf707-21a6-45dc-b94c-b74f47c6b695)
* Make sure you can see the Activation modal
* Make sure the "Activate this design" button is loading during the activation
* Make sure the success notice is shown after the activation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
