### PR TITLE
Jetpack Backup: Fix Atomic post-transfer experience

### DIFF
--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -34,7 +34,6 @@ import {
 	EligibilityData,
 } from 'calypso/state/automated-transfer/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
-import { requestSite } from 'calypso/state/sites/actions';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -166,8 +165,6 @@ export default function WPCOMBusinessAT() {
 		}
 		// Transfer is completed, check if it's already a Jetpack site
 		if ( ! isJetpack ) {
-			// Need to refresh the site data.
-			dispatch( requestSite( siteId ) );
 			return;
 		}
 

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -159,17 +159,21 @@ export function requestSite( siteFragment ) {
 				// If we can't manage the site, don't add it to state.
 				if ( site && site.capabilities ) {
 					const state = getState();
+
 					const wasAtomic = state?.sites?.items?.[ siteFragment ]?.options?.is_wpcom_atomic;
 					const isAtomic = site?.options?.is_wpcom_atomic;
+					const hasSiteTransferredToAtomic = ! wasAtomic && isAtomic;
+
 					const wasAdmin = state?.currentUser?.capabilities?.[ siteFragment ]?.manage_options;
 					const isAdmin = site?.capabilities?.manage_options;
+					const hasMismatchingCapabilities = wasAdmin && ! isAdmin;
 
 					/*
 					 * Capabilities are not immediately propagated to the Atomic site
 					 * after transfer, so let's hold off updating the state until the
 					 * endpoint returns accurate data.
 					 */
-					if ( ! wasAtomic && isAtomic && wasAdmin && ! isAdmin ) {
+					if ( hasSiteTransferredToAtomic && hasMismatchingCapabilities ) {
 						setTimeout( () => dispatch( requestSite( siteFragment ) ), 2000 );
 					} else {
 						dispatch( receiveSite( omit( site, '_headers' ) ) );

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -130,7 +130,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch fetch action when thunk triggered', () => {
-			const site = requestSite( 2916284 )( spy );
+			const site = requestSite( 2916284 )( spy, () => {} );
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: SITE_REQUEST,
@@ -141,7 +141,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch receive site when request completes', async () => {
-			await requestSite( 2916284 )( spy );
+			await requestSite( 2916284 )( spy, () => {} );
 			expect( spy ).toHaveBeenCalledWith(
 				receiveSite( {
 					ID: 2916284,
@@ -152,7 +152,7 @@ describe( 'actions', () => {
 		} );
 
 		test( "should dispatch success and not receive action when request returns site we can't manage", async () => {
-			await requestSite( 8894098 )( spy );
+			await requestSite( 8894098 )( spy, () => {} );
 			expect( spy ).not.toHaveBeenCalledWith(
 				receiveSite( {
 					ID: 8894098,
@@ -166,7 +166,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch request success action when request completes', async () => {
-			await requestSite( 2916284 )( spy );
+			await requestSite( 2916284 )( spy, () => {} );
 			expect( spy ).toHaveBeenCalledWith( {
 				type: SITE_REQUEST_SUCCESS,
 				siteId: 2916284,
@@ -174,7 +174,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch fail action when request fails', async () => {
-			await requestSite( 77203074 )( spy ).catch( () => {} );
+			await requestSite( 77203074 )( spy, () => {} ).catch( () => {} );
 			expect( spy ).toHaveBeenCalledWith( {
 				type: SITE_REQUEST_FAILURE,
 				siteId: 77203074,

--- a/client/state/themes/actions/theme-transfer.js
+++ b/client/state/themes/actions/theme-transfer.js
@@ -103,10 +103,14 @@ export function initiateThemeTransfer( siteId, file, plugin, geoAffinity = '', c
 
 				return dispatch( pollThemeTransferStatus( siteId, transfer_id, 3000, 180000, !! file ) );
 			} )
-			.then( () =>
-				// Get the latest site data after the atomic transfer.
-				dispatch( requestSite( siteId ) )
-			)
+			.then( () => {
+				// Get the latest site data after the atomic transfer. The request
+				// is intentionally delayed because the site endpoint can return
+				// stale data immediately after the transfer.
+				setTimeout( () => {
+					dispatch( requestSite( siteId ) );
+				}, 1000 );
+			} )
 			.catch( ( error ) => {
 				dispatch( transferInitiateFailure( siteId, error, plugin, context ) );
 			} );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -1167,7 +1167,7 @@ describe( 'actions', () => {
 
 		test( 'should dispatch success', () => {
 			return initiateThemeTransfer( siteId )( spy ).then( () => {
-				expect( spy ).toHaveBeenCalledTimes( 4 );
+				expect( spy ).toHaveBeenCalledTimes( 3 );
 
 				expect( spy ).toHaveBeenCalledWith(
 					expect.objectContaining( {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/50687
Requires D163334-code

## Proposed Changes

When a Simple site becomes Atomic, there is a brief period of time where the site endpoint can return data indicating that all capabilities are disabled, presumably because there is a provisioning still running.

This was causing a broken experience after the Atomic transfer initiated in Jetpack > Backup, because users suddenly were not authorized to see the page.

To mitigate that scenario, we now wait for the site endpoint to return accurate capabilities before updating the Redux state.

Before | After
--- | ---
<img width="1265" alt="Screenshot 2024-10-07 at 14 53 54" src="https://github.com/user-attachments/assets/4e29139a-48cd-40d5-ad53-55b956ed8b12"> | <img width="1267" alt="Screenshot 2024-10-08 at 12 09 30" src="https://github.com/user-attachments/assets/9b56bb2b-a415-4134-af1e-89e67b5c38bc">



## Why are these changes being made?

Because the Atomic post-transfer experience in the Jetpack > Backup screen was broken

## Testing Instructions

- Apply D163334-code to your sandbox
- Sandbox the API
- Use the Calypso live link below
- Go to `/start`
- Create a new site and pick the Business plan
- Once the site is created, go to Jetpack > Backup
- Click on the "Activate Jetpack VaultPress Backup" button
- Wait for the Atomic transfer to be completed
- Make sure the latest backup loads successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?