### PR TITLE
Plans (state): `useCurrentPlan` in plans main component

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -546,7 +546,7 @@ const ConnectedPlans = connect(
 
 export default function PlansWrapper( props ) {
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const currentPlan = Plans.useCurrentPlan( { siteIdOrSlug: selectedSiteId } );
+	const currentPlan = Plans.useCurrentPlan( { siteId: selectedSiteId } );
 
 	return (
 		<CalypsoShoppingCartProvider>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -14,7 +14,7 @@ import {
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { WpcomPlansUI } from '@automattic/data-stores';
+import { WpcomPlansUI, Plans } from '@automattic/data-stores';
 import { englishLocales } from '@automattic/i18n-utils';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { useDispatch } from '@wordpress/data';
@@ -39,6 +39,7 @@ import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import { useSelector } from 'calypso/state';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
@@ -48,7 +49,6 @@ import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-f
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoShoppingCartProvider from '../checkout/calypso-shopping-cart-provider';
@@ -148,7 +148,7 @@ function DescriptionMessage( { isDomainUpsell, isFreePlan, yourDomainName, siteS
 	);
 }
 
-class Plans extends Component {
+class PlansComponent extends Component {
 	static propTypes = {
 		context: PropTypes.object.isRequired,
 		redirectToAddDomainFlow: PropTypes.bool,
@@ -511,9 +511,8 @@ class Plans extends Component {
 }
 
 const ConnectedPlans = connect(
-	( state ) => {
-		const selectedSiteId = getSelectedSiteId( state );
-		const currentPlan = getCurrentPlan( state, selectedSiteId );
+	( state, props ) => {
+		const { currentPlan, selectedSiteId } = props;
 		const currentPlanIntervalType = getIntervalTypeForTerm(
 			getPlan( currentPlan?.productSlug )?.term
 		);
@@ -521,7 +520,7 @@ const ConnectedPlans = connect(
 		return {
 			currentPlan,
 			currentPlanIntervalType,
-			purchase: currentPlan ? getByPurchaseId( state, currentPlan.id ) : null,
+			purchase: currentPlan ? getByPurchaseId( state, currentPlan.purchaseId ) : null,
 			selectedSite: getSelectedSite( state ),
 			canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 			isWPForTeamsSite: isSiteWPForTeams( state, selectedSiteId ),
@@ -543,12 +542,15 @@ const ConnectedPlans = connect(
 	( dispatch ) => ( {
 		fetchSitePlans: ( siteId ) => dispatch( fetchSitePlans( siteId ) ),
 	} )
-)( withCartKey( withShoppingCart( localize( Plans ) ) ) );
+)( withCartKey( withShoppingCart( localize( PlansComponent ) ) ) );
 
 export default function PlansWrapper( props ) {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const currentPlan = Plans.useCurrentPlan( { siteIdOrSlug: selectedSiteId } );
+
 	return (
 		<CalypsoShoppingCartProvider>
-			<ConnectedPlans { ...props } />
+			<ConnectedPlans { ...props } currentPlan={ currentPlan } selectedSiteId={ selectedSiteId } />
 		</CalypsoShoppingCartProvider>
 	);
 }

--- a/client/my-sites/plans/woo-express-plans-page/index.tsx
+++ b/client/my-sites/plans/woo-express-plans-page/index.tsx
@@ -11,20 +11,19 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card } from '@automattic/components';
-import { Plans, type SiteDetails } from '@automattic/data-stores';
+import { Plans, type SiteDetails, SitePlan } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
-import { SitePlanData } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { WooExpressPlans } from '../ecommerce-trial/wooexpress-plans';
 
 import './style.scss';
 
 interface WooExpressPlansPageProps {
-	currentPlan: SitePlanData;
+	currentPlan: SitePlan;
 	interval?: 'monthly' | 'yearly';
 	selectedSite: SiteDetails;
 	showIntervalToggle: boolean;
@@ -74,8 +73,8 @@ const WooExpressPlansPage = ( {
 	const planInterval = isAnnualSubscription ? 'yearly' : 'monthly';
 
 	const goToSubscriptionPage = () => {
-		if ( selectedSite?.slug && currentPlan?.id ) {
-			page( `/purchases/subscriptions/${ selectedSite.slug }/${ currentPlan.id }` );
+		if ( selectedSite?.slug && currentPlan?.purchaseId ) {
+			page( `/purchases/subscriptions/${ selectedSite.slug }/${ currentPlan.purchaseId }` );
 		}
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/86638

## Proposed Changes

Make use of data-stores `Plans.useCurrentPlan` in `my-site/plans` and `woo-express-plans-page` components.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Reduce state duplication across local Calypso state and the packaged data-stores.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure visiting `/plans/:site` and `/plans/[ woo express site ]` work as expected.
    * more details to follow as I wrap this up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
