### PR TITLE
A4A: Update page view tracker to split base path and query parameters.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-page-view-tracker/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-page-view-tracker/index.tsx
@@ -9,19 +9,13 @@ type Props = {
 
 export default function A4APageViewTracker( { title, path, properties }: Props ) {
 	// Split the path into its components
-	const [ basePath, queryString ] = path.split( /[?]/ );
-
-	// Parse query string into an object
-	const queryParams = queryString ? Object.fromEntries( new URLSearchParams( queryString ) ) : {};
+	const [ basePath ] = path.split( /[?]/ );
 
 	return (
 		<PageViewTracker
 			title={ title }
 			path={ basePath }
-			properties={ {
-				...queryParams,
-				...properties,
-			} }
+			properties={ { properties } }
 			options={ { useA8CForAgenciesGoogleAnalytics: true } }
 		/>
 	);

--- a/client/a8c-for-agencies/components/a4a-page-view-tracker/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-page-view-tracker/index.tsx
@@ -8,11 +8,20 @@ type Props = {
 };
 
 export default function A4APageViewTracker( { title, path, properties }: Props ) {
+	// Split the path into its components
+	const [ basePath, queryString ] = path.split( /[?]/ );
+
+	// Parse query string into an object
+	const queryParams = queryString ? Object.fromEntries( new URLSearchParams( queryString ) ) : {};
+
 	return (
 		<PageViewTracker
 			title={ title }
-			path={ path }
-			properties={ properties }
+			path={ basePath }
+			properties={ {
+				...queryParams,
+				...properties,
+			} }
 			options={ { useA8CForAgenciesGoogleAnalytics: true } }
 		/>
 	);

--- a/client/a8c-for-agencies/components/a4a-page-view-tracker/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-page-view-tracker/index.tsx
@@ -15,7 +15,7 @@ export default function A4APageViewTracker( { title, path, properties }: Props )
 		<PageViewTracker
 			title={ title }
 			path={ basePath }
-			properties={ { properties } }
+			properties={ properties }
 			options={ { useA8CForAgenciesGoogleAnalytics: true } }
 		/>
 	);

--- a/client/a8c-for-agencies/sections/signup/controller.tsx
+++ b/client/a8c-for-agencies/sections/signup/controller.tsx
@@ -21,7 +21,13 @@ import AgencySignupFinish from './primary/agency-signup-finish';
 // A simple wrapper to ensure the PageViewTracker is only rendered, and the event fired,
 // after the agency has been fetched and we know if the user is an agency user or not.
 // This is because if they're an agency they get redirected and never see the page.
-const PageViewTrackerWrapper = ( { path }: { path: string } ) => {
+const PageViewTrackerWrapper = ( {
+	path,
+	properties,
+}: {
+	path: string;
+	properties: Record< string, string >;
+} ) => {
 	const userLoggedIn = useSelector( isUserLoggedIn );
 	const agency = useSelector( getActiveAgency );
 	const hasFetched = useSelector( hasFetchedAgency );
@@ -50,14 +56,16 @@ const PageViewTrackerWrapper = ( { path }: { path: string } ) => {
 		return null;
 	}
 
-	return <PageViewTracker title="A4A Signup" path={ path } />;
+	return <PageViewTracker title="A4A Signup" path={ path } properties={ properties } />;
 };
 
 export const signUpContext: Callback = ( context, next ) => {
+	const { ref } = context.query;
+
 	context.store.dispatch( hideMasterbar() );
 	context.primary = (
 		<>
-			<PageViewTrackerWrapper path={ context.path } />
+			<PageViewTrackerWrapper path={ context.path } properties={ { ref } } />
 			<AgencySignUp />
 		</>
 	);

--- a/client/a8c-for-agencies/sections/signup/controller.tsx
+++ b/client/a8c-for-agencies/sections/signup/controller.tsx
@@ -21,13 +21,7 @@ import AgencySignupFinish from './primary/agency-signup-finish';
 // A simple wrapper to ensure the PageViewTracker is only rendered, and the event fired,
 // after the agency has been fetched and we know if the user is an agency user or not.
 // This is because if they're an agency they get redirected and never see the page.
-const PageViewTrackerWrapper = ( {
-	path,
-	properties,
-}: {
-	path: string;
-	properties: Record< string, string >;
-} ) => {
+const PageViewTrackerWrapper = ( { path }: { path: string } ) => {
 	const userLoggedIn = useSelector( isUserLoggedIn );
 	const agency = useSelector( getActiveAgency );
 	const hasFetched = useSelector( hasFetchedAgency );
@@ -56,16 +50,14 @@ const PageViewTrackerWrapper = ( {
 		return null;
 	}
 
-	return <PageViewTracker title="A4A Signup" path={ path } properties={ properties } />;
+	return <PageViewTracker title="A4A Signup" path={ path } />;
 };
 
 export const signUpContext: Callback = ( context, next ) => {
-	const { ref } = context.query;
-
 	context.store.dispatch( hideMasterbar() );
 	context.primary = (
 		<>
-			<PageViewTrackerWrapper path={ context.path } properties={ { ref } } />
+			<PageViewTrackerWrapper path={ context.path } />
 			<AgencySignUp />
 		</>
 	);


### PR DESCRIPTION
This PR enhances our page view tracking by separating the base path from query parameters, ensuring accurate grouping of page views by the base path.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1249

## Proposed Changes

* Update the `A4APageViewTracker` to separate the query parameters from the base path during page view tracking.

## Why are these changes being made?

To prevent duplicate track event names on the same page, ensure that the submitted path excludes query parameters, treating it as a single entity.

## Testing Instructions

* Use the A4A live link and go to the `/signup?ref=wordpress.com` page.
* Confirm that the page view tracker correctly captures the base path and the ref parameters.
* You can expect this by filtering the network tab in your browser with `.gif` and looking for requests like the one below.
<img width="1067" alt="Screenshot 2024-10-16 at 5 15 54 PM" src="https://github.com/user-attachments/assets/809cdfe6-f58c-4518-88c6-af36f68bdc48">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
