### PR TITLE
Social: Add "New" badge to Bluesky

### DIFF
--- a/client/my-sites/marketing/connections/services/bluesky.jsx
+++ b/client/my-sites/marketing/connections/services/bluesky.jsx
@@ -1,5 +1,16 @@
 import { SharingService, connectFor } from 'calypso/my-sites/marketing/connections/service';
 
-export class Bluesky extends SharingService {}
+export class Bluesky extends SharingService {
+	static propTypes = {
+		// This foreign propTypes access should be safe because we expect all of them to be removed
+		// eslint-disable-next-line react/forbid-foreign-prop-types
+		...SharingService.propTypes,
+	};
+
+	static defaultProps = {
+		...SharingService.defaultProps,
+		isNew: true,
+	};
+}
 
 export default connectFor( Bluesky, ( state, props ) => props );

--- a/client/my-sites/marketing/connections/services/threads.jsx
+++ b/client/my-sites/marketing/connections/services/threads.jsx
@@ -1,16 +1,5 @@
 import { SharingService, connectFor } from 'calypso/my-sites/marketing/connections/service';
 
-export class Threads extends SharingService {
-	static propTypes = {
-		// This foreign propTypes access should be safe because we expect all of them to be removed
-		// eslint-disable-next-line react/forbid-foreign-prop-types
-		...SharingService.propTypes,
-	};
-
-	static defaultProps = {
-		...SharingService.defaultProps,
-		isNew: true,
-	};
-}
+export class Threads extends SharingService {}
 
 export default connectFor( Threads, ( state, props ) => props );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add "New" badge to Bluesky
* Remove "New" badge from Threads

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Goto `/marketing/connections/:site`
* Confirm that you see the "New" badge for Bluesky
* Confirm that Threads no longer has the "New" badge

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

| Before | After |
|--------|--------|
| <img width="388" alt="Screenshot 2024-10-18 at 10 52 48 AM" src="https://github.com/user-attachments/assets/19476442-9a6b-409d-8b50-8268160f6cf1"> |<img width="388" alt="Screenshot 2024-10-18 at 10 53 48 AM" src="https://github.com/user-attachments/assets/bf21177d-90c0-4523-818a-8897982c391b"> | 