### PR TITLE
Site Profiler: Adjust style for mobile view

### DIFF
--- a/client/site-profiler/components/heading-information/styles.scss
+++ b/client/site-profiler/components/heading-information/styles.scss
@@ -56,4 +56,14 @@
 			top: -3px !important;
 		}
 	}
+
+	@media (max-width: $break-mobile) {
+		.cta-wrapper {
+			flex-direction: column;
+
+			.button-action {
+				justify-content: center;
+			}
+		}
+	}
 }

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -40,6 +40,11 @@ html[dir="rtl"] {
 		font-size: 2.5rem;
 		line-height: 1.15;
 		margin-bottom: 1rem;
+
+		@media ( max-width: $break-small ) {
+			/* stylelint-disable-next-line */
+			font-size: 1.875em;
+		}
 	}
 
 	h3 {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/86446

## Proposed Changes

* Adjust style for mobile view

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler?flags=-site-profiler/metrics`
* Resize window to mobile view resolution
* Enter any domain (example: wordpress.com)
* Check if the CTA and link is one below the other
* Scroll down and check if the h2 element has reduced size to: `1.875rem`

<img width="467" alt="Screenshot 2024-10-16 at 11 38 22" src="https://github.com/user-attachments/assets/4d7caecd-d7bd-4270-ae9a-ab244d8d7b54">

<img width="423" alt="Screenshot 2024-10-16 at 11 42 27" src="https://github.com/user-attachments/assets/09b25ac9-6b65-4b83-8e1b-f902ac76beff">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
