### PR TITLE
Odyssey: Fix post like counts

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -109,12 +109,12 @@ class StatsPostDetail extends Component {
 	}
 
 	getPost() {
-		const { isPostHomepage, post, postFallback } = this.props;
+		const { isPostHomepage, post, postFallback, countLikes } = this.props;
 
 		const postBase = {
 			title: this.getTitle(),
 			type: isPostHomepage ? 'page' : 'post',
-			like_count: post?.like_count || 0,
+			like_count: countLikes || 0,
 		};
 
 		// Check if post is valid.
@@ -256,10 +256,9 @@ const connectComponent = connect( ( state, { postId } ) => {
 	const post = getSitePost( state, siteId, postId ) || {};
 	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
 
-	post.like_count = countLikes;
-
 	return {
 		post,
+		countLikes,
 		// NOTE: Post object from the stats response does not conform to the data structure returned by getSitePost!
 		postFallback: getPostStat( state, siteId, postId, 'post' ),
 		isPostHomepage,

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -253,11 +253,10 @@ const connectComponent = connect( ( state, { postId } ) => {
 	const isPreviewable = isSitePreviewable( state, siteId );
 	const isPostHomepage = postId === 0;
 	const countLikes = countPostLikes( state, siteId, postId ) || 0;
-	const post = getSitePost( state, siteId, postId ) || {};
 	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
 
 	return {
-		post,
+		post: getSitePost( state, siteId, postId ),
 		countLikes,
 		// NOTE: Post object from the stats response does not conform to the data structure returned by getSitePost!
 		postFallback: getPostStat( state, siteId, postId, 'post' ),

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -118,7 +118,7 @@ class StatsPostDetail extends Component {
 		};
 
 		// Check if post is valid.
-		if ( typeof post === 'object' && post.title?.length ) {
+		if ( typeof post === 'object' && post?.title?.length ) {
 			return {
 				...postBase,
 				date: post?.date,
@@ -129,7 +129,7 @@ class StatsPostDetail extends Component {
 		}
 
 		// Check if postFallback is valid.
-		if ( typeof postFallback === 'object' && postFallback.post_title?.length ) {
+		if ( typeof postFallback === 'object' && postFallback?.post_title?.length ) {
 			return {
 				...postBase,
 				date: postFallback?.post_date_gmt,


### PR DESCRIPTION


Related to https://github.com/Automattic/red-team/issues/149

## Proposed Changes

* use likes from likes endpoint

## Why are these changes being made?

* Fix discrepancy from Odyssey to Calypso

## Testing Instructions

* Open a page/post with like > 0 on Odyssey Stats, e.g. `/wp-admin/admin.php?page=stats#!/stats/post/733/193141071?page=stats`
* Ensure likes from the left side matches the actual likes

<img width="1250" alt="Screenshot 2024-10-04 at 1 32 30 PM" src="https://github.com/user-attachments/assets/e8387be3-c425-48c7-94a9-1894e28f5dc9">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
