### PR TITLE
A4A: Submit value for the 'Edit mode' parameter when editing PD expertise form.

### DIFF
--- a/client/a8c-for-agencies/data/partner-directory/use-submit-partner-directory-application.ts
+++ b/client/a8c-for-agencies/data/partner-directory/use-submit-partner-directory-application.ts
@@ -34,6 +34,7 @@ function mutationSubmitPartnerDirectoryApplication(
 			} ) ),
 			feedback_url: application.feedbackUrl,
 			is_published: application.isPublished,
+			edit_mode: application.editMode,
 		},
 	} );
 }

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
@@ -25,9 +25,12 @@ export default function useSubmitForm( { formData, onSubmitSuccess, onSubmitErro
 		}
 	);
 
-	const onSubmit = useCallback( () => {
-		formData && submit( formData );
-	}, [ formData, submit ] );
+	const onSubmit = useCallback(
+		( { editMode }: { editMode: boolean } ) => {
+			formData && submit( { ...formData, editMode } );
+		},
+		[ formData, submit ]
+	);
 
 	return {
 		onSubmit,

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -144,7 +144,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 			}
 			return;
 		}
-		onSubmit();
+		onSubmit( { editMode: !! initialFormData } );
 	};
 
 	const { services, products, directories, feedbackUrl } = formData;

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -156,7 +156,7 @@ const PartnerDirectoryDashboard = () => {
 
 	useEffect( () => {
 		if ( shouldSubmitPublishProfile ) {
-			submitPublishProfile();
+			submitPublishProfile( { editMode: false } );
 			setShouldSubmitPublishProfile( false );
 		}
 	}, [ shouldSubmitPublishProfile, submitPublishProfile ] );

--- a/client/a8c-for-agencies/sections/partner-directory/types.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/types.ts
@@ -9,6 +9,7 @@ export interface AgencyDirectoryApplication {
 	feedbackUrl: string;
 	status?: AgencyDirectoryApplicationStatus;
 	isPublished?: boolean;
+	editMode?: boolean;
 }
 
 export interface DirectoryApplication {


### PR DESCRIPTION
This PR updates the Expertise submit form logic to include the 'Edit mode' parameter, allowing the backend endpoint to be aware that we are submitting a form for editing.

**NOTE: This needs to be tested with D163744-code that patches the backend endpoint to handle the new 'Edit mode' parameter.**

## Proposed Changes

* Update the PD expertise form hook to include the Edit mode parameter as part of the submission field. This is necessary for us to allow the backend endpoint we are processing the form as an edit application and not as a request for published.

## Why are these changes being made?

*

## Testing Instructions

* Follow instructions in D163744-code to setup backend endpoint
* Use the A4A live link below and go to the `/partner-directory/dashboard` page.
* If you haven't approved any expertise, please do so. Make sure you disable the listing in the Agency PD MC tool. See p1727161271252239-slack-C047ACYM8UQ.
* Try to edit an expertise form and submit it.
* Confirm that the disabled listing is not enabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?