### PR TITLE
Privacy: Update inline support links

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -244,11 +244,15 @@ const contextLinks = {
 		post_id: 243475,
 	},
 	privacy: {
-		link: 'https://wordpress.com/support/settings/privacy-settings/',
+		link: 'https://wordpress.com/support/privacy-settings/',
 		post_id: 1507,
 	},
 	'privacy-preview-link': {
 		link: 'https://wordpress.com/support/settings/privacy-settings/#preview-link',
+		post_id: 1507,
+	},
+	'privacy-prevent-third-party-sharing': {
+		link: 'https://wordpress.com/support/privacy-settings/make-your-website-public/#prevent-third-party-sharing',
 		post_id: 1507,
 	},
 	'primary-site-address': {

--- a/client/my-sites/site-settings/site-setting-privacy/form.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/form.tsx
@@ -1,6 +1,5 @@
 import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products';
 import { FormLabel } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
@@ -253,10 +252,7 @@ const SiteSettingPrivacyForm = ( {
 												a: (
 													<InlineSupportLink
 														showIcon={ false }
-														supportLink={ localizeUrl(
-															'https://wordpress.com/support/privacy-settings/#public'
-														) }
-														showSupportModal={ false }
+														supportContext="privacy-prevent-third-party-sharing"
 													/>
 												),
 											},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/95417

## Proposed Changes

This PR updates the privacy support links:

| Old | New |
| --- | --- |
| https://wordpress.com/support/settings/privacy-settings/ | https://wordpress.com/support/privacy-settings/
| https://wordpress.com/support/privacy-settings/#public | https://wordpress.com/support/privacy-settings/make-your-website-public/#prevent-third-party-sharing |

Privacy link
![Screenshot 2024-10-16 at 12 51 20 PM](https://github.com/user-attachments/assets/b5878072-7731-454c-b0db-6f5da14d759b)

Third-party sharing link
![Screenshot 2024-10-16 at 12 51 28 PM](https://github.com/user-attachments/assets/dbafe474-b3b9-4527-959d-d0ecde0600d3)

> [!NOTE]
> The third-party sharing link has been updated to open in Help Center. However, there seems to be an issue where the scrolling isn't landing on the expected anchor. We could either revert the change for the link to open in a new tab, or follow up with the Vertex team to solve this. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Update outdated support links.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/settings/general/{SITE}`.
* Ensure that the support links are updated as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
