### PR TITLE
Add site profiler test started tracks event

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -43,7 +43,7 @@ const usePerformanceReport = (
 ) => {
 	const { url = '', hash = '' } = wpcom_performance_report_url || {};
 
-	const { data: basicMetrics, isError } = useUrlBasicMetricsQuery( url, hash, true );
+	const { data: basicMetrics, isError, isFetched } = useUrlBasicMetricsQuery( url, hash, true );
 	const { final_url: finalUrl, token } = basicMetrics || {};
 	const { data: performanceInsights, isError: isErrorInsights } = useUrlPerformanceInsightsQuery(
 		url,
@@ -79,6 +79,7 @@ const usePerformanceReport = (
 		hash: getHashOrToken( hash, token, activeTab === 'mobile' ? mobileLoaded : desktopLoaded ),
 		isLoading: activeTab === 'mobile' ? ! mobileLoaded : ! desktopLoaded,
 		isError: isError || isErrorInsights,
+		isFetched,
 	};
 };
 
@@ -171,6 +172,14 @@ export const SitePerformance = () => {
 		isSitePublic ? wpcom_performance_report_url : undefined,
 		activeTab
 	);
+
+	useEffect( () => {
+		if ( performanceReport.isFetched && performanceReport.url ) {
+			recordTracksEvent( 'calypso_performance_profiler_test_started', {
+				url: performanceReport.url,
+			} );
+		}
+	}, [ performanceReport.isFetched, performanceReport.url ] );
 
 	useEffect( () => {
 		if ( performanceReport.hash && performanceReport.hash !== wpcom_performance_report_url?.hash ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9065

## Proposed Changes

Context: p1727783727624719/1727703195.299479-slack-C04H4NY6STW
* Added `calypso_performance_profiler_test_started` tracks metric

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To track the usage of the site profiler

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `calypso.localhost:3000/sites/performance/:site`
* See if the tracks event `calypso_performance_profiler_test_started` show up when a test is triggered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?