### PR TITLE
Reader Onboarding: Add load more results functionality

### DIFF
--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -2,7 +2,7 @@ import { LoadingPlaceholder } from '@automattic/components';
 import { useQuery } from '@tanstack/react-query';
 import { Modal, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import React, { useMemo, useState, ComponentType, useEffect } from 'react';
+import React, { useMemo, useState, ComponentType, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import wpcom from 'calypso/lib/wp';
@@ -42,6 +42,8 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 	const followedTags = useSelector( getReaderFollowedTags ) || [];
 	const followedTagSlugs = followedTags.map( ( tag ) => tag.slug );
 
+	const [ currentPage, setCurrentPage ] = useState( 0 );
+
 	const { data: apiRecommendedSites = [], isLoading } = useQuery( {
 		queryKey: [ 'reader-onboarding-recommended-sites', followedTagSlugs ],
 		queryFn: () =>
@@ -52,7 +54,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 				},
 				{
 					tags: followedTagSlugs,
-					site_recs_per_card: 6,
+					site_recs_per_card: 24,
 					tag_recs_per_card: 0,
 				}
 			),
@@ -114,9 +116,24 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 			return b.weight - a.weight;
 		} );
 
-		// Limit to 6 recommendations
-		return sortedRecommendations.slice( 0, 6 );
+		// Limit to 18 recommendations instead of 6
+		return sortedRecommendations.slice( 0, 18 );
 	}, [ followedTagSlugs, apiRecommendedSites ] );
+
+	const displayedRecommendations = useMemo( () => {
+		const startIndex = currentPage * 6;
+		return combinedRecommendations.slice( startIndex, startIndex + 6 );
+	}, [ combinedRecommendations, currentPage ] );
+
+	const handleLoadMore = useCallback( () => {
+		if ( currentPage < 2 ) {
+			setCurrentPage( currentPage + 1 );
+		} else {
+			setCurrentPage( 0 );
+		}
+	}, [ currentPage ] );
+
+	const loadMoreText = currentPage === 2 ? __( 'Start over' ) : __( 'Load more recommendations' );
 
 	const headerActions = (
 		<>
@@ -180,7 +197,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 						) }
 						{ ! isLoading && combinedRecommendations.length > 0 && (
 							<div className="subscribe-modal__recommended-sites">
-								{ combinedRecommendations.map( ( site: CardData ) => (
+								{ displayedRecommendations.map( ( site: CardData ) => (
 									<ConnectedReaderSubscriptionListItem
 										key={ site.feed_ID }
 										feedId={ site.feed_ID }
@@ -198,7 +215,11 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 								) ) }
 							</div>
 						) }
-						<p>{ __( 'Load more recommendations' ) }</p>
+						{ combinedRecommendations.length > 6 && (
+							<Button onClick={ handleLoadMore } variant="link">
+								{ loadMoreText }
+							</Button>
+						) }
 						<Button className="subscribe-modal__continue-button is-primary" onClick={ onClose }>
 							{ __( 'Continue' ) }
 						</Button>

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -121,7 +121,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 			return b.weight - a.weight;
 		} );
 
-		// Limit to 18 recommendations instead of 6
+		// Limit to 18 recommendations.
 		return sortedRecommendations.slice( 0, 18 );
 	}, [ followedTagSlugs, apiRecommendedSites ] );
 
@@ -136,8 +136,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		} else {
 			setCurrentPage( 0 );
 		}
-		// console.log( displayedRecommendations[ 0 ] );
-		// setSelectedSite( displayedRecommendations[ 0 ] );
 	}, [ currentPage ] );
 
 	const loadMoreText = currentPage === 2 ? __( 'Start over' ) : __( 'Load more recommendations' );
@@ -150,16 +148,15 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		</>
 	);
 
-	// Select the first site by default when recommendations are loaded.
+	// Reset the page and selected site when the followed tags change.
 	useEffect( () => {
 		setCurrentPage( 0 );
 		setSelectedSite( null );
 	}, [ followedTagSlugs ] );
 
-	// Select the first site by default when recommendations are loaded.
+	//  Select the first site by default when recommendations are loaded.
 	useEffect( () => {
 		if ( displayedRecommendations.length > 0 ) {
-			console.log( displayedRecommendations[ 0 ] );
 			setSelectedSite( displayedRecommendations[ 0 ] );
 		}
 	}, [ displayedRecommendations ] );
@@ -216,7 +213,11 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 							</div>
 						) }
 						{ combinedRecommendations.length > 6 && (
-							<Button onClick={ handleLoadMore } variant="link">
+							<Button
+								className="subscribe-modal__load-more-button"
+								onClick={ handleLoadMore }
+								variant="link"
+							>
 								{ loadMoreText }
 							</Button>
 						) }

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -73,6 +73,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 				  } ) )
 				: [];
 		},
+		staleTime: Infinity,
 	} );
 
 	const combinedRecommendations = useMemo( () => {

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -154,7 +154,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		setSelectedSite( null );
 	}, [ followedTagSlugs ] );
 
-	//  Select the first site by default when recommendations are loaded.
+	// Select the first site by default when recommendations are loaded.
 	useEffect( () => {
 		if ( displayedRecommendations.length > 0 ) {
 			setSelectedSite( displayedRecommendations[ 0 ] );

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -43,6 +43,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 	const followedTagSlugs = followedTags.map( ( tag ) => tag.slug );
 
 	const [ currentPage, setCurrentPage ] = useState( 0 );
+	const [ selectedSite, setSelectedSite ] = useState< CardData | null >( null );
 
 	const { data: apiRecommendedSites = [], isLoading } = useQuery( {
 		queryKey: [ 'reader-onboarding-recommended-sites', followedTagSlugs ],
@@ -131,7 +132,8 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		} else {
 			setCurrentPage( 0 );
 		}
-	}, [ currentPage ] );
+		setSelectedSite( combinedRecommendations[ ( currentPage + 1 ) * 6 ] );
+	}, [ currentPage, combinedRecommendations ] );
 
 	const loadMoreText = currentPage === 2 ? __( 'Start over' ) : __( 'Load more recommendations' );
 
@@ -142,8 +144,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 			</Button>
 		</>
 	);
-
-	const [ selectedSite, setSelectedSite ] = useState< CardData | null >( null );
 
 	// Select the first site by default when recommendations are loaded.
 	useEffect( () => {

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -130,8 +130,20 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 
 	// Select the first site by default when recommendations are loaded.
 	useEffect( () => {
-		if ( combinedRecommendations.length > 0 && ! selectedSite ) {
-			setSelectedSite( combinedRecommendations[ 0 ] );
+		if ( combinedRecommendations.length > 0 ) {
+			// Check if the current selectedSite is still in the recommendations
+			const isCurrentSiteStillRecommended = combinedRecommendations.some(
+				( site ) => site.feed_ID === selectedSite?.feed_ID
+			);
+
+			if ( ! isCurrentSiteStillRecommended || ! selectedSite ) {
+				// If the current site is not in recommendations or there's no selected site,
+				// select the first site from the new recommendations
+				setSelectedSite( combinedRecommendations[ 0 ] );
+			}
+		} else {
+			// If there are no recommendations, clear the selected site
+			setSelectedSite( null );
 		}
 	}, [ combinedRecommendations, selectedSite ] );
 

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -39,8 +39,11 @@ interface StreamProps {
 const TypedStream: ComponentType< StreamProps > = Stream as ComponentType< StreamProps >;
 
 const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) => {
-	const followedTags = useSelector( getReaderFollowedTags ) || [];
-	const followedTagSlugs = followedTags.map( ( tag ) => tag.slug );
+	const followedTags = useSelector( getReaderFollowedTags );
+
+	const followedTagSlugs = useMemo( () => {
+		return ( followedTags || [] ).map( ( tag ) => tag.slug );
+	}, [ followedTags ] );
 
 	const [ currentPage, setCurrentPage ] = useState( 0 );
 	const [ selectedSite, setSelectedSite ] = useState< CardData | null >( null );
@@ -133,8 +136,9 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		} else {
 			setCurrentPage( 0 );
 		}
-		setSelectedSite( combinedRecommendations[ ( currentPage + 1 ) * 6 ] );
-	}, [ currentPage, combinedRecommendations ] );
+		// console.log( displayedRecommendations[ 0 ] );
+		// setSelectedSite( displayedRecommendations[ 0 ] );
+	}, [ currentPage ] );
 
 	const loadMoreText = currentPage === 2 ? __( 'Start over' ) : __( 'Load more recommendations' );
 
@@ -148,22 +152,17 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 
 	// Select the first site by default when recommendations are loaded.
 	useEffect( () => {
-		if ( combinedRecommendations.length > 0 ) {
-			// Check if the current selectedSite is still in the recommendations
-			const isCurrentSiteStillRecommended = combinedRecommendations.some(
-				( site ) => site.feed_ID === selectedSite?.feed_ID
-			);
+		setCurrentPage( 0 );
+		setSelectedSite( null );
+	}, [ followedTagSlugs ] );
 
-			if ( ! isCurrentSiteStillRecommended || ! selectedSite ) {
-				// If the current site is not in recommendations or there's no selected site,
-				// select the first site from the new recommendations
-				setSelectedSite( combinedRecommendations[ 0 ] );
-			}
-		} else {
-			// If there are no recommendations, clear the selected site
-			setSelectedSite( null );
+	// Select the first site by default when recommendations are loaded.
+	useEffect( () => {
+		if ( displayedRecommendations.length > 0 ) {
+			console.log( displayedRecommendations[ 0 ] );
+			setSelectedSite( displayedRecommendations[ 0 ] );
 		}
-	}, [ combinedRecommendations, selectedSite ] );
+	}, [ displayedRecommendations ] );
 
 	const handleItemClick = ( site: CardData ) => {
 		setSelectedSite( site );

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -56,6 +56,10 @@
 				border-radius: 6px; /* stylelint-disable-line scales/radii */
 			}
 		}
+
+		.subscribe-modal__load-more-button {
+			margin-bottom: 36px;
+		}
 	}
 
 	&__recommended-sites {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/188

## Proposed Changes

* This PR enables the "Load more recommendations" button in Reader Onboarding.
* It does this by creating a list of 18 recommendations (a combination of hand-curated and API loaded) then displays 6 recommendations at a time. Clicking "Load more recommendations" loads the next 6 recommendations or starts over from the begining.



https://github.com/user-attachments/assets/c0fea144-59c2-477a-8d66-04d3afc2f9e7





## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Push reader onboarding project forward.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/onboarding
* Click "Discover and subscribe to sites you'll love"
* Click "Load more recommendations". You should see 6 more recommendations related to the tags you're following.
* If you continue clicking "Load more recommendations," you'll eventually get a "Start over" link, which will loop the recommendations.
* Try breaking it (some things to check)
  * The first recommendation should always be selected by default if the user hasn't selected one.
  * Changing tags should re-load a new set of recommendations
  * Refreshing the browser should load the first page of recommendations with the first recommendation selected by default.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
