### PR TITLE
A4A: Add error handler for 'Create referrals' mutation.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -12,6 +12,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import MissingPaymentSettingsNotice from '../../referrals/common/missing-payment-settings-notice';
 import useGetTipaltiPayee from '../../referrals/hooks/use-get-tipalti-payee';
 import withMarketplaceType, {
@@ -89,12 +90,19 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_referral_checkout_request_payment_click' )
 		);
-		requestPayment( {
-			client_email: email,
-			client_message: message,
-			product_ids: productIds,
-			licenses: licenses,
-		} );
+		requestPayment(
+			{
+				client_email: email,
+				client_message: message,
+				product_ids: productIds,
+				licenses: licenses,
+			},
+			{
+				onError: ( error ) => {
+					dispatch( errorNotice( error.message ) );
+				},
+			}
+		);
 	}, [
 		dispatch,
 		email,

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -99,7 +99,26 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 			},
 			{
 				onError: ( error ) => {
-					dispatch( errorNotice( error.message ) );
+					dispatch(
+						errorNotice(
+							error.code === 'cannot_refer_to_client'
+								? translate(
+										'Referring products to your own company is not allowed and against our {{a}}terms of service{{/a}}.',
+										{
+											components: {
+												a: (
+													<a
+														href="https://automattic.com/for-agencies/program-incentives/"
+														target="_blank"
+														rel="noopener noreferrer"
+													/>
+												),
+											},
+										}
+								  )
+								: error.message
+						)
+					);
 				},
 			}
 		);


### PR DESCRIPTION
This pull request adds an error handler for the 'Create referrals' mutation. We now display the error message in the UI when one is detected.

<img width="946" alt="Screenshot 2024-10-03 at 3 17 07 PM" src="https://github.com/user-attachments/assets/25d60693-7409-4dd0-91f9-8158224ab21b">


**NOTE: This needs to be tested together with D162916-code**

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1139

## Proposed Changes

* Add `onError` callback to the `useRequestClientPaymentMutation` mutation function and show the error message using the error notice.

## Why are these changes being made?
It is important to display the error message when the request fails to avoid confusion.

## Testing Instructions

- Follow the instructions in D162916-code to set up your sandbox. Ensure that you also follow the instructions to test it with an a8c email.
- Create an agency account using an a8c email. This is necessary to simplify testing.
- Use the A4A live link below and log in with the agency account.
- Using this agency account, create a referral and use an email address that is associated with a8c. For example, `jktestclient@automattic.com`.
- Please confirm that you see the error notification.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?