### PR TITLE
Reader: Update excerpt to show if not explicitly set to not show

### DIFF
--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -124,7 +124,7 @@ const ReaderExcerpt = ( { post, hasExcerpt, showExcerpt, setHasExcerpt } ) => {
 		setHasExcerpt?.( excerpt !== '' && excerpt !== null && showExcerpt );
 	}, [ excerpt ] );
 
-	if ( ! hasExcerpt || ! showExcerpt ) {
+	if ( hasExcerpt === false || showExcerpt === false ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/93414

Found a bug (I think) in the logic in `ReaderExcerpt`. It was not showing the except if either  `hasExcerpt` or `showExcerpt` is not set. 

The `PostGallery` component doesn't pass the `hasExcerpt` or `showExcerpt`, so even though the post has an excerpt, it wasn't been shown as `hasExcerpt` and `showExcerpt` were undefined.

This pull request includes a small change to the `client/blocks/reader-excerpt/index.jsx` file. The change modifies the conditional check for `hasExcerpt` and `showExcerpt` to use explicit comparison with `false`.

I've only seen an issue with the 'Gallery' formatted post in streams with missing excerpts. The excerpt appears to show on multiple featured images posts;
<img width="568" alt="Screenshot 2024-10-01 at 16 10 52" src="https://github.com/user-attachments/assets/33c5d86c-db59-4358-b2b1-b0d50b480d20">

Using the `/read/search?q=wordcamp`....

| Before | After |
|--------|-------|
| <img width="573" alt="Screenshot 2024-10-01 at 15 36 34" src="https://github.com/user-attachments/assets/22fc9438-3482-412d-b109-60b0fd954930"> | <img width="576" alt="Screenshot 2024-10-01 at 15 38 04" src="https://github.com/user-attachments/assets/67b02326-e171-4096-8d1c-1c770169b3df"> |
| <img width="572" alt="Screenshot 2024-10-01 at 15 36 49" src="https://github.com/user-attachments/assets/25773bf8-fea4-436a-8083-7c3f36403c06"> | <img width="564" alt="Screenshot 2024-10-01 at 15 38 16" src="https://github.com/user-attachments/assets/3dee6028-9052-4361-82a6-e5eb38d0f8af"> |
| <img width="571" alt="Screenshot 2024-10-01 at 15 37 36" src="https://github.com/user-attachments/assets/82a32370-8fc5-42e5-80d3-fae8db5d9265"> | <img width="567" alt="Screenshot 2024-10-01 at 15 38 46" src="https://github.com/user-attachments/assets/54bbc92a-ce99-4b6d-bd0e-71a99fe8cdb5"> |

## Proposed Changes

* Updates the `ReaderExcerpt` component to only hide the excerpt if explicitly set to do so. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the streams on reader and confirm all the posts have some excerpt. If they don't, click into the post and confirm if that post actually has text. If it has then this PR needs to be updated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
