### PR TITLE
Remove "Course maker" navigation

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -20,7 +20,7 @@ const UniversalNavbarHeader = ( {
 }: HeaderProps ) => {
 	const locale = useLocale();
 	const localizeUrl = useLocalizeUrl();
-	const { __, hasTranslation } = useI18n();
+	const { __ } = useI18n();
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
 	const isEnglishLocale = useIsEnglishLocale();
 
@@ -143,17 +143,6 @@ const UniversalNavbarHeader = ( {
 															titleValue=""
 															content={ __( 'Commerce', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl( '//wordpress.com/ecommerce/' ) }
-															type="dropdown"
-															target="_self"
-														/>
-														<ClickableItem
-															titleValue=""
-															content={
-																locale === 'en' || hasTranslation?.( 'Course Maker' )
-																	? __( 'Course Maker', __i18n_text_domain__ )
-																	: __( 'Course', __i18n_text_domain__ )
-															}
-															urlValue={ localizeUrl( '//wordpress.com/create-a-course/' ) }
 															type="dropdown"
 															target="_self"
 														/>
@@ -508,16 +497,6 @@ const UniversalNavbarHeader = ( {
 												titleValue=""
 												content={ __( 'Commerce', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/ecommerce/' ) }
-												type="menu"
-											/>
-											<ClickableItem
-												titleValue=""
-												content={
-													locale === 'en' || hasTranslation?.( 'Course Maker' )
-														? __( 'Course Maker', __i18n_text_domain__ )
-														: __( 'Course', __i18n_text_domain__ )
-												}
-												urlValue={ localizeUrl( '//wordpress.com/create-a-course/' ) }
 												type="menu"
 											/>
 											<ClickableItem


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9327

## Proposed Changes

We are removing the "Create a course" flow (see paYJgx-5ol-p2), so any links to it need to be removed as well.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the live preview
2. Go to `/patterns`
3. Hover on the `Products` menu on the main navigation
4. Check that `Course Maker` is not there (it would be the next to last element)

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/87a572e1-fb20-406d-97df-073259dab747)|![image](https://github.com/user-attachments/assets/5c8759f0-94b1-4c48-b7f0-0aafa3ff21a6)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?