### PR TITLE
Calypso 404: Redirect user to selected site home when 404 return home is clicked

### DIFF
--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -37,7 +37,7 @@ describe( 'Logged Out Landing Page', () => {
 
 describe( 'Logged In Landing Page', () => {
 	test( 'user with no sites goes to Sites Dashboard', async () => {
-		const state = { currentUser: { id: 1 }, sites: { items: {} } };
+		const state = { currentUser: { id: 1 }, sites: { items: {} }, ui: {} };
 		const { page } = initRouter( { state } );
 
 		page( '/' );
@@ -48,6 +48,7 @@ describe( 'Logged In Landing Page', () => {
 	test( 'user with a primary site but no permissions goes to day stats', async () => {
 		const state = {
 			currentUser: { id: 1, capabilities: { 1: {} }, user: { primary_blog: 1 } },
+			ui: {},
 			sites: {
 				items: {
 					1: {
@@ -67,6 +68,7 @@ describe( 'Logged In Landing Page', () => {
 	test( 'user with a primary site and edit permissions goes to My Home', async () => {
 		const state = {
 			currentUser: { id: 1, capabilities: { 1: { edit_posts: true } }, user: { primary_blog: 1 } },
+			ui: {},
 			sites: {
 				items: {
 					1: {
@@ -86,6 +88,7 @@ describe( 'Logged In Landing Page', () => {
 	test( 'user with a Jetpack site set as their primary site goes to day stats', async () => {
 		const state = {
 			currentUser: { id: 1, capabilities: { 1: { edit_posts: true } }, user: { primary_blog: 1 } },
+			ui: {},
 			sites: {
 				items: {
 					1: {
@@ -115,6 +118,7 @@ describe( 'Logged In Landing Page', () => {
 					'sites-landing-page': { useSitesAsLandingPage: true, updatedAt: 1111 },
 				},
 			},
+			ui: {},
 			sites: {
 				items: {
 					1: {
@@ -134,5 +138,33 @@ describe( 'Logged In Landing Page', () => {
 		page( '/' );
 
 		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
+	} );
+
+	test( 'user with a selected site and edit permissions goes to My Home', async () => {
+		const state = {
+			currentUser: {
+				id: 1,
+				capabilities: { 1: { edit_posts: true }, 2: { edit_posts: true } },
+				user: { primary_blog: 1 },
+			},
+			ui: { selectedSiteId: 2 },
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+					},
+					2: {
+						ID: 2,
+						URL: 'https://selected.wordpress.com',
+					},
+				},
+			},
+		};
+		const { page } = initRouter( { state } );
+
+		page( '/' );
+
+		await waitFor( () => expect( page.current ).toBe( '/home/selected.wordpress.com' ) );
 	} );
 } );

--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -140,7 +140,7 @@ describe( 'Logged In Landing Page', () => {
 		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
 	} );
 
-	test( 'user with a selected site and edit permissions goes to My Home', async () => {
+	test( 'user with a selected site goes to My Home for Default Style interface', async () => {
 		const state = {
 			currentUser: {
 				id: 1,
@@ -157,6 +157,7 @@ describe( 'Logged In Landing Page', () => {
 					2: {
 						ID: 2,
 						URL: 'https://selected.wordpress.com',
+						options: { wpcom_admin_interface: 'calypso' },
 					},
 				},
 			},
@@ -166,5 +167,44 @@ describe( 'Logged In Landing Page', () => {
 		page( '/' );
 
 		await waitFor( () => expect( page.current ).toBe( '/home/selected.wordpress.com' ) );
+	} );
+
+	test( 'user with a selected site goes to WP Admin Dashboard for Classic Style interface', async () => {
+		const state = {
+			currentUser: {
+				id: 1,
+				capabilities: { 1: { edit_posts: true } },
+				user: { primary_blog: 1 },
+			},
+			ui: { selectedSiteId: 1 },
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+						options: {
+							wpcom_admin_interface: 'wp-admin',
+							admin_url: 'https://test.wordpress.com/wp-admin/',
+						},
+					},
+				},
+			},
+		};
+
+		const { page } = initRouter( { state } );
+
+		Object.defineProperty( window, 'location', {
+			value: {
+				assign: jest.fn(),
+			},
+		} );
+
+		page( '/' );
+
+		await waitFor( () => {
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				'https://test.wordpress.com/wp-admin/'
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/94938

## Proposed Changes
Currently if the user encounters 404 on a selected site, the `return home` button redirects to the dashboard of their primary site which is not desirable. This PR

* Returns to the selected site home/dashboard if 404 happens on a selected site route

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As an improvement to the user experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* At `wordpress.com/me/account ` ensure `Admin home is disabled
* Go to `/dev-tools/selectedSite`
* Verify the 404 CTA redirects to the selected site home
* Verify that if there are no selected site eg. `/dev-tools/` the CTA redirects to the home of your primary site. Ensure a primary site is set on the account.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
