### PR TITLE
Reader: Move comment input in reader-full-post view above related posts

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -635,6 +635,24 @@ export class FullPostView extends Component {
 
 							{ ! isLoading && <ReaderPerformanceTrackerStop /> }
 
+							<div className="reader-full-post__comments-wrapper" ref={ this.commentsWrapper }>
+								{ shouldShowComments( post ) && (
+									<Comments
+										showNestingReplyArrow
+										post={ post }
+										initialSize={ startingCommentId ? commentCount : 10 }
+										pageSize={ 25 }
+										startingCommentId={ startingCommentId }
+										commentCount={ commentCount }
+										maxDepth={ 1 }
+										commentsFilterDisplay={ COMMENTS_FILTER_ALL }
+										showConversationFollowButton
+										shouldPollForNewComments={ config.isEnabled( 'reader/comment-polling' ) }
+										shouldHighlightNew
+									/>
+								) }
+							</div>
+
 							{ showRelatedPosts && (
 								<RelatedPostsFromSameSite
 									siteId={ +post.site_ID }
@@ -659,24 +677,6 @@ export class FullPostView extends Component {
 									onPostClick={ this.handleRelatedPostFromSameSiteClicked }
 								/>
 							) }
-
-							<div className="reader-full-post__comments-wrapper" ref={ this.commentsWrapper }>
-								{ shouldShowComments( post ) && (
-									<Comments
-										showNestingReplyArrow
-										post={ post }
-										initialSize={ startingCommentId ? commentCount : 10 }
-										pageSize={ 25 }
-										startingCommentId={ startingCommentId }
-										commentCount={ commentCount }
-										maxDepth={ 1 }
-										commentsFilterDisplay={ COMMENTS_FILTER_ALL }
-										showConversationFollowButton
-										shouldPollForNewComments={ config.isEnabled( 'reader/comment-polling' ) }
-										shouldHighlightNew
-									/>
-								) }
-							</div>
 
 							{ showRelatedPosts && (
 								<RelatedPostsFromOtherSites


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #94800

## Proposed Changes

* Move the comment input in the Reader full post view above related posts

| Before    | After |
| -------- | ------- |
|<img width="714" alt="Screenshot 2024-10-01 at 10 21 40 AM" src="https://github.com/user-attachments/assets/caa002de-0a0c-4b27-bfb7-d711d3764b40">|<img width="714" alt="Screenshot 2024-10-01 at 10 20 37 AM" src="https://github.com/user-attachments/assets/3cb3c793-df52-487b-be06-cf379aaf2246">|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improves the UX by grouping related posts together and moving the comment input closer to the post content.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/read` and click on any post
2. Scroll to bottom of post

**Expected:** Comment input should now be directly under the post actions and if related post sections are displayed, they should now be under the comments section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
