### PR TITLE
Social | Bluesky: Fallback to handle if name is empty

### DIFF
--- a/client/my-sites/marketing/connections/connection.jsx
+++ b/client/my-sites/marketing/connections/connection.jsx
@@ -258,7 +258,7 @@ class SharingConnection extends Component {
 				{ this.getProfileImage() }
 				<div className={ statusClasses }>
 					<span className="sharing-connection__account-name">
-						{ this.props.connection.external_display }
+						{ this.props.connection.external_display || this.props.connection.external_name }
 					</span>
 					<SharingConnectionKeyringUserLabel
 						siteId={ this.props.siteId }


### PR DESCRIPTION
Bluesky allows to leave the Display name empty, which results in blank name in Calypso connections screen.

## Proposed Changes

* Fallback to `external_name` if `external_display` is empty

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Edit your Bluesky profile, and remove Display Name
* Goto `/marketing/connections/:site`
* Connect the above Bluesky account
* Confirm that the connection is displayed with the handle
* Remove the just account 
* Now Add back the display name in Bluesky profile
* Connect the account again
* Confirm that you now see the display name instead of handle

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
