### PR TITLE
Redirect to plugins.php after plugin activation instead of Congrats page

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -43,7 +43,7 @@ import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id'
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import {
 	initiateThemeTransfer as initiateTransfer,
 	installAndActivateTheme,
@@ -260,6 +260,9 @@ const MarketplaceProductInstall = ( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ pluginUploadComplete, installedPlugin, setCurrentStep ] );
 
+	const pluginsUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'plugins.php?activate=true' )
+	);
 	// Check completition of all flows and redirect to thank you page
 	useEffect( () => {
 		if (
@@ -273,13 +276,9 @@ const MarketplaceProductInstall = ( {
 				! isAtomic &&
 				transferStates.COMPLETE === automatedTransferStatus )
 		) {
-			waitFor( 1 ).then( () =>
-				page.redirect(
-					`/marketplace/thank-you/${ selectedSiteSlug }?hide-progress-bar&plugins=${
-						installedPlugin?.slug || pluginSlug || uploadedPluginSlug
-					}`
-				)
-			);
+			waitFor( 1 ).then( () => {
+				window.location.href = pluginsUrl as string;
+			} );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ pluginActive, automatedTransferStatus, atomicFlow, isPluginUploadFlow, isAtomic ] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -1,4 +1,9 @@
-import { PLAN_BUSINESS, WPCOM_FEATURES_ATOMIC, getPlan } from '@automattic/calypso-products';
+import {
+	PLAN_BUSINESS,
+	WPCOM_FEATURES_ATOMIC,
+	getPlan,
+	WPCOM_FEATURES_MANAGE_PLUGINS,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { WordPressWordmark, Button } from '@automattic/components';
 import { ThemeProvider } from '@emotion/react';
@@ -263,25 +268,38 @@ const MarketplaceProductInstall = ( {
 	const pluginsUrl = useSelector( ( state ) =>
 		getSiteAdminUrl( state, siteId, 'plugins.php?activate=true' )
 	);
+	const canManagePlugins = useSelector( ( state ) => {
+		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
+	} );
 	// Check completition of all flows and redirect to thank you page
 	useEffect( () => {
 		if (
 			// Default process
 			( installedPlugin && pluginActive ) ||
 			// Transfer to atomic using a marketplace plugin
-			( atomicFlow && transferStates.COMPLETE === automatedTransferStatus ) ||
+			( atomicFlow && transferStates.COMPLETE === automatedTransferStatus && canManagePlugins ) ||
 			// Transfer to atomic uploading a zip plugin
 			( uploadedPluginSlug &&
 				isPluginUploadFlow &&
 				! isAtomic &&
-				transferStates.COMPLETE === automatedTransferStatus )
+				transferStates.COMPLETE === automatedTransferStatus &&
+				canManagePlugins )
 		) {
-			waitFor( 2 ).then( () => {
+			waitFor( 1 ).then( () => {
 				window.location.href = pluginsUrl as string;
 			} );
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ pluginActive, automatedTransferStatus, atomicFlow, isPluginUploadFlow, isAtomic ] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
+	}, [
+		pluginActive,
+		automatedTransferStatus,
+		atomicFlow,
+		isPluginUploadFlow,
+		isAtomic,
+		canManagePlugins,
+		installedPlugin,
+		uploadedPluginSlug,
+		pluginsUrl,
+	] ); // We need to trigger this hook also when `automatedTransferStatus` changes cause the plugin install is done on the background in that case.
 
 	// Validate theme is already active
 	useEffect( () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -276,7 +276,7 @@ const MarketplaceProductInstall = ( {
 				! isAtomic &&
 				transferStates.COMPLETE === automatedTransferStatus )
 		) {
-			waitFor( 1 ).then( () => {
+			waitFor( 2 ).then( () => {
 				window.location.href = pluginsUrl as string;
 			} );
 		}


### PR DESCRIPTION
https://github.com/Automattic/dotcom-forge/issues/9180

## Proposed Changes

This PR changes to redirect to plugins.php after plugin activation instead of Congrats page. This change applies to free and custom plugin installations on Simple and Atomic (I'll follow up on paid plugins). It is using the Core functionality for showing notices ([`?activate=true`](https://github.com/WordPress/wordpress-develop/blob/4dafd584c91524f0cfd743f728d5f334df761e11/src/wp-admin/plugins.php#L722) query), aligning the behavior with Core.
<img width="1223" alt="Screenshot 2024-10-01 at 17 35 09" src="https://github.com/user-attachments/assets/66eecd4c-7e50-46a3-be3e-dada7a1b68e1">

I prefer this way to what is proposed in the issue: https://github.com/Automattic/dotcom-forge/issues/9180 because;

- This is consistent with the behavior users experience in the core, such as when installing plugins through /wp-admin/plugin-install.php on Atomic.
- By redirecting users to plugins.php instead of keeping them in Calypso, we respect any custom plugin-specific redirection that may occur post-activation, ensuring compatibility with plugins that utilize their own onboarding flows.

Follow-up tasks;

- [x] Extend this functionality to handle paid plugin activations. https://github.com/Automattic/wp-calypso/pull/95181
- [ ] Remove the progress step page during installation and activation. The installation will be inlined on the plugin page using a busy state on the button (with text such as “Installing…” or “Activating…”), followed by redirection to plugins.php once complete.
	- This may need a bit of a spike; the progress step page seems to be doing more handling than I thought while installing.
	- https://github.com/Automattic/wp-calypso/blob/23da1941dcdcac44d20dc72a2449cb6599b8e039/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See pbxlJb-6kE-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test the following on Simple and Atomic site;

- Go to /plugins/<site>
- Install a Free plugin
- Observe it redirects to the progress page, then to /wp-admin/plugins.php with the "Plugin activated." notice
	- In Simple, you are redirected to the plan purchase page before the progress page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?