### PR TITLE
Log `signup_domain_origin` in `calypso_signup_complete`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
@@ -22,6 +22,7 @@ const EXCLUDED_DEPENDENCIES = [
 	'password',
 	'password_confirm',
 	'domainCart',
+	'suggestion',
 ];
 
 export function recordStepNavigation( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -103,7 +103,7 @@ export default function DomainsStep( props: StepProps ) {
 				saveSignupStep={ updateSignupStepState }
 				submitSignupStep={ updateSignupStepState }
 				goToNextStep={ ( state: ProvidedDependencies ) => {
-					const { domainForm, suggestion, ...rest } = mostRecentStateRef.current ?? {};
+					const { domainForm, ...rest } = mostRecentStateRef.current ?? {};
 					props.navigation.submit?.( { ...rest, ...state } );
 				} }
 				step={ stepState }

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -43,8 +43,14 @@ const onboarding: Flow = {
 
 	useStepNavigation( currentStepSlug, navigate ) {
 		const flowName = this.name;
-		const { setDomain, setDomainCartItem, setDomainCartItems, setPlanCartItem, setSiteUrl } =
-			useDispatch( ONBOARD_STORE );
+		const {
+			setDomain,
+			setDomainCartItem,
+			setDomainCartItems,
+			setPlanCartItem,
+			setSiteUrl,
+			setSignupDomainOrigin,
+		} = useDispatch( ONBOARD_STORE );
 
 		const { planCartItem } = useSelect(
 			( select: ( key: string ) => OnboardSelect ) => ( {
@@ -75,6 +81,7 @@ const onboarding: Flow = {
 					setDomain( providedDependencies.suggestion );
 					setDomainCartItem( providedDependencies.domainItem );
 					setDomainCartItems( providedDependencies.domainCart );
+					setSignupDomainOrigin( providedDependencies.signupDomainOrigin );
 
 					if ( providedDependencies.navigateToUseMyDomain ) {
 						setRedirectedToUseMyDomain( true );

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -3,6 +3,7 @@ import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
+import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
@@ -108,6 +109,13 @@ const onboarding: Flow = {
 				case 'plans': {
 					const cartItems = providedDependencies.cartItems as Array< typeof planCartItem >;
 					setPlanCartItem( cartItems?.[ 0 ] ?? null );
+					if ( ! cartItems?.[ 0 ] ) {
+						// Since we're removing the paid domain, it means that the user chose to continue
+						// with a free domain. Because signupDomainOrigin should reflect the last domain
+						// selection status before they land on the checkout page, we switch the value
+						// to "free".
+						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
+					}
 					setSignupCompleteFlowName( flowName );
 					return navigate( 'create-site', undefined, true );
 				}

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -12,18 +12,17 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 	const site = useSite();
 	const siteId = site?.ID || null;
 	const theme = site?.options?.theme_slug || '';
-	const { domainCartItem, planCartItem, siteCount, selectedDomain, isNewUser } = useSelect(
-		( select ) => {
+	const { domainCartItem, planCartItem, siteCount, selectedDomain, isNewUser, signupDomainOrigin } =
+		useSelect( ( select ) => {
 			return {
 				siteCount: ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.site_count,
 				domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
 				planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 				selectedDomain: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
 				isNewUser: ( select( USER_STORE ) as UserSelect ).isNewUser(),
+				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
 			};
-		},
-		[]
-	);
+		}, [] );
 
 	const isNewishUser = useSelector( ( state ) =>
 		isUserRegistrationDaysWithinRange( state, null, 0, 7 )
@@ -71,7 +70,7 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 						hasPaidDomainItem && domainCartItem ? isDomainMapping( domainCartItem ) : undefined,
 					isTransfer:
 						hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
-					signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.NOT_SET,
+					signupDomainOrigin: signupDomainOrigin ?? SIGNUP_DOMAIN_ORIGIN.NOT_SET,
 				},
 				true
 			);

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -429,6 +429,11 @@ export const setDomainsTransferData = ( bulkDomainsData: DomainTransferData | un
 	bulkDomainsData,
 } );
 
+export const setSignupDomainOrigin = ( signupDomainOrigin: string | undefined ) => ( {
+	type: 'SET_SIGNUP_DOMAIN_ORIGIN' as const,
+	signupDomainOrigin,
+} );
+
 export const setShouldImportDomainTransferDnsRecords = (
 	shouldImportDomainTransferDnsRecords: boolean
 ) => ( {
@@ -531,4 +536,5 @@ export type OnboardAction = ReturnType<
 	| typeof setIsMigrateFromWp
 	| typeof setPaidSubscribers
 	| typeof setPartnerBundle
+	| typeof setSignupDomainOrigin
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -598,6 +598,20 @@ const partnerBundle: Reducer< string | null, OnboardAction > = ( state = null, a
 	return state;
 };
 
+const signupDomainOrigin: Reducer< string | undefined, OnboardAction > = (
+	state = undefined,
+	action
+) => {
+	if ( action.type === 'SET_SIGNUP_DOMAIN_ORIGIN' ) {
+		return action.signupDomainOrigin;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return undefined;
+	}
+
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainCartItem,
@@ -647,6 +661,7 @@ const reducer = combineReducers( {
 	profilerData,
 	paidSubscribers,
 	partnerBundle,
+	signupDomainOrigin,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -73,6 +73,7 @@ export const hasSelectedDesign = ( state: State ) => !! state.selectedDesign;
 export const getDomainForm = ( state: State ) => state.domainForm;
 export const getDomainCartItem = ( state: State ) => state.domainCartItem;
 export const getDomainCartItems = ( state: State ) => state.domainCartItems;
+export const getSignupDomainOrigin = ( state: State ) => state.signupDomainOrigin;
 export const getSiteUrl = ( state: State ) => state.siteUrl;
 export const getHideFreePlan = ( state: State ) => state.hideFreePlan;
 export const getHidePlansFeatureComparison = ( state: State ) => state.hidePlansFeatureComparison;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/95124

## Proposed Changes

Log `signup_domain_origin` property in `calypso_signup_complete` event. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In Start we are logging that event, that indicates the choice made by the user in the domains step. And in the plans step, if a free plan is chosen even when having previously selected a custom domain.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding`
* Check the various cases in the [issue](https://github.com/Automattic/wp-calypso/issues/95124), while checking the props passed to `signup_domain_origin`.

