### PR TITLE
A4A: Make the default marketplace hosting section contextually aware.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -49,7 +49,7 @@ export const marketplaceHostingContext: Callback = ( context, next ) => {
 	if ( isEnabled( 'a4a-hosting-page-redesign' ) && ! context.params.section ) {
 		const currentAgency = getActiveAgency( context.store.getState() );
 		page.redirect(
-			// If the agency is managing more than 5 sites, then we make pressable as default section.
+			// If the agency is managing less than 5 sites, then we make wpcom as default section.
 			currentAgency?.number_of_sites === '1-5'
 				? A4A_MARKETPLACE_HOSTING_WPCOM_LINK
 				: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -50,7 +50,7 @@ export const marketplaceHostingContext: Callback = ( context, next ) => {
 		const currentAgency = getActiveAgency( context.store.getState() );
 		page.redirect(
 			// If the agency is managing less than 5 sites, then we make wpcom as default section.
-			currentAgency?.number_of_sites === '1-5'
+			currentAgency?.signup_meta?.number_sites === '1-5'
 				? A4A_MARKETPLACE_HOSTING_WPCOM_LINK
 				: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK
 		);

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -4,8 +4,10 @@ import page from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import {
 	A4A_MARKETPLACE_HOSTING_LINK,
+	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
 import Checkout from './checkout';
@@ -45,7 +47,13 @@ export const marketplaceProductsContext: Callback = ( context, next ) => {
 
 export const marketplaceHostingContext: Callback = ( context, next ) => {
 	if ( isEnabled( 'a4a-hosting-page-redesign' ) && ! context.params.section ) {
-		page.redirect( A4A_MARKETPLACE_HOSTING_WPCOM_LINK );
+		const currentAgency = getActiveAgency( context.store.getState() );
+		page.redirect(
+			// If the agency is managing more than 5 sites, then we make pressable as default section.
+			currentAgency?.number_of_sites === '1-5'
+				? A4A_MARKETPLACE_HOSTING_WPCOM_LINK
+				: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK
+		);
 		return;
 	}
 

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -75,7 +75,9 @@ export interface Agency {
 				},
 		  ]
 		| [];
-	number_of_sites?: string;
+	signup_meta: {
+		number_sites: string;
+	};
 	tier: {
 		id: 'emerging-partner' | 'agency-partner' | 'pro-agency-partner';
 		label: string;

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -75,6 +75,7 @@ export interface Agency {
 				},
 		  ]
 		| [];
+	number_of_sites?: string;
 	tier: {
 		id: 'emerging-partner' | 'agency-partner' | 'pro-agency-partner';
 		label: string;


### PR DESCRIPTION
This needs to be tested together with D164110-code.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1299

## Proposed Changes

* Update the Marketplace hosting route logic so that it is contextually aware of the number of sites the current agency manages. If the agency manages fewer than or equal to five sites, we should default to the **WPCOM** section. Otherwise, we will default to the **Pressable** section.

## Why are these changes being made?

* This is to drive Pressable hosting as the primary hosting option in the marketplace.

## Testing Instructions
This needs to be tested with two accounts: one for managing 1-5 sites and another for managing more than 5 sites. Please sign up for a new Agency account and ensure you select the correct number of sites.

### Agency with 1-5 sites.
* Use the A4A live link and go to the `/overview` page.
* Click the Marketplace menu in the sidebar.
* Confirm that the default page you land on is the **WPCOM hosting page.**


### Agency more than 5 sites.
* Use the A4A live link and go to the `/overview` page.
* Click the Marketplace menu in the sidebar.
* Confirm that the default page you land on is the **Pressable hosting page.**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?