### PR TITLE
Performance Profiler: Pass the filter change callback to update the URL on the CWW recommendations link

### DIFF
--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -148,6 +148,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 							hash={ hash }
 							filter={ filter }
 							displayMigrationBanner={ ! performanceReport?.is_wpcom }
+							onRecommendationsFilterChange={ ( filter ) => updateQueryParams( { filter }, true ) }
 						/>
 					) }
 				</>


### PR DESCRIPTION

## Proposed Changes

Pass the `onRecommendationsFilterChange` on the PerformanceProfilerDashboard so when the user clicks on the `View recommendations` link it updates the URL to filter the Recommendations section.

![Export-1728397782688](https://github.com/user-attachments/assets/a7ab5be9-d5ba-4d60-8a00-6cd2815b59a7)


## Why are these changes being made?
Fixes [Performance Profiler: CWW recommendations link broken - regression](https://github.com/Automattic/dotcom-forge/issues/9336)



## Testing Instructions

* Go to `speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6OTIxNn0.n0Ypw8Xr5Vuw9t2NsMqtOLs8wVpixwGiqbj-NzXbrHQ`
* On the CWW section clicks on the link `View 6 recommendations`
* Check if the the dropdown on the Recommendations section is properly filled.
* The testing instructions on https://github.com/Automattic/wp-calypso/pull/94697 should still be working
