### PR TITLE
Checkout: update sidebar monthly plan upsell color

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -948,7 +948,7 @@ const CheckoutSummaryFeaturesListItem = styled( 'li' )< { isSupported?: boolean 
 	padding-left: 24px;
 	position: relative;
 	overflow-wrap: break-word;
-	color: ${ ( props ) => ( props.isSupported ? 'inherit' : 'var( --color-neutral-40 )' ) };
+	color: ${ ( props ) => ( props.isSupported ? 'inherit' : props.theme.colors.textColorLight ) };
 
 	.rtl & {
 		padding-right: 24px;
@@ -1044,7 +1044,7 @@ const LoadingCopy = styled.p`
 const SwitchToAnnualPlanButton = styled.button`
 	text-align: left;
 	text-decoration: underline;
-	color: var( --color-link );
+	color: ${ ( props ) => props.theme.colors.primary };
 	cursor: pointer;
 
 	.rtl & {


### PR DESCRIPTION
The primary blue for WordPress.com's branding was updated with Color Studio 3.0 to `WordPress Blue 50`, but many parts of Calypso still use the previous `Blue 50`. Most of Checkout was updated in #94147 and #94194, but the monthly -> annual plan sidebar upsell uses the `--color-link` Calypso Sass variable, which hasn't been updated.

This diff updates the sidebar upsell to use Checkout theme color variables, which were updated to the new blue for WPcom in the PRs linked above, and also allow other Checkout clients (like Jetpack and Akismet) to easily override the colors.

Reported: pdKhl6-4n3-p2#comment-7529

| Before      | After |
| ----------- | ----------- |
| <img width="348" alt="Screenshot 2024-10-18 at 10 06 34 PM" src="https://github.com/user-attachments/assets/ba08b414-2173-4caa-ba8e-590903be97c3"> | <img width="359" alt="Screenshot 2024-10-18 at 10 08 55 PM" src="https://github.com/user-attachments/assets/b5074d0e-2262-4fb3-a95d-28ce6ab2cfad"> |

**To test:**
- add a monthly plan to your cart
- visit Checkout
- verify that the upsell has the proper blue