### PR TITLE
Stats: Load usage data for paywall gate on the Insights page

### DIFF
--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -1,7 +1,8 @@
 import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { connect, useDispatch } from 'react-redux';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -11,6 +12,8 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import StatsModuleComments from 'calypso/my-sites/stats/features/modules/stats-comments';
 import StatShares from 'calypso/my-sites/stats/features/modules/stats-shares';
 import StatsModuleTags from 'calypso/my-sites/stats/features/modules/stats-tags';
+import usePlanUsageQuery from 'calypso/my-sites/stats/hooks/use-plan-usage-query';
+import { STATS_PLAN_USAGE_RECEIVE } from 'calypso/state/action-types';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import AllTimeHighlightsSection from '../../sections/all-time-highlights-section';
@@ -26,6 +29,19 @@ const StatsInsights = ( props ) => {
 	const translate = useTranslate();
 	const moduleStrings = statsStrings();
 	const isEmptyStateV2 = config.isEnabled( 'stats/empty-module-v2' );
+	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
+	const reduxDispatch = useDispatch();
+
+	// Dispatch the plan usage data to the Redux store for monthly views check in shouldGateStats.
+	useEffect( () => {
+		if ( ! isPending ) {
+			reduxDispatch( {
+				type: STATS_PLAN_USAGE_RECEIVE,
+				siteId,
+				data: usageInfo,
+			} );
+		}
+	}, [ reduxDispatch, isPending, siteId, usageInfo ] );
 
 	const statsModuleListClass = clsx(
 		'stats__module-list--insights',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1728563254778869-slack-C0438NHCLSY

## Proposed Changes

* Query Stats usage info to check the paywall gate for the Insights page modules.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Stats usage info is fetched in the `LoadStatsPage` component for sharing. We need to query the usage directly on the Insights page for direct page refreshing, as the page is not wrapped with the `LoadStatsPage` component anymore.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Prepare a Jetpack site gated with the Stats commercial paywall.
* Navigate to Stats > Insights page: `/stats/insights/{site-slug}`.
* Refresh the Insights page directly.
* Ensure the `All-time highlights` cards, `All-time insights`, `Tags & categories`, and `Comments` modules are gated behind the paywall overlay.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?