### PR TITLE
Stats: Play nice with JITMs

### DIFF
--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -6,6 +6,17 @@
 
 $stats-card-min-width: 390px;
 
+// Force any JITM from Jetpack to be hidden.
+// We manage a separate jp-admin-notices DIV for these.
+
+.jetpack-jitm-message {
+	display: none;
+}
+
+.jp-admin-notices {
+	display: none;
+}
+
 // Module container
 @include breakpoint-deprecated( ">960px" ) {
 	.stats__module-column {

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -13,7 +13,7 @@ $stats-card-min-width: 390px;
 	display: none;
 }
 
-.jp-admin-notices {
+#jp-admin-notices {
 	display: none;
 }
 

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -7,11 +7,15 @@
 $stats-card-min-width: 390px;
 
 // Force any JITM from Jetpack to be hidden.
-// We manage a separate jp-admin-notices DIV for these.
+// We currently manage our own CTAs across Stats pages.
 
 .jetpack-jitm-message {
 	display: none;
 }
+
+// TODO: Add this DIV to all tabs.
+// Currently only on the Traffic page.
+// JITMs will show above the Stats UI on other tabs.
 
 #jp-admin-notices {
 	display: none;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/188

## Proposed Changes

Prevent duplicate CTAs (JITMs & our own notices) inside the Stats admin pages. There is currently only one JITM shown for Stats and that is a CTA for a plugin review.

fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Swrgcnpx%2Qwvgz%2Swvgz%2Qratvar.cuc%3Se%3Qnp76o288%232196-og

With this in mind all we need to do (for now) is hide the JITM-related DIVs on our Stats pages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Prevents multiple CTAs showing at once inside the Stats admin pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up testing environment per these instructions. — PCYsg-Pp7-p2
* Visit the Stats → Traffic page & append the `force_refresh=1` URL param as needed.
* Inspect the page source and confirm both `jetpack-jitm-message` and `jp-admin-notices` DIVs are present.
* Confirm both DIVs have a `display: none` CSS rule applied.
* Confirm `jetpack-jitm-message` DIV is hidden on the Insights and Subscribers tabs as well.

Of note, we only have a `jp-admin-notices` DIV on the Traffic page. Ideally, we'd have this on the Insights and Subscribers pages as well _IF_ we plan to allow JITMs in the dashboard going forward.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?