### PR TITLE
Reader Onboarding: Add strings for early translation

### DIFF
--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -1,6 +1,7 @@
 import { LoadingPlaceholder } from '@automattic/components';
 import { useQuery } from '@tanstack/react-query';
 import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
@@ -102,11 +103,14 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 
 	return (
 		isOpen && (
-			<Modal title="Discover and Subscribe" onRequestClose={ onClose } isFullScreen>
-				<h2>Suggested blogs based on your interests</h2>
+			<Modal onRequestClose={ onClose } isFullScreen>
+				<h2>{ __( "Discover sites that you'll love" ) }</h2>
+				<p>
+					{ __( 'Preview sites by clicking below, then subscribe to any site that inspires you.' ) }
+				</p>
 				{ isLoading && <LoadingPlaceholder /> }
 				{ ! isLoading && combinedRecommendations.length === 0 && (
-					<p>No recommendations available at the moment.</p>
+					<p>{ __( 'No recommendations available at the moment.' ) }</p>
 				) }
 				{ ! isLoading && combinedRecommendations.length > 0 && (
 					<div className="subscribe-modal__recommended-sites">
@@ -125,6 +129,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 						) ) }
 					</div>
 				) }
+				<p>{ __( 'Load more recommendations' ) }</p>
 			</Modal>
 		)
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/188

## Proposed Changes

* This PR adds strings that need translations, so they'll be ready sooner rather than later. They'll be styled with CSS in a future PR.

<img width="1722" alt="Screenshot 2024-10-15 at 10 20 13 AM" src="https://github.com/user-attachments/assets/b1838725-a89a-4c79-b9d7-3d3498f08ef5">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Queuing up translations so they'll be ready before launch

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/onboarding
* Click on "Discover and subscribe to sites you'll love"
* View the strings

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
