### PR TITLE
A4A Dev Sites: Add `Refer to client` button back to the Hosting settings page

### DIFF
--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products';
 import { Card, CompactCard, Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
@@ -77,10 +76,7 @@ const LaunchSite = () => {
 	const price = formatCurrency( agency?.prices?.actual_price, agency?.prices?.currency );
 	const siteReferralActive = agency?.referral_status === 'active';
 	const shouldShowReferToClientButton =
-		config.isEnabled( 'a4a-dev-sites-referral' ) &&
-		isDevelopmentSite &&
-		! siteReferralActive &&
-		! agencyLoading;
+		isDevelopmentSite && ! siteReferralActive && ! agencyLoading;
 	const shouldShowAgencyBillingMessage =
 		isDevelopmentSite && ! siteReferralActive && ! agencyLoading;
 

--- a/config/development.json
+++ b/config/development.json
@@ -32,7 +32,6 @@
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,7 +13,6 @@
 		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": false,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": true,

--- a/config/production.json
+++ b/config/production.json
@@ -23,7 +23,6 @@
 		"100-year-plan/vip": false,
 		"ad-tracking": true,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -21,7 +21,6 @@
 		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/test.json
+++ b/config/test.json
@@ -24,7 +24,6 @@
 		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypsoify/plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -20,7 +20,6 @@
 		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": true,


### PR DESCRIPTION
> [!WARNING]  
> Please do not merge until we coordinate the launch of the `Refer to client` feature: p1727770352598469/1727769905.028859-slack-C02TCEHP3HA 

---

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9303.

## Proposed Changes

* remove `a4a-dev-sites-referral` feature flag check from the `Refer to client` button
* remove `a4a-dev-sites-referral` feature flag from the config files

![Markup on 2024-10-01 at 10:32:16](https://github.com/user-attachments/assets/5f345cf7-a893-4ab3-82b1-31d287817987)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out and build this PR with `yarn start`.
2. Navigate to [http://calypso.localhost:3000/settings/general/{blog-id}](http://calypso.localhost:3000/settings/general/%7Bblog-id%7D) (`blog-id` needs to be replaced with a blog ID of a A4A dev site that **hasn't been** successfully referred to a client).
3. The "Refer to client" button should be rendered (as can be seen in the screenshot above). It should work as expected - leading to the correct checkout page where the related site plan is in the cart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?