### PR TITLE
A4A: Update Licenses page actions

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -371,6 +371,7 @@ export default function LicensePreview( {
 					{ isWPCOMLicense && isSiteAtomic ? (
 						<LicenseActions
 							siteUrl={ siteUrl }
+							isDevSite={ isDevelopmentSite }
 							attachedAt={ attachedAt }
 							revokedAt={ revokedAt }
 							licenseType={ licenseType }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
@@ -7,6 +7,7 @@ import useLicenseActions from './use-license-actions';
 
 interface Props {
 	siteUrl: string | null;
+	isDevSite: boolean;
 	attachedAt: string | null;
 	revokedAt: string | null;
 	licenseType: LicenseType;
@@ -15,6 +16,7 @@ interface Props {
 
 export default function LicenseActions( {
 	siteUrl,
+	isDevSite,
 	attachedAt,
 	revokedAt,
 	licenseType,
@@ -26,6 +28,7 @@ export default function LicenseActions( {
 
 	const licenseActions = useLicenseActions(
 		siteUrl,
+		isDevSite,
 		attachedAt,
 		revokedAt,
 		licenseType,

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -41,7 +41,7 @@ export default function useLicenseActions(
 		return [
 			{
 				name: translate( 'Set up site' ),
-				href: `https://wordpress.com/home/${ siteSlug }`,
+				href: `https://wordpress.com/overview/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_site_set_up_click' ),
 				isExternalLink: true,
 				isEnabled: true,

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -14,6 +14,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export default function useLicenseActions(
 	siteUrl: string | null,
+	isDevSite: boolean,
 	attachedAt: string | null,
 	revokedAt: string | null,
 	licenseType: LicenseType,
@@ -39,6 +40,13 @@ export default function useLicenseActions(
 
 		const licenseState = getLicenseState( attachedAt, revokedAt );
 		return [
+			{
+				name: translate( 'Prepare for launch' ),
+				href: `https://wordpress.com/settings/general/${ siteSlug }`,
+				onClick: () => handleClickMenuItem( 'prepare_for_launch' ),
+				isExternalLink: true,
+				isEnabled: isDevSite,
+			},
 			{
 				name: translate( 'Set up site' ),
 				href: `https://wordpress.com/overview/${ siteSlug }`,
@@ -94,6 +102,7 @@ export default function useLicenseActions(
 		canRevoke,
 		dispatch,
 		isChildLicense,
+		isDevSite,
 		licenseType,
 		revokedAt,
 		siteUrl,

--- a/packages/components/src/external-link/index.jsx
+++ b/packages/components/src/external-link/index.jsx
@@ -36,7 +36,15 @@ class ExternalLink extends Component {
 		} );
 
 		const props = {
-			...omit( this.props, 'icon', 'iconSize', 'showIconFirst', 'iconClassName', 'iconComponent' ),
+			...omit(
+				this.props,
+				'icon',
+				'iconSize',
+				'showIconFirst',
+				'iconClassName',
+				'iconComponent',
+				'localizeUrl'
+			),
 			className: classes,
 			rel: 'external',
 		};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9370.
Fixes https://github.com/Automattic/dotcom-forge/issues/9383.

## Proposed Changes

* add `Prepare for launch` action item to the Licenses page
* change the `Set up site` action link from `https://wordpress.com/home/${ siteSlug }` to `https://wordpress.com/overview/${ siteSlug }` on the Licenses page
* fix https://github.com/Automattic/dotcom-forge/issues/9383

![Markup on 2024-10-10 at 16:45:39](https://github.com/user-attachments/assets/05350a08-b5c4-4e48-b198-91b90938a37a)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* related task: https://github.com/Automattic/dotcom-forge/issues/9370

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `yarn start-a8c-for-agencies`.
2. Make sure you have at least one Development license.
3. Navigate to the Licenses page at http://agencies.localhost:3000/purchases/licenses.
4. Click on the action menu on the side and review the options:
  - Each Development license row should have a new `Prepare for launch` action that should lead to the correct Hosting (General) settings page. This option shouldn't be available on "non-development" licenses.
  - All `Set up site` actions should link to `https://wordpress.com/overview/${ siteSlug }` instead of `https://wordpress.com/overview/${ siteSlug }`.
5. Whiles on the Licenses page, open the browser Console. There should be no `Warning: React does not recognize the `localizeUrl` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `localizeurl` instead. If you accidentally passed it from a parent component, remove it from the DOM element.` warning.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
