### PR TITLE
use localized date for base backup date on real-time message

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-realtime-message.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-realtime-message.tsx
@@ -48,6 +48,7 @@ export const BackupRealtimeMessage: FunctionComponent< Props > = ( {
 		gmtOffset: gmtOffset,
 	} );
 
+	const baseBackupDateLocal = applySiteOffset( moment( baseBackupDate ), { timezone, gmtOffset } );
 	const isBackupFromToday = baseBackupDate.isSame( today, 'day' );
 	const isBackupFromYesterday = baseBackupDate.isSame( today.subtract( 1, 'days' ), 'day' );
 	const daysDiff = selectedBackupDate.diff( baseBackupDate, 'days' );
@@ -61,7 +62,7 @@ export const BackupRealtimeMessage: FunctionComponent< Props > = ( {
 			{
 				count: eventsCount,
 				args: {
-					baseBackupDate: baseBackupDate.format( 'YYYY-MM-DD hh:mm A' ),
+					baseBackupDate: baseBackupDateLocal.format( 'YYYY-MM-DD hh:mm A' ),
 					eventsCount: eventsCount,
 				},
 				comment: '%(eventsCount)d is the number of changes made since the backup.',
@@ -75,7 +76,7 @@ export const BackupRealtimeMessage: FunctionComponent< Props > = ( {
 			{
 				count: eventsCount,
 				args: {
-					baseBackupDate: baseBackupDate.format( 'YYYY-MM-DD hh:mm A' ),
+					baseBackupDate: baseBackupDateLocal.format( 'YYYY-MM-DD hh:mm A' ),
 					eventsCount: eventsCount,
 				},
 				comment:
@@ -90,7 +91,7 @@ export const BackupRealtimeMessage: FunctionComponent< Props > = ( {
 			{
 				count: eventsCount,
 				args: {
-					baseBackupDate: baseBackupDate.format( 'YYYY-MM-DD hh:mm A' ),
+					baseBackupDate: baseBackupDateLocal.format( 'YYYY-MM-DD hh:mm A' ),
 					eventsCount: eventsCount,
 				},
 				comment:
@@ -105,7 +106,7 @@ export const BackupRealtimeMessage: FunctionComponent< Props > = ( {
 			{
 				count: eventsCount,
 				args: {
-					baseBackupDate: baseBackupDate.format( 'YYYY-MM-DD hh:mm A' ),
+					baseBackupDate: baseBackupDateLocal.format( 'YYYY-MM-DD hh:mm A' ),
 					eventsCount: eventsCount,
 				},
 				comment:
@@ -121,7 +122,7 @@ export const BackupRealtimeMessage: FunctionComponent< Props > = ( {
 				count: eventsCount,
 				args: {
 					daysAgo: daysDiff,
-					baseBackupDate: baseBackupDate.format( 'YYYY-MM-DD hh:mm A' ),
+					baseBackupDate: baseBackupDateLocal.format( 'YYYY-MM-DD hh:mm A' ),
 					eventsCount: eventsCount,
 				},
 				comment:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

Use the localized date to be shown in a real-time message. Currently, we are using the date not localized
<img width="702" alt="Screenshot 2024-10-02 at 11 25 06" src="https://github.com/user-attachments/assets/284dfcd8-8f31-4b2b-ac56-276cd9dce9df">
<img width="716" alt="Screenshot 2024-10-02 at 11 25 22" src="https://github.com/user-attachments/assets/25382c2b-e848-402b-bc26-32ef42bfdf9a">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because the date is not being shown localized

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Jetpack Cloud and verify the date are correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
