### PR TITLE
Plugin installation screen: Update header

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -10,7 +10,6 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
 import EmptyContent from 'calypso/components/empty-content';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
-import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useInterval } from 'calypso/lib/interval';
@@ -493,7 +492,6 @@ const MarketplaceProductInstall = ( {
 			{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 			<Masterbar className="marketplace-plugin-install__masterbar">
 				<WordPressWordmark className="marketplace-plugin-install__wpcom-wordmark" />
-				<Item>{ translate( 'Marketplace installation' ) }</Item>
 			</Masterbar>
 			<div className="marketplace-plugin-install__root">
 				{ renderError() || (

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -1,7 +1,7 @@
 import { PLAN_BUSINESS, WPCOM_FEATURES_ATOMIC, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { WordPressWordmark, Button } from '@automattic/components';
-import { ThemeProvider } from '@emotion/react';
+import { Button } from '@automattic/components';
+import { css, Global, ThemeProvider } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useMemo, useRef } from 'react';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
@@ -9,6 +9,7 @@ import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
 import EmptyContent from 'calypso/components/empty-content';
+import WordPressLogo from 'calypso/components/wordpress-logo';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -491,7 +492,14 @@ const MarketplaceProductInstall = ( {
 			<QueryActiveTheme siteId={ siteId } />
 			{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 			<Masterbar className="marketplace-plugin-install__masterbar">
-				<WordPressWordmark className="marketplace-plugin-install__wpcom-wordmark" />
+				<Global
+					styles={ css`
+						body {
+							--masterbar-height: 72px;
+						}
+					` }
+				/>
+				<WordPressLogo className="marketplace-plugin-install__logo" size={ 24 } />
 			</Masterbar>
 			<div className="marketplace-plugin-install__root">
 				{ renderError() || (

--- a/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
@@ -3,20 +3,17 @@ body.is-section-marketplace.theme-default.color-scheme {
 }
 
 .marketplace-plugin-install__masterbar {
-	display: flex;
-	align-items: baseline;
-	justify-content: flex-start;
+	--color-masterbar-background: var(--studio-white);
+	--color-masterbar-text: var(--studio-gray-60);
+	padding-right: 24px;
+	border-bottom: 0;
 
-	.marketplace-plugin-install__wpcom-wordmark {
-		align-self: center;
-		margin-left: 10px;
-	}
-
-	.masterbar__item,
-	.masterbar__item:hover {
-		color: var(--color-primary-5);
-		flex-grow: 0;
-		background: var(--color-masterbar-background);
+	.marketplace-plugin-install__logo {
+		fill: rgb(54, 54, 54);
+		margin: 24px 12px 24px 24px;
+		@media (min-width: 480px) {
+			margin: 24px;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/93590

## Proposed Changes

* Replace the current purple header with just the WP logo in the top left corner

## Testing Instructions

* Open the live preview
* Go to `/sites`
* On an atomic site, click on the menu and go to `Plugins`
* Install a plugin, check that the installation screen doesn't have a purple header and shows the WP logo instead:

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/0143aefe-27a6-42f0-8912-0fc9c85abadf)|![image](https://github.com/user-attachments/assets/812f68d6-b681-40cf-ae33-989b9788722e)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
