### PR TITLE
A4A: Fix the bug with PD submission redirecting to the Overview page.

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -13,7 +13,9 @@ import { A4A_PARTNER_DIRECTORY_DASHBOARD_LINK } from 'calypso/a8c-for-agencies/c
 import BudgetSelector from 'calypso/a8c-for-agencies/sections/partner-directory/components/budget-selector';
 import { AgencyDetails } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
+import { useSelector } from 'calypso/state';
 import { setActiveAgency } from 'calypso/state/a8c-for-agencies/agency/actions';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import IndustriesSelector from '../components/industries-selector';
@@ -38,9 +40,11 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 
 	const { validate, validationError, updateValidationError } = useDetailsFormValidation();
 
+	const agency = useSelector( getActiveAgency );
+
 	const onSubmitSuccess = useCallback(
 		( response: Agency ) => {
-			response && reduxDispatch( setActiveAgency( response ) );
+			response && reduxDispatch( setActiveAgency( { ...agency, ...response } ) );
 
 			reduxDispatch(
 				successNotice( translate( 'Your agency profile was submitted!' ), {
@@ -50,7 +54,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			);
 			page( A4A_PARTNER_DIRECTORY_DASHBOARD_LINK );
 		},
-		[ translate ]
+		[ agency, translate ]
 	);
 
 	const onSubmitError = useCallback( () => {

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -16,7 +16,9 @@ import {
 	A4A_PARTNER_DIRECTORY_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
+import { useSelector } from 'calypso/state';
 import { setActiveAgency } from 'calypso/state/a8c-for-agencies/agency/actions';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { useFormSelectors } from '../components/hooks/use-form-selectors';
@@ -92,9 +94,11 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 
 	const { availableDirectories } = useFormSelectors();
 
+	const agency = useSelector( getActiveAgency );
+
 	const onSubmitSuccess = useCallback(
 		( response: Agency ) => {
-			response && reduxDispatch( setActiveAgency( response ) );
+			response && reduxDispatch( setActiveAgency( { ...agency, ...response } ) );
 
 			reduxDispatch(
 				successNotice( translate( 'Your Partner Directory application was submitted!' ), {
@@ -104,7 +108,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 			);
 			page( A4A_PARTNER_DIRECTORY_DASHBOARD_LINK );
 		},
-		[ translate ]
+		[ agency, translate ]
 	);
 
 	const onSubmitError = useCallback( () => {

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -98,7 +98,7 @@ const PartnerDirectoryDashboard = () => {
 	const onSubmitPublishProfileSuccess = useCallback(
 		( response: Agency ) => {
 			// Update the store with the new agency data
-			response && reduxDispatch( setActiveAgency( response ) );
+			response && reduxDispatch( setActiveAgency( { ...agency, ...response } ) );
 
 			reduxDispatch(
 				successNotice( translate( 'Your profile has been saved!' ), {
@@ -106,7 +106,7 @@ const PartnerDirectoryDashboard = () => {
 				} )
 			);
 		},
-		[ translate ]
+		[ agency, translate ]
 	);
 
 	const { onSubmit: submitPublishProfile, isSubmitting: isSubmittingPublishProfile } =


### PR DESCRIPTION
This pull request addresses a bug where submitting the PD Agency profile triggers a redirect to the Overview page.


Related to  p1728041863320119-slack-C047ACYM8UQ

## Proposed Changes

* When we submit the profile, the front-end (FE) receives an agency object from the backend endpoint. We use this response to replace the active agency in the Redux state. However, this object does not contain information about user capabilities, which removes access to the user interface (UI), causing the path checking to default to the overview page. To fix this, we need to ensure that we retain all agency data when setting the active agency state with the new agency object.


## Why are these changes being made?

* This prevents frustration from the user with a broken flow.

## Testing Instructions

1. Use the A4A live link and navigate to the `/partner-directory` page.
2. Approve at least one expertise (Ensure that this is hidden in the listing). Refer to the comment on how to do this: p1727161271252239-slack-C047ACYM8UQ
3. After approving one expertise, edit the agency profile.
4. Try to submit the edited profile.
5. Confirm that you are redirected back to the `/partner-directory/dashboard` page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?