### PR TITLE
Performance Profiler: Remove ellipsis from loading messages that already have animations

### DIFF
--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -94,7 +94,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 	return (
 		<div className="metrics-insight-content">
 			{ isLoading ? (
-				<LLMMessage message={ translate( 'Finding the best solution for your page…' ) } rotate />
+				<LLMMessage message={ translate( 'Finding the best solution for your page' ) } rotate />
 			) : (
 				<>
 					<div className="description-area">

--- a/client/performance-profiler/pages/loading-screen/index.tsx
+++ b/client/performance-profiler/pages/loading-screen/index.tsx
@@ -39,7 +39,7 @@ export const LoadingScreen = ( { isSavedReport }: LoadingScreenProps ) => {
 
 	const heading = isSavedReport
 		? translate( 'Your site‘s results are ready' )
-		: translate( 'Testing your site‘s speed…' );
+		: translate( 'Testing your site‘s speed' );
 
 	const tips = [
 		{

--- a/client/performance-profiler/pages/loading-screen/progress.tsx
+++ b/client/performance-profiler/pages/loading-screen/progress.tsx
@@ -117,7 +117,7 @@ const useLoadingSteps = ( {
 		steps = [ translate( 'Getting your site pages' ) ];
 	} else {
 		steps = isSavedReport
-			? [ translate( 'Getting your report…' ) ]
+			? [ translate( 'Getting your report' ) ]
 			: [
 					pageTitle
 						? translate( 'Loading: %(pageTitle)s', { args: { pageTitle } } )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Removes 3 sets of ellipsis from loading messages

![CleanShot 2024-10-14 at 15 05 54](https://github.com/user-attachments/assets/2fe3ccd6-8f19-4595-b204-0e48b0df2f41)

![CleanShot 2024-10-14 at 15 06 24](https://github.com/user-attachments/assets/39869145-2d90-4173-917a-371a89af0a85)

![CleanShot 2024-10-14 at 15 07 08](https://github.com/user-attachments/assets/8b742dfa-ddd4-449c-8b08-dea2c7ed6e87)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This change was discussed here: p1728550887890229/1728470685.840479-slack-C04H4NY6STW

Ellipsis can be a good crutch in contexts where loading animations aren't possible, because it implies that something is "in progress". However in the above 3 situations there's already loading animations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test the first screenshot use `/speed-test-tool?url={{ url }}`
* To test the second screenshot use `/sites/performance/{{ siteSlug }}` and load an existing report. The message will only appear briefly
* To test the third screenshot scroll to the bottom of a performance report and loading some AI insights

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?