### PR TITLE
Update Use your domain help link

### DIFF
--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import { withShoppingCart } from '@automattic/shopping-cart';
-import { CALYPSO_CONTACT } from '@automattic/urls';
+import { CALYPSO_HELP } from '@automattic/urls';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
@@ -136,7 +136,12 @@ function DomainTransferOrConnect( {
 					<div className={ baseClassName + '__support-link' }>
 						{ createInterpolateElement(
 							__( "Not sure what's best for you? <a>We're happy to help!</a>" ),
-							{ a: createElement( 'a', { target: '_blank', href: CALYPSO_CONTACT } ) }
+							{
+								a: createElement( 'a', {
+									target: '_blank',
+									href: CALYPSO_HELP + '?help-center=home',
+								} ),
+							}
 						) }
 					</div>
 				) }

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import { withShoppingCart } from '@automattic/shopping-cart';
-import { CALYPSO_HELP } from '@automattic/urls';
+import { CALYPSO_HELP_WITH_HELP_CENTER } from '@automattic/urls';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
@@ -139,7 +139,7 @@ function DomainTransferOrConnect( {
 							{
 								a: createElement( 'a', {
 									target: '_blank',
-									href: CALYPSO_HELP + '?help-center=home',
+									href: CALYPSO_HELP_WITH_HELP_CENTER,
 								} ),
 							}
 						) }

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -4,7 +4,11 @@ import { Card, Button, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { withShoppingCart } from '@automattic/shopping-cart';
-import { CALYPSO_HELP, INCOMING_DOMAIN_TRANSFER, MAP_EXISTING_DOMAIN } from '@automattic/urls';
+import {
+	CALYPSO_HELP_WITH_HELP_CENTER,
+	INCOMING_DOMAIN_TRANSFER,
+	MAP_EXISTING_DOMAIN,
+} from '@automattic/urls';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
@@ -430,7 +434,7 @@ class UseYourDomainStep extends Component {
 						components: {
 							a: (
 								<a
-									href={ CALYPSO_HELP + '?help-center=home' }
+									href={ CALYPSO_HELP_WITH_HELP_CENTER }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -4,7 +4,7 @@ import { Card, Button, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { withShoppingCart } from '@automattic/shopping-cart';
-import { CALYPSO_CONTACT, INCOMING_DOMAIN_TRANSFER, MAP_EXISTING_DOMAIN } from '@automattic/urls';
+import { CALYPSO_HELP, INCOMING_DOMAIN_TRANSFER, MAP_EXISTING_DOMAIN } from '@automattic/urls';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
@@ -428,7 +428,13 @@ class UseYourDomainStep extends Component {
 				<p className="use-your-domain-step__footer">
 					{ translate( "Not sure what works best for you? {{a}}We're happy to help!{{/a}}", {
 						components: {
-							a: <a href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
+							a: (
+								<a
+									href={ CALYPSO_HELP + '?help-center=home' }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
 						},
 					} ) }
 				</p>

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -3,7 +3,7 @@
 import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import {
-	CALYPSO_CONTACT,
+	CALYPSO_HELP_WITH_HELP_CENTER,
 	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
 	INCOMING_DOMAIN_TRANSFER_SUPPORTED_TLDS,
 	MAP_EXISTING_DOMAIN,
@@ -224,7 +224,13 @@ function getAvailabilityNotice(
 					args: { domain, site },
 					components: {
 						strong: <strong />,
-						a: <a target={ linksTarget } rel="noopener noreferrer" href={ CALYPSO_CONTACT } />,
+						a: (
+							<a
+								target={ linksTarget }
+								rel="noopener noreferrer"
+								href={ CALYPSO_HELP_WITH_HELP_CENTER }
+							/>
+						),
 					},
 				}
 			);
@@ -424,7 +430,7 @@ function getAvailabilityNotice(
 									href="http://wordpressfoundation.org/trademark-policy/"
 								/>
 							),
-							a2: <a target={ linksTarget } href={ CALYPSO_CONTACT } />,
+							a2: <a target={ linksTarget } href={ CALYPSO_HELP_WITH_HELP_CENTER } />,
 						},
 					}
 				);
@@ -479,7 +485,7 @@ function getAvailabilityNotice(
 				'This domain expired recently. To get it back please {{a}}contact support{{/a}}.',
 				{
 					components: {
-						a: <a target={ linksTarget } href={ CALYPSO_CONTACT } />,
+						a: <a target={ linksTarget } href={ CALYPSO_HELP_WITH_HELP_CENTER } />,
 					},
 				}
 			);

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -9,6 +9,7 @@ export const CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS = `${ root }/domains/change-
 export const CONCIERGE_SUPPORT = `${ root }/concierge-support/`;
 export const CONTACT = `${ root }/contact/`;
 export const CALYPSO_CONTACT = '/help/contact';
+export const CALYPSO_HELP = '/help';
 export const CUSTOM_DNS = `${ root }/domains/custom-dns/`;
 export const DESIGNATED_AGENT = `${ root }/update-contact-information/#designated-agent`;
 export const DOMAIN_REGISTRATION_AGREEMENTS = `${ root }/domain-registration-agreements/`;

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -10,7 +10,7 @@ export const CONCIERGE_SUPPORT = `${ root }/concierge-support/`;
 export const CONTACT = `${ root }/contact/`;
 export const CALYPSO_CONTACT = '/help/contact';
 export const CALYPSO_HELP = '/help';
-export const CALYPSO_HELP_WITH_HELP_CENTER = CALYPSO_HELP + '?help_center=home';
+export const CALYPSO_HELP_WITH_HELP_CENTER = CALYPSO_HELP + '?help-center=home';
 export const CUSTOM_DNS = `${ root }/domains/custom-dns/`;
 export const DESIGNATED_AGENT = `${ root }/update-contact-information/#designated-agent`;
 export const DOMAIN_REGISTRATION_AGREEMENTS = `${ root }/domain-registration-agreements/`;

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -10,6 +10,7 @@ export const CONCIERGE_SUPPORT = `${ root }/concierge-support/`;
 export const CONTACT = `${ root }/contact/`;
 export const CALYPSO_CONTACT = '/help/contact';
 export const CALYPSO_HELP = '/help';
+export const CALYPSO_HELP_WITH_HELP_CENTER = CALYPSO_HELP + '?help_center=home';
 export const CUSTOM_DNS = `${ root }/domains/custom-dns/`;
 export const DESIGNATED_AGENT = `${ root }/update-contact-information/#designated-agent`;
 export const DOMAIN_REGISTRATION_AGREEMENTS = `${ root }/domain-registration-agreements/`;


### PR DESCRIPTION
Closes #95109 

## Proposed Changes

This diff updates the help link in "Use your domain" step.

## Why are these changes being made?
Current link brings the users to `https://wordpress.com/help/contact`, that redirects to `https://wordpress.com/help?from=`, as `/contact` is no more used.

I created a new constant `CALYPSO_HELP_WITH_HELP_CENTER` in `@automattic/url` package instead of updating `CALYPSO_CONTACT`, since this one used in many places and I think that the replacement should be evaluated case-by-case.


## Testing Instructions

- Apply this PR locally or use the Calypso Live link and visit `/setup/onboarding` or `/start` url
- Reach the Domains step
- Click on Use a domain I own
- Input one domain
- Click the help link `We're happy to link` and verify that goes to the help center

<img width="878" alt="Screenshot 2024-10-04 alle 08 54 44" src="https://github.com/user-attachments/assets/628b74f4-9bee-413d-bb41-4a96b348e3c2">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
