### PR TITLE
Site Profiler: Prevent active metric tab border overflow

### DIFF
--- a/client/performance-profiler/components/metric-tab-bar/style.scss
+++ b/client/performance-profiler/components/metric-tab-bar/style.scss
@@ -30,7 +30,8 @@ $blueberry-color: #3858e9;
 	&.active {
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 6px;
-		outline: 1px solid $blueberry-color;
+		outline: 1.5px solid $blueberry-color;
+		outline-offset: -0.5px;
 	}
 
 	&:last-child {
@@ -85,6 +86,8 @@ $blueberry-color: #3858e9;
 	&.active {
 		outline: none;
 		border-color: $blueberry-color;
+		border-width: 1.5px;
+		padding: 15.5px 21.5px 15.5px 21.5px;
 	}
 }
 

--- a/client/performance-profiler/components/metric-tab-bar/style.scss
+++ b/client/performance-profiler/components/metric-tab-bar/style.scss
@@ -24,33 +24,17 @@ $blueberry-color: #3858e9;
 	padding: 16px 22px 16px 22px;
 	width: 100%;
 	border: 1px solid transparent;
-	&:not(.active) {
-		border-bottom: 1px solid var(--gutenberg-gray-100, #f0f0f0);
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 6px;
 
-		&:not(:nth-child(-n+2)) {
-			border-top-color: transparent;
-		}
-
-		&:last-child {
-			border-bottom-color: transparent;
-		}
-
-		&.metric-tab-bar__performance {
-			border-bottom-color: transparent;
-		}
-
-	}
+	border-bottom: 1px solid var(--gutenberg-gray-100, #f0f0f0);
 
 	&.active {
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 6px;
-		border-color: transparent;
-		outline: 1.5px solid $blueberry-color;
-		position: relative;
+		outline: 1px solid $blueberry-color;
+	}
 
-		& + .metric-tab-bar__tab {
-			border-top-color: transparent;
-		}
+	&:last-child {
+		border-bottom: 0;
 	}
 
 	&:hover {
@@ -94,17 +78,16 @@ $blueberry-color: #3858e9;
 
 .metric-tab-bar__performance {
 	margin-bottom: 16px;
-	/* stylelint-disable-next-line scales/radii */
-	border-radius: 6px;
-	outline: 1px solid var(--studio-gray-5);
+	border: 1px solid var(--studio-gray-5);
+
+	&.active {
+		outline: none;
+		border-color: $blueberry-color;
+	}
 }
 
 .metric-tab-bar__tab-container {
 	border: 1px solid var(--studio-gray-5);
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 6px;
-
-	.metric-tab-bar__tab:has(+ .metric-tab-bar__tab.active) {
-		border-bottom-color: transparent;
-	}
 }

--- a/client/performance-profiler/components/metric-tab-bar/style.scss
+++ b/client/performance-profiler/components/metric-tab-bar/style.scss
@@ -24,12 +24,12 @@ $blueberry-color: #3858e9;
 	padding: 16px 22px 16px 22px;
 	width: 100%;
 	border: 1px solid transparent;
-	/* stylelint-disable-next-line scales/radii */
-	border-radius: 6px;
 
 	border-bottom: 1px solid var(--gutenberg-gray-100, #f0f0f0);
 
 	&.active {
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 6px;
 		outline: 1px solid $blueberry-color;
 	}
 
@@ -79,6 +79,8 @@ $blueberry-color: #3858e9;
 .metric-tab-bar__performance {
 	margin-bottom: 16px;
 	border: 1px solid var(--studio-gray-5);
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 6px;
 
 	&.active {
 		outline: none;


### PR DESCRIPTION
Related to p1728514629105869-slack-C04H4NY6STW.

## Proposed Changes

Fixes an annoying border overflow whenever the performance tab is selected.

The only difference between before and after, visually, is that the active border is not thicker. I'm not sure at what point we want to restore that, though. I don't think we can have our cake and eat it too: if we define a thicker outline, it will invariably leave the container since it'd be thicker than the defined border.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/2837b455-c228-4822-b094-a2e08e996b65) | ![image](https://github.com/user-attachments/assets/6171f72a-2856-4b46-8ba0-8d5b15ff637a) |

