### PR TITLE
Stepper: Redirect to start when domain is missing on Connect-domain flow

### DIFF
--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -58,7 +58,7 @@ const connectDomain: Flow = {
 		);
 
 		if ( ! domain ) {
-			redirect( ` /setup/${ CONNECT_DOMAIN_FLOW }` ); //TODO
+			redirect( '/start' );
 			result = {
 				state: AssertConditionState.FAILURE,
 				message: 'connect-domain requires a domain query parameter',


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/95121

## Proposed Changes

* Redirect to start step when domain is missing on Connect-domain flow

## Why are these changes being made?

* The Connect-domain flow loops when the domain is missing.

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/connect-domain
* You should be redirected back to the start step
* Go to http://calypso.localhost:3000/setup/connect-domain?domain={test-domain}
* The flow should work as before, redirecting to the plans page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
