### PR TITLE
Help Center: Fix createRoot related console error

### DIFF
--- a/apps/help-center/help-center-wp-admin-disconnected.js
+++ b/apps/help-center/help-center-wp-admin-disconnected.js
@@ -19,4 +19,6 @@ function AdminHelpCenterContent() {
 }
 
 const target = document.getElementById( 'help-center-masterbar' );
-createRoot( target ).render( <AdminHelpCenterContent /> );
+if ( target ) {
+	createRoot( target ).render( <AdminHelpCenterContent /> );
+}

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -80,4 +80,6 @@ function AdminHelpCenterContent() {
 }
 
 const target = document.getElementById( 'help-center-masterbar' );
-createRoot( target ).render( <AdminHelpCenterContent /> );
+if ( target ) {
+	createRoot( target ).render( <AdminHelpCenterContent /> );
+}


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Wrap the render in a conditional statement to check if the target element exists before rendering.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix console errors related to createRoot usage
 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Navigate to `apps/help-center` and sync to sandbox `yarn dev --sync`
* Sandbox widget API and your site
* Regression test Help Center

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
