### PR TITLE
A4A Dev Sites: Hide `Transfer your site` option and `Admin interface style` settings section for dev sites

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -604,6 +604,7 @@ export class SiteSettingsFormGeneral extends Component {
 		const classes = clsx( 'site-settings__general-settings', {
 			'is-loading': isRequestingSettings,
 		} );
+		const isDevelopmentSite = Boolean( site?.is_a4a_dev_site );
 
 		return (
 			<div className={ clsx( classes ) }>
@@ -654,7 +655,7 @@ export class SiteSettingsFormGeneral extends Component {
 					isUnlaunchedSite={ propsisUnlaunchedSite }
 					urlRef="unlaunched-settings"
 				/>
-				{ this.renderAdminInterface() }
+				{ ! isDevelopmentSite && this.renderAdminInterface() }
 				{ ! isWpcomStagingSite && this.giftOptions() }
 				{ ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
 					<>

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -178,7 +178,10 @@ export default compose( [
 				sourceSlug: siteSlug,
 			} );
 
-			const showStartSiteTransfer = canCurrentUserStartSiteOwnerTransfer( state, siteId );
+			const isDevelopmentSite = Boolean( site?.is_a4a_dev_site );
+
+			const showStartSiteTransfer =
+				! isDevelopmentSite && canCurrentUserStartSiteOwnerTransfer( state, siteId );
 
 			return {
 				site,


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/9101.

## Proposed Changes

If the site is a development site, hide the following in the Hosting (General) settings page:
* `Admin interface style` settings section
* `Transfer your site` option

| Before | After |
|--------|--------|
| ![Markup on 2024-10-08 at 15:30:14](https://github.com/user-attachments/assets/b53679a0-fac4-427c-9090-1ba348a8b459) | ![Markup on 2024-10-08 at 15:30:41](https://github.com/user-attachments/assets/0599e5c7-9176-4b32-9a4e-8a453f7822bc) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out and build this PR with `yarn start`.
2. Navigate to [http://calypso.localhost:3000/settings/general/{blog-id}](http://calypso.localhost:3000/settings/general/%7Bblog-id%7D) (`blog-id` needs to be replaced with a blog ID of a A4A dev site).
3. Make sure that `Admin interface style` settings section and `Transfer your site` option are not available.
4. Open the same settings page on a non-dev site. Both, `Admin interface style` settings section and `Transfer your site` option should still be available.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?