### PR TITLE
Stepper: Fix title font site on setup/user

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -37,7 +37,7 @@ body.is-section-stepper .step-route {
 	.step-container__content {
 		.formatted-header {
 			.formatted-header__title {
-				/* this is to match withb start */
+				/* this is to match with start */
 				/* stylelint-disable-next-line scales/font-sizes */
 				font-size: 1.875rem;
 				line-height: 3.25;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -1,4 +1,7 @@
 @import "calypso/signup/style";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 body.is-section-stepper .step-route {
 	--color-accent: #117ac9;
 	--color-accent-60: #0e64a5;
@@ -30,10 +33,22 @@ body.is-section-stepper .step-route {
 		fill: var(--color-text);
 		transform-origin: 0 0;
 	}
-	.formatted-header__title {
-		line-height: 3.25;
-		font-size: 2rem;
+
+	.step-container__content {
+		.formatted-header {
+			.formatted-header__title {
+				/* this is to match withb start */
+				/* stylelint-disable-next-line scales/font-sizes */
+				font-size: 1.875rem;
+				line-height: 3.25;
+
+				@include break-small {
+					font-size: 2rem;
+				}	
+			}
+		}
 	}
+	
 	.signup-form-social-first {
 		width: 327px;
 		margin: 0 auto;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9304
Fixes https://github.com/Automattic/dotcom-forge/issues/9304

## Proposed Changes

* Use the same font-sizes in stepper, specifically on `setup/onboarding/user`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Match the font-size used in `/start` on stepper `(/setup)`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link on incognito
* Navigate to `/setup/onboarding/user`
* Compare the font-sizes against `start/user-social`
* Below 600px it should be `1.875rem`, after that `2rem`
* There are other inconsistencies that will be addressed in other PRs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
