### PR TITLE
Help Center: Fix `<ol>` font-size and color on Help Center

### DIFF
--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -124,6 +124,11 @@
 				margin: 0 0 1.5em 1.5em;
 			}
 
+			ol {
+				font-size: $font-body-small;
+				color: var(--color-neutral-80);
+			}
+
 			span.noticon.noticon-star {
 				color: var(--studio-yellow-20);
 			}

--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -111,7 +111,7 @@
 				}
 			}
 
-			p {
+			p, ol {
 				font-size: $font-body-small;
 				color: var(--color-neutral-80);
 			}
@@ -122,11 +122,6 @@
 				list-style-type: circle;
 				list-style-position: inside;
 				margin: 0 0 1.5em 1.5em;
-			}
-
-			ol {
-				font-size: $font-body-small;
-				color: var(--color-neutral-80);
 			}
 
 			span.noticon.noticon-star {

--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -111,7 +111,7 @@
 				}
 			}
 
-			p, ol {
+			p, ol.wp-block-list {
 				font-size: $font-body-small;
 				color: var(--color-neutral-80);
 			}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/95115

## Proposed Changes

* Fix `<ol>` font-size and color on Help Center

**Before**
<img width="400" alt="Screenshot 2024-10-03 at 10 38 51" src="https://github.com/user-attachments/assets/ebefb7fe-815d-4821-aafa-20154f486179">

**After**
<img width="400" alt="Screenshot 2024-10-03 at 10 38 14" src="https://github.com/user-attachments/assets/ad9d9001-1fac-4393-ba27-9fb13bb2f635">


## Why are these changes being made?

* Wrong font size for `ol` blocks on the Help Center. Color is also slightly different, so I applied the same color from `ul` blocks.

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/hosting-config/{site-slug}
* Scroll down to the **Defensive mode** section
* Click on "Learn More"
* You should see the Help Center on the right side
* In the Help Center, scroll down to the ordered list
  * It's placed after "To enable defensive mode, take the following steps:" paragraph
* The font size and color for the ordered list should match with the other paragraphs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
