### PR TITLE
Stats: Disable settings tooltip delay in Odyssey

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -167,6 +167,9 @@ class StatsNavigation extends Component {
 
 		// @TODO: Add loading status of modules settings to avoid toggling modules before they are loaded.
 
+		// Address flashing tooltip here.
+		console.log( 'Rendering StatsNavigation component' );
+
 		return (
 			<div className={ wrapperClass }>
 				<SectionNav selectedText={ label }>

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -9,10 +9,7 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import version_compare from 'calypso/lib/version-compare';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
-import {
-	useNoticeVisibilityQuery,
-	useNoticesVisibilityQuery,
-} from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isGoogleMyBusinessLocationConnectedSelector from 'calypso/state/selectors/is-google-my-business-location-connected';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
@@ -32,29 +29,20 @@ import './style.scss';
 // Use HOC to wrap hooks of `react-query` for fetching the notice visibility state.
 function withNoticeHook( HookedComponent ) {
 	return function WrappedComponent( props ) {
-		const {
-			data: showSettingsTooltip,
-			isPending,
-			refetch: refetchNotices,
-		} = useNoticeVisibilityQuery( props.siteId, 'traffic_page_settings' );
-		console.log( 'showSettingsTooltip', showSettingsTooltip );
-		console.log( 'isPending', isPending );
-
-		const { data: fullData, isPending: isPendingX } = useNoticesVisibilityQuery( props.siteId );
-		console.log( 'fullData: ', fullData );
-		console.log( 'isPendingX: ', isPendingX );
+		const { data: showSettingsTooltip, refetch: refetchNotices } = useNoticeVisibilityQuery(
+			props.siteId,
+			'traffic_page_settings'
+		);
 
 		const { mutateAsync: mutateNoticeVisbilityAsync } = useNoticeVisibilityMutation(
 			props.siteId,
 			'traffic_page_settings'
 		);
 
-		const debugShowTooltip = showSettingsTooltip;
-
 		return (
 			<HookedComponent
 				{ ...props }
-				showSettingsTooltip={ debugShowTooltip }
+				showSettingsTooltip={ showSettingsTooltip }
 				refetchNotices={ refetchNotices }
 				mutateNoticeVisbilityAsync={ mutateNoticeVisbilityAsync }
 			/>
@@ -172,11 +160,6 @@ class StatsNavigation extends Component {
 			'stats-navigation--modernized': ! isLegacy,
 		} );
 
-		const isJetpackSite = config.isEnabled( 'is_running_in_jetpack_site' );
-		console.log( 'isJetpackSite', isJetpackSite );
-		const delaySettingsTooltip = isNewSite === true && isJetpackSite === false;
-		console.log( 'delaySettingsTooltip', delaySettingsTooltip );
-
 		// Module settings for Odyssey are not supported until stats-admin@0.9.0-alpha.
 		const isModuleSettingsSupported =
 			! config.isEnabled( 'is_running_in_jetpack_site' ) ||
@@ -241,7 +224,7 @@ class StatsNavigation extends Component {
 							pageModules={ pageModules }
 							onToggleModule={ this.onToggleModule }
 							isTooltipShown={
-								showSettingsTooltip && ! isPageSettingsTooltipDismissed && ! delaySettingsTooltip
+								showSettingsTooltip && ! isPageSettingsTooltipDismissed && ! isNewSite
 							}
 							onTooltipDismiss={ this.onTooltipDismiss }
 						/>
@@ -254,14 +237,11 @@ class StatsNavigation extends Component {
 export default connect(
 	( state, { siteId, selectedItem } ) => {
 		const siteCreatedTimeStamp = getSiteOption( state, siteId, 'created_at' );
-		console.log( 'siteCreatedTimeStamp', siteCreatedTimeStamp );
 		const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 		// Check if the site is created within a week.
-		let isNewSite =
+		const isNewSite =
 			siteCreatedTimeStamp &&
 			new Date( siteCreatedTimeStamp ) > new Date( Date.now() - WEEK_IN_MILLISECONDS );
-		console.log( 'isNewSite', isNewSite );
-		isNewSite = true;
 
 		return {
 			isGoogleMyBusinessLocationConnected: isGoogleMyBusinessLocationConnectedSelector(

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -9,7 +9,10 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import version_compare from 'calypso/lib/version-compare';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
-import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import {
+	useNoticeVisibilityQuery,
+	useNoticesVisibilityQuery,
+} from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isGoogleMyBusinessLocationConnectedSelector from 'calypso/state/selectors/is-google-my-business-location-connected';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
@@ -29,20 +32,29 @@ import './style.scss';
 // Use HOC to wrap hooks of `react-query` for fetching the notice visibility state.
 function withNoticeHook( HookedComponent ) {
 	return function WrappedComponent( props ) {
-		const { data: showSettingsTooltip, refetch: refetchNotices } = useNoticeVisibilityQuery(
-			props.siteId,
-			'traffic_page_settings'
-		);
+		const {
+			data: showSettingsTooltip,
+			isPending,
+			refetch: refetchNotices,
+		} = useNoticeVisibilityQuery( props.siteId, 'traffic_page_settings' );
+		console.log( 'showSettingsTooltip', showSettingsTooltip );
+		console.log( 'isPending', isPending );
+
+		const { data: fullData, isPending: isPendingX } = useNoticesVisibilityQuery( props.siteId );
+		console.log( 'fullData: ', fullData );
+		console.log( 'isPendingX: ', isPendingX );
 
 		const { mutateAsync: mutateNoticeVisbilityAsync } = useNoticeVisibilityMutation(
 			props.siteId,
 			'traffic_page_settings'
 		);
 
+		const debugShowTooltip = showSettingsTooltip;
+
 		return (
 			<HookedComponent
 				{ ...props }
-				showSettingsTooltip={ showSettingsTooltip }
+				showSettingsTooltip={ debugShowTooltip }
 				refetchNotices={ refetchNotices }
 				mutateNoticeVisbilityAsync={ mutateNoticeVisbilityAsync }
 			/>
@@ -160,6 +172,11 @@ class StatsNavigation extends Component {
 			'stats-navigation--modernized': ! isLegacy,
 		} );
 
+		const isJetpackSite = config.isEnabled( 'is_running_in_jetpack_site' );
+		console.log( 'isJetpackSite', isJetpackSite );
+		const delaySettingsTooltip = isNewSite === true && isJetpackSite === false;
+		console.log( 'delaySettingsTooltip', delaySettingsTooltip );
+
 		// Module settings for Odyssey are not supported until stats-admin@0.9.0-alpha.
 		const isModuleSettingsSupported =
 			! config.isEnabled( 'is_running_in_jetpack_site' ) ||
@@ -224,7 +241,7 @@ class StatsNavigation extends Component {
 							pageModules={ pageModules }
 							onToggleModule={ this.onToggleModule }
 							isTooltipShown={
-								showSettingsTooltip && ! isPageSettingsTooltipDismissed && ! isNewSite
+								showSettingsTooltip && ! isPageSettingsTooltipDismissed && ! delaySettingsTooltip
 							}
 							onTooltipDismiss={ this.onTooltipDismiss }
 						/>
@@ -237,11 +254,14 @@ class StatsNavigation extends Component {
 export default connect(
 	( state, { siteId, selectedItem } ) => {
 		const siteCreatedTimeStamp = getSiteOption( state, siteId, 'created_at' );
+		console.log( 'siteCreatedTimeStamp', siteCreatedTimeStamp );
 		const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 		// Check if the site is created within a week.
-		const isNewSite =
+		let isNewSite =
 			siteCreatedTimeStamp &&
 			new Date( siteCreatedTimeStamp ) > new Date( Date.now() - WEEK_IN_MILLISECONDS );
+		console.log( 'isNewSite', isNewSite );
+		isNewSite = true;
 
 		return {
 			isGoogleMyBusinessLocationConnected: isGoogleMyBusinessLocationConnectedSelector(

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -250,6 +250,10 @@ export default connect(
 		const isNewSite =
 			siteCreatedTimeStamp &&
 			new Date( siteCreatedTimeStamp ) > new Date( Date.now() - WEEK_IN_MILLISECONDS );
+		// Logging shows this value moving from null to true/false.
+		// In the case of a new site, that means it's null and becomes true.
+		// This causes the tooltip to flash in Odyssey Stats.
+		// console.log( 'isNewSite:', isNewSite );
 
 		return {
 			isGoogleMyBusinessLocationConnected: isGoogleMyBusinessLocationConnectedSelector(

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -168,10 +168,10 @@ class StatsNavigation extends Component {
 		// @TODO: Add loading status of modules settings to avoid toggling modules before they are loaded.
 
 		// Address flashing tooltip here.
-		console.log( 'Rendering StatsNavigation component' );
+		// console.log( 'Rendering StatsNavigation component' );
 		const isJetpackSite = config.isEnabled( 'is_running_in_jetpack_site' );
 		const delayTooltipPresentationForDotCom = isNewSite && ! isJetpackSite;
-		console.log( 'delayTooltipPresentationForDotCom:', delayTooltipPresentationForDotCom );
+		// console.log( 'delayTooltipPresentationForDotCom:', delayTooltipPresentationForDotCom );
 
 		return (
 			<div className={ wrapperClass }>

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -169,6 +169,9 @@ class StatsNavigation extends Component {
 
 		// Address flashing tooltip here.
 		console.log( 'Rendering StatsNavigation component' );
+		const isJetpackSite = config.isEnabled( 'is_running_in_jetpack_site' );
+		const delayTooltipPresentationForDotCom = isNewSite && ! isJetpackSite;
+		console.log( 'delayTooltipPresentationForDotCom:', delayTooltipPresentationForDotCom );
 
 		return (
 			<div className={ wrapperClass }>
@@ -227,7 +230,9 @@ class StatsNavigation extends Component {
 							pageModules={ pageModules }
 							onToggleModule={ this.onToggleModule }
 							isTooltipShown={
-								showSettingsTooltip && ! isPageSettingsTooltipDismissed && ! isNewSite
+								showSettingsTooltip &&
+								! isPageSettingsTooltipDismissed &&
+								! delayTooltipPresentationForDotCom
 							}
 							onTooltipDismiss={ this.onTooltipDismiss }
 						/>

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -169,9 +169,12 @@ class StatsNavigation extends Component {
 
 		// Address flashing tooltip here.
 		// console.log( 'Rendering StatsNavigation component' );
-		const isJetpackSite = config.isEnabled( 'is_running_in_jetpack_site' );
-		const delayTooltipPresentationForDotCom = isNewSite && ! isJetpackSite;
+		// const isJetpackSite = config.isEnabled( 'is_running_in_jetpack_site' );
+		// const delayTooltipPresentationForDotCom = isNewSite && ! isJetpackSite;
 		// console.log( 'delayTooltipPresentationForDotCom:', delayTooltipPresentationForDotCom );
+		console.log( 'showSettingsTooltip: ', showSettingsTooltip );
+		console.log( 'isPageSettingsTooltipDismissed: ', isPageSettingsTooltipDismissed );
+		console.log( 'isNewSite: ', isNewSite );
 
 		return (
 			<div className={ wrapperClass }>
@@ -230,9 +233,7 @@ class StatsNavigation extends Component {
 							pageModules={ pageModules }
 							onToggleModule={ this.onToggleModule }
 							isTooltipShown={
-								showSettingsTooltip &&
-								! isPageSettingsTooltipDismissed &&
-								! delayTooltipPresentationForDotCom
+								showSettingsTooltip && ! isPageSettingsTooltipDismissed && ! isNewSite
 							}
 							onTooltipDismiss={ this.onTooltipDismiss }
 						/>
@@ -245,6 +246,7 @@ class StatsNavigation extends Component {
 export default connect(
 	( state, { siteId, selectedItem } ) => {
 		const siteCreatedTimeStamp = getSiteOption( state, siteId, 'created_at' );
+		console.log( 'siteCreatedTimeStamp:', siteCreatedTimeStamp );
 		const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 		// Check if the site is created within a week.
 		const isNewSite =
@@ -253,7 +255,7 @@ export default connect(
 		// Logging shows this value moving from null to true/false.
 		// In the case of a new site, that means it's null and becomes true.
 		// This causes the tooltip to flash in Odyssey Stats.
-		// console.log( 'isNewSite:', isNewSite );
+		console.log( 'isNewSite:', isNewSite );
 
 		return {
 			isGoogleMyBusinessLocationConnected: isGoogleMyBusinessLocationConnectedSelector(

--- a/client/my-sites/stats/highlights-section/index.tsx
+++ b/client/my-sites/stats/highlights-section/index.tsx
@@ -58,6 +58,7 @@ export default function HighlightsSection( {
 		};
 	}, [ highlights, currentPeriod ] );
 
+	// Handle tooltip for highlights section.
 	const { data: showSettingsTooltip, refetch: refetchNotices } = useNoticeVisibilityQuery(
 		siteId,
 		'traffic_page_highlights_module_settings'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
