### PR TITLE
Issue templates: add new issue type option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Helps us improve our product!
-labels: "Needs triage, [Type] Bug"
+labels: ["Needs triage", "[Type] Bug"]
+type: 'Bug'
 body:
   - type: markdown
     attributes:
@@ -93,7 +94,7 @@ body:
     attributes:
       value: |
         <br>
-        
+
         ## Optional Information
 
         The following section is optional.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Suggest an idea for Calypso!
 title: "Feature Request:"
+type: 'Enhancement'
 labels: ["[Type] Feature Request"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,6 +1,7 @@
 name: Task
 description: Create a task
 title: "Task:"
+type: 'Task'
 labels: ["[Type] Task"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/tooling_request.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_request.yml
@@ -2,6 +2,7 @@ name: Tooling Request
 description: Bug or feature request related to scripts, tooling, DevX, etc.
 title: 'Tooling:'
 labels: '[Type] Tooling'
+type: 'Enhancement'
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION

## Proposed Changes

This was added as an option as part of this set of changes to GitHub issues:
https://github.blog/changelog/2024-10-01-evolving-github-issues-public-preview/

## Why are these changes being made?

Once this is merged, all new issues created via the issue templates will have an issue type automatically added.

## Testing Instructions

Not much to test here, we'll need to wait until this is merged.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
