### PR TITLE
Logged-in Performance Profiler: Fix page selector expanding margin

### DIFF
--- a/client/hosting/performance/style.scss
+++ b/client/hosting/performance/style.scss
@@ -111,7 +111,7 @@ $section-max-width: 1224px;
 
 .site-performance-device-tab-controls__container {
 	display: flex;
-	gap: 24px;
+	gap: 16px;
 	align-items: center;
 	justify-content: space-between;
 	margin-bottom: 16px;
@@ -186,6 +186,12 @@ $section-max-width: 1224px;
 			align-items: center;
 		}
 	}
+}
+
+.site-performance__navigation-header {
+	display: flex;
+	flex-grow: 1;
+	flex-flow: column;
 }
 
 .site-performance__page-selector-drowdown {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
When the the screen size is expanded the space between the page selector and device switcher expands. This should be fixed at `16px`

* Fix the spacing to `16px` always

**Before**
![image](https://github.com/user-attachments/assets/711bb402-eeeb-4757-a3ca-8122b93d942e)

**After**
![image](https://github.com/user-attachments/assets/1e71b5ae-b52a-41e6-ba11-19e2622723c7)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Small polish

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites/performance/site`
* Expanded the page to larger size and verify the distance between the page selector and device switcher remains at `16px`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
