### PR TITLE
Passwordless Core Profiler Auth - Update disclaimer copy

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1058,24 +1058,34 @@ export class JetpackAuthorize extends Component {
 								{ translate( 'Sign in as a different user' ) }
 							</LoggedOutFormLinkItem>
 						</Card>
-						<div className="jetpack-connect__logged-in-bottom">
-							{ this.renderStateAction() }
-							{ ! config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) && (
+						{ ! config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) && (
+							<div className="jetpack-connect__logged-in-bottom">
+								{ this.renderStateAction() }
 								<JetpackFeatures col1Features={ col1Features } col2Features={ col2Features } />
-							) }
-							<Disclaimer
-								siteName={ decodeEntities( authQuery.blogname ) }
-								companyName={ this.getCompanyName() }
-								from={ authQuery.from }
-								isWooCoreProfiler={ this.isWooCoreProfiler() }
-							/>
-							{ ! config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) && (
+								<Disclaimer
+									siteName={ decodeEntities( authQuery.blogname ) }
+									companyName={ this.getCompanyName() }
+									from={ authQuery.from }
+									isWooCoreProfiler={ this.isWooCoreProfiler() }
+								/>
 								<div className="jetpack-connect__jetpack-logo-wrapper">
 									<JetpackLogo monochrome size={ 18 } />{ ' ' }
 									<span>{ translate( 'Jetpack powered' ) }</span>
 								</div>
-							) }
-						</div>
+							</div>
+						) }
+
+						{ config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) && (
+							<div className="jetpack-connect__logged-in-bottom">
+								<Disclaimer
+									siteName={ decodeEntities( authQuery.blogname ) }
+									companyName={ this.getCompanyName() }
+									from={ authQuery.from }
+									isWooCoreProfiler={ this.isWooCoreProfiler() }
+								/>
+								{ this.renderStateAction() }
+							</div>
+						) }
 					</div>
 					{ authQuery.installedExtSuccess && <WooInstallExtSuccessNotice /> }
 				</Fragment>

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1067,6 +1067,7 @@ export class JetpackAuthorize extends Component {
 								siteName={ decodeEntities( authQuery.blogname ) }
 								companyName={ this.getCompanyName() }
 								from={ authQuery.from }
+								isWooCoreProfiler={ this.isWooCoreProfiler() }
 							/>
 							{ ! config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) && (
 								<div className="jetpack-connect__jetpack-logo-wrapper">

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -67,7 +67,7 @@ class JetpackConnectDisclaimer extends PureComponent {
 			);
 
 			text = translate(
-				"By clicking Connect your account, you agree to our {{termsOfServiceLink}}Terms of Service{{/termsOfServiceLink}} and to {{syncDataLink}}sync your site's data{{/syncDataLink}} with us.",
+				"By clicking Connect your account, you agree to our {{termsOfServiceLink}}Terms of Service{{/termsOfServiceLink}} and to {{syncDataLink}}sync your site’s data{{/syncDataLink}} with us.",
 				{
 					components: {
 						termsOfServiceLink,

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -10,6 +11,7 @@ class JetpackConnectDisclaimer extends PureComponent {
 		companyName: PropTypes.string,
 		siteName: PropTypes.string.isRequired,
 		from: PropTypes.string,
+		isWooCoreProfiler: PropTypes.bool,
 	};
 
 	handleClickDisclaimer = () => {
@@ -17,7 +19,14 @@ class JetpackConnectDisclaimer extends PureComponent {
 	};
 
 	render() {
-		const { companyName = 'WordPress.com', siteName, from, translate } = this.props;
+		const {
+			companyName = 'WordPress.com',
+			isWooCoreProfiler = false,
+			siteName,
+			from,
+			translate,
+		} = this.props;
+		let text;
 
 		const detailsLink = (
 			<a
@@ -29,31 +38,48 @@ class JetpackConnectDisclaimer extends PureComponent {
 			/>
 		);
 
-		const text =
-			from === 'my-jetpack'
-				? translate(
-						'By clicking {{strong}}Approve{{/strong}}, you agree to {{detailsLink}}sync your site‘s data{{/detailsLink}} with us.',
-						{
-							components: {
-								strong: <strong />,
-								detailsLink,
-							},
-						}
-				  )
-				: translate(
-						'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between %(companyName)s and %(siteName)s.',
-						{
-							components: {
-								detailsLink,
-							},
-							args: {
-								companyName,
-								siteName,
-							},
-							comment:
-								'`companyName` is the site domain receiving the data (typically WordPress.com), and `siteName` is the site domain sharing the data.',
-						}
-				  );
+		if ( isWooCoreProfiler && config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
+			text = translate(
+				'By connecting your account, you agree to {{detailsLink}}share details{{/detailsLink}} between %(companyName)s and %(siteName)s. This connection does not add any additional plugins or change the way you run your store.',
+				{
+					components: {
+						detailsLink,
+					},
+					args: {
+						companyName,
+						siteName,
+					},
+					comment:
+						'`companyName` is the site domain receiving the data (typically WordPress.com), and `siteName` is the site domain sharing the data.',
+				}
+			);
+		} else {
+			text =
+				from === 'my-jetpack'
+					? translate(
+							'By clicking {{strong}}Approve{{/strong}}, you agree to {{detailsLink}}sync your site‘s data{{/detailsLink}} with us.',
+							{
+								components: {
+									strong: <strong />,
+									detailsLink,
+								},
+							}
+					  )
+					: translate(
+							'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between %(companyName)s and %(siteName)s.',
+							{
+								components: {
+									detailsLink,
+								},
+								args: {
+									companyName,
+									siteName,
+								},
+								comment:
+									'`companyName` is the site domain receiving the data (typically WordPress.com), and `siteName` is the site domain sharing the data.',
+							}
+					  );
+		}
 
 		return <p className="jetpack-connect__tos-link">{ text }</p>;
 	}

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -39,18 +39,40 @@ class JetpackConnectDisclaimer extends PureComponent {
 		);
 
 		if ( isWooCoreProfiler && config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
+			const termsOfServiceLink = (
+				<a
+					href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+					className="jetpack-connect__sso-actions-modal-link"
+					onClick={ () => {
+						this.props.recordTracksEvent( 'calypso_jpc_disclaimer_tos_link_click', {
+							...this.props,
+						} );
+					} }
+				/>
+			);
+			const syncDataLink = (
+				<a
+					href={ localizeUrl( 'https://jetpack.com/support/what-data-does-jetpack-sync/' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+					className="jetpack-connect__sso-actions-modal-link"
+					onClick={ () => {
+						this.props.recordTracksEvent( 'calypso_jpc_disclaimer_sync_data_link_click', {
+							...this.props,
+						} );
+					} }
+				/>
+			);
+
 			text = translate(
-				'By connecting your account, you agree to {{detailsLink}}share details{{/detailsLink}} between %(companyName)s and %(siteName)s. This connection does not add any additional plugins or change the way you run your store.',
+				"By clicking Connect your account, you agree to our {{termsOfServiceLink}}Terms of Service{{/termsOfServiceLink}} and to {{syncDataLink}}sync your site's data{{/syncDataLink}} with us.",
 				{
 					components: {
-						detailsLink,
+						termsOfServiceLink,
+						syncDataLink,
 					},
-					args: {
-						companyName,
-						siteName,
-					},
-					comment:
-						'`companyName` is the site domain receiving the data (typically WordPress.com), and `siteName` is the site domain sharing the data.',
 				}
 			);
 		} else {

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -67,7 +67,7 @@ class JetpackConnectDisclaimer extends PureComponent {
 			);
 
 			text = translate(
-				"By clicking Connect your account, you agree to our {{termsOfServiceLink}}Terms of Service{{/termsOfServiceLink}} and to {{syncDataLink}}sync your site’s data{{/syncDataLink}} with us.",
+				'By clicking Connect your account, you agree to our {{termsOfServiceLink}}Terms of Service{{/termsOfServiceLink}} and to {{syncDataLink}}sync your site’s data{{/syncDataLink}} with us.',
 				{
 					components: {
 						termsOfServiceLink,

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1221,6 +1221,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		.jetpack-connect__tos-link {
 			margin: 24px auto;
+			text-align: left;
+			a {
+				line-height: inherit;
+			}
 		}
 	}
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1220,7 +1220,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 
 		.jetpack-connect__tos-link {
-			margin: 24px auto 70px;
+			margin: 24px auto;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR updates the disclaimer copy on the authorization page and move it above the button.

Issue: https://github.com/woocommerce/woocommerce/issues/52047

## Proposed Changes

* Updated the disclaimer copy.
* Moved the copy above the button.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To reflect the latest design change.

## Testing Instructions

1. Checkout this branch locally.
2. Open `config/development.json` and set `woocommerce/core-profiler-passwordless-auth` flag to true
3. Run `yarn start`
4. Open this [link](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=236381464&redirect_uri=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D32ab4c9508%26redirect%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A2ca8ea2582da1c066074563a12cc8b22&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=13.7&secret=QFoaAXaOIPZTr9p6Z5Hqf6RWkCboPylJ&blogname=Noisily%20Fortunate%20Toucan&site_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&home_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&site_icon=&site_lang=en_US&site_created=2024-08-26%2019%3A40%3A51&allow_site_connection=1&calypso_env=production&source=&_as=search-term&_ak=jetpack&from=woocommerce-core-profiler&_ui=254662545&_ut=wpcom%3Auser_id&purchase_nonce=lbtPaOlO&_wp_nonce=69744335dc&redirect_after_auth=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&lang=es)
5. Confirm the copy changes. Compare it to Y5pUYSJPsGEud1vknUZhi8-fi-3182_10721

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?