### PR TITLE
Help Center: Move HelpCenter navigation to header

### DIFF
--- a/packages/help-center/src/components/back-button.scss
+++ b/packages/help-center/src/components/back-button.scss
@@ -7,6 +7,7 @@
 		font-size: $font-body-small;
 		padding: 0;
 		gap: 4px;
+		cursor: pointer;
 	}
 
 	.help-center-back-button__header {
@@ -20,8 +21,5 @@
 		border-bottom: 1px solid var(--studio-gray-0);
 		padding: 0 16px;
 		box-sizing: border-box;
-	}
-	.back-button__help-center__drag {
-		cursor: move;
 	}
 }

--- a/packages/help-center/src/components/back-button.scss
+++ b/packages/help-center/src/components/back-button.scss
@@ -21,4 +21,7 @@
 		padding: 0 16px;
 		box-sizing: border-box;
 	}
+	.back-button__help-center__drag {
+		cursor: move;
+	}
 }

--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -1,24 +1,15 @@
 import { Icon, chevronLeft } from '@wordpress/icons';
-import clsx from 'clsx';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams, useLocation } from 'react-router-dom';
 
 import './back-button.scss';
 
-export type BackButtonProps = {
-	onClick?: () => void;
-	backToRoot?: boolean;
-	className?: string;
-	children?: React.ReactNode;
-};
-
-export const BackButton = ( { onClick, backToRoot = false, className }: BackButtonProps ) => {
+export const BackButton = () => {
 	const navigate = useNavigate();
 	const [ searchParams ] = useSearchParams();
+	const { pathname } = useLocation();
 
-	const buttonClassName = clsx( 'back-button__help-center', className );
-
-	function defaultOnClick() {
-		if ( backToRoot ) {
+	function handleClick() {
+		if ( pathname === '/success' ) {
 			navigate( '/' );
 		} else if ( searchParams.get( 'query' ) ) {
 			navigate( `/?query=${ searchParams.get( 'query' ) }` );
@@ -28,10 +19,10 @@ export const BackButton = ( { onClick, backToRoot = false, className }: BackButt
 	}
 
 	return (
-		<span className={ buttonClassName }>
+		<span className="back-button__help-center">
 			<Icon
 				data-testid="back-button-icon"
-				onClick={ onClick || defaultOnClick }
+				onClick={ handleClick }
 				icon={ chevronLeft }
 				size={ 18 }
 			/>

--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -52,7 +52,7 @@ export const BackButton = ( {
 
 	return (
 		<Button className={ buttonClassName } onClick={ onClick || defaultOnClick }>
-			<Icon icon={ key === 'default' ? <DragIcon /> : chevronLeft } size={ 18 } />
+			<Icon icon={ isHelpCenterHome ? <DragIcon /> : chevronLeft } size={ 18 } />
 			{ buttonText ?? defaultButtonText }
 		</Button>
 	);

--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -29,7 +29,12 @@ export const BackButton = ( { onClick, backToRoot = false, className }: BackButt
 
 	return (
 		<span className={ buttonClassName }>
-			<Icon onClick={ onClick || defaultOnClick } icon={ chevronLeft } size={ 18 } />
+			<Icon
+				data-testid="back-button-icon"
+				onClick={ onClick || defaultOnClick }
+				icon={ chevronLeft }
+				size={ 18 }
+			/>
 		</span>
 	);
 };

--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@wordpress/components';
 import { Icon, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
@@ -51,9 +50,13 @@ export const BackButton = ( {
 	}
 
 	return (
-		<Button className={ buttonClassName } onClick={ onClick || defaultOnClick }>
-			<Icon icon={ isHelpCenterHome ? <DragIcon /> : chevronLeft } size={ 18 } />
+		<span className={ buttonClassName }>
+			<Icon
+				onClick={ onClick || defaultOnClick }
+				icon={ isHelpCenterHome ? <DragIcon /> : chevronLeft }
+				size={ 18 }
+			/>
 			{ buttonText ?? defaultButtonText }
-		</Button>
+		</span>
 	);
 };

--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -1,8 +1,9 @@
-import { Button, Flex, FlexItem } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { Icon, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
+import { DragIcon } from '../icons';
 
 import './back-button.scss';
 
@@ -11,21 +12,27 @@ export type BackButtonProps = {
 	backToRoot?: boolean;
 	className?: string;
 	children?: React.ReactNode;
+	buttonText?: string;
 };
 
-export const BackButton = ( { onClick, backToRoot = false, className }: BackButtonProps ) => {
+export const BackButton = ( {
+	onClick,
+	backToRoot = false,
+	className,
+	buttonText,
+}: BackButtonProps ) => {
 	const { __ } = useI18n();
+	const defaultButtonText = __( 'Back', __i18n_text_domain__ );
 	const { key } = useLocation();
 	const navigate = useNavigate();
 	const [ searchParams ] = useSearchParams();
-	const buttonClassName = clsx( 'back-button__help-center', className );
+	const buttonClassName = clsx( 'back-button__help-center help-center-header__text', className );
 
 	function defaultOnClick() {
+		if ( key === 'default' ) {
+			return;
+		}
 		if ( backToRoot ) {
-			navigate( '/' );
-		} else if ( key === 'default' ) {
-			// Workaround to detect when we don't have prior history
-			// https://github.com/remix-run/react-router/discussions/9922#discussioncomment-4722480
 			navigate( '/' );
 		} else if ( searchParams.get( 'query' ) ) {
 			navigate( `/?query=${ searchParams.get( 'query' ) }` );
@@ -36,21 +43,8 @@ export const BackButton = ( { onClick, backToRoot = false, className }: BackButt
 
 	return (
 		<Button className={ buttonClassName } onClick={ onClick || defaultOnClick }>
-			<Icon icon={ chevronLeft } size={ 18 } />
-			{ __( 'Back', __i18n_text_domain__ ) }
+			<Icon icon={ key === 'default' ? <DragIcon /> : chevronLeft } size={ 18 } />
+			{ buttonText ?? defaultButtonText }
 		</Button>
-	);
-};
-
-export const BackButtonHeader = ( { children, className }: BackButtonProps ) => {
-	return (
-		<div className={ clsx( 'help-center-back-button__header', className ) }>
-			<Flex justify="space-between">
-				<FlexItem>
-					<BackButton />
-				</FlexItem>
-				{ children }
-			</Flex>
-		</div>
 	);
 };

--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -26,10 +26,19 @@ export const BackButton = ( {
 	const { key } = useLocation();
 	const navigate = useNavigate();
 	const [ searchParams ] = useSearchParams();
-	const buttonClassName = clsx( 'back-button__help-center help-center-header__text', className );
+	const isHelpCenterHome = key === 'default';
+
+	const buttonClassName = clsx(
+		'back-button__help-center help-center-header__text',
+		{
+			'back-button__help-center__drag': isHelpCenterHome,
+		},
+		className
+	);
 
 	function defaultOnClick() {
-		if ( key === 'default' ) {
+		// There's no where to navigate if users are already on home.
+		if ( isHelpCenterHome ) {
 			return;
 		}
 		if ( backToRoot ) {

--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -1,8 +1,6 @@
 import { Icon, chevronLeft } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
-import { DragIcon } from '../icons';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import './back-button.scss';
 
@@ -11,35 +9,15 @@ export type BackButtonProps = {
 	backToRoot?: boolean;
 	className?: string;
 	children?: React.ReactNode;
-	buttonText?: string;
 };
 
-export const BackButton = ( {
-	onClick,
-	backToRoot = false,
-	className,
-	buttonText,
-}: BackButtonProps ) => {
-	const { __ } = useI18n();
-	const defaultButtonText = __( 'Back', __i18n_text_domain__ );
-	const { key } = useLocation();
+export const BackButton = ( { onClick, backToRoot = false, className }: BackButtonProps ) => {
 	const navigate = useNavigate();
 	const [ searchParams ] = useSearchParams();
-	const isHelpCenterHome = key === 'default';
 
-	const buttonClassName = clsx(
-		'back-button__help-center help-center-header__text',
-		{
-			'back-button__help-center__drag': isHelpCenterHome,
-		},
-		className
-	);
+	const buttonClassName = clsx( 'back-button__help-center', className );
 
 	function defaultOnClick() {
-		// There's no where to navigate if users are already on home.
-		if ( isHelpCenterHome ) {
-			return;
-		}
 		if ( backToRoot ) {
 			navigate( '/' );
 		} else if ( searchParams.get( 'query' ) ) {
@@ -51,12 +29,7 @@ export const BackButton = ( {
 
 	return (
 		<span className={ buttonClassName }>
-			<Icon
-				onClick={ onClick || defaultOnClick }
-				icon={ isHelpCenterHome ? <DragIcon /> : chevronLeft }
-				size={ 18 }
-			/>
-			{ buttonText ?? defaultButtonText }
+			<Icon onClick={ onClick || defaultOnClick } icon={ chevronLeft } size={ 18 } />
 		</span>
 	);
 };

--- a/packages/help-center/src/components/help-center-article.tsx
+++ b/packages/help-center/src/components/help-center-article.tsx
@@ -1,28 +1,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button } from '@wordpress/components';
 import { useEffect, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, external } from '@wordpress/icons';
 import { useSearchParams } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { usePostByUrl } from '../hooks';
-import { BackButtonHeader } from './back-button';
 import { BackToTopButton } from './back-to-top-button';
 import ArticleContent from './help-center-article-content';
 
 import './help-center-article.scss';
-
-const ExternalLink = ( { href }: { href?: string } ) => {
-	if ( ! href ) {
-		return null;
-	}
-
-	return (
-		<Button href={ href } target="_blank" className="help-center-article__external-button">
-			<Icon icon={ external } size={ 20 } />
-		</Button>
-	);
-};
 
 export const HelpCenterArticle = () => {
 	const [ searchParams ] = useSearchParams();
@@ -70,9 +55,6 @@ export const HelpCenterArticle = () => {
 
 	return (
 		<div className="help-center-article">
-			<BackButtonHeader className="help-center-article__header">
-				<ExternalLink href={ post?.URL } />
-			</BackButtonHeader>
 			{ ! error && <ArticleContent post={ post } isLoading={ isLoading } /> }
 			{ ! isLoading && error && (
 				<p className="help-center-article__error">

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -38,7 +38,6 @@ import { queryClient } from '../query-client';
 import { HELP_CENTER_STORE } from '../stores';
 import { getSupportVariationFromMode } from '../support-variations';
 import { SearchResult } from '../types';
-import { BackButtonHeader } from './back-button';
 import { HelpCenterGPT } from './help-center-gpt';
 import HelpCenterSearchResults from './help-center-search-results';
 import { HelpCenterSitePicker } from './help-center-site-picker';
@@ -542,7 +541,6 @@ export const HelpCenterContactForm = () => {
 	if ( enableGPTResponse && showingGPTResponse ) {
 		return (
 			<>
-				<BackButtonHeader />
 				<div className="help-center-contact-form__wrapper">
 					<div className="help-center__articles-page">
 						<HelpCenterGPT
@@ -591,7 +589,6 @@ export const HelpCenterContactForm = () => {
 
 	return (
 		<>
-			<BackButtonHeader />
 			<div className="help-center-contact-form__wrapper">
 				{ showingSearchResults ? (
 					<div className="help-center__articles-page">

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -23,7 +23,6 @@ import { EMAIL_SUPPORT_LOCALES } from '../constants';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useChatStatus, useShouldRenderEmailOption, useStillNeedHelpURL } from '../hooks';
 import { Mail } from '../icons';
-import { BackButtonHeader } from './back-button';
 import HelpCenterContactSupportOption from './help-center-contact-support-option';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';
 import { generateContactOnClickEvent } from './utils';
@@ -155,7 +154,6 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 
 	return (
 		<div className="help-center-contact-page">
-			{ ! hideHeaders && <BackButtonHeader /> }
 			<div className="help-center-contact-page__content">
 				{ ! hideHeaders && (
 					<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
@@ -212,7 +210,7 @@ export const HelpCenterContactButton: FC = () => {
 			className="button help-center-contact-page__button"
 		>
 			<Icon icon={ comment } />
-			<span>{ __( 'Still need help?', __i18n_text_domain__ ) }</span>
+			<span>{ __( 'Start new conversation', __i18n_text_domain__ ) }</span>
 		</Link>
 	);
 };

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -210,7 +210,7 @@ export const HelpCenterContactButton: FC = () => {
 			className="button help-center-contact-page__button"
 		>
 			<Icon icon={ comment } />
-			<span>{ __( 'Start new conversation', __i18n_text_domain__ ) }</span>
+			<span>{ __( 'Still need help?', __i18n_text_domain__ ) }</span>
 		</Link>
 	);
 };

--- a/packages/help-center/src/components/help-center-content.scss
+++ b/packages/help-center/src/components/help-center-content.scss
@@ -12,9 +12,5 @@
 				box-sizing: border-box;
 			}
 		}
-
-		&.has-back-button-header {
-			margin-top: 50px;
-		}
 	}
 }

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -6,7 +6,6 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CardBody, Disabled } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
-import clsx from 'clsx';
 import React, { useState } from 'react';
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 /**
@@ -46,7 +45,6 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	currentRoute,
 } ) => {
 	const [ searchTerm, setSearchTerm ] = useState( '' );
-	const [ hasBackButtonHeader, setHasBackButtonHeader ] = useState( false );
 	const location = useLocation();
 	const containerRef = useRef< HTMLDivElement >( null );
 	const navigate = useNavigate();
@@ -97,20 +95,8 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 		}
 	}, [ location ] );
 
-	// The back button header requires extra styling to the container.
-	useEffect( () => {
-		setHasBackButtonHeader(
-			Boolean( containerRef.current?.querySelector( '.help-center-back-button__header' ) )
-		);
-	}, [ location ] );
-
 	return (
-		<CardBody
-			ref={ containerRef }
-			className={ clsx( 'help-center__container-content', {
-				'has-back-button-header': hasBackButtonHeader,
-			} ) }
-		>
+		<CardBody ref={ containerRef } className="help-center__container-content">
 			<Wrapper isDisabled={ isMinimized } className="help-center__container-content-wrapper">
 				<Routes>
 					<Route

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -37,12 +37,12 @@
 
 		.help-center-header__text {
 			margin: 1em 0;
-			font-size: $font-body-small;
+			font-size: $root-font-size;
 			font-weight: 500;
 			display: flex;
 			align-items: center;
 			flex: 1;
-			gap: 4px;
+			gap: 2px;
 
 			svg {
 				margin: 0;

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -36,7 +36,6 @@
 		}
 
 		.help-center-header__text {
-			margin: 1em 0;
 			font-size: $root-font-size;
 			font-weight: 500;
 			display: flex;
@@ -46,6 +45,9 @@
 
 			svg {
 				margin: 0;
+			}
+			:focus{
+				outline: none;
 			}
 
 			.help-center-header__article-title {

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -42,8 +42,7 @@
 			align-items: center;
 			flex: 1;
 			gap: 2px;
-			cursor: move;
-			margin: 0;
+			margin: 0 0 0 4px;
 
 			svg:not(.help-center__drag-icon) {
 				cursor: pointer;

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -42,9 +42,11 @@
 			align-items: center;
 			flex: 1;
 			gap: 2px;
+			cursor: move;
 
-			svg {
+			svg:not(.help-center__drag-icon) {
 				margin: 0;
+				cursor: pointer;
 			}
 			:focus{
 				outline: none;

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -43,11 +43,12 @@
 			flex: 1;
 			gap: 2px;
 			cursor: move;
+			margin: 0;
 
 			svg:not(.help-center__drag-icon) {
-				margin: 0;
 				cursor: pointer;
 			}
+			
 			:focus{
 				outline: none;
 			}

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -5,8 +5,8 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
 import { Route, Routes, useLocation, useSearchParams } from 'react-router-dom';
 import { usePostByUrl } from '../hooks';
-import { DragIcon } from '../icons';
 import { HELP_CENTER_STORE } from '../stores';
+import { BackButton } from './back-button';
 import type { Header } from '../types';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
@@ -57,13 +57,19 @@ const SupportModeTitle = () => {
 
 const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
 	const { __ } = useI18n();
+	const { pathname } = useLocation();
+
+	const getHeaderText = () => {
+		if ( pathname === '/odie' ) {
+			return __( 'Virtual Expert', __i18n_text_domain__ );
+		}
+		return __( 'Help Center', __i18n_text_domain__ );
+	};
 
 	return (
 		<>
 			<span id="header-text" className="help-center-header__text" role="presentation">
-				<DragIcon />
-
-				{ __( 'Help Center', __i18n_text_domain__ ) }
+				<BackButton buttonText={ getHeaderText() } />
 			</span>
 			<Button
 				className="help-center-header__minimize"

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -59,17 +59,15 @@ const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
 	const { __ } = useI18n();
 	const { pathname } = useLocation();
 
-	const getHeaderText = () => {
-		if ( pathname === '/odie' || pathname === '/contact-form' ) {
-			return __( 'Virtual Expert', __i18n_text_domain__ );
-		}
-		return __( 'Help Center', __i18n_text_domain__ );
-	};
+	const headerText =
+		pathname === '/odie' || pathname === '/contact-form'
+			? __( 'Virtual Expert', __i18n_text_domain__ )
+			: __( 'Help Center', __i18n_text_domain__ );
 
 	return (
 		<>
 			<span id="header-text" className="help-center-header__text" role="presentation">
-				<BackButton buttonText={ getHeaderText() } />
+				<BackButton buttonText={ headerText } />
 			</span>
 			<Button
 				className="help-center-header__minimize"
@@ -116,7 +114,7 @@ const ContentMinimized = ( {
 					<Route path="/contact-form" element={ <SupportModeTitle /> } />
 					<Route path="/post" element={ <ArticleTitle /> } />
 					<Route path="/success" element={ __( 'Message Submitted', __i18n_text_domain__ ) } />
-					<Route path="/odie" element={ __( 'Wapuu', __i18n_text_domain__ ) } />
+					<Route path="/odie" element={ __( 'Virtual Expert', __i18n_text_domain__ ) } />
 				</Routes>
 				{ unreadCount > 0 && (
 					<span className="help-center-header__unread-count">{ formattedUnreadCount }</span>

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -60,7 +60,7 @@ const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
 	const { pathname } = useLocation();
 
 	const getHeaderText = () => {
-		if ( pathname === '/odie' ) {
+		if ( pathname === '/odie' || pathname === '/contact-form' ) {
 			return __( 'Virtual Expert', __i18n_text_domain__ );
 		}
 		return __( 'Help Center', __i18n_text_domain__ );

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
 import { Route, Routes, useLocation, useSearchParams } from 'react-router-dom';
 import { usePostByUrl } from '../hooks';
+import { DragIcon } from '../icons';
 import { HELP_CENTER_STORE } from '../stores';
 import { BackButton } from './back-button';
 import type { Header } from '../types';
@@ -57,7 +58,8 @@ const SupportModeTitle = () => {
 
 const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
 	const { __ } = useI18n();
-	const { pathname } = useLocation();
+	const { pathname, key } = useLocation();
+	const isHelpCenterHome = key === 'default';
 
 	const headerText =
 		pathname === '/odie' || pathname === '/contact-form'
@@ -66,8 +68,9 @@ const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
 
 	return (
 		<>
-			<span id="header-text" className="help-center-header__text" role="presentation">
-				<BackButton buttonText={ headerText } />
+			{ isHelpCenterHome ? <DragIcon /> : <BackButton /> }
+			<span id="header-text" role="presentation" className="help-center-header__text">
+				{ headerText }
 			</span>
 			<Button
 				className="help-center-header__minimize"

--- a/packages/help-center/src/components/help-center-odie.tsx
+++ b/packages/help-center/src/components/help-center-odie.tsx
@@ -3,25 +3,16 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Gridicon } from '@automattic/components';
-import OdieAssistantProvider, {
-	OdieAssistant,
-	useOdieAssistantContext,
-	EllipsisMenu,
-	isOdieAllowedBot,
-} from '@automattic/odie-client';
+import OdieAssistantProvider, { OdieAssistant, isOdieAllowedBot } from '@automattic/odie-client';
 import { useSelect } from '@wordpress/data';
-import { useI18n } from '@wordpress/react-i18n';
 import React, { useCallback } from 'react';
 import { useNavigate, Navigate } from 'react-router-dom';
-import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useShouldUseWapuu } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
 /**
  * Internal Dependencies
  */
-import { BackButtonHeader } from './back-button';
 import { ExtraContactOptions } from './help-center-extra-contact-option';
 import './help-center-odie.scss';
 import type { HelpCenterSelect } from '@automattic/data-stores';
@@ -48,26 +39,6 @@ const ProtectedRoute: React.FC< ProtectedRouteProps > = ( {
 		return <Navigate to={ redirectPath } replace />;
 	}
 	return children;
-};
-
-const OdieEllipsisMenu = () => {
-	const { __ } = useI18n();
-	const { clearChat } = useOdieAssistantContext();
-
-	return (
-		<EllipsisMenu
-			popoverClassName="help-center help-center__container-header-menu"
-			position="bottom"
-		>
-			<PopoverMenuItem
-				onClick={ clearChat }
-				className="help-center help-center__container-header-menu-item"
-			>
-				<Gridicon icon="comment" />
-				{ __( 'Clear Conversation' ) }
-			</PopoverMenuItem>
-		</EllipsisMenu>
-	);
 };
 
 export function HelpCenterOdie( {
@@ -141,11 +112,6 @@ export function HelpCenterOdie( {
 				isUserEligible={ isUserEligible }
 			>
 				<div className="help-center__container-content-odie">
-					<div className="help-center__container-odie-header">
-						<BackButtonHeader className="help-center__container-odie-back-button">
-							<OdieEllipsisMenu />
-						</BackButtonHeader>
-					</div>
 					<OdieAssistant />
 				</div>
 			</OdieAssistantProvider>

--- a/packages/help-center/src/components/help-center-third-party-cookies-notice.tsx
+++ b/packages/help-center/src/components/help-center-third-party-cookies-notice.tsx
@@ -5,7 +5,6 @@ import { useEffect } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
-import { BackButtonHeader } from './back-button';
 
 import './help-center-third-party-cookies-notice.scss';
 
@@ -23,8 +22,6 @@ const ThirdPartyCookiesNotice: React.FC = () => {
 
 	return (
 		<div className="help-center-third-party-cookies-notice">
-			<BackButtonHeader />
-
 			<div className="help-center-third-party-cookies-notice__content">
 				<h1>{ __( 'Action needed', __i18n_text_domain__ ) }</h1>
 				<p>

--- a/packages/help-center/src/components/test/back-button.tsx
+++ b/packages/help-center/src/components/test/back-button.tsx
@@ -22,20 +22,6 @@ describe( 'BackButton', () => {
 		mockNavigate.mockClear();
 	} );
 
-	it( 'navigates to the root when back to root is true', async () => {
-		const user = userEvent.setup();
-
-		render(
-			<MemoryRouter initialEntries={ testEntries }>
-				<BackButton backToRoot />
-			</MemoryRouter>
-		);
-
-		await user.click( screen.getByTestId( 'back-button-icon' ) );
-
-		expect( mockNavigate ).toHaveBeenCalledWith( '/' );
-	} );
-
 	it( 'navigates to the previous page by default', async () => {
 		const user = userEvent.setup();
 
@@ -62,21 +48,5 @@ describe( 'BackButton', () => {
 		await user.click( screen.getByTestId( 'back-button-icon' ) );
 
 		expect( mockNavigate ).not.toHaveBeenCalledWith( '/' );
-	} );
-
-	it( 'calls a custom onClick handler when defined instead of modifying history', async () => {
-		const user = userEvent.setup();
-		const onClickSpy = jest.fn();
-
-		render(
-			<MemoryRouter initialEntries={ testEntries }>
-				<BackButton onClick={ onClickSpy } />
-			</MemoryRouter>
-		);
-
-		await user.click( screen.getByTestId( 'back-button-icon' ) );
-
-		expect( onClickSpy ).toHaveBeenCalled();
-		expect( mockNavigate ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/help-center/src/components/test/back-button.tsx
+++ b/packages/help-center/src/components/test/back-button.tsx
@@ -50,7 +50,7 @@ describe( 'BackButton', () => {
 		expect( mockNavigate ).toHaveBeenCalledWith( -1 );
 	} );
 
-	it( "navigates to root when there's no history", async () => {
+	it( 'does not navigate if user is already on homepage', async () => {
 		const user = userEvent.setup();
 
 		render(
@@ -61,7 +61,7 @@ describe( 'BackButton', () => {
 
 		await user.click( screen.getByRole( 'button' ) );
 
-		expect( mockNavigate ).toHaveBeenCalledWith( '/' );
+		expect( mockNavigate ).not.toHaveBeenCalledWith( '/' );
 	} );
 
 	it( 'calls a custom onClick handler when defined instead of modifying history', async () => {

--- a/packages/help-center/src/components/test/back-button.tsx
+++ b/packages/help-center/src/components/test/back-button.tsx
@@ -31,7 +31,7 @@ describe( 'BackButton', () => {
 			</MemoryRouter>
 		);
 
-		await user.click( screen.getByRole( 'button' ) );
+		await user.click( screen.getByTestId( 'back-button-icon' ) );
 
 		expect( mockNavigate ).toHaveBeenCalledWith( '/' );
 	} );
@@ -45,7 +45,7 @@ describe( 'BackButton', () => {
 			</MemoryRouter>
 		);
 
-		await user.click( screen.getByRole( 'button' ) );
+		await user.click( screen.getByTestId( 'back-button-icon' ) );
 
 		expect( mockNavigate ).toHaveBeenCalledWith( -1 );
 	} );
@@ -59,7 +59,7 @@ describe( 'BackButton', () => {
 			</MemoryRouter>
 		);
 
-		await user.click( screen.getByRole( 'button' ) );
+		await user.click( screen.getByTestId( 'back-button-icon' ) );
 
 		expect( mockNavigate ).not.toHaveBeenCalledWith( '/' );
 	} );
@@ -74,7 +74,7 @@ describe( 'BackButton', () => {
 			</MemoryRouter>
 		);
 
-		await user.click( screen.getByRole( 'button' ) );
+		await user.click( screen.getByTestId( 'back-button-icon' ) );
 
 		expect( onClickSpy ).toHaveBeenCalled();
 		expect( mockNavigate ).not.toHaveBeenCalled();

--- a/packages/help-center/src/components/ticket-success-screen.tsx
+++ b/packages/help-center/src/components/ticket-success-screen.tsx
@@ -4,7 +4,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
-import { BackButton } from './back-button';
 import { SuccessIcon } from './success-icon';
 
 import './ticket-success-screen.scss';
@@ -25,7 +24,6 @@ export const SuccessScreen: React.FC = () => {
 
 	return (
 		<div>
-			<BackButton backToRoot />
 			<div className="ticket-success-screen__help-center">
 				<SuccessIcon />
 				<h1 className="ticket-success-screen__help-center-heading">

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -111,6 +111,10 @@
 			.help-center__container-content {
 				display: none;
 			}
+			
+			.help-center-header__text {
+				cursor: pointer;
+			}
 		}
 	}
 
@@ -121,7 +125,7 @@
 		bottom: 0;
 		left: 0;
 		right: 0;
-		// If the masterbar is there, don't cover it, if not, go to the top.
+		/* If the masterbar is there, don't cover it, if not, go to the top. */
 		top: var(--masterbar-height, 0);
 		max-height: calc(100% - 45px);
 		height: calc(100% - var(--masterbar-height, 0));

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -96,6 +96,7 @@
 		height: 80vh;
 		max-height: 800px;
 		box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.12), 0 3px 1px 0 rgba(0, 0, 0, 0.04);
+		border-radius: 2px;
 
 		&.is-minimized {
 			min-height: $head-foot-height;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9226

## Proposed Changes

* This is the 1st step to addressing the design changes being made on the HelpCenter. It integrates the navigation on the HelpCenter header, as in the design CMvR9P4FontAbv2b0TNMzj-fi-282_50631
There will be other PR's addressing other design changes, we decided to split like this to avoid massive PRs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and navigate to /home or anywhere where the help center is available
* Make sure the navigation is moved to the header and the back button is working fine
* Please check any possible regressions by navigating in the HelpCenter

| Old | New |
|--------|--------|
| <img width="414" alt="image" src="https://github.com/user-attachments/assets/49d893e9-e7d3-4f5e-86b8-f223f0739e39"> | <img width="412" alt="image" src="https://github.com/user-attachments/assets/5f48ebd8-f4f1-4502-a8a3-c567db13d9aa"> | 