### PR TITLE
Allow getTitanSetUpMailboxPath for domain only sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -50,6 +50,7 @@ import {
 	getNewTitanAccountPath,
 	getPurchaseNewEmailAccountPath,
 	getTitanControlPanelRedirectPath,
+	getTitanSetUpMailboxPath,
 } from 'calypso/my-sites/email/paths';
 import DIFMLiteInProgress from 'calypso/my-sites/marketing/do-it-for-me/difm-lite-in-progress';
 import NavigationComponent from 'calypso/my-sites/navigation';
@@ -237,6 +238,7 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		getNewTitanAccountPath,
 		getPurchaseNewEmailAccountPath,
 		getTitanControlPanelRedirectPath,
+		getTitanSetUpMailboxPath,
 	];
 
 	// Builds a list of paths using a site slug plus any additional parameter that may be required


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/95147

## Proposed Changes

* Allows getTitanSetUpMailboxPath access for domain only sites

## Why are these changes being made?

* When you remove all your mailboxes you're left with the option to "set up mailbox" for the unused slot.
* Clicking on this takes you to http://calypso.localhost:3000/email/testdomainonlysite123.blog/titan/set-up-mailbox/testdomainonlysite123.blog
* Domain only sites previously restricted this path resulting in a [redirect to domains/manage](https://github.com/Automattic/wp-calypso/blob/5d0c569785bf75723a89120f001a437e2100e770/client/my-sites/controller.js#L372)
* While /mailboxes/:siteslug route already has access, when no mailboxes are found it would redirect to this location as well.

## Testing Instructions

* From `/domains/manage` (Manage all domains page), purchase a domain without it being attached to a site.
* From `/email/:domain/manage/:domain` (Manage emails page), purchase a titan mail email box
* Delete the mailbox
* Attempt to click on "Mailboxes" in the sidebar, it should re-route you to mailbox setup.
* Click "Manage Email" in the sidebar, click the "Set up mailbox" cta in blue, it should take you to the setup page
* Click "Manage Email" again, click "Add a mailbox", it should show a warning and provide a link to setup mailbox again, click that, the setup page should be shown again.

These links should no longer redirect to `/domains/manage`

![Screenshot(66)](https://github.com/user-attachments/assets/492bf703-c438-4a8c-88d1-6d83ada25df0)

![Screenshot(68)](https://github.com/user-attachments/assets/034013a7-a420-44e3-b323-76cd76a5a766)
