### PR TITLE
Fix top border shifting when opening a recommendation

### DIFF
--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -32,6 +32,11 @@ const Card = styled( FoldableCard )`
 	font-size: 16px;
 	line-height: normal;
 	letter-spacing: -0.1px;
+
+	&.foldable-card.card.is-expanded,
+	&.is-compact {
+		margin: 0;
+	}
 `;
 
 type Header = {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9294

## Proposed Changes

https://github.com/user-attachments/assets/efb4c812-c5a1-4df4-bb09-788b1b0a3815

Side effect of this is the animations are removed as the original Foldable Card was using margins to make the animated effect.