### PR TITLE
Proxied Image: fix console error

### DIFF
--- a/client/my-sites/media-library/proxied-image.tsx
+++ b/client/my-sites/media-library/proxied-image.tsx
@@ -15,7 +15,7 @@ export interface ProxiedImageProps {
 	query: string;
 	filePath: string;
 	siteId: number | string;
-	placeholder: ReactNode;
+	placeholder?: ReactNode;
 	component: RenderedComponent;
 	maxSize: number | null;
 	onError?: ( err: Error ) => any;
@@ -43,7 +43,7 @@ const ProxiedImage: FC< ProxiedImageProps > = function ProxiedImage( {
 	siteId,
 	filePath,
 	query,
-	placeholder,
+	placeholder = null,
 	maxSize,
 	onError,
 	component: Component,
@@ -84,10 +84,6 @@ const ProxiedImage: FC< ProxiedImageProps > = function ProxiedImage( {
 
 	/* eslint-disable-next-line jsx-a11y/alt-text */
 	return <Component src={ imageObjectUrl } { ...rest } />;
-};
-
-ProxiedImage.defaultProps = {
-	placeholder: null,
 };
 
 export default ProxiedImage;


### PR DESCRIPTION
## Proposed Changes

Change from using `defaultProps`

## Why are these changes being made?

<img width="1120" alt="Screen Shot 2024-10-02 at 17 27 09" src="https://github.com/user-attachments/assets/4ed3d363-8107-4776-ba56-d9027f02fa04">

There is currently an error in the console that warns of this deprecation. This switches to use the correct method to set a default prop.

## Testing Instructions

Look for regressions on the homepage
