### PR TITLE
Stepper: Fix domains not showed as free first year

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -16,7 +16,7 @@ import {
 	getSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
+import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import {
 	currentUserHasFlag,
 	getCurrentUser,
@@ -61,7 +61,9 @@ const RenderDomainsStepConnect = connect(
 			isPlanSelectionAvailableLaterInFlow: true,
 			userLoggedIn,
 			multiDomainDefaultPlan,
-			domainsWithPlansOnly: currentUserHasFlag( state as object, DOMAINS_WITH_PLANS_ONLY ),
+			domainsWithPlansOnly: getCurrentUser( state as object )
+				? currentUserHasFlag( state as object, NON_PRIMARY_DOMAINS_TO_FREE_USERS ) // this is intentional, not a mistake
+				: true,
 			flowName: flow,
 			path: window.location.pathname,
 			positionInFlow: 1,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1728643686681209/1728637464.426589-slack-C073776NJ66

## Proposed Changes

This changes the way the property `domainsWithPlansOnly` is calculated in Stepper, making the value identical to Start.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There are differences between Start and Stepper

Stepper
<img width="735" alt="image" src="https://github.com/user-attachments/assets/9f35a2ea-d0e9-466c-afbf-4cf13a86744c">

Start
<img width="723" alt="image" src="https://github.com/user-attachments/assets/e9b073a1-9cb4-4ecd-8ce7-68683de92f07">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Incognito, compare /setup/onboarding/es and /start/onboarding/es