### PR TITLE
A4A: Disable the referral CTA button when the current user is unverified.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -225,12 +225,18 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 				</Button>
 
 				<Tooltip
+					className="checkout__verify-account-tooltip"
 					context={ ctaButtonRef.current }
 					isVisible={ showVerifyAccountToolip && isUserUnverified }
 					position="bottom"
 				>
 					{ translate(
-						'Please verify your account email in order to begin referring products to clients.'
+						"Please verify your {{a}}account's email{{/a}} in order to begin referring products to clients.",
+						{
+							components: {
+								a: <a href="https://wordpress.com/me" target="_blank" rel="noopener noreferrer" />,
+							},
+						}
 					) }
 				</Tooltip>
 			</div>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -210,7 +210,6 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 				tabIndex={ 0 }
 				onMouseEnter={ () => setShowVerifyAccountToolip( true ) }
 				onMouseLeave={ () => setShowVerifyAccountToolip( false ) }
-				onMouseDown={ () => setShowVerifyAccountToolip( false ) }
 				onTouchStart={ () => setShowVerifyAccountToolip( true ) }
 			>
 				<Button

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -363,3 +363,10 @@
 		}
 	}
 }
+
+.checkout__verify-account-tooltip {
+	a {
+		color: var(--color-text-inverted);
+		text-decoration: underline;
+	}
+}


### PR DESCRIPTION
Currently, when an unverified user tries to create a referral, a confusing message is displayed that does not explain why the referral request fails.

This pull request disables the "Request Payment" CTA button when the current user is unverified. To avoid confusion, it also displays a message when hovering over the button explaining why the function is disabled.

<img width="557" alt="Screenshot 2024-10-08 at 1 50 37 PM" src="https://github.com/user-attachments/assets/c6e42bc2-7d2e-41c8-9471-a3c03294db57">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1182

## Proposed Changes

* The "Request Payment" button should be disabled when the current user is unverified.
* Display a message about the unverified user when hovering over the button.

## Why are these changes being made?

* To improve user experience and avoid confusion. We need to be very explicit about our error message.

## Testing Instructions

* Create a new Agency account using a random email (gmail works).
* Login with the new agency account and fill up the referrals payment details.
* Use the A4A live link and go to the `/marketplace`.
* Toggle the 'refer products' button.
* Add some items and go to checkout.
* Confirm that the CTA button is disabled and when hovered a message is displayed.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
