### PR TITLE
Post-migration experience: Add front-end URL to new launchpad task

### DIFF
--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
 import wpcomRequest from 'wpcom-proxy-request';
@@ -131,6 +132,18 @@ export const setUpActionsForTasks = ( {
 						updateLaunchpadSettings( siteSlug, {
 							checklist_statuses: { [ task.id ]: true },
 						} );
+					};
+					useCalypsoPath = false;
+					break;
+
+				case 'domain_dns_mapped':
+					action = () => {
+						window.open(
+							localizeUrl(
+								`https://wordpress.com/support/domains/connect-existing-domain/#step-2-connect-your-domain`
+							),
+							'_blank'
+						);
 					};
 					useCalypsoPath = false;
 					break;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/39764

## Proposed Changes

* Adds front-end functionality (click event URL) for the new Update domain DNS task in https://github.com/Automattic/jetpack/pull/39764

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to send users to an external support doc and that has to be done on the front end rather than the Launchpad backend.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR locally or use calypso.live
* Follow the testing instructions in this PR to show the migration task list: https://github.com/Automattic/jetpack/pull/39764
* Clicking on the DNS task should direct you to `https://wordpress.com/support/domains/connect-existing-domain/#step-2-connect-your-domain`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
