### PR TITLE
Performance Profiler: Update the width for the MessageDisplay component

### DIFF
--- a/client/performance-profiler/components/message-display/style.scss
+++ b/client/performance-profiler/components/message-display/style.scss
@@ -47,7 +47,7 @@ $blueberry-color: #3858e9;
 		justify-content: center;
 		gap: 64px;
 		min-height: 700px;
-		width: 50%;
+		max-width: 560px;
 
 		.main-message {
 			display: flex;
@@ -63,6 +63,8 @@ $blueberry-color: #3858e9;
 				padding: 16px;
 				padding-left: 52px;
 				position: relative;
+				max-width: 528px;
+				box-sizing: border-box;
 
 				.gridicon {
 					position: absolute;


### PR DESCRIPTION

Related to https://github.com/Automattic/wp-calypso/pull/95227

## Proposed Changes

Set a `max-width` for the MessageDisplay component and for the error message container.

## Why are these changes being made?

The previous solution was to use 50% of the width which makes it look weird on mobile views. 
A better solution is set a max width for desktop and let it use the entire space when on mobile.

## Testing Instructions


* Go to the pages mentioned on the next points and check if they resize as expected
* Go to the weekly report page: `/speed-test-tool/weekly-report?url=https://wordpress.com/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6OTIxNn0.n0Ypw8Xr5Vuw9t2NsMqtOLs8wVpixwGiqbj-NzXbrHQ&filter=lcp`
* Go to the unsubscribe page: `/speed-test-tool/weekly-report/unsubscribe?url=https://wordpress.com/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6OTIxNn0.n0Ypw8Xr5Vuw9t2NsMqtOLs8wVpixwGiqbj-Nz`
* Go to the error page: `/speed-test-tool?url=https://wordpress.com/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6OTIxNn0.n0Ypw8Xr5Vuw9t2NsMqtOLs8wVpixwGiqbj-Nz`


#### Before  
![old](https://github.com/user-attachments/assets/75e156fc-2609-4699-9910-3d7774fdb26a)

#### After
https://github.com/user-attachments/assets/8863e2b6-5bbd-4a71-a577-75b9446af5b1

