### PR TITLE
i18n: Fix typos in Substack importer

### DIFF
--- a/client/my-sites/importer/newsletter/subscribers/import-subscribers-error.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/import-subscribers-error.tsx
@@ -35,7 +35,7 @@ export default function PaidImportSubscribersError( { error }: Props ) {
 						);
 					case HANDLED_ERROR.IMPORT_RUNNING:
 						return __(
-							'An subscriber import has already started. Please wait till that one finished before starting a new one.'
+							'A subscriber import has already started. Please wait till that one finished before starting a new one.'
 						);
 					case HANDLED_ERROR.MISSING_ARGS:
 					case HANDLED_ERROR.EMPTY_CSV_FILE:

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
@@ -76,7 +76,7 @@ export default function NoPlans( {
 					{ sprintf(
 						// translators: %d is the Stripe account name
 						__(
-							'It looks like the Stripe Account (%s) does not have any active plans. Are you sure you connected the same Stipe account that you use on Substack?'
+							'It looks like the Stripe Account (%s) does not have any active plans. Are you sure you connected the same Stripe account that you use on Substack?'
 						),
 						cardData?.account_display
 					) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/95280

Related to p1728722387443069-slack-CEM18K8LT and p1728780896825829-slack-CEM18K8LT

## Proposed Changes

* Fix typos that were reported by translators

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?