### PR TITLE
POC: Adding DataViews to Plugin Management

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -6,7 +6,7 @@ import {
 import page from '@automattic/calypso-router';
 import { Button, Count } from '@automattic/components';
 import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
-import { Icon, upload, plugins } from '@wordpress/icons';
+import { Icon, upload } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { capitalize, find, flow, isEmpty } from 'lodash';
@@ -18,7 +18,6 @@ import QueryPlugins from 'calypso/components/data/query-plugins';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import EmptyContent from 'calypso/components/empty-content';
 import NavigationHeader from 'calypso/components/navigation-header';
-import Search from 'calypso/components/search';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -57,7 +56,6 @@ import {
 import NoPermissionsError from './no-permissions-error';
 import PluginsListV2 from './plugin-management-v2/plugin-list-v2';
 import UpdatePlugins from './plugin-management-v2/update-plugins';
-import PluginsList from './plugins-list';
 import './style.scss';
 
 export class PluginsMain extends Component {
@@ -156,15 +154,11 @@ export class PluginsMain extends Component {
 	}
 
 	getCurrentPlugins() {
-		const { currentPlugins, currentPluginsOnVisibleSites, search, selectedSiteSlug } = this.props;
-		let plugins = selectedSiteSlug ? currentPlugins : currentPluginsOnVisibleSites;
+		const { currentPlugins, currentPluginsOnVisibleSites, selectedSiteSlug } = this.props;
+		const plugins = selectedSiteSlug ? currentPlugins : currentPluginsOnVisibleSites;
 
 		if ( ! plugins ) {
 			return plugins;
-		}
-
-		if ( search ) {
-			plugins = plugins.filter( this.matchSearchTerms.bind( this, search ) );
 		}
 
 		return this.addWporgDataToPlugins( plugins );
@@ -376,7 +370,11 @@ export class PluginsMain extends Component {
 		}
 
 		const installedPluginsList = showInstalledPluginList && (
-			<PluginsListV2 currentPlugins={ currentPlugins } />
+			<PluginsListV2
+				currentPlugins={ currentPlugins }
+				onSearch={ this.props.doSearch }
+				initialSearch={ this.props.search }
+			/>
 		);
 
 		return <div>{ installedPluginsList }</div>;
@@ -539,25 +537,7 @@ export class PluginsMain extends Component {
 							'plugins__main-content-jc': isJetpackCloud,
 						} ) }
 					>
-						<div className="plugins__content-wrapper">
-							{
-								// Hide the search box only when the request to fetch plugins fail, and there are no sites.
-								! ( this.props.requestPluginsError && ! currentPlugins?.length ) && (
-									<div className="plugins__search">
-										<Search
-											hideFocus
-											isOpen
-											onSearch={ this.props.doSearch }
-											initialValue={ this.props.search }
-											hideClose={ ! this.props.search }
-											analyticsGroup="Plugins"
-											placeholder={ this.props.translate( 'Search plugins' ) }
-										/>
-									</div>
-								)
-							}
-							{ this.renderPluginsContent() }
-						</div>
+						<div className="plugins__content-wrapper">{ this.renderPluginsContent() }</div>
 					</div>
 				</div>
 			</>

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -6,7 +6,7 @@ import {
 import page from '@automattic/calypso-router';
 import { Button, Count } from '@automattic/components';
 import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
-import { Icon, upload } from '@wordpress/icons';
+import { Icon, upload, plugins } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize, translate } from 'i18n-calypso';
 import { capitalize, find, flow, isEmpty } from 'lodash';
@@ -16,6 +16,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackSitesFeatures from 'calypso/components/data/query-jetpack-sites-features';
 import QueryPlugins from 'calypso/components/data/query-plugins';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
+import { DataViews } from 'calypso/components/dataviews';
 import EmptyContent from 'calypso/components/empty-content';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Search from 'calypso/components/search';
@@ -59,7 +60,6 @@ import UpdatePlugins from './plugin-management-v2/update-plugins';
 import PluginsList from './plugins-list';
 
 import './style.scss';
-import { DataViews } from '@wordpress/dataviews';
 
 export class PluginsMain extends Component {
 	constructor( props ) {
@@ -391,16 +391,6 @@ export class PluginsMain extends Component {
 
 		console.log( 'currentPlugins', currentPlugins );
 
-		const data = currentPlugins.map( ( plugin ) => {
-			return {
-				id: plugin.id,
-				name: plugin.name,
-				sites: plugin.sites.length,
-				update: true,
-				imageSrc: plugin.icon,
-			};
-		} );
-
 		const fields = [
 			{
 				id: 'plugins',
@@ -408,7 +398,14 @@ export class PluginsMain extends Component {
 				render: ( { item } ) => {
 					return (
 						<>
-							<img src={ item.imageSrc } />
+							{ item.icon && <img src={ item.icon } /> }
+							{ ! item.icon && (
+								<Icon
+									size={ 32 }
+									icon={ plugins }
+									className="plugin-common-card__plugin-icon plugin-default-icon"
+								/>
+							) }
 							<a href="...">{ item.name }</a>
 						</>
 					);
@@ -420,7 +417,7 @@ export class PluginsMain extends Component {
 				label: 'Sites',
 				enableHiding: false,
 				render: ( { item } ) => {
-					return <span>{ item.sites && item.sites.length }</span>;
+					return <span>{ item.sites && Object.keys( item.sites ).length }</span>;
 				},
 			},
 			{
@@ -464,6 +461,47 @@ export class PluginsMain extends Component {
 				label: translate( 'Manage Plugin' ),
 				isExternalLink: true,
 				isEnabled: true,
+				supportsBulk: false,
+			},
+			{
+				href: `some-url`,
+				callback: () => {
+					console.log( 'Activate' );
+				},
+				label: translate( 'Activate' ),
+				isExternalLink: true,
+				isEnabled: true,
+				supportsBulk: true,
+			},
+			{
+				href: `some-url`,
+				callback: () => {
+					console.log( 'Deactivate' );
+				},
+				label: translate( 'Deactivate' ),
+				isExternalLink: true,
+				isEnabled: true,
+				supportsBulk: true,
+			},
+			{
+				href: `some-url`,
+				callback: () => {
+					console.log( 'Enable Autoupdate' );
+				},
+				label: translate( 'Enable Autoupdate' ),
+				isExternalLink: true,
+				isEnabled: true,
+				supportsBulk: true,
+			},
+			{
+				href: `some-url`,
+				callback: () => {
+					console.log( 'Disable Autoupdate' );
+				},
+				label: translate( 'Disable Autoupdate' ),
+				isExternalLink: true,
+				isEnabled: true,
+				supportsBulk: true,
 			},
 			{
 				href: `some-url`,
@@ -473,18 +511,20 @@ export class PluginsMain extends Component {
 				label: translate( 'Remove' ),
 				isExternalLink: true,
 				isEnabled: true,
-				icon: 'trash',
+				supportsBulk: true,
 			},
 		];
 
 		const installedPluginsList = showInstalledPluginList && (
 			<DataViews
 				// header={ this.props.translate( 'Installed Plugins' ) }
-				data={ data }
+				data={ currentPlugins }
 				fields={ fields }
 				view={ view }
 				actions={ actions }
 				paginationInfo={ paginationInfo }
+				onChangeView={ () => console.log( 'onChangeView' ) }
+				isLoading={ this.props.requestingPluginsForSites }
 			/>
 		);
 

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -8,7 +8,7 @@ import { Button, Count } from '@automattic/components';
 import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
 import { Icon, upload, plugins } from '@wordpress/icons';
 import clsx from 'clsx';
-import { localize, translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { capitalize, find, flow, isEmpty } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -16,7 +16,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackSitesFeatures from 'calypso/components/data/query-jetpack-sites-features';
 import QueryPlugins from 'calypso/components/data/query-plugins';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
-import { DataViews } from 'calypso/components/dataviews';
 import EmptyContent from 'calypso/components/empty-content';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Search from 'calypso/components/search';
@@ -56,9 +55,9 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import NoPermissionsError from './no-permissions-error';
+import PluginsListV2 from './plugin-management-v2/plugin-list-v2';
 import UpdatePlugins from './plugin-management-v2/update-plugins';
 import PluginsList from './plugins-list';
-
 import './style.scss';
 
 export class PluginsMain extends Component {
@@ -376,156 +375,8 @@ export class PluginsMain extends Component {
 			}
 		}
 
-		// const installedPluginsList = showInstalledPluginList && (
-		// 	<PluginsList
-		// 		header={ this.props.translate( 'Installed Plugins' ) }
-		// 		plugins={ currentPlugins }
-		// 		isPlaceholder={ this.shouldShowPluginListPlaceholders() }
-		// 		isLoading={ this.props.requestingPluginsForSites }
-		// 		isJetpackCloud={ this.props.isJetpackCloud }
-		// 		searchTerm={ search }
-		// 		filter={ this.props.filter }
-		// 		requestPluginsError={ this.props.requestPluginsError }
-		// 	/>
-		// );
-
-		console.log( 'currentPlugins', currentPlugins );
-
-		const fields = [
-			{
-				id: 'plugins',
-				label: 'Installed Plugins',
-				render: ( { item } ) => {
-					return (
-						<>
-							{ item.icon && <img src={ item.icon } /> }
-							{ ! item.icon && (
-								<Icon
-									size={ 32 }
-									icon={ plugins }
-									className="plugin-common-card__plugin-icon plugin-default-icon"
-								/>
-							) }
-							<a href="...">{ item.name }</a>
-						</>
-					);
-				},
-				enableSorting: false,
-			},
-			{
-				id: 'sites',
-				label: 'Sites',
-				enableHiding: false,
-				render: ( { item } ) => {
-					return <span>{ item.sites && Object.keys( item.sites ).length }</span>;
-				},
-			},
-			{
-				id: 'update',
-				label: 'Update available',
-				enableHiding: false,
-				render: ( { item } ) => {
-					return <Button>Update to 1.2.3</Button>;
-				},
-			},
-		];
-
-		const view = {
-			type: 'table',
-			search: '',
-			filters: [
-				{ field: 'plugins', operator: 'is', value: 2 },
-				{ field: 'status', operator: 'isAny', value: [ 'publish', 'draft' ] },
-			],
-			page: 1,
-			perPage: 30,
-			sort: {
-				field: 'date',
-				direction: 'desc',
-			},
-			fields: [ 'plugins', 'sites', 'update' ],
-			layout: {},
-		};
-
-		const paginationInfo = {
-			totalItems: 2,
-			totalPages: 5,
-		};
-
-		const actions = [
-			{
-				href: `some-url`,
-				callback: () => {
-					console.log( 'Manage Plugin' );
-				},
-				label: translate( 'Manage Plugin' ),
-				isExternalLink: true,
-				isEnabled: true,
-				supportsBulk: false,
-			},
-			{
-				href: `some-url`,
-				callback: () => {
-					console.log( 'Activate' );
-				},
-				label: translate( 'Activate' ),
-				isExternalLink: true,
-				isEnabled: true,
-				supportsBulk: true,
-			},
-			{
-				href: `some-url`,
-				callback: () => {
-					console.log( 'Deactivate' );
-				},
-				label: translate( 'Deactivate' ),
-				isExternalLink: true,
-				isEnabled: true,
-				supportsBulk: true,
-			},
-			{
-				href: `some-url`,
-				callback: () => {
-					console.log( 'Enable Autoupdate' );
-				},
-				label: translate( 'Enable Autoupdate' ),
-				isExternalLink: true,
-				isEnabled: true,
-				supportsBulk: true,
-			},
-			{
-				href: `some-url`,
-				callback: () => {
-					console.log( 'Disable Autoupdate' );
-				},
-				label: translate( 'Disable Autoupdate' ),
-				isExternalLink: true,
-				isEnabled: true,
-				supportsBulk: true,
-			},
-			{
-				href: `some-url`,
-				callback: () => {
-					console.log( 'Remove' );
-				},
-				label: translate( 'Remove' ),
-				isExternalLink: true,
-				isEnabled: true,
-				supportsBulk: true,
-			},
-		];
-
 		const installedPluginsList = showInstalledPluginList && (
-			<DataViews
-				// header={ this.props.translate( 'Installed Plugins' ) }
-				data={ currentPlugins }
-				fields={ fields }
-				view={ view }
-				actions={ actions }
-				paginationInfo={ paginationInfo }
-				onChangeView={ () => console.log( 'onChangeView' ) }
-				isLoading={ this.props.requestingPluginsForSites }
-			/>
+			<PluginsListV2 currentPlugins={ currentPlugins } />
 		);
 
 		return <div>{ installedPluginsList }</div>;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -8,7 +8,7 @@ import { Button, Count } from '@automattic/components';
 import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
 import { Icon, upload } from '@wordpress/icons';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import { capitalize, find, flow, isEmpty } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -59,6 +59,7 @@ import UpdatePlugins from './plugin-management-v2/update-plugins';
 import PluginsList from './plugins-list';
 
 import './style.scss';
+import { DataViews } from '@wordpress/dataviews';
 
 export class PluginsMain extends Component {
 	constructor( props ) {
@@ -375,16 +376,115 @@ export class PluginsMain extends Component {
 			}
 		}
 
+		// const installedPluginsList = showInstalledPluginList && (
+		// 	<PluginsList
+		// 		header={ this.props.translate( 'Installed Plugins' ) }
+		// 		plugins={ currentPlugins }
+		// 		isPlaceholder={ this.shouldShowPluginListPlaceholders() }
+		// 		isLoading={ this.props.requestingPluginsForSites }
+		// 		isJetpackCloud={ this.props.isJetpackCloud }
+		// 		searchTerm={ search }
+		// 		filter={ this.props.filter }
+		// 		requestPluginsError={ this.props.requestPluginsError }
+		// 	/>
+		// );
+
+		console.log( 'currentPlugins', currentPlugins );
+
+		const data = currentPlugins.map( ( plugin ) => {
+			return {
+				id: plugin.id,
+				name: plugin.name,
+				sites: plugin.sites.length,
+				update: true,
+				imageSrc: plugin.icon,
+			};
+		} );
+
+		const fields = [
+			{
+				id: 'plugins',
+				label: 'Installed Plugins',
+				render: ( { item } ) => {
+					return (
+						<>
+							<img src={ item.imageSrc } />
+							<a href="...">{ item.name }</a>
+						</>
+					);
+				},
+				enableSorting: false,
+			},
+			{
+				id: 'sites',
+				label: 'Sites',
+				enableHiding: false,
+				render: ( { item } ) => {
+					return <span>{ item.sites && item.sites.length }</span>;
+				},
+			},
+			{
+				id: 'update',
+				label: 'Update available',
+				enableHiding: false,
+				render: ( { item } ) => {
+					return <Button>Update to 1.2.3</Button>;
+				},
+			},
+		];
+
+		const view = {
+			type: 'table',
+			search: '',
+			filters: [
+				{ field: 'plugins', operator: 'is', value: 2 },
+				{ field: 'status', operator: 'isAny', value: [ 'publish', 'draft' ] },
+			],
+			page: 1,
+			perPage: 30,
+			sort: {
+				field: 'date',
+				direction: 'desc',
+			},
+			fields: [ 'plugins', 'sites', 'update' ],
+			layout: {},
+		};
+
+		const paginationInfo = {
+			totalItems: 2,
+			totalPages: 5,
+		};
+
+		const actions = [
+			{
+				href: `some-url`,
+				callback: () => {
+					console.log( 'Manage Plugin' );
+				},
+				label: translate( 'Manage Plugin' ),
+				isExternalLink: true,
+				isEnabled: true,
+			},
+			{
+				href: `some-url`,
+				callback: () => {
+					console.log( 'Remove' );
+				},
+				label: translate( 'Remove' ),
+				isExternalLink: true,
+				isEnabled: true,
+				icon: 'trash',
+			},
+		];
+
 		const installedPluginsList = showInstalledPluginList && (
-			<PluginsList
-				header={ this.props.translate( 'Installed Plugins' ) }
-				plugins={ currentPlugins }
-				isPlaceholder={ this.shouldShowPluginListPlaceholders() }
-				isLoading={ this.props.requestingPluginsForSites }
-				isJetpackCloud={ this.props.isJetpackCloud }
-				searchTerm={ search }
-				filter={ this.props.filter }
-				requestPluginsError={ this.props.requestPluginsError }
+			<DataViews
+				// header={ this.props.translate( 'Installed Plugins' ) }
+				data={ data }
+				fields={ fields }
+				view={ view }
+				actions={ actions }
+				paginationInfo={ paginationInfo }
 			/>
 		);
 

--- a/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/index.tsx
@@ -10,10 +10,26 @@ import './style.scss';
 interface Props {
 	currentPlugins: Array;
 	initialSearch?: string;
+	pluginUpdateCount: number;
+	pluginActiveCount: number;
+	pluginInactivecount: number;
 	onSearch?: ( search: string ) => void;
 }
 
-export default function PluginsListV2( { currentPlugins, initialSearch, onSearch }: Props ) {
+export const PLUGINS_STATUS = {
+	ACTIVE: 1,
+	INACTIVE: 2,
+	UPDATE: 3,
+};
+
+export default function PluginsListV2( {
+	currentPlugins,
+	initialSearch,
+	pluginUpdateCount,
+	pluginActiveCount,
+	pluginInactivecount,
+	onSearch,
+}: Props ) {
 	const translate = useTranslate();
 
 	const fields = useMemo(
@@ -21,15 +37,31 @@ export default function PluginsListV2( { currentPlugins, initialSearch, onSearch
 			{
 				id: 'status',
 				label: translate( 'Status' ),
+				getValue: ( { item }: { item } ) => {
+					return item.status;
+				},
 				render: () => null,
 				elements: [
-					{ value: 1, label: translate( 'All' ) },
-					{ value: 2, label: translate( 'Active' ) },
-					{ value: 3, label: translate( 'Inactive' ) },
-					{ value: 4, label: translate( 'Needs update' ) },
+					{
+						value: PLUGINS_STATUS.ACTIVE,
+						label:
+							translate( 'Active' ) + ( pluginActiveCount > 0 ? ' - ' + pluginActiveCount : '' ),
+					},
+					{
+						value: PLUGINS_STATUS.INACTIVE,
+						label:
+							translate( 'Inactive' ) +
+							( pluginInactivecount > 0 ? ' - ' + pluginInactivecount : '' ),
+					},
+					{
+						value: PLUGINS_STATUS.UPDATE,
+						label:
+							translate( 'Needs update' ) +
+							( pluginUpdateCount > 0 ? ' - ' + pluginUpdateCount : '' ),
+					},
 				],
 				filterBy: {
-					operators: [ 'is' ],
+					operators: [ 'isAny' ],
 					isPrimary: true,
 				},
 				enableHiding: false,
@@ -81,18 +113,7 @@ export default function PluginsListV2( { currentPlugins, initialSearch, onSearch
 	const initialDataViewsState = {
 		type: 'table',
 		search: initialSearch || '',
-		// filters:
-		// 	filter?.issueTypes?.map( ( issueType ) => {
-		// 		return {
-		// 			field: 'status',
-		// 			operator: 'is',
-		// 			value: filtersMap.find( ( filterMap ) => filterMap.filterType === issueType )?.ref || 1,
-		// 		};
-		// 	} ) || [],
-		filters: [
-			// { field: 'plugins', operator: 'is', value: 2 },
-			// { field: 'status', operator: 'isAny', value: [ 'publish', 'draft' ] },
-		],
+		filters: [],
 		page: 1,
 		perPage: pluginsPerPage,
 		sort: {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/index.tsx
@@ -1,0 +1,189 @@
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { Icon, plugins } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, useState } from 'react';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import Button from 'calypso/blocks/follow-button/button';
+
+import './style.scss';
+
+interface Props {
+	currentPlugins: Array;
+}
+
+export default function PluginsListV2( { currentPlugins }: Props ) {
+	const translate = useTranslate();
+
+	console.log( 'currentPlugins', currentPlugins );
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'status',
+				label: translate( 'Status' ),
+				render: () => null,
+				elements: [
+					{ value: 1, label: translate( 'All' ) },
+					{ value: 2, label: translate( 'Active' ) },
+					{ value: 3, label: translate( 'Inactive' ) },
+					{ value: 4, label: translate( 'Needs update' ) },
+				],
+				filterBy: {
+					operators: [ 'is' ],
+					isPrimary: true,
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'plugins',
+				label: 'Installed Plugins',
+				render: ( { item } ) => {
+					return (
+						<>
+							{ item.icon && <img src={ item.icon } /> }
+							{ ! item.icon && (
+								<Icon
+									size={ 32 }
+									icon={ plugins }
+									className="plugin-common-card__plugin-icon plugin-default-icon"
+								/>
+							) }
+							<a href="...">{ item.name }</a>
+						</>
+					);
+				},
+				enableSorting: false,
+			},
+			{
+				id: 'sites',
+				label: 'Sites',
+				enableHiding: false,
+				render: ( { item } ) => {
+					return <span>{ item.sites && Object.keys( item.sites ).length }</span>;
+				},
+			},
+			{
+				id: 'update',
+				label: 'Update available',
+				enableHiding: false,
+				render: ( { item } ) => {
+					return <Button>Update to 1.2.3</Button>;
+				},
+			},
+		],
+		[]
+	);
+
+	const pluginsPerPage = 10;
+	const initialDataViewsState = {
+		type: 'table',
+		search: '',
+		// filters:
+		// 	filter?.issueTypes?.map( ( issueType ) => {
+		// 		return {
+		// 			field: 'status',
+		// 			operator: 'is',
+		// 			value: filtersMap.find( ( filterMap ) => filterMap.filterType === issueType )?.ref || 1,
+		// 		};
+		// 	} ) || [],
+		filters: [
+			// { field: 'plugins', operator: 'is', value: 2 },
+			// { field: 'status', operator: 'isAny', value: [ 'publish', 'draft' ] },
+		],
+		page: 1,
+		perPage: pluginsPerPage,
+		sort: {
+			field: 'date',
+			direction: 'desc',
+		},
+		fields: [ 'plugins', 'sites', 'update' ],
+		layout: {},
+	};
+
+	const actions = [
+		{
+			href: `some-url`,
+			callback: () => {
+				console.log( 'Manage Plugin' );
+			},
+			label: translate( 'Manage Plugin' ),
+			isExternalLink: true,
+			isEnabled: true,
+			supportsBulk: false,
+		},
+		{
+			href: `some-url`,
+			callback: () => {
+				console.log( 'Activate' );
+			},
+			label: translate( 'Activate' ),
+			isExternalLink: true,
+			isEnabled: true,
+			supportsBulk: true,
+		},
+		{
+			href: `some-url`,
+			callback: () => {
+				console.log( 'Deactivate' );
+			},
+			label: translate( 'Deactivate' ),
+			isExternalLink: true,
+			isEnabled: true,
+			supportsBulk: true,
+		},
+		{
+			href: `some-url`,
+			callback: () => {
+				console.log( 'Enable Autoupdate' );
+			},
+			label: translate( 'Enable Autoupdate' ),
+			isExternalLink: true,
+			isEnabled: true,
+			supportsBulk: true,
+		},
+		{
+			href: `some-url`,
+			callback: () => {
+				console.log( 'Disable Autoupdate' );
+			},
+			label: translate( 'Disable Autoupdate' ),
+			isExternalLink: true,
+			isEnabled: true,
+			supportsBulk: true,
+		},
+		{
+			href: `some-url`,
+			callback: () => {
+				console.log( 'Remove' );
+			},
+			label: translate( 'Remove' ),
+			isExternalLink: true,
+			isEnabled: true,
+			supportsBulk: true,
+		},
+	];
+
+	const [ dataViewsState, setDataViewsState ] = useState( initialDataViewsState );
+
+	const { data, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( currentPlugins, dataViewsState, fields );
+	}, [ currentPlugins, dataViewsState, fields ] );
+
+	return (
+		<div className="referrals-details-table__container redesigned-a8c-table">
+			<ItemsDataViews
+				data={ {
+					items: data,
+					fields,
+					pagination: paginationInfo,
+					enableSearch: true,
+					actions: actions,
+					dataViewsState: dataViewsState,
+					setDataViewsState: setDataViewsState,
+					defaultLayouts: { table: {} },
+				} }
+			/>
+		</div>
+	);
+}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/index.tsx
@@ -1,9 +1,9 @@
+import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { Icon, plugins } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
-import Button from 'calypso/blocks/follow-button/button';
 
 import './style.scss';
 
@@ -102,7 +102,9 @@ export default function PluginsListV2( {
 				label: 'Update available',
 				enableHiding: false,
 				render: ( { item } ) => {
-					return <Button>Update to 1.2.3</Button>;
+					if ( item.status.includes( PLUGINS_STATUS.UPDATE ) ) {
+						return <Button variant="secondary">Update to 1.2.3</Button>;
+					}
 				},
 			},
 		],

--- a/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/index.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
-import { Icon, plugins } from '@wordpress/icons';
+import { Icon, link, linkOff, plugins, trash } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { navigate } from 'calypso/lib/navigate';
 
 import './style.scss';
 
@@ -83,7 +84,7 @@ export default function PluginsListV2( {
 									className="plugin-common-card__plugin-icon plugin-default-icon"
 								/>
 							) }
-							<a href="...">{ item.name }</a>
+							<a href={ '/plugins/' + item.slug }>{ item.name }</a>
 						</>
 					);
 				},
@@ -129,8 +130,8 @@ export default function PluginsListV2( {
 	const actions = [
 		{
 			href: `some-url`,
-			callback: () => {
-				console.log( 'Manage Plugin' );
+			callback: ( data ) => {
+				data.length && navigate( '/plugins/' + data[ 0 ].slug );
 			},
 			label: translate( 'Manage Plugin' ),
 			isExternalLink: true,
@@ -139,13 +140,14 @@ export default function PluginsListV2( {
 		},
 		{
 			href: `some-url`,
-			callback: () => {
-				console.log( 'Activate' );
+			callback: ( data ) => {
+				console.log( 'Activate Plugin, data: ', data );
 			},
 			label: translate( 'Activate' ),
 			isExternalLink: true,
 			isEnabled: true,
 			supportsBulk: true,
+			icon: <Icon icon={ link } />,
 		},
 		{
 			href: `some-url`,
@@ -156,6 +158,7 @@ export default function PluginsListV2( {
 			isExternalLink: true,
 			isEnabled: true,
 			supportsBulk: true,
+			icon: <Icon icon={ linkOff } />,
 		},
 		{
 			href: `some-url`,
@@ -186,6 +189,7 @@ export default function PluginsListV2( {
 			isExternalLink: true,
 			isEnabled: true,
 			supportsBulk: true,
+			icon: <Icon icon={ trash } />,
 		},
 	];
 
@@ -197,6 +201,7 @@ export default function PluginsListV2( {
 	}, [ dataViewsState.search, onSearch ] );
 
 	const { data, paginationInfo } = useMemo( () => {
+		console.log( 'dataViewsState', dataViewsState );
 		return filterSortAndPaginate( currentPlugins, dataViewsState, fields );
 	}, [ currentPlugins, dataViewsState, fields ] );
 
@@ -213,6 +218,9 @@ export default function PluginsListV2( {
 					actions: actions,
 					dataViewsState: dataViewsState,
 					setDataViewsState: setDataViewsState,
+					onSelectionChange: ( items ) => {
+						console.log( 'items: ', items );
+					},
 					defaultLayouts: { table: {} },
 				} }
 			/>

--- a/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/index.tsx
@@ -1,7 +1,7 @@
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { Icon, plugins } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import Button from 'calypso/blocks/follow-button/button';
 
@@ -9,12 +9,12 @@ import './style.scss';
 
 interface Props {
 	currentPlugins: Array;
+	initialSearch?: string;
+	onSearch?: ( search: string ) => void;
 }
 
-export default function PluginsListV2( { currentPlugins }: Props ) {
+export default function PluginsListV2( { currentPlugins, initialSearch, onSearch }: Props ) {
 	const translate = useTranslate();
-
-	console.log( 'currentPlugins', currentPlugins );
 
 	const fields = useMemo(
 		() => [
@@ -38,6 +38,8 @@ export default function PluginsListV2( { currentPlugins }: Props ) {
 			{
 				id: 'plugins',
 				label: 'Installed Plugins',
+				getValue: ( { item }: { item } ) => item.name,
+				enableGlobalSearch: true,
 				render: ( { item } ) => {
 					return (
 						<>
@@ -78,7 +80,7 @@ export default function PluginsListV2( { currentPlugins }: Props ) {
 	const pluginsPerPage = 10;
 	const initialDataViewsState = {
 		type: 'table',
-		search: '',
+		search: initialSearch || '',
 		// filters:
 		// 	filter?.issueTypes?.map( ( issueType ) => {
 		// 		return {
@@ -166,6 +168,11 @@ export default function PluginsListV2( { currentPlugins }: Props ) {
 
 	const [ dataViewsState, setDataViewsState ] = useState( initialDataViewsState );
 
+	// When search changes, notify the parent component
+	useEffect( () => {
+		onSearch && onSearch( dataViewsState.search );
+	}, [ dataViewsState.search, onSearch ] );
+
 	const { data, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( currentPlugins, dataViewsState, fields );
 	}, [ currentPlugins, dataViewsState, fields ] );
@@ -175,8 +182,10 @@ export default function PluginsListV2( { currentPlugins }: Props ) {
 			<ItemsDataViews
 				data={ {
 					items: data,
+					getItemId: ( item ) => `${ item.id }`,
 					fields,
 					pagination: paginationInfo,
+					searchLabel: translate( 'Search for plugins' ),
 					enableSearch: true,
 					actions: actions,
 					dataViewsState: dataViewsState,

--- a/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-list-v2/style.scss
@@ -1,0 +1,26 @@
+
+body.is-section-plugins .plugin-management-wrapper {
+
+    .dataviews-wrapper {
+        .dataviews-view-table {
+            border: 1px solid var(--color-neutral-5);
+            border-radius: 2px;
+
+            .dataviews-view-table__row {
+                img, .dataviews-view-table__row svg {
+                    max-width: 35px;
+                    margin-right: 15px;
+                }
+
+                .dataviews-view-table-selection-checkbox{
+                    padding-left: 0;
+                }
+            }
+
+            .dataviews-view-table__checkbox-column {
+                padding-left: 18px;
+            }
+        }
+    }
+
+}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -523,32 +523,6 @@ body.is-section-plugins .plugin-management-wrapper {
 		padding-left: 2rem;
 		padding-right: 2rem;
 	}
-
-	.dataviews-wrapper {
-		.dataviews__view-actions {
-			display: none;
-		}
-		.dataviews-view-table {
-			border: 1px solid var(--color-neutral-5);
-			border-radius: 2px;
-	
-			.dataviews-view-table__row {
-				img, .dataviews-view-table__row svg {
-					max-width: 35px;
-					margin-right: 15px;
-				}
-	
-				.dataviews-view-table-selection-checkbox{
-					padding-left: 0;
-				}
-			}
-	
-			.dataviews-view-table__checkbox-column {
-				padding-left: 18px;
-			}
-		}
-	}
-
 }
 
 .plugins__page-title {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -523,6 +523,32 @@ body.is-section-plugins .plugin-management-wrapper {
 		padding-left: 2rem;
 		padding-right: 2rem;
 	}
+
+	.dataviews-wrapper {
+		.dataviews__view-actions {
+			display: none;
+		}
+		.dataviews-view-table {
+			border: 1px solid var(--color-neutral-5);
+			border-radius: 2px;
+	
+			.dataviews-view-table__row {
+				img, .dataviews-view-table__row svg {
+					max-width: 35px;
+					margin-right: 15px;
+				}
+	
+				.dataviews-view-table-selection-checkbox{
+					padding-left: 0;
+				}
+			}
+	
+			.dataviews-view-table__checkbox-column {
+				padding-left: 18px;
+			}
+		}
+	}
+
 }
 
 .plugins__page-title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9364

## Proposed Changes

* We're adding DataViews to the /plugins/manage screen:

<img width="1298" alt="image" src="https://github.com/user-attachments/assets/93eb0309-78ab-4145-bc49-cfb5fb9202ec">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
