### PR TITLE
[Odie] Use canned response when available

### DIFF
--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -18,6 +18,7 @@ export const UserMessage = ( {
 	onDislike: () => void;
 } ) => {
 	const { extraContactOptions, isUserEligible } = useOdieAssistantContext();
+	const hasCannedResponse = message.context?.flags?.canned_response;
 	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support;
 	const hasFeedback = !! message?.rating_value;
 	const isUser = message.role === 'user';
@@ -36,6 +37,7 @@ export const UserMessage = ( {
 	);
 
 	const forwardMessage = isUserEligible ? supportHappinessWording : supportForumWording;
+	const displayMessage = isUserEligible && hasCannedResponse ? message.content : forwardMessage;
 
 	return (
 		<>
@@ -45,7 +47,7 @@ export const UserMessage = ( {
 					a: CustomALink,
 				} }
 			>
-				{ isRequestingHumanSupport ? forwardMessage : message.content }
+				{ isRequestingHumanSupport ? displayMessage : message.content }
 			</Markdown>
 			{ showExtraContactOptions && extraContactOptions }
 			{ ! hasFeedback && ! isUser && (


### PR DESCRIPTION
## Proposed Changes

The canned response flag was not being into account at all. This fix address it

## Why are these changes being made?
If we have a canned_response coming from Odie, we still using the canned_response we have stored in Calypso. This issue made not to be able to configure Odie as its fullest customisation.

## Testing Instructions
Instructions are in our OneBin tool, with ID: 35d63

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
