### PR TITLE
Stats: Remove legacy purchase page forced redirection

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -11,7 +11,6 @@ const DEFAULT_SERVER_NOTICES_VISIBILITY = {
 	traffic_page_settings: false,
 	do_you_love_jetpack_stats: false,
 	commercial_site_upgrade: false,
-	focus_jetpack_purchase: false,
 	// TODO: Check if the site needs to be upgraded to a higher tier on the back end.
 	tier_upgrade: true,
 	gdpr_cookie_consent: false,

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -1,19 +1,13 @@
-import config from '@automattic/calypso-config';
-import page from '@automattic/calypso-router';
 import { ReactNode, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	receiveStatNoticeSettings,
 	requestStatNoticeSettings,
 } from 'calypso/state/stats/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import useSiteCompulsoryPlanSelectionQualifiedCheck from '../hooks/use-site-compulsory-plan-selection-qualified-check';
-import useStatsPurchases from '../hooks/use-stats-purchases';
 import StatsLoader from './stats-loader';
 
 interface StatsRedirectFlowProps {
@@ -22,14 +16,6 @@ interface StatsRedirectFlowProps {
 
 const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) => {
 	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-
-	const { hasLoadedSitePurchases, hasAnyPlan } = useStatsPurchases( siteId );
-
-	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
-		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
-	);
 
 	// TODO: Consolidate permissions checks.
 	// This same code is in LoadStatsPage (which calls this component) so
@@ -47,12 +33,6 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		canUserManageOptions
 	);
 
-	const isLoading = ! hasLoadedSitePurchases || isLoadingNotices;
-	const { isNewSite, shouldShowPaywall } = useSiteCompulsoryPlanSelectionQualifiedCheck( siteId );
-	// to redirect the user can't have a plan purached and can't have the flag true, if either is true the user either has a plan or is postponing
-	const redirectToPurchase =
-		isSiteJetpackNotAtomic && ! hasAnyPlan && purchaseNotPostponed && shouldShowPaywall;
-
 	// TODO: If notices are not used by class components, we don't have any reasons to launch any of those actions anymore. If we do need them, we should consider refactoring them to another component.
 	const dispatch = useDispatch();
 	useEffect( () => {
@@ -68,42 +48,12 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		}
 	}, [ dispatch, siteId, isLoadingNotices, purchaseNotPostponed ] );
 
-	// Render conditions (for readability).
-	// TODO: Determine the paywall redirection for specific routes.
-	const shouldRenderPaywall =
-		false && ! isLoading && redirectToPurchase && siteSlug && canUserManageOptions;
-	const shouldRenderContent = ! isLoading && ( canUserViewStats || canUserManageOptions );
+	const shouldRenderContent = ! isLoadingNotices && ( canUserViewStats || canUserManageOptions );
 
 	// Handle possible render conditions.
 	// Based on render conditions, loading state takes priority.
-	if ( isLoading ) {
+	if ( isLoadingNotices ) {
 		return <StatsLoader />;
-	}
-
-	// Paywall is dependant on site age, type, & plan as well as user permissions.
-	if ( shouldRenderPaywall ) {
-		// We need to ensure we pass the irclick id for impact affiliate tracking if its set.
-		const currentParams = new URLSearchParams( window.location.search );
-		const queryParams = new URLSearchParams();
-
-		queryParams.set( 'productType', 'commercial' );
-		// `cmp-red` means `compulsory redirection` here.
-		queryParams.set( 'from', `cmp-red${ isNewSite ? '-new-site' : '' }` );
-		if ( currentParams.has( 'irclickid' ) ) {
-			queryParams.set( 'irclickid', currentParams.get( 'irclickid' ) || '' );
-		}
-
-		// publish an event
-		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_stats_purchase_flow_redirected` );
-
-		// redirect to the Purchase page
-		setTimeout(
-			() => page.redirect( `/stats/purchase/${ siteSlug }?${ queryParams.toString() }` ),
-			250
-		);
-
-		return null;
 	}
 
 	// Default is to show the user some stats.

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -1,14 +1,7 @@
-import { ReactNode, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
-import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import { ReactNode } from 'react';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import {
-	receiveStatNoticeSettings,
-	requestStatNoticeSettings,
-} from 'calypso/state/stats/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import StatsLoader from './stats-loader';
 
 interface StatsRedirectFlowProps {
 	children: ReactNode;
@@ -27,39 +20,10 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		canCurrentUser( state, siteId, 'view_stats' )
 	);
 
-	const { isLoading: isLoadingNotices, data: purchaseNotPostponed } = useNoticeVisibilityQuery(
-		siteId,
-		'focus_jetpack_purchase',
-		canUserManageOptions
-	);
-
-	// TODO: If notices are not used by class components, we don't have any reasons to launch any of those actions anymore. If we do need them, we should consider refactoring them to another component.
-	const dispatch = useDispatch();
-	useEffect( () => {
-		if ( isLoadingNotices ) {
-			// when react-query is fetching data
-			dispatch( requestStatNoticeSettings( siteId ) );
-		} else {
-			dispatch(
-				receiveStatNoticeSettings( siteId, {
-					focus_jetpack_purchase: purchaseNotPostponed,
-				} )
-			);
-		}
-	}, [ dispatch, siteId, isLoadingNotices, purchaseNotPostponed ] );
-
-	const shouldRenderContent = ! isLoadingNotices && ( canUserViewStats || canUserManageOptions );
-
-	// Handle possible render conditions.
-	// Based on render conditions, loading state takes priority.
-	if ( isLoadingNotices ) {
-		return <StatsLoader />;
-	}
-
 	// Default is to show the user some stats.
 	// There are permissions considerations though, in which case we fall
 	// through and show nothing. Feels broken.
-	if ( shouldRenderContent ) {
+	if ( canUserViewStats || canUserManageOptions ) {
 		return <>{ children }</>;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/139

## Proposed Changes

* Remove the unused code from the always false condition about the `shouldRenderPaywall` flag.
* Remove possibly unused notice id `focus_jetpack_purchase` and related code, which seemed to pause the redirection for the Personal purchase page after clicking the `I will do it later` button.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The force purchase page redirection is no longer used. We use a paywall lock on each module or card now. More information: pejTkB-1t3-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Prepare a site with the commercial paywall.
* Ensure the module paywall on Stats `Traffic,` `Insights`, and module pages work as previously.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?