### PR TITLE
Performance Profiler: Remove unnecessary useEffect and useStates to address bugs

### DIFF
--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -16,7 +16,7 @@ function mapScores( response: UrlBasicMetricsQueryResponse ) {
 
 export const useUrlBasicMetricsQuery = ( url?: string, hash?: string, advance = false ) => {
 	return useQuery( {
-		queryKey: [ 'url', 'basic-metrics', url, hash, advance ],
+		queryKey: [ 'url', 'basic-metrics', url, advance ],
 		queryFn: (): Promise< UrlBasicMetricsQueryResponse > =>
 			wp.req.get(
 				{

--- a/client/data/site-profiler/use-url-performance-insights.ts
+++ b/client/data/site-profiler/use-url-performance-insights.ts
@@ -25,6 +25,6 @@ export const useUrlPerformanceInsightsQuery = ( url?: string, hash?: string ) =>
 		retry: false,
 		refetchOnWindowFocus: false,
 		refetchInterval: ( query ) =>
-			query.state.data?.pagespeed?.status === 'completed' ? false : 5000, // 5 second	;
+			query.state.data?.pagespeed?.status === 'completed' ? false : 5000, // 5 second
 	} );
 };

--- a/client/hosting/performance/components/PerformanceReport.tsx
+++ b/client/hosting/performance/components/PerformanceReport.tsx
@@ -9,6 +9,7 @@ interface PerformanceReportProps {
 	hash: string;
 	isLoading: boolean;
 	isError: boolean;
+	isRetesting: boolean;
 	onRetestClick(): void;
 	pageTitle: string;
 	filter?: string;
@@ -17,6 +18,7 @@ interface PerformanceReportProps {
 
 export const PerformanceReport = ( {
 	isLoading,
+	isRetesting,
 	isError,
 	onRetestClick,
 	performanceReport,
@@ -30,8 +32,13 @@ export const PerformanceReport = ( {
 		return <ReportError onRetestClick={ onRetestClick } />;
 	}
 
-	if ( isLoading ) {
-		return <PerformanceReportLoading isSavedReport={ !! hash } pageTitle={ pageTitle } />;
+	if ( isRetesting || isLoading ) {
+		return (
+			<PerformanceReportLoading
+				isSavedReport={ ! isRetesting && !! hash }
+				pageTitle={ pageTitle }
+			/>
+		);
 	}
 
 	if ( ! performanceReport ) {

--- a/client/hosting/performance/hooks/useSitePerformancePageReports.ts
+++ b/client/hosting/performance/hooks/useSitePerformancePageReports.ts
@@ -145,12 +145,11 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 			const performanceReportUrl = toPerformanceReportUrl( performanceReport );
 
 			if ( pageId === HOME_PAGE_ID ) {
-				dispatch(
+				return await dispatch(
 					saveSiteSettings( siteId, { wpcom_performance_report_url: performanceReportUrl } )
 				);
-			} else {
-				savePageMeta( siteId, parseInt( pageId, 10 ), performanceReportUrl );
 			}
+			return await savePageMeta( siteId, parseInt( pageId, 10 ), performanceReportUrl );
 		},
 		[ siteId, dispatch ]
 	);

--- a/client/hosting/performance/hooks/useSitePerformancePageReports.ts
+++ b/client/hosting/performance/hooks/useSitePerformancePageReports.ts
@@ -77,7 +77,11 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID;
 
-	const { data, isLoading: isInitialLoading } = useQuery( {
+	const {
+		data,
+		isLoading: isInitialLoading,
+		refetch,
+	} = useQuery( {
 		queryKey: [ 'useSitePerformancePageReports', siteId, query ],
 		queryFn: () => getPages( siteId!, query ),
 		refetchOnWindowFocus: false,
@@ -154,5 +158,5 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 		[ siteId, dispatch ]
 	);
 
-	return { pages, isInitialLoading, savePerformanceReportUrl };
+	return { pages, isInitialLoading, savePerformanceReportUrl, refetch };
 };

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -45,7 +45,7 @@ const usePerformanceReport = (
 
 	const [ retestState, setRetestState ] = useState( 'idle' );
 	const [ reportCompleted, setReportCompleted ] = useState( false );
-	const testStartTime = useRef< number | undefined >();
+	const testStartTime = useRef< number | undefined >( 0 );
 
 	const {
 		data: basicMetrics,
@@ -76,14 +76,11 @@ const usePerformanceReport = (
 	const desktopLoaded = typeof performanceInsights?.desktop === 'object';
 	const mobileLoaded = typeof performanceInsights?.mobile === 'object';
 
-	const isTestCompleted = useMemo( () => {
-		const completed = !! testStartTime.current && !! performanceReport;
-		if ( completed ) {
-			testStartTime.current = undefined;
-			setReportCompleted( true );
-		}
-		return completed;
-	}, [ performanceReport ] );
+	const isTestCompleted = !! testStartTime.current && !! performanceReport;
+	if ( isTestCompleted ) {
+		testStartTime.current = undefined;
+		setReportCompleted( true );
+	}
 
 	const getHashOrToken = (
 		hash: string | undefined,

--- a/client/performance-profiler/pages/loading-screen/progress.tsx
+++ b/client/performance-profiler/pages/loading-screen/progress.tsx
@@ -1,7 +1,8 @@
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useInterval } from 'calypso/lib/interval/use-interval';
 
 const LoadingProgressContainer = styled.div`
 	span {
@@ -129,16 +130,13 @@ const useLoadingSteps = ( {
 			  ];
 	}
 
-	useEffect( () => {
-		const timeoutId = setTimeout( () => {
-			if ( step === steps.length - 1 ) {
-				return;
-			}
-			setStep( step + 1 );
-		}, 5000 );
-
-		return () => clearTimeout( timeoutId );
-	} );
+	useInterval(
+		() => {
+			setStep( ( step ) => step + 1 );
+		},
+		// 5 seconds between steps, except make sure we stop _before_ completing the last step
+		step < steps.length - 1 && 5000 // 5 seconds
+	);
 
 	const stepStatus = ( index: number, step: number ) => {
 		if ( step > index ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9244

## Proposed Changes

- Removes unnecessary uses of `useEffect` and `useState`, which appears to fix issues where the ReactQuery cache isn't being used to persist the state of tests when you switch tabs
- Ensures the traffic light loading ticks advance at even 5 second intervals
- Explicitly keeps track of where we're up to in the retesting process since there's no combination of flags that can be used from the `useUrlBasicMetricsQuery` and `useUrlPerformanceInsightsQuery` that can tell us whether this is fetching existing or new test results.


https://github.com/user-attachments/assets/892f276e-bbb8-415c-8cbc-47b64226a690

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Better UX with fixed retest button and up to date reports

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `calypso.localhost:3000/sites/performance/:site`
* Run a test
* Switch to another tab (mimicking users not willing to wait that long and wants to come back later)
* Switch back to the tab, the tab will be at a loading state saying "Getting your report..."
* Check nothing is broken at `calypso.localhost:3000/speed-test-tool?url=<site>`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
