### PR TITLE
Domains: Fix domains placeholder styling

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -16,7 +16,7 @@
 	&.is-clickable {
 		cursor: pointer;
 
-		// NOTE: easeOutExpo easing function from http://easings.net/#easeOutExpo
+		/* NOTE: easeOutExpo easing function from http://easings.net/#easeOutExpo */
 		transition: box-shadow 0.25s cubic-bezier(0.19, 1, 0.22, 1);
 
 		&:hover {
@@ -147,17 +147,9 @@
 
 	@include breakpoint-deprecated( ">660px" ) {
 		.is-placeholder & {
-			margin-right: 50%;
 			min-height: 22px;
 		}
 
-		.is-placeholder:nth-of-type(2n + 1) & {
-			margin-right: 52%;
-		}
-
-		.is-placeholder:nth-of-type(1) & {
-			margin-right: 40%;
-		}
 	}
 
 	> h3 {
@@ -443,7 +435,7 @@ body.is-section-signup.is-white-signup {
 		&:not(.featured-domain-suggestion) {
 			background: none;
 			border-bottom: 1px solid rgba(220, 220, 222, 0.64);
-			border-top: 1px solid #fff; //This white border is to prevent jumpiness while showing borders on hover
+			border-top: 1px solid #fff; /*This white border is to prevent jumpiness while showing borders on hover*/
 			padding: 16px 20px;
 
 			@include break-mobile {

--- a/client/components/domains/featured-domain-suggestions/placeholder.jsx
+++ b/client/components/domains/featured-domain-suggestions/placeholder.jsx
@@ -4,13 +4,12 @@ export default function FeaturedDomainSuggestionsPlaceholder() {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="featured-domain-suggestion featured-domain-suggestion--is-placeholder card is-compact is-clickable">
+			<div className="domain-registration-suggestion__badges" />
 			<div className="domain-suggestion__content">
-				<div className="domain-registration-suggestion__title" />
+				<div className="domain-registration-suggestion__title-info" />
 				<div className="domain-product-price" />
-				<div className="domain-registration-suggestion__badges" />
-				<div className="domain-registration-suggestion__match-reasons" />
 			</div>
-			<div className="domain-suggestion__action" />
+			<div className="domain-suggestion__action-container" />
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/components/domains/featured-domain-suggestions/placeholder.scss
+++ b/client/components/domains/featured-domain-suggestions/placeholder.scss
@@ -32,6 +32,7 @@
 	}
 	.domain-suggestion__action-container {
 		height: 40px;
+		margin-bottom: 6px;
 	}
 
 	.domain-suggestion__content {

--- a/client/components/domains/featured-domain-suggestions/placeholder.scss
+++ b/client/components/domains/featured-domain-suggestions/placeholder.scss
@@ -1,10 +1,14 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
-.featured-domain-suggestion--is-placeholder {
+.featured-domain-suggestion.featured-domain-suggestion--is-placeholder {
 	min-height: 222px;
 
 	.domain-registration-suggestion__title,
 	.domain-registration-suggestion__badges,
-	.domain-registration-suggestion__match-reasons,
+	.domain-suggestion__action-container,
+	.domain-product-price,
+	.domain-registration-suggestion__title-info,
 	.domain-suggestion__action {
 		animation: loading-fade 1.6s ease-in-out infinite;
 		background-color: var(--color-neutral-0);
@@ -16,16 +20,24 @@
 		width: 60%;
 		height: 45px;
 	}
+	.domain-registration-suggestion__title-info,
 	.domain-product-price {
 		height: 18px;
 	}
 	.domain-registration-suggestion__badges {
 		height: 22px;
+		width: 20%;
+		align-self: start !important;
+
 	}
-	.domain-registration-suggestion__match-reasons {
-		height: 52px;
-	}
-	.domain-suggestion__action {
+	.domain-suggestion__action-container {
 		height: 40px;
+	}
+
+	.domain-suggestion__content {
+		flex-grow: 0;
+		@include break-mobile {
+			flex-grow: 1;
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

More context p1728642322633149-slack-C041RHH38NQ

## Proposed Changes

* This [PR](https://github.com/Automattic/wp-calypso/pull/94852) misaligned the placeholders when searching for domains.
This is fixing styling issues and making it look pretty again.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix production styling issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link
* Navigate to any flow using `/start` or `/stepper`, when reaching the `domains` step
* Make sure the placeholders are in place when searching for any domains.


Reference image

Before 
<img width="819" alt="image" src="https://github.com/user-attachments/assets/828301ea-27f7-42a2-9c80-0f8deb634b49">


After
<img width="824" alt="image" src="https://github.com/user-attachments/assets/4adac38c-ef21-4b6c-886b-6b550599817a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?