### PR TITLE
100-year-plan: Integrate Calendly widget into Modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/calendy-widget/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/calendy-widget/index.tsx
@@ -18,6 +18,9 @@ type CalendlyWidgetProps = {
 	url: string;
 	id?: string;
 	prefill?: CalendlyPrefillData;
+	hideLandingPageDetails?: boolean;
+	hideEventTypeDetails?: boolean;
+	hideGdprBanner?: boolean;
 	onSchedule?: () => void;
 };
 
@@ -27,7 +30,16 @@ function isCalendlyEvent( e: MessageEvent ): boolean {
 	);
 }
 
-const CalendlyWidget: React.FC< CalendlyWidgetProps > = ( { url, id, prefill, onSchedule } ) => {
+const CalendlyWidget: React.FC< CalendlyWidgetProps > = ( props ) => {
+	const {
+		url,
+		id,
+		prefill,
+		hideLandingPageDetails,
+		hideEventTypeDetails,
+		hideGdprBanner,
+		onSchedule,
+	} = props;
 	const widgetId = useMemo(
 		() => id || `calendly-widget-${ Math.random().toString( 36 ).substr( 2, 9 ) }`,
 		[ id ]
@@ -60,10 +72,16 @@ const CalendlyWidget: React.FC< CalendlyWidgetProps > = ( { url, id, prefill, on
 
 			const element = document.getElementById( widgetId );
 			if ( element ) {
+				const queryParams = new URLSearchParams();
+
+				queryParams.set( 'hide_landing_page_details', hideLandingPageDetails ? '1' : '0' );
+				queryParams.set( 'hide_event_type_details', hideEventTypeDetails ? '1' : '0' );
+				queryParams.set( 'hide_gdpr_banner', hideGdprBanner ? '1' : '0' );
+
 				// Clear out the container div when props change.
 				element.innerHTML = '';
 				window.Calendly.initInlineWidget( {
-					url: `https://calendly.com/${ url }`,
+					url: `https://calendly.com/${ url }?${ queryParams.toString() }`,
 					parentElement: document.getElementById( widgetId ),
 					prefill: prefill || {},
 					utm: {},
@@ -80,7 +98,7 @@ const CalendlyWidget: React.FC< CalendlyWidgetProps > = ( { url, id, prefill, on
 				existingScript.remove();
 			}
 		};
-	}, [ url, widgetId, prefill ] );
+	}, [ url, widgetId, prefill, hideLandingPageDetails, hideEventTypeDetails, hideGdprBanner ] );
 
 	return <div id={ widgetId } className="calendly-widget" />;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
@@ -1,8 +1,10 @@
 import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
+import ScheduleAppointmentModal from './schedule-appointment-modal';
 import type { Step } from '../../types';
 
 import './styles.scss';
@@ -11,39 +13,49 @@ const HundredYearPlanDIYOrDIFM: Step = function HundredYearPlanDIYOrDIFM( { navi
 	const translate = useTranslate();
 	const { submit } = navigation;
 
+	const [ showModal, setShowModal ] = useState( false );
+
 	return (
 		<HundredYearPlanStepWrapper
 			stepContent={
-				<div>
-					<ul>
-						<li>
-							<Icon size={ 18 } icon={ check } />{ ' ' }
-							{ translate( 'Conduct a comprehensive digital longevity assessment' ) }
-						</li>
-						<li>
-							<Icon size={ 18 } icon={ check } />{ ' ' }
-							{ translate( 'Showcase our comprehensive legacy-building tools' ) }
-						</li>
-						<li>
-							<Icon size={ 18 } icon={ check } />{ ' ' }
-							{ translate( 'Answer all your questions about long-term success' ) }
-						</li>
-						<li>
-							<Icon size={ 18 } icon={ check } />{ ' ' }
-							{ translate( 'Chart a course for the production of your new site' ) }
-						</li>
-					</ul>
+				<>
+					{ showModal && <ScheduleAppointmentModal onClose={ () => setShowModal( false ) } /> }
+					<div>
+						<ul>
+							<li>
+								<Icon size={ 18 } icon={ check } />{ ' ' }
+								{ translate( 'Conduct a comprehensive digital longevity assessment' ) }
+							</li>
+							<li>
+								<Icon size={ 18 } icon={ check } />{ ' ' }
+								{ translate( 'Showcase our comprehensive legacy-building tools' ) }
+							</li>
+							<li>
+								<Icon size={ 18 } icon={ check } />{ ' ' }
+								{ translate( 'Answer all your questions about long-term success' ) }
+							</li>
+							<li>
+								<Icon size={ 18 } icon={ check } />{ ' ' }
+								{ translate( 'Chart a course for the production of your new site' ) }
+							</li>
+						</ul>
 
-					<div className="buttons-container">
-						<Button variant="primary" onClick={ () => submit?.( { diyOrDifmChoice: 'difm' } ) }>
-							{ translate( 'Schedule your free call' ) }
-						</Button>
+						<div className="buttons-container">
+							<Button
+								variant="primary"
+								onClick={ () => {
+									setShowModal( true );
+								} }
+							>
+								{ translate( 'Schedule your free call' ) }
+							</Button>
 
-						<Button variant="link" onClick={ () => submit?.( { diyOrDifmChoice: 'diy' } ) }>
-							{ translate( "I'll create my site on my own" ) }
-						</Button>
+							<Button variant="link" onClick={ () => submit?.( { diyOrDifmChoice: 'diy' } ) }>
+								{ translate( "I'll create my site on my own" ) }
+							</Button>
+						</div>
 					</div>
-				</div>
+				</>
 			}
 			formattedHeader={
 				<FormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/schedule-appointment-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/schedule-appointment-modal.tsx
@@ -2,8 +2,10 @@ import config from '@automattic/calypso-config';
 import { UserSelect } from '@automattic/data-stores';
 import { Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { Icon, captureVideo, scheduled } from '@wordpress/icons';
 import { USER_STORE } from 'calypso/landing/stepper/stores';
 import CalendlyWidget from '../components/calendy-widget';
+import HunderYearPlanLogo from '../hundred-year-plan-step-wrapper/hundred-year-plan-logo';
 
 interface Props {
 	onClose: () => void;
@@ -22,16 +24,34 @@ const ScheduleAppointmentModal = ( props: Props ) => {
 			size="large"
 			className="hundred-year-plan-schedule-appointment-modal"
 			shouldCloseOnClickOutside={ false }
+			__experimentalHideHeader
 			onRequestClose={ () => onClose?.() }
 		>
 			<div className="calendly-container">
 				<div className="calendly-details">
-					<h2>TODO: title</h2>
-					<p>
-						TODO: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus accusantium
-						architecto at consequuntur dolorem doloremque eaque expedita fugiat ipsum labore minus,
-						nisi porro quos recusandae reprehenderit, tenetur, unde velit voluptatibus.
-					</p>
+					<div className="calendly-details__header">
+						<HunderYearPlanLogo />
+					</div>
+					<div className="calendly-details__content">
+						<h3>WordPress.com 100-Year plan</h3>
+						<h2>30 Minute Meeting</h2>
+						<div className="calendly-details__item">
+							<span className="icon">
+								<Icon icon={ scheduled } size={ 28 } />
+							</span>
+							<strong>30 min</strong>
+						</div>
+						<div className="calendly-details__item">
+							<span className="icon">
+								<Icon icon={ captureVideo } size={ 28 } />
+							</span>
+							<strong>Web conferencing details provided upon confirmation.</strong>
+						</div>
+						<p>
+							Join us for an exclusive strategy session where we’ll chart a visionary course for
+							your digital evolution.
+						</p>
+					</div>
 				</div>
 				<CalendlyWidget
 					url={ config( '100_year_plan_calendly_id' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/schedule-appointment-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/schedule-appointment-modal.tsx
@@ -1,0 +1,35 @@
+import config from '@automattic/calypso-config';
+import { UserSelect } from '@automattic/data-stores';
+import { Modal } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { USER_STORE } from 'calypso/landing/stepper/stores';
+import CalendlyWidget from '../components/calendy-widget';
+
+interface Props {
+	onClose: () => void;
+}
+
+const ScheduleAppointmentModal = ( props: Props ) => {
+	const { onClose } = props;
+
+	const currentUser = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+		[]
+	);
+
+	return (
+		<Modal size="large" onRequestClose={ () => onClose?.() }>
+			<CalendlyWidget
+				url={ config( '100_year_plan_calendly_id' ) }
+				prefill={
+					currentUser ? { name: currentUser?.display_name, email: currentUser?.email } : undefined
+				}
+				onSchedule={ () => {
+					// TODO: submit
+				} }
+			/>
+		</Modal>
+	);
+};
+
+export default ScheduleAppointmentModal;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/schedule-appointment-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/schedule-appointment-modal.tsx
@@ -18,16 +18,34 @@ const ScheduleAppointmentModal = ( props: Props ) => {
 	);
 
 	return (
-		<Modal size="large" onRequestClose={ () => onClose?.() }>
-			<CalendlyWidget
-				url={ config( '100_year_plan_calendly_id' ) }
-				prefill={
-					currentUser ? { name: currentUser?.display_name, email: currentUser?.email } : undefined
-				}
-				onSchedule={ () => {
-					// TODO: submit
-				} }
-			/>
+		<Modal
+			size="large"
+			className="hundred-year-plan-schedule-appointment-modal"
+			shouldCloseOnClickOutside={ false }
+			onRequestClose={ () => onClose?.() }
+		>
+			<div className="calendly-container">
+				<div className="calendly-details">
+					<h2>TODO: title</h2>
+					<p>
+						TODO: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus accusantium
+						architecto at consequuntur dolorem doloremque eaque expedita fugiat ipsum labore minus,
+						nisi porro quos recusandae reprehenderit, tenetur, unde velit voluptatibus.
+					</p>
+				</div>
+				<CalendlyWidget
+					url={ config( '100_year_plan_calendly_id' ) }
+					prefill={
+						currentUser ? { name: currentUser?.display_name, email: currentUser?.email } : undefined
+					}
+					hideLandingPageDetails
+					hideEventTypeDetails
+					hideGdprBanner
+					onSchedule={ () => {
+						// TODO: submit
+					} }
+				/>
+			</div>
 		</Modal>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/schedule-appointment-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/schedule-appointment-modal.tsx
@@ -3,6 +3,7 @@ import { UserSelect } from '@automattic/data-stores';
 import { Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { Icon, captureVideo, scheduled } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { USER_STORE } from 'calypso/landing/stepper/stores';
 import CalendlyWidget from '../components/calendy-widget';
 import HunderYearPlanLogo from '../hundred-year-plan-step-wrapper/hundred-year-plan-logo';
@@ -12,6 +13,7 @@ interface Props {
 }
 
 const ScheduleAppointmentModal = ( props: Props ) => {
+	const translate = useTranslate();
 	const { onClose } = props;
 
 	const currentUser = useSelect(
@@ -33,23 +35,38 @@ const ScheduleAppointmentModal = ( props: Props ) => {
 						<HunderYearPlanLogo />
 					</div>
 					<div className="calendly-details__content">
-						<h3>WordPress.com 100-Year plan</h3>
-						<h2>30 Minute Meeting</h2>
+						<h3>{ translate( 'WordPress.com 100-Year plan' ) }</h3>
+						<h2>
+							{ translate( '%(minutes)s Minute Meeting', {
+								args: {
+									minutes: 30,
+								},
+							} ) }
+						</h2>
 						<div className="calendly-details__item">
 							<span className="icon">
 								<Icon icon={ scheduled } size={ 28 } />
 							</span>
-							<strong>30 min</strong>
+							<strong>
+								{ translate( '%(minutes)s min', {
+									args: {
+										minutes: 30,
+									},
+								} ) }
+							</strong>
 						</div>
 						<div className="calendly-details__item">
 							<span className="icon">
 								<Icon icon={ captureVideo } size={ 28 } />
 							</span>
-							<strong>Web conferencing details provided upon confirmation.</strong>
+							<strong>
+								{ translate( 'Web conferencing details provided upon confirmation.' ) }
+							</strong>
 						</div>
 						<p>
-							Join us for an exclusive strategy session where we’ll chart a visionary course for
-							your digital evolution.
+							{ translate(
+								'Join us for an exclusive strategy session where we’ll chart a visionary course for your digital evolution.'
+							) }
 						</p>
 					</div>
 				</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/schedule-appointment-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/schedule-appointment-modal.tsx
@@ -1,8 +1,8 @@
 import config from '@automattic/calypso-config';
 import { UserSelect } from '@automattic/data-stores';
-import { Modal } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { Icon, captureVideo, scheduled } from '@wordpress/icons';
+import { Icon, captureVideo, scheduled, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { USER_STORE } from 'calypso/landing/stepper/stores';
 import CalendlyWidget from '../components/calendy-widget';
@@ -22,68 +22,78 @@ const ScheduleAppointmentModal = ( props: Props ) => {
 	);
 
 	return (
-		<Modal
-			size="large"
-			className="hundred-year-plan-schedule-appointment-modal"
-			shouldCloseOnClickOutside={ false }
-			__experimentalHideHeader
-			onRequestClose={ () => onClose?.() }
-		>
-			<div className="calendly-container">
-				<div className="calendly-details">
-					<div className="calendly-details__header">
-						<HunderYearPlanLogo />
-					</div>
-					<div className="calendly-details__content">
-						<h3>{ translate( 'WordPress.com 100-Year plan' ) }</h3>
-						<h2>
-							{ translate( '%(minutes)s Minute Meeting', {
-								args: {
-									minutes: 30,
-								},
-							} ) }
-						</h2>
-						<div className="calendly-details__item">
-							<span className="icon">
-								<Icon icon={ scheduled } size={ 28 } />
-							</span>
-							<strong>
-								{ translate( '%(minutes)s min', {
+		<>
+			<Button
+				className="hundred-year-plan-schedule-appointment-modal-close"
+				onClick={ () => onClose?.() }
+			>
+				<Icon icon={ close } />
+			</Button>
+			<Modal
+				size="large"
+				className="hundred-year-plan-schedule-appointment-modal"
+				shouldCloseOnClickOutside
+				__experimentalHideHeader
+				onRequestClose={ () => onClose?.() }
+			>
+				<div className="calendly-container">
+					<div className="calendly-details">
+						<div className="calendly-details__header">
+							<HunderYearPlanLogo />
+						</div>
+						<div className="calendly-details__content">
+							<h3>{ translate( 'WordPress.com 100-Year plan' ) }</h3>
+							<h2>
+								{ translate( '%(minutes)s Minute Meeting', {
 									args: {
 										minutes: 30,
 									},
 								} ) }
-							</strong>
+							</h2>
+							<div className="calendly-details__item">
+								<span className="icon">
+									<Icon icon={ scheduled } size={ 28 } />
+								</span>
+								<strong>
+									{ translate( '%(minutes)s min', {
+										args: {
+											minutes: 30,
+										},
+									} ) }
+								</strong>
+							</div>
+							<div className="calendly-details__item">
+								<span className="icon">
+									<Icon icon={ captureVideo } size={ 28 } />
+								</span>
+								<strong>
+									{ translate( 'Web conferencing details provided upon confirmation.' ) }
+								</strong>
+							</div>
+							<p>
+								{ translate(
+									'Join us for an exclusive strategy session where we’ll chart a visionary course for your digital evolution.'
+								) }
+							</p>
 						</div>
-						<div className="calendly-details__item">
-							<span className="icon">
-								<Icon icon={ captureVideo } size={ 28 } />
-							</span>
-							<strong>
-								{ translate( 'Web conferencing details provided upon confirmation.' ) }
-							</strong>
-						</div>
-						<p>
-							{ translate(
-								'Join us for an exclusive strategy session where we’ll chart a visionary course for your digital evolution.'
-							) }
-						</p>
 					</div>
+					<CalendlyWidget
+						url={ config( '100_year_plan_calendly_id' ) }
+						prefill={
+							currentUser
+								? { name: currentUser?.display_name, email: currentUser?.email }
+								: undefined
+						}
+						hideLandingPageDetails
+						hideEventTypeDetails
+						hideGdprBanner
+						onSchedule={ () => {
+							// TODO: submit
+						} }
+					/>
 				</div>
-				<CalendlyWidget
-					url={ config( '100_year_plan_calendly_id' ) }
-					prefill={
-						currentUser ? { name: currentUser?.display_name, email: currentUser?.email } : undefined
-					}
-					hideLandingPageDetails
-					hideEventTypeDetails
-					hideGdprBanner
-					onSchedule={ () => {
-						// TODO: submit
-					} }
-				/>
-			</div>
-		</Modal>
+			</Modal>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
@@ -69,6 +69,10 @@
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;
+
+		@media (max-width: 768px) {
+			flex-direction: column;
+		}
 	}
 
 	.calendly-details__header {
@@ -81,6 +85,10 @@
 
 	.calendly-details__content {
 		padding: 2rem;
+
+		@media (max-width: 768px) {
+			display: none;
+		}
 	}
 
 	.calendly-details__item {
@@ -109,18 +117,28 @@
 	.calendly-widget {
 		flex: 1;
 		width: 50%;
+
+		@media (max-width: 768px) {
+			width: 100%;
+		}
 	}
 
 	.calendly-details {
 		border-inline-end: solid 1px var(--studio-gray-5);
-
-		@media (max-width: 768px) {
-			display: none;
-		}
 	}
 
 	.calendly-widget {
 		max-height: 100%;
 		overflow: scroll;
+		margin-left: auto;
+		margin-right: auto;
+
+		@media (max-width: 768px) {
+			max-width: 649px;
+
+			iframe {
+				min-height: 500px;
+			}
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
@@ -47,3 +47,28 @@
 		}
 	}
 }
+
+.hundred-year-plan-schedule-appointment-modal {
+
+	.calendly-container {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+
+	.calendly-details,
+	.calendly-widget {
+		flex: 1;
+		max-width: 50%;
+	}
+
+	.calendly-details {
+		border-inline-end: solid 1px var(--studio-gray-5);
+		padding-inline-end: 1rem;
+	}
+
+	.calendly-widget {
+		max-width: 376px;
+		height: 500px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
@@ -49,6 +49,21 @@
 }
 
 .hundred-year-plan-schedule-appointment-modal {
+	.components-modal__content {
+		padding: 0;
+
+		h2 {
+			font-weight: bold;
+			font-size: 1.75rem;
+			margin-bottom: 1rem;
+		}
+
+		h3 {
+			font-weight: bold;
+			color: var(--studio-gray-60);
+			margin-bottom: -5px;
+		}
+	}
 
 	.calendly-container {
 		display: flex;
@@ -64,11 +79,45 @@
 
 	.calendly-details {
 		border-inline-end: solid 1px var(--studio-gray-5);
-		padding-inline-end: 1rem;
+	}
+
+	.calendly-details__header {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		padding: 2.5rem 1rem;
+		border-bottom: solid 1px var(--studio-gray-5);
+	}
+
+	.calendly-details__content {
+		padding: 2rem;
+	}
+
+	.calendly-details__item {
+		display: flex;
+		align-items: center;
+		color: var(--studio-gray-60);
+		margin-bottom: 0.5rem;
+
+		&:last-of-type {
+			margin-bottom: 1.5rem;
+		}
+
+		.icon {
+			display: flex;
+			align-items: center;
+			margin-right: 5px;
+
+			svg {
+				fill: var(--studio-gray-60);
+			}
+		}
+
 	}
 
 	.calendly-widget {
-		max-width: 376px;
+		max-width: 415px;
 		height: 500px;
+		margin: 1px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
@@ -71,16 +71,6 @@
 		justify-content: space-between;
 	}
 
-	.calendly-details,
-	.calendly-widget {
-		flex: 1;
-		max-width: 50%;
-	}
-
-	.calendly-details {
-		border-inline-end: solid 1px var(--studio-gray-5);
-	}
-
 	.calendly-details__header {
 		display: flex;
 		justify-content: center;
@@ -115,9 +105,22 @@
 
 	}
 
+	.calendly-details,
 	.calendly-widget {
-		max-width: 415px;
-		height: 500px;
-		margin: 1px;
+		flex: 1;
+		width: 50%;
+	}
+
+	.calendly-details {
+		border-inline-end: solid 1px var(--studio-gray-5);
+
+		@media (max-width: 768px) {
+			display: none;
+		}
+	}
+
+	.calendly-widget {
+		max-height: 100%;
+		overflow: scroll;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
@@ -48,6 +48,27 @@
 	}
 }
 
+.hundred-year-plan-schedule-appointment-modal-close {
+	position: fixed;
+	top: 1rem;
+	right: 1rem;
+	z-index: 100001;
+
+	@media (max-width: 960px) {
+		top: 5rem;
+	}
+
+	@media (min-width: 768px) {
+		svg {
+			fill: var(--studio-white);
+		}
+	}
+
+	@media (max-width: 600px) {
+		top: 3.5rem;
+	}
+}
+
 .hundred-year-plan-schedule-appointment-modal {
 	.components-modal__content {
 		padding: 0;


### PR DESCRIPTION
Related to #

## Proposed Changes

* Updated and integrated the Calendly widget into Modal
* Adjusted styles to match the design

<img width="1840" alt="Screenshot 2024-10-09 at 16 31 57" src="https://github.com/user-attachments/assets/3b208c0e-4435-4366-b4b6-2e603e6a0965">

Figma design: Qn8lSkQCQHwd2xZPaMTYjI-fi-5902_457


## Testing Instructions

* Go to `/setup/hundred-year-plan/diy-or-difm?flags=100year%2Fvip`
* Check the design is matched

NOTE: The scheduled event callback has yet to be handled, so currently, we are not redirecting anywhere. Next PR will bring that.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?