### PR TITLE
Performance Profiler: Quickly switching pages should not kick off new performance report tests

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -4,7 +4,7 @@ import { Button } from '@wordpress/components';
 import { useDebouncedInput } from '@wordpress/compose';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
@@ -44,8 +44,6 @@ const usePerformanceReport = (
 	const { url = '', hash = '' } = wpcom_performance_report_url || {};
 
 	const [ retestState, setRetestState ] = useState( 'idle' );
-	const [ reportCompleted, setReportCompleted ] = useState( false );
-	const testStartTime = useRef< number | undefined >( 0 );
 
 	const {
 		data: basicMetrics,
@@ -62,10 +60,6 @@ const usePerformanceReport = (
 		isLoading: isLoadingInsights,
 	} = useUrlPerformanceInsightsQuery( url, token ?? hash );
 
-	if ( isBasicMetricsFetched && finalUrl && ! reportCompleted ) {
-		testStartTime.current = Date.now();
-	}
-
 	const mobileReport =
 		typeof performanceInsights?.mobile === 'string' ? undefined : performanceInsights?.mobile;
 	const desktopReport =
@@ -75,12 +69,6 @@ const usePerformanceReport = (
 
 	const desktopLoaded = typeof performanceInsights?.desktop === 'object';
 	const mobileLoaded = typeof performanceInsights?.mobile === 'object';
-
-	const isTestCompleted = !! testStartTime.current && !! performanceReport;
-	if ( isTestCompleted ) {
-		testStartTime.current = undefined;
-		setReportCompleted( true );
-	}
 
 	const getHashOrToken = (
 		hash: string | undefined,
@@ -122,7 +110,6 @@ const usePerformanceReport = (
 		isBasicMetricsFetched,
 		testAgain,
 		isRetesting: retestState !== 'idle',
-		testCompleted: isTestCompleted,
 	};
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Sometimes when switching between pages it kicks off a new test when I would have expected it would use an existing saved one.

https://github.com/user-attachments/assets/167522eb-7282-4b0e-a0dd-d24d20d4d224

It looks like the hash isn't always saved back to the post meta when the test is complete

## Proposed Changes

* Instead of using `testCompleted` as the signal for saving the hash to post data, it uses a `useEffect` hook to watch for changes
* Disables the page drop down while we're saving
   * Here I'm trying to avoid a race condition where we might try and switch to a page while we're still saving it. If that happens we might think there's no hash yet and kick off a test, when in reality there is an existing test we just haven't finished saving it yet
* Removes the code for the `testCompleted` field, since it's no longer needed.

> it uses a `useEffect` hook to watch for changes

It's a bit unfortunate to reintroduce a fishy `useEffect` after we've just removed them all. What we really want is for the `useUrlBasicMetricsQuery` hook to have an `onSuccess` callback. However ReactQuery 5 does not have that feature (by design). In order to get an `onSuccess` callback we'd need to change `useUrlBasicMetricsQuery` to something like `useQueuePerformanceTestMutation`, which _would_ support `onSuccess`, and is probably a better way to model starting a long running task anyway.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
