### PR TITLE
Reader Onboarding: Mark step 1 complete if user is following more than 3 tags

### DIFF
--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -3,6 +3,8 @@ import { CircularProgressBar } from '@automattic/components';
 import { Checklist, ChecklistItem, Task } from '@automattic/launchpad';
 import { translate } from 'i18n-calypso';
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 import InterestsModal from './interests-modal';
 import SubscribeModal from './subscribe-modal';
 import './style.scss';
@@ -10,6 +12,7 @@ import './style.scss';
 const ReaderOnboarding = () => {
 	const [ isInterestsModalOpen, setIsInterestsModalOpen ] = useState( false );
 	const [ isDiscoverModalOpen, setIsDiscoverModalOpen ] = useState( false );
+	const followedTags = useSelector( getReaderFollowedTags );
 
 	const handleInterestsContinue = () => {
 		setIsInterestsModalOpen( false );
@@ -28,7 +31,7 @@ const ReaderOnboarding = () => {
 			id: 'select-interests',
 			title: translate( 'Select some of your interests' ),
 			actionDispatch: () => setIsInterestsModalOpen( true ),
-			completed: false,
+			completed: followedTags ? followedTags.length > 2 : false,
 			disabled: false,
 		},
 		{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/189

## Proposed Changes

* If the user is following more than 3 tags, we mark "step 1" as completed (but they can still open it).
* It doesn't matter if they followed >= 3 tags using our onboarding modal, just that they're following >=3 tags.

<img width="1482" alt="Screenshot 2024-10-11 at 1 37 49 PM" src="https://github.com/user-attachments/assets/95d0c20e-f27f-4fa0-887f-d4535975ef1b">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Push reader onboarding forward

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to read?flags=reader/onboarding
* If you're following >= 3 tags, the first step/task should be marked complete.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
