### PR TITLE
Reader Onboarding: Establish Interests Overlay

### DIFF
--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -1,5 +1,6 @@
 import { SelectCardCheckbox } from '@automattic/onboarding';
 import { Modal, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
@@ -61,73 +62,73 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 
 	const categories: Category[] = [
 		{
-			name: 'Lifestyle & Personal Development',
+			name: __( 'Lifestyle & Personal Development' ),
 			topics: [
-				{ name: 'Health', tag: 'health' },
-				{ name: 'Personal Finance', tag: 'personal-finance' },
-				{ name: 'Food', tag: 'food' },
-				{ name: 'Life Hacks', tag: 'life-hacks' },
-				{ name: 'Mental Health', tag: 'mental-health' },
-				{ name: 'Sleep', tag: 'sleep' },
-				{ name: 'Relationships', tag: 'relationships' },
-				{ name: 'Parenting', tag: 'parenting' },
-				{ name: 'Travel', tag: 'travel' },
+				{ name: __( 'Health' ), tag: 'health' },
+				{ name: __( 'Personal Finance' ), tag: 'personal-finance' },
+				{ name: __( 'Food' ), tag: 'food' },
+				{ name: __( 'Life Hacks' ), tag: 'life-hacks' },
+				{ name: __( 'Mental Health' ), tag: 'mental-health' },
+				{ name: __( 'Sleep' ), tag: 'sleep' },
+				{ name: __( 'Relationships' ), tag: 'relationships' },
+				{ name: __( 'Parenting' ), tag: 'parenting' },
+				{ name: __( 'Travel' ), tag: 'travel' },
 			],
 		},
 		{
-			name: 'Technology & Innovation',
+			name: __( 'Technology & Innovation' ),
 			topics: [
-				{ name: 'Gadgets', tag: 'gadgets' },
-				{ name: 'Software', tag: 'software' },
-				{ name: 'Tech News', tag: 'technology' },
-				{ name: 'Design', tag: 'design' },
-				{ name: 'Artificial Intelligence', tag: 'artificial-intelligence' },
-				{ name: 'Cybersecurity', tag: 'cybersecurity' },
-				{ name: 'Gaming', tag: 'gaming' },
-				{ name: 'Crypto', tag: 'cryptocurrency' },
-				{ name: 'Science', tag: 'science' },
+				{ name: __( 'Gadgets' ), tag: 'gadgets' },
+				{ name: __( 'Software' ), tag: 'software' },
+				{ name: __( 'Tech News' ), tag: 'technology' },
+				{ name: __( 'Design' ), tag: 'design' },
+				{ name: __( 'Artificial Intelligence' ), tag: 'artificial-intelligence' },
+				{ name: __( 'Cybersecurity' ), tag: 'cybersecurity' },
+				{ name: __( 'Gaming' ), tag: 'gaming' },
+				{ name: __( 'Crypto' ), tag: 'cryptocurrency' },
+				{ name: __( 'Science' ), tag: 'science' },
 			],
 		},
 		{
-			name: 'Creative Arts & Entertainment',
+			name: __( 'Creative Arts & Entertainment' ),
 			topics: [
-				{ name: 'Music', tag: 'music' },
-				{ name: 'Film & Television', tag: 'movies-and-tv' },
-				{ name: 'Book Reviews', tag: 'books' },
-				{ name: 'Art & Photography', tag: [ 'art', 'photography' ] },
-				{ name: 'Theatre & Performance', tag: 'theatre' },
-				{ name: 'Creative Writing', tag: 'writing' },
-				{ name: 'Architecture', tag: 'architecture' },
-				{ name: 'Comics', tag: 'comics' },
-				{ name: 'DIY Projects', tag: 'diy' },
+				{ name: __( 'Music' ), tag: 'music' },
+				{ name: __( 'Film & Television' ), tag: 'movies-and-tv' },
+				{ name: __( 'Book Reviews' ), tag: 'books' },
+				{ name: __( 'Art & Photography' ), tag: [ 'art', 'photography' ] },
+				{ name: __( 'Theatre & Performance' ), tag: 'theatre' },
+				{ name: __( 'Creative Writing' ), tag: 'writing' },
+				{ name: __( 'Architecture' ), tag: 'architecture' },
+				{ name: __( 'Comics' ), tag: 'comics' },
+				{ name: __( 'DIY Projects' ), tag: 'diy' },
 			],
 		},
 		{
-			name: 'Society & Culture',
+			name: __( 'Society & Culture' ),
 			topics: [
-				{ name: 'Education', tag: 'education' },
-				{ name: 'Nature', tag: 'nature' },
-				{ name: 'Future', tag: 'future' },
-				{ name: 'Politics', tag: 'politics' },
-				{ name: 'Climate', tag: 'climate-change' },
-				{ name: 'History', tag: 'history' },
-				{ name: 'Society', tag: 'society' },
-				{ name: 'Culture', tag: 'culture' },
-				{ name: 'Philosophy', tag: 'philosophy' },
+				{ name: __( 'Education' ), tag: 'education' },
+				{ name: __( 'Nature' ), tag: 'nature' },
+				{ name: __( 'Future' ), tag: 'future' },
+				{ name: __( 'Politics' ), tag: 'politics' },
+				{ name: __( 'Climate' ), tag: 'climate-change' },
+				{ name: __( 'History' ), tag: 'history' },
+				{ name: __( 'Society' ), tag: 'society' },
+				{ name: __( 'Culture' ), tag: 'culture' },
+				{ name: __( 'Philosophy' ), tag: 'philosophy' },
 			],
 		},
 		{
-			name: 'Industry',
+			name: __( 'Industry' ),
 			topics: [
-				{ name: 'Business', tag: 'business' },
-				{ name: 'Startups', tag: 'startups' },
-				{ name: 'Finance', tag: 'finance' },
-				{ name: 'Space', tag: 'space' },
-				{ name: 'Leadership', tag: 'leadership' },
-				{ name: 'Marketing', tag: 'marketing' },
-				{ name: 'Remote Work', tag: 'remote-work' },
-				{ name: 'SaaS', tag: 'saas' },
-				{ name: 'Creator Economy', tag: 'creator-economy' },
+				{ name: __( 'Business' ), tag: 'business' },
+				{ name: __( 'Startups' ), tag: 'startups' },
+				{ name: __( 'Finance' ), tag: 'finance' },
+				{ name: __( 'Space' ), tag: 'space' },
+				{ name: __( 'Leadership' ), tag: 'leadership' },
+				{ name: __( 'Marketing' ), tag: 'marketing' },
+				{ name: __( 'Remote Work' ), tag: 'remote-work' },
+				{ name: __( 'SaaS' ), tag: 'saas' },
+				{ name: __( 'Creator Economy' ), tag: 'creator-economy' },
 			],
 		},
 	];
@@ -135,10 +136,10 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 	const headerActions = (
 		<>
 			<Button onClick={ onClose } variant="link">
-				Cancel
+				{ __( 'Cancel' ) }
 			</Button>
 			<Button onClick={ handleContinue } variant="primary" disabled={ isButtonDisabled }>
-				Continue
+				{ __( 'Continue' ) }
 			</Button>
 		</>
 	);
@@ -146,13 +147,16 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 	return (
 		isOpen && (
 			<Modal
-				title="Select Your Interests"
 				onRequestClose={ onClose }
 				isFullScreen
 				headerActions={ headerActions }
 				isDismissible={ false }
 			>
 				<div className="interests-modal__content">
+					<h2 className="interests-modal__title">{ __( 'What topics interest you?' ) }</h2>
+					<p className="interests-modal__subtitle">
+						{ __( 'Follow at least 3 topics to personalize your Reader feed.' ) }
+					</p>
 					{ categories.map( ( category ) => (
 						<div key={ category.name } className="interests-modal__category">
 							<h3 className="interests-modal__section-header">{ category.name }</h3>
@@ -173,15 +177,6 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 							</div>
 						</div>
 					) ) }
-				</div>
-				<div className="interests-modal__footer">
-					<p className="interests-modal__footer-text">
-						{ isButtonDisabled
-							? `Please select at least ${ 3 - interests.length } more ${
-									interests.length === 2 ? 'interest' : 'interests'
-							  } to continue.`
-							: 'Great! You can now continue.' }
-					</p>
 				</div>
 			</Modal>
 		)

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -24,7 +24,6 @@ interface Category {
 
 interface Tag {
 	slug: string;
-	// Add other properties if needed
 }
 
 const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) => {
@@ -151,6 +150,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 				isFullScreen
 				headerActions={ headerActions }
 				isDismissible={ false }
+				className="interests-modal"
 			>
 				<div className="interests-modal__content">
 					<h2 className="interests-modal__title">{ __( 'What topics interest you?' ) }</h2>
@@ -160,7 +160,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 					{ categories.map( ( category ) => (
 						<div key={ category.name } className="interests-modal__category">
 							<h3 className="interests-modal__section-header">{ category.name }</h3>
-							<div className="interests-list">
+							<div className="interests-modal__topics-list">
 								{ category.topics.map( ( topic ) => (
 									<SelectCardCheckbox
 										key={ topic.name }

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -1,16 +1,192 @@
-import { Modal } from '@wordpress/components';
-import React from 'react';
+import { SelectCardCheckbox } from '@automattic/onboarding';
+import { Modal, Button } from '@wordpress/components';
+import React, { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
+import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
+import './style.scss';
 
 interface InterestsModalProps {
 	isOpen: boolean;
 	onClose: () => void;
 }
 
+interface Topic {
+	name: string;
+	tag: string | string[];
+}
+
+interface Category {
+	name: string;
+	topics: Topic[];
+}
+
+interface Tag {
+	slug: string;
+	// Add other properties if needed
+}
+
 const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) => {
+	const [ interests, setInterests ] = useState< string[] >( [] );
+	const followedTags = useSelector( getReaderFollowedTags );
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( followedTags ) {
+			const initialInterests = followedTags.map( ( tag: Tag ) => tag.slug );
+			setInterests( initialInterests );
+		}
+	}, [ followedTags ] );
+
+	const handleInterestChange = ( tag: string | string[] ) => {
+		const tags = Array.isArray( tag ) ? tag : [ tag ];
+		setInterests( ( prevInterests ) => {
+			const newInterests = new Set( prevInterests );
+			tags.forEach( ( t ) => {
+				if ( newInterests.has( t ) ) {
+					newInterests.delete( t );
+				} else {
+					newInterests.add( t );
+				}
+			} );
+			return Array.from( newInterests );
+		} );
+	};
+
+	const handleContinue = () => {
+		// Unfollow tags that are no longer selected
+		followedTags?.forEach( ( followedTag ) => {
+			if ( ! interests.includes( followedTag.slug ) ) {
+				dispatch( requestUnfollowTag( followedTag.slug ) );
+			}
+		} );
+
+		// Follow newly selected tags
+		interests.forEach( ( tag ) => {
+			const isAlreadyFollowed = followedTags?.some( ( followedTag ) => followedTag.slug === tag );
+			if ( ! isAlreadyFollowed ) {
+				dispatch( requestFollowTag( tag ) );
+			}
+		} );
+
+		onClose();
+	};
+
+	const categories: Category[] = [
+		{
+			name: 'Lifestyle & Personal Development',
+			topics: [
+				{ name: 'Health', tag: 'health' },
+				{ name: 'Personal Finance', tag: 'personal-finance' },
+				{ name: 'Food', tag: 'food' },
+				{ name: 'Life Hacks', tag: 'life-hacks' },
+				{ name: 'Mental Health', tag: 'mental-health' },
+				{ name: 'Sleep', tag: 'sleep' },
+				{ name: 'Relationships', tag: 'relationships' },
+				{ name: 'Parenting', tag: 'parenting' },
+				{ name: 'Travel', tag: 'travel' },
+			],
+		},
+		{
+			name: 'Technology & Innovation',
+			topics: [
+				{ name: 'Gadgets', tag: 'gadgets' },
+				{ name: 'Software', tag: 'software' },
+				{ name: 'Tech News', tag: 'technology' },
+				{ name: 'Design', tag: 'design' },
+				{ name: 'Artificial Intelligence', tag: 'artificial-intelligence' },
+				{ name: 'Cybersecurity', tag: 'cybersecurity' },
+				{ name: 'Gaming', tag: 'gaming' },
+				{ name: 'Crypto', tag: 'cryptocurrency' },
+				{ name: 'Science', tag: 'science' },
+			],
+		},
+		{
+			name: 'Creative Arts & Entertainment',
+			topics: [
+				{ name: 'Music', tag: 'music' },
+				{ name: 'Film & Television', tag: 'movies-and-tv' },
+				{ name: 'Book Reviews', tag: 'books' },
+				{ name: 'Art & Photography', tag: [ 'art', 'photography' ] },
+				{ name: 'Theatre & Performance', tag: 'theatre' },
+				{ name: 'Creative Writing', tag: 'writing' },
+				{ name: 'Architecture', tag: 'architecture' },
+				{ name: 'Comics', tag: 'comics' },
+				{ name: 'DIY Projects', tag: 'diy' },
+			],
+		},
+		{
+			name: 'Society & Culture',
+			topics: [
+				{ name: 'Education', tag: 'education' },
+				{ name: 'Nature', tag: 'nature' },
+				{ name: 'Future', tag: 'future' },
+				{ name: 'Politics', tag: 'politics' },
+				{ name: 'Climate', tag: 'climate-change' },
+				{ name: 'History', tag: 'history' },
+				{ name: 'Society', tag: 'society' },
+				{ name: 'Culture', tag: 'culture' },
+				{ name: 'Philosophy', tag: 'philosophy' },
+			],
+		},
+		{
+			name: 'Industry',
+			topics: [
+				{ name: 'Business', tag: 'business' },
+				{ name: 'Startups', tag: 'startups' },
+				{ name: 'Finance', tag: 'finance' },
+				{ name: 'Space', tag: 'space' },
+				{ name: 'Leadership', tag: 'leadership' },
+				{ name: 'Marketing', tag: 'marketing' },
+				{ name: 'Remote Work', tag: 'remote-work' },
+				{ name: 'SaaS', tag: 'saas' },
+				{ name: 'Creator Economy', tag: 'creator-economy' },
+			],
+		},
+	];
+
+	const headerActions = (
+		<>
+			<Button onClick={ onClose } variant="link">
+				Cancel
+			</Button>
+			<Button onClick={ handleContinue } variant="primary">
+				Continue
+			</Button>
+		</>
+	);
+
 	return (
 		isOpen && (
-			<Modal title="Select Your Interests" onRequestClose={ onClose } isFullScreen>
-				<p>Interest content here.</p>
+			<Modal
+				title="Select Your Interests"
+				onRequestClose={ onClose }
+				isFullScreen
+				headerActions={ headerActions }
+				isDismissible={ false }
+			>
+				<div className="interests-modal__content">
+					{ categories.map( ( category ) => (
+						<div key={ category.name } className="interests-modal__category">
+							<h3 className="interests-modal__section-header">{ category.name }</h3>
+							<div className="interests-list">
+								{ category.topics.map( ( topic ) => (
+									<SelectCardCheckbox
+										key={ topic.name }
+										onChange={ () => handleInterestChange( topic.tag ) }
+										checked={
+											Array.isArray( topic.tag )
+												? topic.tag.every( ( t ) => interests.includes( t ) )
+												: interests.includes( topic.tag )
+										}
+									>
+										{ topic.name }
+									</SelectCardCheckbox>
+								) ) }
+							</div>
+						</div>
+					) ) }
+				</div>
 				<button onClick={ onClose }>Close</button>
 			</Modal>
 		)

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
+
 import './style.scss';
 
 interface InterestsModalProps {
@@ -14,7 +15,7 @@ interface InterestsModalProps {
 
 interface Topic {
 	name: string;
-	tag: string | string[];
+	tag: string;
 }
 
 interface Category {
@@ -27,34 +28,31 @@ interface Tag {
 }
 
 const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) => {
-	const [ interests, setInterests ] = useState< string[] >( [] );
-	const followedTags = useSelector( getReaderFollowedTags );
+	const [ followedTags, setFollowedTags ] = useState< string[] >( [] );
+	const followedTagsFromState = useSelector( getReaderFollowedTags );
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		if ( followedTags ) {
-			const initialInterests = followedTags.map( ( tag: Tag ) => tag.slug );
-			setInterests( initialInterests );
+		if ( followedTagsFromState ) {
+			const initialTags = followedTagsFromState.map( ( tag: Tag ) => tag.slug );
+			setFollowedTags( initialTags );
 		}
-	}, [ followedTags ] );
+	}, [ followedTagsFromState ] );
 
-	const isButtonDisabled = interests.length < 3;
+	const isContinueDisabled = followedTags.length < 3;
 
-	const handleInterestChange = ( tag: string | string[] ) => {
-		const tags = Array.isArray( tag ) ? tag : [ tag ];
-		tags.forEach( ( t ) => {
-			if ( interests.includes( t ) ) {
-				dispatch( requestUnfollowTag( t ) );
-				setInterests( ( prevInterests ) => prevInterests.filter( ( interest ) => interest !== t ) );
-			} else {
-				dispatch( requestFollowTag( t ) );
-				setInterests( ( prevInterests ) => [ ...prevInterests, t ] );
-			}
-		} );
+	const handleTopicChange = ( checked: boolean, tag: string ) => {
+		if ( checked ) {
+			dispatch( requestFollowTag( tag ) );
+			setFollowedTags( ( currentTags ) => [ ...currentTags, tag ] );
+		} else {
+			dispatch( requestUnfollowTag( tag ) );
+			setFollowedTags( ( currentTags ) => currentTags.filter( ( t ) => t !== tag ) );
+		}
 	};
 
 	const handleContinue = () => {
-		if ( ! isButtonDisabled ) {
+		if ( ! isContinueDisabled ) {
 			onClose();
 		}
 	};
@@ -92,13 +90,13 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 			name: __( 'Creative Arts & Entertainment' ),
 			topics: [
 				{ name: __( 'Music' ), tag: 'music' },
-				{ name: __( 'Film & Television' ), tag: 'movies-and-tv' },
-				{ name: __( 'Book Reviews' ), tag: 'books' },
-				{ name: __( 'Art & Photography' ), tag: [ 'art', 'photography' ] },
+				{ name: __( 'Movies' ), tag: 'movies' },
+				{ name: __( 'Books' ), tag: 'books' },
+				{ name: __( 'Art' ), tag: 'art' },
 				{ name: __( 'Theatre & Performance' ), tag: 'theatre' },
 				{ name: __( 'Creative Writing' ), tag: 'writing' },
 				{ name: __( 'Architecture' ), tag: 'architecture' },
-				{ name: __( 'Comics' ), tag: 'comics' },
+				{ name: __( 'Photography' ), tag: 'photography' },
 				{ name: __( 'DIY Projects' ), tag: 'diy' },
 			],
 		},
@@ -137,7 +135,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 			<Button onClick={ onClose } variant="link">
 				{ __( 'Cancel' ) }
 			</Button>
-			<Button onClick={ handleContinue } variant="primary" disabled={ isButtonDisabled }>
+			<Button onClick={ handleContinue } variant="primary" disabled={ isContinueDisabled }>
 				{ __( 'Continue' ) }
 			</Button>
 		</>
@@ -164,11 +162,11 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 								{ category.topics.map( ( topic ) => (
 									<SelectCardCheckbox
 										key={ topic.name }
-										onChange={ () => handleInterestChange( topic.tag ) }
+										onChange={ ( checked ) => handleTopicChange( checked, topic.tag ) }
 										checked={
 											Array.isArray( topic.tag )
-												? topic.tag.every( ( t ) => interests.includes( t ) )
-												: interests.includes( topic.tag )
+												? topic.tag.every( ( t ) => followedTags.includes( t ) )
+												: followedTags.includes( topic.tag )
 										}
 									>
 										{ topic.name }

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -38,38 +38,25 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 		}
 	}, [ followedTags ] );
 
+	const isButtonDisabled = interests.length < 3;
+
 	const handleInterestChange = ( tag: string | string[] ) => {
 		const tags = Array.isArray( tag ) ? tag : [ tag ];
-		setInterests( ( prevInterests ) => {
-			const newInterests = new Set( prevInterests );
-			tags.forEach( ( t ) => {
-				if ( newInterests.has( t ) ) {
-					newInterests.delete( t );
-				} else {
-					newInterests.add( t );
-				}
-			} );
-			return Array.from( newInterests );
+		tags.forEach( ( t ) => {
+			if ( interests.includes( t ) ) {
+				dispatch( requestUnfollowTag( t ) );
+				setInterests( ( prevInterests ) => prevInterests.filter( ( interest ) => interest !== t ) );
+			} else {
+				dispatch( requestFollowTag( t ) );
+				setInterests( ( prevInterests ) => [ ...prevInterests, t ] );
+			}
 		} );
 	};
 
 	const handleContinue = () => {
-		// Unfollow tags that are no longer selected
-		followedTags?.forEach( ( followedTag ) => {
-			if ( ! interests.includes( followedTag.slug ) ) {
-				dispatch( requestUnfollowTag( followedTag.slug ) );
-			}
-		} );
-
-		// Follow newly selected tags
-		interests.forEach( ( tag ) => {
-			const isAlreadyFollowed = followedTags?.some( ( followedTag ) => followedTag.slug === tag );
-			if ( ! isAlreadyFollowed ) {
-				dispatch( requestFollowTag( tag ) );
-			}
-		} );
-
-		onClose();
+		if ( ! isButtonDisabled ) {
+			onClose();
+		}
 	};
 
 	const categories: Category[] = [
@@ -150,7 +137,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 			<Button onClick={ onClose } variant="link">
 				Cancel
 			</Button>
-			<Button onClick={ handleContinue } variant="primary">
+			<Button onClick={ handleContinue } variant="primary" disabled={ isButtonDisabled }>
 				Continue
 			</Button>
 		</>
@@ -187,7 +174,15 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 						</div>
 					) ) }
 				</div>
-				<button onClick={ onClose }>Close</button>
+				<div className="interests-modal__footer">
+					<p className="interests-modal__footer-text">
+						{ isButtonDisabled
+							? `Please select at least ${ 3 - interests.length } more ${
+									interests.length === 2 ? 'interest' : 'interests'
+							  } to continue.`
+							: 'Great! You can now continue.' }
+					</p>
+				</div>
 			</Modal>
 		)
 	);

--- a/client/reader/onboarding/interests-modal/style.scss
+++ b/client/reader/onboarding/interests-modal/style.scss
@@ -1,64 +1,54 @@
-.interests-modal__title {
-	font-family: Recoleta, sans-serif;
-	font-size: 2.75rem;
-	font-weight: 400;
-	text-align: center;
-}
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
-.interests-modal__subtitle {
-	text-align: center;
-}
-
-.interests-modal__content {
-	padding: 24px;
-}
-
-.interests-modal__category {
-	max-width: 1200px;
-	margin: 0 auto 32px auto;
-}
-
-.interests-modal__section-header {
-	margin-bottom: 16px;
-}
-
-.interests-list {
-	display: grid;
-	gap: 16px;
-
-	// Default to 1 column for mobile
-	grid-template-columns: 1fr;
-
-	// 2 columns for medium screens
-	@media ( min-width: 600px ) {
-		grid-template-columns: repeat( 2, 1fr );
+.interests-modal {
+	&__content {
+		padding: 24px;
 	}
 
-	// 3 columns for larger screens
-	@media ( min-width: 900px ) {
-		grid-template-columns: repeat( 3, 1fr );
-	}
-}
-
-.select-card-checkbox__container {
-	height: 100%;
-}
-
-.select-card-checkbox__label {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	text-align: center;
-	height: 100%;
-}
-
-// Styles for the header actions
-.components-modal__header {
-	.components-button.is-link {
-		margin-right: auto; // This will push the button to the left
+	&__title {
+		font-family: Recoleta, sans-serif;
+		font-size: 2.75rem;
+		font-weight: 400;
+		text-align: center;
 	}
 
-	.components-button.is-primary {
-		margin-left: 16px; // Add some space between Cancel and Continue
+	&__subtitle {
+		text-align: center;
+	}
+
+	&__category {
+		max-width: 1200px;
+		margin: 0 auto 32px auto;
+	}
+
+	&__section-header {
+		margin-bottom: 16px;
+	}
+
+	&__topics-list {
+		display: grid;
+		gap: 16px;
+		grid-template-columns: 1fr;
+
+		@include break-small {
+			grid-template-columns: repeat( 2, 1fr );
+		}
+
+		@include break-large {
+			grid-template-columns: repeat( 3, 1fr );
+		}
+	}
+
+	.components-modal__header {
+		.components-button {
+			&.is-link {
+				margin-right: auto;
+			}
+
+			&.is-primary {
+				margin-left: 16px;
+			}
+		}
 	}
 }

--- a/client/reader/onboarding/interests-modal/style.scss
+++ b/client/reader/onboarding/interests-modal/style.scss
@@ -1,9 +1,21 @@
+.interests-modal__title {
+	font-family: Recoleta, sans-serif;
+	font-size: 2.75rem;
+	font-weight: 400;
+	text-align: center;
+}
+
+.interests-modal__subtitle {
+	text-align: center;
+}
+
 .interests-modal__content {
 	padding: 24px;
 }
 
 .interests-modal__category {
-	margin-bottom: 32px;
+	max-width: 1200px;
+	margin: 0 auto 32px auto;
 }
 
 .interests-modal__section-header {

--- a/client/reader/onboarding/interests-modal/style.scss
+++ b/client/reader/onboarding/interests-modal/style.scss
@@ -1,0 +1,52 @@
+.interests-modal__content {
+	padding: 24px;
+}
+
+.interests-modal__category {
+	margin-bottom: 32px;
+}
+
+.interests-modal__section-header {
+	margin-bottom: 16px;
+}
+
+.interests-list {
+	display: grid;
+	gap: 16px;
+
+	// Default to 1 column for mobile
+	grid-template-columns: 1fr;
+
+	// 2 columns for medium screens
+	@media ( min-width: 600px ) {
+		grid-template-columns: repeat( 2, 1fr );
+	}
+
+	// 3 columns for larger screens
+	@media ( min-width: 900px ) {
+		grid-template-columns: repeat( 3, 1fr );
+	}
+}
+
+.select-card-checkbox__container {
+	height: 100%;
+}
+
+.select-card-checkbox__label {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	height: 100%;
+}
+
+// Styles for the header actions
+.components-modal__header {
+	.components-button.is-link {
+		margin-right: auto; // This will push the button to the left
+	}
+
+	.components-button.is-primary {
+		margin-left: 16px; // Add some space between Cancel and Continue
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/187

## Proposed Changes

* This PR introduces the initial "interest overlay," aka "step 1" modal functionality
* The user can select and unselect topics to follow the corresponding tag
* The user can click the continue button if they are following 3 or more tags (not just those recommended in the modal.)

Not included in this PR, but we'll follow up on:
* Tracks
* Having the continue button open the "step 2" modal

Note this PR is behind the `reader/onboarding` feature flag

https://github.com/user-attachments/assets/850dcc7a-3201-4613-b9a2-adc5232a3c49

![Screenshot 2024-10-11 at 17-04-34 Following ‹ Reader — WordPress com](https://github.com/user-attachments/assets/fe568d40-1ec7-4c33-8c1f-98d313042df2)

![Screenshot 2024-10-11 at 17-04-51 Following ‹ Reader — WordPress com](https://github.com/user-attachments/assets/13e3e945-64d2-4be8-90e0-7cd15222a099)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Moving the "Reader Onboarding" project forward.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/onboarding 
* Click on "Select some of your interests" in the top banner
* The interest overlay modal will popup
* Follow and unfollow some topics. Make sure the corresponding tags are un/followed.
* Try to break it
* Double-check that the CSS will not bleed outside of this modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
