### PR TITLE
Stepper: Add locale suggestion to login/user step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -8,6 +8,8 @@ import { AnyAction } from 'redux';
 import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import SignupFormSocialFirst from 'calypso/blocks/signup-form/signup-form-social-first';
 import FormattedHeader from 'calypso/components/formatted-header';
+import LocaleSuggestions from 'calypso/components/locale-suggestions';
+import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
 import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { login } from 'calypso/lib/paths';
@@ -19,8 +21,8 @@ import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { Step } from '../../types';
 import { useHandleSocialResponse } from './handle-social-response';
-import './style.scss';
 import { useSocialService } from './use-social-service';
+import './style.scss';
 
 const UserStepComponent: Step = function UserStep( {
 	flow,
@@ -57,52 +59,64 @@ const UserStepComponent: Step = function UserStep( {
 		redirectTo,
 	} );
 
+	const locale = useFlowLocale();
+	const shouldRenderLocaleSuggestions = ! isLoggedIn; // not sure if this is necessary. It's used in Classic login
+
 	return (
-		<StepContainer
-			stepName={ stepName }
-			isHorizontalLayout={ false }
-			isWideLayout={ false }
-			isFullLayout
-			isLargeSkipLayout={ false }
-			hideBack
-			stepContent={
-				<>
-					<FormattedHeader
-						align="center"
-						headerText={ translate( 'Create your account' ) }
-						brandFont
-					/>
-					<SignupFormSocialFirst
-						stepName={ stepName }
-						flowName={ flow }
-						goToNextStep={ setWpAccountCreateResponse }
-						passDataToNextStep
-						logInUrl={ loginLink }
-						handleSocialResponse={ handleSocialResponse }
-						socialServiceResponse={ socialServiceResponse }
-						redirectToAfterLoginUrl={ window.location.href }
-						queryArgs={ {} }
-						userEmail=""
-						notice={ notice }
-						isSocialFirst
-						onCreateAccountSuccess={ () => setIsNewUser( true ) }
-					/>
-					{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (
-						<WpcomLoginForm
-							authorization={ 'Bearer ' + accountCreateResponse.bearer_token }
-							log={ accountCreateResponse.username }
-							redirectTo={ new URL( redirectTo, window.location.href ).href }
+		<>
+			{ shouldRenderLocaleSuggestions && (
+				<LocaleSuggestions path={ window.location.pathname } locale={ locale } />
+			) }
+			<StepContainer
+				stepName={ stepName }
+				isHorizontalLayout={ false }
+				isWideLayout={ false }
+				isFullLayout
+				isLargeSkipLayout={ false }
+				hideBack
+				stepContent={
+					<>
+						<FormattedHeader
+							align="center"
+							headerText={ translate( 'Create your account' ) }
+							brandFont
 						/>
-					) }
-				</>
-			}
-			recordTracksEvent={ recordTracksEvent }
-			customizedActionButtons={
-				<Button className="step-wrapper__navigation-link forward" href={ loginLink } variant="link">
-					<span>{ translate( 'Log in' ) }</span>
-				</Button>
-			}
-		/>
+						<SignupFormSocialFirst
+							stepName={ stepName }
+							flowName={ flow }
+							goToNextStep={ setWpAccountCreateResponse }
+							passDataToNextStep
+							logInUrl={ loginLink }
+							handleSocialResponse={ handleSocialResponse }
+							socialServiceResponse={ socialServiceResponse }
+							redirectToAfterLoginUrl={ window.location.href }
+							queryArgs={ {} }
+							userEmail=""
+							notice={ notice }
+							isSocialFirst
+							onCreateAccountSuccess={ () => setIsNewUser( true ) }
+						/>
+						{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (
+							<WpcomLoginForm
+								authorization={ 'Bearer ' + accountCreateResponse.bearer_token }
+								log={ accountCreateResponse.username }
+								redirectTo={ new URL( redirectTo, window.location.href ).href }
+							/>
+						) }
+					</>
+				}
+				recordTracksEvent={ recordTracksEvent }
+				customizedActionButtons={
+					<Button
+						className="step-wrapper__navigation-link forward"
+						href={ loginLink }
+						variant="link"
+					>
+						<span>{ translate( 'Log in' ) }</span>
+					</Button>
+				}
+			/>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -60,7 +60,7 @@ const UserStepComponent: Step = function UserStep( {
 	} );
 
 	const locale = useFlowLocale();
-	const shouldRenderLocaleSuggestions = ! isLoggedIn; // not sure if this is necessary. It's used in Classic login
+	const shouldRenderLocaleSuggestions = ! isLoggedIn; // For logged-in users, we respect the user language settings
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -17,7 +17,11 @@ body.is-section-stepper .step-route {
 	@include break-small {
 		margin: 108px 0 0;
 	}
-	
+
+	.locale-suggestions {
+		width: 100%;
+	}
+
 
 	a.step-wrapper__navigation-link {
 		color: #1d2327;
@@ -49,11 +53,11 @@ body.is-section-stepper .step-route {
 				@include break-small {
 					font-size: 2rem;
 					line-height: 3.25;
-				}	
+				}
 			}
 		}
 	}
-	
+
 	.signup-form-social-first {
 		width: 327px;
 		margin: 0 auto;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -19,7 +19,10 @@ body.is-section-stepper .step-route {
 	}
 
 	.locale-suggestions {
-		width: 100%;
+		margin: 0 auto;
+		@include break-medium {
+			width: 100%;
+		}
 	}
 
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/95128

## Proposed Changes

This introduces the en locale suggestion to the login/user step in Stepper, as done in Classic framework.

### Media

<img width="648" alt="Screenshot 2024-10-08 at 2 46 04 PM" src="https://github.com/user-attachments/assets/77f784eb-d0b2-418e-97b0-845b53365004">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Align with Classic.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding/[ es | de | ... ]` so you get a non-en translated User step
* Confirm the notif displays correctly and clicking on it will take you to the specified translation of the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
