### PR TITLE
move legend outside of heading container

### DIFF
--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -160,10 +160,10 @@ export default function SubscribersChartSection( {
 						<StatsPeriodHeader>
 							<Intervals selected={ period } pathTemplate={ pathTemplate } compact />
 						</StatsPeriodHeader>
-						<div className="subscribers-section-legend" ref={ legendRef }></div>
 					</div>
 				</div>
 			</div>
+			<div className="subscribers-section-legend" ref={ legendRef }></div>
 			{ isChartLoading && <StatsModulePlaceholder className="is-chart" isLoading /> }
 			{ ! isChartLoading && chartData.length === 0 && (
 				<p className="subscribers-section__no-data">

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -163,7 +163,6 @@ export default function SubscribersChartSection( {
 					</div>
 				</div>
 			</div>
-			<div className="subscribers-section-legend" ref={ legendRef }></div>
 			{ isChartLoading && <StatsModulePlaceholder className="is-chart" isLoading /> }
 			{ ! isChartLoading && chartData.length === 0 && (
 				<p className="subscribers-section__no-data">
@@ -172,16 +171,19 @@ export default function SubscribersChartSection( {
 			) }
 			{ errorMessage && <div>Error: { errorMessage }</div> }
 			{ ! isChartLoading && chartData.length !== 0 && (
-				<UplotChart
-					data={ chartData }
-					legendContainer={ legendRef }
-					period={ period }
-					// Use variable --studio-jetpack-green for chart colors on Odyssey Stats.
-					mainColor={ isOdysseyStats ? '#069e08' : undefined }
-					fillColorFrom={ isOdysseyStats ? 'rgba(6, 158, 8, 0.4)' : undefined }
-					fillColorTo={ isOdysseyStats ? 'rgba(6, 158, 8, 0)' : undefined }
-					yAxisFilter={ hideFractionNumber }
-				/>
+				<>
+					<div className="subscribers-section-legend" ref={ legendRef }></div>
+					<UplotChart
+						data={ chartData }
+						legendContainer={ legendRef }
+						period={ period }
+						// Use variable --studio-jetpack-green for chart colors on Odyssey Stats.
+						mainColor={ isOdysseyStats ? '#069e08' : undefined }
+						fillColorFrom={ isOdysseyStats ? 'rgba(6, 158, 8, 0.4)' : undefined }
+						fillColorTo={ isOdysseyStats ? 'rgba(6, 158, 8, 0)' : undefined }
+						yAxisFilter={ hideFractionNumber }
+					/>
+				</>
 			) }
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91632

## Proposed Changes

* Moves the Subscriber Stats chart legend out of the heading container in order to fix visual bug causing other elements to jump. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* see comment https://github.com/Automattic/wp-calypso/issues/91632#issuecomment-2401381766

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open calypso live branch for a site with at least one paid subscriber and one free one
* if you need a su-user to test with ping me (annacmc) 
* navigate to `/stats/subscribers/{site URL}`
* hover over different elements of the chart and off the chart to load different data quantities into the chart legend
* confirm this doesn't make any other elements on the header or page jump or shift
* test on different sized displays, mobile, alternative browsers etc. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
