### PR TITLE
e2e: Fix Map block test

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
@@ -47,7 +47,7 @@ export class MapFlow implements BlockFlow {
 			// Enter the supplied address.
 			const editorParent = await context.editorPage.getEditorParent();
 			await editorParent
-				.getByRole( 'textbox', { name: 'Add a marker' } )
+				.getByPlaceholder( 'Add a marker' )
 				.type( this.configurationData.address, { delay: 5 } );
 
 			// Wait for the popover and click on the first matching item.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Switch the test to look for the placeholder specifically, instead of the name, which will work with both the old and new code.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Automattic/jetpack#39708 associated the "Add a location" `<label>` with the `<input>`, which makes Playwright use that as the accessible name for the input rather than the input's placeholder.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the test against jetpackedge sites and other sites, e.g.
  * `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-other.ts`
  * `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" TEST_ON_ATOMIC="true" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-other.ts`
  * `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-other.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
