### PR TITLE
Performance Profiler: Fix accordion styling

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-accordion/styles.scss
+++ b/client/performance-profiler/components/core-web-vitals-accordion/styles.scss
@@ -82,7 +82,6 @@ $blueberry-color: #3858e9;
 			border-top-right-radius: 6px !important;
 
 			border-top: 1px solid var(--studio-gray-5) !important;
-			
 		}
 
 		&.foldable-card {

--- a/client/performance-profiler/components/core-web-vitals-accordion/styles.scss
+++ b/client/performance-profiler/components/core-web-vitals-accordion/styles.scss
@@ -31,7 +31,7 @@ $blueberry-color: #3858e9;
 				border-bottom-left-radius: 6px;
 			}
 
-			&:nth-child(2) {
+			&:nth-child(1) {
 				/* stylelint-disable-next-line scales/radii */
 				border-top-left-radius: 6px;
 				/* stylelint-disable-next-line scales/radii */
@@ -47,7 +47,7 @@ $blueberry-color: #3858e9;
 			&:not(.is-expanded) {
 				border-bottom: 1px solid var(--studio-gray-5);
 
-				&:not(:nth-child(-n+2)) {
+				&:not(:nth-child(-n+1)) {
 					border-top: none;
 				}
 			}
@@ -62,7 +62,7 @@ $blueberry-color: #3858e9;
 				}
 			}
 
-			&.is-expanded:not(:nth-child(-n+2)) {
+			&.is-expanded:not(:nth-child(-n+1)) {
 				border-top: none;
 			}
 		}
@@ -73,6 +73,16 @@ $blueberry-color: #3858e9;
 
 		.card.is-compact {
 			margin-bottom: 24px;
+		}
+
+		+ .card.foldable-card {
+			/* stylelint-disable-next-line scales/radii */
+			border-top-left-radius: 6px !important;
+			/* stylelint-disable-next-line scales/radii */
+			border-top-right-radius: 6px !important;
+
+			border-top: 1px solid var(--studio-gray-5) !important;
+			
 		}
 
 		&.foldable-card {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
PR makes the accordion display the same for both versions of the performance profiler

*Adjust styling so it works for both versions

**Before**
![image](https://github.com/user-attachments/assets/28173d59-386a-4edf-9db8-d705869ca309)

**After**
![image](https://github.com/user-attachments/assets/cac9db79-037c-4a21-9d21-a8d0a0ade5a3)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Have consistency across both versions

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test that the accordion is the same for both versions
* Logged-in: `/sites/performance/`
* Logged-out: `/speed-test-tool` 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
