### PR TITLE
Don't display intro discount if not eligible

### DIFF
--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -13,6 +13,7 @@ import {
 import { getProductCost } from 'calypso/state/products-list/selectors/get-product-cost';
 import { getProductPriceTierList } from 'calypso/state/products-list/selectors/get-product-price-tiers';
 import { isProductsListFetching } from 'calypso/state/products-list/selectors/is-products-list-fetching';
+import getIntroOfferEligibility from 'calypso/state/selectors/get-intro-offer-eligibility';
 import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
 import isRequestingIntroOffers from 'calypso/state/selectors/get-is-requesting-into-offers';
 import {
@@ -113,7 +114,12 @@ const useIntroductoryOfferPrices = (
 		}
 
 		const introOfferPrice = getIntroOfferPrice( state, product.product_id, siteId ?? 'none' );
-		return isNumber( introOfferPrice ) ? introOfferPrice : null;
+		const isEligibleForIntroPrice = getIntroOfferEligibility(
+			state,
+			product.product_id,
+			siteId ?? 'none'
+		);
+		return isNumber( introOfferPrice ) && isEligibleForIntroPrice ? introOfferPrice : null;
 	} );
 
 	return {

--- a/client/state/products-list/test/actions.js
+++ b/client/state/products-list/test/actions.js
@@ -6,19 +6,16 @@ import {
 import useNock from 'calypso/test-helpers/use-nock';
 import { receiveProductsList, requestProductsList } from '../actions';
 
-let windowSpy;
-
 describe( 'actions', () => {
 	let spy;
 
 	beforeEach( () => {
 		spy = jest.fn();
-		windowSpy = jest.spyOn( globalThis, 'window', 'get' );
-		windowSpy.mockImplementation( () => ( {
+		global.window = {
 			location: {
 				search: '',
 			},
-		} ) );
+		};
 	} );
 
 	const businessPlan = {

--- a/client/state/products-list/test/actions.js
+++ b/client/state/products-list/test/actions.js
@@ -6,12 +6,19 @@ import {
 import useNock from 'calypso/test-helpers/use-nock';
 import { receiveProductsList, requestProductsList } from '../actions';
 
+let windowSpy;
+
 describe( 'actions', () => {
 	let spy;
 
 	beforeEach( () => {
 		spy = jest.fn();
-		window.location.search = 'https://example.com';
+		windowSpy = jest.spyOn( globalThis, 'window', 'get' );
+		windowSpy.mockImplementation( () => ( {
+			location: {
+				search: '',
+			},
+		} ) );
 	} );
 
 	const businessPlan = {

--- a/client/state/products-list/test/actions.js
+++ b/client/state/products-list/test/actions.js
@@ -11,6 +11,7 @@ describe( 'actions', () => {
 
 	beforeEach( () => {
 		spy = jest.fn();
+		window.location.search = 'https://example.com';
 	} );
 
 	const businessPlan = {

--- a/client/state/selectors/get-intro-offer-eligibility.ts
+++ b/client/state/selectors/get-intro-offer-eligibility.ts
@@ -1,0 +1,22 @@
+import type { AppState } from 'calypso/types';
+
+/**
+ * @param  {Object}  state       Global state tree
+ * @param  {number}  productId   The productId to check for an intro offer
+ * @param  {number|'none'|undefined}  siteId      The ID of the site we're querying
+ * @returns {boolean}             Whether the site is eligible for an intro offer
+ */
+
+export default function getIntroOfferEligibility(
+	state: AppState,
+	productId: number,
+	siteId: number | 'none' | undefined
+): boolean {
+	const siteIdKey = siteId && typeof siteId === 'number' && siteId > 0 ? siteId : 'none';
+
+	const introOffer = state.sites?.introOffers?.items?.[ siteIdKey ]?.[ productId ];
+
+	const ineligibleReason = introOffer?.ineligibleReason;
+
+	return ! ineligibleReason || ineligibleReason?.length === 0;
+}

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -3,7 +3,7 @@ const base = require( '@automattic/calypso-jest' );
 
 module.exports = {
 	...base,
-	rootDir: '../../client/state/products-list',
+	rootDir: '../../client',
 	cacheDirectory: path.join( __dirname, '../../.cache/jest' ),
 	testPathIgnorePatterns: [ '<rootDir>/server/' ],
 

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -3,7 +3,7 @@ const base = require( '@automattic/calypso-jest' );
 
 module.exports = {
 	...base,
-	rootDir: '../../client',
+	rootDir: '../../client/state/products-list',
 	cacheDirectory: path.join( __dirname, '../../.cache/jest' ),
 	testPathIgnorePatterns: [ '<rootDir>/server/' ],
 


### PR DESCRIPTION
## Proposed Changes

* Update the products API request to include the site ID if it exists in the URL parameters (this allows the backend to check if the site is eligible for an intro discount for specific products)
* Return null for intro discount when calculating price if the site is not eligible
* Retry the query if the site query fails, allowing prices to be shown even if the site doesn't exist or if there was a server error

## Why are these changes being made?

If the site is not eligible for an intro discount, the pricing page shows the intro discount anyway. If somebody were to click to buy that product, they would not see the offer in checkout as it is not eligible for the offer. This creates confusion as the price they see on the pricing page would not match the one in checkout. 

[We already fixed this issue in the Jetpack Plugin](https://github.com/Automattic/jetpack/pull/39403), after this change, the intro discount/product price should be consistent everywhere (except jetpack.com as there is no site context there)

## Testing Instructions

1. Create a Jurassic Ninja testing site and connect it to Jetpack. Also optionally connect your user account (if you don't, you'll be directed to after checkout)
2. Purchase a Jetpack Backup plan
3. Go to the SA or `wordpress.com/me/purchases` and remove the plan from your site
4. From `/wp-admin/admin.php?page=my-jetpack` on your site, click on `Purchase a plan`
![image](https://github.com/user-attachments/assets/e31d0832-8b96-4b15-aaf2-ae6ff859bf00)
5. You will be taken to the pricing page. Open the Calypso Green live link and copy the address. Replace `https://cloud.jetpack.com/` with the Calypso Green live link
6. You should see no intro offer for Jetpack Backup
![image](https://github.com/user-attachments/assets/75890ec1-2f4e-450b-97ef-4da4889d9a1a)
7. In the URL, replace the `?site={site}` value with a site ID that does not exist. Something like `99999999999999`
8. Reload the page and ensure prices still load, but with the intro offer showing now as the site query failed
![image](https://github.com/user-attachments/assets/41a1663d-060a-4b5e-ba8e-f3732aa4a5ce)
9. If you'd like, you can also test going to `/pricing/{site_domain}` with no `?site={site_id}` query parameter and ensure you still don't see the intro discount
![image](https://github.com/user-attachments/assets/aaedf24f-446f-42f1-a7c4-a0299f5d674f)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
