### PR TITLE
Replace overview when site is with a pending migration

### DIFF
--- a/client/components/hosting-card/index.tsx
+++ b/client/components/hosting-card/index.tsx
@@ -22,6 +22,12 @@ interface HostingCardDescriptionProps {
 	children: string | ReactNode;
 }
 
+interface HostingCardLinkButtonProps {
+	to: string;
+	children: string | ReactNode;
+	hideOnMobile?: boolean;
+}
+
 export function HostingCard( { className, headingId, title, children }: HostingCardProps ) {
 	return (
 		<Card className={ clsx( 'hosting-card', className ) }>
@@ -50,12 +56,6 @@ export function HostingCardHeading( { id, title, children }: HostingCardHeadingP
 
 export function HostingCardDescription( { children }: HostingCardDescriptionProps ) {
 	return <p className="hosting-card__description">{ children }</p>;
-}
-
-interface HostingCardLinkButtonProps {
-	to: string;
-	children: string | ReactNode;
-	hideOnMobile?: boolean;
 }
 
 export function HostingCardLinkButton( {

--- a/client/components/hosting-card/index.tsx
+++ b/client/components/hosting-card/index.tsx
@@ -8,6 +8,7 @@ interface HostingCardProps {
 	className?: string;
 	headingId?: string;
 	title?: string;
+	inGrid?: boolean;
 	children: ReactNode;
 }
 
@@ -28,9 +29,13 @@ interface HostingCardLinkButtonProps {
 	hideOnMobile?: boolean;
 }
 
-export function HostingCard( { className, headingId, title, children }: HostingCardProps ) {
+interface HostingCardGridProps {
+	children: ReactNode;
+}
+
+export function HostingCard( { className, headingId, title, inGrid, children }: HostingCardProps ) {
 	return (
-		<Card className={ clsx( 'hosting-card', className ) }>
+		<Card className={ clsx( 'hosting-card', className, { 'hosting-card--in-grid': inGrid } ) }>
 			{ title && (
 				<h3 id={ headingId } className="hosting-card__title">
 					{ title }
@@ -74,4 +79,8 @@ export function HostingCardLinkButton( {
 			{ children }
 		</Button>
 	);
+}
+
+export function HostingCardGrid( props: HostingCardGridProps ) {
+	return <div className="hosting-card-grid">{ props.children }</div>;
 }

--- a/client/components/hosting-card/style.scss
+++ b/client/components/hosting-card/style.scss
@@ -1,5 +1,6 @@
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .hosting-card {
 	width: 100%;
@@ -21,6 +22,22 @@
 	.form-text-input,
 	.form-select {
 		font-size: rem(14px) !important;
+	}
+
+	/* Styles for when it's inside a grid */
+	&--in-grid {
+		> p {
+			font-size: rem(14px);
+			margin-bottom: 20px;
+			color: var(--color-text-subtle);
+			flex-grow: 1;
+		}
+
+		> a {
+			font-size: rem(13px);
+			font-weight: 400;
+			line-height: 16px;
+		}
 	}
 }
 
@@ -56,5 +73,18 @@ a.hosting-card__link-button {
 @media (max-width: $break-xlarge) {
 	.hosting-card__link-button--hide-on-mobile {
 		display: none;
+	}
+}
+
+.hosting-card-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-column-gap: 16px;
+	grid-row-gap: 16px;
+	padding: 0 20px;
+
+	@include break-medium {
+		grid-template-columns: 1fr 1fr 1fr;
+		padding: 0;
 	}
 }

--- a/client/components/hosting-card/style.scss
+++ b/client/components/hosting-card/style.scss
@@ -28,15 +28,20 @@
 	&--in-grid {
 		> p {
 			font-size: rem(14px);
-			margin-bottom: 20px;
+			margin-bottom: 0;
 			color: var(--color-text-subtle);
 			flex-grow: 1;
 		}
 
 		> a {
+			display: inline-block;
 			font-size: rem(13px);
 			font-weight: 400;
 			line-height: 16px;
+		}
+
+		> p + a {
+			margin-top: 20px;
 		}
 	}
 }

--- a/client/components/hosting-hero/index.tsx
+++ b/client/components/hosting-hero/index.tsx
@@ -1,0 +1,16 @@
+import { Button } from '@wordpress/components';
+import type { ReactNode, ComponentProps } from 'react';
+
+import './style.scss';
+
+interface HostingHeroProps {
+	children: ReactNode;
+}
+
+export function HostingHero( { children }: HostingHeroProps ) {
+	return <div className="hosting-hero">{ children }</div>;
+}
+
+export function HostingHeroButton( props: ComponentProps< typeof Button > ) {
+	return <Button variant="primary" className="hosting-hero-button" { ...props } />;
+}

--- a/client/components/hosting-hero/style.scss
+++ b/client/components/hosting-hero/style.scss
@@ -1,0 +1,29 @@
+@import "@automattic/components/src/styles/typography";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.hosting-hero {
+	grid-column: 1 / -1;
+	text-align: center;
+	margin-bottom: 70px;
+
+	> h1 {
+		margin-top: 30px;
+		font-style: normal;
+		font-weight: 500;
+		font-size: rem(36px);
+		font-family: Recoleta, sans-serif;
+	}
+	> p {
+		font-style: normal;
+		font-weight: 400;
+		font-size: rem(18px);
+	}
+}
+
+.hosting-hero-button {
+	margin: 0 5px;
+	padding: 10px 14px;
+	font-size: rem(14px);
+	height: 40px;
+}

--- a/client/components/hosting-hero/style.scss
+++ b/client/components/hosting-hero/style.scss
@@ -1,6 +1,4 @@
 @import "@automattic/components/src/styles/typography";
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
 
 .hosting-hero {
 	grid-column: 1 / -1;

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -2,13 +2,14 @@ import { FEATURE_SFTP, getPlan, PLAN_BUSINESS } from '@automattic/calypso-produc
 import page from '@automattic/calypso-router';
 import { Dialog } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
-import { Button, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useRef, useState, useEffect } from 'react';
 import { AnyAction } from 'redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { HostingCard } from 'calypso/components/hosting-card';
+import { HostingHero, HostingHeroButton } from 'calypso/components/hosting-hero';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSiteTransferStatusQuery } from 'calypso/landing/stepper/hooks/use-site-transfer/query';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -204,9 +205,7 @@ const HostingFeatures = () => {
 		description = activateDescription;
 		buttons = (
 			<>
-				<Button
-					variant="primary"
-					className="hosting-features__button"
+				<HostingHeroButton
 					onClick={ () => {
 						if ( showActivationButton ) {
 							dispatch( recordTracksEvent( 'calypso_hosting_features_activate_click' ) );
@@ -215,7 +214,7 @@ const HostingFeatures = () => {
 					} }
 				>
 					{ translate( 'Activate now' ) }
-				</Button>
+				</HostingHeroButton>
 
 				<Dialog
 					additionalClassNames="plugin-details-cta__dialog-content"
@@ -239,27 +238,25 @@ const HostingFeatures = () => {
 		title = unlockTitle;
 		description = unlockDescription;
 		buttons = (
-			<Button
-				variant="primary"
-				className="hosting-features__button"
+			<HostingHeroButton
 				href={ upgradeLink }
 				onClick={ () =>
 					dispatch( recordTracksEvent( 'calypso_hosting_features_upgrade_plan_click' ) )
 				}
 			>
 				{ translate( 'Upgrade now' ) }
-			</Button>
+			</HostingHeroButton>
 		);
 	}
 
 	return (
 		<div className="hosting-features">
-			<div className="hosting-features__hero">
+			<HostingHero>
 				{ isTransferInProgress && <Spinner className="hosting-features__content-spinner" /> }
 				<h1>{ title }</h1>
 				<p>{ description }</p>
 				{ buttons }
-			</div>
+			</HostingHero>
 			<div className="hosting-features__cards">
 				{ promoCards.map( ( card ) => (
 					<PromoCard

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
 import { useRef, useState, useEffect } from 'react';
 import { AnyAction } from 'redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
-import { HostingCard } from 'calypso/components/hosting-card';
+import { HostingCard, HostingCardGrid } from 'calypso/components/hosting-card';
 import { HostingHero, HostingHeroButton } from 'calypso/components/hosting-hero';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSiteTransferStatusQuery } from 'calypso/landing/stepper/hooks/use-site-transfer/query';
@@ -29,7 +29,7 @@ type PromoCardProps = {
 };
 
 const PromoCard = ( { title, text, supportContext }: PromoCardProps ) => (
-	<HostingCard className="hosting-features__card" title={ title }>
+	<HostingCard inGrid className="hosting-features__card" title={ title }>
 		<p>{ text }</p>
 		{ translate( '{{supportLink}}Learn more{{/supportLink}}', {
 			components: {
@@ -257,7 +257,7 @@ const HostingFeatures = () => {
 				<p>{ description }</p>
 				{ buttons }
 			</HostingHero>
-			<div className="hosting-features__cards">
+			<HostingCardGrid>
 				{ promoCards.map( ( card ) => (
 					<PromoCard
 						key={ card.title }
@@ -266,7 +266,7 @@ const HostingFeatures = () => {
 						supportContext={ card.supportContext }
 					/>
 				) ) }
-			</div>
+			</HostingCardGrid>
 		</div>
 	);
 };

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -260,6 +260,7 @@ const HostingFeatures = () => {
 			<div className="hosting-features__cards">
 				{ promoCards.map( ( card ) => (
 					<PromoCard
+						key={ card.title }
 						title={ card.title }
 						text={ card.text }
 						supportContext={ card.supportContext }

--- a/client/hosting/hosting-features/components/style.scss
+++ b/client/hosting/hosting-features/components/style.scss
@@ -8,30 +8,3 @@
 		margin-top: 0;
 	}
 }
-
-.hosting-features__cards {
-	display: grid;
-	grid-template-columns: 1fr;
-	grid-column-gap: 16px;
-	grid-row-gap: 16px;
-	padding: 0 20px;
-	@include break-medium {
-		grid-template-columns: 1fr 1fr 1fr;
-		padding: 0;
-	}
-}
-
-.hosting-features__card {
-	> p {
-		font-size: rem(14px);
-		margin-bottom: 20px;
-		color: var(--color-text-subtle);
-		flex-grow: 1;
-	}
-
-	> a {
-		font-size: rem(13px);
-		font-weight: 400;
-		line-height: 16px;
-	}
-}

--- a/client/hosting/hosting-features/components/style.scss
+++ b/client/hosting/hosting-features/components/style.scss
@@ -2,35 +2,10 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.hosting-features__hero {
-	grid-column: 1 / -1;
-	text-align: center;
-	margin-bottom: 70px;
-
-	> h1 {
-		margin-top: 30px;
-		font-style: normal;
-		font-weight: 500;
-		font-size: rem(36px);
-		font-family: Recoleta, sans-serif;
-	}
-	> p {
-		font-style: normal;
-		font-weight: 400;
-		font-size: rem(18px);
-	}
-	.hosting-features__button {
-		margin: 0 5px;
-		padding: 10px 14px;
-		font-size: rem(14px);
-		height: 40px;
-	}
-
-	.hosting-features__content-spinner {
-		margin-top: 16px;
-		& + h1 {
-			margin-top: 0;
-		}
+.hosting-features__content-spinner {
+	margin-top: 16px;
+	& + h1 {
+		margin-top: 0;
 	}
 }
 

--- a/client/hosting/overview/components/hosting-overview.tsx
+++ b/client/hosting/overview/components/hosting-overview.tsx
@@ -5,15 +5,21 @@ import ActiveDomainsCard from 'calypso/hosting/overview/components/active-domain
 import PlanCard from 'calypso/hosting/overview/components/plan-card';
 import QuickActionsCard from 'calypso/hosting/overview/components/quick-actions-card';
 import SiteBackupCard from 'calypso/hosting/overview/components/site-backup-card';
-import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils';
+import { isNotAtomicJetpack, isMigrationInProgress } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import MigrationOverview from './migration-overview';
 import SupportCard from './support-card';
 
 import './style.scss';
 
 const HostingOverview: FC = () => {
 	const site = useSelector( getSelectedSite );
+
+	if ( site && isMigrationInProgress( site ) ) {
+		return <MigrationOverview site={ site } />;
+	}
+
 	const isJetpackNotAtomic = site && isNotAtomicJetpack( site );
 	const subtitle = isJetpackNotAtomic
 		? translate( 'Get a quick glance at your plans and upgrades.' )

--- a/client/hosting/overview/components/hosting-overview.tsx
+++ b/client/hosting/overview/components/hosting-overview.tsx
@@ -5,7 +5,11 @@ import ActiveDomainsCard from 'calypso/hosting/overview/components/active-domain
 import PlanCard from 'calypso/hosting/overview/components/plan-card';
 import QuickActionsCard from 'calypso/hosting/overview/components/quick-actions-card';
 import SiteBackupCard from 'calypso/hosting/overview/components/site-backup-card';
-import { isNotAtomicJetpack, isMigrationInProgress } from 'calypso/sites-dashboard/utils';
+import {
+	isNotAtomicJetpack,
+	isMigrationInProgress,
+	getMigrationStatus,
+} from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import MigrationOverview from './migration-overview';
@@ -16,7 +20,7 @@ import './style.scss';
 const HostingOverview: FC = () => {
 	const site = useSelector( getSelectedSite );
 
-	if ( site && isMigrationInProgress( site ) ) {
+	if ( site && isMigrationInProgress( site ) && getMigrationStatus( site ) === 'pending' ) {
 		return <MigrationOverview site={ site } />;
 	}
 

--- a/client/hosting/overview/components/migration-overview.tsx
+++ b/client/hosting/overview/components/migration-overview.tsx
@@ -1,4 +1,4 @@
-import { isFreePlanProduct } from '@automattic/calypso-products';
+import { canInstallPlugins } from '@automattic/sites';
 import { translate } from 'i18n-calypso';
 import { HostingCard, HostingCardGrid } from 'calypso/components/hosting-card';
 import { HostingHero, HostingHeroButton } from 'calypso/components/hosting-hero';
@@ -43,8 +43,6 @@ const MigrationOverview = ( { site }: { site: SiteDetails } ) => {
 	if ( getMigrationStatus( site ) === 'pending' ) {
 		const migrationType = getMigrationType( site );
 
-		const isFreePlan = site.plan && isFreePlanProduct( site.plan );
-
 		const baseQueryArgs = {
 			siteId: site.ID,
 			siteSlug: site.slug,
@@ -54,7 +52,7 @@ const MigrationOverview = ( { site }: { site: SiteDetails } ) => {
 
 		let continueMigrationUrl;
 
-		if ( isFreePlan ) {
+		if ( ! canInstallPlugins( site ) ) {
 			// For the flows where the checkout is after the choice.
 			switch ( migrationType ) {
 				case 'diy':

--- a/client/hosting/overview/components/migration-overview.tsx
+++ b/client/hosting/overview/components/migration-overview.tsx
@@ -3,7 +3,7 @@ import { translate } from 'i18n-calypso';
 import { HostingCard, HostingCardGrid } from 'calypso/components/hosting-card';
 import { HostingHero, HostingHeroButton } from 'calypso/components/hosting-hero';
 import { addQueryArgs } from 'calypso/lib/url';
-import { getMigrationStatus, getMigrationType } from 'calypso/sites-dashboard/utils';
+import { getMigrationType } from 'calypso/sites-dashboard/utils';
 import type { SiteDetails } from '@automattic/data-stores';
 
 const cards = [
@@ -40,93 +40,91 @@ const cards = [
 ];
 
 const MigrationOverview = ( { site }: { site: SiteDetails } ) => {
-	if ( getMigrationStatus( site ) === 'pending' ) {
-		const migrationType = getMigrationType( site );
+	const migrationType = getMigrationType( site );
 
-		const baseQueryArgs = {
-			siteId: site.ID,
-			siteSlug: site.slug,
-			start: 'true',
-			ref: 'hosting-migration-overview',
-		};
+	const baseQueryArgs = {
+		siteId: site.ID,
+		siteSlug: site.slug,
+		start: 'true',
+		ref: 'hosting-migration-overview',
+	};
 
-		let continueMigrationUrl;
+	let continueMigrationUrl;
 
-		if ( ! canInstallPlugins( site ) ) {
-			// For the flows where the checkout is after the choice.
-			switch ( migrationType ) {
-				case 'diy':
-					continueMigrationUrl = addQueryArgs(
-						{
-							...baseQueryArgs,
-							destination: 'upgrade',
-							how: 'myself',
-						},
-						'/setup/site-migration/site-migration-upgrade-plan'
-					);
-					break;
-				case 'difm':
-					continueMigrationUrl = addQueryArgs(
-						{
-							...baseQueryArgs,
-							destination: 'upgrade',
-							how: 'difm',
-						},
-						'/setup/site-migration/site-migration-upgrade-plan'
-					);
-					break;
-				default:
-					continueMigrationUrl = addQueryArgs(
-						baseQueryArgs,
-						'/setup/site-migration/site-migration-how-to-migrate'
-					);
-			}
-		} else {
-			// For the /setup/migration, where the checkout is before the choice.
-			switch ( migrationType ) {
-				case 'diy':
-					continueMigrationUrl = addQueryArgs(
-						baseQueryArgs,
-						'/setup/migration/site-migration-instructions'
-					);
-					break;
-				case 'difm':
-					continueMigrationUrl = addQueryArgs(
-						baseQueryArgs,
-						'/setup/migration/site-migration-credentials'
-					);
-					break;
-				default:
-					continueMigrationUrl = addQueryArgs(
-						baseQueryArgs,
-						'/setup/migration/migration-how-to-migrate'
-					);
-			}
+	if ( ! canInstallPlugins( site ) ) {
+		// For the flows where the checkout is after the choice.
+		switch ( migrationType ) {
+			case 'diy':
+				continueMigrationUrl = addQueryArgs(
+					{
+						...baseQueryArgs,
+						destination: 'upgrade',
+						how: 'myself',
+					},
+					'/setup/site-migration/site-migration-upgrade-plan'
+				);
+				break;
+			case 'difm':
+				continueMigrationUrl = addQueryArgs(
+					{
+						...baseQueryArgs,
+						destination: 'upgrade',
+						how: 'difm',
+					},
+					'/setup/site-migration/site-migration-upgrade-plan'
+				);
+				break;
+			default:
+				continueMigrationUrl = addQueryArgs(
+					baseQueryArgs,
+					'/setup/site-migration/site-migration-how-to-migrate'
+				);
 		}
-
-		return (
-			<div>
-				<HostingHero>
-					<h1>{ translate( 'Your WordPress site is ready to be migrated' ) }</h1>
-					<p>
-						{ translate(
-							'Start your migration today and get ready for unmatched WordPress hosting.'
-						) }
-					</p>
-					<HostingHeroButton href={ continueMigrationUrl }>
-						{ translate( 'Start your migration' ) }
-					</HostingHeroButton>
-				</HostingHero>
-				<HostingCardGrid>
-					{ cards.map( ( { title, text } ) => (
-						<HostingCard inGrid key={ title } title={ title }>
-							<p>{ text }</p>
-						</HostingCard>
-					) ) }
-				</HostingCardGrid>
-			</div>
-		);
+	} else {
+		// For the /setup/migration, where the checkout is before the choice.
+		switch ( migrationType ) {
+			case 'diy':
+				continueMigrationUrl = addQueryArgs(
+					baseQueryArgs,
+					'/setup/migration/site-migration-instructions'
+				);
+				break;
+			case 'difm':
+				continueMigrationUrl = addQueryArgs(
+					baseQueryArgs,
+					'/setup/migration/site-migration-credentials'
+				);
+				break;
+			default:
+				continueMigrationUrl = addQueryArgs(
+					baseQueryArgs,
+					'/setup/migration/migration-how-to-migrate'
+				);
+		}
 	}
+
+	return (
+		<div>
+			<HostingHero>
+				<h1>{ translate( 'Your WordPress site is ready to be migrated' ) }</h1>
+				<p>
+					{ translate(
+						'Start your migration today and get ready for unmatched WordPress hosting.'
+					) }
+				</p>
+				<HostingHeroButton href={ continueMigrationUrl }>
+					{ translate( 'Start your migration' ) }
+				</HostingHeroButton>
+			</HostingHero>
+			<HostingCardGrid>
+				{ cards.map( ( { title, text } ) => (
+					<HostingCard inGrid key={ title } title={ title }>
+						<p>{ text }</p>
+					</HostingCard>
+				) ) }
+			</HostingCardGrid>
+		</div>
+	);
 };
 
 export default MigrationOverview;

--- a/client/hosting/overview/components/migration-overview.tsx
+++ b/client/hosting/overview/components/migration-overview.tsx
@@ -1,0 +1,82 @@
+import { translate } from 'i18n-calypso';
+import { HostingCard, HostingCardGrid } from 'calypso/components/hosting-card';
+import { HostingHero, HostingHeroButton } from 'calypso/components/hosting-hero';
+import { getMigrationStatus, getMigrationType } from 'calypso/sites-dashboard/utils';
+import type { SiteDetails } from '@automattic/data-stores';
+
+const cards = [
+	{
+		title: translate( 'Seriously secure' ),
+		text: translate(
+			'Firewalls, encryption, brute force, and DDoS protection. Your security’s all taken care of so you can stay one step ahead of any threats.'
+		),
+	},
+	{
+		title: translate( 'Unmetered bandwidth' ),
+		text: translate(
+			'With 99.999% uptime and entirely unmetered bandwidth and traffic on every plan, you’ll never need to worry about being too successful.'
+		),
+	},
+	{
+		title: translate( 'Power, meet performance' ),
+		text: translate(
+			'Our custom 28+ location CDN and 99.999% uptime ensure your site is always fast and always available from anywhere in the world.'
+		),
+	},
+	{
+		title: translate( 'Plugins, themes, and custom code' ),
+		text: translate(
+			'Build anything with full support and automatic updates for 50,000+ plugins and themes. Or start from scratch with your own custom code.'
+		),
+	},
+	{
+		title: translate( 'Expert support' ),
+		text: translate(
+			'Whenever you’re stuck, whatever you’re trying to make happen – our Happiness Engineers have the answers.'
+		),
+	},
+];
+
+const MigrationOverview = ( { site }: { site: SiteDetails } ) => {
+	if ( getMigrationStatus( site ) === 'pending' ) {
+		let continueMigrationUrl = 'https://wordpress.com';
+		const migrationType = getMigrationType( site );
+
+		// TODO: Fix links. It should also check if the user already purchased a plan to redirect to the proper step in the proper flow.
+		switch ( migrationType ) {
+			case 'diy':
+				continueMigrationUrl = 'https://wordpress.com/diy';
+				break;
+			case 'difm':
+				continueMigrationUrl = 'https://wordpress.com/difm';
+				break;
+			default:
+				continueMigrationUrl = 'https://wordpress.com/pending';
+		}
+
+		return (
+			<div>
+				<HostingHero>
+					<h1>{ translate( 'Your WordPress site is ready to be migrated' ) }</h1>
+					<p>
+						{ translate(
+							'Start your migration today and get ready for unmatched WordPress hosting.'
+						) }
+					</p>
+					<HostingHeroButton href={ continueMigrationUrl }>
+						{ translate( 'Start your migration' ) }
+					</HostingHeroButton>
+				</HostingHero>
+				<HostingCardGrid>
+					{ cards.map( ( { title, text } ) => (
+						<HostingCard inGrid key={ title } title={ title }>
+							<p>{ text }</p>
+						</HostingCard>
+					) ) }
+				</HostingCardGrid>
+			</div>
+		);
+	}
+};
+
+export default MigrationOverview;

--- a/client/hosting/overview/components/migration-overview.tsx
+++ b/client/hosting/overview/components/migration-overview.tsx
@@ -1,6 +1,7 @@
 import { translate } from 'i18n-calypso';
 import { HostingCard, HostingCardGrid } from 'calypso/components/hosting-card';
 import { HostingHero, HostingHeroButton } from 'calypso/components/hosting-hero';
+import { addQueryArgs } from 'calypso/lib/url';
 import { getMigrationStatus, getMigrationType } from 'calypso/sites-dashboard/utils';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -42,16 +43,31 @@ const MigrationOverview = ( { site }: { site: SiteDetails } ) => {
 		let continueMigrationUrl = 'https://wordpress.com';
 		const migrationType = getMigrationType( site );
 
+		const queryArgs = {
+			siteId: site.ID,
+			siteSlug: site.slug,
+			ref: 'hosting-migration-overview',
+		};
+
 		// TODO: Fix links. It should also check if the user already purchased a plan to redirect to the proper step in the proper flow.
 		switch ( migrationType ) {
 			case 'diy':
-				continueMigrationUrl = 'https://wordpress.com/diy';
+				continueMigrationUrl = addQueryArgs(
+					queryArgs,
+					'/setup/migration/migration-how-to-migrate'
+				);
 				break;
 			case 'difm':
-				continueMigrationUrl = 'https://wordpress.com/difm';
+				continueMigrationUrl = addQueryArgs(
+					queryArgs,
+					'/setup/migration/site-migration-credentials'
+				);
 				break;
 			default:
-				continueMigrationUrl = 'https://wordpress.com/pending';
+				continueMigrationUrl = addQueryArgs(
+					queryArgs,
+					'/setup/migration/migration-how-to-migrate'
+				);
 		}
 
 		return (

--- a/client/hosting/overview/components/migration-overview.tsx
+++ b/client/hosting/overview/components/migration-overview.tsx
@@ -87,7 +87,7 @@ const MigrationOverview = ( { site }: { site: SiteDetails } ) => {
 				case 'diy':
 					continueMigrationUrl = addQueryArgs(
 						baseQueryArgs,
-						'/setup/migration/migration-how-to-migrate'
+						'/setup/migration/site-migration-instructions'
 					);
 					break;
 				case 'difm':

--- a/client/hosting/overview/components/migration-overview.tsx
+++ b/client/hosting/overview/components/migration-overview.tsx
@@ -48,6 +48,7 @@ const MigrationOverview = ( { site }: { site: SiteDetails } ) => {
 		const baseQueryArgs = {
 			siteId: site.ID,
 			siteSlug: site.slug,
+			start: 'true',
 			ref: 'hosting-migration-overview',
 		};
 

--- a/client/hosting/overview/components/test/migration-overview.tsx
+++ b/client/hosting/overview/components/test/migration-overview.tsx
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isFreePlanProduct, PLAN_FREE } from '@automattic/calypso-products';
+import { render } from '@testing-library/react';
+import { getMigrationStatus, getMigrationType } from 'calypso/sites-dashboard/utils';
+import MigrationOverview from '../migration-overview';
+import type { SiteDetails, SiteDetailsPlan } from '@automattic/data-stores';
+
+jest.mock( 'calypso/sites-dashboard/utils' );
+jest.mock( '@automattic/calypso-products' );
+
+describe( 'MigrationOverview', () => {
+	const site = {
+		ID: 123,
+		slug: 'example.com',
+		plan: { product_slug: PLAN_FREE } as SiteDetailsPlan,
+	} as SiteDetails;
+
+	beforeEach( () => {
+		( getMigrationStatus as jest.Mock ).mockReturnValue( 'pending' );
+	} );
+
+	it.each( [
+		[
+			'diy',
+			true,
+			'/setup/site-migration/site-migration-upgrade-plan?siteId=123&siteSlug=example.com&start=true&ref=hosting-migration-overview&destination=upgrade&how=myself',
+		],
+		[
+			'difm',
+			true,
+			'/setup/site-migration/site-migration-upgrade-plan?siteId=123&siteSlug=example.com&start=true&ref=hosting-migration-overview&destination=upgrade&how=difm',
+		],
+		[
+			undefined,
+			true,
+			'/setup/site-migration/site-migration-how-to-migrate?siteId=123&siteSlug=example.com&start=true&ref=hosting-migration-overview',
+		],
+		[
+			'diy',
+			false,
+			'/setup/migration/migration-how-to-migrate?siteId=123&siteSlug=example.com&start=true&ref=hosting-migration-overview',
+		],
+		[
+			'difm',
+			false,
+			'/setup/migration/site-migration-credentials?siteId=123&siteSlug=example.com&start=true&ref=hosting-migration-overview',
+		],
+		[
+			undefined,
+			false,
+			'/setup/migration/migration-how-to-migrate?siteId=123&siteSlug=example.com&start=true&ref=hosting-migration-overview',
+		],
+	] )(
+		'should set continueMigrationUrl correctly for migrationType: %s and isFreePlan: %s',
+		( migrationType, isFreePlan, expectedUrl ) => {
+			( getMigrationType as jest.Mock ).mockReturnValue( migrationType );
+			( isFreePlanProduct as jest.Mock ).mockReturnValue( isFreePlan );
+
+			const { getByText } = render( <MigrationOverview site={ site } /> );
+			const button = getByText( 'Start your migration' );
+
+			expect( button ).toHaveAttribute( 'href', expectedUrl );
+		}
+	);
+} );

--- a/client/hosting/overview/components/test/migration-overview.tsx
+++ b/client/hosting/overview/components/test/migration-overview.tsx
@@ -34,7 +34,7 @@ describe( 'MigrationOverview', () => {
 		[
 			'diy',
 			true,
-			'/setup/migration/migration-how-to-migrate?siteId=123&siteSlug=example.com&start=true&ref=hosting-migration-overview',
+			'/setup/migration/site-migration-instructions?siteId=123&siteSlug=example.com&start=true&ref=hosting-migration-overview',
 		],
 		[
 			'difm',

--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -479,6 +479,7 @@
 			margin-top: 0;
 			margin-left: 0;
 			margin-right: 0;
+			margin-bottom: auto;
 			padding-top: 0;
 			padding-left: 0;
 			padding-right: 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,4 +1,5 @@
 import { StepContainer } from '@automattic/onboarding';
+import { canInstallPlugins } from '@automattic/sites';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,5 +1,4 @@
 import { StepContainer } from '@automattic/onboarding';
-import { canInstallPlugins } from '@automattic/sites';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -1,6 +1,7 @@
 import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { BadgeType } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
+import { canInstallPlugins } from '@automattic/sites';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -47,14 +48,10 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 	const shouldDisplayHostIdentificationMessage =
 		! hostingProviderDetails.is_unknown && ! hostingProviderDetails.is_a8c;
 
-	const canInstallPlugins = site?.plan?.features?.active.find(
-		( feature ) => feature === 'install-plugins'
-	)
-		? true
-		: false;
+	const siteCanInstallPlugins = canInstallPlugins( site );
 
 	const handleClick = ( destination: string ) => {
-		if ( destination === 'migrate' && ! canInstallPlugins ) {
+		if ( destination === 'migrate' && ! siteCanInstallPlugins ) {
 			return navigation.submit?.( { destination: 'upgrade' } );
 		}
 

--- a/client/sites-dashboard/test/utils.js
+++ b/client/sites-dashboard/test/utils.js
@@ -1,5 +1,4 @@
-import { isMigrationInProgress } from 'calypso/sites-dashboard/utils';
-import { getMigrationStatus, getMigrationType } from '../utils'; // Adjust the import path as necessary
+import { getMigrationStatus, getMigrationType, isMigrationInProgress } from '../utils'; // Adjust the import path as necessary
 
 describe( 'isMigrationInProgress', () => {
 	it.each( [

--- a/client/sites-dashboard/test/utils.js
+++ b/client/sites-dashboard/test/utils.js
@@ -1,4 +1,5 @@
 import { isMigrationInProgress } from 'calypso/sites-dashboard/utils';
+import { getMigrationStatus, getMigrationType } from '../utils'; // Adjust the import path as necessary
 
 describe( 'isMigrationInProgress', () => {
 	it.each( [
@@ -15,4 +16,62 @@ describe( 'isMigrationInProgress', () => {
 	] )( 'returns true when the migration is in progress', ( { site } ) => {
 		expect( isMigrationInProgress( site ) ).toBe( true );
 	} );
+} );
+
+describe( 'getMigrationStatus', () => {
+	it.each( [
+		{
+			site: { site_migration: { migration_status: 'migration-started-anything' } },
+			expected: 'started',
+		},
+		{
+			site: { site_migration: { migration_status: 'migration-pending-anything' } },
+			expected: 'pending',
+		},
+		{
+			site: { site_migration: { migration_status: 'migration-completed-anything' } },
+			expected: 'completed',
+		},
+		{
+			site: { site_migration: { migration_status: 'migration-unknown-anything' } },
+			expected: undefined,
+		},
+		{
+			site: { site_migration: {} },
+			expected: undefined,
+		},
+		{
+			site: {},
+			expected: undefined,
+		},
+	] )(
+		'returns $expected for migration status $site.site_migration.migration_status',
+		( { site, expected } ) => {
+			expect( getMigrationStatus( site ) ).toBe( expected );
+		}
+	);
+} );
+
+describe( 'getMigrationType', () => {
+	it.each( [
+		{ site: { site_migration: { migration_status: 'migration-anything-diy' } }, expected: 'diy' },
+		{ site: { site_migration: { migration_status: 'migration-anything-difm' } }, expected: 'difm' },
+		{
+			site: { site_migration: { migration_status: 'migration-anything-unknown' } },
+			expected: undefined,
+		},
+		{
+			site: { site_migration: {} },
+			expected: undefined,
+		},
+		{
+			site: {},
+			expected: undefined,
+		},
+	] )(
+		'returns $expected for migration status $site.site_migration.migration_status',
+		( { site, expected } ) => {
+			expect( getMigrationType( site ) ).toBe( expected );
+		}
+	);
 } );

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -80,6 +80,38 @@ export const isMigrationInProgress = ( site: SiteExcerptData ): boolean => {
 	return ! migrationStatus.startsWith( 'migration-completed' );
 };
 
+export const getMigrationStatus = (
+	site: SiteExcerptData
+): 'pending' | 'started' | 'completed' | undefined => {
+	const migrationStatus = site?.site_migration?.migration_status;
+	if ( ! migrationStatus ) {
+		return undefined;
+	}
+
+	const status = migrationStatus.split( '-' )[ 1 ];
+
+	if ( ! [ 'pending', 'started', 'completed' ].includes( status ) ) {
+		return undefined;
+	}
+
+	return status as 'pending' | 'started' | 'completed';
+};
+
+export const getMigrationType = ( site: SiteExcerptData ): 'diy' | 'difm' | undefined => {
+	const migrationStatus = site?.site_migration?.migration_status;
+	if ( ! migrationStatus ) {
+		return undefined;
+	}
+
+	const type = migrationStatus.split( '-' )[ 2 ];
+
+	if ( ! [ 'difm', 'diy' ].includes( type ) ) {
+		return undefined;
+	}
+
+	return type as 'diy' | 'difm';
+};
+
 export const isHostingTrialSite = ( site: SiteExcerptNetworkData ) => {
 	return site?.plan?.product_slug === PLAN_HOSTING_TRIAL_MONTHLY;
 };

--- a/packages/sites/src/can-install-plugins.ts
+++ b/packages/sites/src/can-install-plugins.ts
@@ -1,0 +1,7 @@
+import type { SiteExcerptData } from '@automattic/sites';
+
+export function canInstallPlugins( site: SiteExcerptData | null ): boolean {
+	return site?.plan?.features?.active.find( ( feature ) => feature === 'install-plugins' )
+		? true
+		: false;
+}

--- a/packages/sites/src/can-install-plugins.ts
+++ b/packages/sites/src/can-install-plugins.ts
@@ -1,4 +1,4 @@
-import type { SiteExcerptData } from '@automattic/sites';
+import type { SiteExcerptData } from './site-excerpt-types';
 
 export function canInstallPlugins( site: SiteExcerptData | null ): boolean {
 	return site?.plan?.features?.active.find( ( feature ) => feature === 'install-plugins' )

--- a/packages/sites/src/index.ts
+++ b/packages/sites/src/index.ts
@@ -19,3 +19,4 @@ export {
 } from './site-excerpt-constants';
 export type { SiteExcerptData, SiteExcerptNetworkData } from './site-excerpt-types';
 export { getSiteLaunchStatus, useSiteLaunchStatusLabel } from './site-status';
+export { canInstallPlugins } from './can-install-plugins';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95379 and #95380

## Proposed Changes

* Extract some components from the "Hosting Features" tab, so we can reuse it.
* It customizes the Sites overview with a button to continue the migration when it's pending.
* The button contains a `ref` as `hosting-migration-overview`, so we can identify when the user is coming from this page.

#### This PR Doesn't Include

* Disable other tabs from the menu.
* Update the header when navigating to the site, similar to the changes we have in the listing.

@donnapep, do you think it's fine to deploy it as it is and implement these other parts in other PRs? I think one issue would be fine for both changes. I'll wait for your answer to then create the new issue, otherwise, I'll continue working on this one.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to offer a way for the users to continue their migration if they stopped in the middle.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If https://github.com/Automattic/wp-calypso/pull/95413 wasn't merged yet, merge it into this branch to make tests more real and easier.
* Navigate to the flow `/setup/migration`.
* Navigate until the "How to migrate" step.
* Navigate to `/sites`.
* Click on the site, and click on "Start your migration".
* Make sure you navigate back to where you were in the flow.
* Click on the "Do it for me" option.
* Navigate again to the `/sites` and click on "Start your migration".
* Make sure you navigate back to your choice.
* Return one step and choose the "Do it myself".
* Navigate to the `/sites`.
* Check that you won't see the button because it changes quickly to the "started" status that will be implemented as part of https://github.com/Automattic/wp-calypso/issues/95383.
* Now repeat the tests using the flow `/setup/hosted-site-migration` and make sure it works properly.

## Screenshots

<img width="1399" alt="Screenshot 2024-10-18 at 18 40 00" src="https://github.com/user-attachments/assets/ec499f54-0781-46c9-b52d-19e7d5e5e741">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
