### PR TITLE
Fix welcome pages content alignment

### DIFF
--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -8,7 +8,7 @@
 	justify-content: center;
 	flex-direction: column;
 	margin-top: -32px;
-	height: 100vh;
+	height: calc( 100vh - 32px );
 
 	&.main.is-wide-layout {
 		max-width: 744px;

--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -3,15 +3,22 @@
 @import "@wordpress/base-styles/variables";
 
 .jetpack-welcome-page {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	flex-direction: column;
-	height: 100vh;
-
 	&.main.is-wide-layout {
 		max-width: 744px;
-		margin-top: -32px;
+		margin-top: 16px;
+
+		@media (min-width: 660px) {
+			margin-top: -16px;
+		}
+
+		@include break-medium {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			flex-direction: column;
+			height: 100vh;
+			margin-top: -32px;
+		}
 	}
 
 	&__card {

--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -8,7 +8,7 @@
 	justify-content: center;
 	flex-direction: column;
 	margin-top: -32px;
-	height: calc( 100vh - 32px );
+	height: 100vh;
 
 	&.main.is-wide-layout {
 		max-width: 744px;

--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -3,9 +3,15 @@
 @import "@wordpress/base-styles/variables";
 
 .jetpack-welcome-page {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+	margin-top: -32px;
+	height: 100vh;
+
 	&.main.is-wide-layout {
 		max-width: 744px;
-		margin-top: 8vw;
 	}
 
 	&__card {

--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -7,11 +7,11 @@
 	align-items: center;
 	justify-content: center;
 	flex-direction: column;
-	margin-top: -32px;
 	height: 100vh;
 
 	&.main.is-wide-layout {
 		max-width: 744px;
+		margin-top: -32px;
 	}
 
 	&__card {


### PR DESCRIPTION
## Proposed Changes

* Center-align content on Jetpack Cloud welcome pages

## Why are these changes being made?

Content on the Jetpack Free welcome page `/pricing/jetpack-free/welcome` was near the bottom of the page and looked bad
![image](https://github.com/user-attachments/assets/d0f065ac-1e2f-4caa-96d3-d60c10d6102b)
This was due to the margin on the top being tied to the width of the page

## Testing Instructions

1. Open the Calypso Green live link and go to `/pricing/jetpack-free/welcome`. Make sure the content is centered
![image](https://github.com/user-attachments/assets/7e38ec91-c22b-4899-9a8d-d4708a3c9d7d)

2. Do the same with `/pricing/jetpack-social/welcome` and `/pricing/jetpack-boost/welcome`
![image](https://github.com/user-attachments/assets/6a961eed-a2f0-4aa2-841b-6feba394840e)
![image](https://github.com/user-attachments/assets/3aae573a-6fa2-475c-8932-35d3fbc06c57)

3. Make sure it looks good on all screen widths


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
