### PR TITLE
Domains: Fix wrong redirect in payment issue domains' table button

### DIFF
--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -101,6 +101,7 @@ export function resolveDomainStatus(
 	const paymentSetupCallToAction = {
 		href: '/me/purchases/payment-methods',
 		label: translate( 'Fix' ),
+		onClick: ( e: MouseEvent ) => e.stopPropagation(),
 	};
 
 	switch ( domain.type ) {

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -226,6 +226,7 @@ export function resolveDomainStatus(
 					icon: 'cached',
 				};
 			}
+
 			if (
 				isPurchasedDomain &&
 				isCreditCardExpiring &&

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -39,7 +39,7 @@ export type ResolveDomainStatusReturn = {
 	noticeText?: TranslateResult | Array< TranslateResult > | null;
 	callToAction?: {
 		href?: string;
-		onClick?(): void;
+		onClick?: React.MouseEventHandler< HTMLAnchorElement | HTMLButtonElement >;
 		label: string;
 	};
 };
@@ -101,7 +101,8 @@ export function resolveDomainStatus(
 	const paymentSetupCallToAction = {
 		href: '/me/purchases/payment-methods',
 		label: translate( 'Fix' ),
-		onClick: ( e: MouseEvent ) => e.stopPropagation(),
+		onClick: ( e: React.MouseEvent< HTMLAnchorElement | HTMLButtonElement, MouseEvent > ) =>
+			e.stopPropagation(),
 	};
 
 	switch ( domain.type ) {


### PR DESCRIPTION
Closes #94457 

When a credit card expires before a domain's renewal, the domains table under domains management page shows an alert and a button to fix the issue. The button should redirects to the purchase page but it goes to the specific domain management page instead.

## Why are these changes being made?
This PR fixes the wrong redirect, setting the correct destination (`me/purchases/payment-methods`).

## Testing Instructions
Apply this PR. If you don't have a domain where the credit card expires before renewal you can simulate this behavior by adding these lines of code right before line 230:
```
// Add these 2 lines to force credit card expiration
isCreditCardExpiring = true;
monthsUtilCreditCardExpires = 2;
if (
	isPurchasedDomain &&
	isCreditCardExpiring &&
	monthsUtilCreditCardExpires &&
	monthsUtilCreditCardExpires < 3
) {
```

Visit domains management page (`domains/manage/{site-slug}`) for a site where you have at least a registered domain, then verify that the domain status column shows `Action required` message and that the `Fix` button goes to `me/purchases/payment-methods}`

<img width="780" alt="Screenshot 2024-10-02 alle 15 20 42" src="https://github.com/user-attachments/assets/d9d85244-864c-4265-a9d0-44a466dae53b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
