### PR TITLE
[2nd try] Redirect to plugins.php after paid plugin activation instead of Congrats page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -129,12 +129,15 @@ const MarketplaceThankYou = ( {
 	useEffect( () => {
 		// We don't want to show the progress bar again when it is hidden.
 		if ( ! showProgressBar ) {
-			// Redirect to plugins.php if there are only plugins and no themes.
+			return;
+		}
+
+		// Redirect to plugins.php if there are only plugins and no themes.
+		if ( isPageReady ) {
 			const isOnlyPlugins = pluginSlugs.length > 0 && themeSlugs.length === 0;
 			if ( isOnlyPlugins && pluginsUrl ) {
 				window.location.href = pluginsUrl;
 			}
-
 			return;
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -13,7 +13,7 @@ import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { isRequesting } from 'calypso/state/plugins/installed/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { MarketplaceGoBackSection } from './marketplace-go-back-section';
@@ -122,15 +122,31 @@ const MarketplaceThankYou = ( {
 		}
 	}, [ isRequestingPlugins, isPageReady, dispatch, siteId, transferStatus, isJetpackSelfHosted ] );
 
+	const pluginsUrl = useSelector( ( state ) => {
+		return getSiteAdminUrl( state, siteId, 'plugins.php?activate=true&plugin_status=active' );
+	} );
 	// Set progressbar (currentStep) depending on transfer/plugin status.
 	useEffect( () => {
 		// We don't want to show the progress bar again when it is hidden.
 		if ( ! showProgressBar ) {
+			// Redirect to plugins.php if there are only plugins and no themes.
+			const isOnlyPlugins = pluginSlugs.length > 0 && themeSlugs.length === 0;
+			if ( isOnlyPlugins && pluginsUrl ) {
+				window.location.href = pluginsUrl;
+			}
+
 			return;
 		}
 
 		setShowProgressBar( ! isPageReady );
-	}, [ setShowProgressBar, showProgressBar, isPageReady ] );
+	}, [
+		setShowProgressBar,
+		showProgressBar,
+		isPageReady,
+		pluginSlugs.length,
+		themeSlugs.length,
+		pluginsUrl,
+	] );
 
 	const { steps, additionalSteps } = useThankYouSteps( {
 		pluginSlugs,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -48,6 +48,7 @@ const MarketplaceThankYou = ( {
 	const [
 		pluginsSection,
 		allPluginsFetched,
+		allPluginsActivated,
 		pluginsGoBackSection,
 		pluginTitle,
 		pluginSubtitle,
@@ -98,6 +99,7 @@ const MarketplaceThankYou = ( {
 
 	const isPageReady =
 		allPluginsFetched &&
+		allPluginsActivated &&
 		allThemesFetched &&
 		isAtomicTransferCheckComplete &&
 		isLoadedPlugins &&

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -135,11 +135,8 @@ const MarketplaceThankYou = ( {
 		}
 
 		// Redirect to plugins.php if there are only plugins and no themes.
-		if ( isPageReady ) {
-			const isOnlyPlugins = pluginSlugs.length > 0 && themeSlugs.length === 0;
-			if ( isOnlyPlugins && pluginsUrl ) {
-				window.location.href = pluginsUrl;
-			}
+		if ( isPageReady && pluginSlugs.length > 0 && themeSlugs.length === 0 && pluginsUrl ) {
+			window.location.href = pluginsUrl;
 			return;
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -16,6 +16,7 @@ import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchas
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginsOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
+import { isPluginActive } from 'calypso/state/plugins/installed/selectors-ts';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { areFetched, areFetching, getPlugins } from 'calypso/state/plugins/wporg/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -26,6 +27,7 @@ import { ThankYouPluginSection } from './marketplace-thank-you-plugin-section';
 
 type ThankYouData = [
 	React.ReactElement[],
+	boolean,
 	boolean,
 	JSX.Element,
 	string,
@@ -61,7 +63,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	);
 
 	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
-	const pluginsOnSite: [] = useSelector( ( state ) =>
+	const pluginsOnSite: Plugin[] = useSelector( ( state ) =>
 		getPluginsOnSite( state, siteId, softwareSlugs )
 	);
 	const wporgPlugins = useSelector(
@@ -86,6 +88,11 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	const areAllWporgPluginsFetched = areWporgPluginsFetched.every( Boolean );
 
 	const allPluginsFetched = pluginsOnSite.every( ( pluginOnSite ) => !! pluginOnSite );
+	const allPluginsActivated = useSelector( ( state ) => {
+		return pluginsOnSite.every( ( pluginOnSite ) => {
+			return isPluginActive( state, siteId as number, pluginOnSite?.slug );
+		} );
+	} );
 
 	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
@@ -225,6 +232,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	return [
 		pluginsSection,
 		allPluginsFetched,
+		allPluginsActivated,
 		goBackSection,
 		title,
 		subtitle,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -155,7 +155,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		if (
 			! siteId ||
 			( ! isJetpackSelfHosted && transferStatus !== transferStates.COMPLETE ) ||
-			allPluginsFetched ||
+			( allPluginsFetched && allPluginsActivated ) ||
 			pluginSlugs.length === 0
 		) {
 			return;
@@ -171,6 +171,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		transferStatus,
 		isJetpackSelfHosted,
 		allPluginsFetched,
+		allPluginsActivated,
 		pluginSlugs,
 	] );
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -266,7 +266,7 @@ const MarketplaceProductInstall = ( {
 	}, [ pluginUploadComplete, installedPlugin, setCurrentStep ] );
 
 	const pluginsUrl = useSelector( ( state ) =>
-		getSiteAdminUrl( state, siteId, 'plugins.php?activate=true' )
+		getSiteAdminUrl( state, siteId, 'plugins.php?activate=true&plugin_status=active' )
 	);
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -285,7 +285,7 @@ const MarketplaceProductInstall = ( {
 				transferStates.COMPLETE === automatedTransferStatus &&
 				canManagePlugins )
 		) {
-			waitFor( 2 ).then( () => {
+			waitFor( 1 ).then( () => {
 				window.location.href = pluginsUrl as string;
 			} );
 		}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -285,7 +285,7 @@ const MarketplaceProductInstall = ( {
 				transferStates.COMPLETE === automatedTransferStatus &&
 				canManagePlugins )
 		) {
-			waitFor( 1 ).then( () => {
+			waitFor( 2 ).then( () => {
 				window.location.href = pluginsUrl as string;
 			} );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

2nd try of https://github.com/Automattic/wp-calypso/pull/95181, fixing the issue where congrats page is not reachable (https://github.com/Automattic/wp-calypso/pull/95274/commits/f5fbe1659d2fdd45dfee9e1503df58311b735f75) caused by https://github.com/Automattic/wp-calypso/pull/95181#discussion_r1793280799.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For the bug fix;

- Prepare a Simple site 
- Put a paid plugin (e.g. "Sensei Pro" and "WP Job Manager - Resume Manager") AND a Business plan into a cart 
- Checkout them
- Observe the congrats page

For the feature;

- Follow the instructions in https://github.com/Automattic/wp-calypso/pull/95181

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
