### PR TITLE
A4A: add tracking events to buttons on Migration Offer page

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
@@ -45,6 +45,14 @@ export default function MigrationsOverview() {
 		dispatch( recordTracksEvent( 'calypso_a4a_migrations_add_bank_details_button_click' ) );
 	}, [ dispatch ] );
 
+	const onMigrateToWPCOMClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_migrations_migrate_to_wpcom_button_click' ) );
+	}, [ dispatch ] );
+
+	const onMigrateToPressableClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_migrations_migrate_to_pressable_button_click' ) );
+	}, [ dispatch ] );
+
 	return (
 		<Layout className="migrations-overview__layout" title={ title } wide>
 			<LayoutTop>
@@ -106,6 +114,7 @@ export default function MigrationsOverview() {
 								<Button
 									primary
 									compact
+									onClick={ onMigrateToWPCOMClick }
 									href="https://developer.wordpress.com/docs/get-started/build-new-or-migrate/migrate-existing/"
 									target="_blank"
 								>
@@ -133,6 +142,7 @@ export default function MigrationsOverview() {
 								<Button
 									primary
 									compact
+									onClick={ onMigrateToPressableClick }
 									href="https://pressable.com/knowledgebase/migrate-a-site-to-pressable/"
 									target="_blank"
 								>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1290

## Proposed Changes

In order to track the actual number of clicks on Migration offers page we are adding tracking events to Mogrations Buttons on `/migrations` page.

New events: 
- **`calypso_a4a_migrations_migrate_to_wpcom_button_click`** 
- **`calypso_a4a_migrations_migrate_to_pressable_button_click`**

<img width="884" alt="Screenshot 2024-10-15 at 11 02 13 AM" src="https://github.com/user-attachments/assets/5f7d122f-28e7-41ae-b0b2-4589569aa649">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up this branch locally or use the live link provided below.
- Navigate to `/migrations` page.
- In your dev console, check Network tab and filter All requests with  `t.gif` in search field. 
- Clicking Migration buttons check that track events are sent.

<img width="632" alt="Screenshot 2024-10-15 at 10 59 01 AM" src="https://github.com/user-attachments/assets/1d4dda0f-e0b7-4fce-a5a2-31a5df5b5380">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
