### PR TITLE
Stepper: Fix how isNewAccount is calculated

### DIFF
--- a/client/lib/signup/api/account.tsx
+++ b/client/lib/signup/api/account.tsx
@@ -123,7 +123,7 @@ export async function createAccount( {
 
 	// Handling special case where users log in via social using signup form.
 	let isNewAccountCreated = true;
-	if ( service && response && 'created_account' in response && !! response?.created_account ) {
+	if ( service && response && 'created_account' in response && ! response?.created_account ) {
 		isNewAccountCreated = false;
 	}
 

--- a/client/lib/signup/api/account.tsx
+++ b/client/lib/signup/api/account.tsx
@@ -117,20 +117,24 @@ export async function createAccount( {
 		} );
 	}
 
-	const isNewAccountCreated = 'created_account' in response && !! response?.created_account;
-
 	if ( 'error' in response ) {
-		return response;
-	} else if ( isNewAccountCreated ) {
-		const username = response?.signup_sandbox_username || response?.username;
-
-		recordNewAccountCreation( {
-			response,
-			flowName,
-			username,
-			signupType: service ? 'social' : 'default',
-		} );
+		return { ...response, isNewAccountCreated: false };
 	}
+
+	// Handling special case where users log in via social using signup form.
+	let isNewAccountCreated = true;
+	if ( service && response && 'created_account' in response && !! response?.created_account ) {
+		isNewAccountCreated = false;
+	}
+
+	const username = response?.signup_sandbox_username || response?.username;
+
+	recordNewAccountCreation( {
+		response,
+		flowName,
+		username,
+		signupType: service ? 'social' : 'default',
+	} );
 
 	return { ...response, isNewAccountCreated };
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Change how `isNewAccountCreated` is calculated in Stepper during account creation. This makes it similar to how [Start](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/signup/step-actions/index.js#L893-L897) calculates it. 
It will later be used, upon signup flow completion, to trigger `calypso_new_user_site_creation`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There is a big discrepancy in the `calypso_new_user_site_creation` event, with Stepper logging a really low number.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Live link
- Go through the onboarding flow in Stepper and in Start and check that both have the same events triggered.
- Check for calypso_new_user_site_creation and calypso_signup_complete

