### PR TITLE
calypso_new_user_site_creation: Add more tracking props

### DIFF
--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -72,6 +72,7 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 						hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
 					signupDomainOrigin: signupDomainOrigin ?? SIGNUP_DOMAIN_ORIGIN.NOT_SET,
 					framework: 'stepper',
+					isNewishUser,
 				},
 				true
 			);

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -55,6 +55,7 @@ export function recordSignupComplete(
 		signupDomainOrigin,
 		elapsedTimeSinceStart = null,
 		framework = 'start',
+		isNewishUser,
 	},
 	now
 ) {
@@ -82,6 +83,7 @@ export function recordSignupComplete(
 				isMapping,
 				signupDomainOrigin,
 				framework,
+				isNewishUser,
 			},
 			true
 		);
@@ -124,7 +126,13 @@ export function recordSignupComplete(
 		const device = resolveDeviceTypeByViewPort();
 
 		// Tracks
-		recordTracksEvent( 'calypso_new_user_site_creation', { flow, device, framework } );
+		recordTracksEvent( 'calypso_new_user_site_creation', {
+			flow,
+			device,
+			framework,
+			is_new_user: isNewUser,
+			is_newish_user: isNewishUser,
+		} );
 		// Google Analytics
 		gaRecordEvent( 'Signup', 'calypso_new_user_site_creation' );
 	}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -592,6 +592,7 @@ class Signup extends Component {
 				isTransfer: isTransfer,
 				signupDomainOrigin: signupDomainOriginValue,
 				framework: 'start',
+				isNewishUser,
 			} );
 		}
 	};


### PR DESCRIPTION
This PR simply adds a couple more props to the `calypso_new_user_site_creation` event.

This could help in determining differences in the Start/Stepper experiment.