### PR TITLE
Help Center: change header back to Wapuu

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -63,7 +63,7 @@ const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
 
 	const headerText =
 		pathname === '/odie' || pathname === '/contact-form'
-			? __( 'Virtual Expert', __i18n_text_domain__ )
+			? __( 'Wapuu', __i18n_text_domain__ )
 			: __( 'Help Center', __i18n_text_domain__ );
 
 	return (
@@ -117,7 +117,7 @@ const ContentMinimized = ( {
 					<Route path="/contact-form" element={ <SupportModeTitle /> } />
 					<Route path="/post" element={ <ArticleTitle /> } />
 					<Route path="/success" element={ __( 'Message Submitted', __i18n_text_domain__ ) } />
-					<Route path="/odie" element={ __( 'Virtual Expert', __i18n_text_domain__ ) } />
+					<Route path="/odie" element={ __( 'Wapuu', __i18n_text_domain__ ) } />
 				</Routes>
 				{ unreadCount > 0 && (
 					<span className="help-center-header__unread-count">{ formattedUnreadCount }</span>


### PR DESCRIPTION
## Proposed Changes

Change name of AI assistant back to Wapuu

## Why are these changes being made?

Working out the details on the new changes to the Help Center. Trying to stay aligned with where support is aiming.

## Testing Instructions

Open Help Center and make sure Virtual Expert shows Wapuu.