### PR TITLE
Odyssey Stats: Try direct public api calls

### DIFF
--- a/apps/odyssey-stats/src/lib/create-odyssey-config.ts
+++ b/apps/odyssey-stats/src/lib/create-odyssey-config.ts
@@ -109,8 +109,7 @@ export class ConfigApi extends Function {
 	// Copied from https://github.com/Automattic/wp-calypso/blob/ca7d8fe3e0a5fb87b0659fbab659078ebbfbc7be/apps/odyssey-stats/src/load-config.js
 	_overrideConfigDataFeatures() {
 		// Set is_running_in_jetpack_site to true if not specified (undefined or null).
-		productionConfig.features.is_running_in_jetpack_site =
-			this.configData.features?.is_running_in_jetpack_site ?? true;
+		productionConfig.features.is_running_in_jetpack_site = false;
 
 		// The option enables loading of the whole translation file, and could be optimized by setting it to `true`, which needs the translation chunks in place.
 		// @see https://github.com/Automattic/wp-calypso/blob/trunk/docs/translation-chunks.md

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -189,18 +189,18 @@ module.exports = {
 			/^calypso\/components\/formatted-header$/,
 			'calypso/components/jetpack/jetpack-header'
 		),
-		new webpack.NormalModuleReplacementPlugin(
-			/^calypso\/components\/data\/query-site-purchases$/,
-			path.resolve( __dirname, 'src/components/odyssey-query-site-purchases' )
-		),
-		new webpack.NormalModuleReplacementPlugin(
-			/^calypso\/components\/data\/query-products-list$/,
-			path.resolve( __dirname, 'src/components/odyssey-query-products' )
-		),
-		new webpack.NormalModuleReplacementPlugin(
-			/^calypso\/components\/data\/query-memberships$/,
-			path.resolve( __dirname, 'src/components/odyssey-query-memberships' )
-		),
+		// new webpack.NormalModuleReplacementPlugin(
+		// 	/^calypso\/components\/data\/query-site-purchases$/,
+		// 	path.resolve( __dirname, 'src/components/odyssey-query-site-purchases' )
+		// ),
+		// new webpack.NormalModuleReplacementPlugin(
+		// 	/^calypso\/components\/data\/query-products-list$/,
+		// 	path.resolve( __dirname, 'src/components/odyssey-query-products' )
+		// ),
+		// new webpack.NormalModuleReplacementPlugin(
+		// 	/^calypso\/components\/data\/query-memberships$/,
+		// 	path.resolve( __dirname, 'src/components/odyssey-query-memberships' )
+		// ),
 		...excludedPackagePlugins,
 		shouldEmitStats &&
 			new BundleAnalyzerPlugin( {

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -13,26 +13,26 @@ const debug = debugFactory( 'calypso:wp' );
 
 let wpcom;
 
-// if ( config.isEnabled( 'oauth' ) ) {
-// 	wpcom = new WPCOM( oauthToken.getToken(), wpcomXhrWrapper );
-// } else if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-// 	wpcom = new WPCOM( jetpack_site_xhr_wrapper );
-// } else {
-wpcom = new WPCOM( wpcomProxyRequest );
+if ( config.isEnabled( 'oauth' ) ) {
+	wpcom = new WPCOM( oauthToken.getToken(), wpcomXhrWrapper );
+} else if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+	wpcom = new WPCOM( jetpack_site_xhr_wrapper );
+} else {
+	wpcom = new WPCOM( wpcomProxyRequest );
 
-// Upgrade to "access all users blogs" mode
-wpcom.request(
-	{
-		metaAPI: { accessAllUsersBlogs: true },
-	},
-	function ( error ) {
-		if ( error ) {
-			throw error;
+	// Upgrade to "access all users blogs" mode
+	wpcom.request(
+		{
+			metaAPI: { accessAllUsersBlogs: true },
+		},
+		function ( error ) {
+			if ( error ) {
+				throw error;
+			}
+			debug( 'Proxy now running in "access all user\'s blogs" mode' );
 		}
-		debug( 'Proxy now running in "access all user\'s blogs" mode' );
-	}
-);
-// }
+	);
+}
 
 wpcom = wpcomSupport( wpcom );
 

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -13,26 +13,26 @@ const debug = debugFactory( 'calypso:wp' );
 
 let wpcom;
 
-if ( config.isEnabled( 'oauth' ) ) {
-	wpcom = new WPCOM( oauthToken.getToken(), wpcomXhrWrapper );
-} else if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-	wpcom = new WPCOM( jetpack_site_xhr_wrapper );
-} else {
-	wpcom = new WPCOM( wpcomProxyRequest );
+// if ( config.isEnabled( 'oauth' ) ) {
+// 	wpcom = new WPCOM( oauthToken.getToken(), wpcomXhrWrapper );
+// } else if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+// 	wpcom = new WPCOM( jetpack_site_xhr_wrapper );
+// } else {
+wpcom = new WPCOM( wpcomProxyRequest );
 
-	// Upgrade to "access all users blogs" mode
-	wpcom.request(
-		{
-			metaAPI: { accessAllUsersBlogs: true },
-		},
-		function ( error ) {
-			if ( error ) {
-				throw error;
-			}
-			debug( 'Proxy now running in "access all user\'s blogs" mode' );
+// Upgrade to "access all users blogs" mode
+wpcom.request(
+	{
+		metaAPI: { accessAllUsersBlogs: true },
+	},
+	function ( error ) {
+		if ( error ) {
+			throw error;
 		}
-	);
-}
+		debug( 'Proxy now running in "access all user\'s blogs" mode' );
+	}
+);
+// }
 
 wpcom = wpcomSupport( wpcom );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
