### PR TITLE
translations for 94640

### DIFF
--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -1,6 +1,4 @@
-.account .notice {
-	margin: 5px 0 0;
-}
+@import "@automattic/typography/styles/variables";
 
 .account__username-form-toggle-enter {
 	opacity: 0.01;
@@ -59,3 +57,24 @@ fieldset.account__settings-admin-home {
 	}
 }
 
+.account .form-input-validation {
+	padding-bottom: 0;
+}
+
+.account__confirm-username-dialog.dialog {
+	max-width: 600px;
+
+	.form-label {
+		font-size: $font-title-small;
+		margin-bottom: 16px;
+	}
+
+	p {
+		font-size: $font-body;
+	}
+
+	a {
+		color: inherit;
+		text-decoration: underline;
+	}
+}

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -85,5 +85,6 @@ body.is-section-me {
 		max-width: 1040px;
 		--color-accent: var(--studio-red);
 		--color-accent-60: var(--studio-red-60);
+		// foo: bar;
 	}
 }

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -85,6 +85,5 @@ body.is-section-me {
 		max-width: 1040px;
 		--color-accent: var(--studio-red);
 		--color-accent-60: var(--studio-red-60);
-		// foo: bar;
 	}
 }


### PR DESCRIPTION
NOTE - this is all taken from @Aurorum's PR https://github.com/Automattic/wp-calypso/pull/94640, please check that PR for previous review and context. We needed to bring these changes into a branch on our repository for translation checks/builds to run. @davemart-in and myself have reviewed and tested this on 94640 and the changes look good to us. We just need new translations to build here.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #94464; fixes #94465

## Proposed Changes

* Improves the "Change username" settings under Me > Account Settings

## Why are these changes being made?

See original issue - this section currently feels 'off' because it doesn't match the Calypso design guidelines. I'd argue that the `Notice` component should really be used to emphasise the important information (ie. the actual warning), and that `FormInputValidation` should inform the user whether their username is valid. 

## Testing Instructions

Navigate to Me > Account Settings and try changing your username. Verify that you still need to confirm your username for this change to work, and that you are still warned about the consequences for this change.

| Current | Proposed |
|--------|--------|
| <img width="765" alt="Screenshot 2024-09-17 at 20 28 41" src="https://github.com/user-attachments/assets/302603d9-a834-4bcc-a1fd-c9199923d71a"> | <img width="967" alt="Screenshot 2024-09-17 at 20 28 46" src="https://github.com/user-attachments/assets/b0d83ff6-903f-44ef-a111-c9374a95fd25"> | 


![image](https://github.com/user-attachments/assets/c18babef-febe-4fe4-b967-3a878d5c8b01)

![image](https://github.com/user-attachments/assets/b677a849-e9fb-472e-b7cd-cdcbd6f4e40d)
