### PR TITLE
Domains: Create 100-Year Domain flow

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -269,17 +269,12 @@ class DomainProductPrice extends Component {
 	}
 
 	/**
-	 * Renders the price of 100-year domains, which are a one time purchase
+	 * Used to render the price of 100-year domains, which are a one time purchase
+	 * TODO: Replace hardcoded value by 100-eyar domain product price when we have it
 	 */
 	renderOneTimePrice() {
-		const { showStrikedOutPrice, price } = this.props;
-
-		const className = clsx( 'domain-product-price domain-product-single-price', {
-			'domain-product-price__domain-step-signup-flow': showStrikedOutPrice,
-		} );
-
 		return (
-			<div className={ className }>
+			<div className="domain-product-price domain-product-single-price">
 				<span>$2,000</span>
 			</div>
 		);

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -268,6 +268,23 @@ class DomainProductPrice extends Component {
 		);
 	}
 
+	/**
+	 * Renders the price of 100-year domains, which are a one time purchase
+	 */
+	renderOneTimePrice() {
+		const { showStrikedOutPrice, price } = this.props;
+
+		const className = clsx( 'domain-product-price domain-product-single-price', {
+			'domain-product-price__domain-step-signup-flow': showStrikedOutPrice,
+		} );
+
+		return (
+			<div className={ className }>
+				<span>{ price }</span>
+			</div>
+		);
+	}
+
 	render() {
 		if ( this.props.isLoading ) {
 			return (
@@ -278,6 +295,8 @@ class DomainProductPrice extends Component {
 		}
 
 		switch ( this.props.rule ) {
+			case 'ONE_TIME_PRICE':
+				return this.renderOneTimePrice();
 			case 'FREE_DOMAIN':
 				return this.renderFree();
 			case 'FREE_FOR_FIRST_YEAR':

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -280,7 +280,7 @@ class DomainProductPrice extends Component {
 
 		return (
 			<div className={ className }>
-				<span>{ price }</span>
+				<span>$2,000</span>
 			</div>
 		);
 	}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { isBlogger, isFreeWordPressComDomain } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, CompactCard, ResponsiveToolbarGroup } from '@automattic/components';
+import { isHundredYearDomainFlow } from '@automattic/onboarding';
 import Search from '@automattic/search';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { Icon } from '@wordpress/icons';
@@ -1071,7 +1072,7 @@ class RegisterDomainStep extends Component {
 
 		// Skip availability check for the 100-year domain flow if the domain is not com/net/org
 		if (
-			this.props.flowName === 'hundred-year-domain' &&
+			isHundredYearDomainFlow( this.props.flowName ) &&
 			! [ 'com', 'net', 'org' ].includes( getTld( domain ) )
 		) {
 			this.showSuggestionErrorMessage( domain, 'hundred_year_domain_tld_restriction', {} );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1069,6 +1069,15 @@ class RegisterDomainStep extends Component {
 			return;
 		}
 
+		// Skip availability check for the 100-year domain flow if the domain is not com/net/org
+		if (
+			this.props.flowName === 'hundred-year-domain' &&
+			! [ 'com', 'net', 'org' ].includes( getTld( domain ) )
+		) {
+			this.showSuggestionErrorMessage( domain, 'hundred_year_domain_tld_restriction', {} );
+			return;
+		}
+
 		return new Promise( ( resolve ) => {
 			checkDomainAvailability(
 				{ domainName: domain, blogId: get( this.props, 'selectedSite.ID', null ) },

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1524,6 +1524,7 @@ class RegisterDomainStep extends Component {
 				this.props.onAddDomain( suggestion, position, previousState );
 			}
 
+			this.setState( { pendingCheckSuggestion: suggestion } );
 			const promise = this.preCheckDomainAvailability( domain )
 				.catch( () => [] )
 				.then( ( { status, trademarkClaimsNoticeInfo } ) => {

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -1,8 +1,7 @@
 import { UserSelect } from '@automattic/data-stores';
-import { HUNDRED_YEAR_DOMAIN_FLOW, addProductsToCart } from '@automattic/onboarding';
+import { HUNDRED_YEAR_DOMAIN_FLOW } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
-import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import {
 	clearSignupDestinationCookie,
 	setSignupCompleteSlug,
@@ -54,29 +53,9 @@ const HundredYearDomainFlow: Flow = {
 		} );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
-			const { domainName, productSlug } = providedDependencies;
-
-			const addDomainToCart = async () => {
-				const productsToAdd = [
-					domainRegistration( {
-						domain: domainName as string,
-						productSlug: productSlug as string,
-						extra: { is_hundred_year_domain: true },
-					} ),
-				];
-				await addProductsToCart( 'no-site', flowName, productsToAdd );
-
-				return {
-					siteId: null,
-					siteSlug: 'no-site',
-					goToCheckout: true,
-				};
-			};
-
 			switch ( _currentStep ) {
 				case 'domains':
 					clearSignupDestinationCookie();
-					addDomainToCart();
 
 					if ( userIsLoggedIn ) {
 						return navigate( 'createSite' );

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -1,5 +1,6 @@
-import { UserSelect } from '@automattic/data-stores';
+import { OnboardSelect } from '@automattic/data-stores';
 import { HUNDRED_YEAR_DOMAIN_FLOW, addProductsToCart } from '@automattic/onboarding';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
@@ -8,18 +9,17 @@ import {
 	setSignupCompleteSlug,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
-import { ONBOARD_STORE, USER_STORE } from '../stores';
-import { useLoginUrl } from '../utils/path';
+import { ONBOARD_STORE } from '../stores';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import type { ProvidedDependencies, Flow } from './internals/types';
 
 const HundredYearDomainFlow: Flow = {
 	name: HUNDRED_YEAR_DOMAIN_FLOW,
+	isSignupFlow: true,
 
 	get title() {
 		return translate( '100-Year Domain' );
 	},
-
-	isSignupFlow: false,
 
 	useSteps() {
 		const steps = [
@@ -27,10 +27,12 @@ const HundredYearDomainFlow: Flow = {
 				slug: 'domains',
 				asyncComponent: () => import( './internals/steps-repository/domains' ),
 			},
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
+			...stepsWithRequiredLogin( [
+				{
+					slug: 'processing',
+					asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+				},
+			] ),
 		];
 
 		return steps;
@@ -38,24 +40,21 @@ const HundredYearDomainFlow: Flow = {
 
 	useStepNavigation( _currentStep, navigate ) {
 		const flowName = this.name;
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+		const checkoutBackUrl = new URL( `/setup/${ flowName }/domains`, window.location.href );
+
+		const { setDomainCartItem } = useDispatch( ONBOARD_STORE );
+
+		const { domainCartItem } = useSelect(
+			( select ) => ( {
+				domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
+			} ),
 			[]
 		);
-		const { setPendingAction } = useDispatch( ONBOARD_STORE );
-
-		const logInUrl = useLoginUrl( {
-			variationName: flowName,
-			redirectTo: `/setup/${ flowName }/processing`,
-			pageTitle: '100-Year Domain',
-		} );
-
-		const checkoutBackUrl = new URL( `/setup/${ flowName }/domains`, window.location.href );
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			const { domainName, productSlug } = providedDependencies;
 
-			const domainCartItem = domainRegistration( {
+			const submittedDomainCartItem = domainRegistration( {
 				productSlug: productSlug as string,
 				domain: domainName as string,
 				extra: { is_hundred_year_domain: true },
@@ -64,29 +63,23 @@ const HundredYearDomainFlow: Flow = {
 			switch ( _currentStep ) {
 				case 'domains':
 					clearSignupDestinationCookie();
+					setDomainCartItem( submittedDomainCartItem );
+					return navigate( 'processing' );
 
-					// Adding the domain product to the cart here because this is a domain-only flow
-					// and we don't need to create a site for this domain
-					await addProductsToCart( 'no-site', flowName, [ domainCartItem ] );
-
-					if ( userIsLoggedIn ) {
-						// Delay to keep the "Setting up your legacy..." page showing for 3 seconds
-						// since there's actually nothing to process there
-						setPendingAction( async () => {
-							await new Promise( ( resolve ) => setTimeout( resolve, 3000 ) );
-						} );
-
-						return navigate( 'processing' );
-					}
-
-					return window.location.assign( logInUrl );
 				case 'processing':
 					setSignupCompleteSlug( providedDependencies.siteSlug );
 					setSignupCompleteFlowName( flowName );
 
+					await addProductsToCart( 'no-site', flowName, [
+						domainCartItem as MinimalRequestCartProduct,
+					] );
+					// Delay to keep the "Setting up your legacy..." page showing for 2 seconds
+					// since there's nothing to actually process in that step
+					await new Promise( ( resolve ) => setTimeout( resolve, 2000 ) );
+
 					// use replace instead of assign to remove the processing URL from history
 					return window.location.replace(
-						`/checkout/no-site?signup=0&isDomainOnly=1&checkoutBackUrl=${ encodeURIComponent(
+						`/checkout/no-site?signup=1&isDomainOnly=1&checkoutBackUrl=${ encodeURIComponent(
 							checkoutBackUrl.href
 						) }`
 					);

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -54,7 +54,6 @@ const HundredYearDomainFlow: Flow = {
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
-
 			const { domainName, productSlug } = providedDependencies;
 
 			const addDomainToCart = async () => {
@@ -62,6 +61,7 @@ const HundredYearDomainFlow: Flow = {
 					domainRegistration( {
 						domain: domainName as string,
 						productSlug: productSlug as string,
+						extra: { is_hundred_year_domain: true },
 					} ),
 				];
 				await addProductsToCart( 'no-site', '100-year-domain', productsToAdd );

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -52,9 +52,9 @@ const HundredYearDomainFlow: Flow = {
 			pageTitle: '100-Year Domain',
 		} );
 
-		function submit( providedDependencies: ProvidedDependencies = {} ) {
-			const checkoutBackUrl = new URL( `/setup/${ flowName }/domains`, window.location.href );
+		const checkoutBackUrl = new URL( `/setup/${ flowName }/domains`, window.location.href );
 
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
 				case 'domains':
 					clearSignupDestinationCookie();

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -1,0 +1,127 @@
+import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
+import { UserSelect } from '@automattic/data-stores';
+import { HUNDRED_YEAR_PLAN_FLOW, addProductsToCart } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from 'react';
+import {
+	clearSignupDestinationCookie,
+	setSignupCompleteSlug,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+import { SiteId, SiteSlug } from 'calypso/types';
+import { ONBOARD_STORE, USER_STORE } from '../stores';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
+import type { ProvidedDependencies, Flow } from './internals/types';
+
+const HundredYearDomainFlow: Flow = {
+	// name: HUNDRED_YEAR_PLAN_FLOW,
+	name: 'hundred-year-domain',
+
+	get title() {
+		return ( getPlan( PLAN_100_YEARS )?.getTitle() || '' ) as string;
+	},
+
+	isSignupFlow: true,
+
+	useSteps() {
+		const steps = [
+			{
+				slug: 'domains',
+				asyncComponent: () => import( './internals/steps-repository/domains' ),
+			},
+			{
+				slug: 'processing',
+				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+			},
+			{
+				slug: 'createSite',
+				asyncComponent: () => import( './internals/steps-repository/create-site' ),
+			},
+		];
+
+		return stepsWithRequiredLogin( steps );
+	},
+
+	useSideEffect() {
+		useEffect( () => {
+			clearSignupDestinationCookie();
+		}, [] );
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		const flowName = this.name;
+		const { setPlanCartItem, setPendingAction } = useDispatch( ONBOARD_STORE );
+		const currentUser = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+			[]
+		);
+		const hasSite = !! currentUser?.site_count;
+
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			const updateCartForExistingSite = async () => {
+				if ( ! providedDependencies?.siteSlug || ! providedDependencies?.siteId ) {
+					return;
+				}
+
+				const siteSlug: SiteSlug = providedDependencies.siteSlug as SiteSlug;
+				const siteId: SiteId = providedDependencies.siteSlug as SiteId;
+
+				const productsToAdd = [
+					{
+						product_slug: '100-year-domain', // TODO: replace by const
+					},
+				];
+				await addProductsToCart( siteSlug, '100-year-domain', productsToAdd );
+
+				return {
+					siteId,
+					siteSlug,
+					goToCheckout: true,
+				};
+			};
+
+			switch ( _currentStep ) {
+				case 'diy-or-difm':
+					if ( 'diy' === providedDependencies?.diyOrDifmChoice ) {
+						return navigate( hasSite ? 'new-or-existing-site' : 'setup' );
+					}
+					// TODO: add VIP flow
+					return navigate( 'schedule-appointment' );
+				case 'schedule-appointment':
+					return navigate( 'thank-you' );
+				case 'new-or-existing-site':
+					if ( 'new-site' === providedDependencies?.newExistingSiteChoice ) {
+						return navigate( 'setup' );
+					}
+					return navigate( 'site-picker' );
+				case 'site-picker':
+					setPendingAction( updateCartForExistingSite );
+					return navigate( 'processing' );
+				case 'setup':
+					return navigate( 'domains' );
+				case 'domains':
+					setPlanCartItem( {
+						product_slug: PLAN_100_YEARS,
+					} );
+					return navigate( 'createSite' );
+				case 'createSite':
+					return navigate( 'processing' );
+				case 'processing':
+					if ( providedDependencies?.goToCheckout && providedDependencies?.siteSlug ) {
+						setSignupCompleteSlug( providedDependencies.siteSlug );
+						setSignupCompleteFlowName( flowName );
+
+						return window.location.assign(
+							`/checkout/${ encodeURIComponent(
+								providedDependencies.siteSlug as string
+							) }?signup=1`
+						);
+					}
+			}
+		}
+
+		return { submit };
+	},
+};
+
+export default HundredYearDomainFlow;

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -1,7 +1,5 @@
 import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
-import { UserSelect } from '@automattic/data-stores';
-import { HUNDRED_YEAR_PLAN_FLOW, addProductsToCart } from '@automattic/onboarding';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { addProductsToCart } from '@automattic/onboarding';
 import { useEffect } from 'react';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import {
@@ -9,13 +7,10 @@ import {
 	setSignupCompleteSlug,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
-import { SiteId, SiteSlug } from 'calypso/types';
-import { ONBOARD_STORE, USER_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import type { ProvidedDependencies, Flow } from './internals/types';
 
 const HundredYearDomainFlow: Flow = {
-	// name: HUNDRED_YEAR_PLAN_FLOW,
 	name: 'hundred-year-domain',
 
 	get title() {
@@ -51,7 +46,6 @@ const HundredYearDomainFlow: Flow = {
 
 	useStepNavigation( _currentStep, navigate ) {
 		const flowName = this.name;
-		const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			const { domainName, productSlug } = providedDependencies;

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -46,7 +46,7 @@ const HundredYearDomainFlow: Flow = {
 
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
-			redirectTo: `/setup/${ flowName }/createSite`,
+			redirectTo: `/setup/${ flowName }/processing`,
 			pageTitle: '100-Year Domain',
 		} );
 

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -1,5 +1,5 @@
 import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
-import { HUNDRED_YEAR_DOMIN_FLOW, addProductsToCart } from '@automattic/onboarding';
+import { HUNDRED_YEAR_DOMAIN_FLOW, addProductsToCart } from '@automattic/onboarding';
 import { useEffect } from 'react';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import {
@@ -11,7 +11,7 @@ import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import type { ProvidedDependencies, Flow } from './internals/types';
 
 const HundredYearDomainFlow: Flow = {
-	name: HUNDRED_YEAR_DOMIN_FLOW,
+	name: HUNDRED_YEAR_DOMAIN_FLOW,
 
 	get title() {
 		return ( getPlan( PLAN_100_YEARS )?.getTitle() || '' ) as string;

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -1,6 +1,6 @@
 import { UserSelect } from '@automattic/data-stores';
 import { HUNDRED_YEAR_DOMAIN_FLOW, addProductsToCart } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import {
@@ -8,7 +8,7 @@ import {
 	setSignupCompleteSlug,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
-import { USER_STORE } from '../stores';
+import { ONBOARD_STORE, USER_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
 import type { ProvidedDependencies, Flow } from './internals/types';
 
@@ -42,6 +42,7 @@ const HundredYearDomainFlow: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
+		const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
@@ -69,6 +70,12 @@ const HundredYearDomainFlow: Flow = {
 					await addProductsToCart( 'no-site', flowName, [ domainCartItem ] );
 
 					if ( userIsLoggedIn ) {
+						// Delay to keep the "Setting up your legacy..." page showing for 3 seconds
+						// since there's actually nothing to process there
+						setPendingAction( async () => {
+							await new Promise( ( resolve ) => setTimeout( resolve, 3000 ) );
+						} );
+
 						return navigate( 'processing' );
 					}
 

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -53,6 +53,8 @@ const HundredYearDomainFlow: Flow = {
 		} );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			const checkoutBackUrl = new URL( `/setup/${ flowName }/domains`, window.location.href );
+
 			switch ( _currentStep ) {
 				case 'domains':
 					clearSignupDestinationCookie();
@@ -63,18 +65,17 @@ const HundredYearDomainFlow: Flow = {
 
 					return window.location.assign( logInUrl );
 				case 'createSite':
-					return navigate( 'processing', undefined );
+					return navigate( 'processing' );
 				case 'processing':
-					if ( providedDependencies?.goToCheckout && providedDependencies?.siteSlug ) {
-						setSignupCompleteSlug( providedDependencies.siteSlug );
-						setSignupCompleteFlowName( flowName );
+					setSignupCompleteSlug( providedDependencies.siteSlug );
+					setSignupCompleteFlowName( flowName );
 
-						return window.location.assign(
-							`/checkout/${ encodeURIComponent(
-								providedDependencies.siteSlug as string
-							) }?signup=1`
-						);
-					}
+					// use replace instead of assign to remove the processing URL from history
+					return window.location.replace(
+						`/checkout/${ encodeURIComponent(
+							providedDependencies.siteSlug as string
+						) }?signup=1&checkoutBackUrl=${ encodeURIComponent( checkoutBackUrl.href ) }`
+					);
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -1,5 +1,5 @@
 import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
-import { addProductsToCart } from '@automattic/onboarding';
+import { HUNDRED_YEAR_DOMIN_FLOW, addProductsToCart } from '@automattic/onboarding';
 import { useEffect } from 'react';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import {
@@ -11,7 +11,7 @@ import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import type { ProvidedDependencies, Flow } from './internals/types';
 
 const HundredYearDomainFlow: Flow = {
-	name: 'hundred-year-domain',
+	name: HUNDRED_YEAR_DOMIN_FLOW,
 
 	get title() {
 		return ( getPlan( PLAN_100_YEARS )?.getTitle() || '' ) as string;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -104,6 +104,7 @@ button {
 .update-design,
 .update-options,
 .hundred-year-plan,
+.hundred-year-domain,
 .link-in-bio-tld,
 .entrepreneur,
 .generate-content {
@@ -120,7 +121,8 @@ button {
 		@include break-small {
 			&.courses,
 			&.site-picker,
-			&.new-or-existing-site {
+			&.new-or-existing-site,
+			&.domains {
 				margin-top: -60px;
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -1,6 +1,6 @@
 import {
 	DOMAIN_UPSELL_FLOW,
-	HUNDRED_YEAR_DOMIN_FLOW,
+	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	isDomainUpsellFlow,
 	LINK_IN_BIO_TLD_FLOW,
@@ -104,7 +104,7 @@ export function DomainFormControl( {
 		includeWordPressDotCom = false;
 	}
 
-	if ( flow === HUNDRED_YEAR_DOMIN_FLOW ) {
+	if ( flow === HUNDRED_YEAR_DOMAIN_FLOW ) {
 		includeWordPressDotCom = false;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -103,6 +103,10 @@ export function DomainFormControl( {
 		includeWordPressDotCom = false;
 	}
 
+	if ( flow === 'hundred-year-domain' ) {
+		includeWordPressDotCom = false;
+	}
+
 	const domainsWithPlansOnly = true;
 	const isPlanSelectionAvailableLaterInFlow = true;
 	const domainSearchInQuery = useQuery().get( 'new' ); // following the convention of /start/domains

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -1,5 +1,6 @@
 import {
 	DOMAIN_UPSELL_FLOW,
+	HUNDRED_YEAR_DOMIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	isDomainUpsellFlow,
 	LINK_IN_BIO_TLD_FLOW,
@@ -103,7 +104,7 @@ export function DomainFormControl( {
 		includeWordPressDotCom = false;
 	}
 
-	if ( flow === 'hundred-year-domain' ) {
+	if ( flow === HUNDRED_YEAR_DOMIN_FLOW ) {
 		includeWordPressDotCom = false;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -133,7 +133,6 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		submit?.( {
 			freeDomain: suggestion?.is_free,
 			domainName: suggestion?.domain_name,
-			productSlug: suggestion?.product_slug,
 		} );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -116,15 +116,9 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			setHideFreePlan( false );
 			setDomainCartItem( undefined );
 		} else {
-			let extra = {};
-			if ( flow === HUNDRED_YEAR_DOMAIN_FLOW ) {
-				extra = { is_hundred_year_domain: true };
-			}
-
 			const domainCartItem = domainRegistration( {
 				domain: suggestion.domain_name,
 				productSlug: suggestion.product_slug || '',
-				extra,
 			} );
 			dispatch( submitDomainStepSelection( suggestion, getAnalyticsSection() ) );
 
@@ -136,7 +130,11 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			changeSiteDomainIfNeeded( suggestion?.domain_name );
 		}
 
-		submit?.( { freeDomain: suggestion?.is_free, domainName: suggestion?.domain_name } );
+		submit?.( {
+			freeDomain: suggestion?.is_free,
+			domainName: suggestion?.domain_name,
+			productSlug: suggestion?.product_slug,
+		} );
 	};
 
 	const handleSkip = ( _googleAppsCartItem = undefined, shouldHideFreePlan = false ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -214,7 +214,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			return __( 'Your domain. Your identity.' );
 		}
 
-		if ( flow === HUNDRED_YEAR_PLAN_FLOW || flow === HUNDRED_YEAR_DOMAIN_FLOW ) {
+		if ( [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( flow ) ) {
 			return __( 'Find the perfect domain' );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -11,7 +11,7 @@ import {
 	HUNDRED_YEAR_PLAN_FLOW,
 	isDomainUpsellFlow,
 	isSiteAssemblerFlow,
-	HUNDRED_YEAR_DOMIN_FLOW,
+	HUNDRED_YEAR_DOMAIN_FLOW,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -193,7 +193,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case DOMAIN_UPSELL_FLOW:
 				return __( 'Enter some descriptive keywords to get started' );
 			case HUNDRED_YEAR_PLAN_FLOW:
-			case HUNDRED_YEAR_DOMIN_FLOW:
+			case HUNDRED_YEAR_DOMAIN_FLOW:
 				return __( 'Secure your 100-Year domain and start building your legacy.' );
 			default:
 				return createInterpolateElement(
@@ -214,7 +214,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			return __( 'Your domain. Your identity.' );
 		}
 
-		if ( flow === HUNDRED_YEAR_PLAN_FLOW || flow === HUNDRED_YEAR_DOMIN_FLOW ) {
+		if ( flow === HUNDRED_YEAR_PLAN_FLOW || flow === HUNDRED_YEAR_DOMAIN_FLOW ) {
 			return __( 'Find the perfect domain' );
 		}
 
@@ -304,7 +304,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		return ! isCopySiteFlow( flow );
 	};
 
-	const Container = [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMIN_FLOW ].includes( flow )
+	const Container = [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( flow )
 		? HundredYearPlanStepWrapper
 		: StepContainer;
 
@@ -324,10 +324,12 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 				<FormattedHeader
 					id="domains-header"
 					align={
-						[ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMIN_FLOW ].includes( flow ) ? 'center' : 'left'
+						[ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( flow )
+							? 'center'
+							: 'left'
 					}
 					subHeaderAlign={
-						[ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMIN_FLOW ].includes( flow )
+						[ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( flow )
 							? 'center'
 							: undefined
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -133,7 +133,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		submit?.( {
 			freeDomain: suggestion?.is_free,
 			domainName: suggestion?.domain_name,
-			productSlug: suggestion.product_slug,
+			productSlug: suggestion?.product_slug,
 		} );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -130,7 +130,11 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			changeSiteDomainIfNeeded( suggestion?.domain_name );
 		}
 
-		submit?.( { freeDomain: suggestion?.is_free, domainName: suggestion?.domain_name } );
+		submit?.( {
+			freeDomain: suggestion?.is_free,
+			domainName: suggestion?.domain_name,
+			productSlug: suggestion.product_slug,
+		} );
 	};
 
 	const handleSkip = ( _googleAppsCartItem = undefined, shouldHideFreePlan = false ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -116,9 +116,15 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			setHideFreePlan( false );
 			setDomainCartItem( undefined );
 		} else {
+			let extra = {};
+			if ( flow === HUNDRED_YEAR_DOMAIN_FLOW ) {
+				extra = { is_hundred_year_domain: true };
+			}
+
 			const domainCartItem = domainRegistration( {
 				domain: suggestion.domain_name,
 				productSlug: suggestion.product_slug || '',
+				extra,
 			} );
 			dispatch( submitDomainStepSelection( suggestion, getAnalyticsSection() ) );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -11,6 +11,7 @@ import {
 	HUNDRED_YEAR_PLAN_FLOW,
 	isDomainUpsellFlow,
 	isSiteAssemblerFlow,
+	HUNDRED_YEAR_DOMIN_FLOW,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -188,6 +189,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case DOMAIN_UPSELL_FLOW:
 				return __( 'Enter some descriptive keywords to get started' );
 			case HUNDRED_YEAR_PLAN_FLOW:
+			case HUNDRED_YEAR_DOMIN_FLOW:
 				return __( 'Secure your 100-Year domain and start building your legacy.' );
 			default:
 				return createInterpolateElement(
@@ -208,7 +210,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			return __( 'Your domain. Your identity.' );
 		}
 
-		if ( flow === HUNDRED_YEAR_PLAN_FLOW ) {
+		if ( flow === HUNDRED_YEAR_PLAN_FLOW || flow === HUNDRED_YEAR_DOMIN_FLOW ) {
 			return __( 'Find the perfect domain' );
 		}
 
@@ -298,7 +300,9 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		return ! isCopySiteFlow( flow );
 	};
 
-	const Container = flow === HUNDRED_YEAR_PLAN_FLOW ? HundredYearPlanStepWrapper : StepContainer;
+	const Container = [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMIN_FLOW ].includes( flow )
+		? HundredYearPlanStepWrapper
+		: StepContainer;
 
 	return (
 		<Container
@@ -315,8 +319,14 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			formattedHeader={
 				<FormattedHeader
 					id="domains-header"
-					align={ flow === HUNDRED_YEAR_PLAN_FLOW ? 'center' : 'left' }
-					subHeaderAlign={ flow === HUNDRED_YEAR_PLAN_FLOW ? 'center' : undefined }
+					align={
+						[ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMIN_FLOW ].includes( flow ) ? 'center' : 'left'
+					}
+					subHeaderAlign={
+						[ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMIN_FLOW ].includes( flow )
+							? 'center'
+							: undefined
+					}
 					headerText={ getHeaderText() }
 					subHeaderText={ getSubHeaderText() }
 				/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -136,10 +136,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			changeSiteDomainIfNeeded( suggestion?.domain_name );
 		}
 
-		submit?.( {
-			freeDomain: suggestion?.is_free,
-			domainName: suggestion?.domain_name,
-		} );
+		submit?.( { freeDomain: suggestion?.is_free, domainName: suggestion?.domain_name } );
 	};
 
 	const handleSkip = ( _googleAppsCartItem = undefined, shouldHideFreePlan = false ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -448,9 +448,6 @@
 	margin-top: -60px;
 }
 
-// .step-container__header {
-// 	margin: 20px 24px 40px 20px;
-
 .hundred-year-domain.domains {
 	.step-container__header {
 		.formatted-header {
@@ -485,10 +482,6 @@
 			@include break-small {
 				padding: 0 48px 0 32px;
 			}
-		}
-		// Hide the "Sale" tag
-		.badge.badge--warning {
-			display: none;
 		}
 		// Change button styles
 		.button.is-primary {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -468,6 +468,80 @@
 			margin-bottom: 40px;
 		}
 	}
+
+	.domains__content {
+		width: 100%;
+		@include break-small {
+			max-width: 960px;
+		}
+
+		.domains__step-content {
+			padding: 0 16px;
+			@include break-small {
+				padding: 0 48px 0 32px;
+			}
+		}
+		// Hide the "Sale" tag
+		.badge.badge--warning {
+			display: none;
+		}
+		// Change button styles
+		.button.is-primary {
+			@include primary-button-black-theme;
+		}
+
+		.domain-suggestion__content {
+			align-items: center;
+
+			.domain-product-price {
+				margin-top: 0;
+				align-items: flex-end;
+				align-self: center;
+			}
+		}
+
+		// Reset styles for the featured domain suggestion
+		.domain-suggestion.card.featured-domain-suggestion {
+			// box-shadow: none;
+			// border-top: 1px solid transparent;
+			// border-bottom: 1px solid var(--studio-gray-5);
+			// border-radius: 0;
+			// margin-bottom: 0;
+			// padding: 16px 20px;
+			// @include break-mobile {
+			// 	padding: 16px 5px;
+			// }
+
+			// &:hover {
+			// 	border-bottom: 1px solid var(--studio-gray-50);
+			// 	border-top: 1px solid var(--studio-gray-50);
+			// }
+
+			.domain-registration-suggestion__title-info {
+				width: auto;
+				max-width: 55%;
+			}
+
+			// .domain-registration-suggestion__title-wrapper {
+			// 	gap: 4px;
+			// 	@include break-mobile {
+			// 		flex-direction: row;
+			// 		align-items: center;
+			// 		gap: 12px;
+			// 	}
+			// 	.domain-registration-suggestion__badges {
+			// 		margin-bottom: 0;
+			// 	}
+			// }
+
+			// .domain-registration-suggestion__domain-title {
+			// 	font-size: 1rem;
+			// 	.domain-registration-suggestion__domain-title-tld {
+			// 		font-weight: 500;
+			// 	}
+			// }
+		}
+	}
 }
 
 // Hundred year plan flow

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -444,6 +444,28 @@
 
 }
 
+.hundred-year-domain.domains {
+	.step-container__header {
+		.formatted-header {
+			.formatted-header__title {
+				font-size: rem(32px);
+				@include break-small {
+					font-size: rem(44px);
+				}
+			}
+			@include break-small {
+				margin-top: 60px;
+				margin-bottom: 0;
+			}
+			margin: 32px 16px;
+		}
+
+		@include break-small {
+			margin-bottom: 40px;
+		}
+	}
+}
+
 // Hundred year plan flow
 .hundred-year-plan.domains {
 	.step-container {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -448,6 +448,9 @@
 	margin-top: -60px;
 }
 
+// .step-container__header {
+// 	margin: 20px 24px 40px 20px;
+
 .hundred-year-domain.domains {
 	.step-container__header {
 		.formatted-header {
@@ -461,8 +464,10 @@
 				margin-top: 60px;
 				margin-bottom: 0;
 			}
-			margin: 32px 16px;
+			margin: 32px 0 16px;
 		}
+
+		margin-bottom: 32px;
 
 		@include break-small {
 			margin-bottom: 40px;
@@ -491,20 +496,49 @@
 		}
 
 		.domain-suggestion__content {
-			align-items: center;
+			align-items: start;
+			gap: 0;
+
+			@include break-small {
+				align-items: center;
+				gap: 16px;
+			}
 
 			.domain-product-price {
 				margin-top: 0;
-				align-items: flex-end;
-				align-self: center;
+				margin-bottom: 16px;
+
+				@include break-small {
+					align-items: flex-end;
+					align-self: center;
+					margin-bottom: 0;
+				}
 			}
 		}
 
-		// Reset styles for the featured domain suggestion
 		.domain-suggestion.card.featured-domain-suggestion {
+			padding: 16px 0;
+
+			@include break-mobile {
+				padding: 16px 20px;
+			}
+
 			.domain-registration-suggestion__title-info {
 				width: auto;
-				max-width: 55%;
+				margin-bottom: 4px;
+
+				@include break-small {
+					max-width: 55%;
+					margin-bottom: auto;
+				}
+			}
+		}
+
+		.domain-suggestion:not(.featured-domain-suggestion) {
+			padding: 16px 0;
+
+			@include break-small {
+				padding: 16px 20px;
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -502,44 +502,10 @@
 
 		// Reset styles for the featured domain suggestion
 		.domain-suggestion.card.featured-domain-suggestion {
-			// box-shadow: none;
-			// border-top: 1px solid transparent;
-			// border-bottom: 1px solid var(--studio-gray-5);
-			// border-radius: 0;
-			// margin-bottom: 0;
-			// padding: 16px 20px;
-			// @include break-mobile {
-			// 	padding: 16px 5px;
-			// }
-
-			// &:hover {
-			// 	border-bottom: 1px solid var(--studio-gray-50);
-			// 	border-top: 1px solid var(--studio-gray-50);
-			// }
-
 			.domain-registration-suggestion__title-info {
 				width: auto;
 				max-width: 55%;
 			}
-
-			// .domain-registration-suggestion__title-wrapper {
-			// 	gap: 4px;
-			// 	@include break-mobile {
-			// 		flex-direction: row;
-			// 		align-items: center;
-			// 		gap: 12px;
-			// 	}
-			// 	.domain-registration-suggestion__badges {
-			// 		margin-bottom: 0;
-			// 	}
-			// }
-
-			// .domain-registration-suggestion__domain-title {
-			// 	font-size: 1rem;
-			// 	.domain-registration-suggestion__domain-title-tld {
-			// 		font-weight: 500;
-			// 	}
-			// }
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -449,6 +449,10 @@
 }
 
 .hundred-year-domain.domains {
+	.step-container {
+		margin: 0;
+	}
+
 	.step-container__header {
 		.formatted-header {
 			.formatted-header__title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -520,6 +520,12 @@
 				padding: 16px 20px;
 			}
 
+			.domain-suggestion__content {
+				@include break-small {
+					flex-direction: row;
+				}
+			}
+
 			.domain-registration-suggestion__title-info {
 				width: auto;
 				margin-bottom: 4px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -444,6 +444,10 @@
 
 }
 
+.hundred-year-domain.step-route {
+	margin-top: -60px;
+}
+
 .hundred-year-domain.domains {
 	.step-container__header {
 		.formatted-header {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -201,12 +201,13 @@ function InfoColumn( { isMobile, openModal }: { isMobile: boolean; openModal: ()
 		( select ) => select( ProductsList.store ).getProductBySlug( PLAN_100_YEARS )?.currency_code,
 		[]
 	);
-	const displayCost =
-		productPrice &&
-		currencyCode &&
-		formatCurrency( productPrice, currencyCode, {
-			stripZeros: true,
-		} );
+	// const displayCost =
+	// 	productPrice &&
+	// 	currencyCode &&
+	// 	formatCurrency( productPrice, currencyCode, {
+	// 		stripZeros: true,
+	// 	} );
+	const displayCost = '$2,000';
 
 	// const planTitle = getPlan( PLAN_100_YEARS )?.getTitle();
 	const planTitle = '100-Yar Domain';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -2,7 +2,11 @@ import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
 import { Gridicon, WordPressLogo, FoldableCard } from '@automattic/components';
 import { ProductsList } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
-import { HUNDRED_YEAR_PLAN_FLOW, StepContainer } from '@automattic/onboarding';
+import {
+	HUNDRED_YEAR_DOMIN_FLOW,
+	HUNDRED_YEAR_PLAN_FLOW,
+	StepContainer,
+} from '@automattic/onboarding';
 import { useBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
@@ -217,7 +221,7 @@ function InfoColumn( {
 		} );
 
 	// TODO: Replace hardcoded value by 100-eyar domain product price when we have it
-	if ( flowName === 'hundred-year-domain' ) {
+	if ( flowName === HUNDRED_YEAR_DOMIN_FLOW ) {
 		displayCost = '$2,000';
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -208,7 +208,8 @@ function InfoColumn( { isMobile, openModal }: { isMobile: boolean; openModal: ()
 			stripZeros: true,
 		} );
 
-	const planTitle = getPlan( PLAN_100_YEARS )?.getTitle();
+	// const planTitle = getPlan( PLAN_100_YEARS )?.getTitle();
+	const planTitle = '100-Yar Domain';
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -293,7 +293,7 @@ function HundredYearPlanStepWrapper( props: Props ) {
 						className={ `hundred-year-plan-step-wrapper ${ stepName }` }
 						isMobile={ isMobile }
 					>
-						{ isOpen && <InfoModal onClose={ closeModal } /> }
+						{ isOpen && <InfoModal flowName={ flowName } onClose={ closeModal } /> }
 						{ ! hideInfoColumn && (
 							<InfoColumnWrapper isMobile={ isMobile }>
 								<InfoColumn isMobile={ isMobile } openModal={ openModal } flowName={ flowName } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -3,7 +3,7 @@ import { Gridicon, WordPressLogo, FoldableCard } from '@automattic/components';
 import { ProductsList } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import {
-	HUNDRED_YEAR_DOMIN_FLOW,
+	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	StepContainer,
 } from '@automattic/onboarding';
@@ -221,7 +221,7 @@ function InfoColumn( {
 		} );
 
 	// TODO: Replace hardcoded value by 100-eyar domain product price when we have it
-	if ( flowName === HUNDRED_YEAR_DOMIN_FLOW ) {
+	if ( flowName === HUNDRED_YEAR_DOMAIN_FLOW ) {
 		displayCost = '$2,000';
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -2,7 +2,7 @@ import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
 import { Gridicon, WordPressLogo, FoldableCard } from '@automattic/components';
 import { ProductsList } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
-import { StepContainer } from '@automattic/onboarding';
+import { HUNDRED_YEAR_PLAN_FLOW, StepContainer } from '@automattic/onboarding';
 import { useBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
@@ -190,7 +190,15 @@ function InfoColumnWrapper( { isMobile, children }: PropsWithChildren< { isMobil
 	);
 }
 
-function InfoColumn( { isMobile, openModal }: { isMobile: boolean; openModal: () => void } ) {
+function InfoColumn( {
+	isMobile,
+	openModal,
+	flowName,
+}: {
+	isMobile: boolean;
+	openModal: () => void;
+	flowName: string;
+} ) {
 	const translate = useTranslate();
 
 	const productPrice = useSelect(
@@ -201,16 +209,20 @@ function InfoColumn( { isMobile, openModal }: { isMobile: boolean; openModal: ()
 		( select ) => select( ProductsList.store ).getProductBySlug( PLAN_100_YEARS )?.currency_code,
 		[]
 	);
-	// const displayCost =
-	// 	productPrice &&
-	// 	currencyCode &&
-	// 	formatCurrency( productPrice, currencyCode, {
-	// 		stripZeros: true,
-	// 	} );
-	const displayCost = '$2,000';
+	let displayCost =
+		productPrice &&
+		currencyCode &&
+		formatCurrency( productPrice, currencyCode, {
+			stripZeros: true,
+		} );
 
-	// const planTitle = getPlan( PLAN_100_YEARS )?.getTitle();
-	const planTitle = '100-Yar Domain';
+	// TODO: Replace hardcoded value by 100-eyar domain product price when we have it
+	if ( flowName === 'hundred-year-domain' ) {
+		displayCost = '$2,000';
+	}
+
+	const planTitle =
+		flowName === HUNDRED_YEAR_PLAN_FLOW ? getPlan( PLAN_100_YEARS )?.getTitle() : '100-Year Domain';
 
 	return (
 		<>
@@ -280,7 +292,7 @@ function HundredYearPlanStepWrapper( props: Props ) {
 						{ isOpen && <InfoModal onClose={ closeModal } /> }
 						{ ! hideInfoColumn && (
 							<InfoColumnWrapper isMobile={ isMobile }>
-								<InfoColumn isMobile={ isMobile } openModal={ openModal } />
+								<InfoColumn isMobile={ isMobile } openModal={ openModal } flowName={ flowName } />
 							</InfoColumnWrapper>
 						) }
 						<FlexWrapper justifyStepContent={ justifyStepContent }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/info-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/info-modal.tsx
@@ -1,6 +1,7 @@
 import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { HUNDRED_YEAR_DOMAIN_FLOW } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { Button, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -142,9 +143,18 @@ const RowContent = styled.div`
 	}
 `;
 
-export default function InfoModal( { onClose }: { onClose: () => void } ) {
+export default function InfoModal( {
+	onClose,
+	flowName,
+}: {
+	onClose: () => void;
+	flowName: string;
+} ) {
 	const translate = useTranslate();
-	const planTitle = getPlan( PLAN_100_YEARS )?.getTitle();
+	const planTitle =
+		flowName === HUNDRED_YEAR_DOMAIN_FLOW
+			? translate( '100-Year Domain' )
+			: getPlan( PLAN_100_YEARS )?.getTitle();
 
 	return (
 		<StyledModal title="" onRequestClose={ onClose } isFullScreen>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
@@ -1,6 +1,7 @@
 @import "@automattic/onboarding/styles/mixins";
 
-.hundred-year-plan {
+.hundred-year-plan,
+.hundred-year-domain {
 	height: 100%;
 	padding: 0;
 	.signup-header {
@@ -8,7 +9,12 @@
 	}
 }
 
-.step-container.hundred-year-plan.hundred-year-plan {
+.hundred-year-domain.step-route {
+	margin-top: -60px;
+}
+
+.step-container.hundred-year-plan.hundred-year-plan,
+.step-container.hundred-year-domain.hundred-year-domain {
 	max-width: none;
 	height: 100%;
 	padding: 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
@@ -9,10 +9,6 @@
 	}
 }
 
-.hundred-year-domain.step-route {
-	margin-top: -60px;
-}
-
 .step-container.hundred-year-plan.hundred-year-plan,
 .step-container.hundred-year-domain.hundred-year-domain {
 	max-width: none;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -3,7 +3,7 @@ import { WordPressLogo } from '@automattic/components';
 import {
 	type SelectItem,
 	IntentScreen,
-	HUNDRED_YEAR_DOMIN_FLOW,
+	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	StepContainer,
 	isBlogOnboardingFlow,
@@ -31,7 +31,7 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 	const translate = useTranslate();
 	switch ( flowName ) {
 		case HUNDRED_YEAR_PLAN_FLOW:
-		case HUNDRED_YEAR_DOMIN_FLOW:
+		case HUNDRED_YEAR_DOMAIN_FLOW:
 			return [
 				{
 					key: 'existing-site',
@@ -108,14 +108,14 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 		}
 		switch ( flow ) {
 			case HUNDRED_YEAR_PLAN_FLOW:
-			case HUNDRED_YEAR_DOMIN_FLOW:
+			case HUNDRED_YEAR_DOMAIN_FLOW:
 				return translate( 'Start your legacy' );
 			default:
 				return null;
 		}
 	};
 
-	const Container = [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMIN_FLOW ].includes( flow )
+	const Container = [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( flow )
 		? HundredYearPlanStepWrapper
 		: StepContainer;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -3,6 +3,7 @@ import { WordPressLogo } from '@automattic/components';
 import {
 	type SelectItem,
 	IntentScreen,
+	HUNDRED_YEAR_DOMIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	StepContainer,
 	isBlogOnboardingFlow,
@@ -30,7 +31,7 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 	const translate = useTranslate();
 	switch ( flowName ) {
 		case HUNDRED_YEAR_PLAN_FLOW:
-		case 'hundred-year-domain':
+		case HUNDRED_YEAR_DOMIN_FLOW:
 			return [
 				{
 					key: 'existing-site',
@@ -107,14 +108,14 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 		}
 		switch ( flow ) {
 			case HUNDRED_YEAR_PLAN_FLOW:
-			case 'hundred-year-domain':
+			case HUNDRED_YEAR_DOMIN_FLOW:
 				return translate( 'Start your legacy' );
 			default:
 				return null;
 		}
 	};
 
-	const Container = [ HUNDRED_YEAR_PLAN_FLOW, 'hundred-year-domain' ].includes( flow )
+	const Container = [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMIN_FLOW ].includes( flow )
 		? HundredYearPlanStepWrapper
 		: StepContainer;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -30,6 +30,7 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 	const translate = useTranslate();
 	switch ( flowName ) {
 		case HUNDRED_YEAR_PLAN_FLOW:
+		case 'hundred-year-domain':
 			return [
 				{
 					key: 'existing-site',
@@ -106,13 +107,16 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 		}
 		switch ( flow ) {
 			case HUNDRED_YEAR_PLAN_FLOW:
+			case 'hundred-year-domain':
 				return translate( 'Start your legacy' );
 			default:
 				return null;
 		}
 	};
 
-	const Container = flow === HUNDRED_YEAR_PLAN_FLOW ? HundredYearPlanStepWrapper : StepContainer;
+	const Container = [ HUNDRED_YEAR_PLAN_FLOW, 'hundred-year-domain' ].includes( flow )
+		? HundredYearPlanStepWrapper
+		: StepContainer;
 
 	return (
 		<Container

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -7,7 +7,7 @@ import {
 	ECOMMERCE_FLOW,
 	isWooExpressFlow,
 	isTransferringHostedSiteCreationFlow,
-	HUNDRED_YEAR_DOMIN_FLOW,
+	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	isAnyHostingFlow,
 } from '@automattic/onboarding';
@@ -158,7 +158,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		return <TailoredFlowPreCheckoutScreen flowName={ flowName } />;
 	}
 
-	if ( HUNDRED_YEAR_PLAN_FLOW === flowName || HUNDRED_YEAR_DOMIN_FLOW === flowName ) {
+	if ( HUNDRED_YEAR_PLAN_FLOW === flowName || HUNDRED_YEAR_DOMAIN_FLOW === flowName ) {
 		return <HundredYearPlanFlowProcessingScreen />;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -7,6 +7,7 @@ import {
 	ECOMMERCE_FLOW,
 	isWooExpressFlow,
 	isTransferringHostedSiteCreationFlow,
+	HUNDRED_YEAR_DOMIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	isAnyHostingFlow,
 } from '@automattic/onboarding';
@@ -157,7 +158,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		return <TailoredFlowPreCheckoutScreen flowName={ flowName } />;
 	}
 
-	if ( HUNDRED_YEAR_PLAN_FLOW === flowName ) {
+	if ( HUNDRED_YEAR_PLAN_FLOW === flowName || HUNDRED_YEAR_DOMIN_FLOW === flowName ) {
 		return <HundredYearPlanFlowProcessingScreen />;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -158,7 +158,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		return <TailoredFlowPreCheckoutScreen flowName={ flowName } />;
 	}
 
-	if ( HUNDRED_YEAR_PLAN_FLOW === flowName || HUNDRED_YEAR_DOMAIN_FLOW === flowName ) {
+	if ( [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( flowName ) ) {
 		return <HundredYearPlanFlowProcessingScreen />;
 	}
 

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -137,6 +137,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	[ 'plugin-bundle' ]: () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' ),
 
+	[ 'hundred-year-domain' ]: () =>
+		import( /* webpackChunkName: "hundred-year-domain" */ './hundred-year-domain' ),
+
 	[ 'hundred-year-plan' ]: () =>
 		import( /* webpackChunkName: "hundred-year-plan" */ './hundred-year-plan' ),
 

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -20,6 +20,7 @@ import {
 	HOSTED_SITE_MIGRATION_FLOW,
 	NEW_HOSTED_SITE_FLOW_USER_INCLUDED,
 	ONBOARDING_FLOW,
+	HUNDRED_YEAR_DOMAIN_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -137,7 +138,7 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	[ 'plugin-bundle' ]: () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' ),
 
-	[ 'hundred-year-domain' ]: () =>
+	[ HUNDRED_YEAR_DOMAIN_FLOW ]: () =>
 		import( /* webpackChunkName: "hundred-year-domain" */ './hundred-year-domain' ),
 
 	[ 'hundred-year-plan' ]: () =>

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -138,9 +138,6 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	[ 'plugin-bundle' ]: () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' ),
 
-	[ HUNDRED_YEAR_DOMAIN_FLOW ]: () =>
-		import( /* webpackChunkName: "hundred-year-domain" */ './hundred-year-domain' ),
-
 	[ 'hundred-year-plan' ]: () =>
 		import( /* webpackChunkName: "hundred-year-plan" */ './hundred-year-plan' ),
 
@@ -182,8 +179,17 @@ const hostedSiteMigrationFlow: Record< string, () => Promise< { default: Flow } 
 		),
 };
 
+const hundredYearDomainFlow: Record< string, () => Promise< { default: Flow } > > =
+	config.isEnabled( '100-year-domain' )
+		? {
+				[ HUNDRED_YEAR_DOMAIN_FLOW ]: () =>
+					import( /* webpackChunkName: "hundred-year-domain" */ './hundred-year-domain' ),
+		  }
+		: {};
+
 export default {
 	...availableFlows,
 	...videoPressTvFlows,
 	...hostedSiteMigrationFlow,
+	...hundredYearDomainFlow,
 };

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -47,7 +47,7 @@ import {
 	is100Year,
 	PLAN_FREE,
 } from '@automattic/calypso-products';
-import { isDomainForGravatarFlow } from '@automattic/onboarding';
+import { isDomainForGravatarFlow, isHundredYearDomainFlow } from '@automattic/onboarding';
 import { isWpComProductRenewal as isRenewal } from '@automattic/wpcom-checkout';
 import { getTld } from 'calypso/lib/domains';
 import { domainProductSlugs } from 'calypso/lib/domains/constants';
@@ -848,7 +848,7 @@ export function getDomainPriceRule(
 	domainAndPlanUpsellFlow: boolean
 ): string {
 	// We want to show a fixed price in the 100-year domain flow
-	if ( flowName === 'hundred-year-domain' ) {
+	if ( isHundredYearDomainFlow( flowName ) ) {
 		return 'ONE_TIME_PRICE';
 	}
 

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -847,7 +847,7 @@ export function getDomainPriceRule(
 	flowName: string,
 	domainAndPlanUpsellFlow: boolean
 ): string {
-	// We want to show a fixed price in the 100-year domain flow
+	// We'll show a fixed, one time price in the 100-year domain flow
 	if ( isHundredYearDomainFlow( flowName ) ) {
 		return 'ONE_TIME_PRICE';
 	}

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -847,6 +847,11 @@ export function getDomainPriceRule(
 	flowName: string,
 	domainAndPlanUpsellFlow: boolean
 ): string {
+	// We want to show a fixed price in the 100-year domain flow
+	if ( flowName === 'hundred-year-domain' ) {
+		return 'ONE_TIME_PRICE';
+	}
+
 	if ( ! suggestion.product_slug || suggestion.cost === 'Free' ) {
 		return 'FREE_DOMAIN';
 	}

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -648,9 +648,7 @@ function getAvailabilityNotice(
 			break;
 
 		case 'hundred_year_domain_tld_restriction':
-			message = translate(
-				'Only .com, .net and .org domains are available for registration for 100 years.'
-			);
+			message = translate( 'Only .com, .net and .org domains can be registered for 100 years.' );
 			severity = 'info';
 			break;
 

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -647,6 +647,13 @@ function getAvailabilityNotice(
 			severity = 'info';
 			break;
 
+		case 'hundred_year_domain_tld_restriction':
+			message = translate(
+				'Only .com, .net and .org domains are available for registration for 100 years.'
+			);
+			severity = 'info';
+			break;
+
 		default:
 			message = translate(
 				'Sorry, there was a problem processing your request. Please try again in a few minutes.'

--- a/config/development.json
+++ b/config/development.json
@@ -30,6 +30,7 @@
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
 	"features": {
 		"100-year-plan/vip": true,
+		"100-year-domain": true,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,6 +19,7 @@
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
 	"features": {
 		"100-year-plan/vip": true,
+		"100-year-domain": true,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -18,6 +18,7 @@
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
 	"features": {
 		"100-year-plan/vip": true,
+		"100-year-domain": true,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,

--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -66,6 +66,9 @@ export function getDomainSuggestionsVendor(
 	if ( isDomainForGravatarFlow( options.flowName ) ) {
 		return 'gravatar';
 	}
+	if ( options.flowName === 'hundred-year-domain' ) {
+		return '100-year-domains';
+	}
 	if ( options.flowName === LINK_IN_BIO_FLOW ) {
 		return 'link-in-bio';
 	}

--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -6,6 +6,7 @@ import {
 	WOOEXPRESS_FLOW,
 	DOMAIN_FOR_GRAVATAR_FLOW,
 	isDomainForGravatarFlow,
+	isHundredYearDomainFlow,
 } from '@automattic/onboarding';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
@@ -58,7 +59,8 @@ type DomainSuggestionsVendor =
 	| 'link-in-bio-tld'
 	| 'newsletter'
 	| 'ecommerce'
-	| 'gravatar';
+	| 'gravatar'
+	| '100-year-domains';
 
 export function getDomainSuggestionsVendor(
 	options: DomainSuggestionsVendorOptions = {}
@@ -66,7 +68,7 @@ export function getDomainSuggestionsVendor(
 	if ( isDomainForGravatarFlow( options.flowName ) ) {
 		return 'gravatar';
 	}
-	if ( options.flowName === 'hundred-year-domain' ) {
+	if ( isHundredYearDomainFlow( options.flowName ) ) {
 		return '100-year-domains';
 	}
 	if ( options.flowName === LINK_IN_BIO_FLOW ) {

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -42,7 +42,7 @@ export const UPDATE_DESIGN_FLOW = 'update-design';
 export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
 export const DOMAIN_TRANSFER = 'domain-transfer';
 export const GOOGLE_TRANSFER = 'google-transfer';
-export const HUNDRED_YEAR_DOMIN_FLOW = 'hundred-year-domain';
+export const HUNDRED_YEAR_DOMAIN_FLOW = 'hundred-year-domain';
 export const HUNDRED_YEAR_PLAN_FLOW = 'hundred-year-plan';
 export const BLOG_FLOW = 'blog';
 export const REBLOGGING_FLOW = 'reblogging';
@@ -238,5 +238,5 @@ export const isDomainForGravatarFlow = ( flowName: string | null | undefined ) =
 };
 
 export const isHundredYearDomainFlow = ( flowName: string | null | undefined ) => {
-	return Boolean( flowName && [ HUNDRED_YEAR_DOMIN_FLOW ].includes( flowName ) );
+	return Boolean( flowName && [ HUNDRED_YEAR_DOMAIN_FLOW ].includes( flowName ) );
 };

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -236,3 +236,7 @@ export const isVideoPressTVFlow = ( flowName: string | null | undefined ) => {
 export const isDomainForGravatarFlow = ( flowName: string | null | undefined ) => {
 	return Boolean( flowName && [ DOMAIN_FOR_GRAVATAR_FLOW ].includes( flowName ) );
 };
+
+export const isHundredYearDomainFlow = ( flowName: string | null | undefined ) => {
+	return Boolean( flowName && [ HUNDRED_YEAR_DOMIN_FLOW ].includes( flowName ) );
+};

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -42,6 +42,7 @@ export const UPDATE_DESIGN_FLOW = 'update-design';
 export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
 export const DOMAIN_TRANSFER = 'domain-transfer';
 export const GOOGLE_TRANSFER = 'google-transfer';
+export const HUNDRED_YEAR_DOMIN_FLOW = 'hundred-year-domain';
 export const HUNDRED_YEAR_PLAN_FLOW = 'hundred-year-plan';
 export const BLOG_FLOW = 'blog';
 export const REBLOGGING_FLOW = 'reblogging';

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -681,6 +681,7 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	signup?: boolean;
 	headstart_theme?: string;
 	feature_slug?: string;
+	is_hundred_year_domain?: boolean;
 	/**
 	 * A way to signal intent to the back end when included as an extra with
 	 * certain products.


### PR DESCRIPTION
## Proposed Changes

This diff creates the 100-Year Domain flow as described in p9Jlb4-e6E-p2.

In this flow, users are able to search and choose a .com/net/org domain.

Notes:
- This PR hardcodes the $2000 price for 100-year domains since we still don't haven't implemented the actual product
- For the same reason, checkout will also use the domains' regular prices instead of $2000

### Screenshots

- Initial step
![Screenshot 2024-10-10 at 19 18 53](https://github.com/user-attachments/assets/443cb382-5eff-4f89-94d3-f8353cfe66d4)
- Checkout
![Markup on 2024-10-10 at 19:20:11](https://github.com/user-attachments/assets/faa1bd19-0422-481c-af35-f40d0168ce3b)

## Why are these changes being made?

We want to offer 100-year domain registrations as a separate offer from the 100-year plan. More details in p9Jlb4-e6E-p2.

## Testing Instructions

- Build this branch locally or open the live Calypso link
- Enable `USE_STORE_SANDBOX` mode in your backend to prevent actual purchases
- Visit the flow at `/setup/hundred-year-domain`

Try to test the flow as thoroughly as possible:
- Complete the flow normally and ensure everything seems ok
  - Ensure that, after the flow is complete, the domain gets a domain-only site
- Test both in mobile and desktop layouts
- Try to hit "Back" in your browser and ensure the flow doesn't break
- Remove the domain from the shopping cart in the checkout page and ensure you go back to the domain search step
- Start the flow logged-in and logged-out
  - If you're logged-out, you should be able to search and select a domain before having to log in
- Ensure the domain search only returns .com/net/org domains

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?