### PR TITLE
Stepper: Add queue possibility to record signup completion

### DIFF
--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -53,29 +53,26 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 			const hasPaidDomainItem =
 				( selectedDomain && ! selectedDomain.is_free ) || !! domainProductSlug;
 
-			recordSignupComplete(
-				{
-					flow,
-					siteId: siteId ?? signupCompletionState?.siteId,
-					isNewUser,
-					hasCartItems,
-					isNew7DUserSite,
-					theme,
-					intent: flow,
-					startingPoint: flow,
-					isBlankCanvas: theme?.includes( 'blank-canvas' ),
-					planProductSlug,
-					domainProductSlug,
-					isMapping:
-						hasPaidDomainItem && domainCartItem ? isDomainMapping( domainCartItem ) : undefined,
-					isTransfer:
-						hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
-					signupDomainOrigin: signupDomainOrigin ?? SIGNUP_DOMAIN_ORIGIN.NOT_SET,
-					framework: 'stepper',
-					isNewishUser,
-				},
-				true
-			);
+			recordSignupComplete( {
+				flow,
+				siteId: siteId ?? signupCompletionState?.siteId,
+				isNewUser,
+				hasCartItems,
+				isNew7DUserSite,
+				theme,
+				intent: flow,
+				startingPoint: flow,
+				isBlankCanvas: theme?.includes( 'blank-canvas' ),
+				planProductSlug,
+				domainProductSlug,
+				isMapping:
+					hasPaidDomainItem && domainCartItem ? isDomainMapping( domainCartItem ) : undefined,
+				isTransfer:
+					hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
+				signupDomainOrigin: signupDomainOrigin ?? SIGNUP_DOMAIN_ORIGIN.NOT_SET,
+				framework: 'stepper',
+				isNewishUser,
+			} );
 		},
 		[
 			domainCartItem,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

p1729151031413209-slack-C073776NJ66


## Proposed Changes

Let the `recordSignupComplete` function have the possibility of being added to a queue, as it happens in Start.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There are discrepancies in the firing of calypso_signup_complete and calypso_new_user_site_creation between Stepper and Start in the ongoing experiment.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live link
* Go through /setup/onboarding
* Verify that all the events get triggered correctly, like when you go through /start

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?