### PR TITLE
DIFM Signup: Redirect user to `/home` after they cancel DIFM checkout

### DIFF
--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -15,6 +15,7 @@ import {
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { useSelector, useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import { saveSignupStep } from 'calypso/state/signup/progress/actions';
 import {
 	changesSaved,
@@ -259,6 +260,7 @@ export default function WrapperWebsiteContent(
 		};
 	} & WebsiteContentStepProps
 ) {
+	const { skippedCheckout } = useSelector( getInitialQueryArguments ) ?? {};
 	const { flowName, stepName, positionInFlow, queryObject } = props;
 	const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSiteId( state, queryObject.siteSlug as string ) );
@@ -299,6 +301,13 @@ export default function WrapperWebsiteContent(
 			page( `/home/${ queryObject.siteSlug }` );
 		}
 	}, [ data, queryObject.siteSlug ] );
+
+	useEffect( () => {
+		if ( skippedCheckout === '1' ) {
+			debug( 'User did not make a DIFM purchase, redirecting to home' );
+			page( `/home/${ queryObject.siteSlug }` );
+		}
+	}, [ skippedCheckout, queryObject.siteSlug ] );
 
 	if ( isLoading ) {
 		return <Loader />;


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

This diff hijacks the 'website-content' step in order to check the value of the `?skippedCheckout=1` query param. If it's set then we go straight to My Home otherwise an error is shown - since the purchase is never completed, the DIFM data isn't set up and that's why there's an error on this page.


![CleanShot 2024-10-07 at 20 33 34@2x](https://github.com/user-attachments/assets/219168b7-c009-48dc-a619-68988f44f267)


The checkout page usually supports both `?redirect_to` and `?cancel_to` query params that let you go to a different location if the user cancels the checkout. Unfortunately the signup framework only gives the ability to set a single "destination" for a flow.
https://github.com/Automattic/wp-calypso/blob/cf0aa1a007213a6cfcf40b420acd7f4b9c1d8441/client/signup/config/flows-pure.js#L506

For reference, the `?skippedCheckout=1` param is set here: https://github.com/Automattic/wp-calypso/blob/cf0aa1a007213a6cfcf40b420acd7f4b9c1d8441/client/signup/config/flows.js#L58


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For reference, the DIFM flows are linked to from the logged-out landing page https://wordpress.com/website-design-service/

- Test `/start/do-it-for-me/new-or-existing-site?ref=do-it-for-me-lp` flow
- Test `/start/do-it-for-me-store/?utm_campaign=happiness` flow
- Test cancelling at the checkout (with the cross in the top-left) and also completing the purchase

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
