### PR TITLE
Theme: Don't show Activation modal if the user comes from the onboarding flow

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -141,9 +141,14 @@ export function useThemesThankYouData(
 	// Redirect to the Theme Details page after the atomic transfer.
 	useEffect( () => {
 		if ( firstTheme && isAtomicNeeded && isJetpack ) {
-			page( addQueryArgs( `/theme/${ firstTheme.id }/${ siteSlug }`, { activating: true } ) );
+			page(
+				addQueryArgs( `/theme/${ firstTheme.id }/${ siteSlug }`, {
+					activating: true,
+					...( isOnboardingFlow ? { onboarding: true } : {} ),
+				} )
+			);
 		}
-	}, [ firstTheme, isAtomicNeeded, isJetpack ] );
+	}, [ firstTheme, isAtomicNeeded, isJetpack, isOnboardingFlow ] );
 
 	return [
 		firstTheme,

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { hasQueryArg } from '@wordpress/url';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { activateTheme } from 'calypso/state/themes/actions/activate-theme';
@@ -28,7 +29,11 @@ import 'calypso/state/themes/init';
  */
 export function activate( themeId, siteId, options ) {
 	return ( dispatch, getState ) => {
-		const { source, purchased, isOnboardingFlow } = options || {};
+		const {
+			source,
+			purchased,
+			isOnboardingFlow = hasQueryArg( window.location.href, 'onboarding' ),
+		} = options || {};
 		const isDotComTheme = !! getTheme( getState(), 'wpcom', themeId );
 		const isDotOrgTheme = !! getTheme( getState(), 'wporg', themeId );
 		const hasThemeBundleSoftwareSet = doesThemeBundleSoftwareSet( getState(), themeId );

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -32,7 +32,8 @@ export function activate( themeId, siteId, options ) {
 		const {
 			source,
 			purchased,
-			isOnboardingFlow = hasQueryArg( window.location.href, 'onboarding' ),
+			isOnboardingFlow = typeof window !== 'undefined' &&
+				hasQueryArg( window.location.href, 'onboarding' ),
 		} = options || {};
 		const isDotComTheme = !! getTheme( getState(), 'wpcom', themeId );
 		const isDotOrgTheme = !! getTheme( getState(), 'wporg', themeId );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/95058

## Proposed Changes

* This is the regression of https://github.com/Automattic/wp-calypso/pull/95058. We redirected the page to the Theme Details page after the atomic transfer but the `onboarding` parameter was missing so that the Activation modal would show. As a result, this PR made a change to keep the `onboarding` parameter to avoid displaying the Activation modal if the theme is being activated from the onboarding flow.
* A better way is to redirect back to the original page after the atomic transfer to continue to complete the onboarding flow. However, it seems to have some issues when the site becomes the atomic site (CMIIW) and the existing behavior was showing the Congrats screen. So, it may be fine to stay on the Theme Details page. Any thoughts?

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Remove the Congrats screen after the theme activation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* When you land on the Design Picker, select `Store` category and pick any Partner theme
* Unlock the theme
* Make sure you can see the Loading screen for the atomic transfer after checkout
* Make sure you can see the Theme Details page after the atomic transfer
* Make sure the theme will be activated automatically without the Activation modal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
