### PR TITLE
Override button text color when pressed

### DIFF
--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -34,6 +34,10 @@
 				background: var(--studio-gray-0);
 			}
 		}
+
+		.responsive-toolbar-group__button-item.is-pressed:hover {
+			color: var(--color-text-inverted);
+		}
 	}
 
 	.is-visible {


### PR DESCRIPTION
Related to p1728499120324969-slack-CRWCHQGUB

## Proposed Changes

Overrides on hover text color for buttons in the responsive toolbar when the button is pressed.

Before

![Screenshot(71)](https://github.com/user-attachments/assets/28fed601-9eb0-4a80-8a11-584df3094ecd)


After

![Screenshot(70)](https://github.com/user-attachments/assets/940cb220-7c7d-4d4c-ba29-2a9fb80aba15)


## Testing Instructions

* Design picker during onboarding
* & Smoke test /themes usage of the same component