### PR TITLE
Hide FollowingIntro when reader onboarding flag is set

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -29,7 +29,7 @@ function FollowingStream( { ...props } ) {
 						'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,
 					} ) }
 				/>
-				<FollowingIntro />
+				{ ! config.isEnabled( 'reader/onboarding' ) && <FollowingIntro /> }
 				{ config.isEnabled( 'reader/onboarding' ) && <ReaderOnboarding /> }
 			</Stream>
 			<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/189

## Proposed Changes

* Hide FollowingIntro when reader onboarding flag is set.

Before | After
---- | ----
<img width="1003" alt="Screen Shot 2024-10-09 at 1 06 01 PM" src="https://github.com/user-attachments/assets/b85653dd-00c3-4fd9-b0c9-29adfab33d19"> | <img width="974" alt="Screen Shot 2024-10-09 at 1 08 57 PM" src="https://github.com/user-attachments/assets/4c4cf2a1-d82e-44ed-a3e4-617bebb8606c">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/Automattic/loop/issues/189#issuecomment-2399712314

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read as a new user (< 2 weeks)
* Check that you see the banner
* Add `?flags=reader/onboarding` to the URL
* Check that you see only the new onboarding component

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
