### PR TITLE
Performance Profiler: Fix rendering of null values in performance profiler history

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details_v2.tsx
@@ -46,11 +46,12 @@ export const CoreWebVitalsDetailsV2: React.FC< CoreWebVitalsDetailsProps > = ( {
 
 	const { good, needsImprovement, bad } = metricsTresholds[ activeTab ];
 
-	const formatUnit = ( value: number ) => {
+	const formatUnit = ( value: number | string ) => {
+		const num = parseFloat( value as string );
 		if ( [ 'lcp', 'fcp', 'ttfb' ].includes( activeTab ) ) {
-			return +( value / 1000 ).toFixed( 2 );
+			return +( num / 1000 ).toFixed( 2 );
 		}
-		return value;
+		return num;
 	};
 
 	const displayUnit = () => {


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94773 and https://github.com/Automattic/dotcom-forge/issues/9284

## Proposed Changes

This diff applies the fix from #94773 to the "V2" component.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Null-value rendering was changed in #94773 so that nulls appeared as gaps in the graph. This change was only made to the "V1" version of the components i.e. the logged-out view.

As of #95108 the logged-out view uses the "V2" version of components and so this fix was lost in the process.



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test this report and see that null-values once again are represented by a gap in the history graph.

```
/speed-test-tool?url=https://stitchandstyle.ie/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzgyOX0.3nU626e3YxQ7lpMXD6t_zXCwJpCAKUVXDVpNquLh0eM
```
