### PR TITLE
Onboarding: Query all products for the with-plugin onboarding flow

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1416,6 +1416,7 @@ export class RenderDomainsStep extends Component {
 
 		const headerText = this.getHeaderText();
 		const fallbackSubHeaderText = this.getSubHeaderText();
+		const queryProductsType = flowName === 'with-plugin' ? 'all' : 'domains';
 
 		if ( useStepperWrapper ) {
 			return (
@@ -1429,7 +1430,7 @@ export class RenderDomainsStep extends Component {
 					shouldHideNavButtons={ this.shouldHideNavButtons() }
 					stepContent={
 						<div>
-							<QueryProductsList type="domains" />
+							<QueryProductsList type={ queryProductsType } />
 							{ this.renderContent() }
 						</div>
 					}
@@ -1466,7 +1467,7 @@ export class RenderDomainsStep extends Component {
 				shouldHideNavButtons={ this.shouldHideNavButtons() }
 				stepContent={
 					<div>
-						<QueryProductsList type="domains" />
+						<QueryProductsList type={ queryProductsType } />
 						{ this.renderContent() }
 					</div>
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9378

The linked task contains a video with the working flow https://github.com/Automattic/dotcom-forge/issues/9378#issuecomment-2407249121

## Proposed Changes

* Check if the onboarding flow is `with-plugin` to query all products

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* An optimization change was done to query only domain products during the domain step as part of this PR https://github.com/Automattic/wp-calypso/pull/89716. But this step can be executed during the `with-plugins` flow that requires all products to be queried

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this patch
- Go to [WordPress.com/plugins](http://wordpress.com/plugins) (logged-out) and select a plugin (Sensei PRO)
Login/create an account
- Pick a domain
- You'll land in checkout (
- Check that the Sensei PRO subscription is in the checkout page
- Purchase the plan and the product
- Check the purchase is completed successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
