### PR TITLE
Signup: fix the title overflow of the classic signup flows.

### DIFF
--- a/client/components/formatted-header/README.md
+++ b/client/components/formatted-header/README.md
@@ -22,3 +22,4 @@ function render() {
 - `subHeaderText` (`node`) - Sub header text (optional)
 - `compactOnMobile` (`bool`) - Display a compact header on small screens (optional)
 - `isSecondary` (`bool`) - Use the H2 element instead of the H1 (optional)
+- `disablePreventWidows` (`bool`) - Disable the default behavior of inserting non-breaking space to prevent dangling words.

--- a/client/components/formatted-header/index.tsx
+++ b/client/components/formatted-header/index.tsx
@@ -18,6 +18,7 @@ interface Props extends PropsWithChildren {
 	subHeaderAs?: ElementType;
 	subHeaderText?: ReactNode;
 	tooltipText?: ReactNode;
+	disablePreventWidows?: boolean;
 }
 
 const FormattedHeader: FC< Props > = ( {
@@ -35,6 +36,7 @@ const FormattedHeader: FC< Props > = ( {
 	subHeaderAs: SubHeaderAs = 'p',
 	subHeaderText,
 	tooltipText,
+	disablePreventWidows,
 } ) => {
 	const classes = clsx( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,
@@ -54,24 +56,27 @@ const FormattedHeader: FC< Props > = ( {
 		</InfoPopover>
 	);
 
+	const formattedHeaderText = disablePreventWidows ? headerText : preventWidows( headerText, 2 );
+	const formattedSubHeaderText = disablePreventWidows
+		? subHeaderText
+		: preventWidows( subHeaderText, 2 );
+
 	return (
 		<header id={ id } className={ classes }>
 			<div>
 				{ ! isSecondary && (
 					<h1 className={ headerClasses }>
-						{ preventWidows( headerText, 2 ) } { tooltip }
+						{ formattedHeaderText } { tooltip }
 					</h1>
 				) }
 				{ isSecondary && (
 					<h2 className={ headerClasses }>
-						{ preventWidows( headerText, 2 ) } { tooltip }
+						{ formattedHeaderText } { tooltip }
 					</h2>
 				) }
 				{ screenReader && <h2 className="screen-reader-text">{ screenReader }</h2> }
-				{ subHeaderText && (
-					<SubHeaderAs className={ subtitleClasses }>
-						{ preventWidows( subHeaderText, 2 ) }
-					</SubHeaderAs>
+				{ formattedSubHeaderText && (
+					<SubHeaderAs className={ subtitleClasses }>{ formattedSubHeaderText }</SubHeaderAs>
 				) }
 			</div>
 			{ children }

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -233,6 +233,7 @@ class StepWrapper extends Component {
 								headerText={ this.headerText() }
 								subHeaderText={ this.subHeaderText() }
 								align={ align }
+								disablePreventWidows
 							/>
 							{ headerImageUrl && (
 								<div className="step-wrapper__header-image">

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -8,6 +8,7 @@
 
 	.formatted-header {
 		flex-grow: 1;
+		text-wrap: pretty;
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #91870 

## Proposed Changes

Currently, the title of a step of a classic signup flow can overflow horizontally since there is no proper text-wrapping configuration and the `preventWidows()` call under the hood will further prevent wrapping. Currently, `de` has it prominently:

<img src="https://github.com/user-attachments/assets/82d25b8a-ae81-471d-931b-a09e14f6fcc0" width="320"/>

Since `<FormattedHeader>` has been used extensively across calypso, this PR takes a safer approach to limit the potential impact:

1. Add `disablePreventWidows` property which can disable the behavior and is defaulted to `false`.
2. Only add `text-wrap: pretty` to the signup step wrapper component, so other use cases won't be affected.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Although we've only caught the `de` instance here, it's a general layout configuration issue that can happen whenever a copy is long and can't be easily broken up. The proposed configuration here won't be able to handle everything, but should better prevent layout breakage.

Here are some screenshots of hand-picked locales with the changes. Note that `de` case no longer has the title overflow issue:

| Locale | /start/plans |
|--------|-------------|
|de | <img src="https://github.com/user-attachments/assets/bed8c095-83eb-4738-a4f8-7e804e9a8ed5" width="320" />| 
| en | <img src="https://github.com/user-attachments/assets/c9fd8f67-157c-46f6-9162-39c9c5bf376f" width="320" />|
|pt-br| <img src="https://github.com/user-attachments/assets/5cc80a85-884a-46aa-bc8a-7091937c47e7" width="320" />|
|ar | <img src="https://github.com/user-attachments/assets/6ef9faf2-7209-4e16-8e23-c119cfed9f37" width="320" />|
| zh-tw| <img src="https://github.com/user-attachments/assets/e21c6612-c726-409d-81e6-ea68d14bd0fa" width="320" />|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through `/start` and make sure the step titles are rendered properly on desktop / mobile resolutions.
* Cherry-pick a few locales and repeat.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
