### PR TITLE
Fix typo in Stats connection notice (on Stats purchase page).

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -207,7 +207,7 @@ const StatsCommercialPurchase = ( {
 			{ tierSelectionElements }
 			{ needsConnectionForUpgrade && (
 				<div className="stats-purchase-wizard__notice connection-notice">
-					{ translate( 'Please {{link}}connect your user account{{/link}} to upgrade stats.', {
+					{ translate( 'Please {{link}}connect your user account{{/link}} to upgrade Stats.', {
 						components: {
 							link: <a href={ `${ adminUrl }admin.php?page=my-jetpack#/connection` } />,
 						},


### PR DESCRIPTION
This tiny PR simply fixes a typo.  It fixes the capitalization of the word Stats, from "stats" to "Stats". 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

### Screenshots

![Screen Shot 2024-10-16 at 09 01 09](https://github.com/user-attachments/assets/c35e5323-ee44-4c28-b5bf-b2419ee18563)


## Proposed Changes

* Fix tiny typo on the Stats commercial purchase page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The name of the product "Stats" should be capitalized.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* It is probably enough to simple look at the code and see there has been a tiny capitalization change of the word 'stats', from "stats" to "Stats".


- Otherwise if you really want to test this change live, you'll need to complete these steps:
    - Checkout this branch and `yarn start`
    - Prepare a Jetpack site that has purchased a Stats commercial subscription, and ensure the site is only site-connected, Not user-connected.
    - Build Odyssey Stats locally following PCYsg-Pp7-p2
    - Go to `/wp-admin/admin.php?page=stats#!/stats/purchase/:siteSlug?from=jetpack-stats-tier-upgrade-usage-section&productType=commercial` (Replace `:siteSlug` with your site's `siteSlug` or `siteId`)
    - You should see the notice that says, "Please connect your user account to upgrade Stats". (See screenshot above)
    - Confim that the last word of the above notice, "Stats" is capitalized.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?