### PR TITLE
Stats: Remove the scroll bar for likes

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -111,6 +111,7 @@
 		padding: 0;
 		margin: 0 0 -7px 0;
 		box-shadow: none;
+		overflow: hidden;
 
 		.module-header {
 			display: none;


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/187

## Proposed Changes

* Remove scroll bar for the avatar list

## Why are these changes being made?



* Bugfix

## Testing Instructions

* Open `/stats/post/117265/(p2 of jetpack).wordpress.com` on Calypso Live Branch
* Ensure the [issue](https://github.com/Automattic/red-team/issues/187) doesn't happen



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
