### PR TITLE
Allow siteless checkout flow to utilize a "redirect_to" url query arg.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
@@ -11,16 +11,20 @@ import {
 	isProductsListFetching as getIsProductListFetching,
 	getProductName,
 } from 'calypso/state/products-list/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { filterAllowedRedirect } from '../src/lib/pending-page';
 import useGetJetpackActivationConfirmationInfo from './use-get-jetpack-activation-confirmation-info';
 
 interface Props {
 	productSlug: string;
 	destinationSiteId: number;
+	redirectTo?: string;
 }
 
 const LicensingActivationThankYouCompleted: FC< Props > = ( {
 	productSlug = 'no_product',
 	destinationSiteId = 0,
+	redirectTo,
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -50,6 +54,14 @@ const LicensingActivationThankYouCompleted: FC< Props > = ( {
 	const productConfirmationInfo = useGetJetpackActivationConfirmationInfo(
 		destinationSiteId,
 		productSlug
+	);
+
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, destinationSiteId ) );
+
+	const finalRedirect = filterAllowedRedirect(
+		redirectTo ?? '',
+		siteSlug ?? '',
+		productConfirmationInfo.buttonUrl
 	);
 
 	return (
@@ -99,7 +111,7 @@ const LicensingActivationThankYouCompleted: FC< Props > = ( {
 									} )
 								)
 							}
-							href={ productConfirmationInfo.buttonUrl }
+							href={ finalRedirect }
 						>
 							{ translate( 'Go to Dashboard' ) }
 						</Button>

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -28,6 +28,7 @@ interface Props {
 	source?: string;
 	jetpackTemporarySiteId?: number;
 	fromSiteSlug?: string;
+	redirectTo?: string;
 }
 
 type JetpackSite = {
@@ -55,6 +56,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 	source = 'onboarding-calypso-ui',
 	jetpackTemporarySiteId = 0,
 	fromSiteSlug,
+	redirectTo,
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -206,6 +208,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 			const thankYouCompletedUrl = addQueryArgs(
 				{
 					destinationSiteId,
+					redirect_to: redirectTo,
 				},
 				`/checkout/jetpack/thank-you/licensing-auto-activate-completed/${ productSlug }`
 			);
@@ -219,6 +222,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 		productName,
 		productsList,
 		productSlug,
+		redirectTo,
 		selectedSite,
 		supportTicketRequestStatus,
 		translate,
@@ -315,31 +319,34 @@ const LicensingActivationThankYou: FC< Props > = ( {
 					className="licensing-thank-you-auto-activation__select"
 					selectedText={ selectedItem ? selectedItem.label : translate( 'Select…' ) }
 				>
-					{ selectDropdownItems.map( ( option ) => (
-						<SelectDropdown.Item { ...option.props }>
-							<div
-								className={ clsx(
-									'licensing-thank-you-auto-activation__dropdown-item-flex-container',
-									{
-										'has-seperator': option.value === 'activate-license-manually',
-									}
-								) }
-							>
-								<span className="licensing-thank-you-auto-activation__dropdown-item-text">
-									{ option.value === 'activate-license-manually' ? (
-										<strong>{ option.label }</strong>
-									) : (
-										option.label
+					{ selectDropdownItems.map( ( option ) => {
+						const { key: itemKey, ...props } = option.props;
+						return (
+							<SelectDropdown.Item key={ itemKey } { ...props }>
+								<div
+									className={ clsx(
+										'licensing-thank-you-auto-activation__dropdown-item-flex-container',
+										{
+											'has-seperator': option.value === 'activate-license-manually',
+										}
 									) }
-								</span>
-								{ option.value !== 'activate-license-manually' && (
-									<span>
-										<Gridicon icon="link" size={ 18 } />
+								>
+									<span className="licensing-thank-you-auto-activation__dropdown-item-text">
+										{ option.value === 'activate-license-manually' ? (
+											<strong>{ option.label }</strong>
+										) : (
+											option.label
+										) }
 									</span>
-								) }
-							</div>
-						</SelectDropdown.Item>
-					) ) }
+									{ option.value !== 'activate-license-manually' && (
+										<span>
+											<Gridicon icon="link" size={ 18 } />
+										</span>
+									) }
+								</div>
+							</SelectDropdown.Item>
+						);
+					} ) }
 				</SelectDropdown>
 				{ error && <FormInputValidation isError={ !! error } text={ error }></FormInputValidation> }
 				<Button

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -477,7 +477,7 @@ export function licensingThankYouAutoActivation( context, next ) {
 	const userHasJetpackSites = currentUser && currentUser.jetpack_visible_site_count >= 1;
 
 	const { product } = context.params;
-	const { receiptId, source, siteId, fromSiteSlug } = context.query;
+	const { receiptId, source, siteId, fromSiteSlug, redirect_to } = context.query;
 
 	if ( ! userHasJetpackSites ) {
 		page.redirect(
@@ -495,6 +495,7 @@ export function licensingThankYouAutoActivation( context, next ) {
 				source={ source }
 				jetpackTemporarySiteId={ siteId }
 				fromSiteSlug={ fromSiteSlug }
+				redirectTo={ redirect_to }
 			/>
 		);
 	}
@@ -503,12 +504,13 @@ export function licensingThankYouAutoActivation( context, next ) {
 }
 
 export function licensingThankYouAutoActivationCompleted( context, next ) {
-	const { destinationSiteId } = context.query;
+	const { destinationSiteId, redirect_to } = context.query;
 
 	context.primary = (
 		<LicensingThankYouAutoActivationCompleted
 			productSlug={ context.params.product }
 			destinationSiteId={ destinationSiteId }
+			redirectTo={ redirect_to }
 		/>
 	);
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -262,6 +262,7 @@ export default function getThankYouPageUrl( {
 					siteId: jetpackTemporarySiteId && parseInt( jetpackTemporarySiteId ),
 					fromSiteSlug,
 					productSlug,
+					redirect_to: redirectTo,
 				},
 				`${ calypsoHost }/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }`
 			);
@@ -286,6 +287,7 @@ export default function getThankYouPageUrl( {
 			{
 				receiptId: receiptIdOrPlaceholder,
 				siteId: jetpackTemporarySiteId && parseInt( jetpackTemporarySiteId ),
+				redirect_to: redirectTo,
 			},
 			thankYouUrl
 		);

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1791,6 +1791,46 @@ describe( 'getThankYouPageUrl', () => {
 			);
 		} );
 
+		it( "Connect-after-checkout flow redirects to the site's wp-admin `connect_url_redirect` url, along with a `redirect_to` query param when available", () => {
+			mockWindowLocation();
+			const adminUrl = 'https://my.site/wp-admin/';
+			const fromSiteSlug = 'my.site';
+			const productSlug = 'jetpack_backup_daily';
+
+			const cart = {
+				...getMockCart(),
+				products: [
+					{
+						...getEmptyResponseCartProduct(),
+						product_slug: productSlug,
+					},
+				],
+			};
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				siteSlug: undefined,
+				cart,
+				receiptId: 'invalid receipt ID' as any,
+				sitelessCheckoutType: 'jetpack',
+				connectAfterCheckout: true,
+				adminUrl: adminUrl,
+				fromSiteSlug: fromSiteSlug,
+				redirectTo: 'https://foo.bar/some-path?with-args=yes',
+			} );
+
+			const redirectAfterAuth = `https://wordpress.com/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }?fromSiteSlug=${ fromSiteSlug }&productSlug=${ productSlug }&redirect_to=https%3A%2F%2Ffoo.bar%2Fsome-path%3Fwith-args%3Dyes`;
+
+			expect( url ).toBe(
+				addQueryArgs(
+					{
+						redirect_after_auth: redirectAfterAuth,
+						from: 'connect-after-checkout',
+					},
+					`${ adminUrl }admin.php?page=jetpack&connect_url_redirect=true&jetpack_connect_login_redirect=true`
+				)
+			);
+		} );
+
 		it( 'Redirects to the 100 year plan thank-you page when the 100 year plan is available', () => {
 			const cart = {
 				...getMockCart(),
@@ -1830,6 +1870,29 @@ describe( 'getThankYouPageUrl', () => {
 			} );
 			expect( url ).toBe(
 				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=80023&siteId=123456789'
+			);
+		} );
+
+		it( 'Siteless checkout redirects with `redirect_to` query param when available', () => {
+			const cart = {
+				...getMockCart(),
+				products: [
+					{
+						...getEmptyResponseCartProduct(),
+						product_slug: 'jetpack_backup_daily',
+					},
+				],
+			};
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				siteSlug: undefined,
+				cart,
+				sitelessCheckoutType: 'jetpack',
+				receiptId: 80023,
+				redirectTo: 'https://foo.bar/some-path?with-args=yes',
+			} );
+			expect( url ).toBe(
+				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=80023&redirect_to=https%3A%2F%2Ffoo.bar%2Fsome-path%3Fwith-args%3Dyes'
 			);
 		} );
 

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -304,7 +304,7 @@ function isRedirectAllowed( url: string, siteSlug: string | undefined ): boolean
  * security hole that could go anywhere. This function will disallow a URL
  * which is absolute and on an unknown host, returning the `fallbackUrl` instead.
  */
-function filterAllowedRedirect(
+export function filterAllowedRedirect(
 	url: string,
 	siteSlug: string | undefined,
 	fallbackUrl: string


### PR DESCRIPTION
This PR allows the Jetpack siteless "connect-after-checkout" flow to accept and use a `redirect_to` url query arg as the final redirect location after completing a siteless purchase.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Each individual Jetpack product should be able to dictate the users final redirect location after completing a siteless (license-based) purchase. Also there should be a way to dynamically choose the user's final redirect location depending on any specific scenario. This PR allows us to define the final redirect location (in a siteless checkout) by using a `redirect_to` url query parameter.

### Implementation notes:

- This PR includes the basic code changes to allow the "connect-after-checkout" flow (in Calypso checkout; The flow is typically initiated from within the My Jetpack page in the plugin) to accept and utilize a `redirect_to` url query parameter to determine the user's final redirect location after the siteless checkout flow is fully completed. This PR works automatically for most products already because My Jetpack (in the plugin) already includes a `redirect_to` query arg in the checkout link for each product (determined & defined by each product), however Jetpack Stats is an exception and there is some work still to be done to the checkout links for Jetpack Stats because Stats and it's interstitials work differently than the other products. The PR for getting the Stats checkout flow to work well with the `redirect_to` query arg is here: [Automattic/wp-calypso#94831](https://github.com/Automattic/wp-calypso/pull/94831), with the intention to ship **After** this PR is shipped.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

(1) Prerequisite:
You need a jetpack site that is either not site or user connected, -or- only site connected and not user connected.
Make sure you are logged into wordpress.com with your A11n account so you can purchase with credits.

**Test "connect-after-checkout" flow:**

- Checkout this branch and `yarn-start`.
- Go to your jetpack site, My Jetpack. Ensure your site is either not user connected, or not site and user connected.
- In My Jetpack, choose any product that allow you to purchase. (Except not Stats or CRM)
- Click into the product interstitial and click to purchase, until you are taken to the Calypso checkout page.
- On checkout, in the URL, replace `https://wordpress.com` with `http://calypso.localhost:3000`
- Also in the url change the &redirect_to= query arg value to something like, https://yoursitedomain.com/wp-admin/admin.php?page=testing_this_redirect, just so you'll definitely identify the final redirect url when you see the final redirect location/link, and you'll so you'll know it worked correctly.
- Go ahead and click the "Complete purchase" button, (using credits is fine). 
- After checkout is completed, your site should auto connect and you should first be redirected to the connection authorization page. Click "Authorize", then you should be redirected to the product licensing thank-you auto activation page. The product license should auto-activate itself.
- Finally once all complete, you should see the "Go to Dashboard" button. Inspect the button and see that the `href` location of the button is the `redirect_to` url you updated in the step above.

**Run Unit Tests:**

- Run: `yarn test-client client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
