### PR TITLE
Jetpack Cloud | Update license activation redirect to My Jetpack

### DIFF
--- a/client/components/jetpack/licensing-activation-banner/index.tsx
+++ b/client/components/jetpack/licensing-activation-banner/index.tsx
@@ -16,7 +16,7 @@ function LicensingActivationBanner( { siteId }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
-	const jetpackDashboardUrl = siteAdminUrl + 'admin.php?page=jetpack#/license/activation';
+	const jetpackDashboardUrl = siteAdminUrl + 'admin.php?page=my-jetpack#/add-license';
 	const userLicensesCounts = useSelector( getUserLicensesCounts );
 	const hasDetachedLicenses = userLicensesCounts && userLicensesCounts[ 'detached' ] !== 0;
 

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -23,7 +23,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 	const userLicenses = useSelector( getUserLicenses );
 	const userLicensesCounts = useSelector( getUserLicensesCounts );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
-	const jetpackDashboardUrl = siteAdminUrl + 'admin.php?page=jetpack#/license/activation';
+	const jetpackDashboardUrl = siteAdminUrl + 'admin.php?page=my-jetpack#/add-license';
 
 	const hasOneDetachedLicense = userLicensesCounts && userLicensesCounts[ 'detached' ] === 1;
 	const hasDetachedLicenses = userLicensesCounts && userLicensesCounts[ 'detached' ] !== 0;


### PR DESCRIPTION
Currently on Jetpack cloud pricing page, when doing a siteful checkout, when there is a siteless purchase available for purchase, we show a prompt and a banner about a plan being available for activation

<img width="404" alt="Screenshot 2024-10-15 at 11 36 07 AM" src="https://github.com/user-attachments/assets/84eedfc6-af60-47cc-bcb7-6a44bfac9f34">

That activation link points to `jetpack#/license/activation`, which works fine when Jetpack plugin is active but it results in a blank page when only a standalone plugin like Social is active.

Thus, we need to change that activation link to point to `my-jetpack#/add-license` instead. That new link works for both Jetpack and standalone plugins and is even better than that previous link because it lists the available license keys, instead of just giving an input to enter the license.

| `jetpack#/license/activation` | `my-jetpack#/add-license` |
|--------|--------|
| <img width="923" alt="Screenshot 2024-10-15 at 11 48 14 AM" src="https://github.com/user-attachments/assets/c0ae3e50-035f-407c-a769-08d7682f114e"> | <img width="901" alt="Screenshot 2024-10-15 at 11 48 24 AM" src="https://github.com/user-attachments/assets/f5064658-110f-4908-a11f-d1e98697e15e"> | 

## Proposed Changes

* Change license activation link redirect from `jetpack#/license/activation` to `my-jetpack#/add-license`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is to fix the redirect for standalone plugins which do not have that Jetpack page available

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Goto https://cloud.jetpack.com/pricing
- Purchase Social and complete the checkout
- Create a JN site and only activate Social, deactivate Jetpack
- Goto Social admin page and connect WPCOM account
- Come back to Social admin page
- Click on upgrade nudge to land at `https://cloud.jetpack.com/pricing/:siteId?site=:siteId&view=products&redirect_to=admin.php`
- You should see the available license popup
- Click Activate for the Social plan
- It lands at `/wp-admin/admin.php?page=jetpack#/license/activation` with a blank page
- Now use this PR (via the Jetpack Cloud Live link below)
- Replace `cloud.jetpack.com` above with the live link
- Confirm that the activation links (both popup and top banner) land you at `/wp-admin/admin.php?page=my-jetpack#/add-license`
- Now activate the Jetpack plugin as well and reload that pricing page
- Confirm that the activation links land you at `/wp-admin/admin.php?page=my-jetpack#/add-license`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
