### PR TITLE
Theme: Redirect back to the Theme Details page after the checkout of the Partner themes

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -52,6 +52,8 @@ export function useThemesThankYouData(
 	);
 	const allThemesFetched = themesList.every( ( theme ) => !! theme );
 
+	const firstTheme = themesList[ 0 ] ?? null;
+
 	const isActive = themesList.some(
 		( theme ) => theme?.stylesheet === themeSlug || theme?.id === themeSlug
 	);
@@ -68,21 +70,6 @@ export function useThemesThankYouData(
 
 	useQueryThemes( 'wpcom', themeSlugs );
 	useQueryThemes( 'wporg', themeSlugs );
-
-	// Clear completed activated theme request state to avoid displaying the Thanks modal
-	useEffect( () => {
-		return () => {
-			dispatch( clearActivated( siteId || 0 ) );
-		};
-	}, [ dispatch, siteId ] );
-
-	useEffect( () => {
-		if ( isActive && continueWithPluginBundle ) {
-			page(
-				`/setup/plugin-bundle/getCurrentThemeSoftwareSets?siteId=${ siteId }&siteSlug=${ siteSlug }`
-			);
-		}
-	}, [ isActive, continueWithPluginBundle, siteId, siteSlug ] );
 
 	const themesSection = themesList
 		.filter( ( theme ) => theme )
@@ -122,18 +109,43 @@ export function useThemesThankYouData(
 
 	// DotOrg (if not also Dotcom) and Externay managed themes
 	// needs an atomic site to be installed.
-	type Theme = { id: string } | undefined;
 	const hasDotOrgThemes = dotOrgThemes.some(
-		( theme: Theme ) =>
-			!! theme && ! dotComThemes.find( ( dotComTheme: Theme ) => dotComTheme?.id === theme.id )
+		( theme: { id: string } | undefined ) =>
+			!! theme &&
+			! dotComThemes.find(
+				( dotComTheme: { id: string } | undefined ) => dotComTheme?.id === theme.id
+			)
 	);
 	const hasExternallyManagedThemes = useSelector( ( state ) =>
 		getHasExternallyManagedThemes( state, themeSlugs )
 	);
 	const isAtomicNeeded = hasDotOrgThemes || hasExternallyManagedThemes;
 
+	// Clear completed activated theme request state to avoid displaying the Thanks modal
+	useEffect( () => {
+		return () => {
+			dispatch( clearActivated( siteId || 0 ) );
+		};
+	}, [ dispatch, siteId ] );
+
+	// Redirect to the plugin bundle flow after the activation.
+	useEffect( () => {
+		if ( isActive && continueWithPluginBundle ) {
+			page(
+				`/setup/plugin-bundle/getCurrentThemeSoftwareSets?siteId=${ siteId }&siteSlug=${ siteSlug }`
+			);
+		}
+	}, [ isActive, continueWithPluginBundle, siteId, siteSlug ] );
+
+	// Redirect to the Theme Details page after the atomic transfer.
+	useEffect( () => {
+		if ( firstTheme && isAtomicNeeded && isJetpack ) {
+			page( `/theme/${ firstTheme.id }/${ siteSlug }` );
+		}
+	}, [ firstTheme, isAtomicNeeded, isJetpack ] );
+
 	return [
-		themesList[ 0 ] ?? null,
+		firstTheme,
 		themesSection,
 		allThemesFetched,
 		goBackSection,
@@ -142,8 +154,9 @@ export function useThemesThankYouData(
 		thankyouSteps,
 		isAtomicNeeded,
 		null,
-		// Always display the loading screen if the theme has plugin bundle because the page will
-		// be redirected to the plugin-bundle flow immediately after the theme is activated.
-		! continueWithPluginBundle,
+		// Always display the loading screen for the following situations:
+		// - Redirect to the plugin-bundle flow after the theme is activated for Woo themes.
+		// - Redirect to the Theme Details page after the atomic transfer if it's required.
+		! ( continueWithPluginBundle || isAtomicNeeded ),
 	];
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9179

## Proposed Changes

* The wpcom will initiate the atomic transfer if the checkout contains the Partner themes, so we have to keep the thank-you page to wait for the completion of the atomic transfer (See the notes of the Partner themes of pbxlJb-6lQ-p2). As a result, this PR just made change to redirect back to the Theme Details page after the atomic transfer instead of displaying the Congrats screen to let user activate the theme manually.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Remove the Congrats screen for the theme activation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Search for Partner themes
* Select any partner theme
* On the Theme Details page, click "Subscribe to activate"
* Make sure you see the loading screen after the checkout
* Make sure the page is redirected back to the Theme Details page after the loading screen, and the button becomes "Activate this design"
* Make sure you can activate the theme
* Remember to remove the subscription of the theme

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?