### PR TITLE
Revert "Revert "A4A Dev Sites: Add `Refer to client` button back to the Hosting settings page""

### DIFF
--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products';
 import { Card, CompactCard, Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
@@ -77,10 +76,7 @@ const LaunchSite = () => {
 	const price = formatCurrency( agency?.prices?.actual_price, agency?.prices?.currency );
 	const siteReferralActive = agency?.referral_status === 'active';
 	const shouldShowReferToClientButton =
-		config.isEnabled( 'a4a-dev-sites-referral' ) &&
-		isDevelopmentSite &&
-		! siteReferralActive &&
-		! agencyLoading;
+		isDevelopmentSite && ! siteReferralActive && ! agencyLoading;
 	const shouldShowAgencyBillingMessage =
 		isDevelopmentSite && ! siteReferralActive && ! agencyLoading;
 

--- a/config/development.json
+++ b/config/development.json
@@ -32,7 +32,6 @@
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,7 +13,6 @@
 		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": false,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": true,

--- a/config/production.json
+++ b/config/production.json
@@ -23,7 +23,6 @@
 		"100-year-plan/vip": false,
 		"ad-tracking": true,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -21,7 +21,6 @@
 		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/test.json
+++ b/config/test.json
@@ -24,7 +24,6 @@
 		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypsoify/plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -20,7 +20,6 @@
 		"100-year-plan/vip": false,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
-		"a4a-dev-sites-referral": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
 		"calypso/ai-blogging-prompts": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#95197
The original PR https://github.com/Automattic/wp-calypso/pull/95051, that aimed to remove the feature flag did not work as expected on server side rendering. So we reverted it https://github.com/Automattic/wp-calypso/pull/95197.

Later we introduced https://github.com/Automattic/wp-calypso/pull/95203 to fix the SSR issue and we are removing the feature flag again.