### PR TITLE
Add migration status to sites dashboard

### DIFF
--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -127,7 +127,7 @@ const SitesDashboard = ( {
 		[],
 		sitesFilterCallback,
 		'all',
-		[ 'is_a4a_dev_site' ],
+		[ 'is_a4a_dev_site', 'site_migration' ],
 		[ 'theme_slug' ]
 	);
 

--- a/client/hosting/sites/components/sites-dataviews/sites-site-status.tsx
+++ b/client/hosting/sites/components/sites-dataviews/sites-site-status.tsx
@@ -120,6 +120,14 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 		);
 	}
 
+	const isMigrationPeding =
+		site.site_migration?.migration_status?.startsWith( 'migration-pending' );
+	const statusElement = isMigrationPeding ? (
+		<span className="sites-dataviews__migration-pending-status">{ translatedStatus }</span>
+	) : (
+		translatedStatus
+	);
+
 	return (
 		<WithAtomicTransfer site={ site }>
 			{ ( result ) =>
@@ -132,7 +140,7 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 							<BadgeDIFM className="site__badge">{ __( 'Express Service' ) }</BadgeDIFM>
 						) : (
 							<div>
-								{ translatedStatus }
+								{ statusElement }
 								<SiteLaunchNag site={ site } />
 							</div>
 						) }

--- a/client/hosting/sites/components/sites-dataviews/style.scss
+++ b/client/hosting/sites/components/sites-dataviews/style.scss
@@ -141,3 +141,12 @@
 	align-items: center;
 	gap: 6px;
 }
+
+.sites-dataviews__migration-pending-status {
+	display: inline-block;
+	padding: 0 10px;
+	border-radius: 4px;
+	background-color: var(--color-warning-20);
+	line-height: 20px;
+	color: var(--color-warning-80);
+}

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -618,6 +618,7 @@ export interface SourceSiteMigrationBase {
 	// Migration meta
 	recent_migration?: boolean;
 	failed_backup_source?: boolean;
+	migration_status?: string;
 }
 
 export interface SourceSiteMigrationDetails extends SourceSiteMigrationBase {

--- a/packages/sites/src/site-excerpt-types.ts
+++ b/packages/sites/src/site-excerpt-types.ts
@@ -21,4 +21,7 @@ export type SiteExcerptData = Pick<
 	is_deleted?: boolean;
 	is_a4a_dev_site?: boolean;
 	options?: Pick< SiteDetailsOptions, ( typeof SITE_EXCERPT_REQUEST_OPTIONS )[ number ] >;
+	site_migration?: {
+		migration_status?: string;
+	};
 };

--- a/packages/sites/src/site-status.tsx
+++ b/packages/sites/src/site-status.tsx
@@ -7,6 +7,8 @@ export const siteLaunchStatuses = [
 	'coming-soon',
 	'redirect',
 	'deleted',
+	'migration-pending',
+	'migration-started',
 ] as const;
 
 export type SiteLaunchStatus = ( typeof siteLaunchStatuses )[ number ];
@@ -19,9 +21,20 @@ export interface SiteObjectWithStatus {
 	options?: {
 		is_redirect?: boolean;
 	};
+	site_migration?: {
+		migration_status?: string;
+	};
 }
 
 export const getSiteLaunchStatus = ( site: SiteObjectWithStatus ): SiteLaunchStatus => {
+	if ( site.site_migration?.migration_status?.startsWith( 'migration-pending' ) ) {
+		return 'migration-pending';
+	}
+
+	if ( site.site_migration?.migration_status?.startsWith( 'migration-started' ) ) {
+		return 'migration-started';
+	}
+
 	if ( site.is_deleted ) {
 		return 'deleted';
 	}
@@ -51,6 +64,8 @@ export const useTranslatedSiteLaunchStatuses = (): { [ K in SiteLaunchStatus ]: 
 			public: _x( 'Public', 'site' ),
 			redirect: _x( 'Redirect', 'site' ),
 			deleted: _x( 'Deleted', 'site' ),
+			'migration-pending': _x( 'Migration pending', 'site' ),
+			'migration-started': _x( 'Migration started', 'site' ),
 		} ),
 		[ _x ]
 	);

--- a/packages/sites/src/site-type.ts
+++ b/packages/sites/src/site-type.ts
@@ -20,4 +20,7 @@ export interface MinimumSite {
 	plan?: {
 		product_name_short: string;
 	};
+	site_migration?: {
+		migration_status?: string;
+	};
 }

--- a/packages/sites/src/use-sites-list-grouping.tsx
+++ b/packages/sites/src/use-sites-list-grouping.tsx
@@ -60,6 +60,8 @@ export const useSitesListGrouping = < T extends SiteForGrouping >(
 			private: 0,
 			redirect: 0,
 			deleted: 0,
+			'migration-pending': 0,
+			'migration-started': 0,
 		};
 
 		const groupedByStatus = allSites.reduce< { [ K in Status[ 'name' ] ]: T[] } >(
@@ -86,6 +88,8 @@ export const useSitesListGrouping = < T extends SiteForGrouping >(
 				private: [],
 				redirect: [],
 				deleted: [],
+				'migration-pending': [],
+				'migration-started': [],
 			}
 		);
 

--- a/packages/sites/tests/create-mock-site.ts
+++ b/packages/sites/tests/create-mock-site.ts
@@ -10,6 +10,7 @@ export function createMockSite( {
 		is_redirect: false,
 		unmapped_url: '',
 	},
+	site_migration,
 }: {
 	ID?: number;
 	name?: string;
@@ -21,6 +22,9 @@ export function createMockSite( {
 	options?: {
 		is_redirect?: boolean;
 		unmapped_url?: string;
+	};
+	site_migration?: {
+		migration_status?: string;
 	};
 } = {} ) {
 	const slug = `site${ ID }.io`;
@@ -35,5 +39,6 @@ export function createMockSite( {
 		is_deleted,
 		visible,
 		options,
+		site_migration,
 	};
 }

--- a/packages/sites/tests/use-sites-list-grouping.test.ts
+++ b/packages/sites/tests/use-sites-list-grouping.test.ts
@@ -57,10 +57,27 @@ describe( 'useSitesListGrouping', () => {
 			options: { is_redirect: true, unmapped_url: 'http://redirect2.com' },
 		} );
 		const deleted1 = createMockSite( { is_deleted: true } );
+		const migrationPending = createMockSite( {
+			site_migration: { migration_status: 'migration-pending-diy' },
+		} );
+		const migrationStarted = createMockSite( {
+			site_migration: { migration_status: 'migration-started-diy' },
+		} );
 
 		const { result } = renderHook( () =>
 			useSitesListGrouping(
-				[ public1, public2, private1, private2, comingSoon, redirect1, redirect2, deleted1 ],
+				[
+					public1,
+					public2,
+					private1,
+					private2,
+					comingSoon,
+					redirect1,
+					redirect2,
+					deleted1,
+					migrationPending,
+					migrationStarted,
+				],
 				{
 					status,
 				}
@@ -70,7 +87,7 @@ describe( 'useSitesListGrouping', () => {
 		expect( result.current.statuses ).toEqual( [
 			{
 				name: 'all',
-				count: 7, // hidden site not included in count
+				count: 9, // hidden site not included in count
 				title: expect.any( String ),
 				hiddenCount: 1,
 			},
@@ -104,6 +121,18 @@ describe( 'useSitesListGrouping', () => {
 				title: expect.any( String ),
 				hiddenCount: 0,
 			},
+			{
+				name: 'migration-pending',
+				count: 1,
+				title: expect.any( String ),
+				hiddenCount: 0,
+			},
+			{
+				name: 'migration-started',
+				count: 1,
+				title: expect.any( String ),
+				hiddenCount: 0,
+			},
 		] );
 	} );
 
@@ -114,18 +143,36 @@ describe( 'useSitesListGrouping', () => {
 		const private2 = createMockSite( { is_private: true, visible: false } );
 		const comingSoon = createMockSite( { is_private: true, is_coming_soon: true } );
 		const deleted1 = createMockSite( { is_deleted: true } );
+		const migrationPending = createMockSite( {
+			site_migration: { migration_status: 'migration-pending-diy' },
+		} );
+		const migrationStarted = createMockSite( {
+			site_migration: { migration_status: 'migration-started-diy' },
+		} );
 
 		const { result } = renderHook( () =>
-			useSitesListGrouping( [ public1, public2, private1, private2, comingSoon, deleted1 ], {
-				showHidden: true,
-				status,
-			} )
+			useSitesListGrouping(
+				[
+					public1,
+					public2,
+					private1,
+					private2,
+					comingSoon,
+					deleted1,
+					migrationPending,
+					migrationStarted,
+				],
+				{
+					showHidden: true,
+					status,
+				}
+			)
 		);
 
 		expect( result.current.statuses ).toEqual( [
 			{
 				name: 'all',
-				count: 6,
+				count: 8,
 				title: expect.any( String ),
 				hiddenCount: 0,
 			},
@@ -155,6 +202,18 @@ describe( 'useSitesListGrouping', () => {
 			},
 			{
 				name: 'deleted',
+				count: 1,
+				title: expect.any( String ),
+				hiddenCount: 0,
+			},
+			{
+				name: 'migration-pending',
+				count: 1,
+				title: expect.any( String ),
+				hiddenCount: 0,
+			},
+			{
+				name: 'migration-started',
 				count: 1,
 				title: expect.any( String ),
 				hiddenCount: 0,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95158

## Proposed Changes

* Add the migration status (_"Migration started"_ and _"Migration pending"_) to the sites dashboard.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to display the migration status as part of the Post-purchase Migration Experience project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff to your sandbox: D163485-code
* Make sure that you have a site where you started a migration, and another one where you navigated through the flow, but stopped before starting the migration. If you need to create them:
  * Migration pending: Go to `/setup/migration`, navigate until the "Need a hand?" step and stop.
  * Migration started: Go through the same steps, but this time select the option "I'll do it myself", and start a migration.
* Navigate to `/sites`, and make sure you see the statuses correctly ("Migration started" without background and "Migration pending" with a yellow background). 

## Screenshots

<img width="983" alt="Screenshot 2024-10-09 at 16 05 25" src="https://github.com/user-attachments/assets/752dedee-2c49-4d12-b4fb-4feef7830936">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?