### PR TITLE
100-year-plan: Match design for "diy or difm" step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
@@ -1,4 +1,6 @@
 import { Button } from '@wordpress/components';
+import { Icon, check } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import type { Step } from '../../types';
@@ -6,26 +8,54 @@ import type { Step } from '../../types';
 import './styles.scss';
 
 const HundredYearPlanDIYOrDIFM: Step = function HundredYearPlanDIYOrDIFM( { navigation, flow } ) {
+	const translate = useTranslate();
 	const { submit } = navigation;
 
 	return (
 		<HundredYearPlanStepWrapper
 			stepContent={
 				<div>
-					<Button onClick={ () => submit?.( { diyOrDifmChoice: 'difm' } ) }>Do it for me</Button>
-					<Button onClick={ () => submit?.( { diyOrDifmChoice: 'diy' } ) }>Do it myself</Button>
+					<ul>
+						<li>
+							<Icon size={ 18 } icon={ check } />{ ' ' }
+							{ translate( 'Conduct a comprehensive digital longevity assessment' ) }
+						</li>
+						<li>
+							<Icon size={ 18 } icon={ check } />{ ' ' }
+							{ translate( 'Showcase our comprehensive legacy-building tools' ) }
+						</li>
+						<li>
+							<Icon size={ 18 } icon={ check } />{ ' ' }
+							{ translate( 'Answer all your questions about long-term success' ) }
+						</li>
+						<li>
+							<Icon size={ 18 } icon={ check } />{ ' ' }
+							{ translate( 'Chart a course for the production of your new site' ) }
+						</li>
+					</ul>
+
+					<div className="buttons-container">
+						<Button variant="primary" onClick={ () => submit?.( { diyOrDifmChoice: 'difm' } ) }>
+							{ translate( 'Schedule your free call' ) }
+						</Button>
+
+						<Button variant="link" onClick={ () => submit?.( { diyOrDifmChoice: 'diy' } ) }>
+							{ translate( "I'll create my site on my own" ) }
+						</Button>
+					</div>
 				</div>
 			}
 			formattedHeader={
 				<FormattedHeader
 					brandFont
-					headerText="TODO: title"
-					subHeaderText="TODO: header"
+					headerText={ translate( "Let's craft your next century" ) }
+					subHeaderText={ translate( "Join us for an exclusive strategy session where we'll" ) }
 					subHeaderAlign="center"
 				/>
 			}
-			stepName="hundred-year-plan-setup"
+			stepName="hundred-year-plan-setup hundred-year-plan-setup__diy-or-difm"
 			flowName={ flow }
+			justifyStepContent="center"
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
@@ -1,1 +1,49 @@
-/* Comment because we cannot have empty files */
+.hundred-year-plan-setup__diy-or-difm {
+
+	.step-container__header {
+		margin-bottom: 0;
+	}
+
+	ul {
+		margin: 0 0.5rem 2.5rem 0.5rem;
+		list-style-type: none;
+
+		li {
+			color: var(--studio-gray-60);
+		}
+
+		svg {
+			position: relative;
+			top: 8px;
+			padding: 5px !important;
+			margin-right: 5px !important;
+			background-color: var(--studio-gray-5);
+			border-radius: 100%;
+		}
+	}
+
+	.buttons-container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+
+		.components-button {
+			margin-bottom: 1rem;
+
+			&.is-primary {
+				padding-left: 1.5rem;
+				padding-right: 1.5rem;
+				background-color: var(--studio-gray-100);
+
+				&:hover {
+					background-color: var(--studio-gray-70);
+				}
+			}
+
+			&.is-link {
+				color: var(--studio-gray-100);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Related to #

## Proposed Changes

* Match a proposed design to "DYI or DIFM" step
* Design details: p9Jlb4-et7-p2

![100-year-plan](https://github.com/user-attachments/assets/fa82e461-0622-4410-ae35-53a2e031c440)


## Testing Instructions

* Go to `/setup/hundred-year-plan/diy-or-difm?flags=100year%2Fvip`
* Check the step to see if it matches the provided design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?