### PR TITLE
Track events: Fix tracking property when transferring domains

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -99,6 +99,7 @@ const onboarding: Flow = {
 					setRedirectedToUseMyDomain( false );
 					return navigate( 'plans' );
 				case 'use-my-domain':
+					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
 					if ( providedDependencies?.mode && providedDependencies?.domain ) {
 						return navigate(
 							`use-my-domain?step=${ providedDependencies.mode }&initialQuery=${ providedDependencies.domain }`

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -75,6 +75,18 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 				true
 			);
 		},
-		[ domainCartItem, flow, planCartItem, selectedDomain, siteCount, siteId, theme ]
+		[
+			domainCartItem,
+			flow,
+			isNewUser,
+			isNewishUser,
+			planCartItem,
+			selectedDomain,
+			signupDomainOrigin,
+			site?.slug,
+			siteCount,
+			siteId,
+			theme,
+		]
 	);
 };

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -565,6 +565,10 @@ class Signup extends Component {
 		// but it's not recommended outside of this, hence the name toStepper. See Automattic/growth-foundations#72 for more context.
 		if ( ! dependencies.toStepper ) {
 			debug( 'Tracking signup completion.', debugProps );
+			const isMapping = domainItem && isDomainMapping( domainItem );
+			const isTransfer = domainItem && isDomainTransfer( domainItem );
+			const isTransferOrMapping =
+				isTransfer || isMapping ? SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN : undefined;
 
 			recordSignupComplete( {
 				flow: this.props.flowName,
@@ -582,9 +586,10 @@ class Signup extends Component {
 				intent,
 				startingPoint,
 				isBlankCanvas: isBlankCanvasDesign( dependencies.selectedDesign ),
-				isMapping: domainItem && isDomainMapping( domainItem ),
-				isTransfer: domainItem && isDomainTransfer( domainItem ),
-				signupDomainOrigin: signupDomainOrigin ?? SIGNUP_DOMAIN_ORIGIN.NOT_SET,
+				isMapping: isMapping,
+				isTransfer: isTransfer,
+				signupDomainOrigin:
+					isTransferOrMapping || signupDomainOrigin || SIGNUP_DOMAIN_ORIGIN.NOT_SET,
 			} );
 		}
 	};

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -567,8 +567,10 @@ class Signup extends Component {
 			debug( 'Tracking signup completion.', debugProps );
 			const isMapping = domainItem && isDomainMapping( domainItem );
 			const isTransfer = domainItem && isDomainTransfer( domainItem );
-			const isTransferOrMapping =
-				isTransfer || isMapping ? SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN : undefined;
+			const signupDomainOriginValue =
+				isTransfer || isMapping
+					? SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN
+					: signupDomainOrigin ?? SIGNUP_DOMAIN_ORIGIN.NOT_SET;
 
 			recordSignupComplete( {
 				flow: this.props.flowName,
@@ -588,8 +590,7 @@ class Signup extends Component {
 				isBlankCanvas: isBlankCanvasDesign( dependencies.selectedDesign ),
 				isMapping: isMapping,
 				isTransfer: isTransfer,
-				signupDomainOrigin:
-					isTransferOrMapping || signupDomainOrigin || SIGNUP_DOMAIN_ORIGIN.NOT_SET,
+				signupDomainOrigin: signupDomainOriginValue,
 			} );
 		}
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3406
Fixes https://github.com/Automattic/martech/issues/3406

## Proposed Changes

* Log the correct property value when transferring domains, the correct property is `signup_domain_origin` and the value is `use-your-domain` when transferring domain with a **paid plan**, for free plans it should be `free`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes the property value being logged on /setup/onboarding/domains and /start/domains

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


Scenario 1
* Using live link
* Navigate to /setup/onboarding/domains
* Choose `Use a domain I own` and proceed further adding a domain to transfer
* Choose `Transfer your domain` and a paid plan and go to checkout
* Check Tracks vigilante

Make sure that
`calypso_signup_complete` event is fired and the value of `signup_domain_origin` is `use-your-domain`


Scenario 2
* Using live link
* Navigate to /setup/onboarding/domains
* Choose `Use a domain I own` and proceed further adding a domain to transfer
* Choose `Connect your domain` and a paid plan and go to checkout
* Check Tracks vigilante

Make sure that
`calypso_signup_complete` event is fired and the value of `signup_domain_origin` is `use-your-domain`

Scenario 3
* Using live link
* Navigate to /setup/onboarding/domains
* Choose `Use a domain I own` and proceed further adding a domain to transfer
* Choose `Connect your domain` and a free plan and go to checkout
* Check Tracks vigilante

Make sure that
`calypso_signup_complete` event is fired and the value of `signup_domain_origin` is `free`

Scenario 4
* Using live link
* Navigate to /setup/onboarding/domains
* Choose `Use a domain I own` and proceed further adding a domain to transfer
* Choose `Transfer your domain` and a free plan and go to checkout
* Check Tracks vigilante

Make sure that
`calypso_signup_complete` event is fired and the value of `signup_domain_origin` is `free`


**Please check the same scenarios on /start/domains**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
