### PR TITLE
100-year-plan: Adjust style for mobile view

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
@@ -43,19 +43,21 @@ const HundredYearPlanDIYOrDIFM: Step = function HundredYearPlanDIYOrDIFM( { navi
 							<ul>
 								<li>
 									<Icon size={ 18 } icon={ check } />{ ' ' }
-									{ translate( 'Conduct a comprehensive digital longevity assessment' ) }
+									<span>
+										{ translate( 'Conduct a comprehensive digital longevity assessment' ) }
+									</span>
 								</li>
 								<li>
 									<Icon size={ 18 } icon={ check } />{ ' ' }
-									{ translate( 'Showcase our comprehensive legacy-building tools' ) }
+									<span>{ translate( 'Showcase our comprehensive legacy-building tools' ) }</span>
 								</li>
 								<li>
 									<Icon size={ 18 } icon={ check } />{ ' ' }
-									{ translate( 'Answer all your questions about long-term success' ) }
+									<span>{ translate( 'Answer all your questions about long-term success' ) }</span>
 								</li>
 								<li>
 									<Icon size={ 18 } icon={ check } />{ ' ' }
-									{ translate( 'Chart a course for the production of your new site' ) }
+									<span>{ translate( 'Chart a course for the production of your new site' ) }</span>
 								</li>
 							</ul>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
@@ -17,7 +17,7 @@
 		svg {
 			position: relative;
 			padding: 5px !important;
-			margin-right: 5px !important;
+			margin-right: 8px !important;
 			background-color: var(--studio-gray-5);
 			border-radius: 100%;
 			min-width: 18px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
@@ -10,15 +10,17 @@
 
 		li {
 			color: var(--studio-gray-60);
+			margin-bottom: 8px;
+			display: flex;
 		}
 
 		svg {
 			position: relative;
-			top: 8px;
 			padding: 5px !important;
 			margin-right: 5px !important;
 			background-color: var(--studio-gray-5);
 			border-radius: 100%;
+			min-width: 18px;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adjust style for mobile device

## Testing Instructions

* Go to `/setup/hundred-year-plan/diy-or-difm?flags=100year%2Fvip`
* Check if the text is aligned next to the bullet on a mobile device

| Before | After |
|--------|--------|
| <img width="371" alt="Screenshot 2024-10-14 at 12 17 58" src="https://github.com/user-attachments/assets/d8d1d700-c162-498f-8242-53fdfbcdb316"> | <img width="368" alt="Screenshot 2024-10-14 at 12 14 22" src="https://github.com/user-attachments/assets/a1cabcec-8347-40ca-a4be-4dd984c0b271"> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
