### PR TITLE
Plans: update grid for introductory offers (formerly 86434)

### DIFF
--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -65,12 +65,11 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 					<div className="plans-grid-next-header-price__pricing-group is-large-currency">
 						<PlanPrice
 							currencyCode={ currencyCode }
-							rawPrice={ 0 }
+							rawPrice={ originalPrice.monthly }
 							displayPerMonthNotation={ false }
 							isLargeCurrency
 							isSmallestUnit
 							priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
-							className="is-placeholder-price" // This is a placeholder price to keep the layout consistent
 							original
 						/>
 						<PlanPrice

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -109,23 +109,23 @@ export default function usePlanBillingDescription( {
 	 */
 	if ( introOffer?.intervalCount && introOffer.intervalUnit && ! introOffer.isOfferComplete ) {
 		if ( originalPriceFullTermText ) {
+			/* Introductory offers for monthly plans */
 			if ( isMonthlyPlan ) {
-				if ( 1 === introOffer.intervalCount ) {
-					return translate(
-						'per month, for your first %(introOfferIntervalUnit)s,{{br/}}' +
-							'then %(rawPrice)s billed monthly, excl. taxes',
-						{
-							args: {
-								rawPrice: originalPriceFullTermText,
-								introOfferIntervalUnit: introOffer.intervalUnit,
-							},
-							components: { br: <br /> },
-							comment: 'excl. taxes is short for excluding taxes',
-						}
-					);
-				}
-
+				/* If the offer is for X months */
 				if ( 'month' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'for your first month,{{br/}}' + 'then %(rawPrice)s billed monthly, excl. taxes',
+							{
+								args: {
+									rawPrice: originalPriceFullTermText,
+								},
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
 						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
 							'then %(rawPrice)s billed monthly, excl. taxes',
@@ -140,7 +140,21 @@ export default function usePlanBillingDescription( {
 					);
 				}
 
+				/* If the offer is for X years of monthly intervals */
 				if ( 'year' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'for your first year,{{br/}}' + 'then %(rawPrice)s billed monthly, excl. taxes',
+							{
+								args: {
+									rawPrice: originalPriceFullTermText,
+								},
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
 						'per month, for your first %(introOfferIntervalCount)s years,{{br/}}' +
 							'then %(rawPrice)s billed monthly, excl. taxes',
@@ -156,23 +170,24 @@ export default function usePlanBillingDescription( {
 				}
 			}
 
+			/* Introductory offers for yearly plans */
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-				if ( 1 === introOffer.intervalCount ) {
-					return translate(
-						'per month, for your first %(introOfferIntervalUnit)s,{{br/}}' +
-							'then %(rawPrice)s billed annually, excl. taxes',
-						{
-							args: {
-								rawPrice: originalPriceFullTermText,
-								introOfferIntervalUnit: introOffer.intervalUnit,
-							},
-							components: { br: <br /> },
-							comment: 'excl. taxes is short for excluding taxes',
-						}
-					);
-				}
-
+				/* If the offer is for X months of a yearly plan */
 				if ( 'month' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'for your first month,{{br/}}' + 'then %(rawPrice)s billed annually, excl. taxes',
+							{
+								args: {
+									rawPrice: originalPriceFullTermText,
+									introOfferIntervalUnit: introOffer.intervalUnit,
+								},
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
 						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
 							'then %(rawPrice)s billed annually, excl. taxes',
@@ -187,12 +202,29 @@ export default function usePlanBillingDescription( {
 					);
 				}
 
+				/* If the offer is for X years of a yearly plan */
 				if ( 'year' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'per month, %(introOfferFormattedPrice)s for your first year,{{br/}}' +
+								'then %(rawPrice)s billed annually, excl. taxes',
+							{
+								args: {
+									introOfferFormattedPrice: introOffer.formattedPrice,
+									rawPrice: originalPriceFullTermText,
+								},
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
-						'per month, for your first %(introOfferIntervalCount)s years,{{br/}}' +
+						'per month, %(introOfferFormattedPrice)s for your first %(introOfferIntervalCount)s years,{{br/}}' +
 							'then %(rawPrice)s billed annually, excl. taxes',
 						{
 							args: {
+								introOfferFormattedPrice: introOffer.formattedPrice,
 								rawPrice: originalPriceFullTermText,
 								introOfferIntervalCount: introOffer.intervalCount,
 							},


### PR DESCRIPTION
This updates the plans grid to properly account for different introductory offers for WPcom plans. It updates the Introductory Offer plan descriptions and consolidates some of the display logic between discounts and introductory offers.

This is a re-make of https://github.com/Automattic/wp-calypso/pull/86434 which had fallen out of date. I've rebased this and removed the merge conflicts.

Requires: D134559-code
See: pbOQVh-4sd-p2

Before             |  After
:-------------------------:|:-------------------------:
<img width="712" alt="Screenshot 2024-10-03 at 5 16 51 PM" src="https://github.com/user-attachments/assets/04a2a845-3109-4967-b96c-6ba147293bee"> | <img width="706" alt="Screenshot 2024-10-03 at 6 14 15 PM" src="https://github.com/user-attachments/assets/9305d158-1809-4886-88b8-4791d5c8f475">
<img width="1050" alt="Screenshot 2024-10-03 at 5 16 59 PM" src="https://github.com/user-attachments/assets/084320cb-1d6a-424f-974c-61ae813dc6dc"> | <img width="1048" alt="Screenshot 2024-10-03 at 6 15 16 PM" src="https://github.com/user-attachments/assets/411af692-ca90-4098-bb9b-1682ee76aad6">

**To test:**
- enable Store Sandbox and sandbox `public-api.wordpress.com`
- create a new user, or use a user that has not previously subscribed to one of these plans
- change your user currency to MXN, PHP, or INR
- create a new site and verify that the different plans grids correctly reflect the introductory offer pricing (reduced monthly breakdown, intro offer full price in the description, and correct billing term in the description)