### PR TITLE
Plugins: remove the wp-fusion-lite plugin

### DIFF
--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -78,4 +78,4 @@ export const ECOMMERCE_BUNDLED_PLUGINS = [
 	'mailpoet-business',
 ];
 
-export const UNLISTED_PLUGINS = [ 'automated-db-schenker-shipping' ];
+export const UNLISTED_PLUGINS = [ 'automated-db-schenker-shipping', 'wp-fusion-lite' ];

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -14,7 +14,7 @@ import usePlugins from '../use-plugins';
 /**
  * Module variables
  */
-const PLUGIN_SLUGS_BLOCKLIST = [];
+const PLUGIN_SLUGS_BLOCKLIST = [ 'wp-fusion-lite' ];
 
 function isNotBlocked( plugin ) {
 	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -7,17 +7,13 @@ import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
 import UpgradeNudge from 'calypso/my-sites/plugins/plugins-discovery-page/upgrade-nudge';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { UNLISTED_PLUGINS } from '../constants';
 import ClearSearchButton from '../plugins-browser/clear-search-button';
 import { PaidPluginsSection } from '../plugins-discovery-page';
 import usePlugins from '../use-plugins';
 
-/**
- * Module variables
- */
-const PLUGIN_SLUGS_BLOCKLIST = [ 'wp-fusion-lite' ];
-
 function isNotBlocked( plugin ) {
-	return PLUGIN_SLUGS_BLOCKLIST.indexOf( plugin.slug ) === -1;
+	return UNLISTED_PLUGINS.indexOf( plugin.slug ) === -1;
 }
 
 const PluginsSearchResultPage = ( {


### PR DESCRIPTION
## Proposed Changes

Delist the plugin with slug `wp-fusion-lite` from the plugin search and the Plugin details page.

## Why are these changes being made?

p1729195801390409-slack-C02JPCHEKDY

## Testing Instructions

* Go to `/plugins?s=wp-fusion-lite` and check the `wp-fusion-lite` is not displayed there
* Go to `/plugins/wp-fusion-lite` and guarantee you see a not found page

## Production

https://github.com/user-attachments/assets/250340c0-41ea-488c-9415-6221938e901c

### This branch

https://github.com/user-attachments/assets/37b94d95-2e13-424c-a2b8-a6e650f66dfc

