### PR TITLE
Middleware redirect: Strip quantity suffix ( :-q-[qty] ) from product slug

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -201,7 +201,9 @@ export function redirectLoggedOutToSignup( context, next ) {
  */
 export function redirectMyJetpack( context, next ) {
 	const state = context.store.getState();
-	const product = getProductSlugFromContext( context );
+	const productSlug = getProductSlugFromContext( context );
+	// Strip the slug's quantity suffix, for upgradable quantity based products.
+	const product = productSlug.replace( /:-q-\d+/, '' );
 	const isJetpackProduct = isJetpackPlanSlug( product ) || isJetpackProductSlug( product );
 
 	if ( isJetpackProduct && ! isUserLoggedIn( state ) && isContextSourceMyJetpack( context ) ) {


### PR DESCRIPTION
There is a middleware redirect within Calypso that we use for My Jetpack (in the Jetpack plugin) in order to redirect checkout to the siteless connect-after-checkout flow when the user is not logged into WordPress.com.

This middleware redirect was not working for upgradeable quantity based products such as Jetpack Stats because `isJetpackPlanOrProduct( productSlug )` did not work correctly when the product slug has the quantity suffix (such as `jetpack_stats_yearly:-q-10000`).

This PR fixes this issue by stripping the quantity suffix from the product slug before calling `isJetpackPlanOrProduct( productSlug )`.

Related to: https://github.com/Automattic/wp-calypso/pull/94831
(the related PR here ⤴️ is dependent on this PR fix.)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Strip the quantity suffix from the product slug before checking if it's a valid jetpack product or plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR && `yarn start`
* In an incognito window (logged out of wordpress.com), go to: http://calypso.localhost:3000/checkout/4553786/jetpack_stats_yearly:-q-10000?site=css-tricks.com&source=my-jetpack&redirect_to=https://css-tricks.com/wp-admin/admin.php?page=stats
* Confirm that you are redirected to the siteless connect-after-checkout flow:
    - The checkout path should be `/checkout/jetpack/jetpack_stats_yearly:-q-10000`
    - There should be url query args for:, `connect_after_checkout`, `from_site_slug`, and `admin_url`
* Now to see the unwanted behavior prior to the changes in this PR, go to the checkout url, but on wordpress.com, instead of calypso.localhost:3000: Here --> https://wordpress.com/checkout/4553786/jetpack_stats_yearly:-q-10000?site=css-tricks.com&source=my-jetpack&redirect_to=https://css-tricks.com/wp-admin/admin.php?page=stats
* Confirm you are not redirected to siteless checkout, but instead redirected to Login page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
