### PR TITLE
Stepper: New user stored with session storage

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -1,6 +1,5 @@
 import { StepContainer } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
-import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -10,11 +9,11 @@ import SignupFormSocialFirst from 'calypso/blocks/signup-form/signup-form-social
 import FormattedHeader from 'calypso/components/formatted-header';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
-import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { login } from 'calypso/lib/paths';
 import { AccountCreateReturn } from 'calypso/lib/signup/api/type';
 import wpcom from 'calypso/lib/wp';
+import { setSignupIsNewUser } from 'calypso/signup/storageUtils';
 import WpcomLoginForm from 'calypso/signup/wpcom-login-form';
 import { useSelector } from 'calypso/state';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
@@ -34,7 +33,6 @@ const UserStepComponent: Step = function UserStep( {
 	const translate = useTranslate();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const dispatch = useDispatch();
-	const { setIsNewUser } = useDataStoreDispatch( USER_STORE );
 	const { handleSocialResponse, notice, accountCreateResponse } = useHandleSocialResponse( flow );
 
 	const [ wpAccountCreateResponse, setWpAccountCreateResponse ] = useState< AccountCreateReturn >();
@@ -61,6 +59,12 @@ const UserStepComponent: Step = function UserStep( {
 
 	const locale = useFlowLocale();
 	const shouldRenderLocaleSuggestions = ! isLoggedIn; // For logged-in users, we respect the user language settings
+
+	const handleCreateAccountSuccess = ( data: AccountCreateReturn ) => {
+		if ( 'username' in data ) {
+			setSignupIsNewUser( data.username );
+		}
+	};
 
 	return (
 		<>
@@ -94,7 +98,7 @@ const UserStepComponent: Step = function UserStep( {
 							userEmail=""
 							notice={ notice }
 							isSocialFirst
-							onCreateAccountSuccess={ () => setIsNewUser( true ) }
+							onCreateAccountSuccess={ handleCreateAccountSuccess }
 						/>
 						{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (
 							<WpcomLoginForm

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
@@ -1,9 +1,8 @@
 // import config from '@automattic/calypso-config';
 // import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 import { useMutation } from '@tanstack/react-query';
-import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
-import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { createAccount } from 'calypso/lib/signup/api/account';
+import { setSignupIsNewUser } from 'calypso/signup/storageUtils';
 import { useDispatch } from 'calypso/state';
 import {
 	SOCIAL_LOGIN_REQUEST,
@@ -13,7 +12,6 @@ import {
 
 export function useCreateAccountMutation() {
 	const dispatch = useDispatch();
-	const { setIsNewUser } = useDataStoreDispatch( USER_STORE );
 
 	return useMutation( {
 		mutationKey: [ 'create' ],
@@ -24,8 +22,8 @@ export function useCreateAccountMutation() {
 			} );
 		},
 		onSuccess: ( data ) => {
-			if ( 'isNewAccountCreated' in data && data.isNewAccountCreated ) {
-				setIsNewUser( true );
+			if ( 'created_account' in data && data.created_account ) {
+				setSignupIsNewUser( data?.username );
 			}
 			dispatch( {
 				type: SOCIAL_LOGIN_REQUEST_SUCCESS,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-create-user-mutation.ts
@@ -22,7 +22,7 @@ export function useCreateAccountMutation() {
 			} );
 		},
 		onSuccess: ( data ) => {
-			if ( 'created_account' in data && data.created_account ) {
+			if ( 'isNewAccountCreated' in data && data.isNewAccountCreated ) {
 				setSignupIsNewUser( data?.username );
 			}
 			dispatch( {

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -119,3 +119,16 @@ export const getSignupCompleteElapsedTime = () => {
 
 	return Math.floor( performance.now() - startTime );
 };
+
+export const setSignupIsNewUser = ( username ) =>
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.setItem( `wpcom_signup_is_new_user_${ username }`, true )
+	);
+export const getSignupIsNewUser = ( username ) =>
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.getItem( `wpcom_signup_is_new_user_${ username }` )
+	);
+export const clearSignupIsNewUser = ( username ) =>
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.removeItem( `wpcom_signup_is_new_user_${ username }` )
+	);

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -10,15 +10,9 @@ export function createActions() {
 		type: 'RECEIVE_CURRENT_USER_FAILED' as const,
 	} );
 
-	const setIsNewUser = ( isNewUser: boolean ) => ( {
-		type: 'SET_IS_NEW_USER' as const,
-		isNewUser,
-	} );
-
 	return {
 		receiveCurrentUser,
 		receiveCurrentUserFailed,
-		setIsNewUser,
 	};
 }
 
@@ -26,9 +20,7 @@ export type ActionCreators = ReturnType< typeof createActions >;
 
 export type Action =
 	| ReturnType<
-			| ActionCreators[ 'receiveCurrentUser' ]
-			| ActionCreators[ 'receiveCurrentUserFailed' ]
-			| ActionCreators[ 'setIsNewUser' ]
+			ActionCreators[ 'receiveCurrentUser' ] | ActionCreators[ 'receiveCurrentUserFailed' ]
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost
 	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/user/reducer.ts
+++ b/packages/data-stores/src/user/reducer.ts
@@ -13,15 +13,7 @@ export const currentUser: Reducer< CurrentUser | null | undefined, Action > = ( 
 	return state;
 };
 
-const isNewUser: Reducer< boolean, Action > = ( state = false, action ) => {
-	switch ( action.type ) {
-		case 'SET_IS_NEW_USER':
-			return action.isNewUser;
-	}
-	return state;
-};
-
-const reducer = combineReducers( { currentUser, isNewUser } );
+const reducer = combineReducers( { currentUser } );
 export type State = ReturnType< typeof reducer >;
 
 export default reducer;

--- a/packages/data-stores/src/user/selectors.ts
+++ b/packages/data-stores/src/user/selectors.ts
@@ -4,4 +4,3 @@ export const getState = ( state: State ) => state;
 
 export const getCurrentUser = ( state: State ) => state.currentUser;
 export const isCurrentUserLoggedIn = ( state: State ) => !! state.currentUser?.ID;
-export const isNewUser = ( state: State ) => state.isNewUser;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1729278139000769/1729151031.413209-slack-C073776NJ66
Fixes https://github.com/Automattic/wp-calypso/issues/95452

## Proposed Changes

Move from the data store to the use of the session storage to keep track of whether the user in the onboarding flow is a new user or not.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

New users that signed up using a social account are not correctly tagged as new now in Stepper, so the event `calypso_new_user_site_registration` is not fired correctly. 
This happens because after social signup a refresh happens, probably cleaning the store. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Signup with a new user in /setup/onboarding, using the email.
* Reach the end of onboarding, you should see the `calypso_new_user_site_registration` event
* Do the same using a social account.
