### PR TITLE
A4A: Remove extra dot on the Growth Accelerator description.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/index.tsx
@@ -48,7 +48,7 @@ export default function OverviewSidebarGrowthAccelerator() {
 
 			<p className="overview__growth-accelerator-body">
 				{ translate(
-					'Schedule a call with the Automattic for Agencies team to help us understand your business better and help you find and retain more clients. .'
+					'Schedule a call with the Automattic for Agencies team to help us understand your business better and help you find and retain more clients.'
 				) }
 			</p>
 


### PR DESCRIPTION
This PR removes an extra dot in the Growth Accelerator CTA description.

## Proposed Changes

*

## Why are these changes being made?


*

## Testing Instructions

* Use the A4A live link and go to the `/overview` page.
* Check that the Growth Accelerator CTA description do not have extra dot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
