### PR TITLE
Help Center: Fix list style and margin for ol blocks

### DIFF
--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -119,7 +119,7 @@
 			ul, ol.wp-block-list {
 				font-size: $font-body-small;
 				color: var(--color-neutral-80);
-				list-style-position: inside;
+				list-style-position: outside;
 				margin: 0 0 1.5em 1.5em;
 			}
 

--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -111,17 +111,20 @@
 				}
 			}
 
-			p, ol.wp-block-list {
+			p {
 				font-size: $font-body-small;
 				color: var(--color-neutral-80);
 			}
 
-			ul {
+			ul, ol.wp-block-list {
 				font-size: $font-body-small;
 				color: var(--color-neutral-80);
-				list-style-type: circle;
 				list-style-position: inside;
 				margin: 0 0 1.5em 1.5em;
+			}
+
+			ul {
+				list-style-type: circle;
 			}
 
 			span.noticon.noticon-star {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/95326

## Proposed Changes

* Fix list style and margin for `ol` blocks on Help Center

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Ordered lists have wrong margin and list style on Help Center.

**Before**
<img width="393" alt="Screenshot 2024-10-14 at 11 27 39" src="https://github.com/user-attachments/assets/faf2a431-df90-48cb-a4f2-f4dba2046c73">

**After**
<img width="393" alt="Screenshot 2024-10-14 at 11 27 39" src="https://github.com/user-attachments/assets/83fa990b-63d3-4651-9be8-4b7457357597">

## Testing Instructions

* Apply this PR to your local or use a testing env
* Test with an Atomic site
* Navigate to `/hosting-config/:your_site`
* Scroll down to the Defensive mode card
* Click the `Learn more` link
* In the Help Center, scroll down to the ordered list below `To enable defensive mode, take the following steps`
* You should see the ordered list with the numbers aligned to the start of the paragraph, as the screenshot below:
<img width="393" alt="Screenshot 2024-10-14 at 11 27 39" src="https://github.com/user-attachments/assets/83fa990b-63d3-4651-9be8-4b7457357597">

* Verify if there is no regression on paragraphs and unordered lists `ul` blocks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
