### PR TITLE
A4A > Agency Tier: Implement agency tier widget on the Overview page

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
@@ -3,16 +3,28 @@ import EmergingPartnerLogo from 'calypso/assets/images/a8c-for-agencies/agency-t
 import ProAgencyPartnerLogo from 'calypso/assets/images/a8c-for-agencies/agency-tier/pro-agency-partner-logo-small.svg';
 import { preventWidows } from 'calypso/lib/formatting';
 
+interface AgencyTierInfo {
+	title: string;
+	fullTitle: string;
+	subtitle: string;
+	description: string;
+	logo: string;
+	includedTiers: string[];
+	emptyStateMessage?: string;
+}
+
 const getAgencyTierInfo = (
 	agencyTier: 'emerging-partner' | 'agency-partner' | 'pro-agency-partner',
 	translate: ( key: string, args?: Record< string, unknown > ) => string
 ) => {
-	let tierInfo = {
+	let tierInfo: AgencyTierInfo = {
 		title: '',
 		fullTitle: '',
 		subtitle: '',
+		description: '',
 		logo: '',
 		includedTiers: [] as string[],
+		emptyStateMessage: '',
 	};
 	switch ( agencyTier ) {
 		case 'emerging-partner':
@@ -31,8 +43,17 @@ const getAgencyTierInfo = (
 					'Your next tier milestone is when your influenced revenue exceeds %(amount)s',
 					{ args: { amount: '$1,200' }, comment: 'Amount of revenue' }
 				),
+				description: translate(
+					'Continue moving towards the next tier to unlock benefits by making more purchases and referrals.'
+				),
 				logo: EmergingPartnerLogo,
 				includedTiers: [ 'emerging-partner' ],
+				emptyStateMessage: translate(
+					'Make your first purchase to get started as an {{b}}Emerging Partner!{{/b}}',
+					{
+						components: { b: <b /> },
+					}
+				),
 			};
 			break;
 		case 'agency-partner':
@@ -54,6 +75,9 @@ const getAgencyTierInfo = (
 						comment: 'Amount of revenue',
 					}
 				),
+				description: translate(
+					"You're well on your way to becoming a Pro Agency Partner and unlocking even more premium benefits!"
+				),
 				logo: AgencyPartnerLogo,
 				includedTiers: [ 'emerging-partner', 'agency-partner' ],
 			};
@@ -71,6 +95,9 @@ const getAgencyTierInfo = (
 					}
 				),
 				subtitle: preventWidows( translate( "You've reached the highest tier!" ) ),
+				description: translate(
+					"You're the best of the best when it comes to agencies for WordPress! Enjoy your premium benefits!"
+				),
 				logo: ProAgencyPartnerLogo,
 				includedTiers: [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ],
 			};

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
@@ -1,0 +1,72 @@
+import { Card, FoldableCard } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { Icon, arrowRight } from '@wordpress/icons';
+import { clsx } from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import getAgencyTierInfo from 'calypso/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+import './style.scss';
+
+export default function OverviewSidebarAgencyTier() {
+	const translate = useTranslate();
+
+	const agency = useSelector( getActiveAgency );
+
+	const currentAgencyTierInfo = agency?.tier?.id
+		? getAgencyTierInfo( agency.tier.id, translate )
+		: null;
+
+	const defaultAgencyTierInfo = getAgencyTierInfo( 'emerging-partner', translate );
+
+	return (
+		<Card className="agency-tier__card">
+			<FoldableCard
+				className="foldable-nav"
+				header={ translate( 'Your Agency Tier' ) }
+				expanded
+				compact
+				iconSize={ 18 }
+			>
+				<div className="agency-tier__bottom-content">
+					<div
+						className={ clsx( 'agency-tier__current-agency-tier-header', {
+							'is-default': ! currentAgencyTierInfo,
+						} ) }
+					>
+						{ currentAgencyTierInfo ? (
+							<>
+								<span className="agency-tier__current-agency-tier-icon">
+									<img src={ currentAgencyTierInfo.logo } alt={ currentAgencyTierInfo.id } />
+								</span>
+								<span className="agency-tier__current-agency-tier-title">
+									{ currentAgencyTierInfo.title }
+								</span>
+							</>
+						) : (
+							<>
+								<span className="agency-tier__current-agency-tier-icon">
+									<img src={ defaultAgencyTierInfo.logo } alt={ defaultAgencyTierInfo.id } />
+								</span>
+								<span className="agency-tier__current-agency-tier-title">
+									{ defaultAgencyTierInfo.emptyStateMessage }
+								</span>
+							</>
+						) }
+					</div>
+					{ currentAgencyTierInfo && (
+						<div className="agency-tier__current-agency-tier-description">
+							{ currentAgencyTierInfo.description }
+						</div>
+					) }
+					<Button href={ A4A_AGENCY_TIER_LINK }>
+						<Icon icon={ arrowRight } size={ 18 } />
+						{ translate( 'Explore tiers and benefits' ) }
+					</Button>
+				</div>
+			</FoldableCard>
+		</Card>
+	);
+}

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
@@ -1,0 +1,74 @@
+.agency-tier__card {
+	padding: 8px;
+	border-radius: 4px;
+
+	.foldable-card__header {
+		padding-inline: 12px;
+	}
+
+	.sidebar-v2__menu-item {
+		&:hover {
+			svg.sidebar-v2__external-icon {
+				color: var(--color-text-inverted);
+			}
+		}
+	}
+}
+
+.agency-tier__bottom-content {
+	padding-inline: 12px;
+
+	.agency-tier__current-agency-tier-header {
+		margin-inline-start: 8px;
+		padding-block: 16px 12px;
+		display: flex;
+		gap: 16px;
+
+		.agency-tier__current-agency-tier-icon img {
+			transform: scale(1.5);
+		}
+
+		.agency-tier__current-agency-tier-title {
+			@include a4a-font-heading-lg;
+		}
+
+		&.is-default {
+			margin-inline-start: 14px;
+			padding-block: 36px;
+			gap: 24px;
+
+			.agency-tier__current-agency-tier-icon {
+				display: flex;
+				width: 80px;
+
+				img {
+					transform: scale(1.6);
+				}
+			}
+
+			.agency-tier__current-agency-tier-title {
+				@include a4a-font-body-lg;
+			}
+		}
+	}
+
+	.agency-tier__current-agency-tier-description {
+		@include a4a-font-body-md;
+		padding-block-end: 8px;
+	}
+}
+
+.foldable-nav.foldable-card.card .foldable-card__content .agency-tier__bottom-content a.components-button {
+	@include a4a-font-body-md;
+	padding: 0;
+	color: var(--color-gray-40);
+
+	svg {
+		margin-inline-end: 8px;
+	}
+
+	&:hover {
+		background: none;
+		box-shadow: none;
+	}
+}

--- a/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
@@ -1,3 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
+import OverviewSidebarAgencyTier from './agency-tier';
 import OverviewSidebarContactSupport from './contact-support';
 import OverviewSidebarGrowthAccelerator from './growth-accelerator';
 import OverviewSidebarQuickLinks from './quick-links';
@@ -5,6 +7,7 @@ import OverviewSidebarQuickLinks from './quick-links';
 const OverviewSidebar = () => {
 	return (
 		<div className="overview-sidebar">
+			{ isEnabled( 'a8c-for-agencies-agency-tier' ) && <OverviewSidebarAgencyTier /> }
 			<OverviewSidebarQuickLinks />
 			<OverviewSidebarGrowthAccelerator />
 			<OverviewSidebarContactSupport />


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/95425

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1250

## Proposed Changes

This PR implements the agency tier widget on the Overview page.

## Why are these changes being made?

* To showcase the current agency tier on the Overview page.

## Testing Instructions

* Open the A4A live link
* Remove your agency tier if it is already set from the MC tool > Go to Agency Tier in the UI > Verify the screen looks as shown below. Clicking on the Explore agency tiers & benefits should take you to /agency-tier. Also, append the URL with ?flags=-a8c-for-agencies-agency-tier and verify the widget is not shown.

<img width="1728" alt="Screenshot 2024-10-17 at 11 09 58 AM" src="https://github.com/user-attachments/assets/80e8c06d-e773-4b38-b431-dd88a25b6abd">

* Update your agency tier to **Emerging Partner** using the MC tool > Refresh the UI & verify the screen looks as shown below:

<img width="1728" alt="Screenshot 2024-10-17 at 10 28 57 AM" src="https://github.com/user-attachments/assets/6c65f851-6f2e-4ee1-9ebe-1a6d206eca0b">

* Change the agency tier to **Agency Partner** > Refresh the UI and verify the screen looks as shown below:

<img width="1728" alt="Screenshot 2024-10-17 at 10 31 10 AM" src="https://github.com/user-attachments/assets/75f6d0f3-a6e1-491f-ab9c-2c8f11bee2c9">

* Change the agency tier to **Pro Agency Partner** > Refresh the UI and verify the screen looks as shown below:

<img width="1728" alt="Screenshot 2024-10-17 at 10 31 21 AM" src="https://github.com/user-attachments/assets/9403e7c0-d6c2-415c-a146-b5dbc9d2749f">


* Verify it looks good on all the screen sizes:

<img width="374" alt="Screenshot 2024-10-17 at 10 32 22 AM" src="https://github.com/user-attachments/assets/8a88be3f-3f62-4041-976e-0764009266ec">

<img width="761" alt="Screenshot 2024-10-17 at 10 32 36 AM" src="https://github.com/user-attachments/assets/2870e3ca-060b-4108-acd3-61f40deb4c10">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
