### PR TITLE
White-labeled plugin: Update copy when referencing the Move to WordPress.com plugin

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key-fallback.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key-fallback.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -9,11 +10,19 @@ export const StepAddMigrationKeyFallback: FC = () => {
 	const translate = useTranslate();
 	const site = useSite();
 	const siteUrl = site?.URL ?? '';
+	const isWhiteLabeledPluginEnabled = config.isEnabled(
+		'migration-flow/enable-white-labeled-plugin'
+	);
+	const migrationKeyLabel = isWhiteLabeledPluginEnabled
+		? 'Migration Key'
+		: 'Migrate Guru Migration Key';
+	const migrateLabel = isWhiteLabeledPluginEnabled ? 'Start migration' : 'Migrate';
+	const pluginName = isWhiteLabeledPluginEnabled ? 'Migrate to WordPress.com' : 'Migrate Guru';
 
 	return (
 		<p>
 			{ translate(
-				'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.',
+				'Go to the {{a}}%(pluginName)s page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.',
 				{
 					components: {
 						a: (
@@ -27,10 +36,7 @@ export const StepAddMigrationKeyFallback: FC = () => {
 						),
 						strong: <strong />,
 					},
-					args: {
-						migrationKeyLabel: 'Migrate Guru Migration Key',
-						migrateLabel: 'Migrate',
-					},
+					args: { pluginName, migrationKeyLabel, migrateLabel },
 				}
 			) }
 		</p>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key-fallback.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key-fallback.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { ExternalLink } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordMigrationInstructionsLinkClick } from '../tracking';
@@ -8,6 +9,7 @@ import type { FC } from 'react';
 
 export const StepAddMigrationKeyFallback: FC = () => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const site = useSite();
 	const siteUrl = site?.URL ?? '';
 	const isWhiteLabeledPluginEnabled = config.isEnabled(
@@ -18,27 +20,38 @@ export const StepAddMigrationKeyFallback: FC = () => {
 		: 'Migrate Guru Migration Key';
 	const migrateLabel = isWhiteLabeledPluginEnabled ? 'Start migration' : 'Migrate';
 	const pluginName = isWhiteLabeledPluginEnabled ? 'Migrate to WordPress.com' : 'Migrate Guru';
+	const ctaTranslationComponents = {
+		a: (
+			<ExternalLink
+				href={ getMigrateGuruPageURL( siteUrl ) }
+				icon
+				iconSize={ 14 }
+				target="_blank"
+				onClick={ () => recordMigrationInstructionsLinkClick( 'copy-key-fallback' ) }
+			/>
+		),
+		strong: <strong />,
+	};
 
 	return (
 		<p>
-			{ translate(
-				'Go to the {{a}}%(pluginName)s page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.',
-				{
-					components: {
-						a: (
-							<ExternalLink
-								href={ getMigrateGuruPageURL( siteUrl ) }
-								icon
-								iconSize={ 14 }
-								target="_blank"
-								onClick={ () => recordMigrationInstructionsLinkClick( 'copy-key-fallback' ) }
-							/>
-						),
-						strong: <strong />,
-					},
-					args: { pluginName, migrationKeyLabel, migrateLabel },
-				}
-			) }
+			{ hasEnTranslation(
+				'Go to the {{a}}%(pluginName)s page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.'
+			)
+				? translate(
+						'Go to the {{a}}%(pluginName)s page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.',
+						{
+							components: ctaTranslationComponents,
+							args: { pluginName, migrationKeyLabel, migrateLabel },
+						}
+				  )
+				: translate(
+						'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.',
+						{
+							components: ctaTranslationComponents,
+							args: { migrationKeyLabel, migrateLabel },
+						}
+				  ) }
 		</p>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { MigrationKeyInput } from '../migration-key-input';
@@ -10,6 +11,13 @@ interface Props {
 
 export const StepAddMigrationKey: FC< Props > = ( { migrationKey, preparationError } ) => {
 	const translate = useTranslate();
+	const isWhiteLabeledPluginEnabled = config.isEnabled(
+		'migration-flow/enable-white-labeled-plugin'
+	);
+	const migrationKeyLabel = isWhiteLabeledPluginEnabled
+		? 'Migration Key'
+		: 'Migrate Guru Migration Key';
+	const migrateLabel = isWhiteLabeledPluginEnabled ? 'Start migration' : 'Migrate';
 
 	if ( '' === migrationKey ) {
 		return (
@@ -33,7 +41,7 @@ export const StepAddMigrationKey: FC< Props > = ( { migrationKey, preparationErr
 						components: {
 							strong: <strong />,
 						},
-						args: { migrationKeyLabel: 'Migrate Guru Migration Key', migrateLabel: 'Migrate' },
+						args: { migrationKeyLabel, migrateLabel },
 					}
 				) }
 			</p>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-started/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-started/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { ExternalLink } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -14,6 +15,9 @@ const recordLinkClick = ( linkname: string ) => {
 
 const SiteMigrationStarted: Step = function () {
 	const translate = useTranslate();
+	const isWhiteLabeledPluginEnabled = config.isEnabled(
+		'migration-flow/enable-white-labeled-plugin'
+	);
 
 	const stepContent = (
 		<div className="migration-started-card">
@@ -59,7 +63,9 @@ const SiteMigrationStarted: Step = function () {
 						<>
 							{ translate( 'Your migration process has started.' ) }
 							<br />
-							{ translate( ' Migrate Guru will email you when the process is finished.' ) }
+							{ isWhiteLabeledPluginEnabled
+								? translate( "We'll email you when the process is finished." )
+								: translate( 'Migrate Guru will email you when the process is finished.' ) }
 						</>
 					}
 					align="center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-started/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-started/index.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { ExternalLink } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -15,6 +16,7 @@ const recordLinkClick = ( linkname: string ) => {
 
 const SiteMigrationStarted: Step = function () {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const isWhiteLabeledPluginEnabled = config.isEnabled(
 		'migration-flow/enable-white-labeled-plugin'
 	);
@@ -63,7 +65,8 @@ const SiteMigrationStarted: Step = function () {
 						<>
 							{ translate( 'Your migration process has started.' ) }
 							<br />
-							{ isWhiteLabeledPluginEnabled
+							{ isWhiteLabeledPluginEnabled &&
+							hasEnTranslation( "We'll email you when the process is finished." )
 								? translate( "We'll email you when the process is finished." )
 								: translate( 'Migrate Guru will email you when the process is finished.' ) }
 						</>


### PR DESCRIPTION
Relates to #94631

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This updates the copy on migration key step and the migration started screen when using the Move to WordPress.com plugin.
* There is some logic repetition which will be cleaned up once the feature flag is enabled permanently.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Soon we will switch from Migrate Guru to the Move to WordPress.com plugin, and these changes need to be reflected on the front end during the migration signup flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR or use calypso.live
* Navigate to `/setup/migration-signup`
* Enable the `migration-flow/enable-white-labeled-plugin` using `window.sessionStorage.setItem('flags', 'migration-flow/enable-white-labeled-plugin');` and refresh the page.
* Go through the flow until you reach the "Add your migration key" instructions step.
* You should see the following:

<img width="388" alt="image" src="https://github.com/user-attachments/assets/9dad4af6-d9a8-4d41-8b8e-480a4e0c4043">


* Click the "Done" button and you should see the following:

![image](https://github.com/user-attachments/assets/aff8e92b-0962-4f27-b5d1-91d02b0f88ec)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
