### PR TITLE
Reader: Basic Column Block support

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -69,6 +69,10 @@
 .is-reader-page .reader-full-post__story-content {
 	padding-top: 0 !important;
 
+	.wp-block-columns {
+		margin-bottom: 24px;
+	}
+
 	.wp-block-jetpack-slideshow_slide img,
 	.wp-block-media-text__media img,
 	.wp-block-image img {

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -12,6 +12,9 @@
 // Import styles for carousel blocks (Newspack Post Carousel, Jetpack Slideshow).
 @import "carousel";
 
+// Import minimal styles for Gutenberg Columns block
+@import "columns";
+
 .reader-full-post__story-content {
 	@extend %rendered-block-content;
 	font-family: $sans;

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -12,9 +12,6 @@
 // Import styles for carousel blocks (Newspack Post Carousel, Jetpack Slideshow).
 @import "carousel";
 
-// Import minimal styles for Gutenberg Columns block
-@import "columns";
-
 .reader-full-post__story-content {
 	@extend %rendered-block-content;
 	font-family: $sans;
@@ -522,7 +519,7 @@
 			background-image: url("data:image/svg+xml,%3Csvg fill='none' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12.3438 17.3438h-4.68755c-.08594 0-.15625.0703-.15625.1562v.625c0 .3457.2793.625.625.625h3.75c.3457 0 .625-.2793.625-.625v-.625c0-.0859-.0703-.1562-.1562-.1562zm-2.3438-16.0938c-3.53711 0-6.40625 2.86914-6.40625 6.40625 0 2.37105 1.28906 4.44145 3.20313 5.54885v2.2637c0 .3457.27929.625.625.625h5.15622c.3457 0 .625-.2793.625-.625v-2.2637c1.9141-1.1074 3.2032-3.1778 3.2032-5.54885 0-3.53711-2.8692-6.40625-6.4063-6.40625zm2.498 10.7383-.7011.4062v2.293h-3.59377v-2.293l-.70118-.4062c-1.53711-.8887-2.50195-2.52541-2.50195-4.33205 0-2.76172 2.23828-5 5-5 2.7617 0 5 2.23828 5 5 0 1.80664-.9648 3.44335-2.502 4.33205z' fill='%231e1e1e'/%3E%3C/svg%3E");
 			background-repeat: no-repeat;
 			background-size: 24px 24px;
-			content: "";
+			content: "";;
 			display: inline-block;
 			height: 24px;
 			left: -5px;
@@ -530,11 +527,11 @@
 			position: absolute;
 			width: 24px;
 			top: 1px;
-		}
-	}
 
 	.jetpack-blogging-prompt__text {
 		font-size: $font-title-medium;
 		margin-bottom: 24px;
+	}
+		}
 	}
 }

--- a/client/blocks/reader-full-post/columns.scss
+++ b/client/blocks/reader-full-post/columns.scss
@@ -1,8 +1,9 @@
 @use 'sass:math';
-@import "@wordpress/base-styles/breakpoints";
+// @import "@wordpress/base-styles/breakpoints";
 
 $column-gap: 19px; // Roughly 1.2rem, which is the gap in Gutenberg columns. This needs to be px for unit consistency in the math.div function.
-$column-min-width: math.div($reader-full-post-story-max-width - $reader-full-post-story-padding * 2 - $column-gap, 3); 
+// $column-min-width: math.div($reader-full-post-story-max-width - $reader-full-post-story-padding * 2 - $column-gap, 3);Roughly1.2rem,whichisthegapinGutenbergcolumns.Thisneedstobepxforunitconsistencyinthemath.divfunction.$column-min-width 
+$column-min-width: 220px; // TODO: Use vars based on content's width, padding, etc.
 
 .wp-block-columns {
 	display: flex;
@@ -26,7 +27,7 @@ $column-min-width: math.div($reader-full-post-story-max-width - $reader-full-pos
 	& > .wp-block-column {
 		flex-basis: 100%;
 
-		@media (min-width: $break-medium) {
+		@media (min-width: 782px) { // TODO: Use Gutenberg vars for breakpoint
 			flex-basis: 0;
 			min-width: $column-min-width; // This is the minimum width of a column in a 3-column layout.
 		}

--- a/client/blocks/reader-full-post/columns.scss
+++ b/client/blocks/reader-full-post/columns.scss
@@ -1,11 +1,15 @@
+@use 'sass:math';
 @import "@wordpress/base-styles/breakpoints";
+
+$column-gap: 19px; // Roughly 1.2rem, which is the gap in Gutenberg columns. This needs to be px for unit consistency in the math.div function.
+$column-min-width: math.div($reader-full-post-story-max-width - $reader-full-post-story-padding * 2 - $column-gap, 3); 
 
 .wp-block-columns {
 	display: flex;
 	flex-wrap: wrap;
 	box-sizing: border-box;
 	align-items: initial;
-	gap: 1.2rem;
+	gap: rem($column-gap);
 
 	&.are-vertically-aligned-top {
 		align-items: flex-start;
@@ -24,6 +28,7 @@
 
 		@media (min-width: $break-medium) {
 			flex-basis: 0;
+			min-width: $column-min-width; // This is the minimum width of a column in a 3-column layout.
 		}
 	}
 
@@ -33,6 +38,7 @@
 		> .wp-block-column {
 			flex-basis: 0;
 			flex-grow: 1;
+			min-width: auto;
 		}
 	}
 }

--- a/client/blocks/reader-full-post/columns.scss
+++ b/client/blocks/reader-full-post/columns.scss
@@ -1,0 +1,67 @@
+@import "@wordpress/base-styles/breakpoints";
+
+.wp-block-columns {
+	display: flex;
+	flex-wrap: wrap;
+	box-sizing: border-box;
+	align-items: initial;
+	gap: 1.2rem;
+
+	&.are-vertically-aligned-top {
+		align-items: flex-start;
+	}
+
+	&.are-vertically-aligned-center {
+		align-items: center;
+	}
+
+	&.are-vertically-aligned-bottom {
+		align-items: flex-end;
+	}
+
+	& > .wp-block-column {
+		flex-basis: 100%;
+
+		@media (min-width: $break-medium) {
+			flex-basis: 0;
+		}
+	}
+
+	&.is-not-stacked-on-mobile {
+		flex-wrap: nowrap;
+
+		> .wp-block-column {
+			flex-basis: 0;
+			flex-grow: 1;
+		}
+	}
+}
+
+.wp-block-column {
+	flex-grow: 1;
+	min-width: 0;
+	word-break: break-word;
+	overflow-wrap: break-word;
+
+	&.is-vertically-aligned-top {
+		align-self: flex-start;
+	}
+
+	&.is-vertically-aligned-center {
+		align-self: center;
+	}
+
+	&.is-vertically-aligned-bottom {
+		align-self: flex-end;
+	}
+
+	&.is-vertically-aligned-stretch {
+		align-self: stretch;
+	}
+
+	&.is-vertically-aligned-top,
+	&.is-vertically-aligned-center,
+	&.is-vertically-aligned-bottom {
+		width: 100%;
+	}
+}

--- a/client/blocks/reader-full-post/columns.scss
+++ b/client/blocks/reader-full-post/columns.scss
@@ -1,9 +1,8 @@
 @use 'sass:math';
-// @import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/breakpoints";
 
 $column-gap: 19px; // Roughly 1.2rem, which is the gap in Gutenberg columns. This needs to be px for unit consistency in the math.div function.
-// $column-min-width: math.div($reader-full-post-story-max-width - $reader-full-post-story-padding * 2 - $column-gap, 3);Roughly1.2rem,whichisthegapinGutenbergcolumns.Thisneedstobepxforunitconsistencyinthemath.divfunction.$column-min-width 
-$column-min-width: 220px; // TODO: Use vars based on content's width, padding, etc.
+$column-min-width: math.div($reader-full-post-story-max-width - $reader-full-post-story-padding * 2 - $column-gap, 3);
 
 .wp-block-columns {
 	display: flex;
@@ -27,7 +26,7 @@ $column-min-width: 220px; // TODO: Use vars based on content's width, padding, e
 	& > .wp-block-column {
 		flex-basis: 100%;
 
-		@media (min-width: 782px) { // TODO: Use Gutenberg vars for breakpoint
+		@media (min-width: $break-medium) {
 			flex-basis: 0;
 			min-width: $column-min-width; // This is the minimum width of a column in a 3-column layout.
 		}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -9,6 +9,8 @@ $reader-full-post-story-max-width: 720px;
 $global-sidebar-and-frame-width: 295px + 16px;
 $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-post-story-max-width + ( $reader-full-post-story-padding * 2 ) + $global-sidebar-and-frame-width;
 
+// Import minimal styles for Gutenberg Columns block
+@import "./columns";
 
 .is-group-reader.has-no-sidebar {
 	.masterbar {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -1,6 +1,3 @@
-// Styles targeted at story content
-@import "./content";
-
 // Since we cannot use css variables in media queries, we need to define the valuess in scss.
 $reader-full-post-sidebar-width: 220px;
 $reader-full-post-story-padding: 24px;
@@ -8,6 +5,9 @@ $reader-full-post-story-max-width: 720px;
 // 295 for sidebar and 16 for the right frame padding.
 $global-sidebar-and-frame-width: 295px + 16px;
 $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-post-story-max-width + ( $reader-full-post-story-padding * 2 ) + $global-sidebar-and-frame-width;
+
+// Styles targeted at story content
+@import "./content";
 
 .is-group-reader.has-no-sidebar {
 	.masterbar {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -1,3 +1,6 @@
+// Styles targeted at story content
+@import "./content";
+
 // Since we cannot use css variables in media queries, we need to define the valuess in scss.
 $reader-full-post-sidebar-width: 220px;
 $reader-full-post-story-padding: 24px;
@@ -6,8 +9,6 @@ $reader-full-post-story-max-width: 720px;
 $global-sidebar-and-frame-width: 295px + 16px;
 $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-post-story-max-width + ( $reader-full-post-story-padding * 2 ) + $global-sidebar-and-frame-width;
 
-// Styles targeted at story content
-@import "./content";
 
 .is-group-reader.has-no-sidebar {
 	.masterbar {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Relates to #46290

## Proposed Changes

* Adds minimal Column block support to Reader:
    * Column content will render in the given number of columns
    * Content alignment (top, center, bottom) is respected
    * "Do not stack on mobile" is respected
    * **Discrete column widths (33%, 200px, etc.) are not supported**

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Authors were confused as to why their content using the Columns block was not rendered in the same column layout in the Reader.
* This change will allow content to be rendered in up to three columns (due to the limited content space in Reader) but specified width won't be respected because that data is not present in the post content in Reader
* If there are more than three columns or the content of the columns will not fit in the available space, the last column will wrap to a new line
* All columns will stack at the mobile breakpoint
* If "Do not stack on mobile" is selected, the columns will never wrap/stack


https://github.com/user-attachments/assets/b7e1d671-54d4-4225-8926-ba8ffe6edcb3

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a post using the Columns block
* View the post in Reader
* Check various configurations and breakpoints to see how to content wraps and flows

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
