### PR TITLE
Handle the page template and page template part commands so they are properly redirected to wp admin

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1109,7 +1109,17 @@ function extractPostIdFromDataValueAttribute( commandItem ) {
 function handleSinglePosts( calypsoPort ) {
 	const selector = `[data-value^="${ __( 'Single Posts' ) }"]`;
 
-	const postMessage = ( commandItem ) => {
+	const callback = ( e ) => {
+		e.preventDefault();
+
+		let commandItem;
+
+		if ( e.type === 'click' ) {
+			commandItem = e.target.closest( '[cmdk-item]' );
+		} else if ( e.type === 'keydown' ) {
+			commandItem = document.querySelector( '[data-selected=true]' );
+		}
+
 		const postId = extractPostIdFromDataValueAttribute( commandItem );
 
 		calypsoPort.postMessage( {
@@ -1121,23 +1131,8 @@ function handleSinglePosts( calypsoPort ) {
 		} );
 	};
 
-	const clickCallback = ( e ) => {
-		e.preventDefault();
-
-		const commandItem = e.target.closest( '[cmdk-item]' );
-		postMessage( commandItem );
-	};
-
-	addEditorListener( selector, clickCallback );
-
-	const enterCallback = ( e ) => {
-		e.preventDefault();
-
-		const commandItem = document.querySelector( '[data-selected=true]' );
-		postMessage( commandItem );
-	};
-
-	addCommandsInputListener( selector, enterCallback );
+	addEditorListener( selector, callback );
+	addCommandsInputListener( selector, callback );
 }
 
 function initPort( message ) {

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1120,7 +1120,15 @@ function handleSinglePosts( calypsoPort ) {
 			commandItem = document.querySelector( '[data-selected=true]' );
 		}
 
+		if ( ! commandItem ) {
+			return;
+		}
+
 		const postId = extractPostIdFromDataValueAttribute( commandItem );
+
+		if ( ! postId ) {
+			return;
+		}
 
 		calypsoPort.postMessage( {
 			action: 'wpAdminRedirect',

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1232,7 +1232,7 @@ function initPort( message ) {
 // Note: domReady is used instead of `(function() { ... })()` because certain
 // things in `initPort` require other scripts to be loaded. (For example, ETK
 // scripts need to be available before some things will work correctly.)
-domReady( async () => {
+domReady( () => {
 	window.addEventListener( 'message', initPort, false );
 
 	//signal module loaded

--- a/apps/wpcom-block-editor/src/utils.js
+++ b/apps/wpcom-block-editor/src/utils.js
@@ -71,17 +71,19 @@ export const isEditorReadyWithBlocks = async () =>
 		} );
 	} );
 
-export const getPages = async () =>
+export const getPostTypeRecords = async ( name ) =>
 	new Promise( ( resolve ) => {
 		const unsubscribe = subscribe( () => {
-			const pages = select( 'core' ).getEntityRecords( 'postType', 'page', { per_page: -1 } );
+			const records = select( 'core' ).getEntityRecords( 'postType', name, { per_page: -1 } );
 
-			if ( pages !== null ) {
+			if ( records !== null ) {
 				unsubscribe();
-				resolve( pages );
+				resolve( records );
 			}
 		} );
 	} );
+
+export const getPages = async () => getPostTypeRecords( 'page' );
 
 // All end-to-end tests use a custom user agent containing this string.
 const E2E_USER_AGENT = 'wp-e2e-tests';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/86000

## Proposed Changes

* Handle the user's interaction with the page template (`Single Posts`, `Single with Sidebar`, ...) and the page template part (`Post Meta`, `Sidebar`) commands on the command palette through the iframe bridge, so the destination page can be opened as expected instead of being blocked because of it being inside an `iframe`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, clicking on the `Single Posts` command on the command palette leaves the users with an error page and this message on the console: `Refused to display 'https://example.wordpress.com/' in a frame because it set 'X-Frame-Options' to 'sameorigin'.`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch locally on the `wp-calypso` folder
2. Go to the `apps/wpcom-block-editor` folder inside `wp-calypso`
3. Run `yarn dev --sync`, this will add the necessary changes to your sandbox
4. Sandbox `widgets.wp.com`
6. Set up a new Creator site.
7. Sandbox that site as well
8. Navigate to the Pages tab.
9. Select the Default View.
10. Create a new page.
11. Click CMD + K.
12. Select "Single Posts".
13. Check that you are redirected to the `Single Posts` template

![image](https://github.com/user-attachments/assets/3ed4f04a-4d89-4b3b-9c67-8e257fb46548)

The same should be true for the following commands:

- Search Results
- Single with Sidebar
- Page with Wide Image
- Index
- All Archives
- Pages
- Page No Title
- Page with Sidebar
- Blog Home
- Page: 404
- Post Meta
- Header
- Sidebar
- Footer

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
