### PR TITLE
Updates the migration status to started

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -7,9 +7,11 @@ import { Icon, globe, group, shield, backup, scheduled } from '@wordpress/icons'
 import { createElement, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { useUpdateMigrationStatus } from 'calypso/data/site-migration/use-update-migration-status';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import './style.scss';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { UserData } from 'calypso/lib/user/user';
@@ -56,6 +58,16 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 			} );
 		},
 	} );
+
+	const { updateMigrationStatus } = useUpdateMigrationStatus();
+	const site = useSite();
+	const siteId = site?.ID;
+
+	useEffect( () => {
+		if ( siteId ) {
+			updateMigrationStatus( siteId, 'migration-started-difm' );
+		}
+	}, [ siteId, updateMigrationStatus ] );
 
 	useEffect( () => {
 		recordTracksEvent( 'wpcom_support_free_migration_request_click', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95156

## Proposed Changes

* Updates the status of the Assisted Migration flow to `started` when the ticket is created. I simply used the mutation introduced on #95199 to update the status to `started` when the ticket is created.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the Post-purchase project, we need to store the state of the migration using the stickers to allow us to better redirect the user back to the flow.
* For the Post-migration experience, we need to know the status of the migration so we can show the Launchpad with for the migrated sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff to your local environment or use Calypso live
* Start a migration and go through the "Do it for me" flow
* Once you reach the "Let's us take it from here" step, go to the blog's RC and verify that you have the following events in the Audit Trail panel:
  * add sticker - migration-pending-difm
  * remove sticker - migration-pending-difm
  * add sticker - migration-started-difm

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
