### PR TITLE
Plans: update "Limited time offer" to "Special offer"

### DIFF
--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -58,7 +58,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 			<div className="plans-grid-next-header-price">
 				{ ! current && (
 					<div className="plans-grid-next-header-price__badge">
-						{ translate( 'Limited Time Offer' ) }
+						{ translate( 'Special Offer' ) }
 					</div>
 				) }
 				<div

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -110,7 +110,7 @@ describe( 'HeaderPrice', () => {
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	test( 'should display "Limited Time Offer" badge when intro offer exists and offer is not complete', () => {
+	test( 'should display "Special Offer" badge when intro offer exists and offer is not complete', () => {
 		const pricing = {
 			currencyCode: 'USD',
 			originalPrice: { full: 120, monthly: 10 },
@@ -137,7 +137,7 @@ describe( 'HeaderPrice', () => {
 		const { container } = render( <HeaderPrice { ...defaultProps } /> );
 		const badge = container.querySelector( '.plans-grid-next-header-price__badge' );
 
-		expect( badge ).toHaveTextContent( 'Limited Time Offer' );
+		expect( badge ).toHaveTextContent( 'Special Offer' );
 	} );
 
 	test( 'should display "One time discount" badge when there is a monthly discounted price', () => {


### PR DESCRIPTION
When we switched the local currency discounts to use introductory offers in #86434, we consolidated the logic for the offer pill to use the same "Limited time offer" text as the Woo Express plans that were already utilizing introductory offers. @niranjan-uma-shankar then pointed out that since these promotions are longer-running, we shouldn't use the "limited time" wording (p58i-fkS-p2#comment-64883).

This PR update the text to use the wording "Special offer", which falls within the constraint of "unique to our normal business offerings". I understand that the original wording was "One time discount", but since this is the fallback wording for all introductory offers, "Special offer" felt more applicable. We can add conditions to use "One time discount" for these specific offers in a follow-up if it's needed.

![Screenshot 2024-10-18 at 11 33 26 AM](https://github.com/user-attachments/assets/7a989d52-7d2b-4084-9d9c-f4df0d320ca2)

**To test:**
- For the `INR`, `PHP`, or `MXN` currencies, on a site that hasn't previously had a plan purchase:
- Visit Upgrades > Plans
- Verify that the introductory offer pill says "Special offer"