### PR TITLE
Start: Domains, do not submit when removing the free domain

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -897,12 +897,6 @@ export class RenderDomainsStep extends Component {
 				domain_name: false,
 			},
 		} );
-		this.props.submitSignupStep(
-			Object.assign( {
-				stepName: this.props.stepName,
-			} ),
-			Object.assign( { siteUrl: false } )
-		);
 	};
 
 	getSideContent = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context: p1729251522419809-slack-C073776NJ66

## Proposed Changes

Avoid submitting the Domains step when removing the free domain.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Removing the free domain shouldn't trigger the step submission

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start and in the domains step add and remove the free domain
* Check that `calypso_signup_actions_submit_step (step: domains)` is not triggered.
* Check that it triggered when actually submitting the step

