### PR TITLE
Odyssey Stats: fix like count for most popular post/page

### DIFF
--- a/client/my-sites/stats/sections/all-time-highlights-section/post-cards-group.tsx
+++ b/client/my-sites/stats/sections/all-time-highlights-section/post-cards-group.tsx
@@ -14,6 +14,7 @@ import {
 	isRequestingSitePost,
 	getPostsForQuery,
 	isRequestingPostsForQuery,
+	countPostLikes,
 } from 'calypso/state/posts/selectors';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import {
@@ -98,6 +99,10 @@ export default function PostCardsGroup( {
 		getStatsTopPostsData( state, siteId, topPostsQuery )
 	);
 
+	const countLikes = useSelector(
+		( state ) => countPostLikes( state, siteId, topViewedPost?.id ) || 0
+	);
+
 	// Prepare the most popular post card.
 	const mostPopularPost = useSelector( ( state ) =>
 		getSitePost( state, siteId, topViewedPost?.id )
@@ -115,7 +120,7 @@ export default function PostCardsGroup( {
 		title: decodeEntities(
 			stripHTML( textTruncator( mostPopularPost?.title, POST_STATS_CARD_TITLE_LIMIT ) )
 		),
-		likeCount: mostPopularPost?.like_count,
+		likeCount: countLikes,
 		viewCount: mostPopularPostViewCount,
 		commentCount: mostPopularPost?.discussion?.comment_count,
 	};


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/88005

## Proposed Changes

* Use like count from the likes endpoint

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* bugfix

## Testing Instructions

* Build Odyssey Stats and Jetpack locally
* Open `/wp-admin/admin.php?page=stats#!/stats/insights/:siteSlug`
* Ensure Top post is showing correct Likes and Comments

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/9e31dc71-da0b-4e2a-a3b0-1886f23d430e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
