### PR TITLE
Substack importer: open "learn more" in Help center instead of new tab

### DIFF
--- a/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
@@ -3,10 +3,13 @@ import { Subscriber } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ProgressBar } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { Icon, cloudUpload } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useState, FormEvent, useEffect } from 'react';
 import DropZone from 'calypso/components/drop-zone';
 import FilePicker from 'calypso/components/file-picker';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../../importer-action-buttons/container';
@@ -20,6 +23,7 @@ type Props = {
 };
 
 export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextStep }: Props ) {
+	const { __ } = useI18n();
 	const [ selectedFile, setSelectedFile ] = useState< File >();
 
 	const [ hasImportError, setHasImportError ] = useState( false );
@@ -70,9 +74,6 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 		importCsvSubscribersUpdate( undefined ); // reset the form.
 	}, [ importCsvSubscribersUpdate ] );
 
-	const importSubscribersUrl =
-		'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/';
-
 	if ( importSelector?.inProgress ) {
 		return (
 			<div className="subscriber-upload-form__dropzone">
@@ -108,8 +109,22 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 
 			{ isSelectedFileValid && selectedFile && ! hasImportError && (
 				<p>
-					By clicking "Continue," you represent that you've obtained the appropriate consent to
-					email each person. <a href={ localizeUrl( importSubscribersUrl ) }>Learn more</a>.
+					{ createInterpolateElement(
+						__(
+							'By clicking "Continue," you represent that you\'ve obtained the appropriate consent to email each person. <learnMoreLink>Learn more</learnMoreLink>.'
+						),
+						{
+							learnMoreLink: (
+								<InlineSupportLink
+									showIcon={ false }
+									supportLink={ localizeUrl(
+										'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'
+									) }
+									supportPostId={ 220199 }
+								/>
+							),
+						}
+					) }
 				</p>
 			) }
 


### PR DESCRIPTION
## Proposed Changes

* Open "Learn more" link in the help center instead of a new tab.

![image](https://github.com/user-attachments/assets/ce7e2fa1-79ec-42a8-880e-dd714bbd4cea)

<img width="770" alt="Screenshot 2024-10-09 at 21 40 31" src="https://github.com/user-attachments/assets/4ef6fcb2-bff6-4b15-9773-e3268ff0eefd">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
