### PR TITLE
Help Center: fix presales chat

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -28,7 +28,7 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 	const translate = useTranslate();
 	const site = useSite();
 	const importSiteQueryParam = useQuery().get( 'from' ) || '';
-	usePresalesChat( 'wpcom', true, true );
+	usePresalesChat( 'wpcom' );
 
 	const options = useMemo(
 		() => [


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9426

## Proposed Changes

Change `usePresalesChat` hook in the migration flow to NOT skip the availability checks

## Why are these changes being made?

Somewhere in WordPress.com users are being served the presales version of Zendesk/Help Center despite having it disabled in the settings. In the migration flow there is a call get the presales chat that ignores the availability check. By skipping this our internal tool that disables it is not taken into account. @valterlorran I am tagging you because I am not 100% if this was an accident or intentional.

## Testing Instructions

We didn't have ways to replicate the error so this is really just a sanity check.