### PR TITLE
Fix the label of the button for cancelling a domain transfer

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -37,6 +37,9 @@ const DomainDeleteInfoCard = ( {
 	const title =
 		domain.type === domainType.TRANSFER ? translate( 'Cancel transfer' ) : translate( 'Delete' );
 
+	const buttonLabel =
+		domain.type === domainType.TRANSFER ? translate( 'Cancel' ) : translate( 'Delete' );
+
 	const getDescription = () => {
 		switch ( domain.type ) {
 			case domainType.SITE_REDIRECT:
@@ -58,7 +61,7 @@ const DomainDeleteInfoCard = ( {
 			purchase={ purchase }
 			className={ removePurchaseClassName }
 		>
-			{ translate( 'Delete' ) }
+			{ buttonLabel }
 		</RemovePurchase>
 	);
 


### PR DESCRIPTION
The card for cancelling a domain transfer has the title  "Cancel transfer" but the button says "Delete" which is weird. Here's a fix for that.

Related to #95450 

## Proposed Changes

* Change the label of the button that cancels a domain transfer from "Delete" to "Cancel"

## Why are these changes being made?

* The current button label is inconsistent with the title and the text

## Testing Instructions

* Initiate a transfer (from the signup flow) and then in the domain management page click on the domain and verify that the button label is Cancel instead of Delete

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
