### PR TITLE
Purchases: List Associated Subscriptions When Deleting Payment Method

### DIFF
--- a/client/me/purchases/payment-methods/main.tsx
+++ b/client/me/purchases/payment-methods/main.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -18,6 +19,7 @@ function PaymentMethods() {
 		<Main wideLayout className="payment-methods__main">
 			<DocumentHead title={ titles.paymentMethods } />
 			<PageViewTracker path="/me/purchases/payment-methods" title="Me > Payment Methods" />
+			<QueryUserPurchases />
 			<NavigationHeader
 				navigationItems={ [] }
 				title={ titles.sectionTitle }

--- a/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
+++ b/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
@@ -8,7 +8,6 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import wpcom from 'calypso/lib/wp';
 import { storedPaymentMethodsQueryKey } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
-
 async function fetchIsBackup( storedDetailsId: string ): Promise< { is_backup: boolean } > {
 	return await wpcom.req.get( `/me/payment-methods/${ storedDetailsId }/is-backup` );
 }

--- a/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
+++ b/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
@@ -8,6 +8,7 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import wpcom from 'calypso/lib/wp';
 import { storedPaymentMethodsQueryKey } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
+
 async function fetchIsBackup( storedDetailsId: string ): Promise< { is_backup: boolean } > {
 	return await wpcom.req.get( `/me/payment-methods/${ storedDetailsId }/is-backup` );
 }

--- a/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
@@ -1,34 +1,52 @@
-import { Button, Dialog } from '@automattic/components';
+import { Gridicon, Dialog } from '@automattic/components';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
+import moment from 'moment';
 import { FunctionComponent } from 'react';
 import CardHeading from 'calypso/components/card-heading';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { getPaymentMethodImageURL } from 'calypso/lib/checkout/payment-methods';
+import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
+import type { Purchase } from 'calypso/lib/purchases/types';
 
 import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface Props {
+	card: StoredPaymentMethod;
 	paymentMethodSummary: TranslateResult;
 	isVisible: boolean;
 	onClose: () => void;
 	onConfirm: () => void;
+	moment: typeof moment;
 }
 
 const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
+	card,
 	paymentMethodSummary,
+	purchases,
 	isVisible,
 	onClose,
 	onConfirm,
 } ) => {
 	const translate = useTranslate();
+	const associatedSubscriptions = purchases.filter(
+		( purchase: Purchase ) =>
+			purchase.payment?.storedDetailsId === card.stored_details_id && purchase.isAutoRenewEnabled
+	);
+
 	return (
 		<Dialog
 			isVisible={ isVisible }
 			additionalClassNames="payment-method-delete-dialog"
 			onClose={ onClose }
 			buttons={ [
-				<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>,
-				<Button onClick={ onConfirm } primary>
-					{ translate( 'Delete' ) }
-				</Button>,
+				{ action: 'cancel', label: translate( 'Cancel' ), onClick: onClose },
+				{
+					action: 'confirm',
+					label: translate( 'Delete' ),
+					isPrimary: true,
+					additionalClassNames: 'is-scary',
+					onClick: onConfirm,
+				},
 			] }
 		>
 			<CardHeading tagName="h2" size={ 24 }>
@@ -44,8 +62,53 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
+			{ associatedSubscriptions.length > 0 && (
+				<div className="payment-method-delete-dialog__affected-subscriptions-wrapper">
+					<div className="payment-method-delete-dialog__affected-subscriptions-title-wrapper">
+						<CardHeading tagName="h2" size={ 20 }>
+							{ translate( 'Associated subscriptions' ) }
+						</CardHeading>
+						<img src={ getPaymentMethodImageURL( card?.card_type ) } alt="" />
+					</div>
+					{ associatedSubscriptions.map( ( subscription: Purchase ) => (
+						<div
+							className="payment-method-delete-dialog__affected-subscription"
+							key={ subscription.id }
+						>
+							<div>
+								<span>{ subscription.productName }</span>
+								<span className="payment-method-delete-dialog__affected-subscription-domain">
+									{ subscription.domain }
+								</span>
+							</div>
+							<div>
+								<span className="payment-method-delete-dialog__affected-subscription-date">
+									{ translate( 'Auto-renews{{br /}}%(date)s', {
+										args: {
+											date: moment( subscription.renewDate ).format( 'll' ),
+										},
+										components: { br: <br /> },
+									} ) }
+								</span>
+							</div>
+						</div>
+					) ) }
+					<div className="payment-method-delete-dialog__warning">
+						<Gridicon icon="notice-outline" size={ 24 } />
+						<p>
+							{ translate(
+								'This subscription will no longer auto-renew until an alternative payment method is added.',
+								'These subscriptions will no longer auto-renew until an alternative payment method is added.',
+								{
+									count: associatedSubscriptions.length,
+								}
+							) }
+						</p>
+					</div>
+				</div>
+			) }
 		</Dialog>
 	);
 };
 
-export default PaymentMethodDeleteDialog;
+export default withLocalizedMoment( PaymentMethodDeleteDialog );

--- a/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
@@ -1,9 +1,8 @@
 import { Gridicon, Dialog } from '@automattic/components';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import moment from 'moment';
 import { FunctionComponent } from 'react';
 import CardHeading from 'calypso/components/card-heading';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { getPaymentMethodImageURL } from 'calypso/lib/checkout/payment-methods';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import type { Purchase } from 'calypso/lib/purchases/types';
@@ -16,7 +15,6 @@ interface Props {
 	isVisible: boolean;
 	onClose: () => void;
 	onConfirm: () => void;
-	moment: typeof moment;
 }
 
 const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
@@ -27,8 +25,9 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 	onClose,
 	onConfirm,
 } ) => {
+	const moment = useLocalizedMoment();
 	const translate = useTranslate();
-	const associatedSubscriptions = purchases.filter(
+	const associatedSubscriptions = purchases?.filter(
 		( purchase: Purchase ) =>
 			purchase.payment?.storedDetailsId === card.stored_details_id && purchase.isAutoRenewEnabled
 	);
@@ -83,12 +82,12 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 							</div>
 							<div>
 								<span className="payment-method-delete-dialog__affected-subscription-date">
-									{ translate( 'Auto-renews{{br /}}%(date)s', {
-										args: {
-											date: moment( subscription.renewDate ).format( 'll' ),
-										},
-										components: { br: <br /> },
-									} ) }
+									<span>
+										{ translate( 'Auto-renews', {
+											comment: 'followed by a date - eg. "Auto-renews 21 Apr 2025"',
+										} ) }
+									</span>
+									<span>{ moment( subscription.renewDate ).format( 'll' ) }</span>
 								</span>
 							</div>
 						</div>
@@ -111,4 +110,4 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 	);
 };
 
-export default withLocalizedMoment( PaymentMethodDeleteDialog );
+export default PaymentMethodDeleteDialog;

--- a/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
@@ -78,7 +78,7 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 							<div>
 								<span>{ subscription.productName }</span>
 								<span className="payment-method-delete-dialog__affected-subscription-domain">
-									{ subscription.domain }
+									{ subscription.meta || subscription.domain }
 								</span>
 							</div>
 							<div>

--- a/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
@@ -1,9 +1,9 @@
-import { Gridicon, Dialog } from '@automattic/components';
+import { Dialog, Gridicon } from '@automattic/components';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { getPaymentMethodImageURL } from 'calypso/lib/checkout/payment-methods';
+import { getPaymentMethodImageURL, isCreditCard } from 'calypso/lib/checkout/payment-methods';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
@@ -12,6 +12,7 @@ import 'calypso/me/purchases/payment-methods/style.scss';
 interface Props {
 	card: StoredPaymentMethod;
 	paymentMethodSummary: TranslateResult;
+	purchases: Purchase[];
 	isVisible: boolean;
 	onClose: () => void;
 	onConfirm: () => void;
@@ -67,7 +68,9 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 						<CardHeading tagName="h2" size={ 20 }>
 							{ translate( 'Associated subscriptions' ) }
 						</CardHeading>
-						<img src={ getPaymentMethodImageURL( card?.card_type ) } alt="" />
+						{ isCreditCard( card ) && (
+							<img src={ getPaymentMethodImageURL( card?.card_type ) } alt="" />
+						) }
 					</div>
 					{ associatedSubscriptions.map( ( subscription: Purchase ) => (
 						<div

--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -4,8 +4,9 @@ import { FunctionComponent, useState, useCallback } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isPaymentAgreement, PaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
 import PaymentMethodDeleteDialog from './payment-method-delete-dialog';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 
@@ -22,6 +23,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	const reduxDispatch = useDispatch();
 	const [ isDialogVisible, setIsDialogVisible ] = useState( false );
 	const closeDialog = useCallback( () => setIsDialogVisible( false ), [] );
+	const purchases = useSelector( ( state ) => getUserPurchases( state ) );
 
 	const handleDelete = useCallback( () => {
 		closeDialog();
@@ -77,6 +79,8 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 				isVisible={ isDialogVisible }
 				onClose={ closeDialog }
 				onConfirm={ handleDelete }
+				card={ card }
+				purchases={ purchases }
 			/>
 			{ renderDeleteButton() }
 		</div>

--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -6,7 +6,8 @@ import { isPaymentAgreement, PaymentMethodSummary } from 'calypso/lib/checkout/p
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { getSitePurchases, getUserPurchases } from 'calypso/state/purchases/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PaymentMethodDeleteDialog from './payment-method-delete-dialog';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 
@@ -23,7 +24,9 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	const reduxDispatch = useDispatch();
 	const [ isDialogVisible, setIsDialogVisible ] = useState( false );
 	const closeDialog = useCallback( () => setIsDialogVisible( false ), [] );
-	const purchases = useSelector( ( state ) => getUserPurchases( state ) );
+	const siteId = useSelector( getSelectedSiteId );
+	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+	const userPurchases = useSelector( ( state ) => getUserPurchases( state ) );
 
 	const handleDelete = useCallback( () => {
 		closeDialog();
@@ -80,7 +83,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 				onClose={ closeDialog }
 				onConfirm={ handleDelete }
 				card={ card }
-				purchases={ purchases }
+				purchases={ userPurchases || sitePurchases }
 			/>
 			{ renderDeleteButton() }
 		</div>

--- a/client/me/purchases/payment-methods/payment-method-list.tsx
+++ b/client/me/purchases/payment-methods/payment-method-list.tsx
@@ -11,7 +11,10 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import PaymentMethod from 'calypso/me/purchases/payment-methods/payment-method';
 import { withStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
-import { hasLoadedUserPurchasesFromServer } from 'calypso/state/purchases/selectors';
+import {
+	hasLoadedSitePurchasesFromServer,
+	hasLoadedUserPurchasesFromServer,
+} from 'calypso/state/purchases/selectors';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import type { WithStoredPaymentMethodsProps } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import type { IAppState } from 'calypso/state/types';
@@ -22,6 +25,7 @@ interface PaymentMethodListProps {
 	addPaymentMethodUrl: string;
 	translate: typeof translate;
 	isAgencyUser: boolean;
+	hasLoadedSitePurchasesFromServer: boolean;
 	hasLoadedUserPurchasesFromServer: boolean;
 }
 
@@ -29,10 +33,10 @@ class PaymentMethodList extends Component<
 	PaymentMethodListProps & WithStoredPaymentMethodsProps
 > {
 	renderPaymentMethods( paymentMethods: StoredPaymentMethod[] ) {
-		if (
-			this.props.paymentMethodsState.isLoading ||
-			! this.props.hasLoadedUserPurchasesFromServer
-		) {
+		const hasLoadedPurchases =
+			this.props.hasLoadedUserPurchasesFromServer || this.props.hasLoadedSitePurchasesFromServer;
+
+		if ( this.props.paymentMethodsState.isLoading || ! hasLoadedPurchases ) {
 			return (
 				<CompactCard className="payment-method-list__loader">
 					<div className="payment-method-list__loading-placeholder-card loading-placeholder__content" />
@@ -108,5 +112,6 @@ class PaymentMethodList extends Component<
 
 export default connect( ( state: IAppState ) => ( {
 	isAgencyUser: isAgencyUser( state ),
+	hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
 	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 } ) )( withStoredPaymentMethods( localize( PaymentMethodList ), { type: 'all', expired: true } ) );

--- a/client/me/purchases/payment-methods/payment-method-list.tsx
+++ b/client/me/purchases/payment-methods/payment-method-list.tsx
@@ -11,6 +11,7 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import PaymentMethod from 'calypso/me/purchases/payment-methods/payment-method';
 import { withStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
+import { hasLoadedUserPurchasesFromServer } from 'calypso/state/purchases/selectors';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import type { WithStoredPaymentMethodsProps } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import type { IAppState } from 'calypso/state/types';
@@ -21,13 +22,17 @@ interface PaymentMethodListProps {
 	addPaymentMethodUrl: string;
 	translate: typeof translate;
 	isAgencyUser: boolean;
+	hasLoadedUserPurchasesFromServer: boolean;
 }
 
 class PaymentMethodList extends Component<
 	PaymentMethodListProps & WithStoredPaymentMethodsProps
 > {
 	renderPaymentMethods( paymentMethods: StoredPaymentMethod[] ) {
-		if ( this.props.paymentMethodsState.isLoading ) {
+		if (
+			this.props.paymentMethodsState.isLoading ||
+			! this.props.hasLoadedUserPurchasesFromServer
+		) {
 			return (
 				<CompactCard className="payment-method-list__loader">
 					<div className="payment-method-list__loading-placeholder-card loading-placeholder__content" />
@@ -103,4 +108,5 @@ class PaymentMethodList extends Component<
 
 export default connect( ( state: IAppState ) => ( {
 	isAgencyUser: isAgencyUser( state ),
+	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 } ) )( withStoredPaymentMethods( localize( PaymentMethodList ), { type: 'all', expired: true } ) );

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -142,7 +142,7 @@
 				font-size: $font-body-extra-small;
 			}
 
-			&.payment-method-delete-dialog__affected-subscription-date {
+			&.payment-method-delete-dialog__affected-subscription-date span {
 				color: var(--color-error);
 				font-size: $font-body-extra-small;
 				text-align: center;
@@ -158,6 +158,7 @@
 	.payment-method-delete-dialog__affected-subscriptions-title-wrapper {
 		display: flex;
 		gap: 12px;
+		flex-wrap: wrap;
 		justify-content: space-between;
 		margin-bottom: 8px;
 

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -131,7 +131,64 @@
 
 .payment-method-delete-dialog {
 	&.dialog {
-		max-width: 440px;
+		max-width: 660px;
+
+		span {
+			display: block;
+			font-size: $font-body-small;
+
+			&.payment-method-delete-dialog__affected-subscription-domain {
+				color: var(--color-text-subtle);
+				font-size: $font-body-extra-small;
+			}
+
+			&.payment-method-delete-dialog__affected-subscription-date {
+				color: var(--color-error);
+				font-size: $font-body-extra-small;
+				text-align: center;
+			}
+		}
+	}
+
+	.payment-method-delete-dialog__affected-subscriptions-wrapper {
+		border-top: 1px solid var(--color-border-subtle);
+		padding-top: 12px;
+	}
+
+	.payment-method-delete-dialog__affected-subscriptions-title-wrapper {
+		display: flex;
+		gap: 12px;
+		justify-content: space-between;
+		margin-bottom: 8px;
+
+		.card-heading {
+			margin: 0;
+		}
+	}
+
+	.payment-method-delete-dialog__affected-subscription {
+		background: var(--color-neutral-0);
+		border-radius: 4px;
+		display: flex;
+		gap: 12px;
+		justify-content: space-between;
+		padding: 12px;
+		margin-top: 14px;
+	}
+
+	.payment-method-delete-dialog__warning {
+		display: flex;
+		margin-top: 12px;
+		gap: 12px;
+
+		.gridicon {
+			fill: var(--color-warning);
+		}
+
+		p {
+			color: var(--color-warning);
+			font-size: $font-body-small;
+		}
 	}
 
 	.card-heading {

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -6,6 +6,7 @@ import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HeaderCake from 'calypso/components/header-cake';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Layout from 'calypso/components/layout';
@@ -29,6 +30,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getAddNewPaymentMethodUrlFor, getPaymentMethodsUrlFor } from '../paths';
 
 function useLogPaymentMethodsError( message: string ) {
@@ -46,12 +48,14 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ) {
 	const logPaymentMethodsError = useLogPaymentMethodsError(
 		'site level payment methods load error'
 	);
+	const siteId = useSelector( getSelectedSiteId );
 
 	return (
 		<Main wideLayout className="purchases">
 			{ isJetpackCloud() && <SidebarNavigation /> }
 			<DocumentHead title={ titles.paymentMethods } />
 			<PageViewTracker path="/purchases/payment-methods" title="Payment Methods" />
+			<QuerySitePurchases siteId={ siteId } />
 			{ ! isJetpackCloud() && (
 				<NavigationHeader
 					title={ titles.sectionTitle }


### PR DESCRIPTION
Fixes #60629

## Proposed Changes

* Displays a list of subscriptions which will be affected by deleting a payment method (ie. those where the subscription is linked to the payment method **and** auto-renewal is active). 

## Why are these changes being made?

See #60629 - at the moment, the user is warned that the payment will be removed from all associated subscriptions, but there's nothing that prompts the user by telling them what subscriptions are actually affected. This should hopefully make it more clear. 

## Testing Instructions

1. Purchase a recurring subscription **and** set it to auto-renew
2. Navigate to `/me/purchases/payment-methods`
3. Select the "Delete this payment method" for the option which you've just purchased the subscription with
4. Confirm that you are now warned that this subscription is linked to the payment method
5. Also confirm that these changes don't appear when the payment method has no subscription linked to it.

<img width="745" alt="Screenshot 2024-10-06 at 23 44 27" src="https://github.com/user-attachments/assets/73611abd-8f4f-4c3f-bf38-ff78072dd63e">

(Just to stress, the design isn't taken from anywhere - it's what I thought looked clear and relatively pretty, but I'm more than happy to change any of it)

cc @sirbrillig, @DavidRothstein 