### PR TITLE
Stepper Onboarding: Add logic to skip submit step event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -54,11 +54,13 @@ export const useStepNavigationWithTracking = ( {
 		() => ( {
 			...( stepNavigation.submit && {
 				submit: ( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) => {
-					handleRecordStepNavigation( {
-						event: STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
-						providedDependencies,
-						additionalProps: tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ],
-					} );
+					if ( ! providedDependencies?.skipSubmitStepTracks ) {
+						handleRecordStepNavigation( {
+							event: STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
+							providedDependencies,
+							additionalProps: tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ],
+						} );
+					}
 					stepNavigation.submit?.( providedDependencies, ...params );
 				},
 			} ),

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -54,7 +54,7 @@ export const useStepNavigationWithTracking = ( {
 		() => ( {
 			...( stepNavigation.submit && {
 				submit: ( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) => {
-					if ( ! providedDependencies?.skipSubmitStepTracks ) {
+					if ( ! providedDependencies?.shouldSkipSubmitTracking ) {
 						handleRecordStepNavigation( {
 							event: STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
 							providedDependencies,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -78,7 +78,7 @@ const UseMyDomain: Step = function UseMyDomain( { navigation, flow } ) {
 	};
 
 	const handleOnNext = ( { mode, domain }: { mode: string; domain: string } ) => {
-		submit?.( { mode, domain } );
+		submit?.( { mode, domain, skipSubmitStepTracks: true } );
 	};
 
 	const getBlogOnboardingFlowStepContent = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -78,7 +78,7 @@ const UseMyDomain: Step = function UseMyDomain( { navigation, flow } ) {
 	};
 
 	const handleOnNext = ( { mode, domain }: { mode: string; domain: string } ) => {
-		submit?.( { mode, domain, skipSubmitStepTracks: true } );
+		submit?.( { mode, domain, shouldSkipSubmitTracking: true } );
 	};
 
 	const getBlogOnboardingFlowStepContent = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/95126

## Proposed Changes

* Adds logic to allow skipping `calypso_signup_actions_submit_step` event

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allows us to skip the event if necessary like in the `use-my-domain` step. The event should only fire after submitting on final screen for that step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to `/setup/onboarding`.
* Open the Chrome dev tools `Network` tab and filter by `calypso_signup_actions_submit_step`
* Click on the `Use a domain I own` link.
* Enter a domain in the input field and verify that the `calypso_signup_actions_submit_step` is NOT triggered.
* Click the `Transfer your domain` and `Connect your domain` options by clicking `Select` and verify the `calypso_signup_actions_submit_step` for both scenarios.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
