### PR TITLE
Fix flacky test based on time

### DIFF
--- a/client/components/jetpack/daily-backup-status/test/backup-realtime-message.jsx
+++ b/client/components/jetpack/daily-backup-status/test/backup-realtime-message.jsx
@@ -11,6 +11,14 @@ jest.mock( 'i18n-calypso' ); // Mock the useTranslate hook
 jest.mock( 'calypso/state' ); // Mock the useDispatch hook
 
 describe( 'BackupRealtimeMessage', () => {
+	beforeAll( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterAll( () => {
+		jest.useRealTimers();
+	} );
+
 	const renderMessage = ( baseBackupDate, eventsCount, selectedDate, learnMoreUrl ) => {
 		return render(
 			<BackupRealtimeMessage


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*  Freeze jest timer to fix flacky test

## Why are these changes being made?
* We have a flaky unit test that is based on the time the CI is running, this PR intent to fix it

<img width="1395" alt="image" src="https://github.com/user-attachments/assets/1bfd8b8b-5dae-4a22-bf19-5cd7d606701f">



## Testing Instructions
* Run the test suite multiple times.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
