### PR TITLE
Reader Onboarding: Clicking "Continue" Opens Step 2

### DIFF
--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -11,6 +11,11 @@ const ReaderOnboarding = () => {
 	const [ isInterestsModalOpen, setIsInterestsModalOpen ] = useState( false );
 	const [ isDiscoverModalOpen, setIsDiscoverModalOpen ] = useState( false );
 
+	const handleInterestsContinue = () => {
+		setIsInterestsModalOpen( false );
+		setIsDiscoverModalOpen( true );
+	};
+
 	const itemClickHandler = ( task: Task ) => {
 		recordTracksEvent( 'calypso_reader_onboarding_task_click', {
 			task: task.id,
@@ -64,6 +69,7 @@ const ReaderOnboarding = () => {
 			<InterestsModal
 				isOpen={ isInterestsModalOpen }
 				onClose={ () => setIsInterestsModalOpen( false ) }
+				onContinue={ handleInterestsContinue }
 			/>
 			<SubscribeModal
 				isOpen={ isDiscoverModalOpen }

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -11,6 +11,7 @@ import './style.scss';
 interface InterestsModalProps {
 	isOpen: boolean;
 	onClose: () => void;
+	onContinue: () => void;
 }
 
 interface Topic {
@@ -27,7 +28,7 @@ interface Tag {
 	slug: string;
 }
 
-const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) => {
+const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onContinue } ) => {
 	const [ followedTags, setFollowedTags ] = useState< string[] >( [] );
 	const followedTagsFromState = useSelector( getReaderFollowedTags );
 	const dispatch = useDispatch();
@@ -54,6 +55,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose } ) 
 	const handleContinue = () => {
 		if ( ! isContinueDisabled ) {
 			onClose();
+			onContinue();
 		}
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/187

## Proposed Changes

* Clicking the "Continue" button in "Step 1" opens the "Step 2" modal.



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Pushing the Reader Onboarding project forward.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/onboarding 
* Click on "Select some of your interests" in the top banner
* The interest overlay modal will popup
* If you're following more than 3 topics, the Continue button will be enabled.
* Click "Continue"
* It should open the "Step 2" discovery modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
