### PR TITLE
 Update Hide Coupon Box and Link Experiment Name

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -325,7 +325,7 @@ export function CouponCostOverride( {
 	const isDisabled = formStatus !== FormStatus.READY;
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
 	const productSlugs = responseCart.products?.map( ( product ) => product.product_slug );
-	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box', {
+	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box_v2', {
 		isEligible: ! productSlugs.some( ( slug ) => 'wp_difm_lite' === slug ),
 	} );
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -210,7 +210,7 @@ export function CouponFieldArea( {
 		}
 	}, [ couponStatus, setCouponFieldValue ] );
 
-	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box', {
+	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box_v2', {
 		isEligible: ! productSlugs.some( ( slug ) => 'wp_difm_lite' === slug ),
 	} );
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -95,7 +95,7 @@ export function WPOrderReviewLineItems( {
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
 	const productSlugs = responseCart.products?.map( ( product ) => product.product_slug );
-	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box', {
+	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box_v2', {
 		isEligible: ! productSlugs.some( ( slug ) => 'wp_difm_lite' === slug ),
 	} );
 


### PR DESCRIPTION
Related to #
https://wp.me/pbxNRc-43C#comment-6141

## Proposed Changes

Update experiment name from `calypso_checkout_hide_coupon_box` to `calypso_checkout_hide_coupon_box_v2`

## Why are these changes being made?

We will be restarting the experiment and need to update the name in code.

## Testing Instructions

Code review should be sufficient 
or 

**How to assign self to treatment bucket** 
To manually assign a variant to yourself or a test user, head over to your experiment’s overview page in ExPlat:

- Go to details for experiment `calypso_checkout_hide_coupon_box`  in ExPlat and click on the Overview tab.
- Navigate to the Audience section and hover over the assignment group to be assigned.
- Upon mouse hover, click on the link to be assigned that assignment group.

1. Apply patch 
2. Navigate to checkout
3. If you are assigned to the treatment you should not see the "Have a coupon?" link 

<img width="228" alt="image" src="https://github.com/user-attachments/assets/b7d815e8-6b2b-4442-a453-4fd998a3c0a5">

4. Embedded a coupon to the checkout URL ?coupon= and refresh. 
5. You should see "Offer Applied" listed where the Coupon code would have been
<img width="228" alt="image" src="https://github.com/user-attachments/assets/c1e2d2b7-8806-48d0-9609-ad2f6aa1ea63">
<img width="326" alt="image" src="https://github.com/user-attachments/assets/548eb791-1ef0-40cc-ad0a-8cf5a4be82f1">
