### PR TITLE
Tailored Flows: Redirect Sensei tailored flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,4 +1,11 @@
-import { isWooExpressFlow } from '@automattic/onboarding';
+import {
+	isWooExpressFlow,
+	SENSEI_FLOW,
+	VIDEOPRESS_FLOW,
+	LINK_IN_BIO_FLOW,
+	FREE_FLOW,
+	BLOG_FLOW,
+} from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { lazy, useEffect } from 'react';
@@ -36,10 +43,11 @@ const lazyCache = new WeakMap<
 >();
 
 const redirects = [
-	{ flow: 'free', to: '/start/free/:lang?' },
-	{ flow: 'blog', to: '/start/:lang?' },
-	{ flow: 'link-in-bio', to: '/start/:lang?' },
-	{ flow: 'videopress', to: '/start/:lang?' },
+	{ flow: BLOG_FLOW, to: '/start/:lang?' },
+	{ flow: FREE_FLOW, to: '/start/free/:lang?' },
+	{ flow: LINK_IN_BIO_FLOW, to: '/start/:lang?' },
+	{ flow: VIDEOPRESS_FLOW, to: '/start/:lang?' },
+	{ flow: SENSEI_FLOW, to: '/plugins/sensei-pro/' },
 ];
 
 type RedirectHandlerProps = {
@@ -51,6 +59,11 @@ type RedirectHandlerProps = {
 const RedirectHandler: React.FC< RedirectHandlerProps > = ( { redirectTo, flow } ) => {
 	const location = useLocation();
 	const { lang } = useParams< { lang?: string } >();
+
+	// If lang exists, prepend it for the SENSEI flow
+	if ( flow === SENSEI_FLOW && lang ) {
+		redirectTo = `/${ lang }${ redirectTo }`;
+	}
 
 	// Generate the redirection URL
 	const redirectUrl = generatePath( redirectTo, { lang: lang || null } ) + location.search;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -43,6 +43,7 @@ export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
 export const DOMAIN_TRANSFER = 'domain-transfer';
 export const GOOGLE_TRANSFER = 'google-transfer';
 export const HUNDRED_YEAR_PLAN_FLOW = 'hundred-year-plan';
+export const BLOG_FLOW = 'blog';
 export const REBLOGGING_FLOW = 'reblogging';
 export const DOMAIN_FOR_GRAVATAR_FLOW = 'domain-for-gravatar';
 export const ONBOARDING_FLOW = 'onboarding';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/9394

## Proposed Changes

* A redirect for the Sensei flow was added.
* Made some minor code improvements.
* A missing BLOG_FLOW constant was added to the flows file.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to redirect the Sensei flow from `/setup` to a non-tailored flow since we're reducing the complexity of the flow that we have in WordPress.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* While logged out
    * Visit `/setup/sensei/senseiSetup?ref=senseilms`, 
    * You should land on `/plugins/sensei-pro?ref=senseilms`
    * Visit `/setup/sensei`
    * You should land on `/plugins/sensei-pro`
    * Visit `/setup/sensei/es`
    * You should land on `/es/plugins/sensei-pro`
* Repeat while logged in


 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
