### PR TITLE
Fix SSH key layout breaking for smaller viewports

### DIFF
--- a/client/hosting/server-settings/components/sftp-card/ssh-keys.scss
+++ b/client/hosting/server-settings/components/sftp-card/ssh-keys.scss
@@ -13,8 +13,15 @@
 
 .ssh-keys__cards-container {
 	display: block;
+
 	> .card:not(:last-child) {
 		margin-bottom: 12px;
+	}
+
+	code {
+		white-space: pre-wrap;
+		word-wrap: break-word;
+		word-break: break-word;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9322

## Proposed Changes

This PR fixes the layout of the SSH key breaking for smaller viewports.

| Before | After |
| --- | --- |
| ![SCR-20241007-ogzv](https://github.com/user-attachments/assets/ad88e6fa-b9c6-4850-9938-65b21739544e)| ![SCR-20241007-ohcy](https://github.com/user-attachments/assets/9c12d706-089f-4122-987a-657f40a75432) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Improve UI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /hosting-config/{SITE} for an Atomic site.
* Add SSK key.
* Ensure that the layout is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
