### PR TITLE
E2E: Fix failing tests on Gutenberg RC

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -400,9 +400,9 @@ export class EditorSettingsSidebarComponent {
 	 */
 	async enterUrlSlug( slug: string ) {
 		const editorParent = await this.editor.parent();
-		// TODO: Once WordPress/gutenberg#60632 is everywhere, remove the alternation.
-		await editorParent.getByRole( 'button', { name: /Change (link|URL):/ } ).click();
-		await editorParent.getByRole( 'textbox', { name: /^(Link|Permalink)$/ } ).fill( slug );
+		// TODO: Once WordPress/gutenberg#63669 is everywhere, remove the alternation.
+		await editorParent.getByRole( 'button', { name: /Change link:/ } ).click();
+		await editorParent.getByRole( 'textbox', { name: /^(Link|Slug)$/ } ).fill( slug );
 		await editorParent.getByRole( 'button', { name: 'Close', exact: true } ).click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -108,12 +108,17 @@ export class EditorToolbarComponent {
 	async openBlockInserter(): Promise< void > {
 		const editorParent = await this.editor.parent();
 
-		const translatedButtonName = await this.translateFromPage(
+		// TODO: Once WordPress/gutenberg#63669 is everywhere, remove the old name.
+		const translatedButtonNameOld = await this.translateFromPage(
 			'Toggle block inserter',
 			'Generic label for block inserter button'
 		);
+		const translatedButtonNameNew = await this.translateFromPage(
+			'Block Inserter',
+			'Generic label for block inserter button'
+		);
 		const blockInserterButton = editorParent.getByRole( 'button', {
-			name: translatedButtonName,
+			name: new RegExp( `^(${ translatedButtonNameOld }|${ translatedButtonNameNew })` ),
 			exact: true,
 		} );
 
@@ -130,12 +135,17 @@ export class EditorToolbarComponent {
 	async closeBlockInserter(): Promise< void > {
 		const editorParent = await this.editor.parent();
 
-		const translatedButtonName = await this.translateFromPage(
+		// TODO: Once WordPress/gutenberg#63669 is everywhere, remove the old name.
+		const translatedButtonNameOld = await this.translateFromPage(
 			'Toggle block inserter',
 			'Generic label for block inserter button'
 		);
+		const translatedButtonNameNew = await this.translateFromPage(
+			'Block Inserter',
+			'Generic label for block inserter button'
+		);
 		const blockInserterButton = editorParent.getByRole( 'button', {
-			name: translatedButtonName,
+			name: new RegExp( `^(${ translatedButtonNameOld }|${ translatedButtonNameNew })` ),
 			exact: true,
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1729177519243639-slack-CBTN58FTJ

## Proposed Changes

* This fixes the failing E2E tests when running on the edge version of Gutenberg: https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_nightly_desktop/13537470?buildTab=tests&status=failed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up your test env using [this guide](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/README.md).
* To run the test on the edge GB version, get the failing test paths listed [here](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_nightly_desktop/13537470?buildTab=tests&status=failed) and run `GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test -- [test path]`. These may be easier ways to run the suite, which I don't know about.
* The PR E2E tests should be passing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?