### PR TITLE
Site Profiler: "Try again" button only works intermittently

### DIFF
--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -16,7 +16,7 @@ function mapScores( response: UrlBasicMetricsQueryResponse ) {
 
 export const useUrlBasicMetricsQuery = ( url?: string, hash?: string, advance = false ) => {
 	return useQuery( {
-		queryKey: [ 'url', 'basic-metrics', url, hash, advance ],
+		queryKey: [ 'url', 'basic-metrics', url, advance ],
 		queryFn: (): Promise< UrlBasicMetricsQueryResponse > =>
 			wp.req.get(
 				{

--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -14,7 +14,11 @@ function mapScores( response: UrlBasicMetricsQueryResponse ) {
 	return { ...response, success: basic.success, basic: basicMetricsScored };
 }
 
-export const useUrlBasicMetricsQuery = ( url?: string, hash?: string, advance = false ) => {
+export const useUrlBasicMetricsQuery = (
+	url?: string,
+	advance = false,
+	{ enabled = true } = {}
+) => {
 	return useQuery( {
 		queryKey: [ 'url', 'basic-metrics', url, advance ],
 		queryFn: (): Promise< UrlBasicMetricsQueryResponse > =>
@@ -29,7 +33,7 @@ export const useUrlBasicMetricsQuery = ( url?: string, hash?: string, advance = 
 		meta: {
 			persist: false,
 		},
-		enabled: !! url && ! hash, // Disable if hash is present
+		enabled: !! url && enabled,
 		retry: false,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -48,7 +48,7 @@ const usePerformanceReport = (
 		isError,
 		isFetched,
 		refetch,
-	} = useUrlBasicMetricsQuery( url, hash, true );
+	} = useUrlBasicMetricsQuery( url, true, { enabled: ! hash } );
 	const { final_url: finalUrl, token } = basicMetrics || {};
 	const { data: performanceInsights, isError: isErrorInsights } = useUrlPerformanceInsightsQuery(
 		url,

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -43,7 +43,12 @@ const usePerformanceReport = (
 ) => {
 	const { url = '', hash = '' } = wpcom_performance_report_url || {};
 
-	const { data: basicMetrics, isError, isFetched } = useUrlBasicMetricsQuery( url, hash, true );
+	const {
+		data: basicMetrics,
+		isError,
+		isFetched,
+		refetch,
+	} = useUrlBasicMetricsQuery( url, hash, true );
 	const { final_url: finalUrl, token } = basicMetrics || {};
 	const { data: performanceInsights, isError: isErrorInsights } = useUrlPerformanceInsightsQuery(
 		url,
@@ -80,6 +85,7 @@ const usePerformanceReport = (
 		isLoading: activeTab === 'mobile' ? ! mobileLoaded : ! desktopLoaded,
 		isError: isError || isErrorInsights,
 		isFetched,
+		refetch,
 	};
 };
 
@@ -147,14 +153,6 @@ export const SitePerformance = () => {
 		setWpcom_performance_report_url( currentPage?.wpcom_performance_report_url );
 	}, [ currentPage?.wpcom_performance_report_url ] );
 
-	const retestPage = () => {
-		recordTracksEvent( 'calypso_performance_profiler_test_again_click' );
-		setWpcom_performance_report_url( {
-			url: currentPage?.url ?? '',
-			hash: '',
-		} );
-	};
-
 	const handleRecommendationsFilterChange = ( filter?: string ) => {
 		setRecommendationsFilter( filter );
 		const url = new URL( window.location.href );
@@ -172,6 +170,15 @@ export const SitePerformance = () => {
 		isSitePublic ? wpcom_performance_report_url : undefined,
 		activeTab
 	);
+
+	const retestPage = () => {
+		recordTracksEvent( 'calypso_performance_profiler_test_again_click' );
+		setWpcom_performance_report_url( {
+			url: currentPage?.url ?? '',
+			hash: '',
+		} );
+		performanceReport.refetch();
+	};
 
 	useEffect( () => {
 		if ( performanceReport.isFetched && performanceReport.url ) {

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -33,7 +33,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 		data: basicMetrics,
 		isError: isBasicMetricsError,
 		isFetched,
-	} = useUrlBasicMetricsQuery( url, hash, true );
+	} = useUrlBasicMetricsQuery( url, true, { enabled: ! hash } );
 	const { final_url: finalUrl, token } = basicMetrics || {};
 	const { data: performanceInsights, isError: isPerformanceInsightsError } =
 		useUrlPerformanceInsightsQuery( url, hash );

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -90,7 +90,7 @@ export default function SiteProfilerV2( props: Props ) {
 
 	const url = useMemo( () => getValidUrl( routerDomain ), [ routerDomain ] );
 
-	const { data: basicMetrics } = useUrlBasicMetricsQuery( url, hash, true );
+	const { data: basicMetrics } = useUrlBasicMetricsQuery( url, true, { enabled: ! hash } );
 
 	const showGetReportForm = !! url && isGetReportFormOpen;
 


### PR DESCRIPTION
Previously the basic metrics request was made by toggling the "hash" to empty. This caused a bug where the "Test again" button only worked intermittently.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
