### PR TITLE
Cleanup experiment code

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,7 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { HOSTING_LP_FLOW, ONBOARDING_FLOW, ONBOARDING_GUIDED_FLOW } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
-import { onEnterOnboarding } from '../flow-actions';
 
 const noop = () => {};
 
@@ -175,7 +174,6 @@ export function generateFlows( {
 			providesDependenciesInQuery: [ 'coupon' ],
 			optionalDependenciesInQuery: [ 'coupon' ],
 			hideProgressIndicator: true,
-			onEnterFlow: onEnterOnboarding,
 		},
 		{
 			name: ONBOARDING_FLOW,
@@ -187,7 +185,6 @@ export function generateFlows( {
 			providesDependenciesInQuery: [ 'coupon' ],
 			optionalDependenciesInQuery: [ 'coupon' ],
 			hideProgressIndicator: true,
-			onEnterFlow: onEnterOnboarding,
 		},
 		{
 			name: 'plans-first',

--- a/client/signup/flow-actions.ts
+++ b/client/signup/flow-actions.ts
@@ -1,8 +1,0 @@
-import { loadExperimentAssignment } from 'calypso/lib/explat';
-
-export const onEnterOnboarding = ( flowName: string ) => {
-	// just to be extra safe since `loadExperimentAssignment` doesn't have the same eligibility check like `useExperiment` does
-	if ( flowName === 'onboarding' ) {
-		loadExperimentAssignment( 'calypso_signup_onboarding_deemphasize_free_plan' );
-	}
-};


### PR DESCRIPTION

## Proposed Changes

* I noticed that the signup page still fires the experiment assignment API for `calypso_signup_onboarding_deemphasize_free_plan`. Since this experiment is no longer active, we can remove the code.

