### PR TITLE
Stepper: Use persisted state on domains step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
@@ -22,6 +22,7 @@ const EXCLUDED_DEPENDENCIES = [
 	'password',
 	'password_confirm',
 	'domainCart',
+	'domainForm',
 	'suggestion',
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -120,8 +120,7 @@ export default function DomainsStep( props: StepProps ) {
 				saveSignupStep={ updateSignupStepState }
 				submitSignupStep={ updateSignupStepState }
 				goToNextStep={ ( state: ProvidedDependencies ) => {
-					const { domainForm, ...rest } = mostRecentStateRef.current ?? {};
-					props.navigation.submit?.( { ...rest, ...state } );
+					props.navigation.submit?.( { ...( mostRecentStateRef.current ?? {} ), ...state } );
 				} }
 				step={ stepState }
 				flowName={ props.flow }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -107,9 +107,7 @@ export default function DomainsStep( props: StepProps ) {
 			wasSignupCheckoutPageUnloaded() && signupDestinationCookieExists && isReEnteringFlow
 		);
 		if ( isManageSiteFlow ) {
-			if ( Object.keys( stepState ).length > 0 ) {
-				props.navigation.submit?.( stepState );
-			}
+			props.navigation.submit?.( stepState );
 		}
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -111,7 +111,7 @@ export default function DomainsStep( props: StepProps ) {
 				props.navigation.submit?.( stepState );
 			}
 		}
-	} );
+	}, [ stepState, props.navigation, props.flow ] );
 
 	return (
 		<CalypsoShoppingCartProvider>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95027
Fixes https://github.com/Automattic/wp-calypso/issues/95027

## Proposed Changes

* Automatically submit the domains step if navigating back (using browser back button) from checkout. The idea is to redirect the user to the plans step with the correct domain previously selected. This behavior is [already introduced](https://github.com/Automattic/wp-calypso/pull/94859) on `/start`, this PR adds it on stepper.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the experience using /start and stepper the same.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using live link or this branch
* Navigate to /setup/onboarding/domains
* Select any domain
* Navigate until you reach the checkout, you need to choose either a paid domain or paid plan.
* When in the checkout page, click on the browser back button
* You should land back on Plans
* Test around navigating again to checkout and make sure the domain is still present
* Test navigating back and changing the domain and the further again to checkout.
* Test transfer domains
* Test free domains

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
