### PR TITLE
Marketplace: allows duplicator installation.

### DIFF
--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -17,8 +17,6 @@ const incompatiblePlugins = new Set( [
 	'better-wp-security',
 	'cf7-pipedrive-integration',
 	'database-browser',
-	'duplicator',
-	'duplicator-pro',
 	'extended-wp-reset',
 	'file-manager-advanced',
 	'file-manager',

--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -17,6 +17,7 @@ const incompatiblePlugins = new Set( [
 	'better-wp-security',
 	'cf7-pipedrive-integration',
 	'database-browser',
+	'duplicator',
 	'extended-wp-reset',
 	'file-manager-advanced',
 	'file-manager',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/39775

## Proposed Changes

* Allows `duplicator-pro` to be activated

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Upload `duplicator-pro` 
* Make sure that the plugin can be activated from Calypso
* Installation whitelisting is handled in https://github.com/Automattic/jetpack/pull/39775

