### PR TITLE
Reader: Disable Council banner

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -602,8 +602,7 @@ class ReaderStream extends Component {
 		const { translate, forcePlaceholders, lastPage, streamHeader, streamKey, selectedPostKey } =
 			this.props;
 		const wideDisplay = this.props.width > WIDE_DISPLAY_CUTOFF;
-		const isCouncilPromoStream =
-			this.props.isDiscoverStream || this.props.streamKey === 'following';
+		const isReaderCouncilStream = false; // Disabling banner. Original condition: ( this.props.isDiscoverStream || this.props.streamKey === 'following' );
 		let { items, isRequesting } = this.props;
 		let body;
 		let showingStream;
@@ -658,7 +657,7 @@ class ReaderStream extends Component {
 					<div className="stream__two-column">
 						<div className="reader__content">
 							{ streamHeader?.() }
-							{ isCouncilPromoStream && <CustomerCouncilBanner translate={ translate } /> }
+							{ isReaderCouncilStream && <CustomerCouncilBanner translate={ translate } /> }
 							{ bodyContent }
 						</div>
 						<div className="stream__right-column">{ sidebarContentFn?.() }</div>
@@ -669,7 +668,7 @@ class ReaderStream extends Component {
 				body = (
 					<>
 						{ streamHeader?.() }
-						{ isCouncilPromoStream && (
+						{ isReaderCouncilStream && (
 							<div style={ { margin: '32px 16px 0' } }>
 								<CustomerCouncilBanner translate={ translate } />
 							</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95295

## Proposed Changes

* Disables the Reader Council banner

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We have enough subscribers to the P2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the Reader Council banner does not appear on any Reader stream, but particularly /read and /discover

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
