### PR TITLE
Add-Ons: Round dynamically generated add-on monthly price

### DIFF
--- a/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
@@ -37,10 +37,10 @@ const useAddOnPrices = ( productSlug: ProductsList.StoreProductSlug, quantity?: 
 		// taking a cursory look, it seems as if this will require deeper investigation. For now, because
 		// we are always working with smallest currency units for add-ons, we explicitly round decimal add-on
 		// monthly prices to suppress the warnings ( something that was already happening in the library ).
-		const rawMonthlyPrice = cost / 12;
-		let monthlyPrice = Number.isInteger( rawMonthlyPrice )
-			? rawMonthlyPrice
-			: Math.round( rawMonthlyPrice );
+		const initialMonthlyPrice = cost / 12;
+		let monthlyPrice = Number.isInteger( initialMonthlyPrice )
+			? initialMonthlyPrice
+			: Math.round( initialMonthlyPrice );
 		let yearlyPrice = cost;
 
 		if ( product?.term === 'month' ) {

--- a/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
@@ -37,6 +37,8 @@ const useAddOnPrices = ( productSlug: ProductsList.StoreProductSlug, quantity?: 
 		// taking a cursory look, it seems as if this will require deeper investigation. For now, because
 		// we are always working with smallest currency units for add-ons, we explicitly round decimal add-on
 		// monthly prices to suppress the warnings ( something that was already happening in the library ).
+		//
+		// Once https://github.com/Automattic/wp-calypso/issues/95416 is resolved, we can remove this rounding.
 		const initialMonthlyPrice = cost / 12;
 		let monthlyPrice = Number.isInteger( initialMonthlyPrice )
 			? initialMonthlyPrice

--- a/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
@@ -35,9 +35,9 @@ const useAddOnPrices = ( productSlug: ProductsList.StoreProductSlug, quantity?: 
 		//
 		// The ideal answer is to trace the root cause of the recalculations and prevent them, but after
 		// taking a cursory look, it seems as if this will require deeper investigation. For now, because
-		// we are always working with smallest currency units for add-ons, we explicitly round the add-on
-		// monthly price to suppress the warnings ( something that was already happening in the library ).
-		let monthlyPrice = Math.round( cost / 12 );
+		// we are always working with smallest currency units for add-ons, we explicitly round decimal add-on
+		// monthly prices to suppress the warnings ( something that was already happening in the library ).
+		let monthlyPrice = Number.isInteger( cost ) ? cost : Math.round( cost / 12 );
 		let yearlyPrice = cost;
 
 		if ( product?.term === 'month' ) {

--- a/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
@@ -36,7 +36,7 @@ const useAddOnPrices = ( productSlug: ProductsList.StoreProductSlug, quantity?: 
 		// The ideal answer is to trace the root cause of the recalculations and prevent them, but after
 		// taking a cursory look, it seems as if this will require deeper investigation. For now, because
 		// we are always working with smallest currency units for add-ons, we explicitly round the add-on
-		// monthly price to supress the warnings ( something that was already happening in the library ).
+		// monthly price to suppress the warnings ( something that was already happening in the library ).
 		let monthlyPrice = Math.round( cost / 12 );
 		let yearlyPrice = cost;
 

--- a/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
@@ -26,7 +26,18 @@ const useAddOnPrices = ( productSlug: ProductsList.StoreProductSlug, quantity?: 
 			cost = priceTier?.maximumPrice;
 		}
 
-		let monthlyPrice = cost / 12;
+		// Although memoized, it appears that add-on prices are unnecessarily recalculated dozens of
+		// times when invoked as part of the PlansFeaturesMain component.
+		//
+		// When we format the cost before displaying it to the end user, the formatting library warns us
+		// that it will round decimal values for smallest currency unit calculations. Because of the
+		// unnecessary recalculations, this warning is repeated and floods the console.
+		//
+		// The ideal answer is to trace the root cause of the recalculations and prevent them, but after
+		// taking a cursory look, it seems as if this will require deeper investigation. For now, because
+		// we are always working with smallest currency units for add-ons, we explicitly round the add-on
+		// monthly price to supress the warnings ( something that was already happening in the library ).
+		let monthlyPrice = Math.round( cost / 12 );
 		let yearlyPrice = cost;
 
 		if ( product?.term === 'month' ) {

--- a/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
@@ -37,7 +37,10 @@ const useAddOnPrices = ( productSlug: ProductsList.StoreProductSlug, quantity?: 
 		// taking a cursory look, it seems as if this will require deeper investigation. For now, because
 		// we are always working with smallest currency units for add-ons, we explicitly round decimal add-on
 		// monthly prices to suppress the warnings ( something that was already happening in the library ).
-		let monthlyPrice = Number.isInteger( cost ) ? cost : Math.round( cost / 12 );
+		const rawMonthlyPrice = cost / 12;
+		let monthlyPrice = Number.isInteger( rawMonthlyPrice )
+			? rawMonthlyPrice
+			: Math.round( rawMonthlyPrice );
 		let yearlyPrice = cost;
 
 		if ( product?.term === 'month' ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95370

## Proposed Changes

* Round dynamically generated monthly price ( something already being done behind-the-scenes with the format currency library )

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

<img width="600" alt="Screenshot 2024-10-14 at 5 07 19 PM" src="https://github.com/user-attachments/assets/30b43177-06d0-43ce-8b28-33b66dbf3c40">

Although memoized, it appears that add-on prices are unnecessarily recalculated dozens of
times when invoked as part of the `PlansFeaturesMain` component.

When we format the cost before displaying it to the end user, the formatting library warns us
that it will round floats and their decimal values for smallest currency unit calculations. Because of the
unnecessary recalculations, this warning is repeated and floods the console.

**The ideal answer** is to trace the root cause of the recalculations and prevent them, but after
taking a cursory look, it seems as if this will require deeper investigation. Tracking issue for this here https://github.com/Automattic/wp-calypso/issues/95416

Because we _always_ work with smallest currency units for add-ons, the currency formatter will _always_ round our floats. To address the warnings, we explicitly round add-on monthly price floats ( something that was already happening in the library ) before feeding the formatter our data . This suppresses the warnings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to any page with the plans grid Ex. `/start/plans` or `/plans/{site_slug}`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
