### PR TITLE
Add mutation to update the Migration status

### DIFF
--- a/client/data/site-migration/use-update-migration-status.ts
+++ b/client/data/site-migration/use-update-migration-status.ts
@@ -1,0 +1,32 @@
+import { useMutation } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wp from 'calypso/lib/wp';
+import { SiteId } from 'calypso/types';
+
+interface MigrationStatusMutationOptions {
+	targetBlogId: SiteId;
+	statusSticker: string;
+}
+
+export const useUpdateMigrationStatus = () => {
+	const updateStatusMutation = useMutation( {
+		mutationFn: ( { targetBlogId, statusSticker }: MigrationStatusMutationOptions ) =>
+			wp.req.post( {
+				path: `/sites/${ targetBlogId }/site-migration-status-sticker`,
+				apiNamespace: 'wpcom/v2',
+				body: {
+					status_sticker: statusSticker,
+				},
+			} ),
+	} );
+
+	const { mutate: updateMigrationStatusMutate, ...updateStatusMutationRest } = updateStatusMutation;
+
+	const updateMigrationStatus = useCallback(
+		( targetBlogId: SiteId, statusSticker: string ) =>
+			updateMigrationStatusMutate( { targetBlogId, statusSticker } ),
+		[ updateMigrationStatusMutate ]
+	);
+
+	return { updateMigrationStatus, updateStatusMutationRest };
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -81,7 +81,8 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 	const handleClick = ( how: string ) => {
 		const destination = canInstallPlugins ? 'migrate' : 'upgrade';
 		if ( site?.ID ) {
-			updateMigrationStatus( site.ID, `migration-pending-${ how }` );
+			const parsedHow = how === HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF ? 'diy' : how;
+			updateMigrationStatus( site.ID, `migration-pending-${ parsedHow }` );
 		}
 		return navigation.submit?.( { how, destination } );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { FC, useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useUpdateMigrationStatus } from 'calypso/data/site-migration/use-update-migration-status';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
@@ -75,8 +76,13 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 		? true
 		: false;
 
+	const { updateMigrationStatus } = useUpdateMigrationStatus();
+
 	const handleClick = ( how: string ) => {
 		const destination = canInstallPlugins ? 'migrate' : 'upgrade';
+		if ( site?.ID ) {
+			updateMigrationStatus( site.ID, `migration-pending-${ how }` );
+		}
 		return navigation.submit?.( { how, destination } );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95156

More links:
* pfuQfP-IF-p2
* p9Jlb4-ep1-p2 

## Proposed Changes

* Adds the Mutation to update the Migration status.
* Update the status on the "How to migrate" step. On this step we will update the migration status to `migration-pending-{difm|diy}`, depending on what the user selects.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the Post-migration experience and Post-purchase projects, we need to have the status for the migration so we can show the Launchpad and/or be able to redirect the users to the appropriate step.
* 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to you sandbox or use the Calypso Live
* Go through the migration flow
* Once you reach the `How to migrate` step, select one of the options and make sure a request is made to `/sites/${ targetBlogId }/site-migration-status-sticker`
* Check that you have the `migration-pending-{difm|diy}` on the RC for the blog you are testing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?