### PR TITLE
Social | Clear Bluesky connection form after connection

### DIFF
--- a/client/my-sites/marketing/connections/bluesky.tsx
+++ b/client/my-sites/marketing/connections/bluesky.tsx
@@ -34,10 +34,7 @@ function isValidBlueskyHandle( handle: string ) {
 }
 
 const isAlreadyConnected = ( connections: Array< Connection >, handle: string ) => {
-	return connections.some( ( connection ) => {
-		const { external_display } = connection;
-		return external_display === handle;
-	} );
+	return connections.some( ( { external_name } ) => external_name === handle );
 };
 
 export const Bluesky: React.FC< Props > = ( {


### PR DESCRIPTION
After we changed the external_display logic for Bluesky in D163108-code, the connection form for Bluesky stopped getting cleared after the connection is complete.

## Proposed Changes

* Fix the handle name for checking whether a Bluesky account is already connected
* Thus, fix the issue of the form not getting cleared after connection is complete

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Goto `/marketing/connections/:site`
* Connect a Bluesky account
* Confirm that the form gets cleared after connection is complete


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?