### PR TITLE
Reader Onboarding: Introduce disableSuggestedFollows prop

### DIFF
--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -23,6 +23,7 @@ class ConnectedSubscriptionListItem extends Component {
 		isFollowing: PropTypes.bool,
 		followSource: PropTypes.string,
 		railcar: PropTypes.object,
+		disableSuggestedFollows: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -31,6 +32,7 @@ class ConnectedSubscriptionListItem extends Component {
 		showNotificationSettings: true,
 		showLastUpdatedDate: true,
 		showFollowedOnDate: true,
+		disableSuggestedFollows: false,
 	};
 
 	componentDidMount() {
@@ -62,6 +64,7 @@ class ConnectedSubscriptionListItem extends Component {
 			isFollowing,
 			followSource,
 			railcar,
+			disableSuggestedFollows,
 		} = this.props;
 
 		return (
@@ -77,6 +80,7 @@ class ConnectedSubscriptionListItem extends Component {
 				isFollowing={ isFollowing }
 				followSource={ followSource }
 				railcar={ railcar }
+				disableSuggestedFollows={ disableSuggestedFollows }
 			/>
 		);
 	}

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -44,6 +44,7 @@ function ReaderSubscriptionListItem( {
 	railcar,
 	isLoggedIn,
 	registerLastActionRequiresLogin: registerLastActionRequiresLoginProp,
+	disableSuggestedFollows,
 } ) {
 	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
@@ -210,7 +211,7 @@ function ReaderSubscriptionListItem( {
 					<ReaderSiteNotificationSettings siteId={ siteId } />
 				) }
 			</div>
-			{ siteId && (
+			{ siteId && ! disableSuggestedFollows && (
 				<ReaderSuggestedFollowsDialog
 					onClose={ onCloseSuggestedFollowModal }
 					siteId={ +siteId }

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -121,6 +121,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 								showNotificationSettings={ false }
 								showFollowedOnDate={ false }
 								followSource="reader-onboarding-modal"
+								disableSuggestedFollows
 							/>
 						) ) }
 					</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9443

## Proposed Changes

* Introduce the `disableSuggestedFollows` prop
* Adds the ability to turn off the "Suggested sites" modal after subscribing to a site using the `ConnectedReaderSubscriptionListItem` component.

> [!NOTE]  
> This PR is NOT behind the `reader/onboarding` feature flag.

Here is screenshot of the modal when it is enabled.

<img width="1723" alt="Screenshot 2024-10-15 at 11 39 52 AM" src="https://github.com/user-attachments/assets/a15a9c96-a60b-48d7-b4e9-5f94f55be958">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Push the Reader Onboarding project forward

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /read?flags=reader/onboarding
* Click on "Discover and subscribe to sites you'll love" and subscribe to any blog
* You should be subscribed to the site and NOT see a recommended sites modal popup
* Go to /discover
* Click on a subscribe button on one of the site in the right hand "Popular sites" column
* You should be subscribed to the site and see the recommended sites modal popup

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
