### PR TITLE
Redirect to plugins.php after paid plugin activation instead of Congrats page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -129,12 +129,15 @@ const MarketplaceThankYou = ( {
 	useEffect( () => {
 		// We don't want to show the progress bar again when it is hidden.
 		if ( ! showProgressBar ) {
-			// Redirect to plugins.php if there are only plugins and no themes.
+			return;
+		}
+
+		// Redirect to plugins.php if there are only plugins and no themes.
+		if ( isPageReady ) {
 			const isOnlyPlugins = pluginSlugs.length > 0 && themeSlugs.length === 0;
 			if ( isOnlyPlugins && pluginsUrl ) {
 				window.location.href = pluginsUrl;
 			}
-
 			return;
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -13,7 +13,7 @@ import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { isRequesting } from 'calypso/state/plugins/installed/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { MarketplaceGoBackSection } from './marketplace-go-back-section';
@@ -122,15 +122,31 @@ const MarketplaceThankYou = ( {
 		}
 	}, [ isRequestingPlugins, isPageReady, dispatch, siteId, transferStatus, isJetpackSelfHosted ] );
 
+	const pluginsUrl = useSelector( ( state ) => {
+		return getSiteAdminUrl( state, siteId, 'plugins.php?activate=true&plugin_status=active' );
+	} );
 	// Set progressbar (currentStep) depending on transfer/plugin status.
 	useEffect( () => {
 		// We don't want to show the progress bar again when it is hidden.
 		if ( ! showProgressBar ) {
+			// Redirect to plugins.php if there are only plugins and no themes.
+			const isOnlyPlugins = pluginSlugs.length > 0 && themeSlugs.length === 0;
+			if ( isOnlyPlugins && pluginsUrl ) {
+				window.location.href = pluginsUrl;
+			}
+
 			return;
 		}
 
 		setShowProgressBar( ! isPageReady );
-	}, [ setShowProgressBar, showProgressBar, isPageReady ] );
+	}, [
+		setShowProgressBar,
+		showProgressBar,
+		isPageReady,
+		pluginSlugs.length,
+		themeSlugs.length,
+		pluginsUrl,
+	] );
 
 	const { steps, additionalSteps } = useThankYouSteps( {
 		pluginSlugs,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -48,6 +48,7 @@ const MarketplaceThankYou = ( {
 	const [
 		pluginsSection,
 		allPluginsFetched,
+		allPluginsActivated,
 		pluginsGoBackSection,
 		pluginTitle,
 		pluginSubtitle,
@@ -98,6 +99,7 @@ const MarketplaceThankYou = ( {
 
 	const isPageReady =
 		allPluginsFetched &&
+		allPluginsActivated &&
 		allThemesFetched &&
 		isAtomicTransferCheckComplete &&
 		isLoadedPlugins &&

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -16,6 +16,7 @@ import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchas
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginsOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
+import { isPluginActive } from 'calypso/state/plugins/installed/selectors-ts';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { areFetched, areFetching, getPlugins } from 'calypso/state/plugins/wporg/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -26,6 +27,7 @@ import { ThankYouPluginSection } from './marketplace-thank-you-plugin-section';
 
 type ThankYouData = [
 	React.ReactElement[],
+	boolean,
 	boolean,
 	JSX.Element,
 	string,
@@ -61,7 +63,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	);
 
 	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
-	const pluginsOnSite: [] = useSelector( ( state ) =>
+	const pluginsOnSite: Plugin[] = useSelector( ( state ) =>
 		getPluginsOnSite( state, siteId, softwareSlugs )
 	);
 	const wporgPlugins = useSelector(
@@ -86,6 +88,11 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	const areAllWporgPluginsFetched = areWporgPluginsFetched.every( Boolean );
 
 	const allPluginsFetched = pluginsOnSite.every( ( pluginOnSite ) => !! pluginOnSite );
+	const allPluginsActivated = useSelector( ( state ) => {
+		return pluginsOnSite.every( ( pluginOnSite ) => {
+			return isPluginActive( state, siteId as number, pluginOnSite?.slug );
+		} );
+	} );
 
 	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
@@ -225,6 +232,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	return [
 		pluginsSection,
 		allPluginsFetched,
+		allPluginsActivated,
 		goBackSection,
 		title,
 		subtitle,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -155,7 +155,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		if (
 			! siteId ||
 			( ! isJetpackSelfHosted && transferStatus !== transferStates.COMPLETE ) ||
-			allPluginsFetched ||
+			( allPluginsFetched && allPluginsActivated ) ||
 			pluginSlugs.length === 0
 		) {
 			return;
@@ -171,6 +171,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		transferStatus,
 		isJetpackSelfHosted,
 		allPluginsFetched,
+		allPluginsActivated,
 		pluginSlugs,
 	] );
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -266,7 +266,7 @@ const MarketplaceProductInstall = ( {
 	}, [ pluginUploadComplete, installedPlugin, setCurrentStep ] );
 
 	const pluginsUrl = useSelector( ( state ) =>
-		getSiteAdminUrl( state, siteId, 'plugins.php?activate=true' )
+		getSiteAdminUrl( state, siteId, 'plugins.php?activate=true&plugin_status=active' )
 	);
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -285,7 +285,7 @@ const MarketplaceProductInstall = ( {
 				transferStates.COMPLETE === automatedTransferStatus &&
 				canManagePlugins )
 		) {
-			waitFor( 2 ).then( () => {
+			waitFor( 1 ).then( () => {
 				window.location.href = pluginsUrl as string;
 			} );
 		}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -285,7 +285,7 @@ const MarketplaceProductInstall = ( {
 				transferStates.COMPLETE === automatedTransferStatus &&
 				canManagePlugins )
 		) {
-			waitFor( 1 ).then( () => {
+			waitFor( 2 ).then( () => {
 				window.location.href = pluginsUrl as string;
 			} );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9180

## Proposed Changes

This PR extends the functionality introduced in https://github.com/Automattic/wp-calypso/pull/95050 to handle paid plugin activations. 

Similar to the changes applied for free and custom plugins, this update ensures that after the successful purchase and activation of a paid plugin, users are redirected to the plugins.php page, with a notice confirming activation (if the installing plugins do not have its custom redirection).
<img width="1257" alt="Screenshot 2024-10-07 at 14 36 12" src="https://github.com/user-attachments/assets/4a7e8086-17f3-4f8d-b29e-6073a9fc31c4">

### Multiple Plugin Purchases
This PR also applies to purchasing multiple plugins. 

In that scenario, the redirections will happen sequentially: first, PluginA's custom redirect when the user visits plugins.php for the first time, followed by PluginB’s when the user visits plugins.php the second time, and so on. This is the same behavior as when multiple plugins are activated once in WordPress Core, allowing each plugin to redirect users to its respective onboarding or settings page. (I think this makes sense.)

However, if we're to discuss, it's about whether this is more or less user-friendly than the previous "Congrats" page, which summarized activations in one step.
<img width="1440" alt="Screenshot 2024-10-07 at 11 24 16 copy" src="https://github.com/user-attachments/assets/3676ad8f-3afc-493b-b9cf-14d064d7d4de">

Note that each plugin also adds the onboarding links to plugins.php, which can replace the above congrats screen, being more aligned with Core. 
<img width="1262" alt="Screenshot 2024-10-07 at 14 32 40" src="https://github.com/user-attachments/assets/9672d895-61e2-4132-b687-cfed5c374e4a">

### Multi-product Purchases
Users purchasing multiple products, such as plugins and themes together, will still be redirected to the "Thank You" page after the purchase. This PR does not cover the scenario of multi-product purchases.

### Implementation Notes

<details><summary>Details</summary>
<p>

- After users purchase paid plugins, they are redirected to /marketplace/thank-you, as defined in the following code: https://github.com/Automattic/wp-calypso/blob/4a88ccb39fcaca0f03302ea074cada582d216fa8/client/my-sites/checkout/get-thank-you-page-url/index.ts#L608-L627 
	- (The actual plugin installation is handled on the backend by activating the subscription): https://github.com/Automattic/wp-calypso/blob/4a88ccb39fcaca0f03302ea074cada582d216fa8/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx#L277-L296
- After landing on the /marketplace/thank-you page, it checks whether the purchased plugins are activated by running the following logic: https://github.com/Automattic/wp-calypso/blob/4a88ccb39fcaca0f03302ea074cada582d216fa8/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx#L99-L104
- This PR modifies the flow by interrupting the behavior of the /marketplace/thank-you page. Instead of staying and displaying the thank-you page, once the plugins are confirmed to be activated, the user is redirected to plugins.php.

</p>
</details> 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See pbxlJb-6kE-p2 and https://github.com/Automattic/dotcom-forge/issues/9180

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Prepare a Simple site with the Business plan or Atomic site with the Business plan
- Go to /plugins/<site> and install a paid plugin. 
	- If you're an a11n, you can put "Sensei Pro" and "WP Job Manager - Resume Manager" into the cart and install them with credits. 
- Observe it redirects to the progress page, then to /wp-admin/plugins.php. 
- Try to go to /wp-admin/plugins.php if you're redirected to a plugins' custom setup page. 
- Observe /wp-admin/plugins.php with onboarding links when it's relevant.
<img width="1256" alt="Screenshot 2024-10-07 at 15 00 24" src="https://github.com/user-attachments/assets/7e660bb5-7e2c-440c-a494-aaa84977a30c">

<!--
 the Resume Manager's setup page.
- Try to go to /wp-admin/plugins.php.
- Observe it redirects to Sensei Pro's onboarding page.
- Try to go to /wp-admin/plugins.php.

-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Fr"eze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added "he "[Status] Needs Privacy Upd"tes" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
