### PR TITLE
Remove plan: Fix button changing its text after submit

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -283,7 +283,9 @@ class CancelPurchaseForm extends Component {
 					} );
 				} );
 
-			this.props.cancelPurchaseSurveyCompleted( purchase.id );
+			if ( this.props.flowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW ) {
+				this.props.cancelPurchaseSurveyCompleted( purchase.id );
+			}
 		}
 
 		this.props.onClickFinalConfirm();

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -596,6 +596,10 @@ class CancelPurchaseForm extends Component {
 		const { surveyStep, isSubmitting } = this.state;
 		const { disableButtons, isImport } = this.props;
 
+		if ( disableButtons || isSubmitting ) {
+			return false;
+		}
+
 		if ( surveyStep === FEEDBACK_STEP ) {
 			if ( isImport && ! this.state.importQuestionRadio ) {
 				return false;

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -540,7 +540,7 @@ class CancelPurchaseForm extends Component {
 									{
 										// Translators: %(planName)s: name of the plan being canceled, eg: "WordPress.com Business"
 										translate(
-											'If you remove your subscription, you will lose access to the features of the %(planName)s plan.',
+											'If you remove your plan, you will lose access to the features of the %(planName)s plan.',
 											{
 												args: {
 													planName: productName,
@@ -553,7 +553,7 @@ class CancelPurchaseForm extends Component {
 									{
 										// Translators: %(planName)s: name of the plan being canceled, eg: "WordPress.com Business". %(purchaseRenewalDate)s: date when the plan will expire, eg: "January 1, 2022"
 										translate(
-											'If you keep your subscription, you will be able to continue using your %(planName)s plan features until {{strong}}%(purchaseRenewalDate)s{{/strong}}.',
+											'If you keep your plan, you will be able to continue using your %(planName)s plan features until {{strong}}%(purchaseRenewalDate)s{{/strong}}.',
 											{
 												args: {
 													planName: productName,

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -29,7 +29,7 @@
 }
 
 .cancel-purchase-form__remove-plan .formatted-header__subtitle {
-	max-width: 290px;
+	max-width: 500px;
 	margin: 0 auto;
 }
 


### PR DESCRIPTION
@mmtr noticed a weird text change on https://github.com/Automattic/wp-calypso/pull/94901, this PR fixes that

## Proposed Changes

Fix the text change while also making sure it's disabled after submit. Also, adjust the text width on the remove plan step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/me/purchases`
* On a non-atomic website, cancel the auto renew
* Click on `Remove plan`
* Check that the `Submit` buttons behave properly throughout the flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
