### PR TITLE
Performance Profiler: Add preview box to timeline screenshots

### DIFF
--- a/client/performance-profiler/components/screenshot-timeline.tsx
+++ b/client/performance-profiler/components/screenshot-timeline.tsx
@@ -1,5 +1,8 @@
 import styled from '@emotion/styled';
+import { Modal } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
+import { useState } from 'react';
 import { ScreenShotsTimeLine } from 'calypso/data/site-profiler/types';
 
 const Container = styled.div`
@@ -39,10 +42,41 @@ const Tick = styled.p`
 	color: var( --studio-gray-80 );
 	font-size: 0.875rem;
 `;
+const Img = styled.img`
+	width: 100%;
+	height: auto;
+`;
+
+const ScreenshotModal = styled( Modal )`
+	@media ( min-width: 600px ) {
+		max-height: initial;
+
+		.components-modal__content {
+			padding: 0;
+			margin-top: 0;
+		}
+
+		.components-modal__header {
+			button {
+				filter: invert( 100% ) contrast( 130% );
+			}
+		}
+	}
+`;
 
 type Props = { screenshots: ScreenShotsTimeLine[] };
 
+type OverlayState = {
+	isOpen: boolean;
+	screenshot?: ScreenShotsTimeLine;
+	timing?: string;
+};
+
 export const ScreenshotTimeline = ( { screenshots }: Props ) => {
+	const { __ } = useI18n();
+	const [ overlay, setOverlay ] = useState< OverlayState >( {
+		isOpen: false,
+	} );
 	if ( ! screenshots || ! screenshots.length ) {
 		return null;
 	}
@@ -51,12 +85,26 @@ export const ScreenshotTimeline = ( { screenshots }: Props ) => {
 		<Container>
 			<H2>{ translate( 'Timeline' ) }</H2>
 			<p>{ translate( 'How your site appears to users while loading.' ) }</p>
+			{ overlay.isOpen && overlay.screenshot && (
+				<ScreenshotModal
+					onRequestClose={ () => setOverlay( { isOpen: false } ) }
+					contentLabel={ __( 'Screenshot preview' ) }
+				>
+					<Img alt={ overlay.timing } src={ overlay.screenshot.data } />
+				</ScreenshotModal>
+			) }
 			<Timeline>
 				{ screenshots.map( ( screenshot, index ) => {
 					const timing = `${ ( screenshot.timing / 1000 ).toFixed( 1 ) }s`;
 					return (
 						<div key={ index }>
-							<Thumbnail alt={ timing } src={ screenshot.data } />
+							<Thumbnail
+								alt={ timing }
+								src={ screenshot.data }
+								onClick={ () =>
+									setOverlay( { isOpen: true, screenshot: screenshot, timing: timing } )
+								}
+							/>
 							<Tick>{ timing }</Tick>
 						</div>
 					);

--- a/client/performance-profiler/components/screenshot-timeline.tsx
+++ b/client/performance-profiler/components/screenshot-timeline.tsx
@@ -58,7 +58,35 @@ const ScreenshotModal = styled( Modal )`
 
 		.components-modal__header {
 			button {
-				filter: invert( 100% ) contrast( 130% );
+				position: relative;
+			}
+
+			button::before,
+			button::after {
+				content: '';
+				position: absolute;
+				top: 0;
+				left: 0;
+				right: 0;
+				bottom: 0;
+				border-radius: 50%;
+				background-color: black;
+				mix-blend-mode: screen;
+			}
+
+			button::before {
+				background-color: white;
+				mix-blend-mode: difference;
+			}
+
+			button::after {
+				background-color: black;
+				mix-blend-mode: screen;
+			}
+
+			button svg {
+				fill: white;
+				mix-blend-mode: difference;
 			}
 		}
 	}

--- a/client/performance-profiler/components/screenshot-timeline.tsx
+++ b/client/performance-profiler/components/screenshot-timeline.tsx
@@ -87,6 +87,8 @@ const ScreenshotModal = styled( Modal )`
 
 			button svg {
 				fill: white;
+				width: 16px;
+				height: 16px;
 				mix-blend-mode: difference;
 			}
 		}

--- a/client/performance-profiler/components/screenshot-timeline.tsx
+++ b/client/performance-profiler/components/screenshot-timeline.tsx
@@ -35,6 +35,7 @@ const Thumbnail = styled.img`
 	border-radius: 6px;
 	width: 100%;
 	min-width: 60px;
+	cursor: pointer;
 `;
 
 const Tick = styled.p`


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9192

## Proposed Changes

* Displays a modal when clicking on a Screenshot of the timeline preview

|Logged-in | Logged-out|
|-------|------|
|![CleanShot 2024-10-18 at 14 06 10@2x](https://github.com/user-attachments/assets/91f8ebbe-0191-46be-a82b-bff4ba76058c)|    ![CleanShot 2024-10-18 at 14 06 30@2x](https://github.com/user-attachments/assets/4857f1b0-d8f9-4ace-871a-c56fee40e054)   |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For consistency with a similar behaviour in the tool. To improve the UX by allowing the user to preview the images in a bigger size.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this changes and navigate to `/speed-test` tool with a valid URL
* Go to the timeline and click on an image
* Check a modal is displayed with the contents of the clicked image
* Repeat using the logged-in version (activate the flag `performance-profiler/logged-in`)
* Check a modal is displayed with the contents of the clicked image

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
