### PR TITLE
A4A > Pressable: Update limit exceeded notice text

### DIFF
--- a/client/a8c-for-agencies/components/pressable-usage-limit-notice/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-limit-notice/index.tsx
@@ -56,7 +56,8 @@ export const PressableUsageLimitNotice = () => {
 	}
 
 	const level = pressablePlanUsageLimitExceeded ? 'warning' : 'info';
-	const learnMoreLink = ''; // TODO: Replace with actual link
+	// todo: add learn more link
+	const learnMoreLink = false;
 
 	return (
 		<LayoutBanner
@@ -87,19 +88,22 @@ export const PressableUsageLimitNotice = () => {
 				>
 					{ translate( 'Upgrade now' ) }
 				</Button>
-				<Button
-					variant="secondary"
-					target="_blank"
-					href={ learnMoreLink }
-					onClick={ () => {
-						dispatch(
-							recordTracksEvent( 'calypso_a4a_pressable_limit_notification_learn_more_click' )
-						);
-					} }
-				>
-					{ translate( 'Learn more' ) }
-					<Icon icon={ external } size={ 18 } />
-				</Button>
+
+				{ learnMoreLink && (
+					<Button
+						variant="secondary"
+						target="_blank"
+						href={ learnMoreLink }
+						onClick={ () => {
+							dispatch(
+								recordTracksEvent( 'calypso_a4a_pressable_limit_notification_learn_more_click' )
+							);
+						} }
+					>
+						{ translate( 'Learn more' ) }
+						<Icon icon={ external } size={ 18 } />
+					</Button>
+				) }
 			</div>
 		</LayoutBanner>
 	);

--- a/client/a8c-for-agencies/components/pressable-usage-limit-notice/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-limit-notice/index.tsx
@@ -55,11 +55,12 @@ export const PressableUsageLimitNotice = () => {
 		return null;
 	}
 
+	const level = pressablePlanUsageLimitExceeded ? 'warning' : 'info';
 	const learnMoreLink = ''; // TODO: Replace with actual link
 
 	return (
 		<LayoutBanner
-			level="warning"
+			level={ level }
 			title={ translate( 'Upgrade Pressable' ) }
 			onClose={ dismissNotice }
 			className="pressable-usage-limit-notice"

--- a/client/a8c-for-agencies/components/pressable-usage-limit-notice/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-limit-notice/index.tsx
@@ -64,7 +64,7 @@ export const PressableUsageLimitNotice = () => {
 			onClose={ dismissNotice }
 			className="pressable-usage-limit-notice"
 		>
-			<div>
+			<p className="pressable-usage-limit-notice__message">
 				{ pressablePlanUsageLimitExceeded
 					? translate(
 							'Your Pressable plan has exceeded its allocated limits. Consider upgrading your plan to avoid additional fees.'
@@ -72,30 +72,34 @@ export const PressableUsageLimitNotice = () => {
 					: translate(
 							'Your Pressable plan is close to exceeding its allocated limits. Consider upgrading your plan to avoid additional fees.'
 					  ) }
-			</div>
+			</p>
 
-			<Button
-				className="is-dark"
-				href={ A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK }
-				onClick={ () => {
-					dispatch( recordTracksEvent( 'calypso_a4a_pressable_limit_notification_upgrade_click' ) );
-				} }
-			>
-				{ translate( 'Upgrade now' ) }
-			</Button>
-			<Button
-				variant="secondary"
-				target="_blank"
-				href={ learnMoreLink }
-				onClick={ () => {
-					dispatch(
-						recordTracksEvent( 'calypso_a4a_pressable_limit_notification_learn_more_click' )
-					);
-				} }
-			>
-				{ translate( 'Learn more' ) }
-				<Icon icon={ external } size={ 18 } />
-			</Button>
+			<div className="pressable-usage-limit-notice__actions">
+				<Button
+					className="is-dark"
+					href={ A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK }
+					onClick={ () => {
+						dispatch(
+							recordTracksEvent( 'calypso_a4a_pressable_limit_notification_upgrade_click' )
+						);
+					} }
+				>
+					{ translate( 'Upgrade now' ) }
+				</Button>
+				<Button
+					variant="secondary"
+					target="_blank"
+					href={ learnMoreLink }
+					onClick={ () => {
+						dispatch(
+							recordTracksEvent( 'calypso_a4a_pressable_limit_notification_learn_more_click' )
+						);
+					} }
+				>
+					{ translate( 'Learn more' ) }
+					<Icon icon={ external } size={ 18 } />
+				</Button>
+			</div>
 		</LayoutBanner>
 	);
 };

--- a/client/a8c-for-agencies/components/pressable-usage-limit-notice/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-limit-notice/style.scss
@@ -15,3 +15,8 @@
 		}
 	}
 }
+
+p.pressable-usage-limit-notice__message {
+	@include a4a-font-body-lg;
+	margin: 0;
+}

--- a/client/a8c-for-agencies/sections/marketplace/common/pressable-usage-limit-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/pressable-usage-limit-notice/index.tsx
@@ -41,6 +41,8 @@ export const PressableUsageLimitNotice = () => {
 	const limitType = 'traffic'; // TODO: Replace with actual limit type
 	const limitTypeHumanised = limitTypes[ limitType ];
 
+	const isLimitExceeded = false; // TODO: Replace with actual check
+
 	return (
 		<LayoutBanner
 			level="warning"
@@ -49,13 +51,21 @@ export const PressableUsageLimitNotice = () => {
 			className="pressable-usage-limit-notice"
 		>
 			<div>
-				{ translate(
-					'Your Pressable plan has exceeded its allocated %s limit. Consider upgrading your plan to avoid additional fees.',
-					{
-						args: [ limitTypeHumanised ],
-						comment: 'The limit type is storage or traffic which is already translated',
-					}
-				) }
+				{ isLimitExceeded
+					? translate(
+							'Your Pressable plan has exceeded its allocated %s limit. Consider upgrading your plan to avoid additional fees.',
+							{
+								args: [ limitTypeHumanised ],
+								comment: 'The limit type is storage or traffic which is already translated',
+							}
+					  )
+					: translate(
+							'Your Pressable plan is close to exceeding its allocated %s limit. Consider upgrading your plan to avoid additional fees.',
+							{
+								args: [ limitTypeHumanised ],
+								comment: 'The limit type is storage or traffic which is already translated',
+							}
+					  ) }
 			</div>
 
 			<Button

--- a/client/a8c-for-agencies/sections/marketplace/common/pressable-usage-limit-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/pressable-usage-limit-notice/index.tsx
@@ -53,16 +53,20 @@ export const PressableUsageLimitNotice = () => {
 			<div>
 				{ isLimitExceeded
 					? translate(
-							'Your Pressable plan has exceeded its allocated %s limit. Consider upgrading your plan to avoid additional fees.',
+							'Your Pressable plan has exceeded its allocated %(limitType)s limit. Consider upgrading your plan to avoid additional fees.',
 							{
-								args: [ limitTypeHumanised ],
+								args: {
+									limitType: limitTypeHumanised,
+								},
 								comment: 'The limit type is storage or traffic which is already translated',
 							}
 					  )
 					: translate(
-							'Your Pressable plan is close to exceeding its allocated %s limit. Consider upgrading your plan to avoid additional fees.',
+							'Your Pressable plan is close to exceeding its allocated %(limitType)s limit. Consider upgrading your plan to avoid additional fees.',
 							{
-								args: [ limitTypeHumanised ],
+								args: {
+									limitType: limitTypeHumanised,
+								},
 								comment: 'The limit type is storage or traffic which is already translated',
 							}
 					  ) }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -12,6 +12,7 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import PendingPaymentNotification from 'calypso/a8c-for-agencies/components/pending-payment-notification';
+import PressableUsageLimitNotice from 'calypso/a8c-for-agencies/components/pressable-usage-limit-notice';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
@@ -20,7 +21,6 @@ import {
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import PressableUsageLimitNotice from '../common/pressable-usage-limit-notice';
 import ReferralToggle from '../common/referral-toggle';
 import withMarketplaceType from '../hoc/with-marketplace-type';
 import useShoppingCart from '../hooks/use-shopping-cart';

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -7,6 +7,7 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import PressableUsageLimitNotice from 'calypso/a8c-for-agencies/components/pressable-usage-limit-notice';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import OverviewBody from './body';
 import OverviewHeaderActions from './header-actions';
@@ -22,6 +23,7 @@ export default function Overview() {
 	return (
 		<Layout title={ title } wide>
 			<LayoutTop>
+				<PressableUsageLimitNotice />
 				<LayoutHeader className="a4a-overview-header">
 					<Title>{ title }</Title>
 					<Actions className="a4a-overview__header-actions">

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -7,6 +7,7 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import PressableUsageLimitNotice from 'calypso/a8c-for-agencies/components/pressable-usage-limit-notice';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
@@ -67,6 +68,7 @@ export default function LicensesOverview( {
 		<Layout className="licenses-overview" title={ title } wide withBorder>
 			<LicensesOverviewContext.Provider value={ context }>
 				<LayoutTop withNavigation>
+					<PressableUsageLimitNotice />
 					<LayoutHeader>
 						<Title>{ title } </Title>
 						<Actions className="a4a-licenses__header-actions">

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -67,6 +67,14 @@ export interface Agency {
 		capabilities: string[];
 	};
 	can_issue_licenses: boolean;
+	notifications:
+		| [
+				{
+					timestamp: number;
+					reference: string;
+				},
+		  ]
+		| [];
 }
 
 export interface AgencyStore {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1234

## Proposed Changes

This PR handles a scenario when the Pressable limit is about to be exceeded. 

**Note:** This diff D163375-code should be deployed into production before this PR. You can use that diff to test this PR.

## Why are these changes being made?

* To handle different scenarios for Pressable limit notice.

## Testing Instructions

* Switch to this branch locally
* Read instructions to apply D163375-code
* Ensure you are pointing public-api.wordpress.com to your sandbox.
* Add this notification to your agency: `pressable_plan_usage_limit_exeeded`
* Test it, go to the Marketplace, Overview, and Purchase sections, and you will see the banner.

<img width="1721" alt="Screenshot 2024-10-08 at 10 46 34 AM" src="https://github.com/user-attachments/assets/c4c76c1b-9f88-4772-b410-a72740b70433">

<img width="1721" alt="Screenshot 2024-10-08 at 10 46 55 AM" src="https://github.com/user-attachments/assets/679fb28b-8529-4007-a7ac-c7a2ae3c99e9">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?