### PR TITLE
Site Profiler: Align domain analyzer block

### DIFF
--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -116,7 +116,7 @@ export default function SiteProfiler( props: Props ) {
 	return (
 		<>
 			{ ! showResultScreen && (
-				<LayoutBlock className="domain-analyzer-block" width="medium">
+				<LayoutBlock className="domain-analyzer-block">
 					<DocumentHead title={ translate( 'Site Profiler' ) } />
 					<DomainAnalyzer
 						domain={ domain }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/86426

## Proposed Changes

* Align the domain analyzer block with the block below; more details: https://github.com/Automattic/wp-calypso/issues/86426


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler?flags=-site-profiler/metrics`
* Check the alignment, domain analyzer and intro banner blocks should be aligned

![296855005-4d6e89fa-e3d7-4c3a-818d-0c2f73e42545](https://github.com/user-attachments/assets/299c7f7d-8e6a-47a5-a66d-b71d810a7f12)
<img width="1362" alt="Screenshot 2024-10-17 at 14 22 22" src="https://github.com/user-attachments/assets/ecb64068-4ec7-4c59-a6e2-8abead39f466">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
