### PR TITLE
White-labeled plugin: Install the wpcom-migration plugin from wp.org

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { captureException } from '@automattic/calypso-sentry';
 import { CircularProgressBar } from '@automattic/components';
 import { LaunchpadContainer } from '@automattic/launchpad';
@@ -6,10 +5,7 @@ import { StepContainer } from '@automattic/onboarding';
 import { useEffect } from 'react';
 import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-migration-sticker';
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
-import {
-	usePrepareSiteForMigrationWithMigrateGuru,
-	usePrepareSiteForMigrationWithMigrateToWPCOM,
-} from 'calypso/landing/stepper/hooks/use-prepare-site-for-migration';
+import { usePrepareSiteForMigration } from 'calypso/landing/stepper/hooks/use-prepare-site-for-migration';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -99,9 +95,7 @@ const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
 		completed: preparationCompleted,
 		error: preparationError,
 		migrationKey,
-	} = config.isEnabled( 'migration-flow/enable-white-labeled-plugin' )
-		? usePrepareSiteForMigrationWithMigrateToWPCOM( siteId ) // eslint-disable-line react-hooks/rules-of-hooks -- Temporary workaround until we completely replace the migrate guru hook.
-		: usePrepareSiteForMigrationWithMigrateGuru( siteId ); // eslint-disable-line react-hooks/rules-of-hooks
+	} = usePrepareSiteForMigration( siteId );
 	const migrationKeyStatus = detailedStatus.migrationKey;
 
 	// Register events and logs.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-migration-sticker';
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
-import { usePrepareSiteForMigrationWithMigrateGuru } from 'calypso/landing/stepper/hooks/use-prepare-site-for-migration';
+import { usePrepareSiteForMigration } from 'calypso/landing/stepper/hooks/use-prepare-site-for-migration';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -49,7 +49,7 @@ describe( 'SiteMigrationInstructions', () => {
 			deleteMigrationSticker: jest.fn(),
 		} );
 
-		( usePrepareSiteForMigrationWithMigrateGuru as jest.Mock ).mockReturnValue( {
+		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
 			detailedStatus: {},
 			completed: false,
 			migrationKey: 'migration-key-here',
@@ -160,7 +160,7 @@ describe( 'SiteMigrationInstructions', () => {
 	} );
 
 	it( 'should display a fallback in the last step when preparation completes and there is an error with the migration key', async () => {
-		( usePrepareSiteForMigrationWithMigrateGuru as jest.Mock ).mockReturnValue( {
+		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
 			detailedStatus: { migrationKey: 'error' },
 			completed: true,
 			migrationKey: '',
@@ -178,7 +178,7 @@ describe( 'SiteMigrationInstructions', () => {
 	} );
 
 	it( 'should animate skeleton when waiting for completion', async () => {
-		( usePrepareSiteForMigrationWithMigrateGuru as jest.Mock ).mockReturnValue( {
+		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
 			detailedStatus: {},
 			completed: false,
 			migrationKey: '',
@@ -196,7 +196,7 @@ describe( 'SiteMigrationInstructions', () => {
 	} );
 
 	it( 'should not animate skeleton when error happens', async () => {
-		( usePrepareSiteForMigrationWithMigrateGuru as jest.Mock ).mockReturnValue( {
+		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
 			detailedStatus: {},
 			completed: false,
 			migrationKey: '',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/94750 https://github.com/Automattic/dotcom-forge/issues/9171 

## Proposed Changes

* Now that the new plugin is on wp.org, this updates the following:
  * Reverts https://github.com/Automattic/wp-calypso/pull/94677 because we'll no longer install the plugin using the Atomic backend. The decision is documented here: p1727799668680179-slack-C07GG60B2AD
  * Switching back to using the `usePrepareSiteForMigration` hook to install the plugin when the feature flag is enabled. This is the original hook used for installing the Migrate Guru plugin, no modifications are made.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The white-labeled plugin is now on wp.org, so we're switching to installing the plugin from there instead of relying on the Atomic backend.

## Testing Instructions

* Switch to PR, navigate to `/setup/migration-signup`.
* Ensure the `migration-flow/enable-white-labeled-plugin` feature flag is enabled. One option is to update your session storage by running the following in your console, hitting enter, and reloading: `window.sessionStorage.setItem('flags', 'migration-flow/enable-white-labeled-plugin');`
* Go through the flow to migrate a site. This includes having a site to migrate (you can use jurassic.ninja), checking out the business plan, following the migration instructions, and waiting for the provisioning steps to complete.
* Make sure the plugin is installed and the migration key can be retrieved. Check out the video below.
* (optional) You can test the other migration flows:
  * `/setup/hosted-site-migration`
  * `/start` -> `Import existing content or website` -> `Migrate Site` -> `I'll do it myself`


https://github.com/user-attachments/assets/94bfbe30-adfb-402a-ac5f-bce50babdd97



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?