### PR TITLE
Domains: Remove remaining unused `domains/kracken-ui/*` feature flags

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { isBlogger, isFreeWordPressComDomain } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, CompactCard, ResponsiveToolbarGroup } from '@automattic/components';
@@ -84,9 +83,6 @@ import './style.scss';
 
 const debug = debugFactory( 'calypso:domains:register-domain-step' );
 
-// TODO: Enable A/B test handling for M2.1 release
-const isPaginationEnabled = config.isEnabled( 'domains/kracken-ui/pagination' );
-
 const noop = () => {};
 const domains = wpcom.domains();
 
@@ -94,7 +90,7 @@ const domains = wpcom.domains();
 const PAGE_SIZE = 10;
 const EXACT_MATCH_PAGE_SIZE = 4;
 const MAX_PAGES = 3;
-const SUGGESTION_QUANTITY = isPaginationEnabled ? PAGE_SIZE * MAX_PAGES : PAGE_SIZE;
+const SUGGESTION_QUANTITY = PAGE_SIZE * MAX_PAGES;
 const MIN_QUERY_LENGTH = 2;
 
 // session storage key for query cache
@@ -412,14 +408,8 @@ class RegisterDomainStep extends Component {
 	getSuggestionsFromProps() {
 		const { pageNumber, pageSize } = this.state;
 		const searchResults = this.state.searchResults || [];
-		const isKrackenUi = isPaginationEnabled;
 
-		let suggestions;
-		if ( isKrackenUi ) {
-			suggestions = searchResults.slice( 0, pageNumber * pageSize );
-		} else {
-			suggestions = [ ...searchResults ];
-		}
+		const suggestions = searchResults.slice( 0, pageNumber * pageSize );
 
 		if ( this.isSubdomainResultsVisible() ) {
 			if ( this.state.loadingSubdomainResults && ! this.state.loadingResults ) {
@@ -531,13 +521,11 @@ class RegisterDomainStep extends Component {
 	}
 
 	renderSearchFilters() {
-		const isKrackenUi = config.isEnabled( 'domains/kracken-ui/exact-match-filter' );
 		const isRenderingInitialSuggestions =
 			! Array.isArray( this.state.searchResults ) &&
 			! this.state.loadingResults &&
 			! this.props.showExampleSuggestions;
-		const showFilters =
-			( isKrackenUi && ! isRenderingInitialSuggestions ) || this.props.isReskinned;
+		const showFilters = ! isRenderingInitialSuggestions || this.props.isReskinned;
 
 		const showTldFilter =
 			( Array.isArray( this.state.availableTlds ) && this.state.availableTlds.length > 0 ) ||
@@ -675,10 +663,6 @@ class RegisterDomainStep extends Component {
 	}
 
 	renderPaginationControls() {
-		if ( ! isPaginationEnabled ) {
-			return null;
-		}
-
 		const { searchResults, pageNumber, pageSize, loadingResults: isLoading } = this.state;
 
 		if ( searchResults === null ) {

--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -152,8 +152,6 @@ export class DropdownFilters extends Component {
 			showTldFilter,
 		} = this.props;
 
-		const isExactMatchFilterEnabled = config.isEnabled( 'domains/kracken-ui/exact-match-filter' );
-
 		return (
 			<Popover
 				aria-label="Domain Search Filters"
@@ -184,24 +182,22 @@ export class DropdownFilters extends Component {
 				) }
 
 				<FormFieldset className="search-filters__checkboxes-fieldset">
-					{ isExactMatchFilterEnabled && (
-						<FormLabel
-							className="search-filters__label"
-							htmlFor="search-filters-show-exact-matches-only"
-						>
-							<FormInputCheckbox
-								className="search-filters__checkbox"
-								checked={ exactSldMatchesOnly }
-								id="search-filters-show-exact-matches-only"
-								name="exactSldMatchesOnly"
-								onChange={ this.handleOnChange }
-								value="exactSldMatchesOnly"
-							/>
-							<span className="search-filters__checkbox-label">
-								{ translate( 'Show exact matches only' ) }
-							</span>
-						</FormLabel>
-					) }
+					<FormLabel
+						className="search-filters__label"
+						htmlFor="search-filters-show-exact-matches-only"
+					>
+						<FormInputCheckbox
+							className="search-filters__checkbox"
+							checked={ exactSldMatchesOnly }
+							id="search-filters-show-exact-matches-only"
+							name="exactSldMatchesOnly"
+							onChange={ this.handleOnChange }
+							value="exactSldMatchesOnly"
+						/>
+						<span className="search-filters__checkbox-label">
+							{ translate( 'Show exact matches only' ) }
+						</span>
+					</FormLabel>
 				</FormFieldset>
 
 				<ValidationFieldset className="search-filters__buttons-fieldset">

--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Count, FormLabel, Popover } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import clsx from 'clsx';

--- a/client/components/domains/search-filters/filter-reset-notice.jsx
+++ b/client/components/domains/search-filters/filter-reset-notice.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -30,7 +29,6 @@ export class FilterResetNotice extends Component {
 
 	render() {
 		return (
-			config.isEnabled( 'domains/kracken-ui/pagination' ) &&
 			this.hasActiveFilters() &&
 			this.hasTooFewSuggestions() && (
 				<Card

--- a/config/development.json
+++ b/config/development.json
@@ -62,8 +62,6 @@
 		"devdocs": true,
 		"devdocs/color-scheme-picker": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domains/kracken-ui/exact-match-filter": true,
-		"domains/kracken-ui/pagination": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -32,8 +32,6 @@
 		"current-site/stale-cart-notice": false,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
-		"domains/kracken-ui/exact-match-filter": true,
-		"domains/kracken-ui/pagination": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/production.json
+++ b/config/production.json
@@ -43,8 +43,6 @@
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
 		"desktop-promo": true,
-		"domains/kracken-ui/exact-match-filter": true,
-		"domains/kracken-ui/pagination": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -43,8 +43,6 @@
 		"desktop-promo": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
-		"domains/kracken-ui/exact-match-filter": true,
-		"domains/kracken-ui/pagination": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -48,8 +48,6 @@
 		"devdocs": true,
 		"devdocs/color-scheme-picker": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domains/kracken-ui/exact-match-filter": true,
-		"domains/kracken-ui/pagination": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
## Proposed Changes

This PR removes the `domains/kracken-ui/pagination` and `domains/kracken-ui/exact-match-filter` feature flags which are always `true`.

These flags were introduced in #24018 to allow for more fine-grained testing of Kracken features, and were released into production in #24929.

For reference, the Kracken project was an old project (2018) whose goal was revamping and improving the domain search experience in WPCOM. More info at p8kIbR-c4-p2.

## Why are these changes being made?

Removing obsolete and dead code.

## Testing Instructions

Nothing should have changed, but please test the domain search page and ensure everything is working normally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?