### PR TITLE
Theme: Improve the activation experience after the checkout and atomic transfer

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useQueryThemes } from 'calypso/components/data/query-theme';
@@ -140,7 +141,7 @@ export function useThemesThankYouData(
 	// Redirect to the Theme Details page after the atomic transfer.
 	useEffect( () => {
 		if ( firstTheme && isAtomicNeeded && isJetpack ) {
-			page( `/theme/${ firstTheme.id }/${ siteSlug }` );
+			page( addQueryArgs( `/theme/${ firstTheme.id }/${ siteSlug }`, { activating: true } ) );
 		}
 	}, [ firstTheme, isAtomicNeeded, isJetpack ] );
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -24,6 +24,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Icon, external } from '@wordpress/icons';
+import { hasQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import photon from 'photon';
@@ -325,16 +326,30 @@ class ThemeSheet extends Component {
 		this.unsubscribeBreakpoint = subscribeIsWithinBreakpoint( '>960px', ( isWide ) => {
 			this.setState( { isWide } );
 		} );
+
+		this.maybeAutoActivate();
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.themeId !== prevProps.themeId ) {
+		const { themeId, defaultOption } = this.props;
+		if ( themeId !== prevProps.themeId ) {
 			this.scrollToTop();
+		}
+
+		if ( defaultOption?.key !== prevProps.defaultOption?.key ) {
+			this.maybeAutoActivate();
 		}
 	}
 
 	componentWillUnmount() {
 		this.unsubscribeBreakpoint();
+	}
+
+	maybeAutoActivate() {
+		const { defaultOption } = this.props;
+		if ( defaultOption?.key === 'activate' && hasQueryArg( window.location.href, 'activating' ) ) {
+			this.onButtonClick();
+		}
 	}
 
 	isLoaded = () => {

--- a/client/my-sites/themes/atomic-transfer-dialog.tsx
+++ b/client/my-sites/themes/atomic-transfer-dialog.tsx
@@ -8,6 +8,7 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	acceptAtomicTransferDialog,
 	dismissAtomicTransferDialog,
+	acceptActivationModal,
 	activate as activateTheme,
 	initiateThemeTransfer,
 } from 'calypso/state/themes/actions';
@@ -40,6 +41,7 @@ interface AtomicTransferDialogProps {
 	uploadError?: boolean;
 	dispatchAcceptAtomicTransferDialog: typeof acceptAtomicTransferDialog;
 	dispatchDismissAtomicTransferDialog: typeof dismissAtomicTransferDialog;
+	dispatchAcceptActivationModal: typeof acceptActivationModal;
 	dispatchActivateTheme: typeof activateTheme;
 	dispatchInitiateThemeTransfer: typeof initiateThemeTransfer;
 }
@@ -93,9 +95,16 @@ class AtomicTransferDialog extends Component< AtomicTransferDialogProps > {
 	}
 
 	continueToActivate() {
-		const { siteId, theme, dispatchActivateTheme, dispatchAcceptAtomicTransferDialog } = this.props;
+		const {
+			siteId,
+			theme,
+			dispatchActivateTheme,
+			dispatchAcceptAtomicTransferDialog,
+			dispatchAcceptActivationModal,
+		} = this.props;
 		if ( siteId ) {
 			dispatchAcceptAtomicTransferDialog( theme.id );
+			dispatchAcceptActivationModal( theme.id );
 			dispatchActivateTheme( theme.id, siteId );
 		}
 	}
@@ -228,6 +237,7 @@ export default connect(
 	{
 		dispatchAcceptAtomicTransferDialog: acceptAtomicTransferDialog,
 		dispatchDismissAtomicTransferDialog: dismissAtomicTransferDialog,
+		dispatchAcceptActivationModal: acceptActivationModal,
 		dispatchActivateTheme: activateTheme,
 		dispatchInitiateThemeTransfer: initiateThemeTransfer,
 	}

--- a/client/my-sites/themes/atomic-transfer-dialog.tsx
+++ b/client/my-sites/themes/atomic-transfer-dialog.tsx
@@ -34,7 +34,7 @@ interface AtomicTransferDialogProps {
 	isMarketplaceProduct?: boolean;
 	activeTheme?: string | null;
 	uploadError?: boolean;
-	isJetpack: boolean;
+	isJetpack?: boolean;
 	dispatchAcceptAtomicTransferDialog: typeof acceptAtomicTransferDialog;
 	dispatchDismissAtomicTransferDialog: typeof dismissAtomicTransferDialog;
 	dispatchAcceptActivationModal: typeof acceptActivationModal;

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -88,6 +88,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			const redirectTo = encodeURIComponent(
 				addQueryArgs( `/theme/${ themeId }/${ slug }`, {
 					style_variation: options?.styleVariationSlug,
+					activating: true,
 				} )
 			);
 
@@ -223,7 +224,9 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 				typeof window !== 'undefined' ? window.location : {};
 			const slug = getSiteSlug( state, siteId );
 
-			const redirectTo = encodeURIComponent( `${ origin }/theme/${ themeId }/${ slug }` );
+			const redirectTo = encodeURIComponent(
+				addQueryArgs( `${ origin }/theme/${ themeId }/${ slug }`, { activating: true } )
+			);
 
 			const currentPlanSlug = getSitePlanSlug( state, siteId );
 			const isEcommerceTrialMonthly = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9179

## Proposed Changes

* There are lots of clicks when you want to activate non-free themes (e.g.: checkout, atomic transfer modal, theme activation modal). As a result, this PR tries to reduce the number of clicks to provide the better experience.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the experience of theme activation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**On your free site**

* Activate a Personal/Premium theme
  * Make sure the Activation modal is open on the Theme Details page after the checkout
* Activate a Woo/DotOrg theme
  * Make sure the Atomic Transfer modal is open on the Theme Details page after the checkout
  * Click "Continue"
  * Make sure the theme will be activated automatically after the atomic transfer
* Activate a Partner theme
  * Make sure you can see the Loading screen after the checkout
  * When you redirect back to the Theme Details page, make sure the Activation modal is open

**On your business site before AT**

* Activate a Woo/DotOrg theme
  * Make sure the Atomic Transfer modal is open
  * Click "Continue"
  * Make sure the theme will be activated automatically after the atomic transfer
* Activate a Partner theme
  * Make sure you can see the Loading screen after the checkout
  * When you redirect back to the Theme Details page, make sure the Activation modal is open

**On your business site after AT**

* Activate a Partner theme
* Make sure the Activation modal is open on the Theme Details page after the checkout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
