### PR TITLE
Plans (grid): Reflect storage add-on selection on intro offer price and billing desc

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -153,7 +153,7 @@ $business-plan-color: #7f54b3;
 				font-size: 1.25rem;
 			}
 		}
-		.improt__upgrade-plan-price-discounted {
+		.import__upgrade-plan-price-discounted {
 			.plan-price__fraction {
 				line-height: 1;
 				font-size: 2.75rem;

--- a/client/blocks/importer/wordpress/upgrade-plan/test/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/upgrade-plan-details.tsx
@@ -39,8 +39,8 @@ function getPricing(): PricingMetaForGridPlan {
 		introOffer: {
 			formattedPrice: '$150',
 			rawPrice: {
-				monthly: 12.5,
-				full: 150,
+				monthly: 1250,
+				full: 15000,
 			},
 			isOfferComplete: false,
 			intervalUnit: 'year',

--- a/client/blocks/importer/wordpress/upgrade-plan/test/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/upgrade-plan-details.tsx
@@ -38,7 +38,10 @@ function getPricing(): PricingMetaForGridPlan {
 		},
 		introOffer: {
 			formattedPrice: '$150',
-			rawPrice: 150,
+			rawPrice: {
+				monthly: 150,
+				full: 150,
+			},
 			isOfferComplete: false,
 			intervalUnit: 'year',
 			intervalCount: 1,

--- a/client/blocks/importer/wordpress/upgrade-plan/test/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/upgrade-plan-details.tsx
@@ -39,7 +39,7 @@ function getPricing(): PricingMetaForGridPlan {
 		introOffer: {
 			formattedPrice: '$150',
 			rawPrice: {
-				monthly: 150,
+				monthly: 12.5,
 				full: 150,
 			},
 			isOfferComplete: false,

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -115,6 +115,7 @@ const PlanPriceOffer = ( props: PlanPriceOfferProps ) => {
 					args: {
 						discountedPrice: formatCurrency( introOfferFullPrice, currencyCode, {
 							stripZeros: true,
+							isSmallestUnit: true,
 						} ),
 						originalPrice: formatCurrency( originalFullPrice, currencyCode, {
 							isSmallestUnit: true,
@@ -158,9 +159,10 @@ const PlanPriceOffer = ( props: PlanPriceOfferProps ) => {
 					isSmallestUnit
 				/>
 				<PlanPrice
-					className="improt__upgrade-plan-price-discounted"
+					className="import__upgrade-plan-price-discounted"
 					rawPrice={ introOfferMonthlyPrice }
 					currencyCode={ currencyCode }
+					isSmallestUnit
 				/>
 			</div>
 		</UpgradePlanPrice>

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
-	calculateMonthlyPriceForPlan,
 	getPlan,
 	Plan,
 	PLAN_BUSINESS,
@@ -169,7 +168,6 @@ const PlanPriceOffer = ( props: PlanPriceOfferProps ) => {
 };
 
 const preparePlanPriceOfferProps = (
-	selectedPlan: string,
 	introOfferAvailable: boolean,
 	plan?: Plan,
 	pricing?: PricingMetaForGridPlan
@@ -177,10 +175,8 @@ const preparePlanPriceOfferProps = (
 	const currencyCode = pricing?.currencyCode;
 	const originalMonthlyPrice = pricing?.originalPrice.monthly ?? undefined;
 
-	const introOfferFullPrice = pricing?.introOffer?.rawPrice ?? undefined;
-	const introOfferMonthlyPrice = introOfferFullPrice
-		? calculateMonthlyPriceForPlan( selectedPlan, introOfferFullPrice )
-		: undefined;
+	const introOfferFullPrice = pricing?.introOffer?.rawPrice.full ?? undefined;
+	const introOfferMonthlyPrice = pricing?.introOffer?.rawPrice.monthly ?? undefined;
 
 	const originalFullPrice = pricing?.originalPrice.full ?? undefined;
 
@@ -207,12 +203,7 @@ export const UpgradePlanDetails = ( props: UpgradePlanDetailsProps ) => {
 
 	const plan = getPlan( selectedPlan );
 
-	const planPriceOfferProps = preparePlanPriceOfferProps(
-		selectedPlan,
-		introOfferAvailable,
-		plan,
-		pricing
-	);
+	const planPriceOfferProps = preparePlanPriceOfferProps( introOfferAvailable, plan, pricing );
 
 	const { mutate: setSelectedPlanSlug } = useSelectedPlanUpgradeMutation();
 

--- a/packages/data-stores/src/add-ons/mocks.ts
+++ b/packages/data-stores/src/add-ons/mocks.ts
@@ -1,0 +1,28 @@
+import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+import { ADD_ON_50GB_STORAGE } from './constants';
+import spaceUpgradeIcon from './icons/space-upgrade';
+import type { AddOnMeta } from './types';
+
+const STORAGE_ADD_ONS_MOCK: AddOnMeta[] = [
+	{
+		addOnSlug: ADD_ON_50GB_STORAGE,
+		productSlug: PRODUCT_1GB_SPACE,
+		featureSlugs: null,
+		icon: spaceUpgradeIcon,
+		quantity: 50,
+		name: '50 GB Storage',
+		displayCost: '50',
+		prices: {
+			monthlyPrice: 10,
+			yearlyPrice: 120,
+			formattedMonthlyPrice: 'USD10',
+			formattedYearlyPrice: 'USD120',
+		},
+		description: 'Make more space for high-quality photos, videos, and other media. ',
+		featured: false,
+		purchased: false,
+		checkoutLink: 'checkout:storage-50gb',
+	},
+];
+
+export { STORAGE_ADD_ONS_MOCK };

--- a/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -5,38 +5,40 @@
 /**
  * Default mock implementations
  */
-jest.mock( '@wordpress/data' );
-// jest.mock( '@automattic/data-stores', () => ( {
-// 	Plans: {
-// 		usePlans: jest.fn(),
-// 		useSitePlans: jest.fn(),
-// 		useIntroOffers: jest.fn(),
-// 		useCurrentPlan: jest.fn(),
-// 	},
-// 	Purchases: {
-// 		useSitePurchaseById: jest.fn(),
-// 	},
-// } ) );
-
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	combineReducers: jest.fn(),
+	createReduxStore: jest.fn(),
+	createSelector: jest.fn(),
+	register: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
 jest.mock( '../../', () => ( {
 	usePlans: jest.fn(),
 	useSitePlans: jest.fn(),
 	useIntroOffers: jest.fn(),
 	useCurrentPlan: jest.fn(),
 } ) );
-
 jest.mock( '../../../purchases', () => ( {
 	useSitePurchaseById: jest.fn(),
 } ) );
+jest.mock( '../../../wpcom-plans-ui', () => ( {
+	store: 'wpcom-plans-ui',
+} ) );
 
-import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
+import { PLAN_PERSONAL, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { useSelect } from '@wordpress/data';
 import * as Plans from '../../';
+import { ADD_ON_50GB_STORAGE } from '../../../add-ons/constants';
+import { STORAGE_ADD_ONS_MOCK } from '../../../add-ons/mocks';
 import * as Purchases from '../../../purchases';
+import * as WpcomPlansUI from '../../../wpcom-plans-ui';
 import { COST_OVERRIDE_REASONS } from '../../constants';
 import usePricingMetaForGridPlans from '../use-pricing-meta-for-grid-plans';
 
+const siteId = 100;
 const SITE_PLANS = {
-	[ PLAN_PREMIUM ]: {
+	[ PLAN_BUSINESS ]: {
 		expiry: null,
 		pricing: {
 			billPeriod: 365,
@@ -52,9 +54,8 @@ const SITE_PLANS = {
 		},
 	},
 };
-
 const PLANS = {
-	[ PLAN_PREMIUM ]: {
+	[ PLAN_BUSINESS ]: {
 		pricing: {
 			billPeriod: 365,
 			currencyCode: 'USD',
@@ -69,13 +70,29 @@ const PLANS = {
 		},
 	},
 };
+const introOffer = {
+	formattedPrice: '$150',
+	rawPrice: {
+		monthly: 12.5,
+		full: 150,
+	},
+	isOfferComplete: false,
+	intervalUnit: 'year',
+	intervalCount: 1,
+};
+const useCheckPlanAvailabilityForPurchase = () => {
+	return {
+		[ PLAN_BUSINESS ]: true,
+		[ PLAN_PERSONAL ]: true,
+	};
+};
 
 describe( 'usePricingMetaForGridPlans', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		Purchases.useSitePurchaseById.mockImplementation( () => undefined );
 		Plans.useIntroOffers.mockImplementation( () => ( {
-			[ PLAN_PREMIUM ]: null,
+			[ PLAN_BUSINESS ]: null,
 		} ) );
 		Plans.usePlans.mockImplementation( () => ( {
 			isLoading: false,
@@ -88,90 +105,22 @@ describe( 'usePricingMetaForGridPlans', () => {
 		Plans.useCurrentPlan.mockImplementation( () => undefined );
 	} );
 
-	it( 'should return intro offer when available', () => {
-		const introOffer = {
-			formattedPrice: '$150',
-			rawPrice: {
-				monthly: 12.5,
-				full: 150,
-			},
-			isOfferComplete: false,
-			intervalUnit: 'year',
-			intervalCount: 1,
-		};
-
-		const useCheckPlanAvailabilityForPurchase = () => {
-			return {
-				[ PLAN_PREMIUM ]: true,
-			};
-		};
-
-		Plans.useIntroOffers.mockImplementation( () => ( {
-			[ PLAN_PREMIUM ]: introOffer,
-		} ) );
-		Plans.useSitePlans.mockImplementation( () => ( {
-			isLoading: false,
-			data: {
-				[ PLAN_PREMIUM ]: {
-					...SITE_PLANS[ PLAN_PREMIUM ],
-					pricing: {
-						...SITE_PLANS[ PLAN_PREMIUM ].pricing,
-						introOffer,
-					},
-				},
-			},
-		} ) );
-
-		const pricingMeta = usePricingMetaForGridPlans( {
-			planSlugs: [ PLAN_PREMIUM ],
-			storageAddOns: null,
-			siteId: 100,
-			coupon: undefined,
-			useCheckPlanAvailabilityForPurchase,
-		} );
-
-		const expectedPricingMeta = {
-			[ PLAN_PREMIUM ]: {
-				originalPrice: {
-					full: 500,
-					monthly: 500,
-				},
-				discountedPrice: {
-					full: 250,
-					monthly: 250,
-				},
-				billingPeriod: 365,
-				currencyCode: 'USD',
-				expiry: null,
-				introOffer,
-			},
-		};
-
-		expect( pricingMeta ).toEqual( expectedPricingMeta );
-	} );
-
 	it( 'should return the original price as the site plan price and discounted price as Null for the current plan', () => {
 		Plans.useCurrentPlan.mockImplementation( () => ( {
-			productSlug: PLAN_PREMIUM,
-			planSlug: PLAN_PREMIUM,
+			productSlug: PLAN_BUSINESS,
+			planSlug: PLAN_BUSINESS,
 		} ) );
 
-		const useCheckPlanAvailabilityForPurchase = () => {
-			return {
-				[ PLAN_PREMIUM ]: true,
-			};
-		};
-
 		const pricingMeta = usePricingMetaForGridPlans( {
-			planSlugs: [ PLAN_PREMIUM ],
+			planSlugs: [ PLAN_BUSINESS ],
 			storageAddOns: null,
-			siteId: 100,
+			siteId,
 			coupon: undefined,
 			useCheckPlanAvailabilityForPurchase,
 		} );
 
 		const expectedPricingMeta = {
-			[ PLAN_PREMIUM ]: {
+			[ PLAN_BUSINESS ]: {
 				originalPrice: {
 					full: 500,
 					monthly: 500,
@@ -192,26 +141,20 @@ describe( 'usePricingMetaForGridPlans', () => {
 
 	it( 'should return the original price as the site plan price and discounted price as Null for plans not available for purchase', () => {
 		Plans.useCurrentPlan.mockImplementation( () => ( {
-			productSlug: PLAN_PREMIUM,
-			planSlug: PLAN_PREMIUM,
+			productSlug: PLAN_BUSINESS,
+			planSlug: PLAN_BUSINESS,
 		} ) );
 
-		const useCheckPlanAvailabilityForPurchase = () => {
-			return {
-				[ PLAN_PREMIUM ]: false,
-			};
-		};
-
 		const pricingMeta = usePricingMetaForGridPlans( {
-			planSlugs: [ PLAN_PREMIUM ],
+			planSlugs: [ PLAN_BUSINESS ],
 			storageAddOns: null,
-			siteId: 100,
+			siteId,
 			coupon: undefined,
 			useCheckPlanAvailabilityForPurchase,
 		} );
 
 		const expectedPricingMeta = {
-			[ PLAN_PREMIUM ]: {
+			[ PLAN_BUSINESS ]: {
 				originalPrice: {
 					full: 500,
 					monthly: 500,
@@ -236,15 +179,8 @@ describe( 'usePricingMetaForGridPlans', () => {
 			planSlug: PLAN_PERSONAL,
 		} ) );
 
-		const useCheckPlanAvailabilityForPurchase = () => {
-			return {
-				[ PLAN_PREMIUM ]: true,
-				[ PLAN_PERSONAL ]: true,
-			};
-		};
-
 		const pricingMeta = usePricingMetaForGridPlans( {
-			planSlugs: [ PLAN_PREMIUM ],
+			planSlugs: [ PLAN_BUSINESS ],
 			storageAddOns: null,
 			siteId: undefined,
 			coupon: undefined,
@@ -252,7 +188,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 		} );
 
 		const expectedPricingMeta = {
-			[ PLAN_PREMIUM ]: {
+			[ PLAN_BUSINESS ]: {
 				originalPrice: {
 					full: 500,
 					monthly: 500,
@@ -277,24 +213,17 @@ describe( 'usePricingMetaForGridPlans', () => {
 			planSlug: PLAN_PERSONAL,
 		} ) );
 
-		const useCheckPlanAvailabilityForPurchase = () => {
-			return {
-				[ PLAN_PREMIUM ]: true,
-				[ PLAN_PERSONAL ]: true,
-			};
-		};
-
 		const pricingMeta = usePricingMetaForGridPlans( {
-			planSlugs: [ PLAN_PREMIUM ],
+			planSlugs: [ PLAN_BUSINESS ],
 			storageAddOns: null,
-			siteId: 100,
+			siteId,
 			coupon: undefined,
 			useCheckPlanAvailabilityForPurchase,
 			withProratedDiscounts: true,
 		} );
 
 		const expectedPricingMeta = {
-			[ PLAN_PREMIUM ]: {
+			[ PLAN_BUSINESS ]: {
 				originalPrice: {
 					full: 500,
 					monthly: 500,
@@ -322,34 +251,27 @@ describe( 'usePricingMetaForGridPlans', () => {
 		Plans.useSitePlans.mockImplementation( () => ( {
 			isLoading: false,
 			data: {
-				[ PLAN_PREMIUM ]: {
-					...SITE_PLANS[ PLAN_PREMIUM ],
+				[ PLAN_BUSINESS ]: {
+					...SITE_PLANS[ PLAN_BUSINESS ],
 					pricing: {
-						...SITE_PLANS[ PLAN_PREMIUM ].pricing,
+						...SITE_PLANS[ PLAN_BUSINESS ].pricing,
 						costOverrides: [ { overrideCode: COST_OVERRIDE_REASONS.RECENT_PLAN_PRORATION } ],
 					},
 				},
 			},
 		} ) );
 
-		const useCheckPlanAvailabilityForPurchase = () => {
-			return {
-				[ PLAN_PREMIUM ]: true,
-				[ PLAN_PERSONAL ]: true,
-			};
-		};
-
 		const pricingMeta = usePricingMetaForGridPlans( {
-			planSlugs: [ PLAN_PREMIUM ],
+			planSlugs: [ PLAN_BUSINESS ],
 			storageAddOns: null,
-			siteId: 100,
+			siteId,
 			coupon: undefined,
 			useCheckPlanAvailabilityForPurchase,
 			withProratedDiscounts: false,
 		} );
 
 		const expectedPricingMeta = {
-			[ PLAN_PREMIUM ]: {
+			[ PLAN_BUSINESS ]: {
 				originalPrice: {
 					full: 500,
 					monthly: 500,
@@ -362,6 +284,118 @@ describe( 'usePricingMetaForGridPlans', () => {
 				currencyCode: 'USD',
 				expiry: null,
 				introOffer: undefined,
+			},
+		};
+
+		expect( pricingMeta ).toEqual( expectedPricingMeta );
+	} );
+
+	it( 'should return intro offer when available', () => {
+		Plans.useIntroOffers.mockImplementation( () => ( {
+			[ PLAN_BUSINESS ]: introOffer,
+		} ) );
+		Plans.useSitePlans.mockImplementation( () => ( {
+			isLoading: false,
+			data: {
+				[ PLAN_BUSINESS ]: {
+					...SITE_PLANS[ PLAN_BUSINESS ],
+					pricing: {
+						...SITE_PLANS[ PLAN_BUSINESS ].pricing,
+						introOffer,
+					},
+				},
+			},
+		} ) );
+
+		const pricingMeta = usePricingMetaForGridPlans( {
+			planSlugs: [ PLAN_BUSINESS ],
+			storageAddOns: null,
+			siteId,
+			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
+		} );
+
+		const expectedPricingMeta = {
+			[ PLAN_BUSINESS ]: {
+				...SITE_PLANS[ PLAN_BUSINESS ].pricing,
+				billPeriod: undefined,
+				billingPeriod: SITE_PLANS[ PLAN_BUSINESS ].pricing.billPeriod,
+				expiry: null,
+				introOffer,
+			},
+		};
+
+		expect( pricingMeta ).toEqual( expectedPricingMeta );
+	} );
+
+	it( 'should return intro offer pricing and standard pricing adjusted by storage selection', () => {
+		Plans.useIntroOffers.mockImplementation( () => ( {
+			[ PLAN_BUSINESS ]: introOffer,
+		} ) );
+		Plans.useSitePlans.mockImplementation( () => ( {
+			isLoading: false,
+			data: {
+				[ PLAN_BUSINESS ]: {
+					...SITE_PLANS[ PLAN_BUSINESS ],
+					pricing: {
+						...SITE_PLANS[ PLAN_BUSINESS ].pricing,
+						introOffer,
+					},
+				},
+			},
+		} ) );
+		useSelect.mockImplementation( ( selectFunc ) => {
+			const select = ( store ) => {
+				if ( store === WpcomPlansUI.store ) {
+					return {
+						getSelectedStorageOptions: () => ( {
+							[ PLAN_BUSINESS ]: ADD_ON_50GB_STORAGE,
+						} ),
+					};
+				}
+
+				return null;
+			};
+
+			return selectFunc( select );
+		} );
+
+		const pricingMeta = usePricingMetaForGridPlans( {
+			planSlugs: [ PLAN_BUSINESS ],
+			storageAddOns: STORAGE_ADD_ONS_MOCK,
+			siteId,
+			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
+		} );
+
+		const expectedPricingMeta = {
+			[ PLAN_BUSINESS ]: {
+				originalPrice: {
+					full:
+						SITE_PLANS[ PLAN_BUSINESS ].pricing.originalPrice.full +
+						STORAGE_ADD_ONS_MOCK[ 0 ].prices.yearlyPrice,
+					monthly:
+						SITE_PLANS[ PLAN_BUSINESS ].pricing.originalPrice.monthly +
+						STORAGE_ADD_ONS_MOCK[ 0 ].prices.monthlyPrice,
+				},
+				discountedPrice: {
+					full:
+						SITE_PLANS[ PLAN_BUSINESS ].pricing.discountedPrice.full +
+						STORAGE_ADD_ONS_MOCK[ 0 ].prices.yearlyPrice,
+					monthly:
+						SITE_PLANS[ PLAN_BUSINESS ].pricing.discountedPrice.monthly +
+						STORAGE_ADD_ONS_MOCK[ 0 ].prices.monthlyPrice,
+				},
+				billingPeriod: SITE_PLANS[ PLAN_BUSINESS ].pricing.billPeriod,
+				currencyCode: SITE_PLANS[ PLAN_BUSINESS ].pricing.currencyCode,
+				expiry: null,
+				introOffer: {
+					...introOffer,
+					rawPrice: {
+						monthly: 12.5 + STORAGE_ADD_ONS_MOCK[ 0 ].prices.monthlyPrice,
+						full: 150 + STORAGE_ADD_ONS_MOCK[ 0 ].prices.yearlyPrice,
+					},
+				},
 			},
 		};
 

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -94,6 +94,7 @@ const usePricingMetaForGridPlans = ( {
 		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptions( siteId ),
 		[]
 	);
+
 	const planAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase( {
 		planSlugs,
 		siteId,

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -112,6 +112,7 @@ const usePricingMetaForGridPlans = ( {
 					originalPrice: Plans.PlanPricing[ 'originalPrice' ];
 					discountedPrice: Plans.PlanPricing[ 'discountedPrice' ];
 					currencyCode: Plans.PlanPricing[ 'currencyCode' ];
+					introOffer: Plans.PlanPricing[ 'introOffer' ];
 				};
 		  }
 		| null = null;
@@ -136,6 +137,17 @@ const usePricingMetaForGridPlans = ( {
 					: null;
 				const storageAddOnPriceMonthly = selectedStorageAddOn?.prices?.monthlyPrice || 0;
 				const storageAddOnPriceYearly = selectedStorageAddOn?.prices?.yearlyPrice || 0;
+
+				const introOffer = introOffers?.[ planSlug ];
+
+				const introOfferPrice = introOffer
+					? ( {
+							monthly: introOffer.rawPrice.monthly + storageAddOnPriceMonthly,
+							full:
+								introOffer.rawPrice.full +
+								( 'year' === introOffer.intervalUnit ? storageAddOnPriceYearly : 0 ),
+					  } as const )
+					: undefined;
 
 				/**
 				 * 0. No plan or sitePlan (when selected site exists): planSlug is for a priceless plan.
@@ -228,6 +240,12 @@ const usePricingMetaForGridPlans = ( {
 									full: null,
 								},
 								currencyCode: sitePlan?.pricing?.currencyCode,
+								...( sitePlan?.pricing.introOffer && {
+									introOffer: {
+										...sitePlan?.pricing.introOffer,
+										rawPrice: introOfferPrice,
+									},
+								} ),
 							},
 						];
 					}
@@ -246,6 +264,12 @@ const usePricingMetaForGridPlans = ( {
 							originalPrice,
 							discountedPrice,
 							currencyCode: sitePlan?.pricing?.currencyCode,
+							...( sitePlan?.pricing.introOffer && {
+								introOffer: {
+									...sitePlan?.pricing.introOffer,
+									rawPrice: introOfferPrice,
+								},
+							} ),
 						},
 					];
 				}
@@ -272,6 +296,12 @@ const usePricingMetaForGridPlans = ( {
 							originalPrice,
 							discountedPrice,
 							currencyCode: plan?.pricing?.currencyCode,
+							...( plan?.pricing.introOffer && {
+								introOffer: {
+									...plan?.pricing.introOffer,
+									rawPrice: introOfferPrice,
+								},
+							} ),
 						},
 					];
 				}
@@ -294,6 +324,12 @@ const usePricingMetaForGridPlans = ( {
 							full: null,
 						},
 						currencyCode: plan?.pricing?.currencyCode,
+						...( plan?.pricing.introOffer && {
+							introOffer: {
+								...plan?.pricing.introOffer,
+								rawPrice: introOfferPrice,
+							},
+						} ),
 					},
 				];
 			} )
@@ -314,7 +350,7 @@ const usePricingMetaForGridPlans = ( {
 					// TODO clk: the condition on `.pricing` here needs investigation. There should be a pricing object for all returned API plans.
 					currencyCode: planPrices?.[ planSlug ]?.currencyCode,
 					expiry: sitePlans.data?.[ planSlug ]?.expiry,
-					introOffer: introOffers?.[ planSlug ],
+					introOffer: planPrices?.[ planSlug ]?.introOffer,
 				},
 			} ),
 			{} as { [ planSlug in PlanSlug ]?: Plans.PricingMetaForGridPlan }

--- a/packages/data-stores/src/plans/mock/next/store/plans.ts
+++ b/packages/data-stores/src/plans/mock/next/store/plans.ts
@@ -28,9 +28,12 @@ export const NEXT_STORE_SITE_PLAN_BUSINESS: SitePlan = {
 	productId: 2,
 	pricing: {
 		introOffer: {
-			formattedPrice: '$15.00',
-			rawPrice: 15,
-			intervalUnit: 'month',
+			formattedPrice: '$150.00',
+			rawPrice: {
+				monthly: 1250,
+				full: 15000,
+			},
+			intervalUnit: 'year',
 			intervalCount: 1,
 			isOfferComplete: false,
 		},
@@ -84,9 +87,12 @@ export const NEXT_STORE_PLAN_BUSINESS: PlanNext = {
 		billPeriod: 365,
 		currencyCode: 'USD',
 		introOffer: {
-			formattedPrice: '$25.00',
-			rawPrice: 25,
-			intervalUnit: 'month',
+			formattedPrice: '$300.00',
+			rawPrice: {
+				monthly: 2500,
+				full: 30000,
+			},
+			intervalUnit: 'year',
 			intervalCount: 1,
 			isOfferComplete: false,
 		},

--- a/packages/data-stores/src/plans/queries/lib/unpack-intro-offer.ts
+++ b/packages/data-stores/src/plans/queries/lib/unpack-intro-offer.ts
@@ -6,8 +6,11 @@ import type { PlanIntroductoryOffer, PricedAPIPlan, PricedAPISitePlan } from '..
 const unpackIntroOffer = (
 	plan: PricedAPISitePlan | PricedAPIPlan
 ): PlanIntroductoryOffer | null => {
-	// these aren't grouped or separated. so no introductory offer if no cost or interval
-	if ( ! plan.introductory_offer_interval_unit && ! plan.introductory_offer_interval_count ) {
+	// these aren't grouped or separated. so no introductory offer if missing or malformed raw_price
+	if (
+		typeof plan.introductory_offer_raw_price_integer !== 'number' ||
+		! plan.introductory_offer_interval_count
+	) {
 		return null;
 	}
 
@@ -30,9 +33,25 @@ const unpackIntroOffer = (
 
 	return {
 		formattedPrice: plan.introductory_offer_formatted_price as string,
-		rawPrice: plan.introductory_offer_raw_price as number,
+		rawPrice: {
+			monthly:
+				/**
+				 * IMPORTANT:
+				 * we make the raw assumption that the interval unit is either "year" or "month"
+				 * to compute mmonthly/full price
+				 */
+				'year' === plan.introductory_offer_interval_unit
+					? parseFloat(
+							(
+								plan.introductory_offer_raw_price_integer /
+								( plan.introductory_offer_interval_count * 12 )
+							).toFixed( 2 )
+					  )
+					: plan.introductory_offer_raw_price_integer,
+			full: plan.introductory_offer_raw_price_integer,
+		},
 		intervalUnit: plan.introductory_offer_interval_unit as string,
-		intervalCount: plan.introductory_offer_interval_count as number,
+		intervalCount: plan.introductory_offer_interval_count,
 		isOfferComplete,
 	};
 };

--- a/packages/data-stores/src/plans/queries/lib/unpack-intro-offer.ts
+++ b/packages/data-stores/src/plans/queries/lib/unpack-intro-offer.ts
@@ -38,7 +38,7 @@ const unpackIntroOffer = (
 				/**
 				 * IMPORTANT:
 				 * we make the raw assumption that the interval unit is either "year" or "month"
-				 * to compute mmonthly/full price
+				 * to compute monthly/full price
 				 */
 				'year' === plan.introductory_offer_interval_unit
 					? parseFloat(

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -67,6 +67,9 @@ export interface PlanProduct {
 }
 
 export interface PlanIntroductoryOffer {
+	/**
+	 * @deprecated use `formatCurrency` call instead on the respective price (monthly/full)
+	 */
 	formattedPrice: string;
 	rawPrice: {
 		monthly: number;
@@ -75,7 +78,7 @@ export interface PlanIntroductoryOffer {
 	/**
 	 * IMPORTANT:
 	 * we make the raw assumption that the interval unit is either "year" or "month"
-	 * to compute mmonthly/full price
+	 * to compute monthly/full price
 	 */
 	intervalUnit: string;
 	intervalCount: number;
@@ -181,12 +184,16 @@ export interface PlanNext {
 }
 
 export interface PricedAPIPlanIntroductoryOffer {
+	/**
+	 * @deprecated use `formatCurrency` call instead on the respective price (monthly/full)
+	 * - no need to pass this from the API at all
+	 */
 	introductory_offer_formatted_price?: string;
 	introductory_offer_raw_price_integer?: number;
 	/**
 	 * IMPORTANT:
 	 * we make the raw assumption that the interval unit is either "year" or "month"
-	 * to compute mmonthly/full price
+	 * to compute monthly/full price
 	 */
 	introductory_offer_interval_unit?: string;
 	introductory_offer_interval_count?: number;

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -68,7 +68,15 @@ export interface PlanProduct {
 
 export interface PlanIntroductoryOffer {
 	formattedPrice: string;
-	rawPrice: number;
+	rawPrice: {
+		monthly: number;
+		full: number;
+	};
+	/**
+	 * IMPORTANT:
+	 * we make the raw assumption that the interval unit is either "year" or "month"
+	 * to compute mmonthly/full price
+	 */
 	intervalUnit: string;
 	intervalCount: number;
 	isOfferComplete: boolean;
@@ -174,7 +182,12 @@ export interface PlanNext {
 
 export interface PricedAPIPlanIntroductoryOffer {
 	introductory_offer_formatted_price?: string;
-	introductory_offer_raw_price?: number;
+	introductory_offer_raw_price_integer?: number;
+	/**
+	 * IMPORTANT:
+	 * we make the raw assumption that the interval unit is either "year" or "month"
+	 * to compute mmonthly/full price
+	 */
 	introductory_offer_interval_unit?: string;
 	introductory_offer_interval_count?: number;
 	introductory_offer_end_date?: string;

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -50,10 +50,6 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	}
 
 	if ( isGridPlanOnIntroOffer ) {
-		const introOfferPrice =
-			introOffer.intervalUnit === 'year'
-				? parseFloat( ( introOffer.rawPrice / ( introOffer.intervalCount * 12 ) ).toFixed( 2 ) )
-				: introOffer.rawPrice;
 		return (
 			<div className="plans-grid-next-header-price">
 				{ ! current && (
@@ -77,10 +73,10 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 					/>
 					<PlanPrice
 						currencyCode={ currencyCode }
-						rawPrice={ introOfferPrice }
+						rawPrice={ introOffer.rawPrice.monthly }
 						displayPerMonthNotation={ false }
 						isLargeCurrency
-						isSmallestUnit={ false }
+						isSmallestUnit
 						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
 						discounted
 					/>

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -108,7 +108,15 @@ export default function usePlanBillingDescription( {
 	 *   2. We only expose month & year based intervals for now (so no need to introduce more translations just yet)
 	 */
 	if ( introOffer?.intervalCount && introOffer.intervalUnit && ! introOffer.isOfferComplete ) {
-		if ( originalPriceFullTermText ) {
+		const introOfferFullTermText =
+			currencyCode && introOffer.rawPrice
+				? formatCurrency( introOffer.rawPrice.full, currencyCode, {
+						stripZeros: true,
+						isSmallestUnit: true,
+				  } )
+				: null;
+
+		if ( originalPriceFullTermText && introOfferFullTermText ) {
 			/* Introductory offers for monthly plans */
 			if ( isMonthlyPlan ) {
 				/* If the offer is for X months */
@@ -210,7 +218,7 @@ export default function usePlanBillingDescription( {
 								'then %(rawPrice)s billed annually, excl. taxes',
 							{
 								args: {
-									introOfferFormattedPrice: introOffer.formattedPrice,
+									introOfferFormattedPrice: introOfferFullTermText,
 									rawPrice: originalPriceFullTermText,
 								},
 								components: { br: <br /> },
@@ -224,7 +232,7 @@ export default function usePlanBillingDescription( {
 							'then %(rawPrice)s billed annually, excl. taxes',
 						{
 							args: {
-								introOfferFormattedPrice: introOffer.formattedPrice,
+								introOfferFormattedPrice: introOfferFullTermText,
 								rawPrice: originalPriceFullTermText,
 								introOfferIntervalCount: introOffer.intervalCount,
 							},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/95342

## Proposed Changes

- Enables storage selection in the plans grid to be reflected on the intro offer prices.

I'll skip a long description as I've run out of time. Read https://github.com/Automattic/wp-calypso/issues/95342 as this precisely addresses the issue

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fix https://github.com/Automattic/wp-calypso/issues/95342 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Main:**

* Switch to INR currency (or other currency that gives first-year discount)
* Go to `/plans/:site` and `/start/plans` (or `/setup/onboarding/plans`)
* Confirm prices and billing descriptions are rendered correctly with the intro & cross-out pricing
* Go to Business or Commerce plans in the grid and select a storage add-on upgrade
* Confirm the pricing is updated to reflect the additional cost (as done for non discounted currencies)
* Repeat with USD/EUR and confirm the same

**Other:**

These changes also affect intro-offers displayed elsewhere.
- Confirm the upgrade-plan for the migration flow renders the intro pricing correctly cc @merkushin 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
