### PR TITLE
Reader Onboarding: Setup basic framework and feature flag

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,9 +1,11 @@
+import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
 import withDimensions from 'calypso/lib/with-dimensions';
+import ReaderOnboarding from 'calypso/reader/onboarding';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import Stream, { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
 import ReaderListFollowedSites from 'calypso/reader/stream/reader-list-followed-sites';
@@ -28,6 +30,7 @@ function FollowingStream( { ...props } ) {
 					} ) }
 				/>
 				<FollowingIntro />
+				{ config.isEnabled( 'reader/onboarding' ) && <ReaderOnboarding /> }
 			</Stream>
 			<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
 		</>

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import InterestsModal from './interests-modal';
+import SubscribeModal from './subscribe-modal';
+
+import './style.scss';
+
+const ReaderOnboarding = () => {
+	const [ isInterestsModalOpen, setIsInterestsModalOpen ] = useState( false );
+	const [ isDiscoverModalOpen, setIsDiscoverModalOpen ] = useState( false );
+
+	return (
+		<>
+			<div className="reader-onboarding">
+				<div className="reader-onboarding__intro-column">
+					<h2>Your personal reading adventure</h2>
+					<p>Tailor your feed, connect with your favorite topics</p>
+				</div>
+				<div className="reader-onboarding__steps-column">
+					<ul>
+						<li>
+							<button
+								className="reader-onboarding__link-button"
+								onClick={ () => setIsInterestsModalOpen( true ) }
+							>
+								Select some of your interests
+							</button>
+						</li>
+						<li>
+							<button
+								className="reader-onboarding__link-button"
+								onClick={ () => setIsDiscoverModalOpen( true ) }
+							>
+								Discover and subscribe to sites you'll love
+							</button>
+						</li>
+					</ul>
+				</div>
+			</div>
+
+			<InterestsModal
+				isOpen={ isInterestsModalOpen }
+				onClose={ () => setIsInterestsModalOpen( false ) }
+			/>
+			<SubscribeModal
+				isOpen={ isDiscoverModalOpen }
+				onClose={ () => setIsDiscoverModalOpen( false ) }
+			/>
+		</>
+	);
+};
+
+export default ReaderOnboarding;

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -1,0 +1,20 @@
+import { Modal } from '@wordpress/components';
+import React from 'react';
+
+interface InterestsModalProps {
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) => {
+	return (
+		isOpen && (
+			<Modal title="Select Your Interests" onRequestClose={ onClose } isFullScreen={ false }>
+				<p>Interest content here.</p>
+				<button onClick={ onClose }>Close</button>
+			</Modal>
+		)
+	);
+};
+
+export default InterestsModal;

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -9,7 +9,7 @@ interface InterestsModalProps {
 const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) => {
 	return (
 		isOpen && (
-			<Modal title="Select Your Interests" onRequestClose={ onClose } isFullScreen={ false }>
+			<Modal title="Select Your Interests" onRequestClose={ onClose } isFullScreen>
 				<p>Interest content here.</p>
 				<button onClick={ onClose }>Close</button>
 			</Modal>

--- a/client/reader/onboarding/style.scss
+++ b/client/reader/onboarding/style.scss
@@ -1,0 +1,30 @@
+.reader-onboarding {
+	display: flex;
+	width: 100%;
+	flex-wrap: wrap;
+
+	&__link-button {
+		background: none;
+		border: none;
+		padding: 0;
+		color: #00e;
+		text-decoration: underline;
+		cursor: pointer;
+		font: inherit;
+	}
+
+	&__intro-column,
+	&__steps-column {
+		flex: 1 1 300px;
+		min-width: 300px; // Minimum width before wrapping
+		padding: 20px;
+	}
+
+	&__intro-column {
+		background-color: #aaa;
+	}
+
+	&__steps-column {
+		background-color: #eee;
+	}
+}

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -9,7 +9,7 @@ interface SubscribeModalProps {
 const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) => {
 	return (
 		isOpen && (
-			<Modal title="Discover and Subscribe" onRequestClose={ onClose } isFullScreen={ false }>
+			<Modal title="Discover and Subscribe" onRequestClose={ onClose } isFullScreen>
 				<p>Subscription content here.</p>
 				<button onClick={ onClose }>Close</button>
 			</Modal>

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -1,0 +1,20 @@
+import { Modal } from '@wordpress/components';
+import React from 'react';
+
+interface SubscribeModalProps {
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) => {
+	return (
+		isOpen && (
+			<Modal title="Discover and Subscribe" onRequestClose={ onClose } isFullScreen={ false }>
+				<p>Subscription content here.</p>
+				<button onClick={ onClose }>Close</button>
+			</Modal>
+		)
+	);
+};
+
+export default SubscribeModal;

--- a/config/development.json
+++ b/config/development.json
@@ -197,6 +197,7 @@
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,
+		"reader/onboarding": true,
 		"readymade-templates/showcase": true,
 		"redirect-fallback-browsers": false,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/189

## Proposed Changes

* This PR introduces the `reader/onboarding` feature flag.
* It also proposes file locations and a fundamental framework to start building out the Reader Onboarding banner and modals.

> [!NOTE]  
> This code is behind the `reader/onboarding` feature flag in the development.config file. It is NOT visible to customers and is only visible if you're running Calypso locally. This PR is meant to be merged but is simply a starting place to begin iterative development.



https://github.com/user-attachments/assets/cf66796c-0647-42d1-8dc2-ae4e3e655bea




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To stake out a building site for the Reader Onboarding project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link and go to /read
* Verify that the banner in the video above is not visible because it's behind a feature flag
* Apply this PR to your local dev environment (be sure to restart `yarn` so it'll pick up the changes to config file.)
* Go to http://calypso.localhost:3000/read and verify that the banner is visible
* What do you think of the file locations and initial framework?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
