### PR TITLE
Post-migration Experience: Add the completion logic for the Review Site task

### DIFF
--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -123,6 +123,17 @@ export const setUpActionsForTasks = ( {
 					useCalypsoPath = false;
 					break;
 
+				case 'review_site':
+					action = () => {
+						// redirects to the site slug home page in a new tab
+						window.open( `https://${ siteSlug }`, '_blank' );
+						updateLaunchpadSettings( siteSlug, {
+							checklist_statuses: { [ task.id ]: true },
+						} );
+					};
+					useCalypsoPath = false;
+					break;
+
 				default:
 					logMissingCalypsoPath = true;
 					useCalypsoPath = false;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #39611

## Proposed Changes

* Adds the completion logic for the "Review the site's content" task.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the Post-migration Experience project, we need to encourage the users to check if the site works properly after the migration. The task "Review the site's content" will redirect the user to the site's home page. It should be marked as complete upon clicking on the task.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions in the Jetpack change so we can display the "Review the site's content" task: https://github.com/Automattic/jetpack/pull/39641
* Apply this PR to your local environment or use Calypso live
* Navigate to the Customer Home of your testing site and click on the "Review the site's content"
* You should be redirected to the home page of your testing site, and the task should be marked as complete.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
