### PR TITLE
White-labeled plugin: Fix reverted sites can't be used for migration

### DIFF
--- a/client/landing/stepper/hooks/use-site-transfer/query.ts
+++ b/client/landing/stepper/hooks/use-site-transfer/query.ts
@@ -41,6 +41,12 @@ const isTransferring = ( status: TransferState ) => {
 	return ! endStates.includes( status );
 };
 
+const readyToTransferStates: TransferState[] = [ transferStates.NONE, transferStates.REVERTED ];
+
+const isReadyToTransfer = ( status: TransferState ) => {
+	return readyToTransferStates.includes( status );
+};
+
 export function getSiteTransferStatusQueryKey( siteId: number ) {
 	return [ 'sites', siteId, 'atomic', 'transfers', 'latest' ];
 }
@@ -68,7 +74,9 @@ export const useSiteTransferStatusQuery = ( siteId: number | undefined, options?
 		select: ( data ) => {
 			return {
 				isTransferring: data?.status ? isTransferring( data.status as TransferStates ) : false,
-				isReadyToTransfer: data?.status === transferStates.NONE,
+				isReadyToTransfer: data?.status
+					? isReadyToTransfer( data.status as TransferStates )
+					: false,
 				completed: data?.status === transferStates.COMPLETED,
 				status: data.status,
 				error: null,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #95089

## Proposed Changes

* This fixes the issue where reverted sites (AT -> Simple) can't be used for migration.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is an edge case but the fix helps when testing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to PR, navigate to `/setup/migration-signup`.
* Ensure the `migration-flow/enable-white-labeled-plugin'` feature flag is enabled. One option is to update your session storage by running the following in your console, hitting enter, and reloading: `window.sessionStorage.setItem('flags', 'migration-flow/enable-white-labeled-plugin');`
* Go through the flow; check out. You should land on the site instructions page.
* The provisioning step (`Provisioning your new site`) should be passing.
* Write down the generated `siteSlug` and `siteId` from the URL.
* Go to [mc]/automated-transfer/revert.php?blog_id=[siteId] (URL not supported by tampermonkey so ping me if you can't figure it out).
* For the revert reason, choice "Developmen/Intesnal testing" and revert the site.
* Navigate to `/setup/migration-signup?siteSlug=[siteSlug]` and go through the flow again.
* The provisioning should be passing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
