### PR TITLE
Tracking: Add user_lang to calypso events

### DIFF
--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -195,6 +195,12 @@ export function signalUserFromAnotherProduct( userId: string, userIdType: string
 export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 	eventProperties = eventProperties || {};
 
+	const currentUser = getCurrentUser();
+
+	if ( currentUser?.localeSlug ) {
+		eventProperties[ 'user_lang' ] = currentUser.localeSlug;
+	}
+
 	const trackingPrefs = getTrackingPrefs();
 	if ( ! trackingPrefs?.buckets.analytics ) {
 		debug(

--- a/packages/calypso-analytics/src/utils/current-user.ts
+++ b/packages/calypso-analytics/src/utils/current-user.ts
@@ -9,6 +9,7 @@ export interface SetCurrentUserParams {
 	ID: string;
 	username: string;
 	email: string;
+	localeSlug: string;
 }
 
 export interface CurrentUserHashedPii {
@@ -22,6 +23,7 @@ export interface CurrentUser {
 	username: string;
 	email: string;
 	hashedPii: CurrentUserHashedPii;
+	localeSlug: string;
 }
 
 /**
@@ -51,6 +53,7 @@ export function setCurrentUser( currentUser: SetCurrentUserParams ): CurrentUser
 		ID: parseInt( currentUser.ID, 10 ),
 		username: currentUser.username,
 		email: currentUser.email,
+		localeSlug: currentUser.localeSlug,
 		hashedPii: {
 			ID: hashPii( currentUser.ID ),
 			username: hashPii( currentUser.username.toLowerCase().replace( /\s/g, '' ) ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1728549835064569-slack-C073776NJ66

## Proposed Changes

Let's add `user-lang` to the tracking!

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

With `wpcom_...`events, we are able to build funnels using `user_lang` property to segment the users. With calypso events, this is not possible.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Live link
2. Go through onboarding and check that `calypso...` events have a `user_lang` property
