### PR TITLE
Domains: Cleanup - remove `domains/kracken-ui/dashes-filter` feature flag and related code

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -269,7 +269,6 @@ class RegisterDomainStep extends Component {
 
 	getInitialFiltersState() {
 		return {
-			includeDashes: false,
 			maxCharacters: '',
 			exactSldMatchesOnly: false,
 			tlds: [],
@@ -534,7 +533,6 @@ class RegisterDomainStep extends Component {
 
 	renderSearchFilters() {
 		const isKrackenUi =
-			config.isEnabled( 'domains/kracken-ui/dashes-filter' ) ||
 			config.isEnabled( 'domains/kracken-ui/exact-match-filter' ) ||
 			config.isEnabled( 'domains/kracken-ui/max-characters-filter' );
 		const isRenderingInitialSuggestions =

--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -12,19 +12,17 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import TokenField from 'calypso/components/token-field';
 import ValidationFieldset from 'calypso/signup/validation-fieldset';
 
-const HANDLED_FILTER_KEYS = [ 'tlds', 'includeDashes', 'maxCharacters', 'exactSldMatchesOnly' ];
+const HANDLED_FILTER_KEYS = [ 'tlds', 'maxCharacters', 'exactSldMatchesOnly' ];
 
 export class DropdownFilters extends Component {
 	static propTypes = {
 		availableTlds: PropTypes.array,
 		filters: PropTypes.shape( {
-			includeDashes: PropTypes.bool,
 			maxCharacters: PropTypes.string,
 			exactSldMatchesOnly: PropTypes.bool,
 			tlds: PropTypes.array,
 		} ).isRequired,
 		lastFilters: PropTypes.shape( {
-			includeDashes: PropTypes.bool,
 			maxCharacters: PropTypes.string,
 			exactSldMatchesOnly: PropTypes.bool,
 			tlds: PropTypes.array,
@@ -67,7 +65,6 @@ export class DropdownFilters extends Component {
 	getFiltercounts() {
 		return (
 			( this.props.lastFilters.tlds?.length || 0 ) +
-			( this.props.lastFilters.includeDashes && 1 ) +
 			( this.props.lastFilters.exactSldMatchesOnly && 1 ) +
 			( this.props.lastFilters.maxCharacters !== '' && 1 )
 		);
@@ -112,7 +109,7 @@ export class DropdownFilters extends Component {
 	handleFiltersReset = () => {
 		this.setState( { showOverallValidationError: false }, () => {
 			this.togglePopover( { discardChanges: false } );
-			this.props.onReset( 'tlds', 'includeDashes', 'maxCharacters', 'exactSldMatchesOnly' );
+			this.props.onReset( 'tlds', 'maxCharacters', 'exactSldMatchesOnly' );
 		} );
 	};
 	handleFiltersSubmit = () => {
@@ -183,13 +180,12 @@ export class DropdownFilters extends Component {
 
 	renderPopover() {
 		const {
-			filters: { includeDashes, maxCharacters, exactSldMatchesOnly },
+			filters: { maxCharacters, exactSldMatchesOnly },
 			popoverId,
 			translate,
 			showTldFilter,
 		} = this.props;
 
-		const isDashesFilterEnabled = config.isEnabled( 'domains/kracken-ui/dashes-filter' );
 		const isExactMatchFilterEnabled = config.isEnabled( 'domains/kracken-ui/exact-match-filter' );
 		const isLengthFilterEnabled = config.isEnabled( 'domains/kracken-ui/max-characters-filter' );
 
@@ -259,22 +255,6 @@ export class DropdownFilters extends Component {
 							/>
 							<span className="search-filters__checkbox-label">
 								{ translate( 'Show exact matches only' ) }
-							</span>
-						</FormLabel>
-					) }
-
-					{ isDashesFilterEnabled && (
-						<FormLabel className="search-filters__label" htmlFor="search-filters-include-dashes">
-							<FormInputCheckbox
-								className="search-filters__checkbox"
-								checked={ includeDashes }
-								id="search-filters-include-dashes"
-								name="includeDashes"
-								onChange={ this.handleOnChange }
-								value="includeDashes"
-							/>
-							<span className="search-filters__checkbox-label">
-								{ translate( 'Enable dashes' ) }
 							</span>
 						</FormLabel>
 					) }

--- a/client/components/domains/search-filters/filter-reset-notice.jsx
+++ b/client/components/domains/search-filters/filter-reset-notice.jsx
@@ -8,7 +8,6 @@ export class FilterResetNotice extends Component {
 	static propTypes = {
 		isLoading: PropTypes.bool.isRequired,
 		lastFilters: PropTypes.shape( {
-			includeDashes: PropTypes.bool,
 			maxCharacters: PropTypes.string,
 			exactSldMatchesOnly: PropTypes.bool,
 			tlds: PropTypes.arrayOf( PropTypes.string ),
@@ -17,9 +16,8 @@ export class FilterResetNotice extends Component {
 	};
 
 	hasActiveFilters() {
-		const { lastFilters: { includeDashes, exactSldMatchesOnly, maxCharacters, tlds = [] } = {} } =
-			this.props;
-		return includeDashes || exactSldMatchesOnly || maxCharacters !== '' || tlds.length > 0;
+		const { lastFilters: { exactSldMatchesOnly, maxCharacters, tlds = [] } = {} } = this.props;
+		return exactSldMatchesOnly || maxCharacters !== '' || tlds.length > 0;
 	}
 
 	hasTooFewSuggestions() {

--- a/config/development.json
+++ b/config/development.json
@@ -63,7 +63,6 @@
 		"devdocs/color-scheme-picker": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"domains/gdpr-consent-page": true,
-		"domains/kracken-ui/dashes-filter": false,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/max-characters-filter": false,
 		"domains/kracken-ui/pagination": true,


### PR DESCRIPTION
## Proposed Changes

This PR removes the `domains/kracken-ui/dashes-filter` feature flag from the code, which has been `false` in the `development.json` flags since #52874. I don't think this flag was ever introduced into `production.json` (at least I couldn't find it).

That flag only gated the TLD filter that had a "Include dashes" checkbox. When checked, the query string sent for the `suggestions` endpoint contained a `include_dashes` parameter, which is not even used anymore in the backend.

For reference, the Kracken project was an old project (2018) whose goal was revamping and improving the domain search experience in WPCOM. More info at p8kIbR-c4-p2.

### Screenshots

For posterity, this is what the filter gated by the feature flag looked like:

![Markup on 2024-10-18 at 16:40:37](https://github.com/user-attachments/assets/e7f6874c-0c66-44d4-a395-995cdb70928a)

This is how it looks currently:

![Markup on 2024-10-18 at 16:40:56](https://github.com/user-attachments/assets/0a671639-9f64-45e2-bbd3-5d34c905a4e1)

## Why are these changes being made?

Removing obsolete and dead code.

## Testing Instructions

- Build this branch locally or open the live Calypso link
- Go to a page with the domain serach component, e.g. `/start/domains` or "Add new domain" in an existing site
- Ensure the TLD filter is working as it should

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?