### PR TITLE
A4A: Do not count a WPCOM dev site as an active license.

### DIFF
--- a/client/a8c-for-agencies/hooks/use-wpcom-owned-sites.ts
+++ b/client/a8c-for-agencies/hooks/use-wpcom-owned-sites.ts
@@ -50,7 +50,10 @@ export default function useWPCOMOwnedSites() {
 	return {
 		count: isReady
 			? licenses.filter(
-					( license ) => license.productId === creatorPlan?.product_id && ! license.referral // We make sure we do not count referrals
+					( license ) =>
+						license.productId === creatorPlan?.product_id &&
+						! license.referral && // We make sure we do not count referrals
+						! license.meta?.isDevSite // And also a dev site
 			  ).length
 			: 0,
 		isReady,


### PR DESCRIPTION
This PR resolves the issue where the UI incorrectly counts WPCOM dev sites as valid licenses for discount calculations. We need to disregard dev sites when determining WPCOM discount tiers.

Context: p1728601341722189-slack-C06JY8QL0T

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1255

## Proposed Changes

* Update the license filtering when calculating the total licenses owned to account for dev sites.

## Why are these changes being made?
We must ensure the appropriate discount is applied to billed licenses.

## Testing Instructions

**Suggestion: Revoking your active WPCOM licenses beforehand will make this testing much easier.**

* Count how much active WPCOM licenses you have. This can easily be checked if you go to the `/marketplace/hosting/wpcom` page. The page should display a counter.
* Now spin up a WPCOM dev site.
* Confirm that the WPCOM license count does not increment.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?