### PR TITLE
Stats: Fix potential empty visits state

### DIFF
--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -232,7 +232,13 @@ const getStatsQueries = createSelector(
 
 const getStatsData = createSelector(
 	( state, siteId, chartQuery, insightsQuery, topPostsQuery ) => {
-		const counts = getCountRecords( state, siteId, chartQuery.period );
+		const counts = getCountRecords(
+			state,
+			siteId,
+			chartQuery.date,
+			chartQuery.period,
+			chartQuery.quantity
+		);
 		const chartData = buildChartData(
 			[],
 			chartQuery.chartTab,
@@ -268,14 +274,16 @@ const getStatsData = createSelector(
 		};
 	},
 	( state, siteId, chartQuery, insightsQuery, topPostsQuery ) => [
-		getCountRecords( state, siteId, chartQuery.period ),
+		getCountRecords( state, siteId, chartQuery.date, chartQuery.period, chartQuery.quantity ),
 		insightsQuery,
 		topPostsQuery,
 	]
 );
 
 const isLoadingStats = ( state, siteId, chartQuery, insightsQuery, topPostsQuery ) =>
-	getLoadingTabs( state, siteId, chartQuery.period ).includes( chartQuery.chartTab ) ||
+	getLoadingTabs( state, siteId, chartQuery.date, chartQuery.period, chartQuery.quantity ).includes(
+		chartQuery.chartTab
+	) ||
 	isRequestingSiteStatsForQuery( state, siteId, 'statsInsights', insightsQuery ) ||
 	isRequestingSiteStatsForQuery( state, siteId, 'statsTopPosts', topPostsQuery );
 

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -90,7 +90,9 @@ class StatModuleChartTabs extends Component {
 		this.intervalId = setInterval( this.makeQuery, DEFAULT_HEARTBEAT );
 	}
 
-	makeQuery = () => this.props.requestChartCounts( this.props.query );
+	makeQuery = () => {
+		return this.props.requestChartCounts( this.props.query );
+	};
 
 	render() {
 		const { isActiveTabLoading } = this.props;
@@ -160,11 +162,6 @@ const connectComponent = connect(
 		// Set up quantity for API call.
 		const defaultQuantity = 'year' === period ? 10 : 30;
 		const quantity = customQuantity ? customQuantity : defaultQuantity;
-
-		const counts = getCountRecords( state, siteId, period );
-		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
-		const loadingTabs = getLoadingTabs( state, siteId, period );
-		const isActiveTabLoading = loadingTabs.includes( chartTab ) || chartData.length < quantity;
 		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
 
 		// The end date of the chart depends on the customRange.
@@ -175,6 +172,11 @@ const connectComponent = connect(
 
 		const queryKey = `${ date }-${ period }-${ quantity }-${ siteId }`;
 		const query = memoizedQuery( chartTab, date, period, quantity, siteId );
+
+		const counts = getCountRecords( state, siteId, query.date, query.period, query.quantity );
+		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
+		const loadingTabs = getLoadingTabs( state, siteId, query.date, query.period, query.quantity );
+		const isActiveTabLoading = loadingTabs.includes( chartTab ) || chartData.length < quantity;
 
 		return {
 			chartData,

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -90,9 +90,7 @@ class StatModuleChartTabs extends Component {
 		this.intervalId = setInterval( this.makeQuery, DEFAULT_HEARTBEAT );
 	}
 
-	makeQuery = () => {
-		return this.props.requestChartCounts( this.props.query );
-	};
+	makeQuery = () => this.props.requestChartCounts( this.props.query );
 
 	render() {
 		const { isActiveTabLoading } = this.props;

--- a/client/state/data-layer/wpcom/sites/stats/visits/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/visits/index.js
@@ -43,7 +43,8 @@ export const fetch = ( action ) => {
 	];
 };
 
-export const onSuccess = ( { siteId, period }, data ) => receiveChartCounts( siteId, period, data );
+export const onSuccess = ( { siteId, period, date, quantity }, data ) =>
+	receiveChartCounts( siteId, date, period, quantity, data );
 
 registerHandlers( 'state/data-layer/wpcom/sites/stats/visits/index.js', {
 	[ STATS_CHART_COUNTS_REQUEST ]: [

--- a/client/state/data-layer/wpcom/sites/stats/visits/test/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/visits/test/index.js
@@ -61,7 +61,10 @@ describe( 'onSuccess', () => {
 				],
 			},
 		};
-		const output = onSuccess( { siteId: 1, period: 'year' }, data );
-		expect( output ).toEqual( receiveChartCounts( 1, 'year', data ) );
+		const output = onSuccess(
+			{ siteId: 1, date: '2018-09-20', period: 'year', quantity: 1 },
+			data
+		);
+		expect( output ).toEqual( receiveChartCounts( 1, '2018-09-20', 'year', 1, data ) );
 	} );
 } );

--- a/client/state/stats/chart-tabs/actions.js
+++ b/client/state/stats/chart-tabs/actions.js
@@ -6,15 +6,17 @@ import 'calypso/state/stats/init';
 /**
  * Returns an action thunk which, when invoked, triggers a network request to
  * retrieve visitor counts for StatsChartTabs.
- * @param  {string}  date  			   The most recent day to include in results (YYYY-MM-DD format)
- * @param  {string}  period   		 Type of duration to include in the query (such as daily)
- * @param  {number}  quantity      Number of periods to include in the query
- * @param  {number}  siteId        Site ID
- * @param  {Array}   statFields    Comma separated list of stat fields
- * @returns {Object}  Action object
+ * @param   {string} date The most recent day to include in results (YYYY-MM-DD format)
+ * @param   {string} period Type of duration to include in the query (such as daily)
+ * @param   {number} quantity Number of periods to include in the query
+ * @param   {number} siteId Site ID
+ * @param   {Array} statFields Comma separated list of stat fields
+ * @returns {Object} Action object
  */
 
 export function requestChartCounts( { chartTab, date, period, quantity, siteId, statFields } ) {
+	const requestKey = `${ date }-${ period }-${ quantity }`;
+
 	return {
 		type: STATS_CHART_COUNTS_REQUEST,
 		chartTab,
@@ -23,22 +25,28 @@ export function requestChartCounts( { chartTab, date, period, quantity, siteId, 
 		quantity,
 		siteId,
 		statFields,
+		requestKey,
 	};
 }
 
 /**
  * Returns an action object to be used in signalling that a visitor count object has
  * been received.
- * @param  {number}  siteId   		 Site ID
- * @param  {string}  period   		 Type of duration to include in the query (such as daily)
- * @param  {Object}  data   			 Visitor counts API response
- * @returns {Object}  Action object
+ * @param   {number} siteId Site ID
+ * @param   {string} date The most recent day to include in results (YYYY-MM-DD format)
+ * @param   {string} period Type of duration to include in the query (such as daily)
+ * @param   {number} quantity Number of periods to include in the query
+ * @param   {Object} data Visitor counts API response
+ * @returns {Object} Action object
  */
-export function receiveChartCounts( siteId, period, data ) {
+export function receiveChartCounts( siteId, date, period, quantity, data ) {
+	const requestKey = `${ date }-${ period }-${ quantity }`;
+
 	return {
 		type: STATS_CHART_COUNTS_RECEIVE,
 		siteId,
 		period,
 		data,
+		requestKey,
 	};
 }

--- a/client/state/stats/chart-tabs/reducer.js
+++ b/client/state/stats/chart-tabs/reducer.js
@@ -17,6 +17,9 @@ import { countsSchema } from './schema';
  */
 const countsReducer = ( state = [], action ) => {
 	switch ( action.type ) {
+		case STATS_CHART_COUNTS_REQUEST: {
+			return [];
+		}
 		case STATS_CHART_COUNTS_RECEIVE: {
 			// Workaround to prevent new data from being appended to previous data when range period differs.
 			// See https://github.com/Automattic/wp-calypso/pull/41441#discussion_r415918092
@@ -56,7 +59,7 @@ const countsReducer = ( state = [], action ) => {
 
 export const counts = withSchemaValidation(
 	countsSchema,
-	keyedReducer( 'siteId', keyedReducer( 'period', withPersistence( countsReducer ) ) )
+	keyedReducer( 'siteId', keyedReducer( 'requestKey', withPersistence( countsReducer ) ) )
 );
 
 /**
@@ -84,6 +87,6 @@ const isLoadingReducer = ( state = {}, action ) => {
 	return state;
 };
 
-export const isLoading = keyedReducer( 'siteId', keyedReducer( 'period', isLoadingReducer ) );
+export const isLoading = keyedReducer( 'siteId', keyedReducer( 'requestKey', isLoadingReducer ) );
 
 export default combineReducers( { counts, isLoading } );

--- a/client/state/stats/chart-tabs/selectors.js
+++ b/client/state/stats/chart-tabs/selectors.js
@@ -7,24 +7,32 @@ const EMPTY_RESULT = [];
 
 /**
  * Returns the count records for a given site and period
- * @param   {Object}  state    Global state tree
- * @param   {number}  siteId   Site ID
- * @param   {string}  period   Type of duration to include in the query (such as daily)
- * @returns {Array}            Array of count objects
+ * @param   {Object} state Global state tree
+ * @param   {number} siteId Site ID
+ * @param   {string} date The most recent day to include in results (YYYY-MM-DD format)
+ * @param   {string} period Type of duration to include in the query (such as daily)
+ * @param   {number} quantity Number of periods to include in the query
+ * @returns {Array} Array of count objects
  */
-export function getCountRecords( state, siteId, period ) {
-	return get( state, [ 'stats', 'chartTabs', 'counts', siteId, period ], EMPTY_RESULT );
+export function getCountRecords( state, siteId, date, period, quantity ) {
+	const requestKey = `${ date }-${ period }-${ quantity }`;
+
+	return get( state, [ 'stats', 'chartTabs', 'counts', siteId, requestKey ], EMPTY_RESULT );
 }
 
 /**
  * Returns an array of strings denoting the query fields that are still loading
- * @param   {Object}  state    Global state tree
- * @param   {number}  siteId   Site ID
- * @param   {string}  period   Type of duration to include in the query (such as daily)
- * @returns {Array}          	 Array of stat types as strings
+ * @param   {Object} state Global state tree
+ * @param   {number} siteId Site ID
+ * @param   {string} date The most recent day to include in results (YYYY-MM-DD format)
+ * @param   {string} period Type of duration to include in the query (such as daily)
+ * @param   {number} quantity Number of periods to include in the query
+ * @returns {Array}  Array of stat types as strings
  */
-export function getLoadingTabs( state, siteId, period ) {
+export function getLoadingTabs( state, siteId, date, period, quantity ) {
+	const requestKey = `${ date }-${ period }-${ quantity }`;
+
 	return QUERY_FIELDS.filter( ( type ) =>
-		get( state, [ 'stats', 'chartTabs', 'isLoading', siteId, period, type ] )
+		get( state, [ 'stats', 'chartTabs', 'isLoading', siteId, requestKey, type ] )
 	);
 }

--- a/client/state/stats/chart-tabs/test/reducer.js
+++ b/client/state/stats/chart-tabs/test/reducer.js
@@ -4,7 +4,9 @@ import { counts, isLoading } from '../reducer';
 
 describe( 'reducer', () => {
 	const siteId = 1234;
+	const date = '2018-09-20';
 	const period = 'day';
+	const quantity = 1;
 	const responseWithViews = [
 		{
 			period: '2018-09-20',
@@ -38,17 +40,20 @@ describe( 'reducer', () => {
 			expect( counts( undefined, {} ) ).toEqual( {} );
 		} );
 
+		const requestKey = `${ date }-${ period }-${ quantity }`;
+
 		test( 'should append count records onto the state if no prior records exist', () => {
 			const state = counts( undefined, {
 				type: STATS_CHART_COUNTS_RECEIVE,
 				siteId,
 				period,
 				data: responseWithViews,
+				requestKey,
 			} );
 
 			expect( state ).toEqual( {
 				[ siteId ]: {
-					[ period ]: [
+					[ requestKey ]: [
 						{
 							period: '2018-09-20',
 							views: 247,
@@ -63,19 +68,20 @@ describe( 'reducer', () => {
 		test( 'should merge count records with the same siteId and period', () => {
 			const state = counts(
 				{
-					[ siteId ]: { [ period ]: responseWithViews },
+					[ siteId ]: { [ requestKey ]: responseWithViews },
 				},
 				{
 					type: STATS_CHART_COUNTS_RECEIVE,
 					siteId,
 					period,
 					data: responseWithVisitors,
+					requestKey,
 				}
 			);
 
 			expect( state ).toEqual( {
 				[ siteId ]: {
-					[ period ]: [
+					[ requestKey ]: [
 						{
 							period: '2018-09-20',
 							views: 247,
@@ -91,19 +97,20 @@ describe( 'reducer', () => {
 		test( 'should not merge count records with differing period values', () => {
 			const state = counts(
 				{
-					[ siteId ]: { [ period ]: responseWithViews },
+					[ siteId ]: { [ requestKey ]: responseWithViews },
 				},
 				{
 					type: STATS_CHART_COUNTS_RECEIVE,
 					siteId,
 					period,
 					data: responseWithADifferentPeriod,
+					requestKey,
 				}
 			);
 
 			expect( state ).toEqual( {
 				[ siteId ]: {
-					[ period ]: [
+					[ requestKey ]: [
 						{
 							period: '2018-09-30',
 							views: 487,
@@ -130,16 +137,19 @@ describe( 'reducer', () => {
 			expect( isLoading( undefined, {} ) ).toEqual( {} );
 		} );
 
+		const requestKey = `${ date }-${ period }-${ quantity }`;
+
 		test( 'should mark status as loading upon receving the corresponding event', () => {
 			const state = isLoading( undefined, {
 				type: STATS_CHART_COUNTS_REQUEST,
 				siteId,
 				period,
 				statFields: [ 'views', 'visitors' ],
+				requestKey,
 			} );
 			expect( state ).toEqual( {
 				[ siteId ]: {
-					[ period ]: {
+					[ requestKey ]: {
 						views: true,
 						visitors: true,
 					},
@@ -151,7 +161,7 @@ describe( 'reducer', () => {
 			const state = isLoading(
 				{
 					[ siteId ]: {
-						[ period ]: {
+						[ requestKey ]: {
 							apples: false,
 						},
 					},
@@ -161,11 +171,12 @@ describe( 'reducer', () => {
 					siteId,
 					period,
 					statFields: [ 'views', 'visitors' ],
+					requestKey,
 				}
 			);
 			expect( state ).toEqual( {
 				[ siteId ]: {
-					[ period ]: {
+					[ requestKey ]: {
 						apples: false,
 						views: true,
 						visitors: true,
@@ -180,10 +191,11 @@ describe( 'reducer', () => {
 				siteId,
 				period,
 				data: responseWithViewsAndVisitors,
+				requestKey,
 			} );
 			expect( state ).toEqual( {
 				[ siteId ]: {
-					[ period ]: {
+					[ requestKey ]: {
 						views: false,
 						visitors: false,
 					},
@@ -195,7 +207,7 @@ describe( 'reducer', () => {
 			const state = isLoading(
 				{
 					[ siteId ]: {
-						[ period ]: {
+						[ requestKey ]: {
 							apples: true,
 						},
 					},
@@ -205,12 +217,13 @@ describe( 'reducer', () => {
 					siteId,
 					period,
 					data: responseWithViewsAndVisitors,
+					requestKey,
 				}
 			);
 
 			expect( state ).toEqual( {
 				[ siteId ]: {
-					[ period ]: {
+					[ requestKey ]: {
 						apples: true,
 						views: false,
 						visitors: false,

--- a/client/state/stats/chart-tabs/test/selectors.js
+++ b/client/state/stats/chart-tabs/test/selectors.js
@@ -2,14 +2,18 @@ import { getCountRecords, getLoadingTabs } from '../selectors';
 
 describe( 'selectors', () => {
 	const siteId = 1234;
+	const date = '2100-11-10';
 	const period = 'month';
+	const quantity = 3;
+
+	const requestKey = `${ date }-${ period }-${ quantity }`;
 
 	const state = {
 		stats: {
 			chartTabs: {
 				counts: {
 					[ siteId ]: {
-						[ period ]: [
+						[ requestKey ]: [
 							{
 								period: '2100-11-10',
 								views: 247,
@@ -33,7 +37,7 @@ describe( 'selectors', () => {
 				},
 				isLoading: {
 					[ siteId ]: {
-						[ period ]: {
+						[ requestKey ]: {
 							views: false,
 							visitors: true,
 							likes: true,
@@ -53,7 +57,7 @@ describe( 'selectors', () => {
 		} );
 
 		test( "should return a site's chart counts given a duration period", () => {
-			expect( getCountRecords( state, siteId, period ) ).toEqual( [
+			expect( getCountRecords( state, siteId, date, period, quantity ) ).toEqual( [
 				{
 					period: '2100-11-10',
 					views: 247,
@@ -76,7 +80,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 	describe( '#getLoadingTabs()', () => {
-		const loadingTabs = getLoadingTabs( state, siteId, period );
+		const loadingTabs = getLoadingTabs( state, siteId, date, period, quantity );
 		test( 'should return an array', () => {
 			expect( Array.isArray( loadingTabs ) ).toBeTruthy();
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/179

## Proposed Changes

* Add the request key to patch data for the same request from batch endpoint API requests.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because the Stats visits data fetch was [split into two API requests](https://github.com/Automattic/wp-calypso/blob/2d5166efe4e6479014885b6ac5d7531ada483c72/client/state/data-layer/wpcom/sites/stats/visits/index.js#L10-L43) for current tab fields and other fields queries, the slower request would [incorrectly overwrite the other new request's data](https://github.com/Automattic/wp-calypso/blob/6cbfbe3d733e1946eae603c25722dcda7cfabc56/client/state/stats/chart-tabs/reducer.js#L21-L28) due to quickly toggling between `My Home` and `Stats` pages. Using unique request keys, requests can be located to respective Redux store objects under the same site state.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Click on the `My Home` sidebar item and then immediately click on the `Stats` sidebar item.
* Ensure the Stats > `Traffic` page visits bar chart shows data correctly after all requests are finished.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
