### PR TITLE
Site profiler: Adjust style for mobile view

### DIFF
--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -64,6 +64,17 @@ export default function DomainAnalyzer( props: Props ) {
 							onKeyDown={ onInputEscape }
 							spellCheck="false"
 						/>
+						<div className="domain-analyzer--msg">
+							<p
+								className={ clsx( 'error', {
+									'vis-hidden': ! showError,
+								} ) }
+							>
+								<Icon icon={ info } size={ 20 } />{ ' ' }
+								{ isDomainValid === false && translate( 'Please enter a valid website address' ) }
+								{ domainFetchingError && domainFetchingError.message }
+							</p>
+						</div>
 					</div>
 					<div className="col-2">
 						<Button isBusy={ isBusy } type="submit" className="button-action">
@@ -75,17 +86,6 @@ export default function DomainAnalyzer( props: Props ) {
 							}
 						</Button>
 					</div>
-				</div>
-				<div className="domain-analyzer--msg">
-					<p
-						className={ clsx( 'error', {
-							'vis-hidden': ! showError,
-						} ) }
-					>
-						<Icon icon={ info } size={ 20 } />{ ' ' }
-						{ isDomainValid === false && translate( 'Please enter a valid website address' ) }
-						{ domainFetchingError && domainFetchingError.message }
-					</p>
 				</div>
 			</form>
 		</div>

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -99,7 +99,7 @@
 .domain-analyzer--msg {
 	margin-top: 0.5rem;
 
-	@media (min-width: $break-small) {
+	@media (min-width: $break-small + 1px) {
 		position: absolute;
 		left: 0;
 		margin-top: 1.5rem;

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -25,6 +25,7 @@
 
 .domain-analyzer--form-container {
 	display: flex;
+	position: relative;
 
 	@media (min-width: $break-small + 1px) {
 		@include input-style;
@@ -96,7 +97,13 @@
 
 
 .domain-analyzer--msg {
-	margin-top: 1rem;
+	margin-top: 0.5rem;
+
+	@media (min-width: $break-small) {
+		position: absolute;
+		left: 0;
+		margin-top: 1.5rem;
+	}
 
 	p {
 		font-size: 1rem !important;

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -192,8 +192,9 @@ html[dir="rtl"] {
 
 	.domain-analyzer-block {
 		padding-top: 10rem;
+
 		@media (max-width: $break-small) {
-			padding-top: 4rem;
+			padding-top: 5.5rem;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/82641

## Proposed Changes

* Adjust style for mobile view
  * Match padding with the proposed design
  * Move the error message below the input field

NOTE: Task "We should increase the width of the primary CTA so it spans the whole width of the card, like we do in the home page." is handled in PR: https://github.com/Automattic/wp-calypso/pull/95424

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler?flags=-site-profiler/metrics`
* Resize window for mobile resolution
* Check the top padding (above the Site Profiler heading)
* Enter a wrong url
* Check if the error is below the input field

| Before | After |
|--------|--------|
| <img width="600" alt="Screenshot 2024-10-16 at 21 27 19" src="https://github.com/user-attachments/assets/14049abb-819f-4e51-ae4f-491400b3bc70"> | <img width="598" alt="Screenshot 2024-10-16 at 21 27 29" src="https://github.com/user-attachments/assets/31b162c3-7222-48cb-9500-af19105d9d72"> |
| <img width="402" alt="Screenshot 2024-10-16 at 21 55 10" src="https://github.com/user-attachments/assets/3c2bda3d-8af9-46bf-8bd1-663c9897c277"> | <img width="402" alt="Screenshot 2024-10-16 at 21 55 20" src="https://github.com/user-attachments/assets/cac4a65a-6e22-441c-a664-5107b60ae63b"> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
