### PR TITLE
Show the price in the Renew Now button on the domain management screen

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -130,11 +130,6 @@ const RegisteredDomainDetails = ( {
 				selectedSite={ selectedSite }
 				subscriptionId={ parseInt( domain.subscriptionId ?? '', 10 ) }
 				tracksProps={ { source: 'registered-domain-status', domain_status: 'active' } }
-				customLabel={
-					! domain.expired || domain.isRenewable
-						? translate( 'Renew now' )
-						: translate( 'Redeem now' )
-				}
 				disabled={ isLoadingPurchase }
 			/>
 		);


### PR DESCRIPTION
We don't show the renewal price in the domain management screen anywhere as mentioned in #80967 . Looking at the code it should be easy to just show the price in the "Renew now" button - it doesn't change the design that much since the buttons are shown in a separate row.

| Before | After |
|--------|--------|
| <img width="683" alt="Screenshot 2024-10-14 at 14 18 19" src="https://github.com/user-attachments/assets/cc32c5ac-e124-4f8a-8c46-a0ae266753b3"> | <img width="677" alt="Screenshot 2024-10-14 at 14 16 27" src="https://github.com/user-attachments/assets/1c98a268-13e8-459a-9e25-8896f23466e1"> |
| <img width="376" alt="Screenshot 2024-10-14 at 14 18 36" src="https://github.com/user-attachments/assets/333e33e3-442b-4302-86cf-80262b35c302"> | <img width="379" alt="Screenshot 2024-10-14 at 14 17 38" src="https://github.com/user-attachments/assets/96c91907-8b9b-4599-a605-b6ead91e2550"> |

Related to #80967 

## Proposed Changes

* Show the renewal price in the "Renew now" button on the domain management screen

## Why are these changes being made?

* In order to make the data we show to customers more consistent.

## Testing Instructions

* Go to any domain management screen and verify that the renewal price is visible in the "Renew now" button

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
