### PR TITLE
Global Sidebar: aligns back link when collapsed.

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -141,6 +141,11 @@ $brand-text: "SF Pro Text", $sans;
 			}
 
 			&.is-collapsed {
+				.sidebar__back-link {
+					justify-content: center;
+					padding-left: 0;
+				}
+
 				li.sidebar__menu-item--plugins a {
 					padding-top: 6px;
 					padding-bottom: 6px;

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -144,6 +144,10 @@ $brand-text: "SF Pro Text", $sans;
 				.sidebar__back-link {
 					justify-content: center;
 					padding-left: 0;
+
+					a {
+						padding: 6px 10px;
+					}
 				}
 
 				li.sidebar__menu-item--plugins a {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1729160104270079-slack-C029GN3KD

## Proposed Changes

* Aligns icon when sidebar is collapsed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check for rergressions
* Go to `/plugins/scheduled-updates/`
* Make sure that Back Link and Icon are aligned well ( same as in production )

![CleanShot 2024-10-17 at 13 48 26@2x](https://github.com/user-attachments/assets/57a9587a-5d05-47ff-a74e-f1ffe7d554f1)


Check the change
* Go to `/plugins/scheduled-updates/create`
* Make sure that Back Icon is aligned with the rest

![CleanShot 2024-10-17 at 13 47 12@2x](https://github.com/user-attachments/assets/75332a77-2dae-4461-a1b0-ad5d63c70c0a)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?