### PR TITLE
Launchpad: Remove experiment code

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -20,7 +20,8 @@ interface SiteProps {
 }
 
 export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
-	const showCustomerHome = true;
+	// placeholder field for the experiment assignment
+	const showCustomerHome = false;
 
 	let launchpadStateOnSkip: null | 'skipped' = null;
 	if ( showCustomerHome ) {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -1,6 +1,5 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { ExperimentAssignment } from '@automattic/explat-client';
-import { useExperiment } from 'calypso/lib/explat';
 
 export const LAUNCHPAD_EXPERIMENT_NAME = 'calypso_onboarding_launchpad_removal_test_2024_08';
 
@@ -21,8 +20,7 @@ interface SiteProps {
 }
 
 export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
-	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( LAUNCHPAD_EXPERIMENT_NAME );
-	const showCustomerHome = shouldShowCustomerHome( isLoadingExperiment, experimentAssignment );
+	const showCustomerHome = true;
 
 	let launchpadStateOnSkip: null | 'skipped' = null;
 	if ( showCustomerHome ) {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -8,7 +8,6 @@ import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import { useIsSiteAssemblerEnabled } from 'calypso/data/site-assembler';
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { useExperiment } from 'calypso/lib/explat';
 import { ImporterMainPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/route';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
@@ -20,11 +19,7 @@ import { useSiteData } from '../hooks/use-site-data';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE, STEPPER_INTERNAL_STORE } from '../stores';
 import { shouldRedirectToSiteMigration } from './helpers';
-import {
-	useLaunchpadDecider,
-	getLaunchpadStateBasedOnExperiment,
-	LAUNCHPAD_EXPERIMENT_NAME,
-} from './internals/hooks/use-launchpad-decider';
+import { useLaunchpadDecider } from './internals/hooks/use-launchpad-decider';
 import { STEPS } from './internals/steps';
 import { redirect } from './internals/steps-repository/import/util';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
@@ -167,9 +162,6 @@ const siteSetupFlow: Flow = {
 		const { setDesignOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 
-		const [ isLoadingLaunchpadExperiment, launchpadExperimentAssigment ] =
-			useExperiment( LAUNCHPAD_EXPERIMENT_NAME );
-
 		const getLaunchpadScreenValue = (
 			intent: string,
 			shouldSkip: boolean
@@ -178,17 +170,6 @@ const siteSetupFlow: Flow = {
 				return 'off';
 			}
 
-			const launchpadState = getLaunchpadStateBasedOnExperiment(
-				isLoadingLaunchpadExperiment,
-				launchpadExperimentAssigment,
-				shouldSkip
-			);
-
-			if ( launchpadState ) {
-				return launchpadState;
-			}
-
-			// We shouldn't get here, but match the default/existing behaviour
 			if ( shouldSkip ) {
 				return 'skipped';
 			}

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,7 +1,6 @@
 import page from '@automattic/calypso-router';
 import { fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
@@ -68,11 +67,7 @@ export async function maybeRedirect( context, next ) {
 			checklist: launchpadChecklist,
 		} = await fetchLaunchpad( slug );
 
-		const experimentAssignment = await loadExperimentAssignment(
-			'calypso_onboarding_launchpad_removal_test_2024_08'
-		);
-
-		const shouldShowLaunchpad = 'treatment' !== experimentAssignment?.variationName;
+		const shouldShowLaunchpad = true;
 
 		if (
 			shouldShowLaunchpad &&


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/93205

## Proposed Changes

* Remove the experiment variant check since the experiment has expired, and we decided to keep the flow as it was before the experiment
* Keep util functions for the next launchpad experiment efforts added by #93205 PR

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The experiment ended and we decided the keep the control variant

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- go to `/setup/site-setup?siteSlug={SITE_SLUG}`
- choose "Promote myself or business"
- select "Choose a theme"
- select a theme
- press "continue" button
- check if there is a full-screen launchpad

Check any scenario described here: https://github.com/Automattic/wp-calypso/pull/93205
It should open the full launchpad screen.

NOTE: Some of the flows are not the same anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
