### PR TITLE
Performance Profiler: logged-out profiler uses the same components as the logged-in profiler

### DIFF
--- a/client/hosting/performance/components/PerformanceReport.tsx
+++ b/client/hosting/performance/components/PerformanceReport.tsx
@@ -43,7 +43,6 @@ export const PerformanceReport = ( {
 			performanceReport={ performanceReport }
 			url={ url }
 			hash={ hash }
-			useLoggedInCopy
 			overallScoreIsTab
 			filter={ filter }
 			displayNewsletterBanner={ false }

--- a/client/hosting/performance/components/PerformanceReport.tsx
+++ b/client/hosting/performance/components/PerformanceReport.tsx
@@ -43,9 +43,9 @@ export const PerformanceReport = ( {
 			performanceReport={ performanceReport }
 			url={ url }
 			hash={ hash }
-			showV2
+			useLoggedInCopy
+			overallScoreIsTab
 			filter={ filter }
-			displayThumbnail={ false }
 			displayNewsletterBanner={ false }
 			displayMigrationBanner={ false }
 			onRecommendationsFilterChange={ onFilterChange }

--- a/client/performance-profiler/components/core-web-vitals-accordion/core-web-vitals-accordion-v2.tsx
+++ b/client/performance-profiler/components/core-web-vitals-accordion/core-web-vitals-accordion-v2.tsx
@@ -16,6 +16,7 @@ type Props = Record< Metrics, number > & {
 	activeTab: Metrics | null;
 	setActiveTab: ( tab: Metrics | null ) => void;
 	children: React.ReactNode;
+	showOverall?: boolean;
 };
 type HeaderProps = {
 	displayName: string;
@@ -52,7 +53,7 @@ const CardHeader = ( props: HeaderProps ) => {
 };
 
 export const CoreWebVitalsAccordionV2 = ( props: Props ) => {
-	const { activeTab, setActiveTab, children } = props;
+	const { activeTab, setActiveTab, children, showOverall } = props;
 	const translate = useTranslate();
 
 	const onClick = ( key: Metrics ) => {
@@ -71,7 +72,8 @@ export const CoreWebVitalsAccordionV2 = ( props: Props ) => {
 	const overallEntry = entries.find( ( [ key ] ) => key === 'overall' );
 	const otherEntries = entries.filter( ( [ key ] ) => key !== 'overall' );
 
-	const reorderedEntries = overallEntry ? [ overallEntry, ...otherEntries ] : otherEntries;
+	const reorderedEntries =
+		showOverall && overallEntry ? [ overallEntry, ...otherEntries ] : otherEntries;
 
 	return (
 		<div className="core-web-vitals-accordion-v2">

--- a/client/performance-profiler/components/core-web-vitals-display/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/index.tsx
@@ -1,16 +1,12 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
-import clsx from 'clsx';
 import { useState } from 'react';
 import {
 	Metrics,
 	PerformanceMetricsHistory,
 	PerformanceMetricsItemQueryResponse,
 } from 'calypso/data/site-profiler/types';
-import { CoreWebVitalsAccordion } from '../core-web-vitals-accordion';
 import { CoreWebVitalsAccordionV2 } from '../core-web-vitals-accordion/core-web-vitals-accordion-v2';
-import { MetricTabBar } from '../metric-tab-bar';
 import MetricTabBarV2 from '../metric-tab-bar/metric-tab-bar-v2';
-import { CoreWebVitalsDetails } from './core-web-vitals-details';
 import { CoreWebVitalsDetailsV2 } from './core-web-vitals-details_v2';
 import './style.scss';
 
@@ -18,43 +14,39 @@ type CoreWebVitalsDisplayProps = Record< Metrics, number > & {
 	history: PerformanceMetricsHistory;
 	audits: Record< string, PerformanceMetricsItemQueryResponse >;
 	recommendationsRef: React.RefObject< HTMLDivElement > | null;
-	showV2?: boolean;
+	overallScoreIsTab?: boolean;
 	onRecommendationsFilterChange?: ( filter: string ) => void;
 };
 
 export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
-	const defaultTab = props.showV2 ? 'overall' : 'fcp';
+	const defaultTab = props.overallScoreIsTab ? 'overall' : 'fcp';
 	const [ activeTab, setActiveTab ] = useState< Metrics | null >( defaultTab );
 	const isDesktop = useDesktopBreakpoint();
 
-	const MetricBar = props.showV2 ? MetricTabBarV2 : MetricTabBar;
-	const CoreWebVitalsDetail = props.showV2 ? CoreWebVitalsDetailsV2 : CoreWebVitalsDetails;
-
-	const Accordion = props.showV2 ? CoreWebVitalsAccordionV2 : CoreWebVitalsAccordion;
+	if ( isDesktop ) {
+		return (
+			<div className="core-web-vitals-display core-web-vitals-display-v2">
+				<MetricTabBarV2
+					activeTab={ activeTab ?? defaultTab }
+					setActiveTab={ setActiveTab }
+					showOverall={ props.overallScoreIsTab }
+					{ ...props }
+				/>
+				<CoreWebVitalsDetailsV2 activeTab={ activeTab } { ...props } />
+			</div>
+		);
+	}
 
 	return (
-		<>
-			{ isDesktop && (
-				<div
-					className={ clsx( 'core-web-vitals-display', {
-						[ 'core-web-vitals-display-v2' ]: props.showV2,
-					} ) }
-				>
-					<MetricBar
-						activeTab={ activeTab ?? defaultTab }
-						setActiveTab={ setActiveTab }
-						{ ...props }
-					/>
-					<CoreWebVitalsDetail activeTab={ activeTab } { ...props } />
-				</div>
-			) }
-			{ ! isDesktop && (
-				<div className="core-web-vitals-display">
-					<Accordion activeTab={ activeTab } setActiveTab={ setActiveTab } { ...props }>
-						<CoreWebVitalsDetail activeTab={ activeTab } { ...props } />
-					</Accordion>
-				</div>
-			) }
-		</>
+		<div className="core-web-vitals-display">
+			<CoreWebVitalsAccordionV2
+				activeTab={ activeTab }
+				setActiveTab={ setActiveTab }
+				showOverall={ props.overallScoreIsTab }
+				{ ...props }
+			>
+				<CoreWebVitalsDetailsV2 activeTab={ activeTab } { ...props } />
+			</CoreWebVitalsAccordionV2>
+		</div>
 	);
 };

--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -22,7 +22,8 @@ type PerformanceProfilerDashboardContentProps = {
 	displayNewsletterBanner?: boolean;
 	displayMigrationBanner?: boolean;
 	activeTab?: TabType;
-	showV2?: boolean;
+	overallScoreIsTab?: boolean;
+	useLoggedInCopy: boolean;
 	onRecommendationsFilterChange?: ( filter: string ) => void;
 };
 
@@ -31,11 +32,11 @@ export const PerformanceProfilerDashboardContent = ( {
 	url,
 	hash,
 	filter,
-	displayThumbnail = true,
 	displayNewsletterBanner = true,
 	displayMigrationBanner = true,
 	activeTab = TabType.mobile,
-	showV2 = false,
+	overallScoreIsTab = false,
+	useLoggedInCopy,
 	onRecommendationsFilterChange,
 }: PerformanceProfilerDashboardContentProps ) => {
 	const {
@@ -57,20 +58,18 @@ export const PerformanceProfilerDashboardContent = ( {
 	return (
 		<div className="performance-profiler-content">
 			<div className="l-block-wrapper container">
-				{ ! showV2 && (
+				{ ! overallScoreIsTab && (
 					<div className="top-section">
 						<PerformanceScore
 							value={ overall_score * 100 }
 							recommendationsQuantity={ Object.keys( audits ).length }
 							recommendationsRef={ insightsRef }
 						/>
-						{ displayThumbnail && (
-							<ScreenshotThumbnail
-								alt={ translate( 'Website thumbnail' ) }
-								src={ screenshots?.[ screenshots.length - 1 ].data }
-								activeTab={ activeTab }
-							/>
-						) }
+						<ScreenshotThumbnail
+							alt={ translate( 'Website thumbnail' ) }
+							src={ screenshots?.[ screenshots.length - 1 ].data }
+							activeTab={ activeTab }
+						/>
 					</div>
 				) }
 				<CoreWebVitalsDisplay
@@ -81,7 +80,7 @@ export const PerformanceProfilerDashboardContent = ( {
 					ttfb={ ttfb }
 					tbt={ tbt }
 					overall={ overall_score * 100 }
-					showV2={ showV2 }
+					overallScoreIsTab={ overallScoreIsTab }
 					history={ history }
 					audits={ audits }
 					recommendationsRef={ insightsRef }
@@ -109,7 +108,7 @@ export const PerformanceProfilerDashboardContent = ( {
 						ref={ insightsRef }
 						hash={ hash }
 						filter={ filter }
-						isLoggedInVersion={ showV2 }
+						useLoggedInCopy={ useLoggedInCopy }
 						onRecommendationsFilterChange={ onRecommendationsFilterChange }
 					/>
 				) }

--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -23,7 +23,6 @@ type PerformanceProfilerDashboardContentProps = {
 	displayMigrationBanner?: boolean;
 	activeTab?: TabType;
 	overallScoreIsTab?: boolean;
-	useLoggedInCopy: boolean;
 	onRecommendationsFilterChange?: ( filter: string ) => void;
 };
 
@@ -36,7 +35,6 @@ export const PerformanceProfilerDashboardContent = ( {
 	displayMigrationBanner = true,
 	activeTab = TabType.mobile,
 	overallScoreIsTab = false,
-	useLoggedInCopy,
 	onRecommendationsFilterChange,
 }: PerformanceProfilerDashboardContentProps ) => {
 	const {
@@ -108,7 +106,6 @@ export const PerformanceProfilerDashboardContent = ( {
 						ref={ insightsRef }
 						hash={ hash }
 						filter={ filter }
-						useLoggedInCopy={ useLoggedInCopy }
 						onRecommendationsFilterChange={ onRecommendationsFilterChange }
 					/>
 				) }

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -92,16 +92,10 @@ export const InsightsSection = forwardRef(
 				<div className="header">
 					<div>
 						<h2 className="title">
-							{ props.useLoggedInCopy ? (
-								translate( 'Recommendations' )
-							) : (
-								<>
-									{ translate( 'Personalized recommendations' ) }
-									<AIBadge className={ clsx( { 'is-mobile': isMobile } ) }>
-										{ translate( 'Generated with AI' ) }
-									</AIBadge>
-								</>
-							) }
+							{ translate( 'Personalized Recommendations' ) }
+							<AIBadge className={ clsx( { 'is-mobile': isMobile } ) }>
+								{ translate( 'Generated with AI' ) }
+							</AIBadge>
 						</h2>
 						<p className="subtitle">
 							{ getSubtitleText(

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -1,4 +1,7 @@
 import { SelectDropdown } from '@automattic/components';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import styled from '@emotion/styled';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { ForwardedRef, forwardRef, useCallback, useEffect, useState } from 'react';
 import {
@@ -18,13 +21,38 @@ type InsightsSectionProps = {
 	isWpcom: boolean;
 	hash: string;
 	filter?: string;
-	isLoggedInVersion?: boolean;
+	useLoggedInCopy: boolean;
 	onRecommendationsFilterChange?: ( filter: string ) => void;
 };
+
+const AIBadge = styled.span`
+	padding: 0 8px;
+	margin-left: 8px;
+	width: fit-content;
+	border-radius: 4px;
+	float: right;
+	font-size: 12px;
+	line-height: 20px;
+	color: var( --studio-gray-100 );
+	background: linear-gradient(
+			0deg,
+			rgba( 255, 255, 255, 0.95 ) 0%,
+			rgba( 255, 255, 255, 0.95 ) 100%
+		),
+		linear-gradient( 90deg, #4458e4 0%, #069e08 100% );
+
+	&.is-mobile {
+		float: none;
+		display: block;
+		margin-left: 0;
+		margin-top: 8px;
+	}
+`;
 
 export const InsightsSection = forwardRef(
 	( props: InsightsSectionProps, ref: ForwardedRef< HTMLDivElement > ) => {
 		const translate = useTranslate();
+		const isMobile = ! useDesktopBreakpoint();
 		const { audits, fullPageScreenshot, isWpcom, hash, filter, onRecommendationsFilterChange } =
 			props;
 		const [ selectedFilter, setSelectedFilter ] = useState( filter ?? 'all' );
@@ -58,41 +86,30 @@ export const InsightsSection = forwardRef(
 				setSelectedFilter( filter );
 			}
 		}, [ selectedFilter, filter ] );
-		const siteOrPageSubtitle = props.isLoggedInVersion
-			? translate( 'your page' )
-			: translate( 'your site' );
+
 		return (
 			<div className="performance-profiler-insights-section" ref={ ref }>
 				<div className="header">
 					<div>
 						<h2 className="title">
-							{ props.isLoggedInVersion
-								? translate( 'Recommendations' )
-								: translate( 'Improve your site‘s performance' ) }
+							{ props.useLoggedInCopy ? (
+								translate( 'Recommendations' )
+							) : (
+								<>
+									{ translate( 'Personalized recommendations' ) }
+									<AIBadge className={ clsx( { 'is-mobile': isMobile } ) }>
+										{ translate( 'Generated with AI' ) }
+									</AIBadge>
+								</>
+							) }
 						</h2>
 						<p className="subtitle">
-							{ filteredAudits.length
-								? translate(
-										'We found %(quantity)d thing you can do for improving %(metric)s.',
-										'We found %(quantity)d things you can do for improving %(metric)s.',
-										{
-											args: {
-												quantity: filteredAudits.length,
-												metric:
-													selectedFilter === 'all'
-														? siteOrPageSubtitle
-														: metricsNames[ selectedFilter as keyof typeof metricsNames ]?.name,
-											},
-											count: filteredAudits.length,
-										}
-								  )
-								: translate( "Great job! We didn't find any recommendations for improving %s.", {
-										args: [
-											selectedFilter === 'all'
-												? translate( 'the speed of your site' )
-												: metricsNames[ selectedFilter as keyof typeof metricsNames ]?.name,
-										],
-								  } ) }
+							{ getSubtitleText(
+								selectedFilter,
+								filteredAudits.length,
+								props.useLoggedInCopy,
+								translate
+							) }
 						</p>
 					</div>
 					<div className="filter">
@@ -142,3 +159,61 @@ export const InsightsSection = forwardRef(
 		);
 	}
 );
+
+function getSubtitleText(
+	selectedFilter: string,
+	numRecommendations: number,
+	useLoggedInCopy: boolean,
+	translate: ReturnType< typeof useTranslate >
+) {
+	if ( numRecommendations ) {
+		if ( selectedFilter === 'all' ) {
+			if ( useLoggedInCopy ) {
+				return translate(
+					'We found %(numRecommendations)d thing you can do for improving your page.',
+					'We found %(numRecommendations)d things you can do for improving your page.',
+					{
+						args: { numRecommendations },
+						count: numRecommendations,
+					}
+				);
+			}
+			return translate(
+				'We found %(numRecommendations)d thing you can do for improving your site.',
+				'We found %(numRecommendations)d things you can do for improving your site.',
+				{
+					args: { numRecommendations },
+					count: numRecommendations,
+				}
+			);
+		}
+		return translate(
+			'We found %(numRecommendations)d thing you can do for improving %(metric)s.',
+			'We found %(numRecommendations)d things you can do for improving %(metric)s.',
+			{
+				args: {
+					numRecommendations,
+					metric: metricsNames[ selectedFilter as keyof typeof metricsNames ]?.name,
+				},
+				count: numRecommendations,
+			}
+		);
+	}
+
+	if ( selectedFilter === 'all' ) {
+		if ( useLoggedInCopy ) {
+			return translate(
+				"Great job! We didn't find any recommendations for improving the speed of your page."
+			);
+		}
+		return translate(
+			"Great job! We didn't find any recommendations for improving the speed of your site."
+		);
+	}
+
+	return translate( "Great job! We didn't find any recommendations for improving %(metric)s.", {
+		args: {
+			metric: metricsNames[ selectedFilter as keyof typeof metricsNames ]?.name,
+		},
+	} );
+}

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -25,7 +25,8 @@ type InsightsSectionProps = {
 export const InsightsSection = forwardRef(
 	( props: InsightsSectionProps, ref: ForwardedRef< HTMLDivElement > ) => {
 		const translate = useTranslate();
-		const { audits, fullPageScreenshot, isWpcom, hash, filter } = props;
+		const { audits, fullPageScreenshot, isWpcom, hash, filter, onRecommendationsFilterChange } =
+			props;
 		const [ selectedFilter, setSelectedFilter ] = useState( filter ?? 'all' );
 
 		const sumMetricSavings = ( key: string ) =>
@@ -37,17 +38,20 @@ export const InsightsSection = forwardRef(
 		const filteredAudits = Object.keys( audits )
 			.filter( ( key ) => filterRecommendations( selectedFilter, audits[ key ] ) )
 			.sort( sortInsightKeys );
-		const onFilter = useCallback( ( option: { label: string; value: string } ) => {
-			recordTracksEvent( 'calypso_performance_profiler_recommendations_filter_change', {
-				filter: option.value,
-			} );
-			setSelectedFilter( option.value );
-			if ( props.onRecommendationsFilterChange ) {
-				props.onRecommendationsFilterChange( option.value );
-			} else {
-				updateQueryParams( { filter: option.value }, true );
-			}
-		}, [] );
+		const onFilter = useCallback(
+			( option: { label: string; value: string } ) => {
+				recordTracksEvent( 'calypso_performance_profiler_recommendations_filter_change', {
+					filter: option.value,
+				} );
+				setSelectedFilter( option.value );
+				if ( onRecommendationsFilterChange ) {
+					onRecommendationsFilterChange( option.value );
+				} else {
+					updateQueryParams( { filter: option.value }, true );
+				}
+			},
+			[ onRecommendationsFilterChange ]
+		);
 
 		useEffect( () => {
 			if ( filter && filter !== selectedFilter ) {

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -21,7 +21,6 @@ type InsightsSectionProps = {
 	isWpcom: boolean;
 	hash: string;
 	filter?: string;
-	useLoggedInCopy: boolean;
 	onRecommendationsFilterChange?: ( filter: string ) => void;
 };
 
@@ -98,12 +97,7 @@ export const InsightsSection = forwardRef(
 							</AIBadge>
 						</h2>
 						<p className="subtitle">
-							{ getSubtitleText(
-								selectedFilter,
-								filteredAudits.length,
-								props.useLoggedInCopy,
-								translate
-							) }
+							{ getSubtitleText( selectedFilter, filteredAudits.length, translate ) }
 						</p>
 					</div>
 					<div className="filter">
@@ -157,24 +151,13 @@ export const InsightsSection = forwardRef(
 function getSubtitleText(
 	selectedFilter: string,
 	numRecommendations: number,
-	useLoggedInCopy: boolean,
 	translate: ReturnType< typeof useTranslate >
 ) {
 	if ( numRecommendations ) {
 		if ( selectedFilter === 'all' ) {
-			if ( useLoggedInCopy ) {
-				return translate(
-					'We found %(numRecommendations)d thing you can do for improving your page.',
-					'We found %(numRecommendations)d things you can do for improving your page.',
-					{
-						args: { numRecommendations },
-						count: numRecommendations,
-					}
-				);
-			}
 			return translate(
-				'We found %(numRecommendations)d thing you can do for improving your site.',
-				'We found %(numRecommendations)d things you can do for improving your site.',
+				'We found %(numRecommendations)d thing you can do for improving your page.',
+				'We found %(numRecommendations)d things you can do for improving your page.',
 				{
 					args: { numRecommendations },
 					count: numRecommendations,
@@ -195,13 +178,8 @@ function getSubtitleText(
 	}
 
 	if ( selectedFilter === 'all' ) {
-		if ( useLoggedInCopy ) {
-			return translate(
-				"Great job! We didn't find any recommendations for improving the speed of your page."
-			);
-		}
 		return translate(
-			"Great job! We didn't find any recommendations for improving the speed of your site."
+			"Great job! We didn't find any recommendations for improving the speed of your page."
 		);
 	}
 

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -22,6 +22,7 @@
 		font-size: 1rem;
 		font-weight: 500;
 		margin-bottom: 8px;
+		width: fit-content;
 	}
 
 	.subtitle {

--- a/client/performance-profiler/components/metric-tab-bar/metric-tab-bar-v2.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/metric-tab-bar-v2.tsx
@@ -13,10 +13,11 @@ import './style_v2.scss';
 type Props = Record< Metrics, number > & {
 	activeTab: Metrics;
 	setActiveTab: ( tab: Metrics ) => void;
+	showOverall?: boolean;
 };
 
 const MetricTabBarV2 = ( props: Props ) => {
-	const { activeTab, setActiveTab } = props;
+	const { activeTab, setActiveTab, showOverall } = props;
 
 	const handleTabClick = ( tab: Metrics ) => {
 		setActiveTab( tab );
@@ -25,26 +26,28 @@ const MetricTabBarV2 = ( props: Props ) => {
 
 	return (
 		<div className="metric-tab-bar-v2">
-			<button
-				className={ clsx( 'metric-tab-bar-v2__tab metric-tab-bar-v2__performance', {
-					active: activeTab === 'overall',
-				} ) }
-				onClick={ () => handleTabClick( 'overall' ) }
-			>
-				<div className="metric-tab-bar-v2__tab-text">
-					<div
-						className="metric-tab-bar-v2__tab-header"
-						css={ {
-							marginBottom: '6px',
-						} }
-					>
-						Performance Score
+			{ showOverall && (
+				<button
+					className={ clsx( 'metric-tab-bar-v2__tab metric-tab-bar-v2__performance', {
+						active: activeTab === 'overall',
+					} ) }
+					onClick={ () => handleTabClick( 'overall' ) }
+				>
+					<div className="metric-tab-bar-v2__tab-text">
+						<div
+							className="metric-tab-bar-v2__tab-header"
+							css={ {
+								marginBottom: '6px',
+							} }
+						>
+							Performance Score
+						</div>
+						<div className="metric-tab-bar-v2__tab-metric">
+							<CircularPerformanceScore score={ props.overall } size={ 48 } />
+						</div>
 					</div>
-					<div className="metric-tab-bar-v2__tab-metric">
-						<CircularPerformanceScore score={ props.overall } size={ 48 } />
-					</div>
-				</div>
-			</button>
+				</button>
+			) }
 			<div className="metric-tab-bar-v2__tab-container">
 				{ Object.entries( metricsNames ).map( ( [ key, { name: displayName } ] ) => {
 					if ( props[ key as Metrics ] === undefined || props[ key as Metrics ] === null ) {

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -36,8 +36,6 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 		setFeedbackSent( true );
 	};
 
-	const isPerformancePage = window.location.pathname.includes( '/sites/performance/' );
-
 	const renderFeedbackForm = () => {
 		if ( feedbackSent ) {
 			return <div className="survey">{ translate( 'Thanks for the feedback!' ) }</div>;
@@ -96,14 +94,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 	return (
 		<div className="metrics-insight-content">
 			{ isLoading ? (
-				<LLMMessage
-					message={
-						isPerformancePage
-							? translate( 'Finding the best solution for your page…' )
-							: translate( 'Finding the best solution for your site…' )
-					}
-					rotate
-				/>
+				<LLMMessage message={ translate( 'Finding the best solution for your page…' ) } rotate />
 			) : (
 				<>
 					<div className="description-area">

--- a/client/performance-profiler/components/metrics-insight/insight-header.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-header.tsx
@@ -1,5 +1,6 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 import Markdown from 'react-markdown';
 import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
 
@@ -9,6 +10,7 @@ interface InsightHeaderProps {
 }
 export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
 	const isMobile = ! useDesktopBreakpoint();
+	const translate = useTranslate();
 	const { data, index } = props;
 	const title = data.title ?? '';
 	const value = data.displayValue ?? '';
@@ -22,7 +24,11 @@ export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
 			return null;
 		}
 
-		return <span className={ clsx( 'impact fail', { 'is-mobile': isMobile } ) }>High Impact</span>;
+		return (
+			<span className={ clsx( 'impact fail', { 'is-mobile': isMobile } ) }>
+				{ translate( 'High Impact' ) }
+			</span>
+		);
 	};
 
 	return (

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -148,6 +148,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 							hash={ hash }
 							filter={ filter }
 							displayMigrationBanner={ ! performanceReport?.is_wpcom }
+							useLoggedInCopy={ false }
 						/>
 					) }
 				</>

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -148,7 +148,6 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 							hash={ hash }
 							filter={ filter }
 							displayMigrationBanner={ ! performanceReport?.is_wpcom }
-							useLoggedInCopy={ false }
 						/>
 					) }
 				</>

--- a/client/performance-profiler/pages/dashboard/style.scss
+++ b/client/performance-profiler/pages/dashboard/style.scss
@@ -28,9 +28,7 @@ $blueberry-color: #3858e9;
 		flex-wrap: wrap;
 		column-gap: 20px;
 		align-items: center;
-		@media (max-width: $break-mobile) {
-			justify-content: center;
-		}
+		justify-content: center;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9284

## Proposed Changes

* Switches the logged-in view over to use the V2 version of components e.g. `CoreWebVitalsDetailsV2`
   * Most of the logic for doing this is in `client/performance-profiler/components/core-web-vitals-display/index.tsx`
* Replaces the `showV2` prop with `useLoggedInCopy` and `overallScoreIsTab` props
   * These are more semantic prop names that will continue to be relevant even as the memory of V1/V2 fades from our memories
   * `useLoggedInCopy` controls the subtle copy tweaks between the two views e.g. "your site" vs. "your page"
   * `overallScoreIsTab` controls whether the summary is supposed to appear as one of the tabs alongside FCP etc., or whether the "overall" metric appears above as it's own thing
* The `displayThumbnail` prop is unused so I removed it
   * The thumbnail of the site is always displayed in the logged out view, and never displayed in the logged in view
* Updated copy in the insights section to match Figma
   * "Recommendations" vs. "Personalized recommendations"
   * Added "Generated with AI" badge

Other fixes:
* Ensure the "High Impact" badge text is translated
* Ensure the thumbnail is correctly centred on mobile device screens that are wider than 480px
* Rejig how the subtitle of the insights section is calculated. It's best practice to not insert sentence fragments into other sentences i.e. not append " your site" onto the end of the sentence. It may work in English, but not necessarily in other languages. We're still inserting metric names into sentences, but this should be fine because these are proper nouns with Capital Letters. So they _should_ be translatable.

I haven't removed the old "V1" components and css in this PR because this PR is big enough as it is. I'll make a followup for that.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Unnecessary deviation of design between logged in and logged out views is a vector for bugs and regressions. We're less likely to introduce regressions in one view while maintaining the other.

Some sensible differences between the two views are still necessary e.g. one works with homepages only, while one works with specific pages on your site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test logged in view at `http://calypso.localhost:3000/sites/performance/philipmjackson76.wpcomstaging.com?filter=all`
* Test logged out view at `http://calypso.localhost:3000/speed-test-tool?url=https://philipmjackson76.wpcomstaging.com`

Compare with Figma Iix1FFHIQdfECIXn5JKT5s-fi-5426_141260

## Screenshots

**Logged out desktop**
![logged out desktop Speed Test _ WordPress_com](https://github.com/user-attachments/assets/caf8afe7-a414-434a-b40b-f823aa90e49d)

**Logged out mobile**
![logged out mobile Speed Test _ WordPress_com](https://github.com/user-attachments/assets/dbec2323-17cd-4516-859c-06911a880309)

**Logged in desktop**
![logged in Sites _ My WordPress Site _ WordPress_com](https://github.com/user-attachments/assets/e66aa06b-c066-447b-8a95-ef84364d1971)

**Logged in mobile**
![logged in mobile Sites _ My WordPress Site _ WordPress_com](https://github.com/user-attachments/assets/6fbde5d1-5b68-4791-9277-7cdde48e936f)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?