### PR TITLE
Disable Assembler

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -81,7 +81,7 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 	} = props;
 	const themesListRef = useRef( null );
 	const [ showSecondUpsellNudge, setShowSecondUpsellNudge ] = useState( false );
-	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'theme-showcase' );
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp();
 	const updateShowSecondUpsellNudge = useCallback( () => {
 		const minColumnWidth = 320; // $theme-item-min-width: 320px;
 		const margin = 32; // $theme-item-horizontal-margin: 32px;

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -13,7 +13,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { connect, useSelector } from 'react-redux';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import Theme from 'calypso/components/theme';
-import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
+import { useIsSiteAssemblerEnabled } from 'calypso/data/site-assembler';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { getWooMyCustomThemeOptions } from 'calypso/my-sites/themes/theme-options';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -81,7 +81,7 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 	} = props;
 	const themesListRef = useRef( null );
 	const [ showSecondUpsellNudge, setShowSecondUpsellNudge ] = useState( false );
-	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp();
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabled();
 	const updateShowSecondUpsellNudge = useCallback( () => {
 		const minColumnWidth = 320; // $theme-item-min-width: 320px;
 		const margin = 32; // $theme-item-horizontal-margin: 32px;

--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -15,7 +15,7 @@ jest.mock( 'calypso/components/theme', () => ( { theme } ) => (
 ) );
 
 jest.mock( 'calypso/data/site-assembler', () => ( {
-	useIsSiteAssemblerEnabledExp: () => true,
+	useIsSiteAssemblerEnabled: () => true,
 } ) );
 
 jest.mock( 'react-redux', () => ( {

--- a/client/data/site-assembler/index.ts
+++ b/client/data/site-assembler/index.ts
@@ -1,32 +1,3 @@
-import { useExperiment } from 'calypso/lib/explat';
-import { useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-
-export const useIsSiteAssemblerEnabledExp = (
-	source: 'design-choices' | 'design-picker' | 'theme-showcase'
-) => {
-	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
-	const [ isLoading, assignment ] = useExperiment( 'calypso_disable_site_assembler' );
-	const variationName = assignment?.variationName;
-
-	if ( isLoading ) {
-		return false;
-	}
-
-	if ( variationName === 'treatment_disable_onboarding' ) {
-		switch ( source ) {
-			case 'theme-showcase':
-				return isLoggedIn;
-			case 'design-choices':
-			case 'design-picker':
-			default:
-				return false;
-		}
-	}
-
-	if ( variationName === 'treatment_disable_all' ) {
-		return false;
-	}
-
-	return isLoggedIn;
+export const useIsSiteAssemblerEnabledExp = () => {
+	return false;
 };

--- a/client/data/site-assembler/index.ts
+++ b/client/data/site-assembler/index.ts
@@ -1,3 +1,3 @@
-export const useIsSiteAssemblerEnabledExp = () => {
+export const useIsSiteAssemblerEnabled = () => {
 	return false;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -35,7 +35,7 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const { isEligible, isLoading } = useIsBigSkyEligible();
 
-	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'design-choices' );
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp();
 
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -10,7 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
+import { useIsSiteAssemblerEnabled } from 'calypso/data/site-assembler';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useIsBigSkyEligible } from '../../../../hooks/use-is-site-big-sky-eligible';
 import { ONBOARD_STORE } from '../../../../stores';
@@ -35,7 +35,7 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const { isEligible, isLoading } = useIsBigSkyEligible();
 
-	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp();
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabled();
 
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -44,7 +44,7 @@ import {
 } from 'calypso/components/theme-tier/constants';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgrade-modal';
-import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
+import { useIsSiteAssemblerEnabled } from 'calypso/data/site-assembler';
 import { ActiveTheme, useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
@@ -130,7 +130,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
 	const { data: siteActiveTheme } = useActiveThemeQuery( site?.ID ?? 0, !! site?.ID );
 
-	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp();
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabled();
 
 	const isDesignFirstFlow =
 		flow === DESIGN_FIRST_FLOW || queryParams.get( 'flowToReturnTo' ) === DESIGN_FIRST_FLOW;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -130,7 +130,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
 	const { data: siteActiveTheme } = useActiveThemeQuery( site?.ID ?? 0, !! site?.ID );
 
-	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'design-picker' );
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp();
 
 	const isDesignFirstFlow =
 		flow === DESIGN_FIRST_FLOW || queryParams.get( 'flowToReturnTo' ) === DESIGN_FIRST_FLOW;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -5,7 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
-import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
+import { useIsSiteAssemblerEnabled } from 'calypso/data/site-assembler';
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useExperiment } from 'calypso/lib/explat';
@@ -155,7 +155,7 @@ const siteSetupFlow: Flow = {
 			[]
 		);
 
-		const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp();
+		const isSiteAssemblerEnabled = useIsSiteAssemblerEnabled();
 
 		const { isEligible: isBigSkyEligible } = useIsBigSkyEligible();
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -155,7 +155,7 @@ const siteSetupFlow: Flow = {
 			[]
 		);
 
-		const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'design-choices' );
+		const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp();
 
 		const { isEligible: isBigSkyEligible } = useIsBigSkyEligible();
 

--- a/client/my-sites/themes/pattern-assembler-button/index.tsx
+++ b/client/my-sites/themes/pattern-assembler-button/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
+import { useIsSiteAssemblerEnabled } from 'calypso/data/site-assembler';
 import './style.scss';
 
 type Props = {
@@ -10,7 +10,7 @@ type Props = {
 
 export default function PatternAssemblerButton( { isPrimary, onClick }: Props ) {
 	const translate = useTranslate();
-	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp();
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabled();
 
 	if ( ! isSiteAssemblerEnabled ) {
 		return null;

--- a/client/my-sites/themes/pattern-assembler-button/index.tsx
+++ b/client/my-sites/themes/pattern-assembler-button/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export default function PatternAssemblerButton( { isPrimary, onClick }: Props ) {
 	const translate = useTranslate();
-	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'theme-showcase' );
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp();
 
 	if ( ! isSiteAssemblerEnabled ) {
 		return null;


### PR DESCRIPTION
## Proposed Changes

As mentioned in the post pbxlJb-6na-p2, we'll be removing the Assembler.
This will be the first step of the removal, which effectively disables the Design Your Own flow entry points. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Removal of the Assembler.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Head to the Theme Showcase and ensure that neither the DYO button nor the banner is available.
2. Also check the same for the onboarding Design Picker.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?