### PR TITLE
Performance Profiler: Add translate method

### DIFF
--- a/client/performance-profiler/components/metric-tab-bar/index.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/index.tsx
@@ -1,4 +1,5 @@
 import { clsx } from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 import { Metrics } from 'calypso/data/site-profiler/types';
 import { CircularPerformanceScore } from 'calypso/hosting/performance/components/circular-performance-score/circular-performance-score';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -17,6 +18,7 @@ type Props = Record< Metrics, number > & {
 };
 
 const MetricTabBar = ( props: Props ) => {
+	const translate = useTranslate();
 	const { activeTab, setActiveTab, showOverall } = props;
 
 	const handleTabClick = ( tab: Metrics ) => {
@@ -40,7 +42,7 @@ const MetricTabBar = ( props: Props ) => {
 								marginBottom: '6px',
 							} }
 						>
-							Performance Score
+							{ translate( 'Performance Score' ) }
 						</div>
 						<div className="metric-tab-bar__tab-metric">
 							<CircularPerformanceScore score={ props.overall } size={ 48 } />


### PR DESCRIPTION

## Proposed Changes

Wrap `Performance Score` into a `translate` method.

## Why are these changes being made?

To get it translated when needed users sees this page in other languages.

## Testing Instructions

* If your default language is English, change it to a different one on `https://wordpress.com/me/account`
* Go to `/sites/performance/:site`
* Check if the Performance Score as highlighted below is translated.

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-10-09 at 19 41 53@2x](https://github.com/user-attachments/assets/0bdd7428-41aa-450a-b367-1f2e101d48c1)|![CleanShot 2024-10-09 at 19 45 43@2x](https://github.com/user-attachments/assets/d2a4dffe-5ed4-4bae-9f81-48c956875e8a)|
