### PR TITLE
A4A: Pass a specific tag when submitting support via the Migration offer banner.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/index.tsx
@@ -107,7 +107,14 @@ export default function MigrationContactSupportForm( { show, onClose }: Props ) 
 			} )
 		);
 
-		submit( { message, name, email, product, no_of_sites: site } );
+		submit( {
+			message,
+			name,
+			email,
+			product,
+			no_of_sites: site,
+			tags: [ 'a4a_form_dash_migration' ],
+		} );
 	}, [ hasCompletedForm, dispatch, message, submit, name, email, product, site ] );
 
 	useEffect( () => {

--- a/client/a8c-for-agencies/data/support/types.ts
+++ b/client/a8c-for-agencies/data/support/types.ts
@@ -14,4 +14,5 @@ export interface SubmitContactSupportParams {
 	no_of_sites?: number;
 	contact_type?: string;
 	pressable_id?: number;
+	tags?: string[];
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1292

## Proposed Changes

* Update the contact support form to pass the `a4a_form_dash_migration` tag when submitting from the migration offer banner.

## Why are these changes being made?

* This allows easier management of support tickets.

## Testing Instructions

* Use the A4A live link and go to the `/overview` page.
* Click the **'Contact us to learn more'** button in the Migration offer banner. 
   <img width="1018" alt="Screenshot 2024-10-16 at 7 15 07 PM" src="https://github.com/user-attachments/assets/8bbb0ded-1b40-448b-ae26-91a4f3f35bdd">
* Submit the form.
* Refer to D163944-code to verify if the new tag has been processed successfully.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?