### PR TITLE
A4A > Agency Tier: Initial implementation of agency tier section and feature flags

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -9,6 +9,7 @@ import {
 	cog,
 	commentAuthorAvatar,
 	people,
+	starEmpty,
 } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -29,6 +30,7 @@ import {
 	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 	A4A_REFERRALS_DASHBOARD,
 	A4A_TEAM_LINK,
+	A4A_AGENCY_TIER_LINK,
 } from '../lib/constants';
 import { createItem } from '../lib/utils';
 
@@ -170,6 +172,19 @@ const useMainMenuItems = ( path: string ) => {
 							title: translate( 'Team' ),
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Team',
+							},
+						},
+				  ]
+				: [] ),
+			...( isSectionNameEnabled( 'a8c-for-agencies-agency-tier' )
+				? [
+						{
+							icon: starEmpty,
+							path: '/',
+							link: A4A_AGENCY_TIER_LINK,
+							title: translate( 'Agency Tier' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Agency Tier',
 							},
 						},
 				  ]

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -1,3 +1,6 @@
+// IMPORTANT: We need to make sure that we update
+// the 'calypso/a8c-for-agencies/lib/permission.ts' file
+// to include the necessary permissions for the new routes.
 export const A4A_LANDING_LINK = '/landing';
 export const A4A_OVERVIEW_LINK = '/overview';
 export const A4A_SITES_LINK = '/sites';
@@ -40,6 +43,7 @@ export const A4A_TEAM_LINK = '/team';
 export const A4A_TEAM_INVITE_LINK = '/team/invite';
 export const A4A_TEAM_ACCEPT_INVITE_LINK = '/team/invite/accept';
 export const EXTERNAL_A4A_KNOWLEDGE_BASE = 'http://automattic.com/for-agencies/help';
+export const A4A_AGENCY_TIER_LINK = '/agency-tier';
 
 // Client
 export const A4A_CLIENT_LANDING_LINK = '/client/landing';

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -36,6 +36,7 @@ import {
 	A4A_PAYMENT_METHODS_ADD_LINK,
 	A4A_MIGRATIONS_LINK,
 	A4A_TEAM_INVITE_LINK,
+	A4A_AGENCY_TIER_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import type { Agency } from 'calypso/state/a8c-for-agencies/types';
 
@@ -77,6 +78,7 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_PAYMENT_METHODS_ADD_LINK ]: [ 'a4a_jetpack_licensing' ],
 	[ A4A_MIGRATIONS_LINK ]: [ 'a4a_read_migrations' ],
 	[ A4A_TEAM_INVITE_LINK ]: [ 'a4a_edit_user_invites' ],
+	[ A4A_AGENCY_TIER_LINK ]: [ 'a4a_read_agency_tier' ],
 };
 
 const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {

--- a/client/a8c-for-agencies/sections/agency-tier/controller.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/controller.tsx
@@ -1,0 +1,15 @@
+import { type Callback } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
+import MainSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/main';
+import AgencyTierOverview from './primary/agency-tier-overview';
+
+export const agencyTierContext: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker title="Agency Tier" path={ context.path } />
+			<AgencyTierOverview />
+		</>
+	);
+	context.secondary = <MainSidebar path={ context.path } />;
+	next();
+};

--- a/client/a8c-for-agencies/sections/agency-tier/index.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/index.ts
@@ -1,0 +1,15 @@
+import page from '@automattic/calypso-router';
+import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import * as controller from './controller';
+
+export default function () {
+	page(
+		A4A_AGENCY_TIER_LINK,
+		requireAccessContext,
+		controller.agencyTierContext,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -1,0 +1,7 @@
+export default function AgencyTierOverview() {
+	return (
+		<div>
+			<h1>Agency Tier Overview</h1>
+		</div>
+	);
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -873,6 +873,12 @@ const sections = [
 		module: 'calypso/a8c-for-agencies/sections/client',
 		group: 'a8c-for-agencies',
 	},
+	{
+		name: 'a8c-for-agencies-agency-tier',
+		paths: [ '/agency-tier' ],
+		module: 'calypso/a8c-for-agencies/sections/agency-tier',
+		group: 'a8c-for-agencies',
+	},
 ];
 
 module.exports = sections;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -174,6 +174,7 @@
 		"a8c-for-agencies-partner-directory": false,
 		"a8c-for-agencies-client": false,
 		"a8c-for-agencies-team": false,
+		"a8c-for-agencies-agency-tier": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -41,7 +41,8 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
-		"a4a-dev-sites": true
+		"a4a-dev-sites": true,
+		"a8c-for-agencies-agency-tier": true
 	},
 	"enable_all_sections": false,
 	"sections": {
@@ -59,7 +60,8 @@
 		"a8c-for-agencies-partner-directory": true,
 		"a8c-for-agencies-migrations": true,
 		"a8c-for-agencies-client": true,
-		"a8c-for-agencies-team": true
+		"a8c-for-agencies-team": true,
+		"a8c-for-agencies-agency-tier": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -34,7 +34,8 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
-		"a4a-dev-sites": true
+		"a4a-dev-sites": true,
+		"a8c-for-agencies-agency-tier": true
 	},
 	"enable_all_sections": false,
 	"sections": {
@@ -52,7 +53,8 @@
 		"a8c-for-agencies-partner-directory": true,
 		"a8c-for-agencies-migrations": true,
 		"a8c-for-agencies-client": true,
-		"a8c-for-agencies-team": true
+		"a8c-for-agencies-team": true,
+		"a8c-for-agencies-agency-tier": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1273

## Proposed Changes

This PR:

- Adds a new menu item for Agency Tier
- Updates permission for agency tier route
- Creates the section & context required for the page
- Adds the feature flags and section to dev & horizon environments for the agency tier.

## Why are these changes being made?

* To set up the initial implementation for the agency tier.

## Testing Instructions

- Patch D163771-code
- Open the A4A live link
- Verify that you can now see a menu item on the left nav for Agency Tier, and clicking on the item shows the page as displayed below:

<img width="1721" alt="Screenshot 2024-10-14 at 5 28 08 PM" src="https://github.com/user-attachments/assets/d45ca441-b22e-44b9-83e2-95b4f4868936">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?