### PR TITLE
Post-migration Experience: Add action for "Connect your domain" task

### DIFF
--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -134,6 +134,11 @@ export const setUpActionsForTasks = ( {
 					useCalypsoPath = false;
 					break;
 
+				case 'connect_migration_domain':
+					logMissingCalypsoPath = true;
+					task.calypso_path = `/domains/add/use-my-domain/${ siteSlug }?initialQuery=`;
+					break;
+
 				default:
 					logMissingCalypsoPath = true;
 					useCalypsoPath = false;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/39680 and https://github.com/Automattic/wp-calypso/issues/95076

## Proposed Changes

* Add front-end link to the domain configuration screen at `/domains/add/use-my-domain/siteSlug` for the "Connect your domain" task
* TODO: Figure out how to get the user's domain from signup if available and add it to the query param.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Adding a new task to the post migration experience task list, it needs a front-end functionality piece.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the setup instructions in https://github.com/Automattic/jetpack/pull/39680 to show the task list in My Home
* Once you've done that, switch to this branch locally or on calypso.live and click on the task
* If this test site went through the site migration configuration setup, you should be brought to `/domains/add/use-my-domain/siteSlug?initialQuery=example.com`
* Otherwise you should be brought to `/domains/add/use-my-domain/siteSlug`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
