### PR TITLE
Stats: DateRange Picker Update: Update tracks event names

### DIFF
--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -17,7 +17,7 @@ const COMPONENT_CLASS_NAME = 'stats-date-control';
 type EventNameKey =
 	| 'last_7_days'
 	| 'last_30_days'
-	| 'last_90_days'
+	| 'last_3_months'
 	| 'last_year'
 	| 'custom_date_range'
 	| 'apply_button'
@@ -32,22 +32,22 @@ interface EventNames {
 // Define the tracking event names object. Hardcoding event names ensures consistency, searchability, and prevents errors per Tracks naming conventions.
 const eventNames: EventNames = {
 	jetpack_odyssey: {
-		last_7_days: 'jetpack_odyssey_stats_date_picker_shortcut_last_7_days_click',
-		last_30_days: 'jetpack_odyssey_stats_date_picker_shortcut_last_30_days_click',
-		last_90_days: 'jetpack_odyssey_stats_date_picker_shortcut_last_90_days_click',
-		last_year: 'jetpack_odyssey_stats_date_picker_shortcut_last_year_click',
-		custom_date_range: 'jetpack_odyssey_stats_date_picker_shortcut_custom_date_range_click',
-		apply_button: 'jetpack_odyssey_stats_date_picker_apply_button_click',
-		trigger_button: 'jetpack_odyssey_stats_date_picker_trigger_click',
+		last_7_days: 'jetpack_odyssey_stats_date_picker_shortcut_last_7_days_clicked',
+		last_30_days: 'jetpack_odyssey_stats_date_picker_shortcut_last_30_days_clicked',
+		last_3_months: 'jetpack_odyssey_stats_date_picker_shortcut_last_3_months_clicked',
+		last_year: 'jetpack_odyssey_stats_date_picker_shortcut_last_year_clicked',
+		custom_date_range: 'jetpack_odyssey_stats_date_picker_shortcut_custom_date_range_clicked',
+		apply_button: 'jetpack_odyssey_stats_date_picker_apply_button_clicked',
+		trigger_button: 'jetpack_odyssey_stats_date_picker_opened',
 	},
 	calypso: {
-		last_7_days: 'calypso_stats_date_picker_shortcut_last_7_days_click',
-		last_30_days: 'calypso_stats_date_picker_shortcut_last_30_days_click',
-		last_90_days: 'calypso_stats_date_picker_shortcut_last_90_days_click',
-		last_year: 'calypso_stats_date_picker_shortcut_last_year_click',
-		custom_date_range: 'calypso_stats_date_picker_shortcut_custom_date_range_click',
-		apply_button: 'calypso_stats_date_picker_apply_button_click',
-		trigger_button: 'calypso_stats_date_picker_trigger_click',
+		last_7_days: 'calypso_stats_date_picker_shortcut_last_7_days_clicked',
+		last_30_days: 'calypso_stats_date_picker_shortcut_last_30_days_clicked',
+		last_3_months: 'calypso_stats_date_picker_shortcut_last_3_months_clicked',
+		last_year: 'calypso_stats_date_picker_shortcut_last_year_clicked',
+		custom_date_range: 'calypso_stats_date_picker_shortcut_custom_date_range_clicked',
+		apply_button: 'calypso_stats_date_picker_apply_button_clicked',
+		trigger_button: 'calypso_stats_date_picker_opened',
 	},
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This is coming out quickly just to rectify the event names. There is another PR less urgent to follow addressing some TS upgrades. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* see discussion thread in pejTkB-1It-p2#comment-1706

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the live branch or locally
* turn on tracking debugging in the JS developer console using `localStorage.setItem('debug', 'calypso:analytics*');`
* open up the daterange picker, check for the analytics event for `calypso_stats_date_picker_trigger_clicked` 
* click on the different shortcuts, check for their events `calypso_stats_date_picker_shortcut_last_year_clicked` and that they match the correct shortcut as per below table
* click on the apply button, check for the event `calypso_stats_date_picker_apply_button_clicked`
* check again in Odyssey, and the events should be prefixed with `jetpack_odyssey` rather than `calypso`
* ensure all events are logging correctly. 

| Incorrect/Before  | Correct/After |
| ------------- | ------------- |
| all clicks were suffixed with present tense eg. `click`  | replace to past tense eg. `clicked`  |
| `date_picker_trigger_clicked` | replaced with original event name `date_picker_opened   | 
| `last_90_days`   | replaced with original event name `last_3_months` |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
