### PR TITLE
Revert "Podcasting Settings: Don't show the plan upsell nudge if the plan already support audio upload"

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -31,14 +31,10 @@ import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 import { isSavingSiteSettings } from 'calypso/state/site-settings/selectors';
-import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
+import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isRequestingTermsForQueryIgnoringPage } from 'calypso/state/terms/selectors';
-import {
-	getSelectedSite,
-	getSelectedSiteId,
-	getSelectedSiteSlug,
-} from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PodcastFeedUrl from './feed-url';
 import PodcastingNoPermissionsMessage from './no-permissions';
 import PodcastingNotSupportedMessage from './not-supported';
@@ -170,20 +166,15 @@ class PodcastingDetails extends Component {
 	render() {
 		const {
 			handleSubmitForm,
-			site,
 			siteId,
 			translate,
-			isJetpack,
 			isPodcastingEnabled,
 			isSavingSettings,
 			plansDataLoaded,
 		} = this.props;
-
 		const { isCoverImageUploading } = this.state;
-		const isAudioUploadEnabled =
-			plansDataLoaded && ( site?.options?.upgraded_filetypes_enabled || isJetpack );
 
-		if ( ! site || ! siteId ) {
+		if ( ! siteId ) {
 			return null;
 		}
 
@@ -210,7 +201,7 @@ class PodcastingDetails extends Component {
 				/>
 
 				<form id="site-settings" onSubmit={ handleSubmitForm }>
-					{ ! error && plansDataLoaded && ! isAudioUploadEnabled && (
+					{ ! error && plansDataLoaded && (
 						<UpsellNudge
 							plan={ PLAN_PERSONAL }
 							title={ translate( 'Upload Audio with WordPress.com %(personalPlanName)s', {
@@ -437,7 +428,6 @@ const getFormSettings = ( settings ) => {
 };
 
 const connectComponent = connect( ( state, ownProps ) => {
-	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 
 	// The settings form wrapper gives us a string here, but inside this
@@ -463,9 +453,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 	const newPostUrl = `/post/${ siteSlug }`;
 
 	return {
-		site,
 		siteId,
-		isJetpack,
 		isPrivate: isPrivateSite( state, siteId ),
 		isComingSoon: isSiteComingSoon( state, siteId ),
 		isPodcastingEnabled,
@@ -476,7 +464,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 		isUnsupportedSite: isJetpack && ! isAutomatedTransfer,
 		isSavingSettings,
 		newPostUrl,
-		plansDataLoaded: hasLoadedSitePlansFromServer( state, siteId ),
+		plansDataLoaded: ! isRequestingSitePlans( state, siteId ),
 	};
 } );
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#95447