### PR TITLE
Check if tipaltiData is set before using it.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -74,6 +74,9 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 	const { data: tipaltiData } = useGetTipaltiPayee();
 
 	useEffect( () => {
+		if ( ! tipaltiData ) {
+			return;
+		}
 		if ( ! tipaltiData.IsPayable ) {
 			setTipaltiActionRequiredVisible( true );
 		}
@@ -165,7 +168,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 						onClick={ () =>
 							dispatch( recordTracksEvent( 'calypso_a4a_client_referral_form_email_click' ) )
 						}
-						disabled={ ! tipaltiData.IsPayable }
+						disabled={ ! tipaltiData?.IsPayable }
 					/>
 					<div
 						className={ clsx( 'checkout__client-referral-form-footer-error', {
@@ -187,7 +190,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 						onClick={ () =>
 							dispatch( recordTracksEvent( 'calypso_a4a_client_referral_form_message_click' ) )
 						}
-						disabled={ ! tipaltiData.IsPayable }
+						disabled={ ! tipaltiData?.IsPayable }
 					/>
 				</FormFieldset>
 			</div>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -74,10 +74,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 	const { data: tipaltiData } = useGetTipaltiPayee();
 
 	useEffect( () => {
-		if ( ! tipaltiData ) {
-			return;
-		}
-		if ( ! tipaltiData.IsPayable ) {
+		if ( tipaltiData && ! tipaltiData.IsPayable ) {
 			setTipaltiActionRequiredVisible( true );
 		}
 	}, [ tipaltiData ] );


### PR DESCRIPTION
## Proposed Changes

Sometimes during server side rendering `tipaltiData` is not available.
When that happens, the checkout page for A44 dev sites referal may break with `Cannot read properties of undefined (reading 'IsPayable')`

![image](https://github.com/user-attachments/assets/d6e3a493-94b6-4327-a8f9-839e2699b5d6)


## Testing Instructions

Create a new dev site, and copy its blog_id (the long one, from atomic, not the short one from A4A)
Open http://agencies.localhost:3000/ with this branch.
Clear all site data, using browser dev tools, including third party cookies.
Reload the page, you will need to login on wordpress SSO again.
On a new tab open:
`http://agencies.localhost:3000/marketplace/checkout?referral_blog_id={you_blog_id}`

The site should not break.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
