### PR TITLE
Update social previews to not add url to Bluesky posts by default

### DIFF
--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.1.0-beta.7",
+	"version": "2.1.0-beta.8",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/src/bluesky-preview/post-preview.tsx
+++ b/packages/social-previews/src/bluesky-preview/post-preview.tsx
@@ -9,14 +9,14 @@ import type { BlueskyPreviewProps } from './types';
 import './styles.scss';
 
 export const BlueskyPostPreview: React.FC< BlueskyPreviewProps > = ( props ) => {
-	const { user, media } = props;
+	const { user, media, appendUrl } = props;
 
 	return (
 		<div className="bluesky-preview__post">
 			<BlueskyPostSidebar user={ user } />
 			<div>
 				<BlueskyPostHeader user={ user } />
-				<BlueskyPostBody { ...props }>
+				<BlueskyPostBody { ...props } appendUrl={ appendUrl ?? Boolean( media?.length ) }>
 					{ media?.length ? (
 						<div className={ clsx( 'bluesky-preview__media', { 'as-grid': media.length > 1 } ) }>
 							{ media.map( ( mediaItem, index ) => (

--- a/packages/social-previews/src/bluesky-preview/post/body/index.tsx
+++ b/packages/social-previews/src/bluesky-preview/post/body/index.tsx
@@ -5,16 +5,20 @@ import './styles.scss';
 
 type Props = BlueskyPreviewProps & { children?: React.ReactNode };
 
-const BlueskyPostBody: React.FC< Props > = ( { customText, url, children } ) => {
+const BlueskyPostBody: React.FC< Props > = ( { customText, url, children, appendUrl } ) => {
 	return (
 		<div className="bluesky-preview__body">
 			{ customText ? (
 				<>
 					<div>{ blueskyBody( customText ) }</div>
-					<br />
-					<a href={ url } target="_blank" rel="noreferrer noopener">
-						{ blueskyUrl( url.replace( /^https?:\/\//, '' ) ) }
-					</a>
+					{ appendUrl && url ? (
+						<>
+							<br />
+							<a href={ url } target="_blank" rel="noreferrer noopener">
+								{ blueskyUrl( url.replace( /^https?:\/\//, '' ) ) }
+							</a>
+						</>
+					) : null }
 				</>
 			) : null }
 			{ children }

--- a/packages/social-previews/src/bluesky-preview/types.ts
+++ b/packages/social-previews/src/bluesky-preview/types.ts
@@ -7,6 +7,7 @@ export type BlueskyUser = {
 };
 
 export type BlueskyPreviewProps = SocialPreviewBaseProps & {
+	appendUrl?: boolean;
 	user?: BlueskyUser;
 	customText?: string;
 	customImage?: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/39659

## Proposed Changes

* Do not add the link to the preview when showing the link preview
* Retain the link when there is custom media attached

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review https://github.com/Automattic/jetpack/pull/39659
* Confirm that there is no link when link preview is shown, i.e. when there is no custom media
* Confirm that the link is shown when there is custom media

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

- When there is custom media attached
    <img width="586" alt="Screenshot 2024-10-09 at 5 18 36 PM" src="https://github.com/user-attachments/assets/7b8e9fd0-d699-4805-8621-75d2d74aea61">
- When there is no custom media
    <img width="599" alt="Screenshot 2024-10-09 at 5 18 07 PM" src="https://github.com/user-attachments/assets/7cd23b33-795b-494f-ba1f-f02257279664">
