### PR TITLE
Performance Profiler: Update the texts on the Unsubscribe page

### DIFF
--- a/client/performance-profiler/components/message-display/style.scss
+++ b/client/performance-profiler/components/message-display/style.scss
@@ -84,8 +84,11 @@ $blueberry-color: #3858e9;
 
 			.message {
 				font-size: $font-body;
-				font-weight: 500;
 				line-height: $font-title-medium;
+
+				strong {
+					font-weight: 500;
+				}
 			}
 
 			.cta-button {

--- a/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
+++ b/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -9,6 +10,12 @@ import {
 } from 'calypso/performance-profiler/components/message-display';
 import LoaderText from 'calypso/performance-profiler/components/weekly-report/loader-text';
 import { WeeklyReportProps } from 'calypso/performance-profiler/types/weekly-report';
+
+const Subtitle = styled.span`
+	color: #a7aaad;
+	font-size: 14px;
+	font-weight: 400;
+`;
 
 export const WeeklyReportUnsubscribe = ( props: WeeklyReportProps ) => {
 	const translate = useTranslate();
@@ -31,10 +38,6 @@ export const WeeklyReportUnsubscribe = ( props: WeeklyReportProps ) => {
 		}
 	}, [ isSuccess, url, hash ] );
 
-	const secondaryMessage = translate(
-		'You can opt in again for weekly reports to receive performance change emails.'
-	);
-
 	return (
 		<div className="peformance-profiler-weekly-report-container">
 			<DocumentHead title={ translate( 'Speed Test weekly reports' ) } />
@@ -49,7 +52,6 @@ export const WeeklyReportUnsubscribe = ( props: WeeklyReportProps ) => {
 							} ) }
 						</LoaderText>
 					}
-					secondaryMessage={ secondaryMessage }
 				/>
 			) }
 			{ isError && (
@@ -69,21 +71,26 @@ export const WeeklyReportUnsubscribe = ( props: WeeklyReportProps ) => {
 							</ErrorSecondLine>
 						</>
 					}
-					secondaryMessage={ secondaryMessage }
 				/>
 			) }
 			{ isSuccess && (
 				<MessageDisplay
 					displayBadge
-					title={ translate( 'Unsubscribed!' ) }
+					title={ translate( 'Farewell, friend' ) }
 					message={ translate(
-						'You‘ll no longer receive weekly performance reports for {{strong}}%s{{/strong}}',
-						{ args: [ siteUrl.host ], components: { strong: <strong /> } }
+						'You’ll no longer receive performance reports for {{strong}}%s{{/strong}}{{br}}{{/br}}{{br}}{{/br}}{{subtitle}}If you ever change your mind, you can subscribe for {{br}}{{/br}}performance reports again from the results page.{{/subtitle}}',
+						{
+							args: [ siteUrl.host ],
+							components: {
+								strong: <strong />,
+								br: <br />,
+								subtitle: <Subtitle />,
+							},
+						}
 					) }
-					ctaText={ translate( '← Back to speed test' ) }
+					ctaText={ translate( 'Test a site' ) }
 					ctaHref="/speed-test"
 					ctaIcon="arrow-left"
-					secondaryMessage={ secondaryMessage }
 				/>
 			) }
 		</div>

--- a/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
+++ b/client/performance-profiler/pages/weekly-report/unsubscribe.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -10,12 +9,6 @@ import {
 } from 'calypso/performance-profiler/components/message-display';
 import LoaderText from 'calypso/performance-profiler/components/weekly-report/loader-text';
 import { WeeklyReportProps } from 'calypso/performance-profiler/types/weekly-report';
-
-const Subtitle = styled.span`
-	color: #a7aaad;
-	font-size: 14px;
-	font-weight: 400;
-`;
 
 export const WeeklyReportUnsubscribe = ( props: WeeklyReportProps ) => {
 	const translate = useTranslate();
@@ -84,7 +77,7 @@ export const WeeklyReportUnsubscribe = ( props: WeeklyReportProps ) => {
 							components: {
 								strong: <strong />,
 								br: <br />,
-								subtitle: <Subtitle />,
+								subtitle: <span className="secondary-message" />,
 							},
 						}
 					) }


### PR DESCRIPTION


## Proposed Changes

Update the texts on the `Unsubscribe` page.

## Why are these changes being made?

Fixes [Performance Profiler: Update unsubscribe result page designs / texts](https://github.com/Automattic/dotcom-forge/issues/9149)

## Testing Instructions


* Go to the `/speed-test-tool/weekly-report/unsubscribe` url. Ex: `http://calypso.localhost:3000/speed-test-tool/weekly-report/unsubscribe?url=https://wordpress.com/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6OTIxNn0.n0Ypw8Xr5Vuw9t2NsMqtOLs8wVpixwGiqbj-NzXbrHQ&filter=lcp`
* Check if the texts and design matches the one below

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-10-08 at 16 44 33@2x](https://github.com/user-attachments/assets/bef6b604-fbb9-4ed2-bc96-f8c33927d38b)|![CleanShot 2024-10-08 at 16 43 59@2x](https://github.com/user-attachments/assets/e97387b1-dcf0-40aa-a7af-ea57292eee5b)|
