### PR TITLE
[WIP] Payments: Include mandate options in SetupIntent creation

### DIFF
--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -231,6 +231,19 @@ export async function createStripeSetupIntent(
 				card: element,
 				billing_details: paymentDetails,
 			},
+			payment_method_options: {
+				card: {
+					mandate_options: {
+						amount: 10,
+						amount_type: 'maximum',
+						currency: 'INR',
+						interval: 'sporadic',
+						reference: '{{Reference Number}}',
+						start_date: Date( 'now' ),
+						payment_method_options,
+					},
+				},
+			},
 		} );
 	} catch ( error ) {
 		// Some errors are thrown by confirmCardSetup and not returned as an error

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -286,6 +286,27 @@ export async function confirmStripePaymentIntent(
 }
 
 /**
+ * Return Object with mandate option values to be included in creating a SetupIntent
+ *
+ * @param {ShoppingCart} ShoppingCart The shopping cart for the SetupIntent
+ * @returns {Object} An object keyed by the fields needed for the mandate options
+ */
+function getMandateOptionsFromShoppingCart(
+	shoppingCart: ShoppingCart
+): Object {
+	return {
+		amount: 10, // Get value from shopping cart
+		amount_type: 'maximum',
+		currency: 'INR', // Get currency from shopping cart
+		interval: 'sporadic',
+		reference: '{{Reference Number}}', // Get Order ID from shopping cart
+		description: 'WordPress.com Billing', // Get service from shopping cart
+		start_date: Date(), // Get the current timestamp
+		supported_types: 'india',
+	};
+}
+
+/**
  * Extract validation errors from a Stripe error
  *
  * Returns null if validation errors cannot be found.

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -225,6 +225,7 @@ export async function createStripeSetupIntent(
 ): Promise< StripeSetupIntent > {
 	debug( 'creating setup intent...', paymentDetails );
 	let stripeResponse;
+	const mandateOptions = getMandateOptionsFromShoppingCart();
 	try {
 		stripeResponse = await stripe.confirmCardSetup( setupIntentId, {
 			payment_method: {
@@ -234,13 +235,14 @@ export async function createStripeSetupIntent(
 			payment_method_options: {
 				card: {
 					mandate_options: {
-						amount: 10,
-						amount_type: 'maximum',
-						currency: 'INR',
-						interval: 'sporadic',
-						reference: '{{Reference Number}}',
-						start_date: Date( 'now' ),
-						payment_method_options,
+						amount: mandateOptions.amount,
+						amount_type: mandateOptions.amount_type,
+						currency: mandateOptions.currency,
+						interval: mandateOptions.interval,
+						reference: mandateOptions.reference,
+						description: mandateOptions.description,
+						start_date: mandateOptions.start_date,
+						supported_types: mandateOptions.supported_types,
 					},
 				},
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This is a work in progress. The code is not meant to be deployed as is. It is a placeholder of pseudocode to start exploring where to add e-mandate objects to the SetupIntent creation.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
