### PR TITLE
A4A: Make the onboarding tasks list dismissable when it is completed.

### DIFF
--- a/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
+++ b/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
@@ -48,9 +48,7 @@ export default function useOnboardingTours() {
 	);
 
 	const dismiss = useCallback( () => {
-		dispatch(
-			savePreference( A4A_ONBOARDING_TOURS_DISMISSED_PREFERENCE_NAME, { dismiss: false } )
-		);
+		dispatch( savePreference( A4A_ONBOARDING_TOURS_DISMISSED_PREFERENCE_NAME, true ) );
 	}, [ dispatch ] );
 
 	const isDismissed = useSelector( ( state ) =>

--- a/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
+++ b/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
@@ -5,7 +5,7 @@ import { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
-import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
+import { getAllRemotePreferences, getPreference } from 'calypso/state/preferences/selectors';
 import {
 	A4A_MARKETPLACE_LINK,
 	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
@@ -14,7 +14,10 @@ import {
 	A4A_SITES_LINK_WALKTHROUGH_TOUR,
 	A4A_TEAM_LINK,
 } from '../components/sidebar-menu/lib/constants';
-import { A4A_ONBOARDING_TOURS_PREFERENCE_NAME } from '../sections/onboarding-tours/constants';
+import {
+	A4A_ONBOARDING_TOURS_DISMISSED_PREFERENCE_NAME,
+	A4A_ONBOARDING_TOURS_PREFERENCE_NAME,
+} from '../sections/onboarding-tours/constants';
 import useNoActiveSite from './use-no-active-site';
 
 const checkTourCompletion = ( preferences: object, prefSlug: string ): boolean => {
@@ -44,7 +47,17 @@ export default function useOnboardingTours() {
 		[ dispatch ]
 	);
 
-	return useMemo( () => {
+	const dismiss = useCallback( () => {
+		dispatch(
+			savePreference( A4A_ONBOARDING_TOURS_DISMISSED_PREFERENCE_NAME, { dismiss: false } )
+		);
+	}, [ dispatch ] );
+
+	const isDismissed = useSelector( ( state ) =>
+		getPreference( state, A4A_ONBOARDING_TOURS_DISMISSED_PREFERENCE_NAME )
+	);
+
+	const tasks = useMemo( () => {
 		const addNewSiteTask: Task = {
 			calypso_path: A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
 			completed: checkTourCompletion( preferences, 'addSiteStep1' ),
@@ -150,4 +163,15 @@ export default function useOnboardingTours() {
 
 		return tasks;
 	}, [ dispatch, noActiveSite, preferences, resetTour, translate ] );
+
+	const completedTasks = tasks.filter( ( task ) => task.completed );
+	const isCompleted = completedTasks.length === tasks.length;
+
+	return {
+		tasks,
+		dismiss,
+		isDismissed: isDismissed && isCompleted, // In case we add more tasks, we need to check the list is complete before concluding the onboarding is dismissed.
+		isCompleted,
+		completedTasks,
+	};
 }

--- a/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
+++ b/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
@@ -15,3 +15,5 @@ export const A4A_ONBOARDING_TOURS_EVENT_NAMES: Record< string, string > = {
 	startTour: 'calypso_a4a_start_tour',
 	endTour: 'calypso_a4a_end_tour',
 };
+
+export const A4A_ONBOARDING_TOURS_DISMISSED_PREFERENCE_NAME = 'a4a-onboarding-tour-dismissed';

--- a/client/a8c-for-agencies/sections/overview/body/next-steps/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/index.tsx
@@ -1,5 +1,6 @@
 import { Card, CircularProgressBar } from '@automattic/components';
 import { Checklist, ChecklistItem } from '@automattic/launchpad';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import useOnboardingTours from 'calypso/a8c-for-agencies/hooks/use-onboarding-tours';
 
@@ -8,24 +9,30 @@ import './style.scss';
 export default function OverviewBodyNextSteps() {
 	const translate = useTranslate();
 
-	const tasks = useOnboardingTours();
+	const { tasks, completedTasks, isCompleted, isDismissed, dismiss } = useOnboardingTours();
 
-	const numberOfTasks = tasks.length;
-	const completedTasks = tasks.filter( ( task ) => task.completed ).length;
-
-	const isCompleted = completedTasks === numberOfTasks;
+	if ( isDismissed ) {
+		return null;
+	}
 
 	return (
 		<Card>
 			<div className="next-steps">
 				<div className="next-steps__header">
 					<h2>{ isCompleted ? translate( '🎉 Congratulations!' ) : translate( 'Next Steps' ) }</h2>
-					<CircularProgressBar
-						size={ 32 }
-						enableDesktopScaling
-						numberOfSteps={ numberOfTasks }
-						currentStep={ completedTasks }
-					/>
+
+					{ isCompleted ? (
+						<Button variant="tertiary" onClick={ dismiss }>
+							{ translate( 'Dismiss' ) }
+						</Button>
+					) : (
+						<CircularProgressBar
+							size={ 32 }
+							enableDesktopScaling
+							numberOfSteps={ tasks.length }
+							currentStep={ completedTasks.length }
+						/>
+					) }
 				</div>
 				{ isCompleted && (
 					<p>
@@ -34,6 +41,7 @@ export default function OverviewBodyNextSteps() {
 						) }
 					</p>
 				) }
+
 				<Checklist>
 					{ tasks.map( ( task ) => (
 						<ChecklistItem task={ task } key={ task.id } />


### PR DESCRIPTION
This pull request introduces a feature that allows users to dismiss the onboarding task list once it's completed, freeing up space on the Overview page.

| Before | After |
|--------|--------|
| <img width="1012" alt="Screenshot 2024-10-01 at 6 48 18 PM" src="https://github.com/user-attachments/assets/88d681f4-d0dc-40c1-ac8d-0b9f5af049d8"> | <img width="1021" alt="Screenshot 2024-10-01 at 6 47 46 PM" src="https://github.com/user-attachments/assets/787d8fcd-42f4-4319-939f-9e5f2ab13907"> | 


Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1082

## Proposed Changes

- Add a new preference to store the state of dismissing the onboarding tour.
- Expand the useOnboardingTours hook and include the dismissible feature of the onboarding tours.
- Implement the new hook in the Onboarding task list component and display a dismiss button when tasks are completed.

## Why are these changes being made?

* This feature helps the users to clean up the Overview page with irrelevant cards.

## Testing Instructions

* Use the A4A live link and go to the `/overview` page.
* Reset all onboarding task preferences using the Calypso debug tool.
   <img width="643" alt="Screenshot 2024-10-01 at 6 52 25 PM" src="https://github.com/user-attachments/assets/4b262374-89fc-4a70-9012-52a3db678b8d">
   <img width="286" alt="Screenshot 2024-10-01 at 6 55 42 PM" src="https://github.com/user-attachments/assets/a1505b74-9cd8-4ef2-864d-583feae98101">

* Confirm that when completing all the onboarding tours, the dismiss button appears.
* Click the dismiss button and confirm this hides the card.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
