### PR TITLE
Tracking: Improve selected sign up domain origin

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -70,6 +70,12 @@ const onboarding: Flow = {
 			}
 		};
 
+		const { signupDomainOrigin } = useSelect( ( select ) => {
+			return {
+				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
+			};
+		}, [] );
+
 		clearUseMyDomainsQueryParams();
 
 		const [ redirectedToUseMyDomain, setRedirectedToUseMyDomain ] = useState( false );
@@ -113,9 +119,9 @@ const onboarding: Flow = {
 					if ( ! cartItems?.[ 0 ] ) {
 						// Since we're removing the paid domain, it means that the user chose to continue
 						// with a free domain. Because signupDomainOrigin should reflect the last domain
-						// selection status before they land on the checkout page, we switch the value
-						// to "free".
-						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
+						// selection status before they land on the checkout page, this value can be
+						// 'free' or 'choose-later'
+						setSignupDomainOrigin( signupDomainOrigin );
 					}
 					setSignupCompleteFlowName( flowName );
 					return navigate( 'create-site', undefined, true );

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -121,7 +121,11 @@ const onboarding: Flow = {
 						// with a free domain. Because signupDomainOrigin should reflect the last domain
 						// selection status before they land on the checkout page, this value can be
 						// 'free' or 'choose-later'
-						setSignupDomainOrigin( signupDomainOrigin );
+						if ( signupDomainOrigin === 'choose-later' ) {
+							setSignupDomainOrigin( signupDomainOrigin );
+						} else {
+							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
+						}
 					}
 					setSignupCompleteFlowName( flowName );
 					return navigate( 'create-site', undefined, true );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95225
Fixes https://github.com/Automattic/wp-calypso/issues/95225

## Proposed Changes

* Use the value previously stored in `signupDomainOrigin` to log/track the correct domain selection.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to make sure we're tracking the correct domain selection.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link (The link will be generated below)
* Test the scenarios described in this [issue](https://github.com/Automattic/wp-calypso/issues/95225) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
