### PR TITLE
Handle A4A Pressable sites which have jetpack deactivated, when it is listed on dotcom.

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -288,8 +288,10 @@ export function redirectIfJetpackNonAtomic( context, next ) {
 	const site = getSelectedSite( state );
 	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
 	const isJetpackNonAtomic = ! isAtomicSite && !! site?.jetpack;
+	const isDisconnectedJetpackAndNotAtomic =
+		! site?.is_wpcom_atomic && site?.jetpack_connection && ! site?.jetpack;
 
-	if ( isJetpackNonAtomic ) {
+	if ( isJetpackNonAtomic || isDisconnectedJetpackAndNotAtomic ) {
 		return redirectToDashboard( context );
 	}
 

--- a/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -21,6 +21,7 @@ import {
 	isNotAtomicJetpack,
 	isMigrationInProgress,
 	isStagingSite,
+	isDisconnectedJetpackAndNotAtomic,
 } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -72,7 +73,12 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const isAdmin = useSelector( ( state ) => canCurrentUser( state, site.ID, 'manage_options' ) );
 
 	const onSiteClick = ( event: React.MouseEvent ) => {
-		if ( isAdmin && ! isP2Site && ! isNotAtomicJetpack( site ) ) {
+		if (
+			isAdmin &&
+			! isP2Site &&
+			! isNotAtomicJetpack( site ) &&
+			! isDisconnectedJetpackAndNotAtomic( site )
+		) {
 			openSitePreviewPane && openSitePreviewPane( site );
 		} else {
 			navigate( adminUrl );

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -39,6 +39,7 @@ import {
 	isNotAtomicJetpack,
 	isSimpleSite,
 	isP2Site,
+	isDisconnectedJetpackAndNotAtomic,
 } from '../utils';
 import SitePreviewModal from './site-preview-modal';
 import type { SiteExcerptData } from '@automattic/sites';
@@ -269,6 +270,22 @@ const WpAdminItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_wpadmin_click' ) }
 		>
 			{ __( 'WP Admin' ) }
+		</MenuItemLink>
+	);
+};
+
+const MigrateToWordPress = ( { recordTracks }: SitesMenuItemProps ) => {
+	const { __ } = useI18n();
+
+	return (
+		<MenuItemLink
+			href="https://wordpress.com/move/"
+			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_migrate_to_wpcom_click' ) }
+			target="_blank"
+			icon={ external }
+			iconPosition="right"
+		>
+			{ __( 'Migrate to WordPress.com' ) }
 		</MenuItemLink>
 	);
 };
@@ -519,6 +536,7 @@ export const SitesEllipsisMenu = ( {
 	};
 
 	const isSiteJetpackNotAtomic = isNotAtomicJetpack( site );
+	const isSiteDisconnectedJetpackAndNotAtomic = isDisconnectedJetpackAndNotAtomic( site );
 	const hasHostingFeatures = ! isSiteJetpackNotAtomic && ! isP2Site( site );
 	const { shouldShowSiteCopyItem, startSiteCopy } = useSiteCopy( site );
 	const hasCustomDomain = isCustomDomain( site.slug );
@@ -534,6 +552,14 @@ export const SitesEllipsisMenu = ( {
 				<SiteMenuGroup>
 					<WpAdminItem { ...props } />
 					<JetpackSiteItems { ...props } />
+				</SiteMenuGroup>
+			);
+		}
+		if ( isSiteDisconnectedJetpackAndNotAtomic ) {
+			return (
+				<SiteMenuGroup>
+					<WpAdminItem { ...props } />
+					<MigrateToWordPress { ...props } />
 				</SiteMenuGroup>
 			);
 		}

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -50,6 +50,11 @@ export const isNotAtomicJetpack = ( site: SiteExcerptNetworkData ) => {
 	return site.jetpack && ! site?.is_wpcom_atomic;
 };
 
+// Sites connected through A4A plugin are listed on wordpress.com/sites even when Jetpack is deactivated.
+export const isDisconnectedJetpackAndNotAtomic = ( site: SiteExcerptNetworkData ) => {
+	return ! site?.is_wpcom_atomic && site?.jetpack_connection && ! site?.jetpack;
+};
+
 export const isSimpleSite = ( site: SiteExcerptNetworkData ) => {
 	return ! site?.jetpack && ! site?.is_wpcom_atomic;
 };

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -134,6 +134,7 @@ export interface SiteDetails {
 	is_a4a_client?: boolean;
 	is_a4a_dev_site?: boolean;
 	jetpack: boolean;
+	jetpack_connection?: boolean;
 	lang?: string;
 	launch_status: string;
 	locale: string;

--- a/packages/sites/src/site-excerpt-constants.ts
+++ b/packages/sites/src/site-excerpt-constants.ts
@@ -14,6 +14,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'p2_thumbnail_elements',
 	'plan',
 	'jetpack',
+	'jetpack_connection',
 	'is_wpcom_atomic',
 	'is_wpcom_staging_site',
 	'user_interactions',


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/9388

## Proposed Changes
At https://wordpress.com/sites a few types of sites are listed, including:
- Simple sites (Free plan)
- Atomic
- Non Atomic, that are connected with Jetpack

Sites that are connected through A4A plugin are also listed, even when Jetpack plugin is disabled.
This is the case for sites created under Pressable/A4A Integration.

When that happens Calypso defaults to Simple site experience, which is not compatible with Pressable product. This includes CTAs to upgrade to dotcom business plan.

![image](https://github.com/user-attachments/assets/270a1bf8-86d6-477b-8b45-a7508beb9b31)

For those sites we are introducing 2 changes:
1 - When clicking on the site row, instead of opening the right side of the panel with hosting configurations, redirect to `wp-admin`. This is the same behavior we already have with self hosted sites connected with Jetpack.
2 - When clicking on the `…` Action menu, display only 2 options: `WP Admin` and `Migrate to wordpress.com`. Other actions are not relevant for sites on that state.
![image](https://github.com/user-attachments/assets/90ba88a6-6693-48b6-90cc-c4adccc7aec7)


## Testing Instructions

Before start you need a Pressable site connected with A4A. For that:
- Login on https://agencies.automattic.com.
- Issue Pressable license.
- Login on Pressable and create a new site on it.
- Login on wp-admin of your new Pressable site.
- Open the installed plugins page.
- Automattic for Agencies Client should be installed. Use it to connect the site.
- Check if Jetpack plugin is deactivated. If not, deactivate it.

Testing the changes:
- Apply this PR locally.
- Access http://calypso.localhost:3000/sites
- Find your Pressable site on the list.
- Click on the `…` action menu. You should see only 2 items.
- Click on the sire row. It should redirect to wp-admin.
- Try to manually input `http://calypso.localhost:3000/overview/{site-url}`. It should redirect to dashboard.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
