### PR TITLE
Update ReactDom.render and ReactDom.hydrate to React 18 under /client

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -413,6 +413,10 @@ export const getRootNode = () => {
 	return wpcomRootNode;
 };
 
+export const setRootNode = ( rootNode ) => {
+	wpcomRootNode = rootNode;
+};
+
 function renderLayout( reduxStore, reactQueryClient ) {
 	getRootNode().render(
 		<ProviderWrappedLayout store={ reduxStore } queryClient={ reactQueryClient } />

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -202,6 +202,8 @@ const unsavedFormsMiddleware = () => {
 	page.exit( '*', checkFormHandler );
 };
 
+export const getRootDomElement = () => document.getElementById( 'wpcom' );
+
 const utils = () => {
 	debug( 'Executing Calypso utils.' );
 
@@ -217,7 +219,7 @@ const utils = () => {
 	accessibleFocus();
 
 	// Configure app element that React Modal will aria-hide when modal is open
-	Modal.setAppElement( document.getElementById( 'wpcom' ) );
+	Modal.setAppElement( getRootDomElement() );
 };
 
 const configureReduxStore = ( currentUser, reduxStore ) => {
@@ -402,8 +404,17 @@ const setupMiddlewares = ( currentUser, reduxStore, reactQueryClient ) => {
 	}
 };
 
+let wpcomRootNode;
+export const getRootNode = () => {
+	if ( wpcomRootNode == null ) {
+		wpcomRootNode = createRoot( getRootDomElement() );
+	}
+
+	return wpcomRootNode;
+};
+
 function renderLayout( reduxStore, reactQueryClient ) {
-	createRoot( document.getElementById( 'wpcom' ) ).render(
+	getRootNode().render(
 		<ProviderWrappedLayout store={ reduxStore } queryClient={ reactQueryClient } />
 	);
 }

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -8,11 +8,10 @@ import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { getToken } from '@automattic/oauth-token';
 import { JETPACK_PRICING_PAGE } from '@automattic/urls';
 import debugFactory from 'debug';
-import { createRoot } from 'react-dom/client';
 import Modal from 'react-modal';
 import store from 'store';
 import emailVerification from 'calypso/components/email-verification';
-import { ProviderWrappedLayout } from 'calypso/controller';
+import { ProviderWrappedLayout, getRootDomElement, render } from 'calypso/controller';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import getSuperProps from 'calypso/lib/analytics/super-props';
@@ -201,8 +200,6 @@ const unsavedFormsMiddleware = () => {
 	// warn against navigating from changed, unsaved forms
 	page.exit( '*', checkFormHandler );
 };
-
-export const getRootDomElement = () => document.getElementById( 'wpcom' );
 
 const utils = () => {
 	debug( 'Executing Calypso utils.' );
@@ -404,23 +401,8 @@ const setupMiddlewares = ( currentUser, reduxStore, reactQueryClient ) => {
 	}
 };
 
-let wpcomRootNode;
-export const getRootNode = () => {
-	if ( wpcomRootNode == null ) {
-		wpcomRootNode = createRoot( getRootDomElement() );
-	}
-
-	return wpcomRootNode;
-};
-
-export const setRootNode = ( rootNode ) => {
-	wpcomRootNode = rootNode;
-};
-
 function renderLayout( reduxStore, reactQueryClient ) {
-	getRootNode().render(
-		<ProviderWrappedLayout store={ reduxStore } queryClient={ reactQueryClient } />
-	);
+	render( <ProviderWrappedLayout store={ reduxStore } queryClient={ reactQueryClient } /> );
 }
 
 const boot = async ( currentUser, registerRoutes ) => {

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -11,7 +11,7 @@ import debugFactory from 'debug';
 import Modal from 'react-modal';
 import store from 'store';
 import emailVerification from 'calypso/components/email-verification';
-import { ProviderWrappedLayout, getRootDomElement, render } from 'calypso/controller';
+import { ProviderWrappedLayout, render, getRootDomElement } from 'calypso/controller';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import getSuperProps from 'calypso/lib/analytics/super-props';

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -8,7 +8,7 @@ import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { getToken } from '@automattic/oauth-token';
 import { JETPACK_PRICING_PAGE } from '@automattic/urls';
 import debugFactory from 'debug';
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import Modal from 'react-modal';
 import store from 'store';
 import emailVerification from 'calypso/components/email-verification';
@@ -403,9 +403,8 @@ const setupMiddlewares = ( currentUser, reduxStore, reactQueryClient ) => {
 };
 
 function renderLayout( reduxStore, reactQueryClient ) {
-	ReactDom.render(
-		<ProviderWrappedLayout store={ reduxStore } queryClient={ reactQueryClient } />,
-		document.getElementById( 'wpcom' )
+	createRoot( document.getElementById( 'wpcom' ) ).render(
+		<ProviderWrappedLayout store={ reduxStore } queryClient={ reactQueryClient } />
 	);
 }
 

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -90,6 +90,7 @@ export const redirectIfJetpackNonAtomic = () => {};
 export const redirectToHostingPromoIfNotAtomic = () => {};
 // eslint-disable-next-line no-unused-vars
 export const render = ( context ) => {};
+export const getRootDomElement = () => {};
 export const ProviderWrappedLayout = () => null;
 export const notFound = () => null;
 export const setSelectedSiteIdByOrigin = () => {};

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -40,7 +40,7 @@ import { hydrate, render } from './web-util.js';
  * Re-export
  */
 export { setLocaleMiddleware, setSectionMiddleware } from './shared.js';
-export { hydrate, render } from './web-util.js';
+export { hydrate, render, getRootDomElement } from './web-util.js';
 
 export const ProviderWrappedLayout = ( {
 	store,

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,9 +1,9 @@
-import ReactDom from 'react-dom';
+import { createRoot, hydrateRoot } from 'react-dom/client';
 
 export function render( context ) {
-	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
+	createRoot( document.getElementById( 'wpcom' ) ).render( context.layout );
 }
 
 export function hydrate( context ) {
-	ReactDom.hydrate( context.layout, document.getElementById( 'wpcom' ) );
+	hydrateRoot( document.getElementById( 'wpcom' ), context.layout );
 }

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,9 +1,10 @@
-import { createRoot, hydrateRoot } from 'react-dom/client';
+import { hydrateRoot } from 'react-dom/client';
+import { getRootNode, getRootDomElement } from 'calypso/boot/common';
 
 export function render( context ) {
-	createRoot( document.getElementById( 'wpcom' ) ).render( context.layout );
+	getRootNode().render( context.layout );
 }
 
 export function hydrate( context ) {
-	hydrateRoot( document.getElementById( 'wpcom' ), context.layout );
+	hydrateRoot( getRootDomElement(), context.layout );
 }

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,10 +1,18 @@
-import { hydrateRoot } from 'react-dom/client';
-import { getRootNode, setRootNode, getRootDomElement } from 'calypso/boot/common';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+
+export function getRootDomElement() {
+	return document.getElementById( 'wpcom' );
+}
+
+let wpcomRootNode;
 
 export function render( context ) {
-	getRootNode().render( context.layout );
+	if ( wpcomRootNode == null ) {
+		wpcomRootNode = createRoot( getRootDomElement() );
+	}
+	wpcomRootNode.render( context.layout );
 }
 
 export function hydrate( context ) {
-	setRootNode( hydrateRoot( getRootDomElement(), context.layout ) );
+	wpcomRootNode = hydrateRoot( getRootDomElement(), context.layout );
 }

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,10 +1,10 @@
 import { hydrateRoot } from 'react-dom/client';
-import { getRootNode, getRootDomElement } from 'calypso/boot/common';
+import { getRootNode, setRootNode, getRootDomElement } from 'calypso/boot/common';
 
 export function render( context ) {
 	getRootNode().render( context.layout );
 }
 
 export function hydrate( context ) {
-	hydrateRoot( getRootDomElement(), context.layout );
+	setRootNode( hydrateRoot( getRootDomElement(), context.layout ) );
 }

--- a/client/lib/account-settings-helper/index.jsx
+++ b/client/lib/account-settings-helper/index.jsx
@@ -1,5 +1,5 @@
 import languages from '@automattic/languages';
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { useInView } from 'react-intersection-observer';
 import { Provider, useDispatch, useSelector } from 'react-redux';
 import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
@@ -66,9 +66,8 @@ export function AccountSettingsHelper() {
 	);
 }
 export default ( element, store ) =>
-	ReactDom.render(
+	createRoot( element ).render(
 		<Provider store={ store }>
 			<AccountSettingsHelper />
-		</Provider>,
-		element
+		</Provider>
 	);

--- a/client/lib/auth-helper/index.jsx
+++ b/client/lib/auth-helper/index.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import './style.scss';
 
@@ -40,4 +40,4 @@ function AuthHelper() {
 	);
 }
 
-export default ( element ) => ReactDom.render( <AuthHelper />, element );
+export default ( element ) => createRoot( element ).render( <AuthHelper /> );

--- a/client/lib/features-helper/index.js
+++ b/client/lib/features-helper/index.js
@@ -1,4 +1,4 @@
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import FeatureList from './feature-list';
 
 import './style.scss';
@@ -7,5 +7,5 @@ import './style.scss';
  * @param element HTML Element
  */
 export default function injectFeatureHelper( element ) {
-	ReactDom.render( <FeatureList />, element );
+	createRoot( element ).render( <FeatureList /> );
 }

--- a/client/lib/preferences-helper/index.js
+++ b/client/lib/preferences-helper/index.js
@@ -1,14 +1,13 @@
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import PreferenceList from './preference-list';
 
 import './style.scss';
 
 export default function injectPreferenceHelper( element, store ) {
-	ReactDom.render(
+	createRoot( element ).render(
 		<Provider store={ store }>
 			<PreferenceList />
-		</Provider>,
-		element
+		</Provider>
 	);
 }

--- a/client/lib/react-query-devtools-helper/index.jsx
+++ b/client/lib/react-query-devtools-helper/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useEffect, useState } from 'react';
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { setStoredItem, getStoredItem } from 'calypso/lib/browser-storage';
 
 import './style.scss';
@@ -59,4 +59,4 @@ function ReactQueryDevtoolsHelper() {
 	);
 }
 
-export default ( element ) => ReactDom.render( <ReactQueryDevtoolsHelper />, element );
+export default ( element ) => createRoot( element ).render( <ReactQueryDevtoolsHelper /> );

--- a/client/lib/store-sandbox-helper/index.tsx
+++ b/client/lib/store-sandbox-helper/index.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ToggleControl } from '@wordpress/components';
 import { useState, useEffect } from 'react';
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import useStoreSandboxStatusQuery from 'calypso/data/store-sandbox/use-store-sandbox-status';
 import wp from 'calypso/lib/wp';
 
@@ -74,9 +74,8 @@ export function StoreSandboxHelper() {
 	);
 }
 export default ( element: HTMLElement ) =>
-	ReactDom.render(
+	createRoot( element ).render(
 		<QueryClientProvider client={ new QueryClient() }>
 			<StoreSandboxHelper />
-		</QueryClientProvider>,
-		element
+		</QueryClientProvider>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fix #95339

## Proposed Changes

This PR updates the `ReactDom.render` calls that has caused the deprecation warnings:
![image](https://github.com/user-attachments/assets/6ee67121-ffdf-41d3-bf2a-727704f55887)

Several changes are introduced:

1. Update all the `ReactDom.render()` calls that triggered the deprecation warnings to `createRoot( ... ).render` accordingly under /client. That means those don't trigger the warnings are not updated in this PR, e.g. those in README.md and unit tests. Those in packages are also untouched.
2. `createRoot()` returns the React root object that is meant to be reused. If we don't, there will be another warning about it. Thus, this PR introduces `getRootNode()` to share that root instance. Along side of it, `getRootDomElement()` is also introduced to avoid duplication of `documents.getElementById( 'wpcom')`.
![CleanShot 2024-10-18 at 16 35 51@2x](https://github.com/user-attachments/assets/d9948a45-9186-45ff-b6f4-be5bdc60c669)
3. `ReactDom.hydrate()` is also updated as `hydrateRoot()` accordingly as pointed out by @jsnajdr .

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It doesn't do harm in production, but the deprecation warnings have been creating noises for developers. Plus, if one day we want to utilize new React 18 features like [the concurrent mode](https://react.dev/blog/2022/03/29/react-v18#what-is-concurrent-react) more widely, we will need to update these calls anyway.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that there is no `ReactDom.render` warnings.
* All the CI tests should pass.
* The pre-release tests should pass, which I will trigger after creating this PR shortly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
