### PR TITLE
Help Center: fix margin with contact support

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.scss
+++ b/packages/help-center/src/components/help-center-contact-page.scss
@@ -3,7 +3,6 @@
 .help-center-contact-page {
 	.help-center-contact-page__content {
 		padding: 8px 16px;
-		margin-top: 50px;
 		margin-bottom: 40px;
 
 		h3 {

--- a/packages/help-center/src/components/help-center-contact-page.scss
+++ b/packages/help-center/src/components/help-center-contact-page.scss
@@ -2,7 +2,7 @@
 
 .help-center-contact-page {
 	.help-center-contact-page__content {
-		padding: 8px 16px;
+		padding: 8px;
 		margin-bottom: 40px;
 
 		h3 {


### PR DESCRIPTION
## Proposed Changes

Remove top margin of the contact support page.

## Why are these changes being made?

Bug raised here - p1728235845242839/1728235793.701999-slack-C07D72S1135

The Contact support page is used as a component in the messages and as a stand alone page. The margin some how sneaked in during the refactoring of the styling probably.

<img width="300" alt="Screen Shot 2024-10-08 at 10 06 40" src="https://github.com/user-attachments/assets/ca1f86de-e9f5-43a4-a251-a332519abd93">

<img width="300" alt="Screen Shot 2024-10-08 at 10 06 53" src="https://github.com/user-attachments/assets/d263e1a8-8aa1-4748-985a-8f9e8b0ceaf8">

## Testing Instructions

1. Using live link open help center
2. Ask Wapuu a question and click the `Feeling stuck? Contact our support team.` link to check out the contact page
3. Then ask wapuu to talk to a human to see the button.