### PR TITLE
Substack importer: add translation functions to stable strings

### DIFF
--- a/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
@@ -219,7 +219,7 @@ class AuthorMappingPane extends PureComponent {
 						importerStatus?.customData?.attachmentsNumber || 0
 					) }
 				</Notice>
-				<h2>Author mapping</h2>
+				<h2>{ this.props.translate( 'Author mapping' ) }</h2>
 				<div className="importer__mapping-description">{ mappingDescription }</div>
 				<div className="importer__mapping-header">
 					<span className="importer__mapping-source-title">{ sourceTitle }</span>
@@ -240,7 +240,7 @@ class AuthorMappingPane extends PureComponent {
 				</div>
 				<ImporterActionButtonContainer noSpacing>
 					<ImporterActionButton primary disabled={ ! canStartImport } onClick={ onStartImport }>
-						Import
+						{ this.props.translate( 'Import' ) }
 					</ImporterActionButton>
 				</ImporterActionButtonContainer>
 			</div>

--- a/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
@@ -187,7 +187,7 @@ export class ImportingPane extends PureComponent {
 				{ isImporting && (
 					<>
 						<ImporterActionButton primary busy disabled>
-							Importing
+							{ this.props.translate( 'Importing' ) }
 						</ImporterActionButton>
 						<ImporterActionButton href={ nextStepUrl }>
 							{ this.props.translate( 'Continue' ) }
@@ -247,7 +247,7 @@ export class ImportingPane extends PureComponent {
 						onMap={ this.handleOnMap }
 						onStartImport={ () => {
 							this.props.startImporting( this.props.importerStatus );
-							this.props.infoNotice( 'We’re importing your content', {
+							this.props.infoNotice( this.props.translate( 'We’re importing your content' ), {
 								displayOnNextPage: true,
 								duration: 5000,
 							} );
@@ -265,8 +265,8 @@ export class ImportingPane extends PureComponent {
 				) }
 				{ ( this.isImporting() || this.isProcessing() ) && (
 					<>
-						<h2>Import your content to WordPress.com</h2>
-						<p>Please, wait while we import your content…</p>
+						<h2>{ this.props.translate( 'Import your content to WordPress.com' ) }</h2>
+						<p>{ this.props.translate( 'Please, wait while we import your content…' ) }</p>
 						<div className="importer__import-progress">
 							<ProgressBar className="importer__import-progress-bar" value={ percentComplete } />
 							{ blockingMessage && <p>{ blockingMessage }</p> }
@@ -280,9 +280,9 @@ export class ImportingPane extends PureComponent {
 				) }
 				{ this.isFinished() && ! this.isError() && (
 					<>
-						<h2>Import your content to WordPress.com</h2>
+						<h2>{ this.props.translate( 'Import your content to WordPress.com' ) }</h2>
 						<Notice status="success" className="importer__notice" isDismissible={ false }>
-							Success! Your content has been imported!
+							{ this.props.translate( 'Success! Your content has been imported!' ) }
 						</Notice>
 					</>
 				) }

--- a/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
@@ -265,7 +265,7 @@ export class UploadingPane extends PureComponent {
 						onClick={ skipNextStep }
 						disabled={ skipButtonDisabled }
 					>
-						Skip for now
+						{ this.props.translate( 'Skip for now' ) }
 					</ImporterActionButton>
 				</ImporterActionButtonContainer>
 			</div>

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -1,7 +1,9 @@
 import { Card } from '@automattic/components';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { external } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import exportSubstackDataImg from 'calypso/assets/images/importer/export-substack-content.png';
 import importerConfig from 'calypso/lib/importer/importer-config';
@@ -32,6 +34,7 @@ export default function Content( {
 	fromSite,
 	skipNextStep,
 }: ContentProps ) {
+	const { __ } = useI18n();
 	const siteTitle = selectedSite.title;
 	const siteId = selectedSite.ID;
 
@@ -80,15 +83,20 @@ export default function Content( {
 
 			{ showExportDataHint && (
 				<>
-					<h2>Step 1: Export your content from Substack</h2>
+					<h2>{ __( 'Step 1: Export your content from Substack' ) }</h2>
 					<p>
-						Generate a ZIP file of all your Substack posts. On Substack, go to Settings &gt;
-						Exports, click <strong>New export</strong>, and upload the downloaded ZIP file in the
-						next step.
+						{ createInterpolateElement(
+							__(
+								'Generate a ZIP file of all your Substack posts. On Substack, go to Settings > Exports, click <strong>New export</strong>, and upload the downloaded ZIP file in the next step.'
+							),
+							{
+								strong: <strong />,
+							}
+						) }
 					</p>
 					<img
 						src={ exportSubstackDataImg }
-						alt="Export Substack data"
+						alt={ __( 'Export Substack data' ) }
 						className="export-content"
 					/>
 					<Button
@@ -98,10 +106,10 @@ export default function Content( {
 						icon={ external }
 						variant="primary"
 					>
-						Open Substack settings
+						{ __( 'Open Substack settings' ) }
 					</Button>
 					<hr />
-					<h2>Step 2: Import your content to WordPress.com</h2>
+					<h2>{ __( 'Step 2: Import your content to WordPress.com' ) }</h2>
 				</>
 			) }
 			{ importerStatus && (

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -1,3 +1,4 @@
+import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { useState, useEffect, useRef } from 'react';
@@ -38,10 +39,14 @@ type NewsletterImporterProps = {
 
 function getTitle( engine: EngineTypes, urlData?: UrlData ) {
 	if ( urlData?.meta?.title && urlData?.platform === engine ) {
-		return `Import ${ urlData.meta.title }`;
+		return sprintf(
+			// translators: %s is the site name
+			__( 'Import %s' ),
+			urlData.meta.title
+		);
 	}
 
-	return 'Import your newsletter';
+	return __( 'Import your newsletter' );
 }
 
 function updatePathToContent( path: string ) {

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
@@ -18,6 +19,7 @@ export default function SelectNewsletterForm( {
 	isLoading,
 	isError,
 }: SelectNewsletterFormProps ) {
+	const { __ } = useI18n();
 	const [ isUrlInvalid, setIsUrlInvalid ] = useState( false );
 
 	const handleAction = ( fromSite: string ) => {
@@ -47,16 +49,18 @@ export default function SelectNewsletterForm( {
 			<FormTextInputWithAction
 				onAction={ handleAction }
 				placeholder="https://example.substack.com"
-				action="Continue"
+				action={ __( 'Continue' ) }
 				isError={ hasError }
 				defaultValue={ value }
 			/>
 			{ hasError && (
-				<p className="select-newsletter-form__help is-error">Please enter a valid Substack URL.</p>
+				<p className="select-newsletter-form__help is-error">
+					{ __( 'Please enter a valid Substack URL.' ) }
+				</p>
 			) }
 			{ ! hasError && (
 				<p className="select-newsletter-form__help">
-					Enter the URL of the Substack newsletter that you wish to import.
+					{ __( 'Enter the URL of the Substack newsletter that you wish to import.' ) }
 				</p>
 			) }
 		</Card>

--- a/client/my-sites/importer/newsletter/subscribers/import-subscribers-error.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/import-subscribers-error.tsx
@@ -1,12 +1,14 @@
 import { FormInputValidation } from '@automattic/components';
 import { Subscriber } from '@automattic/data-stores';
 import { Icon, warning } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 
 type Props = {
 	error: Subscriber.ImportSubscribersError;
 };
 
 export default function PaidImportSubscribersError( { error }: Props ) {
+	const { __ } = useI18n();
 	const HANDLED_ERROR = {
 		IMPORT_LIMIT: 'subscriber_import_limit_reached',
 		IMPORT_BLOCKED: 'blocked_import',
@@ -23,17 +25,23 @@ export default function PaidImportSubscribersError( { error }: Props ) {
 			{ ( (): React.ReactNode => {
 				switch ( error.code ) {
 					case HANDLED_ERROR.IMPORT_LIMIT:
-						return 'We couldn’t import your subscriber list as you’ve hit the 100 email limit for our free plan. The good news? You can upload a list of any size after upgrading to any paid plan.';
+						return __(
+							'We couldn’t import your subscriber list as you’ve hit the 100 email limit for our free plan. The good news? You can upload a list of any size after upgrading to any paid plan.'
+						);
 
 					case HANDLED_ERROR.IMPORT_BLOCKED:
-						return 'We ran into a security issue with your subscriber list. It’s nothing to worry about. If you reach out to our support team when you’ve finished setting things up, they’ll help resolve this for you.';
+						return __(
+							'We ran into a security issue with your subscriber list. It’s nothing to worry about. If you reach out to our support team when you’ve finished setting things up, they’ll help resolve this for you.'
+						);
 					case HANDLED_ERROR.IMPORT_RUNNING:
-						return 'An subscriber import has already started. Please wait till that one finished before starting a new one.';
+						return __(
+							'An subscriber import has already started. Please wait till that one finished before starting a new one.'
+						);
 					case HANDLED_ERROR.MISSING_ARGS:
 					case HANDLED_ERROR.EMPTY_CSV_FILE:
 					case HANDLED_ERROR.CSV_UPLOAD_ERROR:
 					case HANDLED_ERROR.CSV_INVALID_TYPE:
-						return 'Please double check your CSV file to make sure that it contains emails.';
+						return __( 'Please double check your CSV file to make sure that it contains emails.' );
 
 					default:
 						return typeof error.message === 'string' ? error.message : '';

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers.tsx
@@ -1,3 +1,4 @@
+import { useI18n } from '@wordpress/react-i18n';
 import { hasQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
 import { useDispatch } from 'calypso/state';
@@ -17,6 +18,7 @@ export default function PaidSubscribers( {
 	setAutoFetchData,
 	status,
 }: SubscribersStepProps ) {
+	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const isCancelled = hasQueryArg( window.location.href, 'stripe_connect_cancelled' );
 	const isSuccess = hasQueryArg( window.location.href, 'stripe_connect_success' );
@@ -24,11 +26,11 @@ export default function PaidSubscribers( {
 
 	useEffect( () => {
 		if ( isSuccess ) {
-			dispatch( successNotice( 'Stripe account connected successfully' ) );
+			dispatch( successNotice( __( 'Stripe account connected successfully' ) ) );
 		} else if ( isCancelled ) {
-			dispatch( infoNotice( 'Stripe account connection cancelled' ) );
+			dispatch( infoNotice( __( 'Stripe account connection cancelled' ) ) );
 		}
-	}, [ isSuccess, dispatch, isCancelled ] );
+	}, [ isSuccess, dispatch, isCancelled, __ ] );
 
 	return (
 		<>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -1,6 +1,8 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
-import StripeLogo from 'calypso/assets/images/jetpack/stripe-logo-white.svg';
+import StripeLogoSvg from 'calypso/assets/images/jetpack/stripe-logo-white.svg';
 import { navigate } from 'calypso/lib/navigate';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ImporterActionButton from '../../../importer-action-buttons/action-button';
@@ -33,6 +35,7 @@ export default function ConnectStripe( {
 	selectedSite,
 	siteSlug,
 }: SubscribersStepProps ) {
+	const { __ } = useI18n();
 	if ( cardData?.connect_url === undefined ) {
 		return null;
 	}
@@ -43,10 +46,16 @@ export default function ConnectStripe( {
 	return (
 		<>
 			<SuccessNotice allEmailsCount={ allEmailsCount } />
-			<h2>Do you have paid subscribers?</h2>
+			<h2>{ __( 'Do you have paid subscribers?' ) } </h2>
 			<p>
-				To migrate your <strong>paid subscribers</strong> to WordPress.com, make sure you're
-				connecting the <strong>same</strong> Stripe account you use with Substack.
+				{ createInterpolateElement(
+					__(
+						"To migrate your <strong>paid subscribers</strong> to WordPress.com, make sure you're connecting the <strong>same</strong> Stripe account you use with Substack."
+					),
+					{
+						strong: <strong />,
+					}
+				) }
 			</p>
 			<ImporterActionButtonContainer noSpacing>
 				<ImporterActionButton
@@ -55,8 +64,13 @@ export default function ConnectStripe( {
 					onClick={ () => {
 						recordTracksEvent( 'calypso_paid_importer_connect_stripe' );
 					} }
+					ariaLabel={ __( 'Connect Stripe' ) }
 				>
-					Connect <img src={ StripeLogo } className="stripe-logo" width="48px" alt="Stripe logo" />
+					{ createInterpolateElement( __( 'Connect <StripeLogo />' ), {
+						StripeLogo: (
+							<img src={ StripeLogoSvg } className="stripe-logo" width="48" alt="Stripe" />
+						),
+					} ) }
 				</ImporterActionButton>
 				<StartImportButton
 					engine={ engine }
@@ -66,7 +80,7 @@ export default function ConnectStripe( {
 					navigate={ () => {
 						navigate( `/import/newsletter/${ engine }/${ siteSlug }/summary?from=${ fromSite }` );
 					} }
-					label="I have only free subscribers"
+					label={ __( 'I have only free subscribers' ) }
 				/>
 			</ImporterActionButtonContainer>
 		</>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plan.tsx
@@ -113,7 +113,7 @@ export function MapPlan( {
 							onProductAdd( tierToAdd, plan.product_id );
 						} }
 					>
-						{ __( 'Add Newsletter Tier' ) }
+						{ __( 'Add newsletter tier' ) }
 					</Button>
 				</div>
 			) }
@@ -135,7 +135,7 @@ export function MapPlan( {
 						{ selectedProduct ? (
 							<ProductInfo product={ selectedProduct } />
 						) : (
-							__( 'Select a Newsletter Tier' )
+							__( 'Select a newsletter tier' )
 						) }
 					</Button>
 					<DropdownMenu
@@ -143,7 +143,7 @@ export function MapPlan( {
 							setIsOpen( openState );
 						} }
 						icon={ chevronDown }
-						label={ __( 'Choose a Newsletter Tier' ) }
+						label={ __( 'Choose a newsletter tier' ) }
 						open={ isOpen }
 					>
 						{ ( { onClose }: { onClose: () => void } ) => (
@@ -167,7 +167,7 @@ export function MapPlan( {
 											onProductAdd( tierToAdd, plan.product_id );
 										} }
 									>
-										{ __( 'Add Newsletter Tier' ) }
+										{ __( 'Add newsletter tier' ) }
 									</MenuItem>
 								</MenuGroup>
 							</Fragment>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plan.tsx
@@ -1,7 +1,7 @@
 import { formatCurrency } from '@automattic/format-currency';
 import { DropdownMenu, MenuGroup, MenuItem, MenuItemsChoice, Button } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { chevronDown, Icon, arrowRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState, KeyboardEvent } from 'react';
@@ -33,18 +33,18 @@ type MapPlanProps = {
 	selectedProductId: string;
 };
 
-type ProductInfoProps = {
-	product: Product;
-};
+function displayProduct( product?: Product ) {
+	if ( ! product ) {
+		return __( 'Select a newsletter tier' );
+	}
 
-function ProductInfo( { product }: ProductInfoProps ) {
 	return (
-		<>
-			{ product.title && <strong>{ product.title }</strong> }
+		<div>
+			<strong>{ product.title || '' }</strong>
 			<p>
 				{ formatCurrency( parseFloat( product.price ), product.currency ) }/{ product.interval }
 			</p>
-		</>
+		</div>
 	);
 }
 
@@ -66,7 +66,12 @@ export function MapPlan( {
 	tierToAdd,
 	selectedProductId,
 }: MapPlanProps ) {
-	const { __, _n } = useI18n();
+	const { __ } = useI18n();
+	let active_subscriptions = '';
+	if ( plan.active_subscriptions ) {
+		active_subscriptions = ` • ${ plan.active_subscriptions } active subscribers`;
+	}
+
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const selectedProduct = products.find(
@@ -86,17 +91,7 @@ export function MapPlan( {
 						isSmallestUnit: true,
 						stripZeros: true,
 					} ) }
-					/{ plan.plan_interval }
-					{ plan.active_subscriptions && (
-						<>
-							{ ' • ' }
-							{ sprintf(
-								// translators: %d is number of subscribers
-								_n( '%d active subscriber', '%d active subscribers', plan.active_subscriptions ),
-								plan.active_subscriptions
-							) }
-						</>
-					) }
+					/{ plan.plan_interval } { active_subscriptions }
 				</p>
 			</div>
 			<div className="map-plan__arrow">
@@ -132,11 +127,7 @@ export function MapPlan( {
 							}
 						} }
 					>
-						{ selectedProduct ? (
-							<ProductInfo product={ selectedProduct } />
-						) : (
-							__( 'Select a newsletter tier' )
-						) }
+						{ displayProduct( selectedProduct ) }
 					</Button>
 					<DropdownMenu
 						onToggle={ ( openState: boolean ) => {

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plan.tsx
@@ -1,7 +1,9 @@
 import { formatCurrency } from '@automattic/format-currency';
 import { DropdownMenu, MenuGroup, MenuItem, MenuItemsChoice, Button } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { chevronDown, Icon, arrowRight } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import { useState, KeyboardEvent } from 'react';
 import { Product, Plan } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
@@ -31,18 +33,18 @@ type MapPlanProps = {
 	selectedProductId: string;
 };
 
-function displayProduct( product?: Product ) {
-	if ( ! product ) {
-		return 'Select a Newsletter Tier';
-	}
+type ProductInfoProps = {
+	product: Product;
+};
 
+function ProductInfo( { product }: ProductInfoProps ) {
 	return (
-		<div>
-			<strong>{ product.title || '' }</strong>
+		<>
+			{ product.title && <strong>{ product.title }</strong> }
 			<p>
 				{ formatCurrency( parseFloat( product.price ), product.currency ) }/{ product.interval }
 			</p>
-		</div>
+		</>
 	);
 }
 
@@ -64,11 +66,7 @@ export function MapPlan( {
 	tierToAdd,
 	selectedProductId,
 }: MapPlanProps ) {
-	let active_subscriptions = '';
-	if ( plan.active_subscriptions ) {
-		active_subscriptions = ` • ${ plan.active_subscriptions } active subscribers`;
-	}
-
+	const { __, _n } = useI18n();
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const selectedProduct = products.find(
@@ -88,7 +86,17 @@ export function MapPlan( {
 						isSmallestUnit: true,
 						stripZeros: true,
 					} ) }
-					/{ plan.plan_interval } { active_subscriptions }
+					/{ plan.plan_interval }
+					{ plan.active_subscriptions && (
+						<>
+							{ ' • ' }
+							{ sprintf(
+								// translators: %d is number of subscribers
+								_n( '%d active subscriber', '%d active subscribers', plan.active_subscriptions ),
+								plan.active_subscriptions
+							) }
+						</>
+					) }
 				</p>
 			</div>
 			<div className="map-plan__arrow">
@@ -105,7 +113,7 @@ export function MapPlan( {
 							onProductAdd( tierToAdd, plan.product_id );
 						} }
 					>
-						Add Newsletter Tier
+						{ __( 'Add Newsletter Tier' ) }
 					</Button>
 				</div>
 			) }
@@ -124,19 +132,23 @@ export function MapPlan( {
 							}
 						} }
 					>
-						{ displayProduct( selectedProduct ) }
+						{ selectedProduct ? (
+							<ProductInfo product={ selectedProduct } />
+						) : (
+							__( 'Select a Newsletter Tier' )
+						) }
 					</Button>
 					<DropdownMenu
 						onToggle={ ( openState: boolean ) => {
 							setIsOpen( openState );
 						} }
 						icon={ chevronDown }
-						label="Choose a Newsletter Tier"
+						label={ __( 'Choose a Newsletter Tier' ) }
 						open={ isOpen }
 					>
 						{ ( { onClose }: { onClose: () => void } ) => (
 							<Fragment>
-								<MenuGroup label="Select">
+								<MenuGroup label={ __( 'Select' ) }>
 									<MenuItemsChoice
 										choices={ getProductChoices( sameIntervalProducts ) }
 										onSelect={ ( productId ) => {
@@ -147,7 +159,7 @@ export function MapPlan( {
 										value={ selectedProductId }
 									/>
 								</MenuGroup>
-								<MenuGroup label="OR">
+								<MenuGroup label={ __( 'OR' ) }>
 									<MenuItem
 										key="add-new"
 										onClick={ () => {
@@ -155,7 +167,7 @@ export function MapPlan( {
 											onProductAdd( tierToAdd, plan.product_id );
 										} }
 									>
-										Add Newsletter Tier
+										{ __( 'Add Newsletter Tier' ) }
 									</MenuItem>
 								</MenuGroup>
 							</Fragment>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
@@ -1,5 +1,7 @@
 import { formatCurrency } from '@automattic/format-currency';
 import { useQueryClient } from '@tanstack/react-query';
+import { createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import { useMapStripePlanToProductMutation } from 'calypso/data/paid-newsletter/use-map-stripe-plan-to-product-mutation';
 import { navigate } from 'calypso/lib/navigate';
@@ -57,6 +59,7 @@ export default function MapPlans( {
 	siteSlug,
 	fromSite,
 }: SubscribersStepProps ) {
+	const { __ } = useI18n();
 	const [ productToAdd, setProductToAdd ] = useState< TierToAdd | null >( null );
 
 	const currentStep = 'subscribers';
@@ -137,7 +140,7 @@ export default function MapPlans( {
 		currency: monthyPlan.plan_currency,
 		price: formatCurrencyFloat( monthyPlan.plan_amount_decimal, monthyPlan.plan_currency ),
 		type: TYPE_TIER,
-		title: 'Newsletter tier',
+		title: __( 'Newsletter tier' ),
 		interval: PLAN_MONTHLY_FREQUENCY,
 		annualProduct: {
 			currency: annualPlan.plan_currency,
@@ -163,16 +166,20 @@ export default function MapPlans( {
 	return (
 		<>
 			<SuccessNotice allEmailsCount={ allEmailsCount } />
-			<h2>Paid subscribers</h2>
+			<h2>{ __( 'Paid subscribers' ) }</h2>
 			<p>
-				<strong>
-					Review the plans retrieved from Stripe and create equivalents in WordPress.com
-				</strong>{ ' ' }
-				to prevent disruptions for your current paid subscribers.
+				{ createInterpolateElement(
+					__(
+						'<strong>Review the plans retrieved from Stripe and create equivalents in WordPress.com</strong> to prevent disruptions for your current paid subscribers.'
+					),
+					{
+						strong: <strong />,
+					}
+				) }
 			</p>
 			<div className="map-plans__mapping">
 				<p>
-					<strong>Existing Stripe plans</strong>
+					<strong>{ __( 'Existing Stripe plans' ) }</strong>
 				</p>
 				{ cardData.plans.map( ( plan: any ) => {
 					tierToAdd.via = plan.product_id;

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
@@ -74,7 +74,7 @@ export default function NoPlans( {
 			<div className="no-plans__info">
 				<p>
 					{ sprintf(
-						// translators: %d is the Stripe account email address
+						// translators: %d is the Stripe account name
 						__(
 							'It looks like the Stripe Account (%s) does not have any active plans. Are you sure you connected the same Stipe account that you use on Substack?'
 						),
@@ -92,7 +92,7 @@ export default function NoPlans( {
 					siteId={ selectedSite.ID }
 					primary={ false }
 					step={ currentStep }
-					label={ __( 'Only Import free subscrivers' ) }
+					label={ __( 'Only import free subscribers' ) }
 					navigate={ () => {
 						navigate( `/import/newsletter/${ engine }/${ siteSlug }/summary?from=${ fromSite }` );
 					} }

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
@@ -1,6 +1,8 @@
 import { Dialog } from '@automattic/components';
 import { useQueryClient } from '@tanstack/react-query';
 import { Notice } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect } from 'react';
 import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import { navigate } from 'calypso/lib/navigate';
@@ -26,6 +28,7 @@ export default function NoPlans( {
 	siteSlug,
 	fromSite,
 }: NoPlansProps ) {
+	const { __ } = useI18n();
 	const currentStep = 'subscribers';
 	const [ showDisconnectStripeDialog, setShowDisconnectStripeDialog ] = useState( false );
 	const [ shouldCheckConnection, setShouldCheckConnection ] = useState( false );
@@ -52,8 +55,8 @@ export default function NoPlans( {
 			dispatch(
 				requestDisconnectSiteStripeAccount(
 					selectedSite.ID,
-					'Please wait, disconnecting Stripe\u2026',
-					'Stripe account is disconnected.'
+					__( 'Please wait, disconnecting Stripe…' ),
+					__( 'Stripe account is disconnected.' )
 				)
 			);
 			setTimeout( () => {
@@ -66,17 +69,22 @@ export default function NoPlans( {
 	return (
 		<>
 			<Notice isDismissible={ false } status="warning">
-				We couldn't find any plans in your connected Stripe account.
+				{ __( "We couldn't find any plans in your connected Stripe account." ) }
 			</Notice>
 			<div className="no-plans__info">
 				<p>
-					It looks like the Stripe Account ( { cardData?.account_display } ) does not have any
-					active plans. Are you sure you connected the same Stipe account that you use on Substack?
+					{ sprintf(
+						// translators: %d is the Stripe account email address
+						__(
+							'It looks like the Stripe Account (%s) does not have any active plans. Are you sure you connected the same Stipe account that you use on Substack?'
+						),
+						cardData?.account_display
+					) }
 				</p>
 			</div>
 			<ImporterActionButtonContainer>
 				<ImporterActionButton onClick={ disconnectStripe } primary>
-					Try a different Stripe account
+					{ __( 'Try a different Stripe account' ) }
 				</ImporterActionButton>
 
 				<StartImportButton
@@ -84,7 +92,7 @@ export default function NoPlans( {
 					siteId={ selectedSite.ID }
 					primary={ false }
 					step={ currentStep }
-					label="Only Import free subscrivers"
+					label={ __( 'Only Import free subscrivers' ) }
 					navigate={ () => {
 						navigate( `/import/newsletter/${ engine }/${ siteSlug }/summary?from=${ fromSite }` );
 					} }
@@ -95,11 +103,11 @@ export default function NoPlans( {
 				isVisible={ showDisconnectStripeDialog }
 				buttons={ [
 					{
-						label: 'Cancel',
+						label: __( 'Cancel' ),
 						action: 'cancel',
 					},
 					{
-						label: 'Disconnect Payments from Stripe',
+						label: __( 'Disconnect Payments from Stripe' ),
 						isPrimary: true,
 						additionalClassNames: 'is-scary',
 						action: 'disconnect',
@@ -107,10 +115,11 @@ export default function NoPlans( {
 				] }
 				onClose={ onCloseDisconnectStripeAccount }
 			>
-				<h1>Disconnect Stripe?</h1>
+				<h1>{ __( 'Disconnect Stripe?' ) }</h1>
 				<p>
-					Once you disconnect Payments from Stripe, new subscribers won’t be able to sign up and
-					existing subscriptions will stop working.
+					{ __(
+						'Once you disconnect Payments from Stripe, new subscribers won’t be able to sign up and existing subscriptions will stop working.'
+					) }
 				</p>
 			</Dialog>
 		</>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/success-notice.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/success-notice.tsx
@@ -1,9 +1,21 @@
 import { Notice } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 
 export default function SuccessNotice( { allEmailsCount }: { allEmailsCount: number } ) {
 	return (
 		<Notice status="success" className="importer__notice" isDismissible={ false }>
-			All set! We’ve found <strong>{ allEmailsCount } subscribers</strong> to import.
+			{ createInterpolateElement(
+				sprintf(
+					// @TODO: add _n() translation function once we finalize this copy.
+					// translators: %d is the number of subscribers
+					'All set! We’ve found <strong>%d subscribers</strong> to import.',
+					allEmailsCount
+				),
+				{
+					strong: <strong />,
+				}
+			) }
 		</Notice>
 	);
 }

--- a/client/my-sites/importer/newsletter/subscribers/start-import-button.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/start-import-button.tsx
@@ -1,3 +1,4 @@
+import { useI18n } from '@wordpress/react-i18n';
 import { StepId } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import { useSubscriberImportMutation } from 'calypso/data/paid-newsletter/use-subscriber-import-mutation';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
@@ -21,6 +22,7 @@ export default function StartImportButton( {
 	primary = true,
 	label,
 }: Props ) {
+	const { __ } = useI18n();
 	const { enqueueSubscriberImport } = useSubscriberImportMutation();
 
 	const importSubscribers = () => {
@@ -30,7 +32,7 @@ export default function StartImportButton( {
 
 	return (
 		<ImporterActionButton primary={ primary } disabled={ disabled } onClick={ importSubscribers }>
-			{ label || 'Import subscribers' }
+			{ label || __( 'Import subscribers' ) }
 		</ImporterActionButton>
 	);
 }

--- a/client/my-sites/importer/newsletter/subscribers/step-done.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-done.tsx
@@ -1,18 +1,20 @@
 import { Card } from '@automattic/components';
 import { Notice } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 import { SubscribersStepProps } from '../types';
 
 export default function StepDone( { cardData, nextStepUrl }: SubscribersStepProps ) {
+	const { __ } = useI18n();
 	const subscribedCount = parseInt( cardData?.meta?.email_count || '0' );
 
 	return (
 		<Card>
-			<h2>Import your subscribers to WordPress.com</h2>
+			<h2>{ __( 'Import your subscribers to WordPress.com' ) }</h2>
 			<Notice status="success" className="importer__notice" isDismissible={ false }>
 				Success! { subscribedCount } subscribers have been added!
 			</Notice>
-			<ImporterActionButton href={ nextStepUrl }>View Summary</ImporterActionButton>
+			<ImporterActionButton href={ nextStepUrl }>{ __( 'View Summary' ) }</ImporterActionButton>
 		</Card>
 	);
 }

--- a/client/my-sites/importer/newsletter/subscribers/step-importing.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-importing.tsx
@@ -1,25 +1,28 @@
 import { Card } from '@automattic/components';
 import { ProgressBar } from '@wordpress/components';
 import { Icon, atSymbol } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 import { SubscribersStepProps } from '../types';
 
 export default function StepImporting( { nextStepUrl }: SubscribersStepProps ) {
+	const { __ } = useI18n();
 	return (
 		<Card>
 			<div className="summary__content">
 				<p>
-					<Icon icon={ atSymbol } /> <strong>We're importing your subscribers</strong>
+					<Icon icon={ atSymbol } /> <strong>{ __( "We're importing your subscribers" ) }</strong>
 				</p>
 			</div>
 			<p>
-				This may take a few minutes. Feel free to leave this window – we'll let you know when it's
-				done.
+				{ __(
+					"This may take a few minutes. Feel free to leave this window – we'll let you know when it's done."
+				) }
 			</p>
 			<p>
 				<ProgressBar className="is-larger-progress-bar" />
 			</p>
-			<ImporterActionButton href={ nextStepUrl }>View Summary</ImporterActionButton>
+			<ImporterActionButton href={ nextStepUrl }>{ __( 'View Summary' ) }</ImporterActionButton>
 		</Card>
 	);
 }

--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -3,6 +3,7 @@ import { Subscriber } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { external } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useRef } from 'react';
 import exportSubstackSubscribersImg from 'calypso/assets/images/importer/export-substack-subscribers.png';
 import { SubscribersStepProps } from '../types';
@@ -18,6 +19,7 @@ export default function StepInitial( {
 	engine,
 	setAutoFetchData,
 }: SubscribersStepProps ) {
+	const { __ } = useI18n();
 	const { importSelector } = useSelect( ( select ) => {
 		const subscriber = select( Subscriber.store );
 		return {
@@ -35,15 +37,15 @@ export default function StepInitial( {
 
 	return (
 		<Card>
-			<h2>Step 1: Export your subscribers from Substack</h2>
+			<h2>{ __( 'Step 1: Export your subscribers from Substack' ) }</h2>
 			<p>
-				Generate a CSV file of all your Substack subscribers. On Substack, go to the{ ' ' }
-				<strong>Subscribers</strong> tab and click the <strong>Export</strong> button you’ll find on
-				top of the table. Then, upload the downloaded CSV in the next step.
+				{ __(
+					'Generate a CSV file of all your Substack subscribers. On Substack, go to the <strong>Subscribers</strong> tab and click the <strong>Export</strong> button you’ll find on top of the table. Then, upload the downloaded CSV in the next step.'
+				) }
 			</p>
 			<img
 				src={ exportSubstackSubscribersImg }
-				alt="Export Substack subscribers"
+				alt={ __( 'Export Substack subscribers' ) }
 				className="export-subscribers"
 			/>
 			<Button
@@ -53,10 +55,10 @@ export default function StepInitial( {
 				icon={ external }
 				variant="primary"
 			>
-				Open Substack subscribers
+				{ __( 'Open Substack subscribers' ) }
 			</Button>
 			<hr />
-			<h2>Step 2: Import your subscribers to WordPress.com</h2>
+			<h2>{ __( 'Step 2: Import your subscribers to WordPress.com' ) }</h2>
 			{ selectedSite.ID && (
 				<SubscriberUploadForm
 					siteId={ selectedSite.ID }

--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -2,6 +2,7 @@ import { Card } from '@automattic/components';
 import { Subscriber } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useRef } from 'react';
@@ -39,8 +40,13 @@ export default function StepInitial( {
 		<Card>
 			<h2>{ __( 'Step 1: Export your subscribers from Substack' ) }</h2>
 			<p>
-				{ __(
-					'Generate a CSV file of all your Substack subscribers. On Substack, go to the <strong>Subscribers</strong> tab and click the <strong>Export</strong> button you’ll find on top of the table. Then, upload the downloaded CSV in the next step.'
+				{ createInterpolateElement(
+					__(
+						'Generate a CSV file of all your Substack subscribers. On Substack, go to the <strong>Subscribers</strong> tab and click the <strong>Export</strong> button you’ll find on top of the table. Then, upload the downloaded CSV in the next step.'
+					),
+					{
+						strong: <strong />,
+					}
 				) }
 			</p>
 			<img

--- a/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
@@ -4,6 +4,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { ProgressBar } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { Icon, cloudUpload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useState, FormEvent, useEffect } from 'react';
@@ -79,7 +80,7 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 			<div className="subscriber-upload-form__dropzone">
 				<div className="subscriber-upload-form__in-progress">
 					<Icon icon={ cloudUpload } viewBox="4 4 16 16" size={ 16 } />
-					<p>Uploading...</p>
+					<p>{ __( 'Uploading…' ) }</p>
 					<ProgressBar className="is-larger-progress-bar" />
 				</div>
 			</div>
@@ -90,18 +91,28 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 		<form onSubmit={ onSubmit } autoComplete="off" className="subscriber-upload-form">
 			{ ! isSelectedFileValid && selectedFile && (
 				<FormInputValidation className="is-file-validation" isError text="">
-					Sorry, you can only upload CSV files. Please try again with a valid file.
+					{ __( 'Sorry, you can only upload CSV files. Please try again with a valid file.' ) }
 				</FormInputValidation>
 			) }
 			<div className="subscriber-upload-form__dropzone">
 				<DropZone onFilesDrop={ onFileSelect } />
 				<FilePicker accept="text/csv" onPick={ onFileSelect } multiple={ false }>
 					<Icon icon={ cloudUpload } viewBox="4 4 16 16" size={ 16 } />
-					{ ! selectedFile && <p>Drag a file here, or click to upload a file</p> }
+					{ ! selectedFile && <p>{ __( 'Drag a file here, or click to upload a file' ) }</p> }
 					{ selectedFile && (
 						<p>
-							To replace this <em className="file-name">{ selectedFile?.name }</em>
-							<br /> drag a file, or click to upload different one.
+							{ createInterpolateElement(
+								sprintf(
+									// translators: %s is a file name, e.g. example.csv
+									__(
+										'To replace this <fileName>%s</fileName> drag a file, or click to upload different one.'
+									),
+									selectedFile?.name || '-'
+								),
+								{
+									fileName: <em className="file-name" />,
+								}
+							) }
 						</p>
 					) }
 				</FilePicker>
@@ -141,7 +152,7 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 					} }
 					disabled={ ! ( isSelectedFileValid && selectedFile ) || hasImportError }
 				>
-					Continue
+					{ __( 'Continue' ) }
 				</ImporterActionButton>
 				<ImporterActionButton
 					href={ nextStepUrl }
@@ -150,7 +161,7 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 						recordTracksEvent( 'calypso_paid_importer_connect_stripe_skipped' );
 					} }
 				>
-					Skip for now
+					{ __( 'Skip for now' ) }
 				</ImporterActionButton>
 			</ImporterActionButtonContainer>
 		</form>

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -1,6 +1,9 @@
 import { Card, ConfettiAnimation } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
-import { Notice } from '@wordpress/components';
+import { ExternalLink, Notice } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import { Steps, StepStatus } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import { useResetMutation } from 'calypso/data/paid-newsletter/use-reset-mutation';
@@ -13,14 +16,14 @@ import { getImporterStatus, normalizeFromSite } from './utils';
 
 function getStepTitle( importerStatus: StepStatus ) {
 	if ( importerStatus === 'done' ) {
-		return 'Success! 🎉';
+		return __( 'Success! 🎉' );
 	}
 
 	if ( importerStatus === 'importing' ) {
-		return 'Almost there…';
+		return __( 'Almost there…' );
 	}
 
-	return 'Summary';
+	return __( 'Summary' );
 }
 
 interface SummaryProps {
@@ -40,6 +43,7 @@ export default function Summary( {
 	showConfetti,
 	shouldShownConfetti,
 }: SummaryProps ) {
+	const { __ } = useI18n();
 	const { resetPaidNewsletter } = useResetMutation();
 	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 
@@ -75,18 +79,23 @@ export default function Summary( {
 
 			{ showPauseSubstackBillingWarning && (
 				<Notice status="warning" className="importer__notice" isDismissible={ false }>
-					<h2>Action Required</h2>
-					To prevent any charges from your old provider, go to your{ ' ' }
-					<a
-						href={ `https://${ normalizeFromSite(
-							fromSite
-						) }/publish/settings?search=Pause%20subscription` }
-						target="_blank"
-						rel="noreferrer"
-					>
-						Substack Payments Settings ↗
-					</a>
-					, select "Pause billing" and click "<strong>Pause indefinitely</strong>".
+					<h2>{ __( 'Action required' ) }</h2>
+					{ createInterpolateElement(
+						__(
+							'To prevent any charges from Substack, go to your <substackPaymentsSettingsLink>Substack Payments Settings</substackPaymentsSettingsLink>, select "Pause billing" and click "<strong>Pause indefinitely</strong>".'
+						),
+						{
+							strong: <strong />,
+							substackPaymentsSettingsLink: (
+								// @ts-expect-error Used in createInterpolateElement doesn't need children.
+								<ExternalLink
+									href={ `https://${ normalizeFromSite(
+										fromSite
+									) }/publish/settings?search=Pause%20subscription` }
+								/>
+							),
+						}
+					) }
 				</Notice>
 			) }
 
@@ -96,16 +105,16 @@ export default function Summary( {
 					onClick={ onButtonClick }
 					primary
 				>
-					Customize your newsletter
+					{ __( 'Customize your newsletter' ) }
 				</ImporterActionButton>
 				<ImporterActionButton href={ '/posts/' + selectedSite.slug } onClick={ onButtonClick }>
-					View content
+					{ __( 'View content' ) }
 				</ImporterActionButton>
 				<ImporterActionButton
 					href={ '/subscribers/' + selectedSite.slug }
 					onClick={ onButtonClick }
 				>
-					Check subscribers
+					{ __( 'Check subscribers' ) }
 				</ImporterActionButton>
 			</ImporterActionButtonContainer>
 		</Card>

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -16,7 +16,7 @@ import { getImporterStatus, normalizeFromSite } from './utils';
 
 function getStepTitle( importerStatus: StepStatus ) {
 	if ( importerStatus === 'done' ) {
-		return __( 'Success! 🎉' );
+		return __( 'Success!' ) + ' 🎉';
 	}
 
 	if ( importerStatus === 'importing' ) {

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -1,4 +1,6 @@
+import { createInterpolateElement } from '@wordpress/element';
 import { Icon, post } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import { ContentStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
 function getSummaryCopy( postsNumber: number, pagesNumber: number, attachmentsNumber: number ) {
@@ -70,11 +72,15 @@ interface ContentSummaryProps {
 }
 
 export default function ContentSummary( { status, stepContent }: ContentSummaryProps ) {
+	const { __ } = useI18n();
 	if ( status === 'skipped' ) {
 		return (
 			<div className="summary__content">
 				<p>
-					<Icon icon={ post } /> You <strong>skipped</strong> content importing.
+					<Icon icon={ post } />
+					{ createInterpolateElement( __( 'You <strong>skipped</strong> content importing.' ), {
+						strong: <strong />,
+					} ) }
 				</p>
 			</div>
 		);
@@ -84,10 +90,11 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 		return (
 			<div className="summary__content">
 				<p>
-					<Icon icon={ post } /> <strong>We're importing your content.</strong>
+					<Icon icon={ post } /> <strong>{ __( "We're importing your content." ) }</strong>
 					<br />
-					This may take a few minutes. Feel free to leave this window – we'll let you know when it's
-					done.
+					{ __(
+						"This may take a few minutes. Feel free to leave this window — we'll let you know when it's done."
+					) }
 				</p>
 			</div>
 		);

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,5 +1,6 @@
 import { ProgressBar } from '@wordpress/components';
 import { Icon, people, atSymbol, payment, info, warning } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
 interface SubscriberSummaryProps {
@@ -8,6 +9,7 @@ interface SubscriberSummaryProps {
 }
 
 export default function SubscriberSummary( { stepContent, status }: SubscriberSummaryProps ) {
+	const { __ } = useI18n();
 	if ( status === 'skipped' ) {
 		return (
 			<div className="summary__content">
@@ -23,13 +25,15 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 			<>
 				<div className="summary__content">
 					<p>
-						<Icon icon={ atSymbol } /> <strong>We're importing your subscribers.</strong>
+						<Icon icon={ atSymbol } />{ ' ' }
+						<strong>{ __( "We're importing your subscribers." ) }</strong>
 						<br />
 					</p>
 				</div>
 				<p>
-					This may take a few minutes. Feel free to leave this window – we'll let you know when it's
-					done.
+					{ __(
+						"This may take a few minutes. Feel free to leave this window – we'll let you know when it's done."
+					) }
 				</p>
 				<p>
 					<ProgressBar className="is-larger-progress-bar" />

--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -107,3 +107,14 @@ export function normalizeFromSite( fromSite: string ) {
 
 	return fromSite;
 }
+
+// Temporary i18n function placeholders because we don't want to send some strings for translations just yet.
+// Check with Zap team.
+
+export function todo__( text: string ) {
+	return text;
+}
+
+export function todo_n( textSingular: string, textPlural: string, count: number ) {
+	return count > 1 ? textPlural : textSingular;
+}

--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -107,14 +107,3 @@ export function normalizeFromSite( fromSite: string ) {
 
 	return fromSite;
 }
-
-// Temporary i18n function placeholders because we don't want to send some strings for translations just yet.
-// Check with Zap team.
-
-export function todo__( text: string ) {
-	return text;
-}
-
-export function todo_n( textSingular: string, textPlural: string, count: number ) {
-	return count > 1 ? textPlural : textSingular;
-}


### PR DESCRIPTION
## Proposed Changes

* Wraps most of the string with translation functions. The UI itself is still behind feature flags so fine to merge to prod.

Some of the screens:

<img width="1255" alt="Screenshot 2024-10-10 at 18 04 34" src="https://github.com/user-attachments/assets/4043d58c-958b-4c14-83af-d319e59fdf18">
<img width="1449" alt="Screenshot 2024-10-10 at 18 07 15" src="https://github.com/user-attachments/assets/753390ed-010e-40a1-87a4-0f76ec094527">
<img width="1459" alt="Screenshot 2024-10-10 at 18 06 03" src="https://github.com/user-attachments/assets/053696d4-47a7-48b7-a1a9-a300c4b945c8">
<img width="1445" alt="Screenshot 2024-10-10 at 18 05 37" src="https://github.com/user-attachments/assets/ffc39035-39fe-4f26-9295-73a1201e61b6">
<img width="1447" alt="Screenshot 2024-10-10 at 18 05 25" src="https://github.com/user-attachments/assets/4cd35513-4cbb-4623-84d7-25e2ebfc2441">
<img width="1446" alt="Screenshot 2024-10-10 at 18 05 15" src="https://github.com/user-attachments/assets/e1237088-7a78-4e5f-a9c6-739a7959c0b2">
<img width="1448" alt="Screenshot 2024-10-10 at 18 05 03" src="https://github.com/user-attachments/assets/7aa4c6d6-ad28-4723-bb99-63a7bbd4b9d7">
<img width="1462" alt="Screenshot 2024-10-10 at 18 04 44" src="https://github.com/user-attachments/assets/24cd648a-538c-4b9a-bcb2-fb01ed6f146f">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the flow from Tools -> Import -> Substack

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
