### PR TITLE
Stats: Fix post details page layout

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -29,7 +29,7 @@
 
 	.highlight-cards-list {
 		display: grid;
-		grid-template-columns: 3fr 2fr;
+		grid-template-columns: minmax(600px, 3fr) minmax(200px, 1fr);
 		grid-template-rows: 1fr;
 		column-gap: 10px;
 		overflow-x: auto;
@@ -49,7 +49,6 @@
 			}
 
 			.highlight-card {
-				min-width: unset;
 				height: 180px;
 				margin: math.div($vertical-margin, 2) 0;
 				border-left: 0;
@@ -62,7 +61,6 @@
 	.post-stats-card {
 		margin: 0;
 		max-height: unset;
-		min-width: 770px;
 
 		@media (max-width: $break-small) {
 			gap: 24px 12px;
@@ -78,10 +76,10 @@
 	}
 
 	.highlight-card {
+		width: 100%;
+		max-height: 300px;
 		padding: 24px;
-		height: 300px;
 		overflow-y: auto;
-		min-width: 300px;
 	}
 
 	.highlight-card-heading {

--- a/client/my-sites/stats/sections/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/sections/all-time-highlights-section/style.scss
@@ -71,8 +71,9 @@
 		height: unset;
 	}
 
+	// For scrollable cards on narrow screens.
 	.highlight-cards-list {
-		overflow-x: unset;
+		overflow-x: auto;
 	}
 
 	.highlight-card-heading {

--- a/packages/components/src/post-stats-card/style.scss
+++ b/packages/components/src/post-stats-card/style.scss
@@ -91,11 +91,13 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 }
 
 .post-stats-card__counts {
-	display: flex;
-	flex-flow: row;
 	grid-area: counts;
-	gap: 64px;
+	display: flex;
 	align-self: flex-end;
+	flex-flow: row;
+	flex-wrap: wrap;
+	column-gap: 64px;
+	row-gap: 24px;
 }
 
 .post-stats-card__count {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix the grid layout of the post details page highlights cards.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The grid layout of the highlights cards was spaced on a bigger screen if there were fewer likers.

<img width="1285" alt="截圖 2024-10-04 下午11 56 54" src="https://github.com/user-attachments/assets/bdf107a2-2fdf-40e4-8493-14d9fd05a0ba">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Click any post from the `Posts & pages` module.
* Ensure the layout of the post details page highlights cards works well.

|Bigger screen|Narrower screen|
|-|-|
|<img width="1290" alt="截圖 2024-10-04 下午11 58 24" src="https://github.com/user-attachments/assets/44a5aa7d-cef3-47ca-8e48-61404234dfb7">|<img width="847" alt="截圖 2024-10-04 下午11 58 35" src="https://github.com/user-attachments/assets/bc70d43f-2956-4787-be5d-bec1973ef6b0">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
