### PR TITLE
Logged-in Profiler: Improve page selector readability 

### DIFF
--- a/client/hosting/performance/components/PageSelector.tsx
+++ b/client/hosting/performance/components/PageSelector.tsx
@@ -17,19 +17,9 @@ export const PageSelector = ( props: ComponentProps< typeof SearchableDropdown >
 					{ ...props }
 					className="site-performance__page-selector-drowdown"
 					__experimentalRenderItem={ ( { item } ) => (
-						<div
-							aria-label={ item.label }
-							css={ {
-								display: 'flex',
-								flexDirection: 'column',
-								paddingInline: '16px',
-								paddingBlock: '8px',
-								fontSize: '0.875rem',
-								gap: '4px',
-							} }
-						>
+						<div className="site-performance__page-selector-item" aria-label={ item.label }>
 							<span>{ item.label }</span>
-							<span>{ item.path }</span>
+							<span className="subtitle">{ item.path }</span>
 						</div>
 					) }
 				/>

--- a/client/hosting/performance/hooks/useSitePerformancePageReports.ts
+++ b/client/hosting/performance/hooks/useSitePerformancePageReports.ts
@@ -91,7 +91,7 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 				return {
 					url: page.link,
 					path,
-					label: page.title.rendered,
+					label: page.title.rendered || __( 'No Title' ),
 					value: page.id.toString(),
 					wpcom_performance_report_url: toPerformanceReportParts(
 						page.link,
@@ -119,7 +119,7 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 			return [
 				{
 					url: site?.URL,
-					path: '/',
+					path: 'homepage',
 					label: __( 'Home' ),
 					value: HOME_PAGE_ID,
 					wpcom_performance_report_url: toPerformanceReportParts(

--- a/client/hosting/performance/hooks/useSitePerformancePageReports.ts
+++ b/client/hosting/performance/hooks/useSitePerformancePageReports.ts
@@ -119,7 +119,7 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 			return [
 				{
 					url: site?.URL,
-					path: 'homepage',
+					path: '/',
 					label: __( 'Home' ),
 					value: HOME_PAGE_ID,
 					wpcom_performance_report_url: toPerformanceReportParts(

--- a/client/hosting/performance/style.scss
+++ b/client/hosting/performance/style.scss
@@ -1,6 +1,8 @@
 @use "sass:math";
 @import "@automattic/color-studio/dist/color-variables";
 @import "@wordpress/base-styles/breakpoints";
+@import '@automattic/components/src/styles/typography';
+
 
 $section-max-width: 1224px;
 
@@ -202,6 +204,24 @@ $section-max-width: 1224px;
 
 	}
 
+	.site-performance__page-selector-item {
+		display: flex;
+		flex-direction: column;
+		padding-inline: 16px;
+		padding-block: 8px;
+		font-size: $font-body-small;
+		font-family: $font-sf-pro-text;
+		gap: 4px;
+
+		.subtitle {
+			font-size: $font-body-extra-small;
+			color: #949494;
+			font-family: $font-sf-pro-text;
+			line-height: 20px;
+		}
+		
+	}
+
 	input.components-combobox-control__input[type="text"] {
 		height: 34px;
 		padding-right: 30px;
@@ -210,11 +230,17 @@ $section-max-width: 1224px;
 
 	.components-form-token-field__suggestions-list {
 		max-height: initial !important;
-		box-shadow: inset 0 -1px 0 0 var(--color-neutral-50);
 	}
 
 	.components-form-token-field__suggestions-list li {
 		padding: 0 !important;
+		&:not(:first-child) {
+			border-top: 1px solid #F0F0F0;
+		}
+
+		&.is-selected * {
+			color: #fff !important;
+		}
 	}
 
 	@media (max-width: $break-medium) {

--- a/client/hosting/performance/style.scss
+++ b/client/hosting/performance/style.scss
@@ -211,7 +211,6 @@ $section-max-width: 1224px;
 		padding-block: 8px;
 		font-size: $font-body-small;
 		font-family: $font-sf-pro-text;
-		gap: 4px;
 
 		.subtitle {
 			font-size: $font-body-extra-small;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Cft pdtkmj-2Z1-p2#comment-5750 

## Proposed Changes

* show `homepage` for Home subtitle instead of `/`
* Add separator between items
* Add `No Title` for pages that do not have a title so black is not displayed when selected

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve quality of the product

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `sites/performance/site`
* Verify page selector matches design

![image](https://github.com/user-attachments/assets/c5134e99-3ce6-4707-8299-bf3cd69519a3)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?