### PR TITLE
Hosting dashboard: Add flags to remove console warnings about bottom margin.

### DIFF
--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -114,6 +114,7 @@ const DataCenterPicker = ( {
 			{ isFormShowing && (
 				<Form>
 					<SelectControl
+						__nextHasNoMarginBottom
 						label={ <StyledLabel>{ translate( 'Pick your primary data center' ) }</StyledLabel> }
 						help={
 							hasEnTranslation(

--- a/client/hosting/logs/components/site-logs.tsx
+++ b/client/hosting/logs/components/site-logs.tsx
@@ -211,6 +211,7 @@ export const SiteLogs = ( {
 				requestStatus={ requestStatus }
 			>
 				<ToggleControl
+					__nextHasNoMarginBottom
 					className="site-logs__auto-refresh"
 					label={ __( 'Auto-refresh' ) }
 					checked={ autoRefresh }

--- a/client/hosting/server-settings/components/cache-card/index.tsx
+++ b/client/hosting/server-settings/components/cache-card/index.tsx
@@ -181,6 +181,7 @@ export default function CacheCard( { disabled }: CacheCardProps ) {
 							} ) }
 						</div>
 						<ToggleControl
+							__nextHasNoMarginBottom
 							className="cache-card__edge-cache-toggle"
 							checked={ isEdgeCacheActive && isEdgeCacheEligible }
 							disabled={ isClearingEdgeCache || isEdgeCacheLoading || ! isEdgeCacheEligible }

--- a/client/hosting/server-settings/components/sftp-card/index.js
+++ b/client/hosting/server-settings/components/sftp-card/index.js
@@ -186,6 +186,7 @@ export const SftpCard = ( {
 		return (
 			<div className="sftp-card__ssh-field">
 				<ToggleControl
+					__nextHasNoMarginBottom
 					disabled={ isLoading || isSshAccessLoading }
 					checked={ isSshAccessEnabled }
 					onChange={ () => toggleSshAccess() }

--- a/client/lib/store-sandbox-helper/index.tsx
+++ b/client/lib/store-sandbox-helper/index.tsx
@@ -62,6 +62,7 @@ export function StoreSandboxHelper() {
 			<div className={ menuItemClasses.join( ' ' ) }>Store Sandbox</div>
 			<div className="store-sandbox-helper__popover">
 				<ToggleControl
+					__nextHasNoMarginBottom
 					label="Store Sandbox"
 					checked={ isStoreSandboxed || false }
 					disabled={ ! isEditable }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/94676

## Proposed Changes

* Adds a `__nextHasNoMarginBottom` to remove this warning from the console:

> Bottom margin styles for wp.components.ToggleControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To reduce noise in the console. @holdercp noticed that this warning shows up when opening the Data Center picker. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /hosting-features for a site that has a Business plan, but isn't yet Atomic.
* Click "Activate now."
* Click "customize it" to open the data center picker.
* Verify that no console warning for `wp.components.SelectControl` appears.
* Verify that no console warning for `wp.components.ToggleControl` appears when on the Logs (/site-logs) and Server Settings (/hosting-config) pages.
* Verify that no console warning for `wp.components.ToggleControl` appears when on /sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
