### PR TITLE
E2E tests fix in GB build

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -20,8 +20,10 @@ export class InstagramBlockFlow implements BlockFlow {
 		this.configurationData = configurationData;
 	}
 
-	blockSidebarName = 'Instagram';
+	blockSidebarName = 'Instagram Embed';
+	blockTestFallBackName = 'Instagram';
 	blockEditorSelector = '[aria-label="Block: Embed"]:has-text("Instagram URL")';
+	noSearch = false;
 
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
@@ -29,7 +29,6 @@ export class TwitterBlockFlow implements BlockFlow {
 	}
 
 	blockSidebarName = 'Twitter Embed';
-	blockTestFallBackName = 'Twitter';
 	blockEditorSelector = blockParentSelector;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
@@ -9,6 +9,7 @@ export interface BlockFlow {
 	blockTestName?: string;
 	blockTestFallBackName?: string;
 	blockEditorSelector: string;
+	noSearch?: boolean;
 	configure?( context: EditorContext ): Promise< void >;
 	validateAfterPublish?( context: PublishedPostContext ): Promise< void >;
 }

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
@@ -29,7 +29,6 @@ export class YouTubeBlockFlow implements BlockFlow {
 	}
 
 	blockSidebarName = 'YouTube Embed';
-	blockTestFallBackName = 'YouTube';
 	blockEditorSelector = blockParentSelector;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
@@ -10,7 +10,7 @@ const selectors = {
 	embedUrlInput: `${ blockParentSelector } input`,
 	embedButton: `${ blockParentSelector } button:has-text("Embed")`,
 	editorYouTubeIframe: 'iframe[title="Embedded content from www.youtube.com"]',
-	publishedYouTubeIframe: `iframe.youtube-player`,
+	publishedYouTubeIframe: '',
 };
 
 /**
@@ -26,6 +26,7 @@ export class YouTubeBlockFlow implements BlockFlow {
 	 */
 	constructor( configurationData: ConfigurationData ) {
 		this.configurationData = configurationData;
+		selectors.publishedYouTubeIframe = `iframe[title="${ this.configurationData.expectedVideoTitle }"]`;
 	}
 
 	blockSidebarName = 'YouTube Embed';

--- a/test/e2e/specs/blocks/blocks__core.ts
+++ b/test/e2e/specs/blocks/blocks__core.ts
@@ -13,7 +13,7 @@ import { createBlockTests } from './shared/block-smoke-testing';
 const blockFlows: BlockFlow[] = [
 	new YouTubeBlockFlow( {
 		embedUrl: 'https://www.youtube.com/watch?v=twGLN4lug-I',
-		expectedVideoTitle: 'Getting Started on @wordpress-com',
+		expectedVideoTitle: 'Getting started on @wordpressdotcom',
 	} ),
 	new LayoutGridBlockFlow( {
 		leftColumnText: DataHelper.getRandomPhrase(),

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -17,9 +17,13 @@ import {
 	envVariables,
 	getTestAccountByFeature,
 	envToFeatureKey,
+	BlockFlow,
+	LayoutGridBlockFlow,
+	YouTubeBlockFlow,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH, TEST_AUDIO_PATH, TEST_VIDEO_PATH } from '../constants';
+import { createBlockTests } from './shared/block-smoke-testing';
 
 declare const browser: Browser;
 
@@ -169,3 +173,16 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		} );
 	} );
 } );
+
+const blockFlows: BlockFlow[] = [
+	new YouTubeBlockFlow( {
+		embedUrl: 'https://www.youtube.com/watch?v=twGLN4lug-I',
+		expectedVideoTitle: 'Getting Started on @wordpress-com',
+	} ),
+	new LayoutGridBlockFlow( {
+		leftColumnText: DataHelper.getRandomPhrase(),
+		rightColumnText: DataHelper.getRandomPhrase(),
+	} ),
+];
+
+createBlockTests( 'Blocks: Core', blockFlows );

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -17,13 +17,9 @@ import {
 	envVariables,
 	getTestAccountByFeature,
 	envToFeatureKey,
-	BlockFlow,
-	LayoutGridBlockFlow,
-	YouTubeBlockFlow,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH, TEST_AUDIO_PATH, TEST_VIDEO_PATH } from '../constants';
-import { createBlockTests } from './shared/block-smoke-testing';
 
 declare const browser: Browser;
 
@@ -173,16 +169,3 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		} );
 	} );
 } );
-
-const blockFlows: BlockFlow[] = [
-	new YouTubeBlockFlow( {
-		embedUrl: 'https://www.youtube.com/watch?v=twGLN4lug-I',
-		expectedVideoTitle: 'Getting Started on @wordpress-com',
-	} ),
-	new LayoutGridBlockFlow( {
-		leftColumnText: DataHelper.getRandomPhrase(),
-		rightColumnText: DataHelper.getRandomPhrase(),
-	} ),
-];
-
-createBlockTests( 'Blocks: Core', blockFlows );

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -69,7 +69,7 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 						blockFlow.blockSidebarName,
 						blockFlow.blockEditorSelector,
 						{
-							noSearch: ! blockFlow.noSearch === false,
+							noSearch: blockFlow.noSearch === false ? false : true,
 							blockFallBackName: blockFlow.blockTestFallBackName,
 						}
 					);

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -68,7 +68,10 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 					const blockHandle = await editorPage.addBlockFromSidebar(
 						blockFlow.blockSidebarName,
 						blockFlow.blockEditorSelector,
-						{ noSearch: true, blockFallBackName: blockFlow.blockTestFallBackName }
+						{
+							noSearch: ! blockFlow.noSearch === false,
+							blockFallBackName: blockFlow.blockTestFallBackName,
+						}
 					);
 					const id = await blockHandle.getAttribute( 'id' );
 					const editorCanvas = await editorPage.getEditorCanvas();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to fixing e2e tests on Gutenberg build https://teamcity.a8c.com/viewLog.html?buildId=13488805

## Proposed Changes

* Gutenberg has a set of social icon blocks which often have the same name as the Embed blocks. So some E2E tests insert the social icon block instead which fails the rest of the test.

"YouTube Embed" block had a fallback named "YouTube", we've removed that to prevent the E2E from selecting the YouTube icon because of that.

Instagram's embed block name should be changed to "Instagram Embed" from "Instagram". As both of these blocks have the same name, I've made the test search in the inserter first using "Instagram embed" so that only the Embedding block remains. And then went with the inserting process.

The actual solution for this Instagram block would be to change the block's name in Gutenberg. So the current fix is a temporary one to enable a faster release. I'll create a PR on GB changing the name of the block later. Then we can remove this workaround.

<img width="695" alt="Screenshot 2024-10-10 at 7 38 53 PM" src="https://github.com/user-attachments/assets/bc47b0fb-08e0-42a1-97c6-178329d6b52c">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Gutenberg E2E tests should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
