### PR TITLE
Users: Fix total team member count number

### DIFF
--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -55,7 +55,7 @@ function TeamMembers( props: Props ) {
 		( obj ) => obj.linked_user_ID === false
 	);
 
-	const membersTotal = nonPendingMembersSorted.length;
+	const membersTotal = data?.total;
 	const addTeamMemberLink = `/people/new/${ site?.slug }`;
 
 	function getPersonRef( user: Member ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/89506
Fixes https://github.com/Automattic/wp-calypso/issues/89506

## Proposed Changes

* Currently in `wordpress.com/people/team/{yourSIte}` we show the amount of team members that are rendered on the screen, since it is an infinite scroll list, it increases the team members count as the user scrolls, this is a bit confusing for users.
This PR shows the total of members, even without considering if the full list is rendered.

Now, both counts should match:
<img width="823" alt="image" src="https://github.com/user-attachments/assets/18eb30b6-58e5-4829-bbd7-b1431ab64bc3">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It got confusing for users as [raised here](https://github.com/Automattic/wp-calypso/issues/89506)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link or pull this branch
* Navigate to `live_link/people/team/{yourSIte}`
* Make sure you have a huge number of users on your site (I used [fake press](https://wordpress.org/plugins/fakerpress/) to help)
* Make sure both numbers are matching as in the image above.


c/c Big thank you to @ivan-ottinger 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
