### PR TITLE
Create pending sticker when loading the "how to migrate" step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -62,7 +62,7 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 		urlData
 	);
 
-	const { onOptionClick } = usePendingMigrationStatus( { onSubmit: navigation.submit } );
+	const { setPendingMigration } = usePendingMigrationStatus( { onSubmit: navigation.submit } );
 
 	const hostingProviderSlug = hostingProviderData?.hosting_provider?.slug;
 	const shouldDisplayHostIdentificationMessage =
@@ -78,7 +78,7 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 						key={ i }
 						title={ option.label }
 						text={ option.description }
-						onClick={ () => onOptionClick( option.value ) }
+						onClick={ () => setPendingMigration( option.value ) }
 					/>
 				) ) }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,59 +1,20 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import { FC, useMemo, useEffect } from 'react';
+import { FC, useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { useUpdateMigrationStatus } from 'calypso/data/site-migration/use-update-migration-status';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
 import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
 import FlowCard from '../components/flow-card';
-import type { NavigationControls, StepProps } from '../../types';
+import usePendingMigrationStatus from './use-pending-migration-status';
+import type { StepProps } from '../../types';
 
 import './style.scss';
-
-interface PendingMigrationStatusProps {
-	onSubmit?: Pick< NavigationControls, 'submit' >[ 'submit' ];
-}
-
-const usePendingMigrationStatus = ( { onSubmit }: PendingMigrationStatusProps ) => {
-	const site = useSite();
-	const siteId = site?.ID;
-
-	const canInstallPlugins = site?.plan?.features?.active.find(
-		( feature ) => feature === 'install-plugins'
-	)
-		? true
-		: false;
-
-	const { updateMigrationStatus } = useUpdateMigrationStatus();
-
-	// Register pending migration status when loading the step.
-	useEffect( () => {
-		if ( siteId ) {
-			updateMigrationStatus( siteId, 'migration-pending' );
-		}
-	}, [ siteId, updateMigrationStatus ] );
-
-	const onOptionClick = ( how: string ) => {
-		const destination = canInstallPlugins ? 'migrate' : 'upgrade';
-		if ( siteId ) {
-			const parsedHow = how === HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF ? 'diy' : how;
-			updateMigrationStatus( siteId, `migration-pending-${ parsedHow }` );
-		}
-
-		if ( onSubmit ) {
-			return onSubmit( { how, destination } );
-		}
-	};
-
-	return { onOptionClick };
-};
 
 interface Props extends StepProps {
 	headerText?: string;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+import { useUpdateMigrationStatus } from 'calypso/data/site-migration/use-update-migration-status';
+import { RenderStepOptions, mockStepProps, renderStep } from '../../test/helpers';
+import SiteMigrationHowToMigrate from '../index';
+import type { StepProps } from '../../../types';
+
+const siteId = 1;
+
+jest.mock( 'calypso/data/site-migration/use-update-migration-status', () => ( {
+	useUpdateMigrationStatus: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/presales-chat', () => ( {
+	usePresalesChat: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/data/site-profiler/use-analyze-url-query', () => ( {
+	useAnalyzeUrlQuery: () => ( { data: {} } ),
+} ) );
+
+jest.mock( 'calypso/data/site-profiler/use-hosting-provider-query', () => ( {
+	useHostingProviderQuery: () => ( { data: {} } ),
+} ) );
+
+jest.mock( 'calypso/site-profiler/hooks/use-hosting-provider-name', () => jest.fn() );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
+	useSite: jest.fn( () => ( {
+		ID: siteId,
+	} ) ),
+} ) );
+
+const render = ( props?: Partial< StepProps >, renderOptions?: RenderStepOptions ) => {
+	const combinedProps = { ...mockStepProps( props ) };
+	return renderStep( <SiteMigrationHowToMigrate { ...combinedProps } />, renderOptions );
+};
+
+describe( 'SiteMigrationHowToMigrate', () => {
+	const mockSubmit = jest.fn();
+	let mockUpdateMigrationStatus;
+
+	beforeEach( () => {
+		mockUpdateMigrationStatus = jest.fn();
+		( useUpdateMigrationStatus as jest.Mock ).mockReturnValue( {
+			updateMigrationStatus: mockUpdateMigrationStatus,
+		} );
+	} );
+
+	it( 'should register pending migration status when the component is loaded', () => {
+		render( { navigation: { submit: mockSubmit } } );
+
+		expect( mockUpdateMigrationStatus ).toHaveBeenCalledWith( siteId, 'migration-pending' );
+	} );
+
+	it( 'should call updateMigrationStatus with correct value for DIFM option', () => {
+		const { getByText } = render( { navigation: { submit: mockSubmit } } );
+
+		const optionButton = getByText( 'Do it for me' );
+		fireEvent.click( optionButton );
+
+		// Check the last call value
+		const lastCallValue =
+			mockUpdateMigrationStatus.mock.calls[ mockUpdateMigrationStatus.mock.calls.length - 1 ][ 1 ];
+		expect( lastCallValue ).toBe( 'migration-pending-difm' );
+	} );
+
+	it( 'should call updateMigrationStatus with correct value for DIY option', () => {
+		const { getByText } = render( { navigation: { submit: mockSubmit } } );
+
+		const optionButton = getByText( "I'll do it myself" );
+		fireEvent.click( optionButton );
+
+		// Check the last call value
+		const lastCallValue =
+			mockUpdateMigrationStatus.mock.calls[ mockUpdateMigrationStatus.mock.calls.length - 1 ][ 1 ];
+		expect( lastCallValue ).toBe( 'migration-pending-diy' );
+	} );
+
+	it( 'should call submit with correct value when DIFM option is clicked', () => {
+		const { getByText } = render( { navigation: { submit: mockSubmit } } );
+
+		const optionButton = getByText( 'Do it for me' );
+		fireEvent.click( optionButton );
+
+		expect( mockSubmit ).toHaveBeenCalledWith( { destination: 'upgrade', how: 'difm' } );
+	} );
+
+	it( 'should call submit with correct value for DIY option', () => {
+		const { getByText } = render( { navigation: { submit: mockSubmit } } );
+
+		const optionButton = getByText( "I'll do it myself" );
+		fireEvent.click( optionButton );
+
+		expect( mockSubmit ).toHaveBeenCalledWith( { destination: 'upgrade', how: 'myself' } );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/use-pending-migration-status.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/use-pending-migration-status.ts
@@ -27,7 +27,7 @@ const usePendingMigrationStatus = ( { onSubmit }: PendingMigrationStatusProps ) 
 		}
 	}, [ siteId, updateMigrationStatus ] );
 
-	const onOptionClick = ( how: string ) => {
+	const setPendingMigration = ( how: string ) => {
 		const destination = canInstallPlugins ? 'migrate' : 'upgrade';
 		if ( siteId ) {
 			const parsedHow = how === HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF ? 'diy' : how;
@@ -39,7 +39,7 @@ const usePendingMigrationStatus = ( { onSubmit }: PendingMigrationStatusProps ) 
 		}
 	};
 
-	return { onOptionClick };
+	return { setPendingMigration };
 };
 
 export default usePendingMigrationStatus;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/use-pending-migration-status.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/use-pending-migration-status.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { useUpdateMigrationStatus } from 'calypso/data/site-migration/use-update-migration-status';
+import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import type { NavigationControls } from '../../types';
+
+interface PendingMigrationStatusProps {
+	onSubmit?: Pick< NavigationControls, 'submit' >[ 'submit' ];
+}
+
+const usePendingMigrationStatus = ( { onSubmit }: PendingMigrationStatusProps ) => {
+	const site = useSite();
+	const siteId = site?.ID;
+
+	const canInstallPlugins = site?.plan?.features?.active.find(
+		( feature ) => feature === 'install-plugins'
+	)
+		? true
+		: false;
+
+	const { updateMigrationStatus } = useUpdateMigrationStatus();
+
+	// Register pending migration status when loading the step.
+	useEffect( () => {
+		if ( siteId ) {
+			updateMigrationStatus( siteId, 'migration-pending' );
+		}
+	}, [ siteId, updateMigrationStatus ] );
+
+	const onOptionClick = ( how: string ) => {
+		const destination = canInstallPlugins ? 'migrate' : 'upgrade';
+		if ( siteId ) {
+			const parsedHow = how === HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF ? 'diy' : how;
+			updateMigrationStatus( siteId, `migration-pending-${ parsedHow }` );
+		}
+
+		if ( onSubmit ) {
+			return onSubmit( { how, destination } );
+		}
+	};
+
+	return { onOptionClick };
+};
+
+export default usePendingMigrationStatus;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95288

## Proposed Changes

* Create the sticker when loading the "How to migrate" step.
* Extract hook to simplify step code.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to register the `migration-pending` when the user is navigating through the migration flow. See more in p1728684758970459/1728480467.656839-slack-C07N53UNUQJ.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To check the status creation, you check the network tab of your browser filtering by `/site-migration-status-sticker`. To make sure the status was created, you can check it directly in your sandbox (p1729023356708799/1728480467.656839-slack-C07N53UNUQJ). 

Test the following steps in `/setup/migration` and in the `/setup/hosted-site-migration`:

* Navigate to the "How to migrate" step.
* Check that it register the pending status.
* Click on the options, and make sure it continues registering the pending status for the "DIY" and "DIFM".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?