### PR TITLE
Domains: Remove `domains/gdpr-consent-page` feature flag that's not used anymore

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-privacy-info.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-privacy-info.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { memo } from 'react';
 import { connect } from 'react-redux';
 import { getSelectedDomain } from 'calypso/lib/domains';
@@ -26,16 +25,14 @@ const ContactsPrivacy = ( props: ContactsInfoProps ): null | JSX.Element => {
 			isPendingIcannVerification,
 			registeredViaTrustee,
 			registeredViaTrusteeUrl,
+			supportsGdprConsentManagement,
 		} = domain;
-
-		const canManageConsent =
-			config.isEnabled( 'domains/gdpr-consent-page' ) && domain.supportsGdprConsentManagement;
 
 		return (
 			<ContactsPrivacyCard
 				selectedDomainName={ props.selectedDomainName }
 				selectedSite={ props.selectedSite }
-				canManageConsent={ canManageConsent }
+				canManageConsent={ supportsGdprConsentManagement }
 				privateDomain={ privateDomain }
 				privacyAvailable={ privacyAvailable }
 				contactInfoDisclosed={ contactInfoDisclosed }

--- a/config/development.json
+++ b/config/development.json
@@ -62,7 +62,6 @@
 		"devdocs": true,
 		"devdocs/color-scheme-picker": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/max-characters-filter": false,
 		"domains/kracken-ui/pagination": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -32,7 +32,6 @@
 		"current-site/stale-cart-notice": false,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
-		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"external-media": true,

--- a/config/production.json
+++ b/config/production.json
@@ -43,7 +43,6 @@
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
 		"desktop-promo": true,
-		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"external-media": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -43,7 +43,6 @@
 		"desktop-promo": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
-		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"external-media": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -48,7 +48,6 @@
 		"devdocs": true,
 		"devdocs/color-scheme-picker": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"email-accounts/enabled": true,


### PR DESCRIPTION
## Proposed Changes

This PR removes the `domains/gdpr-consent-page` feature flag that's always true and not used anymore.

It was introduced in #24993 and the feature was released into production in #25051, making the flag obsolete.

That flag was gating the "Manage Consent for Personal Data Use" page, which is only accessible for OpenSRS domains. Eventually we'll be able to remove that page altogether.

### Screenshots

<img width="771" alt="Screenshot 2024-10-18 at 20 13 04" src="https://github.com/user-attachments/assets/f2425724-74d9-4b6c-8cf7-1d500010038a">

## Why are these changes being made?

Removing obsolete code.

## Testing Instructions

The flag was always true, so careful code inspection should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?