### PR TITLE
Plans: fix the horizontal overflow when the text in a comparison cell is too long.

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -180,6 +180,8 @@
 			font-size: 0.875rem;
 			font-weight: 500;
 			text-align: center;
+			text-wrap: pretty;
+			hyphens: auto;
 		}
 
 		%plan-comparison-grid__plan-subtitle,
@@ -189,6 +191,8 @@
 			text-align: center;
 			line-height: 1.4;
 			margin-bottom: 5px;
+			text-wrap: pretty;
+			hyphens: auto;
 		}
 		&.title-is-subtitle .plan-comparison-grid__plan-title {
 			@extend %plan-comparison-grid__plan-subtitle;

--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -180,7 +180,7 @@
 			font-size: 0.875rem;
 			font-weight: 500;
 			text-align: center;
-			text-wrap: pretty;
+			text-wrap: balance;
 			hyphens: auto;
 		}
 
@@ -191,7 +191,7 @@
 			text-align: center;
 			line-height: 1.4;
 			margin-bottom: 5px;
-			text-wrap: pretty;
+			text-wrap: balance;
 			hyphens: auto;
 		}
 		&.title-is-subtitle .plan-comparison-grid__plan-title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #91870 

## Proposed Changes

Currently, a longer text can overflow a comparison grid cell and cause layout breakage. The most notable case reported in #91870 is `de`. This PR fixes the issue by introducing `text-wrap` and `hyphens` CSS properties:

Before:

https://github.com/user-attachments/assets/17191e13-2156-46df-8d49-8818bc32490a 

After:

https://github.com/user-attachments/assets/c89df6ec-ec6d-41dd-895d-cb051da6175f

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

While the case caught our attention is `de`, it's a general layout configuration issue whenever a copy is long and can't be broken up easily by the browser. Introducing `pretty` text wrapping and auto-hyphening is not perfect, but can prevent layout breakage from happening again.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a mobile resolution, confirm that the eCommerce features 
* Repeat the same on a few more locales.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
