### PR TITLE
Revert "Redirect to plugins.php after paid plugin activation instead of Congrats page"

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -13,7 +13,7 @@ import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { isRequesting } from 'calypso/state/plugins/installed/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { MarketplaceGoBackSection } from './marketplace-go-back-section';
@@ -48,7 +48,6 @@ const MarketplaceThankYou = ( {
 	const [
 		pluginsSection,
 		allPluginsFetched,
-		allPluginsActivated,
 		pluginsGoBackSection,
 		pluginTitle,
 		pluginSubtitle,
@@ -99,7 +98,6 @@ const MarketplaceThankYou = ( {
 
 	const isPageReady =
 		allPluginsFetched &&
-		allPluginsActivated &&
 		allThemesFetched &&
 		isAtomicTransferCheckComplete &&
 		isLoadedPlugins &&
@@ -124,9 +122,6 @@ const MarketplaceThankYou = ( {
 		}
 	}, [ isRequestingPlugins, isPageReady, dispatch, siteId, transferStatus, isJetpackSelfHosted ] );
 
-	const pluginsUrl = useSelector( ( state ) => {
-		return getSiteAdminUrl( state, siteId, 'plugins.php?activate=true&plugin_status=active' );
-	} );
 	// Set progressbar (currentStep) depending on transfer/plugin status.
 	useEffect( () => {
 		// We don't want to show the progress bar again when it is hidden.
@@ -134,24 +129,8 @@ const MarketplaceThankYou = ( {
 			return;
 		}
 
-		// Redirect to plugins.php if there are only plugins and no themes.
-		if ( isPageReady ) {
-			const isOnlyPlugins = pluginSlugs.length > 0 && themeSlugs.length === 0;
-			if ( isOnlyPlugins && pluginsUrl ) {
-				window.location.href = pluginsUrl;
-			}
-			return;
-		}
-
 		setShowProgressBar( ! isPageReady );
-	}, [
-		setShowProgressBar,
-		showProgressBar,
-		isPageReady,
-		pluginSlugs.length,
-		themeSlugs.length,
-		pluginsUrl,
-	] );
+	}, [ setShowProgressBar, showProgressBar, isPageReady ] );
 
 	const { steps, additionalSteps } = useThankYouSteps( {
 		pluginSlugs,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -16,7 +16,6 @@ import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchas
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginsOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
-import { isPluginActive } from 'calypso/state/plugins/installed/selectors-ts';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { areFetched, areFetching, getPlugins } from 'calypso/state/plugins/wporg/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -27,7 +26,6 @@ import { ThankYouPluginSection } from './marketplace-thank-you-plugin-section';
 
 type ThankYouData = [
 	React.ReactElement[],
-	boolean,
 	boolean,
 	JSX.Element,
 	string,
@@ -63,7 +61,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	);
 
 	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
-	const pluginsOnSite: Plugin[] = useSelector( ( state ) =>
+	const pluginsOnSite: [] = useSelector( ( state ) =>
 		getPluginsOnSite( state, siteId, softwareSlugs )
 	);
 	const wporgPlugins = useSelector(
@@ -88,11 +86,6 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	const areAllWporgPluginsFetched = areWporgPluginsFetched.every( Boolean );
 
 	const allPluginsFetched = pluginsOnSite.every( ( pluginOnSite ) => !! pluginOnSite );
-	const allPluginsActivated = useSelector( ( state ) => {
-		return pluginsOnSite.every( ( pluginOnSite ) => {
-			return isPluginActive( state, siteId as number, pluginOnSite?.slug );
-		} );
-	} );
 
 	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
@@ -155,7 +148,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		if (
 			! siteId ||
 			( ! isJetpackSelfHosted && transferStatus !== transferStates.COMPLETE ) ||
-			( allPluginsFetched && allPluginsActivated ) ||
+			allPluginsFetched ||
 			pluginSlugs.length === 0
 		) {
 			return;
@@ -171,7 +164,6 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		transferStatus,
 		isJetpackSelfHosted,
 		allPluginsFetched,
-		allPluginsActivated,
 		pluginSlugs,
 	] );
 
@@ -233,7 +225,6 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	return [
 		pluginsSection,
 		allPluginsFetched,
-		allPluginsActivated,
 		goBackSection,
 		title,
 		subtitle,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -266,7 +266,7 @@ const MarketplaceProductInstall = ( {
 	}, [ pluginUploadComplete, installedPlugin, setCurrentStep ] );
 
 	const pluginsUrl = useSelector( ( state ) =>
-		getSiteAdminUrl( state, siteId, 'plugins.php?activate=true&plugin_status=active' )
+		getSiteAdminUrl( state, siteId, 'plugins.php?activate=true' )
 	);
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#95181