### PR TITLE
Theme: Display the Atomic Transfer dialog for wporg-only themes

### DIFF
--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -38,12 +38,11 @@ export function activate( themeId, siteId, options ) {
 		const isDotComTheme = !! getTheme( getState(), 'wpcom', themeId );
 		const isDotOrgTheme = !! getTheme( getState(), 'wporg', themeId );
 		const hasThemeBundleSoftwareSet = doesThemeBundleSoftwareSet( getState(), themeId );
-
-		// The DotOrg themes will be handled by the marketplace install page.
-		// The theme with the plugin bundle will be handled by the plugin bundle flow.
 		const shouldAtomicTransfer =
 			isExternallyManagedTheme( getState(), themeId ) ||
-			isDotOrgTheme ||
+			// The wporg-only themes need the atomic transfer.
+			( isDotOrgTheme && ! isDotComTheme ) ||
+			// On the onboarding flow, the plugin-bundle theme will continue to the plugin bundle flow.
 			( isDotComTheme && hasThemeBundleSoftwareSet && ! isOnboardingFlow );
 
 		/**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1728148852080749-slack-C048CUFRGFQ

## Proposed Changes

* Fix the atomic transfer dialog shown for a theme belonging to both wpcom and wporg

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The atomic transfer dialog is not required for wpcom themes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to themes on your free sites
* Select a theme belonging to both wpcom and wporg, e.g.: TT4, TextBook
* Activate theme
* Make sure the Atomic Transfer dialog is not shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?