### PR TITLE
Stats: Align the total subscriber count with the chart when subscriber accounts deleted

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -10,6 +10,8 @@ const querySubscribersTotals = ( siteId: number | null, filterAdmin?: boolean ):
 		{
 			type: 'all',
 			filter_admin: filterAdmin ? true : false,
+			// Only one-page results adjust visible subscribers with deleted accounts to align with the subscriber list.
+			max: 10,
 		}
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/41

## Proposed Changes

* Apply the max query parameter to `10` to ignore deleted subscriber accounts, aligning with the total subscriber counts in the chart below. More details about the endpoint to handle deleted subscriber accounts: fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qfgngf%2Qsbyybjref%2Qi1%2Q1%2Qraqcbvag.cuc%3Se%3Q8o344s6p%23100%2Q117-og.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As the 30 / 60 / 90 Day counts now include admin as the subscriber, the `Total subscribers` card displayed an incorrect number when **_some subscriber accounts were deleted_** compared to the Subscribers chart below.
> Note: The discrepancy would still happen when the total subscriber count is <= 10.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live branch.
* Navigate to Stats > Subscribers page with a site having deleted subscriber accounts.
* Ensure the `Total subscribers` card number is the same as the last day of subscriber count on the Subscribers chart below.

|Before|After|
|-|-|
|<img width="1280" alt="截圖 2024-10-08 上午1 10 34" src="https://github.com/user-attachments/assets/1b10cb21-fdc8-4b77-9242-71915dde90eb">|<img width="1264" alt="截圖 2024-10-08 上午1 14 49" src="https://github.com/user-attachments/assets/383c6ce3-3e7d-4600-8ba4-5fc00e15760e">|
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?