### PR TITLE
Media Library: Fix error message

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -172,8 +172,8 @@ export class MediaLibraryContent extends Component {
 					break;
 				case MediaValidationErrors.FILE_TYPE_UNSUPPORTED:
 					message = translate(
-						'%d file could not be uploaded because the file type is not supported.',
-						'%d files could not be uploaded because their file types are unsupported.',
+						'%(occurrences)d file could not be uploaded because the file type is not supported.',
+						'%(occurrences)d files could not be uploaded because their file types are unsupported.',
 						i18nOptions
 					);
 					actionText = translate( 'See supported file types' );
@@ -182,15 +182,15 @@ export class MediaLibraryContent extends Component {
 					break;
 				case MediaValidationErrors.UPLOAD_VIA_URL_404:
 					message = translate(
-						'%d file could not be uploaded because no image exists at the specified URL.',
-						'%d files could not be uploaded because no images exist at the specified URLs',
+						'%(occurrences)d file could not be uploaded because no image exists at the specified URL.',
+						'%(occurrences)d files could not be uploaded because no images exist at the specified URLs',
 						i18nOptions
 					);
 					break;
 				case MediaValidationErrors.EXCEEDS_MAX_UPLOAD_SIZE:
 					message = translate(
-						'%d file could not be uploaded because it exceeds the maximum upload size.',
-						'%d files could not be uploaded because they exceed the maximum upload size.',
+						'%(occurrences)d file could not be uploaded because it exceeds the maximum upload size.',
+						'%(occurrences)d files could not be uploaded because they exceed the maximum upload size.',
 						i18nOptions
 					);
 					break;
@@ -198,8 +198,8 @@ export class MediaLibraryContent extends Component {
 					upgradeNudgeName = 'plan-media-storage-error';
 					upgradeNudgeFeature = 'extra-storage';
 					message = translate(
-						'%d file could not be uploaded because there is not enough space left.',
-						'%d files could not be uploaded because there is not enough space left.',
+						'%(occurrences)d file could not be uploaded because there is not enough space left.',
+						'%(occurrences)d files could not be uploaded because there is not enough space left.',
 						i18nOptions
 					);
 					break;
@@ -213,8 +213,8 @@ export class MediaLibraryContent extends Component {
 						upgradeNudgeFeature = 'extra-storage';
 					}
 					message = translate(
-						'%d file could not be uploaded because you have reached your plan storage limit.',
-						'%d files could not be uploaded because you have reached your plan storage limit.',
+						'%(occurrences)d file could not be uploaded because you have reached your plan storage limit.',
+						'%(occurrences)d files could not be uploaded because you have reached your plan storage limit.',
 						i18nOptions
 					);
 					break;
@@ -236,8 +236,8 @@ export class MediaLibraryContent extends Component {
 
 				default:
 					message = translate(
-						'%d file could not be uploaded because an error occurred while uploading.',
-						'%d files could not be uploaded because errors occurred while uploading.',
+						'%(occurrences)d file could not be uploaded because an error occurred while uploading.',
+						'%(occurrences)d files could not be uploaded because errors occurred while uploading.',
 						i18nOptions
 					);
 					break;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94189

## Proposed Changes

This PR fixes Media Library error messages by passing the correct arguments to `translate()`.

| Before | After |
| --- | --- |
| ![Screenshot 2024-10-09 at 2 51 52 PM](https://github.com/user-attachments/assets/6f9b42dd-014a-491a-b65a-e71e5cd44cc9) | ![Screenshot 2024-10-09 at 2 51 24 PM](https://github.com/user-attachments/assets/2b270a83-acd7-4b83-a20d-5c5811726070) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WP.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Head to `/media/{SITE}`.
2. Upload an SVG file by drag and drop. For example, https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/AJ_Digital_Camera.svg.
3. Ensure that the error message displays "1 file" instead of "0 file".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
