### PR TITLE
A4A > Marketplace: Implement Pressable usage limit warning banner

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/pressable-usage-limit-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/pressable-usage-limit-notice/index.tsx
@@ -1,0 +1,87 @@
+import { Button } from '@wordpress/components';
+import { Icon, external } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+
+import './style.scss';
+
+const PRESSABLE_LIMIT_NOTIFICATION_DISMISS_PREFERENCE = 'pressable-limit-notification-dismissed';
+
+export const PressableUsageLimitNotice = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const isDismissed = useSelector( ( state ) =>
+		getPreference( state, PRESSABLE_LIMIT_NOTIFICATION_DISMISS_PREFERENCE )
+	);
+
+	const dismissNotice = () => {
+		dispatch( savePreference( PRESSABLE_LIMIT_NOTIFICATION_DISMISS_PREFERENCE, true ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_pressable_limit_notification_dismissed' ) );
+	};
+
+	const showBanner = false; // TODO: Remove this when the banner is ready to be shown
+
+	if ( isDismissed || ! showBanner ) {
+		return null;
+	}
+
+	const learnMoreLink = ''; // TODO: Replace with actual link
+
+	const limitTypes = {
+		storage: translate( 'storage' ),
+		traffic: translate( 'traffic' ),
+	};
+
+	const limitType = 'traffic'; // TODO: Replace with actual limit type
+	const limitTypeHumanised = limitTypes[ limitType ];
+
+	return (
+		<LayoutBanner
+			level="warning"
+			title={ translate( 'Upgrade Pressable' ) }
+			onClose={ dismissNotice }
+			className="pressable-usage-limit-notice"
+		>
+			<div>
+				{ translate(
+					'Your Pressable plan has exceeded its allocated %s limit. Consider upgrading your plan to avoid additional fees.',
+					{
+						args: [ limitTypeHumanised ],
+						comment: 'The limit type is storage or traffic which is already translated',
+					}
+				) }
+			</div>
+
+			<Button
+				className="is-dark"
+				href={ A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK }
+				onClick={ () => {
+					dispatch( recordTracksEvent( 'calypso_a4a_pressable_limit_notification_upgrade_click' ) );
+				} }
+			>
+				{ translate( 'Upgrade now' ) }
+			</Button>
+			<Button
+				variant="secondary"
+				target="_blank"
+				href={ learnMoreLink }
+				onClick={ () => {
+					dispatch(
+						recordTracksEvent( 'calypso_a4a_pressable_limit_notification_learn_more_click' )
+					);
+				} }
+			>
+				{ translate( 'Learn more' ) }
+				<Icon icon={ external } size={ 18 } />
+			</Button>
+		</LayoutBanner>
+	);
+};
+
+export default PressableUsageLimitNotice;

--- a/client/a8c-for-agencies/sections/marketplace/common/pressable-usage-limit-notice/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/pressable-usage-limit-notice/style.scss
@@ -1,0 +1,17 @@
+.pressable-usage-limit-notice {
+	.notice-banner {
+		margin-block-end: 24px;
+	}
+
+	.components-button {
+		margin-block-start: 1rem;
+
+		&.is-secondary {
+			margin-inline-start: 8px;
+
+			svg {
+				margin-inline-start: 4px;
+			}
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -20,6 +20,7 @@ import {
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import PressableUsageLimitNotice from '../common/pressable-usage-limit-notice';
 import ReferralToggle from '../common/referral-toggle';
 import withMarketplaceType from '../hoc/with-marketplace-type';
 import useShoppingCart from '../hooks/use-shopping-cart';
@@ -81,6 +82,7 @@ function Hosting( { section }: Props ) {
 		>
 			<LayoutTop>
 				<PendingPaymentNotification />
+				<PressableUsageLimitNotice />
 				<LayoutHeader>
 					<Breadcrumb
 						items={ [

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -233,6 +233,7 @@
 		&:hover,
 		&:focus-visible {
 			background-color: var(--color-accent-100);
+			color: var(--color-surface);
 		}
 	}
 
@@ -377,7 +378,8 @@
 
 // New navigation will not include a masterbar
 .theme-a8c-for-agencies .layout.has-no-masterbar {
-	/* We are ignoring these lines because without the px value the calc function does not work as expected */
+	/* We are ignoring these lines because without the
+	// px value the calc function does not work as expected */
 	/* stylelint-disable-next-line length-zero-no-unit */
 	--masterbar-height: 0px;
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1194

## Proposed Changes

This PR adds a warning banner to inform about the Pressable usage limit on A4A.

## Why are these changes being made?

* To show the Pressable usage limit

## Testing Instructions

* Switch to this branch locally and start the server.
* Set the constant `showBanner` to false in the `PressableUsageLimitNotice` component.
* Go to Marketplace > Hosting and verify that the banner is displayed as shown below.
* Clicking on the Upgrade now should take you to /marketplace/hosting/pressable. Note: the Learn more link will be updated in another PR. 
* Dismissing the notice should make it disappear and not appear again.

<img width="1721" alt="Screenshot 2024-10-04 at 3 43 01 PM" src="https://github.com/user-attachments/assets/c9dcc11c-9619-43a5-8f8b-c98d07c6c596">

<img width="1721" alt="Screenshot 2024-10-04 at 3 43 15 PM" src="https://github.com/user-attachments/assets/802d49a4-1af7-4ada-ab85-da9b6d802bc3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
