### PR TITLE
Handle optional query parameter to skip pricing page after user connection

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -975,8 +975,12 @@ export class JetpackAuthorize extends Component {
 			return `/checkout/${ urlToSlug( homeUrl ) }/${ selectedPlanSlug }`;
 		}
 
-		// If the site has a Jetpack paid product send the user back to wp-admin rather than to the Plans page.
-		if ( siteHasJetpackPaidProduct ) {
+		const urlParams = new URLSearchParams( window.location.search );
+		const skipPricing = urlParams.get( 'skip_pricing' );
+
+		// If the site has a Jetpack paid product or the manual query parameter to skip plans
+		// send the user back to wp-admin rather than to the Plans page.
+		if ( siteHasJetpackPaidProduct || skipPricing ) {
 			debug(
 				'authorization-form: getRedirectionTarget -> Site already has a paid product, redirection target is: %s',
 				redirectAfterAuth


### PR DESCRIPTION
## Proposed Changes

* Handle an optional query parameter to skip pricing page after user connection

## Why are these changes being made?

P2: pbNhbs-bPS-p2

There are some instances in the plugin where we don't want to show the user a pricing page if they are just trying to connect their account to use a feature

## Testing Instructions

1. Create a Jurassic Ninja site
2. Go to `/wp-admin/admin.php?page=my-jetpack#/connection`
3. Select `Connect your user account`
4. When you get to the authorization screen, add `&skip_pricing=true` to the end of your current URL and replace `wordpress.com` with the base of the Calypso blue live link ([example URL](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=237899194&redirect_uri=https%3A%2F%2Fdevotedly-fluffy-tern.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D8a91375f6f%26redirect%3Dhttps%253A%252F%252Fdevotedly-fluffy-tern.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dmy-jetpack&state=1&scope=administrator%3A8a5190eb0c635e17eae460eb262c0887&user_email=dylan.munson%40automattic.com&user_login=munson1996&jp_version=14.0-a.1&secret=SVt9r3pwYvNghioZWZqTJvbrjr5yfriF&blogname=Devotedly+Fluffy+Tern&site_url=https%3A%2F%2Fdevotedly-fluffy-tern.jurassic.ninja&home_url=https%3A%2F%2Fdevotedly-fluffy-tern.jurassic.ninja&site_icon&site_lang=en_US&site_created=2024-10-10+18%3A38%3A56&allow_site_connection=1&calypso_env&source&locale=en&_ui=218809874&_ut=wpcom%3Auser_id&_as=wp-cli&from=my-jetpack&purchase_nonce=cks4fKfZ&_wp_nonce=0cc71c6ac8&redirect_after_auth=https%3A%2F%2Fdevotedly-fluffy-tern.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dmy-jetpack&site=https%3A%2F%2Fdevotedly-fluffy-tern.jurassic.ninja&skip_pricing=true)
5. Either log-in or click "Approve"
6. Ensure you are redirected back to My Jetpack instead of the pricing page

https://github.com/user-attachments/assets/7813b8fd-c755-485e-a3ff-372272007a05



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?