### PR TITLE
Reader Onboarding: Implement preview pane and selectable sites

### DIFF
--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -24,6 +24,7 @@ class ConnectedSubscriptionListItem extends Component {
 		followSource: PropTypes.string,
 		railcar: PropTypes.object,
 		disableSuggestedFollows: PropTypes.bool,
+		onItemClick: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -33,6 +34,7 @@ class ConnectedSubscriptionListItem extends Component {
 		showLastUpdatedDate: true,
 		showFollowedOnDate: true,
 		disableSuggestedFollows: false,
+		onItemClick: () => {},
 	};
 
 	componentDidMount() {
@@ -65,6 +67,7 @@ class ConnectedSubscriptionListItem extends Component {
 			followSource,
 			railcar,
 			disableSuggestedFollows,
+			onItemClick,
 		} = this.props;
 
 		return (
@@ -81,6 +84,7 @@ class ConnectedSubscriptionListItem extends Component {
 				followSource={ followSource }
 				railcar={ railcar }
 				disableSuggestedFollows={ disableSuggestedFollows }
+				onItemClick={ onItemClick }
 			/>
 		);
 	}

--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -25,6 +25,7 @@ class ConnectedSubscriptionListItem extends Component {
 		railcar: PropTypes.object,
 		disableSuggestedFollows: PropTypes.bool,
 		onItemClick: PropTypes.func,
+		isSelected: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -68,6 +69,7 @@ class ConnectedSubscriptionListItem extends Component {
 			railcar,
 			disableSuggestedFollows,
 			onItemClick,
+			isSelected,
 		} = this.props;
 
 		return (
@@ -85,6 +87,7 @@ class ConnectedSubscriptionListItem extends Component {
 				railcar={ railcar }
 				disableSuggestedFollows={ disableSuggestedFollows }
 				onItemClick={ onItemClick }
+				isSelected={ isSelected }
 			/>
 		);
 	}

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -45,6 +45,7 @@ function ReaderSubscriptionListItem( {
 	isLoggedIn,
 	registerLastActionRequiresLogin: registerLastActionRequiresLoginProp,
 	disableSuggestedFollows,
+	onItemClick,
 } ) {
 	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
@@ -111,8 +112,13 @@ function ReaderSubscriptionListItem( {
 		}
 	};
 
+	const handleClick = ( event ) => {
+		event.preventDefault();
+		onItemClick();
+	};
+
 	return (
-		<div className={ clsx( 'reader-subscription-list-item', className ) }>
+		<div className={ clsx( 'reader-subscription-list-item', className ) } onClick={ handleClick }>
 			<div className="reader-subscription-list-item__avatar">
 				<ReaderAvatar
 					siteIcon={ siteIcon }

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -113,19 +113,20 @@ function ReaderSubscriptionListItem( {
 		}
 	};
 
-	const handleClick = ( event ) => {
-		event.preventDefault();
+	const handleClick = () => {
 		onItemClick();
 	};
 
 	return (
 		<div
-			className={ clsx(
-				'reader-subscription-list-item',
-				className,
-				{ 'is-selected': isSelected } // Add this class when the item is selected
-			) }
+			className={ clsx( 'reader-subscription-list-item', className, {
+				'is-selected': isSelected,
+			} ) }
 			onClick={ handleClick }
+			onKeyDown={ ( e ) => e.key === 'Enter' && handleClick( e ) }
+			role="button"
+			tabIndex={ 0 }
+			aria-pressed={ isSelected }
 		>
 			<div className="reader-subscription-list-item__avatar">
 				<ReaderAvatar

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -46,6 +46,7 @@ function ReaderSubscriptionListItem( {
 	registerLastActionRequiresLogin: registerLastActionRequiresLoginProp,
 	disableSuggestedFollows,
 	onItemClick,
+	isSelected,
 } ) {
 	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
@@ -118,7 +119,14 @@ function ReaderSubscriptionListItem( {
 	};
 
 	return (
-		<div className={ clsx( 'reader-subscription-list-item', className ) } onClick={ handleClick }>
+		<div
+			className={ clsx(
+				'reader-subscription-list-item',
+				className,
+				{ 'is-selected': isSelected } // Add this class when the item is selected
+			) }
+			onClick={ handleClick }
+		>
 			<div className="reader-subscription-list-item__avatar">
 				<ReaderAvatar
 					siteIcon={ siteIcon }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -1,21 +1,21 @@
 .reader-subscription-list-item__byline {
-	color: var(--color-text);
+	color: var( --color-text );
 	margin: 0 12px;
 	flex: 1 1 0;
 }
 
 .reader-subscription-list-item__link,
 .reader-subscription-list-item__link:visited {
-	color: var(--color-neutral-100);
+	color: var( --color-neutral-100 );
 
 	&:hover {
-		color: var(--color-text-subtle);
+		color: var( --color-text-subtle );
 	}
 }
 
 .reader-subscription-list-item__site-excerpt {
 	display: -webkit-box;
-	color: var(--color-neutral-70);
+	color: var( --color-neutral-70 );
 	font-weight: 600;
 	font-size: $font-body-extra-small;
 	line-height: 18px;
@@ -49,9 +49,8 @@
 
 .reader-subscription-list-item__site-url,
 .reader-subscription-list-item__site-url:visited,
-.reader-subscription-list-item__timestamp
-.reader-subscription-list-item__date-subscribed {
-	color: var(--color-text-subtle);
+.reader-subscription-list-item__timestamp .reader-subscription-list-item__date-subscribed {
+	color: var( --color-text-subtle );
 }
 
 .reader-subscription-list-item__timestamp {
@@ -67,12 +66,12 @@
 	width: auto;
 	-webkit-line-clamp: 1;
 	-webkit-box-orient: vertical;
-	color: var(--color-neutral-100);
+	color: var( --color-neutral-100 );
 	font-weight: 600;
 	font-size: $font-body-small;
 
 	&:hover {
-		color: var(--color-text-subtle);
+		color: var( --color-text-subtle );
 	}
 
 	.reader-sidebar-site_nameurl,
@@ -97,7 +96,7 @@
 	word-wrap: break-word;
 	word-break: break-all;
 
-	&:not(.is-placeholder)::after {
+	&:not( .is-placeholder )::after {
 		@include long-content-fade( $size: 20% );
 		height: 16px * 1.3;
 		top: auto;
@@ -111,20 +110,20 @@
 	max-height: 16px * 6.2;
 	min-width: 100%;
 
-	@include breakpoint-deprecated( "<960px" ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		height: auto;
 		flex-direction: column;
 	}
 
-	@include breakpoint-deprecated( "<660px" ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: row;
 	}
 
-	@include breakpoint-deprecated( "<480px" ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-direction: column;
 	}
 
-	&:not(.is-placeholder)::after {
+	&:not( .is-placeholder )::after {
 		@include long-content-fade( $size: 20% );
 		height: 100%;
 		top: auto;
@@ -138,7 +137,7 @@
 		display: flex;
 		justify-content: space-between;
 		list-style-type: disc;
-		color: var(--color-text-subtle);
+		color: var( --color-text-subtle );
 		font-weight: 400;
 		font-size: 0.75rem;
 		line-height: 18px;
@@ -163,24 +162,24 @@
 	width: initial;
 	max-height: 16px * 1.3;
 
-	@include breakpoint-deprecated( "<960px" ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		height: 20px;
 		flex: 1 1 auto;
 		max-width: none;
 	}
 
-	@include breakpoint-deprecated( "<660px" ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex: 0 1 auto;
 	}
 
-	@include breakpoint-deprecated( "<480px" ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex: 1 1 auto;
 		max-width: none;
 	}
 }
 
 .reader-subscription-list-item .follow-button .gridicon {
-	@include breakpoint-deprecated( "<660px" ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		left: 3px;
 	}
 }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -1,21 +1,21 @@
 .reader-subscription-list-item__byline {
-	color: var( --color-text );
+	color: var(--color-text);
 	margin: 0 12px;
 	flex: 1 1 0;
 }
 
 .reader-subscription-list-item__link,
 .reader-subscription-list-item__link:visited {
-	color: var( --color-neutral-100 );
+	color: var(--color-neutral-100);
 
 	&:hover {
-		color: var( --color-text-subtle );
+		color: var(--color-text-subtle);
 	}
 }
 
 .reader-subscription-list-item__site-excerpt {
 	display: -webkit-box;
-	color: var( --color-neutral-70 );
+	color: var(--color-neutral-70);
 	font-weight: 600;
 	font-size: $font-body-extra-small;
 	line-height: 18px;
@@ -49,8 +49,9 @@
 
 .reader-subscription-list-item__site-url,
 .reader-subscription-list-item__site-url:visited,
-.reader-subscription-list-item__timestamp .reader-subscription-list-item__date-subscribed {
-	color: var( --color-text-subtle );
+.reader-subscription-list-item__timestamp
+.reader-subscription-list-item__date-subscribed {
+	color: var(--color-text-subtle);
 }
 
 .reader-subscription-list-item__timestamp {
@@ -66,12 +67,12 @@
 	width: auto;
 	-webkit-line-clamp: 1;
 	-webkit-box-orient: vertical;
-	color: var( --color-neutral-100 );
+	color: var(--color-neutral-100);
 	font-weight: 600;
 	font-size: $font-body-small;
 
 	&:hover {
-		color: var( --color-text-subtle );
+		color: var(--color-text-subtle);
 	}
 
 	.reader-sidebar-site_nameurl,
@@ -96,7 +97,7 @@
 	word-wrap: break-word;
 	word-break: break-all;
 
-	&:not( .is-placeholder )::after {
+	&:not(.is-placeholder)::after {
 		@include long-content-fade( $size: 20% );
 		height: 16px * 1.3;
 		top: auto;
@@ -110,20 +111,20 @@
 	max-height: 16px * 6.2;
 	min-width: 100%;
 
-	@include breakpoint-deprecated( '<960px' ) {
+	@include breakpoint-deprecated( "<960px" ) {
 		height: auto;
 		flex-direction: column;
 	}
 
-	@include breakpoint-deprecated( '<660px' ) {
+	@include breakpoint-deprecated( "<660px" ) {
 		flex-direction: row;
 	}
 
-	@include breakpoint-deprecated( '<480px' ) {
+	@include breakpoint-deprecated( "<480px" ) {
 		flex-direction: column;
 	}
 
-	&:not( .is-placeholder )::after {
+	&:not(.is-placeholder)::after {
 		@include long-content-fade( $size: 20% );
 		height: 100%;
 		top: auto;
@@ -137,7 +138,7 @@
 		display: flex;
 		justify-content: space-between;
 		list-style-type: disc;
-		color: var( --color-text-subtle );
+		color: var(--color-text-subtle);
 		font-weight: 400;
 		font-size: 0.75rem;
 		line-height: 18px;
@@ -162,24 +163,24 @@
 	width: initial;
 	max-height: 16px * 1.3;
 
-	@include breakpoint-deprecated( '<960px' ) {
+	@include breakpoint-deprecated( "<960px" ) {
 		height: 20px;
 		flex: 1 1 auto;
 		max-width: none;
 	}
 
-	@include breakpoint-deprecated( '<660px' ) {
+	@include breakpoint-deprecated( "<660px" ) {
 		flex: 0 1 auto;
 	}
 
-	@include breakpoint-deprecated( '<480px' ) {
+	@include breakpoint-deprecated( "<480px" ) {
 		flex: 1 1 auto;
 		max-width: none;
 	}
 }
 
 .reader-subscription-list-item .follow-button .gridicon {
-	@include breakpoint-deprecated( '<660px' ) {
+	@include breakpoint-deprecated( "<660px" ) {
 		left: 3px;
 	}
 }

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -64,7 +64,12 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 				( card: Card ) => card.type === 'recommended_blogs'
 			);
 
-			return recommendedBlogsCard ? recommendedBlogsCard.data : [];
+			return recommendedBlogsCard
+				? recommendedBlogsCard.data.map( ( site: CardData & { URL?: string } ) => ( {
+						...site,
+						site_URL: site.URL || site.site_URL,
+				  } ) )
+				: [];
 		},
 	} );
 
@@ -124,7 +129,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 
 	const [ selectedSite, setSelectedSite ] = useState< CardData | null >( null );
 
-	// Add this useEffect hook to select the first site when recommendations are loaded
+	// Select the first site by default when recommendations are loaded.
 	useEffect( () => {
 		if ( combinedRecommendations.length > 0 && ! selectedSite ) {
 			setSelectedSite( combinedRecommendations[ 0 ] );
@@ -133,6 +138,12 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 
 	const handleItemClick = ( site: CardData ) => {
 		setSelectedSite( site );
+	};
+
+	const formatUrl = ( url: string ): string => {
+		return url
+			.replace( /^(https?:\/\/)?(www\.)?/, '' ) // Remove protocol and www
+			.replace( /\/$/, '' ); // Remove trailing slash
 	};
 
 	return (
@@ -184,14 +195,19 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 					<div className="subscribe-modal__preview-column">
 						<div className="subscribe-modal__preview-placeholder">
 							{ selectedSite ? (
-								<div className="subscribe-modal__preview-stream-container">
-									<TypedStream
-										streamKey={ `feed:${ selectedSite.feed_ID }` }
-										className="is-site-stream subscribe-modal__preview-stream"
-										followSource="reader_subscribe_modal"
-										useCompactCards
-									/>
-								</div>
+								<>
+									<div className="subscribe-modal__preview-stream-header">
+										<h3>{ formatUrl( selectedSite.site_URL ) }</h3>
+									</div>
+									<div className="subscribe-modal__preview-stream-container">
+										<TypedStream
+											streamKey={ `feed:${ selectedSite.feed_ID }` }
+											className="is-site-stream subscribe-modal__preview-stream"
+											followSource="reader_subscribe_modal"
+											useCompactCards
+										/>
+									</div>
+								</>
 							) : (
 								<div className="subscribe-modal__preview-placeholder-text">
 									{ __( 'Select a blog to preview its posts' ) }

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -111,6 +111,10 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		</>
 	);
 
+	const handleItemClick = () => {
+		console.log( 'hello world' );
+	};
+
 	return (
 		isOpen && (
 			<Modal
@@ -146,6 +150,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 										showFollowedOnDate={ false }
 										followSource="reader-onboarding-modal"
 										disableSuggestedFollows
+										onItemClick={ handleItemClick }
 									/>
 								) ) }
 							</div>

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -2,7 +2,7 @@ import { LoadingPlaceholder } from '@automattic/components';
 import { useQuery } from '@tanstack/react-query';
 import { Modal, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import React, { useMemo, useState, ComponentType } from 'react';
+import React, { useMemo, useState, ComponentType, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import wpcom from 'calypso/lib/wp';
@@ -124,6 +124,13 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 
 	const [ selectedSite, setSelectedSite ] = useState< CardData | null >( null );
 
+	// Add this useEffect hook to select the first site when recommendations are loaded
+	useEffect( () => {
+		if ( combinedRecommendations.length > 0 && ! selectedSite ) {
+			setSelectedSite( combinedRecommendations[ 0 ] );
+		}
+	}, [ combinedRecommendations, selectedSite ] );
+
 	const handleItemClick = ( site: CardData ) => {
 		setSelectedSite( site );
 	};
@@ -136,7 +143,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 				className="subscribe-modal"
 				headerActions={ headerActions }
 				isDismissible={ false }
-				isScrollable={ false }
 			>
 				<div className="subscribe-modal__content">
 					<div className="subscribe-modal__site-list-column">

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -2,10 +2,11 @@ import { LoadingPlaceholder } from '@automattic/components';
 import { useQuery } from '@tanstack/react-query';
 import { Modal, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, ComponentType } from 'react';
 import { useSelector } from 'react-redux';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import wpcom from 'calypso/lib/wp';
+import FeedStream from 'calypso/reader/feed-stream';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 import { curatedBlogs } from '../curated-blogs';
 
@@ -27,6 +28,18 @@ interface Card {
 	type: string;
 	data: CardData[];
 }
+
+interface FeedStreamProps {
+	feedId: number;
+	siteId?: number;
+	showBack?: boolean;
+	trackScrollPage: () => void;
+	streamKey: string;
+	// Add other props as needed
+}
+
+const TypedFeedStream: ComponentType< FeedStreamProps > =
+	FeedStream as ComponentType< FeedStreamProps >;
 
 const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) => {
 	const followedTags = useSelector( getReaderFollowedTags ) || [];
@@ -111,8 +124,15 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		</>
 	);
 
+	const [ selectedSite, setSelectedSite ] = useState< CardData | null >( null );
+
 	const handleItemClick = ( site: CardData ) => {
-		console.log( 'hello world', site );
+		setSelectedSite( site );
+	};
+
+	const trackScrollPage = () => {
+		// Implement scroll tracking logic here if needed
+		console.log( 'Scroll tracked' );
 	};
 
 	return (
@@ -161,9 +181,19 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 						</Button>
 					</div>
 					<div className="subscribe-modal__preview-column">
-						<div className="subscribe-modal__preview-placeholder">
-							{ __( 'Select a blog to preview its posts' ) }
-						</div>
+						{ selectedSite ? (
+							<TypedFeedStream
+								feedId={ selectedSite.feed_ID }
+								siteId={ selectedSite.site_ID }
+								showBack={ false }
+								trackScrollPage={ trackScrollPage }
+								streamKey={ `feed:${ selectedSite.feed_ID }` }
+							/>
+						) : (
+							<div className="subscribe-modal__preview-placeholder">
+								{ __( 'Select a blog to preview its posts' ) }
+							</div>
+						) }
 					</div>
 				</div>
 			</Modal>

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -171,6 +171,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 										followSource="reader-onboarding-modal"
 										disableSuggestedFollows
 										onItemClick={ () => handleItemClick( site ) }
+										isSelected={ selectedSite?.feed_ID === site.feed_ID }
 									/>
 								) ) }
 							</div>

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -6,7 +6,7 @@ import React, { useMemo, useState, ComponentType } from 'react';
 import { useSelector } from 'react-redux';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import wpcom from 'calypso/lib/wp';
-import FeedStream from 'calypso/reader/feed-stream';
+import Stream from 'calypso/reader/stream';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 import { curatedBlogs } from '../curated-blogs';
 
@@ -29,17 +29,15 @@ interface Card {
 	data: CardData[];
 }
 
-interface FeedStreamProps {
-	feedId: number;
-	siteId?: number;
-	showBack?: boolean;
-	trackScrollPage: () => void;
+interface StreamProps {
 	streamKey: string;
-	// Add other props as needed
+	className?: string;
+	followSource?: string;
+	useCompactCards?: boolean;
+	// Add other props as needed based on the Stream component's requirements
 }
 
-const TypedFeedStream: ComponentType< FeedStreamProps > =
-	FeedStream as ComponentType< FeedStreamProps >;
+const TypedStream: ComponentType< StreamProps > = Stream as ComponentType< StreamProps >;
 
 const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) => {
 	const followedTags = useSelector( getReaderFollowedTags ) || [];
@@ -130,11 +128,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		setSelectedSite( site );
 	};
 
-	const trackScrollPage = () => {
-		// Implement scroll tracking logic here if needed
-		console.log( 'Scroll tracked' );
-	};
-
 	return (
 		isOpen && (
 			<Modal
@@ -181,19 +174,22 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 						</Button>
 					</div>
 					<div className="subscribe-modal__preview-column">
-						{ selectedSite ? (
-							<TypedFeedStream
-								feedId={ selectedSite.feed_ID }
-								siteId={ selectedSite.site_ID }
-								showBack={ false }
-								trackScrollPage={ trackScrollPage }
-								streamKey={ `feed:${ selectedSite.feed_ID }` }
-							/>
-						) : (
-							<div className="subscribe-modal__preview-placeholder">
-								{ __( 'Select a blog to preview its posts' ) }
-							</div>
-						) }
+						<div className="subscribe-modal__preview-placeholder">
+							{ selectedSite ? (
+								<div className="subscribe-modal__preview-stream-container">
+									<TypedStream
+										streamKey={ `feed:${ selectedSite.feed_ID }` }
+										className="is-site-stream subscribe-modal__preview-stream"
+										followSource="reader_subscribe_modal"
+										useCompactCards
+									/>
+								</div>
+							) : (
+								<div className="subscribe-modal__preview-placeholder-text">
+									{ __( 'Select a blog to preview its posts' ) }
+								</div>
+							) }
+						</div>
 					</div>
 				</div>
 			</Modal>

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -111,8 +111,8 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		</>
 	);
 
-	const handleItemClick = () => {
-		console.log( 'hello world' );
+	const handleItemClick = ( site: CardData ) => {
+		console.log( 'hello world', site );
 	};
 
 	return (
@@ -150,7 +150,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 										showFollowedOnDate={ false }
 										followSource="reader-onboarding-modal"
 										disableSuggestedFollows
-										onItemClick={ handleItemClick }
+										onItemClick={ () => handleItemClick( site ) }
 									/>
 								) ) }
 							</div>

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -34,7 +34,6 @@ interface StreamProps {
 	className?: string;
 	followSource?: string;
 	useCompactCards?: boolean;
-	// Add other props as needed based on the Stream component's requirements
 }
 
 const TypedStream: ComponentType< StreamProps > = Stream as ComponentType< StreamProps >;

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -136,6 +136,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 				className="subscribe-modal"
 				headerActions={ headerActions }
 				isDismissible={ false }
+				isScrollable={ false }
 			>
 				<div className="subscribe-modal__content">
 					<div className="subscribe-modal__site-list-column">

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -62,6 +62,7 @@
 		background-color: #e0e0e0;
 		font-style: italic;
 		border: 1px solid #ccc;
-		border-radius: 6px; /* stylelint-disable-line scales/radii */
+		border-radius: 6px;
+		overflow: hidden;
 	}
 }

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -14,18 +14,23 @@
 	&__content {
 		display: flex;
 		flex-direction: column;
-		height: 100%;
+		height: calc( 100vh - 200px );
+		align-items: center;
 
-		@include break-medium {
+		@media ( min-width: 1200px ) {
 			flex-direction: row;
+			overflow: hidden;
+			align-items: initial;
 		}
 	}
 
 	&__site-list-column {
 		flex: 1;
-		padding: 30px;
+		padding: 30px 30px 0;
+		overflow-y: auto;
+		max-width: 600px;
 
-		@include break-medium {
+		@media ( min-width: 1200px ) {
 			max-width: 450px;
 		}
 
@@ -39,30 +44,41 @@
 		}
 	}
 
-	&__preview-column {
-		flex: 1;
-		padding: 24px;
-		display: flex;
-		flex-direction: column;
-
-		@include break-medium {
-			display: flex;
-		}
-	}
-
 	&__recommended-sites {
 		margin-bottom: 24px;
 	}
 
+	&__preview-column {
+		flex: 1;
+		padding: 24px;
+		display: none;
+		flex-direction: column;
+		overflow: hidden;
+
+		clip-path: inset( 0 0 0 0 );
+
+		@media ( min-width: 1200px ) {
+			display: flex;
+		}
+
+		.reader-post-actions {
+			display: none;
+		}
+	}
+
 	&__preview-placeholder {
 		display: flex;
-		align-items: center;
 		justify-content: center;
 		flex-grow: 1;
-		background-color: #e0e0e0;
-		font-style: italic;
 		border: 1px solid #ccc;
 		border-radius: 6px;
+		background-color: #e0e0e0;
+		height: calc( 100vh - 212px );
+		width: calc( 100vw - 620px );
+		font-style: italic;
+
 		overflow: hidden;
+
+		position: fixed;
 	}
 }

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -26,7 +26,7 @@
 
 	&__site-list-column {
 		flex: 1;
-		padding: 30px 30px 0;
+		padding: 20px 20px 0;
 		overflow-y: auto;
 		max-width: 600px;
 
@@ -41,6 +41,20 @@
 
 		p {
 			text-wrap: balance;
+		}
+
+		.reader-subscription-list-item {
+			padding: 12px;
+			border: 1px solid var( --color-neutral-5 );
+			border-radius: 4px;
+			cursor: pointer;
+			margin-bottom: 12px;
+
+			&.is-selected {
+				background-color: #e6f3fa;
+				border: 1px solid #0087be;
+				border-radius: 4px;
+			}
 		}
 	}
 
@@ -70,10 +84,10 @@
 		display: flex;
 		justify-content: center;
 		flex-grow: 1;
-		border: 1px solid #ccc;
+		border: 1px solid #f2f2f2;
 		border-radius: 6px;
-		background-color: #e0e0e0;
-		height: calc( 100vh - 212px );
+		background-color: #f2f2f2;
+		height: calc( 100vh - 224px );
 		width: calc( 100vw - 620px );
 		font-style: italic;
 

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -46,14 +46,14 @@
 		.reader-subscription-list-item {
 			padding: 12px;
 			border: 1px solid var( --color-neutral-5 );
-			border-radius: 4px;
+			border-radius: 6px; /* stylelint-disable-line scales/radii */
 			cursor: pointer;
 			margin-bottom: 12px;
 
 			&.is-selected {
 				background-color: #e6f3fa;
 				border: 1px solid #0087be;
-				border-radius: 4px;
+				border-radius: 6px; /* stylelint-disable-line scales/radii */
 			}
 		}
 	}
@@ -77,24 +77,31 @@
 
 		.reader-post-actions,
 		.comments__comment-list,
-		.reader-post-options-menu__ellipsis-menu {
+		.reader-post-options-menu__ellipsis-menu,
+		.reader-update-notice {
 			display: none;
 		}
 	}
 
 	&__preview-placeholder {
-		display: flex;
 		justify-content: center;
-		flex-grow: 1;
 		border: 1px solid #f2f2f2;
-		border-radius: 6px;
+		border-radius: 6px; /* stylelint-disable-line scales/radii */
 		background-color: #f2f2f2;
 		height: calc( 100vh - 224px );
 		width: calc( 100vw - 620px );
-		font-style: italic;
-
 		overflow: hidden;
-
 		position: fixed;
+	}
+
+	&__preview-stream-header {
+		background-color: #fff;
+		text-align: center;
+		line-height: rem( 36px );
+		font-size: rem( 14px );
+	}
+
+	&__preview-stream-container {
+		padding-top: 40px;
 	}
 }

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -75,7 +75,9 @@
 			display: flex;
 		}
 
-		.reader-post-actions {
+		.reader-post-actions,
+		.comments__comment-list,
+		.reader-post-options-menu__ellipsis-menu {
 			display: none;
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/188

## Proposed Changes

* This PR introduces the preview panel and "highlighted" selectable sites for "step 2"
* It adds `onItemClick` and `isSelected` props to the `ConnectedReaderSubscriptionListItem` and `ReaderSubscriptionListItem` components.

> [!NOTE]  
> This PR does NOT implement a "completed" state when you click the "Continue" button. We'll handle that in a followup PR. It also does NOT implement the "Load more recommendations" feature, but the copy is left in to keep the translations warm.

Before | After
--|--
<img width="1723" alt="Screenshot 2024-10-18 at 9 02 28 AM" src="https://github.com/user-attachments/assets/241286a8-8ba3-4fe0-b3fe-4cb0c978f632"> | <img width="1728" alt="Screenshot 2024-10-18 at 9 13 53 AM" src="https://github.com/user-attachments/assets/c993cde1-dd71-4057-9fcd-b88751b3ca7a"> 





## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Push Reader Onboarding forward.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /read?flags=reader/onboarding
* Ensure you are following 3 or more tags to unlock the "Discover and subscribe to sites you'll love" button.
* Click "Discover and subscribe to sites you'll love" to view the suggested sites.
* Click on some suggested sites to see them load in the preview pane.
* Check for regressions by going to /discover and interact with the sites listed under "Popular sites"
* Click on all the links and subscribe button in some of the sites under "Popular sites" and ensure they still work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
