### PR TITLE
Reader: update list stream paging

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -468,6 +468,7 @@ class ReaderStream extends Component {
 			props.trackScrollPage( pageId );
 		}
 		const pageHandle = this.getPageHandle( stream.pageHandle, startDate );
+		console.log( 'fetchNextPage', { streamKey, stream, options, pageHandle, localeSlug } );
 		props.requestPage( { streamKey, pageHandle, localeSlug } );
 	};
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -468,7 +468,6 @@ class ReaderStream extends Component {
 			props.trackScrollPage( pageId );
 		}
 		const pageHandle = this.getPageHandle( stream.pageHandle, startDate );
-		console.log( 'fetchNextPage', { streamKey, stream, options, pageHandle, localeSlug } );
 		props.requestPage( { streamKey, pageHandle, localeSlug } );
 	};
 

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -318,20 +318,9 @@ const streamApis = {
 			return `/read/list/${ owner }/${ slug }/posts`;
 		},
 		dateProperty: 'date',
-		query: ( extras, { streamKey, pageHandle } ) => {
-			const { owner, slug } = JSON.parse( streamKeySuffix( streamKey ) );
+		query: ( extras, { pageHandle } ) => {
 			return {
-				owner,
-				slug,
-				...extras,
-				...pageHandle,
-			};
-		},
-		pollQuery: ( extraFields = [], extraQueryParams = {}, { pageHandle } ) => {
-			return {
-				number: PER_POLL,
-				fields: [ SITE_LIMITER_FIELDS, ...extraFields ].join( ',' ),
-				...extraQueryParams,
+				...{ extras, number: 40 },
 				...pageHandle,
 			};
 		},

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -363,16 +363,15 @@ export function requestPage( action ) {
 	// There is a race condition in switchLocale when retrieving the language file
 	// The stream request can occur before the language file is loaded, so we need a way to explicitly set the lang in the request
 	const lang = localeSlug || i18n.getLocaleSlug();
-	const q = isPoll
-		? pollQuery( [], { ...algorithm } )
-		: query( { ...pageHandle, ...algorithm, number, lang }, action.payload );
 
 	return http( {
 		method: 'GET',
 		path: path( { ...action.payload } ),
 		apiVersion,
 		apiNamespace: api.apiNamespace ?? null,
-		query: q,
+		query: isPoll
+			? pollQuery( [], { ...algorithm } )
+			: query( { ...pageHandle, ...algorithm, number, lang }, action.payload ),
 		onSuccess: action,
 		onFailure: action,
 	} );

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -318,6 +318,7 @@ const streamApis = {
 			return `/read/list/${ owner }/${ slug }/posts`;
 		},
 		dateProperty: 'date',
+		apiVersion: '1.3',
 		query: ( extras, { pageHandle } ) => {
 			return {
 				...{ extras, number: 40 },
@@ -365,7 +366,6 @@ export function requestPage( action ) {
 	const q = isPoll
 		? pollQuery( [], { ...algorithm } )
 		: query( { ...pageHandle, ...algorithm, number, lang }, action.payload );
-	console.log( 'q', q );
 
 	return http( {
 		method: 'GET',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/184

This PR works with the patch D163263-code. The patch adds an API handler for https://public-api.wordpress.com/rest/v1.3/read/list/automattic/a12s/posts API call from this PR.

The paging on the list posts page doesn't work well. This has to do with how the API handler for version `1.2` mishandles pagination on large lists like `/read/list/automattic/a12s`.

If you scroll down far enough on https://wordpress.com/read/list/automattic/a12s you probably will see the stream only load past couple of months of posts.

Now you should be able to keep streaming posts as you scroll down.

## Before

https://github.com/user-attachments/assets/5e95836e-5f85-42b7-b4bf-b8760582ed6a

## After

https://github.com/user-attachments/assets/bdcc8a47-ce5f-4b06-9f62-d346c4bba4fa

## Proposed Changes

* Updates the `/read/list` Reader stream API call to include a `page_handle` and to use API version `1.3`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure `public-api.wordpress.com` is sandboxed
* Go to `/read/list/automattic/a12s` and confirm the stream loads as expected in chronological order
* Go to `/read/list/kristastevens/favorite-magazines` and confirm the stream loads as expected in chronological order

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
