### PR TITLE
A4A: Display Pressable plan usage information

### DIFF
--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -3,9 +3,9 @@ import formatNumber, {
 	STANDARD_FORMATTING_OPTIONS,
 } from '@automattic/components/src/number-formatters/lib/format-number';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+//import { useSelector } from 'react-redux';
 import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+//import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
@@ -16,8 +16,14 @@ type Props = {
 
 export default function PressableUsageDetails( { existingPlan }: Props ) {
 	const translate = useTranslate();
-	const agency = useSelector( getActiveAgency );
-	const planUsage = agency?.third_party?.pressable?.usage;
+	// @todo (dev-testing mode) => Before merge, get the plan usage from the agency object instead of mocked one
+	// const agency = useSelector( getActiveAgency );
+	// const planUsage = agency?.third_party?.pressable?.usage;
+	const planUsage = {
+		storage_gb: 16,
+		sites_count: 2,
+		visits_count: 12589,
+	};
 
 	const planInfo = existingPlan?.slug ? getPressablePlan( existingPlan?.slug ) : null;
 
@@ -31,11 +37,17 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 				<div className="pressable-usage-details__info-item">
 					<div className="pressable-usage-details__info-header">
 						<div className="pressable-usage-details__info-label">{ translate( 'Storage' ) }</div>
-						<div className="pressable-usage-details__info-top-right">
-							Using { planUsage.storage_gb } of { planInfo.storage } GB
+						<div className="pressable-usage-details__info-top-right storage">
+							{ translate( 'Using %(used_storage)d of %(max_storage)d GB', {
+								args: {
+									used_storage: planUsage.storage_gb,
+									max_storage: planInfo.storage,
+								},
+								comment: '%(used_storage)d and %(max_storage)d are the storage values in GB.',
+							} ) }
 						</div>
 					</div>
-					<div className="pressable-usage-details__info-value">[ Progress-bar ]</div>
+					<div className="pressable-usage-details__info-value">[ Progress-bar here ]</div>
 				</div>
 			</div>
 
@@ -44,11 +56,21 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 					<div className="pressable-usage-details__info-header">
 						<div className="pressable-usage-details__info-label">{ translate( 'Sites' ) }</div>
 						<div className="pressable-usage-details__info-top-right">
-							{ planInfo.install } { translate( 'maximum of sites' ) }
+							{ translate( '%(max_sites)d maximum of sites', {
+								args: {
+									max_sites: planInfo.install,
+								},
+								comment: '%(max_sites)d is the maximum number of sites.',
+							} ) }
 						</div>
 					</div>
 					<div className="pressable-usage-details__info-value">
-						{ planUsage.sites_count } { translate( 'installed sites' ) }
+						{ translate( '%(total_sites)d installed sites', {
+							args: {
+								total_sites: planUsage.sites_count,
+							},
+							comment: '%(total_sites)d is the number of installed sites.',
+						} ) }
 					</div>
 				</div>
 
@@ -56,12 +78,29 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 					<div className="pressable-usage-details__info-header">
 						<div className="pressable-usage-details__info-label">{ translate( 'Visits' ) }</div>
 						<div className="pressable-usage-details__info-top-right">
-							{ formatNumber( planInfo.visits, DEFAULT_LOCALE, STANDARD_FORMATTING_OPTIONS ) }
-							{ translate( 'per month' ) }
+							{ translate( '%(max_visits)s per month', {
+								args: {
+									max_visits: formatNumber(
+										planInfo.visits,
+										DEFAULT_LOCALE,
+										STANDARD_FORMATTING_OPTIONS
+									),
+								},
+								comment: '%(max_visits)s is the number of traffic visits of the site.',
+							} ) }
 						</div>
 					</div>
 					<div className="pressable-usage-details__info-value">
-						{ formatNumber( planUsage.visits_count ) } { translate( 'visits this month' ) }
+						{ translate( '%(visits_count)s visits this month', {
+							args: {
+								visits_count: formatNumber(
+									planUsage.visits_count,
+									DEFAULT_LOCALE,
+									STANDARD_FORMATTING_OPTIONS
+								),
+							},
+							comment: '%(visits_count)s is the number of month visits of the site.',
+						} ) }
 					</div>
 				</div>
 			</div>

--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -1,0 +1,59 @@
+import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+//import getPressableShortName from '../lib/get-pressable-short-name';
+
+import './style.scss';
+
+type Props = {
+	existingPlan: APIProductFamilyProduct | null;
+};
+
+export default function PressableUsageDetails( { existingPlan }: Props ) {
+	const translate = useTranslate();
+	const agency = useSelector( getActiveAgency );
+	const planUsage = agency?.third_party?.pressable?.usage;
+
+	const planInfo = existingPlan?.slug ? getPressablePlan( existingPlan?.slug ) : null;
+
+	return (
+		<div className="plan-card">
+			{ planUsage && planInfo && (
+				<>
+					<div className="plan-storage">
+						<p className="storage-label">{ translate( 'Storage' ) } </p>
+					</div>
+
+					<div className="plan-info">
+						<div className="info-item sites">
+							<div className="info-header">
+								<p className="info-label">{ translate( 'Sites' ) }</p>
+								<p className="info-top-right">
+									{ planInfo.install } { translate( 'maximum of sites' ) }
+								</p>
+							</div>
+							<p className="info-value">
+								{ planUsage.sites_count } { translate( 'installed sites' ) }
+							</p>
+						</div>
+
+						<div className="info-item visits">
+							<div className="info-header">
+								<p className="info-label">{ translate( 'Visits' ) }</p>
+								<p className="info-top-right">
+									{ formatNumber( planInfo.visits ) } { translate( 'per month' ) }
+								</p>
+							</div>
+							<p className="info-value">
+								{ formatNumber( planUsage.visits_count ) } { translate( 'visits this month' ) }
+							</p>
+						</div>
+					</div>
+				</>
+			) }
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -3,6 +3,7 @@ import formatNumber, {
 	DEFAULT_LOCALE,
 	STANDARD_FORMATTING_OPTIONS,
 } from '@automattic/components/src/number-formatters/lib/format-number';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
@@ -27,19 +28,29 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 	}
 
 	return (
-		<div className="pressable-usage-details__card">
+		<div
+			className={ clsx( 'pressable-usage-details__card', {
+				'is-empty': ! planUsage,
+			} ) }
+		>
+			{ ! planUsage && (
+				<div className="pressable-usage-details__empty-message">
+					{ translate( "View your usage data here when it's available." ) }
+				</div>
+			) }
 			<div className="pressable-usage-details__info">
 				<div className="pressable-usage-details__info-item">
 					<div className="pressable-usage-details__info-header">
 						<div className="pressable-usage-details__info-label">{ translate( 'Storage' ) }</div>
 						<div className="pressable-usage-details__info-top-right storage">
-							{ translate( 'Using %(used_storage)s of %(max_storage)s GB', {
-								args: {
-									used_storage: planUsage ? planUsage.storage_gb : '?',
-									max_storage: planInfo.storage,
-								},
-								comment: '%(used_storage)s and %(max_storage)d are the storage values in GB.',
-							} ) }
+							{ planUsage &&
+								translate( 'Using %(used_storage)s of %(max_storage)s GB', {
+									args: {
+										used_storage: planUsage ? planUsage.storage_gb : '?',
+										max_storage: planInfo.storage,
+									},
+									comment: '%(used_storage)s and %(max_storage)d are the storage values in GB.',
+								} ) }
 						</div>
 					</div>
 					<div className="pressable-usage-details__info-value">
@@ -67,12 +78,13 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 						</div>
 					</div>
 					<div className="pressable-usage-details__info-value">
-						{ translate( '%(total_sites)s installed sites', {
-							args: {
-								total_sites: planUsage ? planUsage.sites_count : '?',
-							},
-							comment: '%(total_sites)s is the number of installed sites.',
-						} ) }
+						{ planUsage &&
+							translate( '%(total_sites)s installed sites', {
+								args: {
+									total_sites: planUsage.sites_count,
+								},
+								comment: '%(total_sites)s is the number of installed sites.',
+							} ) }
 					</div>
 				</div>
 
@@ -93,18 +105,17 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 						</div>
 					</div>
 					<div className="pressable-usage-details__info-value">
-						{ translate( '%(visits_count)s visits this month', {
-							args: {
-								visits_count: planUsage
-									? formatNumber(
-											planUsage.visits_count,
-											DEFAULT_LOCALE,
-											STANDARD_FORMATTING_OPTIONS
-									  )
-									: '?',
-							},
-							comment: '%(visits_count)s is the number of month visits of the site.',
-						} ) }
+						{ planUsage &&
+							translate( '%(visits_count)s visits this month', {
+								args: {
+									visits_count: formatNumber(
+										planUsage.visits_count,
+										DEFAULT_LOCALE,
+										STANDARD_FORMATTING_OPTIONS
+									),
+								},
+								comment: '%(visits_count)s is the number of month visits of the site.',
+							} ) }
 					</div>
 				</div>
 			</div>

--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -1,10 +1,12 @@
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
+import formatNumber, {
+	DEFAULT_LOCALE,
+	STANDARD_FORMATTING_OPTIONS,
+} from '@automattic/components/src/number-formatters/lib/format-number';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
-//import getPressableShortName from '../lib/get-pressable-short-name';
 
 import './style.scss';
 
@@ -19,41 +21,50 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 
 	const planInfo = existingPlan?.slug ? getPressablePlan( existingPlan?.slug ) : null;
 
+	if ( ! planUsage || ! planInfo ) {
+		return null;
+	}
+
 	return (
-		<div className="plan-card">
-			{ planUsage && planInfo && (
-				<>
-					<div className="plan-storage">
-						<p className="storage-label">{ translate( 'Storage' ) } </p>
-					</div>
-
-					<div className="plan-info">
-						<div className="info-item sites">
-							<div className="info-header">
-								<p className="info-label">{ translate( 'Sites' ) }</p>
-								<p className="info-top-right">
-									{ planInfo.install } { translate( 'maximum of sites' ) }
-								</p>
-							</div>
-							<p className="info-value">
-								{ planUsage.sites_count } { translate( 'installed sites' ) }
-							</p>
-						</div>
-
-						<div className="info-item visits">
-							<div className="info-header">
-								<p className="info-label">{ translate( 'Visits' ) }</p>
-								<p className="info-top-right">
-									{ formatNumber( planInfo.visits ) } { translate( 'per month' ) }
-								</p>
-							</div>
-							<p className="info-value">
-								{ formatNumber( planUsage.visits_count ) } { translate( 'visits this month' ) }
-							</p>
+		<div className="pressable-usage-details__card">
+			<div className="pressable-usage-details__info">
+				<div className="pressable-usage-details__info-item">
+					<div className="pressable-usage-details__info-header">
+						<div className="pressable-usage-details__info-label">{ translate( 'Storage' ) }</div>
+						<div className="pressable-usage-details__info-top-right">
+							Using { planUsage.storage_gb } of { planInfo.storage } GB
 						</div>
 					</div>
-				</>
-			) }
+					<div className="pressable-usage-details__info-value">[ Progress-bar ]</div>
+				</div>
+			</div>
+
+			<div className="pressable-usage-details__info">
+				<div className="pressable-usage-details__info-item sites">
+					<div className="pressable-usage-details__info-header">
+						<div className="pressable-usage-details__info-label">{ translate( 'Sites' ) }</div>
+						<div className="pressable-usage-details__info-top-right">
+							{ planInfo.install } { translate( 'maximum of sites' ) }
+						</div>
+					</div>
+					<div className="pressable-usage-details__info-value">
+						{ planUsage.sites_count } { translate( 'installed sites' ) }
+					</div>
+				</div>
+
+				<div className="pressable-usage-details__info-item visits">
+					<div className="pressable-usage-details__info-header">
+						<div className="pressable-usage-details__info-label">{ translate( 'Visits' ) }</div>
+						<div className="pressable-usage-details__info-top-right">
+							{ formatNumber( planInfo.visits, DEFAULT_LOCALE, STANDARD_FORMATTING_OPTIONS ) }
+							{ translate( 'per month' ) }
+						</div>
+					</div>
+					<div className="pressable-usage-details__info-value">
+						{ formatNumber( planUsage.visits_count ) } { translate( 'visits this month' ) }
+					</div>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -22,7 +22,7 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 
 	const planInfo = existingPlan?.slug ? getPressablePlan( existingPlan?.slug ) : null;
 
-	if ( ! planUsage || ! planInfo ) {
+	if ( ! planInfo ) {
 		return null;
 	}
 
@@ -33,12 +33,12 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 					<div className="pressable-usage-details__info-header">
 						<div className="pressable-usage-details__info-label">{ translate( 'Storage' ) }</div>
 						<div className="pressable-usage-details__info-top-right storage">
-							{ translate( 'Using %(used_storage)d of %(max_storage)d GB', {
+							{ translate( 'Using %(used_storage)s of %(max_storage)s GB', {
 								args: {
-									used_storage: planUsage.storage_gb,
+									used_storage: planUsage ? planUsage.storage_gb : '?',
 									max_storage: planInfo.storage,
 								},
-								comment: '%(used_storage)d and %(max_storage)d are the storage values in GB.',
+								comment: '%(used_storage)s and %(max_storage)d are the storage values in GB.',
 							} ) }
 						</div>
 					</div>
@@ -46,7 +46,7 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 						<ProgressBar
 							className="pressable-usage-details__storage-bar"
 							compact
-							value={ planUsage.storage_gb }
+							value={ planUsage ? planUsage.storage_gb : 0 }
 							total={ planInfo.storage }
 						/>
 					</div>
@@ -58,20 +58,20 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 					<div className="pressable-usage-details__info-header">
 						<div className="pressable-usage-details__info-label">{ translate( 'Sites' ) }</div>
 						<div className="pressable-usage-details__info-top-right">
-							{ translate( 'up to %(max_sites)d sites', {
+							{ translate( 'up to %(max_sites)s sites', {
 								args: {
 									max_sites: planInfo.install,
 								},
-								comment: '%(max_sites)d is the maximum number of sites.',
+								comment: '%(max_sites)s is the maximum number of sites.',
 							} ) }
 						</div>
 					</div>
 					<div className="pressable-usage-details__info-value">
-						{ translate( '%(total_sites)d installed sites', {
+						{ translate( '%(total_sites)s installed sites', {
 							args: {
-								total_sites: planUsage.sites_count,
+								total_sites: planUsage ? planUsage.sites_count : '?',
 							},
-							comment: '%(total_sites)d is the number of installed sites.',
+							comment: '%(total_sites)s is the number of installed sites.',
 						} ) }
 					</div>
 				</div>
@@ -95,11 +95,13 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 					<div className="pressable-usage-details__info-value">
 						{ translate( '%(visits_count)s visits this month', {
 							args: {
-								visits_count: formatNumber(
-									planUsage.visits_count,
-									DEFAULT_LOCALE,
-									STANDARD_FORMATTING_OPTIONS
-								),
+								visits_count: planUsage
+									? formatNumber(
+											planUsage.visits_count,
+											DEFAULT_LOCALE,
+											STANDARD_FORMATTING_OPTIONS
+									  )
+									: '?',
 							},
 							comment: '%(visits_count)s is the number of month visits of the site.',
 						} ) }

--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -4,9 +4,9 @@ import formatNumber, {
 	STANDARD_FORMATTING_OPTIONS,
 } from '@automattic/components/src/number-formatters/lib/format-number';
 import { useTranslate } from 'i18n-calypso';
-//import { useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
-//import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
@@ -17,14 +17,8 @@ type Props = {
 
 export default function PressableUsageDetails( { existingPlan }: Props ) {
 	const translate = useTranslate();
-	// @todo (dev-testing mode) => Before merge, get the plan usage from the agency object instead of mocked one
-	// const agency = useSelector( getActiveAgency );
-	// const planUsage = agency?.third_party?.pressable?.usage;
-	const planUsage = {
-		storage_gb: 20,
-		sites_count: 2,
-		visits_count: 12589,
-	};
+	const agency = useSelector( getActiveAgency );
+	const planUsage = agency?.third_party?.pressable?.usage;
 
 	const planInfo = existingPlan?.slug ? getPressablePlan( existingPlan?.slug ) : null;
 

--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -1,3 +1,4 @@
+import { ProgressBar } from '@automattic/components';
 import formatNumber, {
 	DEFAULT_LOCALE,
 	STANDARD_FORMATTING_OPTIONS,
@@ -20,7 +21,7 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 	// const agency = useSelector( getActiveAgency );
 	// const planUsage = agency?.third_party?.pressable?.usage;
 	const planUsage = {
-		storage_gb: 16,
+		storage_gb: 20,
 		sites_count: 2,
 		visits_count: 12589,
 	};
@@ -47,7 +48,14 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 							} ) }
 						</div>
 					</div>
-					<div className="pressable-usage-details__info-value">[ Progress-bar here ]</div>
+					<div className="pressable-usage-details__info-value">
+						<ProgressBar
+							className="pressable-usage-details__storage-bar"
+							compact
+							value={ planUsage.storage_gb }
+							total={ planInfo.storage }
+						/>
+					</div>
 				</div>
 			</div>
 
@@ -56,7 +64,7 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 					<div className="pressable-usage-details__info-header">
 						<div className="pressable-usage-details__info-label">{ translate( 'Sites' ) }</div>
 						<div className="pressable-usage-details__info-top-right">
-							{ translate( '%(max_sites)d maximum of sites', {
+							{ translate( 'up to %(max_sites)d sites', {
 								args: {
 									max_sites: planInfo.install,
 								},

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -15,15 +15,24 @@
 
 	.pressable-usage-details__info {
 		display: flex;
+		flex-direction: column;
 		justify-content: space-between;
 		gap: 8px;
+
+		@include break-large {
+			flex-direction: row;
+		}
 	}
 
 	.pressable-usage-details__info-item {
 		background: var(--color-neutral-0);
 		padding: 16px;
 		border-radius: 4px;
-		width: 100%;
+		width: auto;
+
+		@include break-large {
+			width: 100%;
+		}
 	}
 
 	.pressable-usage-details__info-header {

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -24,6 +24,19 @@
 		}
 	}
 
+	.pressable-usage-details__storage-bar {
+		margin-top: 16px;
+		background-color: var(--color-neutral-5);
+		border-radius: 4px;
+		height: 8px;
+
+		.progress-bar__progress {
+			border-radius: 4px;
+			height: 100%;
+			background-color: var(--studio-automattic-blue-50);
+		}
+	}
+
 	.pressable-usage-details__info-item {
 		background: var(--color-neutral-0);
 		padding: 16px;

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -2,9 +2,9 @@
 @import "@wordpress/base-styles/mixins";
 
 .pressable-usage-details__card {
-	padding: 20px;
-	border: 1px solid var(--color-neutral-5);
-	border-radius: 4px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
 	width: 100%;
 	margin: 0 auto;
 
@@ -16,12 +16,12 @@
 	.pressable-usage-details__info {
 		display: flex;
 		justify-content: space-between;
+		gap: 8px;
 	}
 
 	.pressable-usage-details__info-item {
 		background: var(--color-neutral-0);
-		padding: 15px;
-		margin: 10px;
+		padding: 16px;
 		border-radius: 4px;
 		width: 100%;
 	}
@@ -33,17 +33,22 @@
 	}
 
 	.pressable-usage-details__info-label {
-		font-size: 0.75rem;
+		font-size: 0.875rem;
 		text-transform: uppercase;
 	}
 
 	.pressable-usage-details__info-top-right {
-		font-size: 0.75rem;
+		font-size: 0.875rem;
 		color: var(--color-neutral-60);
+
+		&.storage {
+			font-weight: bold;
+			font-size: 1rem;
+		}
 	}
 
 	.pressable-usage-details__info-value {
-		font-size: 1.25rem;
+		font-size: 1rem;
 		font-weight: bold;
 		margin-top: 5px;
 	}

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -1,375 +1,50 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.plan-card {
-	background-color: #f4f4f4;
+.pressable-usage-details__card {
 	padding: 20px;
+	border: 1px solid var(--color-neutral-5);
 	border-radius: 4px;
-	max-width: 600px;
+	width: 100%;
 	margin: 0 auto;
-	font-family: Arial, sans-serif;
 
-	.plan-title {
+	.pressable-usage-details__title {
 		font-size: 1.5rem;
 		margin-bottom: 10px;
 	}
 
-	.plan-storage {
-		background-color: #fff;
-		padding: 15px;
-		border-radius: 4px;
-		margin-bottom: 20px;
-
-		.storage-label {
-			font-size: 0.75rem;
-			margin-bottom: 5px;
-		}
-	}
-
-	.plan-info {
+	.pressable-usage-details__info {
 		display: flex;
 		justify-content: space-between;
-
-		.info-item {
-			background-color: #fff;
-			padding: 15px;
-			border-radius: 4px;
-			width: 48%;
-
-			.info-header {
-				display: flex;
-				justify-content: space-between;
-				align-items: center;
-
-				.info-label {
-					font-size: 0.75rem;
-					color: #6b6b6b;
-				}
-
-				.info-top-right {
-					font-size: 0.75rem;
-					color: #6b6b6b;
-				}
-			}
-
-			.info-value {
-				font-size: 1.25rem;
-				font-weight: bold;
-				margin-top: 5px;
-			}
-		}
 	}
 
-	/* Mobile responsiveness */
-	@media (max-width: 768px) {
-		.plan-info {
-			flex-direction: column;
-
-			.info-item {
-				width: 100%;
-				margin-bottom: 10px;
-
-				&:last-child {
-					margin-bottom: 0;
-				}
-			}
-		}
-	}
-}
-
-
-.pressable-overview-plan-selection {
-	width: 100%;
-
-	@include break-large {
-		width: 800px;
-		margin-inline: auto;
-	}
-}
-
-.pressable-overview-plan-selection__details {
-	display: grid;
-	grid-template-columns: 1fr;
-	grid-auto-rows: auto;
-	margin-block: 32px 64px;
-	row-gap: 32px;
-
-	@include break-large {
-		grid-template-columns: repeat(2, 1fr);
-		column-gap: 32px;
-		row-gap: 8px;
-
-		> * {
-			// Make items span full width if they're the only child
-			grid-column: auto / span 2;
-		}
-
-		// If there are 2 or more children, reset the grid span
-		> *:nth-child(1):nth-last-child(n+2),
-		> *:nth-child(2):nth-last-child(n+2) {
-			grid-column: auto / span 1;
-		}
-
-	}
-}
-
-.pressable-overview-plan-selection__details-hint {
-	@include a4a-font-body-md;
-}
-
-.pressable-overview-plan-selection__details-card {
-	border-radius: 4px;
-	padding: 24px;
-	display: flex;
-	flex-direction: column;
-	gap: 32px;
-}
-
-.pressable-overview-plan-selection__details-card:not(.is-aside) {
-	background: var(--color-light-backdrop);
-}
-
-.pressable-overview-plan-selection__details-card.is-aside {
-	border: 1px solid var(--color-neutral-5);
-}
-
-.pressable-overview-plan-selection__details-card-header-title {
-	font-size: 1rem;
-	line-height: 1.4;
-	font-weight: 600;
-}
-
-.pressable-overview-plan-selection__details-card-header-coming-soon {
-	@include a4a-font-heading-md($font-weight: 400);
-}
-
-.pressable-overview-plan-selection__details-card-header-subtitle {
-	@include a4a-font-body-md;
-
-	&.is-regular-ownership {
-		padding-block-start: 32px;
-	}
-
-	&.is-refer-mode {
-		@include a4a-font-body-sm;
-		padding-block-end: 16px;
-	}
-
-}
-
-.pressable-overview-plan-selection__details-card-header-price {
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-}
-
-.pressable-overview-plan-selection__details-card-header-price-value {
-	font-size: 2rem;
-	line-height: 1;
-	font-weight: 600;
-	display: block;
-}
-
-.pressable-overview-plan-selection__details-card-header-price-interval {
-	font-size: 0.75rem;
-	line-height: 0.85;
-	font-weight: 400;
-	color: var(--color-neutral-60);
-}
-
-.pressable-overview-plan-selection__details-card-cta-button {
-	display: flex;
-	justify-content: center;
-	border-radius: 4px;
-	font-weight: 600;
-	font-size: 0.875rem;
-	min-height: 40px;
-}
-
-.pressable-overview-plan-selection__filter-owned-plan {
-	text-align: center;
-
-	.badge {
-		display: inline-flex;
-		flex-direction: row;
-		gap: 16px;
-
-		background-color: var(--color-neutral-0);
-		padding: 8px 16px;
-		margin: 0 auto 32px;
+	.pressable-usage-details__info-item {
+		background: var(--color-neutral-0);
+		padding: 15px;
+		margin: 10px;
 		border-radius: 4px;
-
-		align-items: center;
-		justify-content: center;
-	}
-}
-
-.pressable-overview-plan-selection__filter-type {
-	display: flex;
-	flex-direction: row;
-	gap: 16px;
-
-	align-items: center;
-	justify-content: center;
-
-	.pressable-overview-plan-selection__filter-label {
-		font-weight: 600;
-		font-size: 1rem;
-		margin: 0;
-	}
-
-	.pressable-overview-plan-selection__filter-buttons {
-		button:first-child {
-			margin-inline-end: 1rem;
-		}
-	}
-
-	@include breakpoint-deprecated( "<660px" ) {
-		display: block;
-		margin: 0;
-		text-align: center;
-
-		.pressable-overview-plan-selection__filter-label {
-			width: 100%;
-			margin-block-end: 0.5rem;
-		}
-
-		.pressable-overview-plan-selection__filter-buttons {
-			display: inline-flex;
-			justify-content: space-around;
-			width: 100%;
-			button {
-				width: 50%;
-				text-align: center;
-				justify-content: center;
-			}
-		}
-	}
-}
-
-.theme-a8c-for-agencies .components-button.pressable-overview-plan-selection__filter-button {
-	border: 1.5px solid var(--color-surface-backdrop);
-	font-size: 0.875rem;
-	font-weight: 600;
-	line-height: 1.1;
-
-	/* stylelint-disable-next-line scales/radii */
-	border-radius: 29px;
-	padding: 6px 12px;
-
-	&:focus {
-		box-shadow: none;
-	}
-
-	&:focus-visible {
-		background: var(--color-neutral-60);
-		color: var(--color-text-inverted);
-	}
-}
-
-.pressable-overview-plan-selection__filter {
-	.a4a-slider__marker-label {
-		height: 0.95rem;
-	}
-}
-
-.a4a-pressable-filter-wrapper-visits {
-	@include breakpoint-deprecated( "<660px" ) {
-		.a4a-slider__marker-label {
-			font-size: 0.75rem;
-		}
-	}
-}
-
-.pressable-overview-plan-selection__filter.is-placeholder {
-	.pressable-overview-plan-selection__filter-type,
-	.pressable-overview-plan-selection__filter-slider {
-		animation: loading-fade 1.6s ease-in-out infinite;
-		background: var(--color-neutral-10);
-		border-radius: 4px;
-	}
-
-	.pressable-overview-plan-selection__filter-type {
-		max-width: 350px;
 		width: 100%;
-		height: 36px;
-		margin: 0 auto 8px;
 	}
 
-	.pressable-overview-plan-selection__filter-slider {
-		max-width: 800px;
-		width: 100%;
-		height: 53.2px;
-		margin: 0 auto;
-	}
-}
-
-
-.pressable-overview-plan-selection__details.is-loader {
-	display: flex;
-	justify-content: space-between;
-	max-width: 800px;
-
-	.pressable-overview-plan-selection__details-card {
-		animation: loading-fade 1.6s ease-in-out infinite;
-		background: var(--color-neutral-10);
-		border-radius: 4px;
-		max-width: 350px;
-		height: 256px;
-	}
-}
-
-.is-new-hosting-page.pressable-overview-plan-selection {
-
-	@include break-huge {
-		width: 1000px;
-	}
-
-	.pressable-overview-plan-selection__filter-owned-plan {
-		margin-block-start: 32px;
-	}
-
-	.pressable-overview-plan-selection__details-card {
-		flex: 1;
-		border: 1px solid var(--color-neutral-5);
+	.pressable-usage-details__info-header {
+		display: flex;
 		justify-content: space-between;
+		align-items: center;
 	}
 
-	.pressable-overview-plan-selection__details-card-header-title {
-		@include a4a-font-heading-lg;
-
-		&.plan-name {
-			margin-block-end: 8px;
-			@include a4a-font-heading-xl;
-		}
+	.pressable-usage-details__info-label {
+		font-size: 0.75rem;
+		text-transform: uppercase;
 	}
 
-	.pressable-overview-plan-selection__details-card-header-price {
-		gap: 8px;
+	.pressable-usage-details__info-top-right {
+		font-size: 0.75rem;
+		color: var(--color-neutral-60);
 	}
 
-	.pressable-overview-plan-selection__details-card-header-price-value {
-		@include a4a-font-heading-xl;
+	.pressable-usage-details__info-value {
+		font-size: 1.25rem;
+		font-weight: bold;
+		margin-top: 5px;
 	}
-
-	.pressable-overview-plan-selection__details > * {
-		gap: 24px;
-	}
-
-	&.is-slider-hidden {
-		.pressable-overview-plan-selection__details {
-			margin-block-start: 24px;
-		}
-	}
-}
-
-.pressable-overview-plan-selection__manage-account-button-container {
-	&,
-	a.button {
-		width: 100%;
-	}
-}
-
-.pressable-overview-plan-selection__tooltip {
-	max-width: 400px;
 }

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -8,6 +8,11 @@
 	width: 100%;
 	margin: 0 auto;
 
+	.pressable-usage-details__empty-message {
+		font-size: 0.875rem;
+		margin-bottom: 16px;
+	}
+
 	.pressable-usage-details__title {
 		font-size: 1.5rem;
 		margin-bottom: 10px;
@@ -42,6 +47,7 @@
 		padding: 16px;
 		border-radius: 4px;
 		width: auto;
+		min-height: 45px;
 
 		@include break-large {
 			width: 100%;
@@ -57,6 +63,13 @@
 	.pressable-usage-details__info-label {
 		font-size: 0.875rem;
 		text-transform: uppercase;
+	}
+
+	&.is-empty {
+		.pressable-usage-details__info-top-right,
+		.pressable-usage-details__info-label {
+			color: var(--studio-gray-40);
+		}
 	}
 
 	.pressable-usage-details__info-top-right {

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -1,0 +1,375 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.plan-card {
+	background-color: #f4f4f4;
+	padding: 20px;
+	border-radius: 4px;
+	max-width: 600px;
+	margin: 0 auto;
+	font-family: Arial, sans-serif;
+
+	.plan-title {
+		font-size: 1.5rem;
+		margin-bottom: 10px;
+	}
+
+	.plan-storage {
+		background-color: #fff;
+		padding: 15px;
+		border-radius: 4px;
+		margin-bottom: 20px;
+
+		.storage-label {
+			font-size: 0.75rem;
+			margin-bottom: 5px;
+		}
+	}
+
+	.plan-info {
+		display: flex;
+		justify-content: space-between;
+
+		.info-item {
+			background-color: #fff;
+			padding: 15px;
+			border-radius: 4px;
+			width: 48%;
+
+			.info-header {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+
+				.info-label {
+					font-size: 0.75rem;
+					color: #6b6b6b;
+				}
+
+				.info-top-right {
+					font-size: 0.75rem;
+					color: #6b6b6b;
+				}
+			}
+
+			.info-value {
+				font-size: 1.25rem;
+				font-weight: bold;
+				margin-top: 5px;
+			}
+		}
+	}
+
+	/* Mobile responsiveness */
+	@media (max-width: 768px) {
+		.plan-info {
+			flex-direction: column;
+
+			.info-item {
+				width: 100%;
+				margin-bottom: 10px;
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+	}
+}
+
+
+.pressable-overview-plan-selection {
+	width: 100%;
+
+	@include break-large {
+		width: 800px;
+		margin-inline: auto;
+	}
+}
+
+.pressable-overview-plan-selection__details {
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-auto-rows: auto;
+	margin-block: 32px 64px;
+	row-gap: 32px;
+
+	@include break-large {
+		grid-template-columns: repeat(2, 1fr);
+		column-gap: 32px;
+		row-gap: 8px;
+
+		> * {
+			// Make items span full width if they're the only child
+			grid-column: auto / span 2;
+		}
+
+		// If there are 2 or more children, reset the grid span
+		> *:nth-child(1):nth-last-child(n+2),
+		> *:nth-child(2):nth-last-child(n+2) {
+			grid-column: auto / span 1;
+		}
+
+	}
+}
+
+.pressable-overview-plan-selection__details-hint {
+	@include a4a-font-body-md;
+}
+
+.pressable-overview-plan-selection__details-card {
+	border-radius: 4px;
+	padding: 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+}
+
+.pressable-overview-plan-selection__details-card:not(.is-aside) {
+	background: var(--color-light-backdrop);
+}
+
+.pressable-overview-plan-selection__details-card.is-aside {
+	border: 1px solid var(--color-neutral-5);
+}
+
+.pressable-overview-plan-selection__details-card-header-title {
+	font-size: 1rem;
+	line-height: 1.4;
+	font-weight: 600;
+}
+
+.pressable-overview-plan-selection__details-card-header-coming-soon {
+	@include a4a-font-heading-md($font-weight: 400);
+}
+
+.pressable-overview-plan-selection__details-card-header-subtitle {
+	@include a4a-font-body-md;
+
+	&.is-regular-ownership {
+		padding-block-start: 32px;
+	}
+
+	&.is-refer-mode {
+		@include a4a-font-body-sm;
+		padding-block-end: 16px;
+	}
+
+}
+
+.pressable-overview-plan-selection__details-card-header-price {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.pressable-overview-plan-selection__details-card-header-price-value {
+	font-size: 2rem;
+	line-height: 1;
+	font-weight: 600;
+	display: block;
+}
+
+.pressable-overview-plan-selection__details-card-header-price-interval {
+	font-size: 0.75rem;
+	line-height: 0.85;
+	font-weight: 400;
+	color: var(--color-neutral-60);
+}
+
+.pressable-overview-plan-selection__details-card-cta-button {
+	display: flex;
+	justify-content: center;
+	border-radius: 4px;
+	font-weight: 600;
+	font-size: 0.875rem;
+	min-height: 40px;
+}
+
+.pressable-overview-plan-selection__filter-owned-plan {
+	text-align: center;
+
+	.badge {
+		display: inline-flex;
+		flex-direction: row;
+		gap: 16px;
+
+		background-color: var(--color-neutral-0);
+		padding: 8px 16px;
+		margin: 0 auto 32px;
+		border-radius: 4px;
+
+		align-items: center;
+		justify-content: center;
+	}
+}
+
+.pressable-overview-plan-selection__filter-type {
+	display: flex;
+	flex-direction: row;
+	gap: 16px;
+
+	align-items: center;
+	justify-content: center;
+
+	.pressable-overview-plan-selection__filter-label {
+		font-weight: 600;
+		font-size: 1rem;
+		margin: 0;
+	}
+
+	.pressable-overview-plan-selection__filter-buttons {
+		button:first-child {
+			margin-inline-end: 1rem;
+		}
+	}
+
+	@include breakpoint-deprecated( "<660px" ) {
+		display: block;
+		margin: 0;
+		text-align: center;
+
+		.pressable-overview-plan-selection__filter-label {
+			width: 100%;
+			margin-block-end: 0.5rem;
+		}
+
+		.pressable-overview-plan-selection__filter-buttons {
+			display: inline-flex;
+			justify-content: space-around;
+			width: 100%;
+			button {
+				width: 50%;
+				text-align: center;
+				justify-content: center;
+			}
+		}
+	}
+}
+
+.theme-a8c-for-agencies .components-button.pressable-overview-plan-selection__filter-button {
+	border: 1.5px solid var(--color-surface-backdrop);
+	font-size: 0.875rem;
+	font-weight: 600;
+	line-height: 1.1;
+
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 29px;
+	padding: 6px 12px;
+
+	&:focus {
+		box-shadow: none;
+	}
+
+	&:focus-visible {
+		background: var(--color-neutral-60);
+		color: var(--color-text-inverted);
+	}
+}
+
+.pressable-overview-plan-selection__filter {
+	.a4a-slider__marker-label {
+		height: 0.95rem;
+	}
+}
+
+.a4a-pressable-filter-wrapper-visits {
+	@include breakpoint-deprecated( "<660px" ) {
+		.a4a-slider__marker-label {
+			font-size: 0.75rem;
+		}
+	}
+}
+
+.pressable-overview-plan-selection__filter.is-placeholder {
+	.pressable-overview-plan-selection__filter-type,
+	.pressable-overview-plan-selection__filter-slider {
+		animation: loading-fade 1.6s ease-in-out infinite;
+		background: var(--color-neutral-10);
+		border-radius: 4px;
+	}
+
+	.pressable-overview-plan-selection__filter-type {
+		max-width: 350px;
+		width: 100%;
+		height: 36px;
+		margin: 0 auto 8px;
+	}
+
+	.pressable-overview-plan-selection__filter-slider {
+		max-width: 800px;
+		width: 100%;
+		height: 53.2px;
+		margin: 0 auto;
+	}
+}
+
+
+.pressable-overview-plan-selection__details.is-loader {
+	display: flex;
+	justify-content: space-between;
+	max-width: 800px;
+
+	.pressable-overview-plan-selection__details-card {
+		animation: loading-fade 1.6s ease-in-out infinite;
+		background: var(--color-neutral-10);
+		border-radius: 4px;
+		max-width: 350px;
+		height: 256px;
+	}
+}
+
+.is-new-hosting-page.pressable-overview-plan-selection {
+
+	@include break-huge {
+		width: 1000px;
+	}
+
+	.pressable-overview-plan-selection__filter-owned-plan {
+		margin-block-start: 32px;
+	}
+
+	.pressable-overview-plan-selection__details-card {
+		flex: 1;
+		border: 1px solid var(--color-neutral-5);
+		justify-content: space-between;
+	}
+
+	.pressable-overview-plan-selection__details-card-header-title {
+		@include a4a-font-heading-lg;
+
+		&.plan-name {
+			margin-block-end: 8px;
+			@include a4a-font-heading-xl;
+		}
+	}
+
+	.pressable-overview-plan-selection__details-card-header-price {
+		gap: 8px;
+	}
+
+	.pressable-overview-plan-selection__details-card-header-price-value {
+		@include a4a-font-heading-xl;
+	}
+
+	.pressable-overview-plan-selection__details > * {
+		gap: 24px;
+	}
+
+	&.is-slider-hidden {
+		.pressable-overview-plan-selection__details {
+			margin-block-start: 24px;
+		}
+	}
+}
+
+.pressable-overview-plan-selection__manage-account-button-container {
+	&,
+	a.button {
+		width: 100%;
+	}
+}
+
+.pressable-overview-plan-selection__tooltip {
+	max-width: 400px;
+}

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -33,7 +33,7 @@
 		.progress-bar__progress {
 			border-radius: 4px;
 			height: 100%;
-			background-color: var(--studio-automattic-blue-50);
+			background-color: var(--color-primary-50);
 		}
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
@@ -1,6 +1,9 @@
 import { JetpackLogo } from '@automattic/components';
 import { layout, blockMeta, shuffle, help, keyboardReturn, tip } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import PressableUsageDetails from 'calypso/a8c-for-agencies/components/pressable-usage-details';
+import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
+import useExistingPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-existing-pressable-plan';
 import ProfileAvatar1 from 'calypso/assets/images/a8c-for-agencies/hosting/premier-testimonial-1.png';
 import ProfileAvatar2 from 'calypso/assets/images/a8c-for-agencies/hosting/premier-testimonial-2.png';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -20,8 +23,37 @@ type Props = {
 export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 	const translate = useTranslate();
 
+	const { pressablePlans } = useProductAndPlans( {
+		selectedSite: null,
+		productSearchQuery: '',
+	} );
+
+	const { existingPlan, isReady: isExistingPlanFetched } = useExistingPressablePlan( {
+		plans: pressablePlans,
+	} );
+
 	return (
 		<div className="premier-agency-hosting">
+			{ isExistingPlanFetched && existingPlan && (
+				<section className="pressable-overview-plan-existing ok">
+					<div className="pressable-overview-plan-existing__details-card">
+						<div className="pressable-overview-plan-existing__header">
+							<div className="pressable-overview-plan-existing__owned-plan">
+								{ translate( 'You own the' ) }
+							</div>
+							<div className="pressable-overview-plan-existing__name">
+								{ translate( '%(plan_name)s plan', {
+									args: {
+										plan_name: existingPlan.name,
+									},
+									comment: '%(plan_name)s is the plan name.',
+								} ) }
+							</div>
+						</div>
+						<PressableUsageDetails existingPlan={ existingPlan } />
+					</div>
+				</section>
+			) }
 			<PressableOverviewPlanSelection onAddToCart={ onAddToCart } />
 			<HostingAdditionalFeaturesSection
 				icon={ <JetpackLogo size={ 16 } /> }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
@@ -35,7 +35,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 	return (
 		<div className="premier-agency-hosting">
 			{ isExistingPlanFetched && existingPlan && (
-				<section className="pressable-overview-plan-existing ok">
+				<section className="pressable-overview-plan-existing">
 					<div className="pressable-overview-plan-existing__details-card">
 						<div className="pressable-overview-plan-existing__header">
 							<div className="pressable-overview-plan-existing__owned-plan">

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/style.scss
@@ -40,3 +40,34 @@
 		}
 	}
 }
+
+.pressable-overview-plan-existing {
+	background-image: linear-gradient(0deg, var(--color-primary-0) 0%, #fff 100%);
+	padding-bottom: 48px;
+	margin-bottom: 32px;
+
+	.pressable-overview-plan-existing__details-card{
+		flex: 1;
+		border: 1px solid var(--color-neutral-5);
+		border-radius: 4px;
+		padding: 24px;
+		justify-content: space-between;
+		max-width: 1000px;
+		margin: 0 auto;
+		background-color: #fff;
+	}
+
+	.pressable-overview-plan-existing__owned-plan {
+		font-size: 0.75rem;
+		color: var(--color-neutral-60);
+	}
+	.pressable-overview-plan-existing__name {
+		font-size: 1.50rem;
+		font-weight: bold;
+		color: var(--color-accent-100);
+	}
+
+	.pressable-overview-plan-existing__header {
+		margin-bottom: 16px;
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/style.scss
@@ -43,18 +43,26 @@
 
 .pressable-overview-plan-existing {
 	background-image: linear-gradient(0deg, var(--color-primary-0) 0%, #fff 100%);
-	padding-bottom: 48px;
+	padding: 32px 16px 48px;
 	margin-bottom: 32px;
+
+	@include break-large {
+		padding: 32px 32px 48px;
+	}
 
 	.pressable-overview-plan-existing__details-card{
 		flex: 1;
 		border: 1px solid var(--color-neutral-5);
 		border-radius: 4px;
-		padding: 24px;
+		padding: 16px;
 		justify-content: space-between;
 		max-width: 1000px;
 		margin: 0 auto;
 		background-color: #fff;
+
+		@include break-large {
+			padding: 24px;
+		}
 	}
 
 	.pressable-overview-plan-existing__owned-plan {
@@ -69,5 +77,10 @@
 
 	.pressable-overview-plan-existing__header {
 		margin-bottom: 16px;
+		text-align: center;
+
+		@include break-large {
+			text-align: left;
+		}
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/style.scss
@@ -43,11 +43,11 @@
 
 .pressable-overview-plan-existing {
 	background-image: linear-gradient(0deg, var(--color-primary-0) 0%, #fff 100%);
-	padding: 32px 16px 48px;
+	padding: 0 16px 48px;
 	margin-bottom: 32px;
 
 	@include break-large {
-		padding: 32px 32px 48px;
+		padding: 0 32px 48px;
 	}
 
 	.pressable-overview-plan-existing__details-card{

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { Icon, info } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
@@ -15,7 +14,6 @@ import { FilterType } from '../types';
 type Props = {
 	selectedPlan: APIProductFamilyProduct | null;
 	plans: APIProductFamilyProduct[];
-	existingPlan?: APIProductFamilyProduct | null;
 	pressablePlan?: PressablePlan | null;
 	onSelectPlan: ( plan: APIProductFamilyProduct | null ) => void;
 	isLoading?: boolean;
@@ -25,7 +23,6 @@ export default function PlanSelectionFilter( {
 	selectedPlan,
 	plans,
 	onSelectPlan,
-	existingPlan,
 	pressablePlan,
 	isLoading,
 }: Props ) {
@@ -113,26 +110,6 @@ export default function PlanSelectionFilter( {
 
 	return (
 		<section className={ wrapperClass }>
-			{ !! existingPlan && (
-				<div className="pressable-overview-plan-selection__filter-owned-plan">
-					<div className="badge">
-						<Icon icon={ info } size={ 24 } />
-
-						<span>
-							{ translate( 'You own {{b}}%(planName)s plan{{/b}}', {
-								args: {
-									planName: existingPlan.name,
-								},
-								components: {
-									b: <strong />,
-								},
-								comment: '%(planName)s is the name of the Pressable plan the user owns.',
-							} ) }
-						</span>
-					</div>
-				</div>
-			) }
-
 			<div className="pressable-overview-plan-selection__filter-type">
 				<p className="pressable-overview-plan-selection__filter-label">
 					{ translate( 'Filter by:' ) }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
@@ -1,8 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState, useContext } from 'react';
-import PressableUsageDetails from 'calypso/a8c-for-agencies/components/pressable-usage-details';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -21,7 +19,6 @@ type Props = {
 
 export default function PressableOverviewPlanSelection( { onAddToCart }: Props ) {
 	const dispatch = useDispatch();
-	const translate = useTranslate();
 
 	const [ selectedPlan, setSelectedPlan ] = useState< APIProductFamilyProduct | null >( null );
 
@@ -84,25 +81,13 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 			} ) }
 		>
 			{ pressableOwnership !== 'regular' && ! isReferMode && (
-				<>
-					<section className="pressable-overview-plan-selection__details">
-						{ !! existingPlan && (
-							<div className="pressable-overview-plan-selection__filter-owned-plan">
-								<div>{ translate( 'You own the' ) }</div>
-								<h2>{ existingPlan.name }</h2>
-							</div>
-						) }
-						<PressableUsageDetails existingPlan={ existingPlan } />
-					</section>
-
-					<PlanSelectionFilter
-						selectedPlan={ selectedPlan }
-						plans={ pressablePlans }
-						onSelectPlan={ onSelectPlan }
-						pressablePlan={ pressablePlan }
-						isLoading={ ! isExistingPlanFetched }
-					/>
-				</>
+				<PlanSelectionFilter
+					selectedPlan={ selectedPlan }
+					plans={ pressablePlans }
+					onSelectPlan={ onSelectPlan }
+					pressablePlan={ pressablePlan }
+					isLoading={ ! isExistingPlanFetched }
+				/>
 			) }
 
 			<PlanSelectionDetails

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
@@ -92,9 +92,7 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 								<h2>{ existingPlan.name }</h2>
 							</div>
 						) }
-						<div className="pressable-overview-plan-selection__details-card">
-							<PressableUsageDetails existingPlan={ existingPlan } />
-						</div>
+						<PressableUsageDetails existingPlan={ existingPlan } />
 					</section>
 
 					<PlanSelectionFilter

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState, useContext } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -19,6 +20,7 @@ type Props = {
 
 export default function PressableOverviewPlanSelection( { onAddToCart }: Props ) {
 	const dispatch = useDispatch();
+	const translate = useTranslate();
 
 	const [ selectedPlan, setSelectedPlan ] = useState< APIProductFamilyProduct | null >( null );
 
@@ -81,13 +83,20 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 			} ) }
 		>
 			{ pressableOwnership !== 'regular' && ! isReferMode && (
-				<PlanSelectionFilter
-					selectedPlan={ selectedPlan }
-					plans={ pressablePlans }
-					onSelectPlan={ onSelectPlan }
-					pressablePlan={ pressablePlan }
-					isLoading={ ! isExistingPlanFetched }
-				/>
+				<>
+					{ existingPlan && (
+						<div className="pressable-overview-plan-selection__upgrade-title">
+							{ translate( 'Upgrade your plan' ) }
+						</div>
+					) }
+					<PlanSelectionFilter
+						selectedPlan={ selectedPlan }
+						plans={ pressablePlans }
+						onSelectPlan={ onSelectPlan }
+						pressablePlan={ pressablePlan }
+						isLoading={ ! isExistingPlanFetched }
+					/>
+				</>
 			) }
 
 			<PlanSelectionDetails

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
@@ -1,6 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState, useContext } from 'react';
+import PressableUsageDetails from 'calypso/a8c-for-agencies/components/pressable-usage-details';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -19,6 +21,7 @@ type Props = {
 
 export default function PressableOverviewPlanSelection( { onAddToCart }: Props ) {
 	const dispatch = useDispatch();
+	const translate = useTranslate();
 
 	const [ selectedPlan, setSelectedPlan ] = useState< APIProductFamilyProduct | null >( null );
 
@@ -81,14 +84,27 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 			} ) }
 		>
 			{ pressableOwnership !== 'regular' && ! isReferMode && (
-				<PlanSelectionFilter
-					selectedPlan={ selectedPlan }
-					plans={ pressablePlans }
-					onSelectPlan={ onSelectPlan }
-					existingPlan={ existingPlan }
-					pressablePlan={ pressablePlan }
-					isLoading={ ! isExistingPlanFetched }
-				/>
+				<>
+					<section className="pressable-overview-plan-selection__details">
+						{ !! existingPlan && (
+							<div className="pressable-overview-plan-selection__filter-owned-plan">
+								<div>{ translate( 'You own the' ) }</div>
+								<h2>{ existingPlan.name }</h2>
+							</div>
+						) }
+						<div className="pressable-overview-plan-selection__details-card">
+							<PressableUsageDetails existingPlan={ existingPlan } />
+						</div>
+					</section>
+
+					<PlanSelectionFilter
+						selectedPlan={ selectedPlan }
+						plans={ pressablePlans }
+						onSelectPlan={ onSelectPlan }
+						pressablePlan={ pressablePlan }
+						isLoading={ ! isExistingPlanFetched }
+					/>
+				</>
 			) }
 
 			<PlanSelectionDetails

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -40,7 +40,7 @@
 	@include a4a-font-body-md;
 }
 
-.pressable-overview-plan-selection__details-card {
+.pressable-overview-plan-selection__details-card,.pressable-usage__details-card {
 	border-radius: 4px;
 	padding: 24px;
 	display: flex;

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -40,7 +40,7 @@
 	@include a4a-font-body-md;
 }
 
-.pressable-overview-plan-selection__details-card,.pressable-usage__details-card {
+.pressable-overview-plan-selection__details-card {
 	border-radius: 4px;
 	padding: 24px;
 	display: flex;

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -14,7 +14,7 @@
 	display: grid;
 	grid-template-columns: 1fr;
 	grid-auto-rows: auto;
-	margin-block: 32px 64px;
+	margin-block: 56px 64px;
 	row-gap: 32px;
 
 	@include break-large {
@@ -248,8 +248,11 @@
 		width: 1000px;
 	}
 
-	.pressable-overview-plan-selection__filter-owned-plan {
-		margin-block-start: 32px;
+	.pressable-overview-plan-selection__upgrade-title {
+		font-size: 2rem;
+		font-weight: bold;
+		text-align: center;
+		margin-block: 56px 32px;
 	}
 
 	.pressable-overview-plan-selection__details-card {

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -2,7 +2,10 @@ import config from '@automattic/calypso-config';
 import { Card, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import PressableUsageDetails from 'calypso/a8c-for-agencies/components/pressable-usage-details';
+import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
 import { isPressableHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
+import useExistingPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-existing-pressable-plan';
 import FormattedDate from 'calypso/components/formatted-date';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { getLicenseState, noop } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
@@ -48,6 +51,15 @@ export default function LicenseDetails( {
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
 
+	const { pressablePlans } = useProductAndPlans( {
+		selectedSite: null,
+		productSearchQuery: '',
+	} );
+
+	const { existingPlan: pressablePlan } = useExistingPressablePlan( {
+		plans: pressablePlans,
+	} );
+
 	const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
 
 	return (
@@ -78,9 +90,12 @@ export default function LicenseDetails( {
 					</li>
 				) }
 				{ isPressableLicense && licenseState !== LicenseState.Revoked && (
-					<h4 className="license-details__label">
-						{ translate( 'Manage your Pressable licenses' ) }
-					</h4>
+					<div>
+						<h4 className="license-details__label">
+							{ translate( 'Manage your Pressable licenses' ) }
+						</h4>
+						{ pressablePlan && <PressableUsageDetails existingPlan={ pressablePlan } /> }
+					</div>
 				) }
 
 				<li className="license-details__list-item-small">

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
@@ -104,6 +104,10 @@
 			display: none;
 		}
 	}
+	
+	.pressable-usage-details__card {
+		margin: 24px 0 8px;
+	}
 }
 
 .license-details--child-license {

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -22,6 +22,15 @@ export interface Agency {
 			email: string;
 			name: string;
 			pressable_id: number;
+			usage: null | {
+				status: string;
+				storage_gb: number;
+				visits_count: number;
+				sites_count: number;
+				start_date: string;
+				end_date: string;
+				created_at: number;
+			};
 		};
 	};
 	profile: {

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -22,7 +22,7 @@ export interface Agency {
 			email: string;
 			name: string;
 			pressable_id: number;
-			usage: null | {
+			usage?: null | {
 				status: string;
 				storage_gb: number;
 				visits_count: number;


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/1124

## Proposed Changes

This PR adds the current Pressable plan usage overview to the Marketplace > hosting section:

**Desktop**
![image](https://github.com/user-attachments/assets/f42bf800-4792-451f-8c68-2ac047b2ed29)

**Mobile**
![image](https://github.com/user-attachments/assets/30812d75-f742-4d8e-a616-6a4d45bb93f4)

**Purchases > Licenses section**

![image](https://github.com/user-attachments/assets/81559e8f-e755-4ef8-bad2-19658a0c7584)


**Agency without Pressable usage data**

If an A4A Pressable agency doesn't have usage data, for instance, the first day because the usage information is not available until the next day, we have to display this case with `?` as value

![image](https://github.com/user-attachments/assets/8decee57-c1b0-4bfc-85b2-1eaa4be67af1)


## Testing Instructions

- Check the code
- Launch a horizon live site and check the design
- I hardcoded the usage data for testing purposes, but once it's reviewed and before merge this, I'll get the data from the agency object.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
