### PR TITLE
Data center picker: Add a wrap style to the label

### DIFF
--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -71,6 +71,7 @@ const StyledLabel = styled.div`
 	text-transform: none;
 	font-size: 0.875rem;
 	color: var( --studio-gray-50 );
+	text-wrap: wrap;
 `;
 
 const DataCenterPicker = ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/94676

## Proposed Changes

* Add `text-wrap: wrap` to the label so that it wraps vs. getting cut off on smaller screen sizes.

Before | After
---- | ----
<img width="242" alt="Screen Shot 2024-10-07 at 3 55 06 PM" src="https://github.com/user-attachments/assets/7174a427-a06d-4d7c-8db2-50066deeedab"> | <img width="215" alt="Screen Shot 2024-10-07 at 3 54 45 PM" src="https://github.com/user-attachments/assets/0cc742a3-ae78-4331-8c25-ceee011d2932">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the mobile experience for this tool.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /hosting-features for a site that has a Business plan, but isn't yet Atomic.
* Switch to a mobile screen size, and switch your locale to French or Japanese.
* Click "Activate now."
* Click "customize it" for the data center picker.
* Check that the label wraps and isn't cut off.

Known issue: translations haven't been deployed for other text in the modal yet.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
