### PR TITLE
Professional Email: Better Handle Long Domains in Registration

### DIFF
--- a/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/style.scss
@@ -287,6 +287,7 @@ $width-left-panel-card: 55%;
 		.form-text-input-with-affixes__suffix {
 			border-left-width: 0;
 			border-top-width: 1px;
+			max-width: 65%;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #95305

## Proposed Changes

* Better handle long domains on the Professional Email registration step. 

## Why are these changes being made?

The field currently overlaps for long domains - see original issue. 

## Testing Instructions

* Go to `/email/` on a custom domain
* You should be prompted to register a Professional Email
* Force the string to something excessively long
* Confirm that it now wraps properly (incl. on mobile where it should be full width)

| Before | After |
|--------|--------|
| <img width="1117" alt="Screenshot 2024-10-12 at 22 05 15" src="https://github.com/user-attachments/assets/2c140fbd-f6bc-4d85-8b5d-6a380102bbe4"> | <img width="1052" alt="Screenshot 2024-10-12 at 22 04 44" src="https://github.com/user-attachments/assets/615c29f7-a3aa-42cb-972b-cfa784260b7c"> | 

cc @renancarvalho, @arcangelini

