### PR TITLE
Stats: Clean up tooltip delay logic

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -64,6 +64,7 @@ class StatsNavigation extends Component {
 		showLock: PropTypes.bool,
 		hideModuleSettings: PropTypes.bool,
 		isNewSite: PropTypes.bool,
+		delayTooltipPresentation: PropTypes.bool,
 	};
 
 	state = {
@@ -150,7 +151,7 @@ class StatsNavigation extends Component {
 			statsAdminVersion,
 			showLock,
 			hideModuleSettings,
-			isNewSite,
+			delayTooltipPresentation,
 		} = this.props;
 		const { pageModules, isPageSettingsTooltipDismissed } = this.state;
 		const { label, showIntervals, path } = navItems[ selectedItem ];
@@ -167,11 +168,6 @@ class StatsNavigation extends Component {
 			!! ( statsAdminVersion && version_compare( statsAdminVersion, '0.9.0-alpha', '>=' ) );
 
 		// @TODO: Add loading status of modules settings to avoid toggling modules before they are loaded.
-
-		// The isNewSite value can be null so we need to guard against that.
-		// This is semantically incorrect as we expect a boolean value.
-		// TODO: Update logic in connect() function to send only true/false value.
-		const delayTooltipPresentation = isNewSite === null || isNewSite;
 
 		return (
 			<div className={ wrapperClass }>
@@ -242,6 +238,25 @@ class StatsNavigation extends Component {
 	}
 }
 
+function shouldDelayTooltipPresentation( state, siteId ) {
+	// Check the 'created_at' time stamp.
+	// Can return null (Redux hydration?) which we'll treat as a delay.
+	const siteCreatedTimeStamp = getSiteOption( state, siteId, 'created_at' );
+	if ( siteCreatedTimeStamp === null ) {
+		return true;
+	}
+
+	// Check if the site is less than one week old.
+	const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
+	const siteIsLessThanOneWeekOld =
+		new Date( siteCreatedTimeStamp ) > new Date( Date.now() - WEEK_IN_MILLISECONDS );
+	if ( siteIsLessThanOneWeekOld ) {
+		return true;
+	}
+
+	return false;
+}
+
 export default connect(
 	( state, { siteId, selectedItem } ) => {
 		const siteCreatedTimeStamp = getSiteOption( state, siteId, 'created_at' );
@@ -264,6 +279,7 @@ export default connect(
 			pageModuleToggles: getModuleToggles( state, siteId, [ selectedItem ] ),
 			statsAdminVersion: getJetpackStatsAdminVersion( state, siteId ),
 			adminUrl: getSiteAdminUrl( state, siteId ),
+			delayTooltipPresentation: shouldDelayTooltipPresentation( state, siteId ),
 			isNewSite,
 		};
 	},

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -63,7 +63,6 @@ class StatsNavigation extends Component {
 		adminUrl: PropTypes.string,
 		showLock: PropTypes.bool,
 		hideModuleSettings: PropTypes.bool,
-		isNewSite: PropTypes.bool,
 		delayTooltipPresentation: PropTypes.bool,
 	};
 
@@ -259,13 +258,6 @@ function shouldDelayTooltipPresentation( state, siteId ) {
 
 export default connect(
 	( state, { siteId, selectedItem } ) => {
-		const siteCreatedTimeStamp = getSiteOption( state, siteId, 'created_at' );
-		const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
-		// Check if the site is created within a week.
-		const isNewSite =
-			siteCreatedTimeStamp &&
-			new Date( siteCreatedTimeStamp ) > new Date( Date.now() - WEEK_IN_MILLISECONDS );
-
 		return {
 			isGoogleMyBusinessLocationConnected: isGoogleMyBusinessLocationConnectedSelector(
 				state,
@@ -280,7 +272,6 @@ export default connect(
 			statsAdminVersion: getJetpackStatsAdminVersion( state, siteId ),
 			adminUrl: getSiteAdminUrl( state, siteId ),
 			delayTooltipPresentation: shouldDelayTooltipPresentation( state, siteId ),
-			isNewSite,
 		};
 	},
 	{ requestModuleToggles, updateModuleToggles }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/red-team/issues/192
- https://github.com/Automattic/wp-calypso/pull/95466

## Proposed Changes

Updates the logic checking for new sites to properly handle a `null` value from `getSiteOption()`. In this way, the tooltip is not addressed until the timestamp is available.

Refactors the code to encapsulate the necessary checks and clarify the intent.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Keeps the additional state setup together instead of doing some setup in the `connect()` function and then needing additional checks for validity inside the component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See steps in: https://github.com/Automattic/wp-calypso/pull/95466

To force the bug condition you'll need to build locally, force the `showSettingsTooltip` to `true`, and set the `siteCreatedTimeStamp` to a value representing a date less than one week old. With those conditions in place, reload the Traffic page a few times and confirm the tooltip is never flashed on screen temporarily.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
