### PR TITLE
Fix/notifications focus styles

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/actions.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/actions.scss
@@ -1,6 +1,10 @@
 .wpnc__note-actions {
 	.wpnc__note-actions__buttons {
 		padding-bottom: 16px;
+
+		button:focus {
+			outline: var(--color-primary-light) solid 2px;
+		}
 	}
 
 	.wpnc__reply-box {

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -185,6 +185,16 @@ $with-sidebar-min-page-width: 1114px;
 		fill: currentColor;
 	}
 
+	.wpnc__user a:focus,
+	.wpnc__user a:focus span.wpnc__excerpt,
+	.wpnc__user button:focus {
+		outline: var(--color-primary-light) solid 2px;
+	}
+
+	.wpnc__user .wpnc__user__site .wpnc__excerpt {
+		margin: 2px 0 0 2px;
+	}
+
 	.wpnc__user__username,
 	span.wpnc__user {
 		font-weight: 600;
@@ -662,10 +672,6 @@ $with-sidebar-min-page-width: 1114px;
 				@extend %ellipsy-box;
 				white-space: nowrap;
 				display: block;
-			}
-
-			a {
-				outline: 0;
 			}
 		}
 

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -509,6 +509,7 @@ $with-sidebar-min-page-width: 1114px;
 		}
 
 		.wpnc__time-group-title {
+			align-items: center;
 			display: flex;
 			@extend %headertext;
 			color: var(--color-neutral-40);
@@ -529,6 +530,12 @@ $with-sidebar-min-page-width: 1114px;
 				margin-left: auto;
 				margin-right: $wpnc__padding-small;
 			}
+
+			.wpnc__time-title {
+				align-items: center;
+				display: flex;
+				flex: 1;
+			}
 		}
 
 		.wpnc__time-group-wrap {
@@ -541,7 +548,6 @@ $with-sidebar-min-page-width: 1114px;
 			.wpnc__settings,
 			.wpnc__keyboard-shortcuts-button {
 				display: flex;
-				flex-grow: 1;
 
 				&:focus svg {
 					outline: var(--color-primary-light) solid 2px;

--- a/apps/notifications/src/panel/boot/stylesheets/shared/reset.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/reset.scss
@@ -103,7 +103,7 @@
 		quotes: "" "";
 	}
 	a:focus {
-		outline: thin dotted;
+		outline: var(--color-primary-light) solid 2px;
 	}
 	a:hover,
 	a:active {

--- a/apps/notifications/src/panel/templates/block-user.jsx
+++ b/apps/notifications/src/panel/templates/block-user.jsx
@@ -127,7 +127,7 @@ export class UserBlock extends Component {
 			const homeClassName =
 				timeIndicator !== '' ? 'wpnc__user__meta wpnc__user__bulleted' : 'wpnc__user__meta';
 			homeTemplate = (
-				<p className={ homeClassName }>
+				<div className={ homeClassName }>
 					<span className="wpnc__user__ago">{ timeIndicator }</span>
 					<a
 						className="wpnc__user__site"
@@ -138,7 +138,7 @@ export class UserBlock extends Component {
 					>
 						{ home_title }
 					</a>
-				</p>
+				</div>
 			);
 		} else {
 			homeTemplate = (
@@ -168,11 +168,13 @@ export class UserBlock extends Component {
 					<a className="wpnc__user__site" href={ home_url } target="_blank" rel="noreferrer">
 						<img src={ grav.url } height={ grav.height } width={ grav.width } alt="Avatar" />
 					</a>
-					<span className="wpnc__user__username">
-						<a className="wpnc__user__home" href={ home_url } target="_blank" rel="noreferrer">
-							{ this.props.block.text }
-						</a>
-					</span>
+					<div>
+						<span className="wpnc__user__username">
+							<a className="wpnc__user__home" href={ home_url } target="_blank" rel="noreferrer">
+								{ this.props.block.text }
+							</a>
+						</span>
+					</div>
 					{ homeTemplate }
 					{ followLink }
 				</div>

--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -375,8 +375,6 @@ class Layout extends Component {
 					 */
 					activateKeyboard();
 					this.props.selectNote( this.state.selectedNote );
-				} else if ( this.props.selectedNoteId ) {
-					this.props.unselectNote();
 				}
 				break;
 			case KEY_DOWN:

--- a/apps/notifications/src/panel/templates/list-header.jsx
+++ b/apps/notifications/src/panel/templates/list-header.jsx
@@ -10,8 +10,10 @@ export const ListHeader = ( { isFirst, title, viewSettings } ) => {
 	return (
 		<li className="wpnc__time-group-wrap">
 			<div className="wpnc__time-group-title">
-				<Gridicon icon="time" size={ 18 } />
-				{ title }
+				<span className="wpnc__time-title">
+					<Gridicon icon="time" size={ 18 } />
+					{ title }
+				</span>
 				{ isFirst && (
 					<>
 						<span


### PR DESCRIPTION
## Description

This PR addresses two specific issues:

1) Fix title/cog so that cog cannot be triggered accidentally

Prior to this PR if you clicked anywhere between the title and the cog icon, it triggered the cog link. This should not happen, so I fixed it.

2) Added tab styles to links in popout menu

None of the links in the popout menu had focus styles. I fixed that

**Before**

![tab-before](https://github.com/user-attachments/assets/17d9a1d2-fcee-4da9-93e6-450cbd9f1330)

**After**

![tab-after](https://github.com/user-attachments/assets/338c50ad-4739-41a0-83df-ccfd02bf654d)
