### PR TITLE
Add Bluesky preview to social-previews

### DIFF
--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.1.0
 
-- Added Threads preview
+- Added Threads and Bluesky preview
 - Fixed media image URL for Tumblr and Instagram previews
 
 ## v2.0.1 (2024-06-10)

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.1.0-beta.6",
+	"version": "2.1.0-beta.7",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/src/bluesky-preview/helpers.ts
+++ b/packages/social-previews/src/bluesky-preview/helpers.ts
@@ -1,0 +1,31 @@
+import {
+	firstValid,
+	hardTruncation,
+	shortEnough,
+	stripHtmlTags,
+	preparePreviewText,
+	Formatter,
+} from '../helpers';
+
+const TITLE_LENGTH = 200;
+const BODY_LENGTH = 300;
+const URL_LENGTH = 40;
+
+export const blueskyTitle: Formatter = ( text ) =>
+	firstValid(
+		shortEnough( TITLE_LENGTH ),
+		hardTruncation( TITLE_LENGTH )
+	)( stripHtmlTags( text ) ) || '';
+
+export const blueskyBody = ( text: string, options: { offset?: number } = {} ) => {
+	const { offset = 0 } = options;
+
+	return preparePreviewText( text, {
+		platform: 'bluesky',
+		maxChars: BODY_LENGTH - URL_LENGTH - offset,
+	} );
+};
+
+export const blueskyUrl: Formatter = ( text ) =>
+	firstValid( shortEnough( URL_LENGTH ), hardTruncation( URL_LENGTH ) )( stripHtmlTags( text ) ) ||
+	'';

--- a/packages/social-previews/src/bluesky-preview/index.tsx
+++ b/packages/social-previews/src/bluesky-preview/index.tsx
@@ -1,0 +1,3 @@
+export * from './link-preview';
+export * from './post-preview';
+export * from './previews';

--- a/packages/social-previews/src/bluesky-preview/link-preview.tsx
+++ b/packages/social-previews/src/bluesky-preview/link-preview.tsx
@@ -1,0 +1,6 @@
+import { BlueskyPostPreview } from './post-preview';
+import type { BlueskyPreviewProps } from './types';
+
+export const BlueskyLinkPreview: React.FC< BlueskyPreviewProps > = ( props ) => {
+	return <BlueskyPostPreview { ...props } user={ undefined } media={ undefined } customText="" />;
+};

--- a/packages/social-previews/src/bluesky-preview/post-preview.tsx
+++ b/packages/social-previews/src/bluesky-preview/post-preview.tsx
@@ -1,0 +1,45 @@
+import clsx from 'clsx';
+import BlueskyPostActions from './post/actions';
+import BlueskyPostBody from './post/body';
+import BlueskyPostCard from './post/card';
+import BlueskyPostHeader from './post/header';
+import { BlueskyPostSidebar } from './post/sidebar';
+import type { BlueskyPreviewProps } from './types';
+
+import './styles.scss';
+
+export const BlueskyPostPreview: React.FC< BlueskyPreviewProps > = ( props ) => {
+	const { user, media } = props;
+
+	return (
+		<div className="bluesky-preview__post">
+			<BlueskyPostSidebar user={ user } />
+			<div>
+				<BlueskyPostHeader user={ user } />
+				<BlueskyPostBody { ...props }>
+					{ media?.length ? (
+						<div className={ clsx( 'bluesky-preview__media', { 'as-grid': media.length > 1 } ) }>
+							{ media.map( ( mediaItem, index ) => (
+								<div
+									key={ `bluesky-preview__media-item-${ index }` }
+									className="bluesky-preview__media-item"
+								>
+									{ mediaItem.type.startsWith( 'video/' ) ? (
+										// eslint-disable-next-line jsx-a11y/media-has-caption
+										<video controls>
+											<source src={ mediaItem.url } type={ mediaItem.type } />
+										</video>
+									) : (
+										<img alt={ mediaItem.alt || '' } src={ mediaItem.url } />
+									) }
+								</div>
+							) ) }
+						</div>
+					) : null }
+				</BlueskyPostBody>
+				{ ! media?.length ? <BlueskyPostCard { ...props } /> : null }
+				<BlueskyPostActions />
+			</div>
+		</div>
+	);
+};

--- a/packages/social-previews/src/bluesky-preview/post/actions/index.tsx
+++ b/packages/social-previews/src/bluesky-preview/post/actions/index.tsx
@@ -1,0 +1,72 @@
+import './styles.scss';
+
+const BlueskyPostActions: React.FC = () => (
+	<div className="bluesky-preview__post-actions">
+		<div>
+			<svg
+				fill="none"
+				width="18"
+				viewBox="0 0 24 24"
+				height="18"
+				style={ { color: 'rgb(111, 134, 159)' } }
+				aria-hidden="true"
+			>
+				<path
+					fill="hsl(211, 20%, 53%)"
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M2.002 6a3 3 0 0 1 3-3h14a3 3 0 0 1 3 3v10a3 3 0 0 1-3 3H12.28l-4.762 2.858A1 1 0 0 1 6.002 21v-2h-1a3 3 0 0 1-3-3V6Zm3-1a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h2a1 1 0 0 1 1 1v1.234l3.486-2.092a1 1 0 0 1 .514-.142h7a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-14Z"
+				></path>
+			</svg>
+			<span>{ 0 }</span>
+		</div>
+		<div>
+			<svg
+				fill="none"
+				width="18"
+				viewBox="0 0 24 24"
+				height="18"
+				style={ { color: 'rgb(111, 134, 159)' } }
+				aria-hidden="true"
+			>
+				<path
+					fill="hsl(211, 20%, 53%)"
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M17.957 2.293a1 1 0 1 0-1.414 1.414L17.836 5H6a3 3 0 0 0-3 3v3a1 1 0 1 0 2 0V8a1 1 0 0 1 1-1h11.836l-1.293 1.293a1 1 0 0 0 1.414 1.414l2.47-2.47a1.75 1.75 0 0 0 0-2.474l-2.47-2.47ZM20 12a1 1 0 0 1 1 1v3a3 3 0 0 1-3 3H6.164l1.293 1.293a1 1 0 1 1-1.414 1.414l-2.47-2.47a1.75 1.75 0 0 1 0-2.474l2.47-2.47a1 1 0 0 1 1.414 1.414L6.164 17H18a1 1 0 0 0 1-1v-3a1 1 0 0 1 1-1Z"
+				></path>
+			</svg>
+			<span>{ 0 }</span>
+		</div>
+		<div>
+			<svg
+				fill="none"
+				width="18"
+				viewBox="0 0 24 24"
+				height="18"
+				style={ { color: 'rgb(111, 134, 159)' } }
+				aria-hidden="true"
+			>
+				<path
+					fill="hsl(211, 20%, 53%)"
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M16.734 5.091c-1.238-.276-2.708.047-4.022 1.38a1 1 0 0 1-1.424 0C9.974 5.137 8.504 4.814 7.266 5.09c-1.263.282-2.379 1.206-2.92 2.556C3.33 10.18 4.252 14.84 12 19.348c7.747-4.508 8.67-9.168 7.654-11.7-.541-1.351-1.657-2.275-2.92-2.557Zm4.777 1.812c1.604 4-.494 9.69-9.022 14.47a1 1 0 0 1-.978 0C2.983 16.592.885 10.902 2.49 6.902c.779-1.942 2.414-3.334 4.342-3.764 1.697-.378 3.552.003 5.169 1.286 1.617-1.283 3.472-1.664 5.17-1.286 1.927.43 3.562 1.822 4.34 3.764Z"
+				></path>
+			</svg>
+			<span>{ 0 }</span>
+		</div>
+		<div>
+			<svg fill="none" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+				<path
+					fill="hsl(211, 20%, 53%)"
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M2 12a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm16 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm-6-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"
+				></path>
+			</svg>
+		</div>
+	</div>
+);
+
+export default BlueskyPostActions;

--- a/packages/social-previews/src/bluesky-preview/post/actions/styles.scss
+++ b/packages/social-previews/src/bluesky-preview/post/actions/styles.scss
@@ -1,0 +1,20 @@
+@import "../../variables";
+
+.bluesky-preview__post-actions {
+	margin-top: 0.5rem;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	& > div {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		color: rgb(111, 134, 159);
+	}
+
+	svg {
+		fill: currentColor;
+	}
+}

--- a/packages/social-previews/src/bluesky-preview/post/body/index.tsx
+++ b/packages/social-previews/src/bluesky-preview/post/body/index.tsx
@@ -1,0 +1,25 @@
+import { blueskyBody, blueskyUrl } from '../../helpers';
+import type { BlueskyPreviewProps } from '../../types';
+
+import './styles.scss';
+
+type Props = BlueskyPreviewProps & { children?: React.ReactNode };
+
+const BlueskyPostBody: React.FC< Props > = ( { customText, url, children } ) => {
+	return (
+		<div className="bluesky-preview__body">
+			{ customText ? (
+				<>
+					<div>{ blueskyBody( customText ) }</div>
+					<br />
+					<a href={ url } target="_blank" rel="noreferrer noopener">
+						{ blueskyUrl( url.replace( /^https?:\/\//, '' ) ) }
+					</a>
+				</>
+			) : null }
+			{ children }
+		</div>
+	);
+};
+
+export default BlueskyPostBody;

--- a/packages/social-previews/src/bluesky-preview/post/body/styles.scss
+++ b/packages/social-previews/src/bluesky-preview/post/body/styles.scss
@@ -1,0 +1,12 @@
+@import "../../variables";
+
+.bluesky-preview__body {
+	margin-bottom: 1rem;
+
+	color: $bluesky-body-text-color;
+
+	> p {
+		margin-bottom: 1.25rem;
+	}
+}
+

--- a/packages/social-previews/src/bluesky-preview/post/card/index.tsx
+++ b/packages/social-previews/src/bluesky-preview/post/card/index.tsx
@@ -1,0 +1,26 @@
+import { baseDomain, getTitleFromDescription, stripHtmlTags } from '../../../helpers';
+import { blueskyTitle } from '../../helpers';
+import { BlueskyPreviewProps } from '../../types';
+
+import './styles.scss';
+
+const BlueskyPostCard: React.FC< BlueskyPreviewProps > = ( { title, description, url, image } ) => {
+	return (
+		<div className="bluesky-preview__card">
+			{ image ? (
+				<div className="bluesky-preview__card-image">
+					<img src={ image } alt="" />
+				</div>
+			) : null }
+			<div className="bluesky-preview__card-text">
+				<div className="bluesky-preview__card-site">{ baseDomain( url ) }</div>
+				<div className="bluesky-preview__card-title">
+					{ blueskyTitle( title ) || getTitleFromDescription( description ) }
+				</div>
+				<div className="bluesky-preview__card-description">{ stripHtmlTags( description ) }</div>
+			</div>
+		</div>
+	);
+};
+
+export default BlueskyPostCard;

--- a/packages/social-previews/src/bluesky-preview/post/card/styles.scss
+++ b/packages/social-previews/src/bluesky-preview/post/card/styles.scss
@@ -1,0 +1,70 @@
+@import "../../variables";
+
+.bluesky-preview__card {
+	display: flex;
+	flex-direction: column;
+	margin-top: 1rem;
+
+	border: solid 1px #d9e1e8;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 8px;
+	overflow: hidden;
+	color: $bluesky-body-text-color;
+}
+
+.bluesky-preview__card-image img {
+	width: 100%;
+	object-fit: cover;
+}
+
+.bluesky-preview__card-text {
+	border-bottom-width: 1px;
+    border-left-width: 1px;
+    border-right-width: 1px;
+    flex: 1 1 0%;
+    padding: 8px 14px;
+    border-color: rgb(212, 219, 226);
+    /* stylelint-disable-next-line scales/radii */
+    border-bottom-right-radius: 8px;
+    /* stylelint-disable-next-line scales/radii */
+    border-bottom-left-radius: 8px;
+}
+
+.bluesky-preview__card-title {
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 3;
+	display: -webkit-box;
+	overflow: hidden;
+	text-overflow: ellipsis;
+    color: rgb(11, 15, 20);
+    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 0.25px;
+}
+
+.bluesky-preview__card-site {
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+	font-size: 14px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+    color: rgb(66, 87, 108);
+    font-weight: 400;
+    letter-spacing: 0.25px;
+    margin-bottom: 2px;
+    margin-top: 2px;
+}
+
+.bluesky-preview__card-description {
+	-webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+	color: rgb(11, 15, 20);
+	display: -webkit-box;
+    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
+    font-size: 15px;
+    font-weight: 400;
+    letter-spacing: 0.25px;
+	margin-top: 4px;
+	overflow: hidden;
+}

--- a/packages/social-previews/src/bluesky-preview/post/header/index.tsx
+++ b/packages/social-previews/src/bluesky-preview/post/header/index.tsx
@@ -1,0 +1,34 @@
+import { __, _x } from '@wordpress/i18n';
+import type { BlueskyPreviewProps } from '../../types';
+
+import './styles.scss';
+
+type Props = Pick< BlueskyPreviewProps, 'user' >;
+
+const BlueskyPostHeader: React.FC< Props > = ( { user } ) => {
+	const { displayName, address } = user || {};
+
+	return (
+		<div className="bluesky-preview__post-header">
+			<div className="bluesky-preview__post-header-user">
+				<span className="bluesky-preview__post-header--displayname">
+					{ displayName || __( 'Account name' ) }
+				</span>
+				&nbsp;
+				<span className="bluesky-preview__post-header--username">
+					{ address || 'username.bsky.social' }
+				</span>
+			</div>
+			<div className="bluesky-preview__post-header--separator">·</div>
+			<div className="bluesky-preview__post-header--date">
+				{ _x(
+					'1h',
+					'refers to the time since the post was published, e.g. "1h"',
+					'social-previews'
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default BlueskyPostHeader;

--- a/packages/social-previews/src/bluesky-preview/post/header/styles.scss
+++ b/packages/social-previews/src/bluesky-preview/post/header/styles.scss
@@ -1,0 +1,33 @@
+@import "../../variables";
+
+.bluesky-preview__post-header {
+	display: flex;
+	align-items: start;
+	gap: 4px;
+
+	margin-bottom: 0.625rem;
+
+	/* stylelint-disable-next-line scales/font-sizes */
+	font-size: 0.9375rem;
+	line-height: 1.47;
+
+	&--displayname {
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		font-size: 16px;
+		letter-spacing: 0.25px;
+		font-weight: 700;
+		line-height: 19px;
+		color: rgb(11, 15, 20);
+	}
+
+	&--username,
+	&--separator,
+	&--date {
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		font-size: 15px;
+		letter-spacing: 0.25px;
+		font-weight: 400;
+		color: rgb(66, 87, 108);
+	}
+
+}

--- a/packages/social-previews/src/bluesky-preview/post/sidebar/index.tsx
+++ b/packages/social-previews/src/bluesky-preview/post/sidebar/index.tsx
@@ -1,0 +1,36 @@
+import type { BlueskyPreviewProps } from '../../types';
+
+import './styles.scss';
+
+type Props = Pick< BlueskyPreviewProps, 'user' >;
+
+export const BlueskyPostSidebar: React.FC< Props > = ( { user } ) => {
+	const { avatarUrl } = user || {};
+
+	return (
+		<div className="bluesky-preview__post-sidebar">
+			<div className="bluesky-preview__post-sidebar-user">
+				{ avatarUrl ? (
+					<img className="bluesky-preview__post-avatar" src={ avatarUrl } alt="" />
+				) : (
+					<svg
+						className="bluesky-preview__post-avatar"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="none"
+						role="presentation"
+					>
+						<circle cx="12" cy="12" r="12" fill="#0070ff"></circle>
+						<circle cx="12" cy="9.5" r="3.5" fill="#fff"></circle>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							fill="#fff"
+							d="M 12.058 22.784 C 9.422 22.784 7.007 21.836 5.137 20.262 C 5.667 17.988 8.534 16.25 11.99 16.25 C 15.494 16.25 18.391 18.036 18.864 20.357 C 17.01 21.874 14.64 22.784 12.058 22.784 Z"
+						></path>
+					</svg>
+				) }
+			</div>
+		</div>
+	);
+};

--- a/packages/social-previews/src/bluesky-preview/post/sidebar/styles.scss
+++ b/packages/social-previews/src/bluesky-preview/post/sidebar/styles.scss
@@ -1,0 +1,6 @@
+
+.bluesky-preview__post-avatar {
+	width: 52px;
+	height: 52px;
+	border-radius: 50%;
+}

--- a/packages/social-previews/src/bluesky-preview/previews.tsx
+++ b/packages/social-previews/src/bluesky-preview/previews.tsx
@@ -1,0 +1,56 @@
+import { ExternalLink } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { SectionHeading } from '../shared/section-heading';
+import { SocialPreviewsBaseProps } from '../types';
+import { BlueskyLinkPreview } from './link-preview';
+import { BlueskyPostPreview } from './post-preview';
+import { BlueskyPreviewProps } from './types';
+
+export type BlueskyPreviewsProps = BlueskyPreviewProps & SocialPreviewsBaseProps;
+
+export const BlueskyPreviews: React.FC< BlueskyPreviewsProps > = ( {
+	headingLevel,
+	hidePostPreview,
+	hideLinkPreview,
+	...props
+} ) => {
+	return (
+		<div className="social-preview bluesky-preview">
+			{ ! hidePostPreview && (
+				<section className="social-preview__section bluesky-preview__section">
+					<SectionHeading level={ headingLevel }>
+						{
+							// translators: refers to a social post on Bluesky
+							__( 'Your post', 'social-previews' )
+						}
+					</SectionHeading>
+					<p className="social-preview__section-desc">
+						{ __( 'This is what your social post will look like on Bluesky:', 'social-previews' ) }
+					</p>
+					<BlueskyPostPreview { ...props } />
+				</section>
+			) }
+			{ ! hideLinkPreview && (
+				<section className="social-preview__section bluesky-preview__section">
+					<SectionHeading level={ headingLevel }>
+						{
+							// translators: refers to a link to a Bluesky post
+							__( 'Link preview', 'social-previews' )
+						}
+					</SectionHeading>
+					<p className="social-preview__section-desc">
+						{ __(
+							'This is what it will look like when someone shares the link to your WordPress post on Bluesky.',
+							'social-previews'
+						) }
+						&nbsp;
+						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
+							{ __( 'Learn more about links', 'social-previews' ) }
+						</ExternalLink>
+					</p>
+					<BlueskyLinkPreview { ...props } />
+				</section>
+			) }
+		</div>
+	);
+};

--- a/packages/social-previews/src/bluesky-preview/styles.scss
+++ b/packages/social-previews/src/bluesky-preview/styles.scss
@@ -1,0 +1,65 @@
+@import "./variables";
+@import "../shared";
+
+.bluesky-preview__section {
+	max-width: 100%;
+	width: $bluesky-preview-width;
+	margin-inline: auto;
+}
+
+.bluesky-preview__post {
+	display: flex;
+    flex-direction: row;
+    gap: 10px;
+
+	width: 100%;
+	overflow-y: hidden;
+	box-sizing: border-box;
+	padding: 1rem;
+
+	background-color: $bluesky-preview-background-color;
+	border: 1px solid #c0cdd9;
+	color: $bluesky-preview-text-color;
+
+	font-family: $bluesky-preview-font-family;
+	/* stylelint-disable-next-line scales/font-sizes */
+	font-size: 0.9375rem;
+	line-height: 1.47;
+
+	:any-link {
+		color: $bluesky-preview-accent-color;
+
+		text-decoration: none;
+	}
+}
+
+.bluesky-preview__media {
+
+	margin-top: 8px;
+	min-height: 64px;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 8px;
+
+	&.as-grid {
+		display: grid;
+		gap: 2px;
+		grid-template-columns: 50% 50%;
+		width: 100%;
+		overflow: hidden;
+	}
+
+	&-item {
+		display: flex;
+		border: 0;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 8px;
+		overflow: hidden;
+
+		img,
+		video {
+			width: 100%;
+			object-fit: cover;
+		}
+	}
+
+}

--- a/packages/social-previews/src/bluesky-preview/types.ts
+++ b/packages/social-previews/src/bluesky-preview/types.ts
@@ -1,0 +1,13 @@
+import type { SocialPreviewBaseProps } from '../types';
+
+export type BlueskyUser = {
+	displayName: string;
+	avatarUrl: string;
+	address: string;
+};
+
+export type BlueskyPreviewProps = SocialPreviewBaseProps & {
+	user?: BlueskyUser;
+	customText?: string;
+	customImage?: string;
+};

--- a/packages/social-previews/src/bluesky-preview/variables.scss
+++ b/packages/social-previews/src/bluesky-preview/variables.scss
@@ -1,0 +1,6 @@
+$bluesky-preview-width: 578px;
+$bluesky-preview-text-color: #444b5d;
+$bluesky-body-text-color: #000;
+$bluesky-preview-background-color: #fff;
+$bluesky-preview-font-family: "bluesky-font-sans-serif",sans-serif;
+$bluesky-preview-accent-color: #3a3bff;

--- a/packages/social-previews/src/helpers.tsx
+++ b/packages/social-previews/src/helpers.tsx
@@ -82,13 +82,14 @@ export const formatMastodonDate = new Intl.DateTimeFormat( 'en-US', {
 } ).format;
 
 export type Platform =
-	| 'twitter'
+	| 'bluesky'
 	| 'facebook'
-	| 'linkedin'
 	| 'instagram'
+	| 'linkedin'
 	| 'mastodon'
 	| 'nextdoor'
-	| 'threads';
+	| 'threads'
+	| 'twitter';
 
 type PreviewTextOptions = {
 	platform: Platform;
@@ -107,6 +108,7 @@ export const hashtagUrlMap: Record< Platform, string > = {
 	mastodon: 'https://%2$s/tags/%1$s',
 	nextdoor: 'https://nextdoor.com/hashtag/%1$s',
 	threads: 'https://www.threads.net/search?q=%1$s&serp_type=tags',
+	bluesky: 'https://bsky.app/hashtag/%1$s',
 };
 
 /**
@@ -130,7 +132,7 @@ export function preparePreviewText( text: string, options: PreviewTextOptions ):
 	result = result.replaceAll( /(?:\s*[\n\r]){2,}/g, '\n\n' );
 
 	if ( maxChars && result.length > maxChars ) {
-		result = result.substring( 0, maxChars );
+		result = hardTruncation( maxChars )( result );
 	}
 
 	if ( maxLines ) {

--- a/packages/social-previews/src/index.ts
+++ b/packages/social-previews/src/index.ts
@@ -5,6 +5,7 @@ export * from './tumblr-preview';
 export * from './facebook-preview';
 export * from './mastodon-preview';
 export * from './nextdoor-preview';
+export * from './bluesky-preview';
 export * from './threads-preview';
 export * from './constants';
 export * from './instagram-preview';

--- a/packages/social-previews/test/helpers.js
+++ b/packages/social-previews/test/helpers.js
@@ -57,7 +57,7 @@ describe( 'preparePreviewText', () => {
 			const { container } = render( preparePreviewText( text, { platform, maxChars: 60 } ) );
 
 			expect( container.innerHTML ).toBe(
-				'This is the first line<br>This is the second line<br>this third an'
+				'This is the first line<br>This is the second line<br>this third an…'
 			);
 		}
 	} );


### PR DESCRIPTION

Related to https://github.com/Automattic/jetpack/pull/39659

## Proposed Changes

* Add Bluesky preview to `social-previews`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are adding Bluesky support to Jetpack Social 🎉 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Please follow the instructions given in https://github.com/Automattic/jetpack/pull/39659

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
