### PR TITLE
Jetpack Cloud: Remove Sites V2 section from staging

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config, { enable, isEnabled } from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 import JetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 import SitesSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/sites';
@@ -45,10 +45,6 @@ export const agencyDashboardContext: Callback = ( context, next ) => {
 	const showSitesDashboardV2 =
 		isSectionNameEnabled( 'jetpack-cloud-agency-sites-v2' ) &&
 		context.section.paths[ 0 ] === sitesPath();
-
-	if ( showSitesDashboardV2 && ! isEnabled( 'jetpack/manage-sites-v2-menu' ) ) {
-		enable( 'jetpack/manage-sites-v2-menu' );
-	}
 
 	// TODO: This insert dynamically into the body the class sites-dashboard-v2 to be able to modify some styles outside
 	//  of the SitesDashboardV2 context. This way it won't affect the current styles in any context (dev, staging, production).

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -87,7 +87,7 @@
 		"jetpack-cloud": true,
 		"jetpack-cloud-overview": true,
 		"jetpack-cloud-agency-dashboard": true,
-		"jetpack-cloud-agency-sites-v2": true,
+		"jetpack-cloud-agency-sites-v2": false,
 		"jetpack-cloud-agency-signup": true,
 		"jetpack-cloud-auth": true,
 		"jetpack-cloud-features-comparison": true,


### PR DESCRIPTION
Context: p1728641232513569-slack-C06DN6QQVAQ 

## Proposed Changes

This PR removes the Sites V2 from Jetpack Cloud (Staging). This section is activated only if you type `https://cloud.jetpack.com/sites` **in staging (only)**. The intention was to facilitate the development and the design review. Now, that project was moved to A4A and the new version of Jetpack Manage was temporary abandoned.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Test it on staging.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?