### PR TITLE
Stepper: Fix mobile spacing and sizes on user

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -48,7 +48,7 @@ body.is-section-stepper .step-route {
 				line-height: 40px;
 				@include break-small {
 					font-size: 2rem;
-					line-height: 3.25;	
+					line-height: 3.25;
 				}	
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -13,7 +13,7 @@ body.is-section-stepper .step-route {
 	align-items: center;
 	justify-content: center;
 	min-height: calc(100vh - 96px);
-	margin: 144px 0 0;
+	margin: 140px 0 0;
 	@include break-small {
 		margin: 108px 0 0;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -13,7 +13,11 @@ body.is-section-stepper .step-route {
 	align-items: center;
 	justify-content: center;
 	min-height: calc(100vh - 96px);
-	margin: 48px 0 0;
+	margin: 144px 0 0;
+	@include break-small {
+		margin: 108px 0 0;
+	}
+	
 
 	a.step-wrapper__navigation-link {
 		color: #1d2327;
@@ -36,14 +40,15 @@ body.is-section-stepper .step-route {
 
 	.step-container__content {
 		.formatted-header {
+			margin: 24px 20px;
 			.formatted-header__title {
 				/* this is to match with start */
 				/* stylelint-disable-next-line scales/font-sizes */
 				font-size: 1.875rem;
-				line-height: 3.25;
-
+				line-height: 40px;
 				@include break-small {
 					font-size: 2rem;
+					line-height: 3.25;	
 				}	
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

 * Use the same mobile spacings in stepper, specifically on setup/onboarding/user

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Match the mobile spacings used in /start on stepper (/setup)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use live link on incognito
- Navigate to /setup/onboarding/user
- Simulate mobile using dev tools
- Compare the mobile layout against `/start`
