### PR TITLE
Sites Dashboard: Layout improvements

### DIFF
--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -74,30 +74,32 @@
 	}
 
 	.sites-banner-container {
+		box-sizing: border-box;
 		display: flex;
 		justify-content: center;
+		margin: 0 auto;
+		padding-inline: 48px;
+		width: 100%;
+
+		@media (max-width: 402px) {
+			padding-inline: 24px;
+		}
+
+		@include break-huge {
+			max-width: 1400px;
+		}
 	}
 
 	.sites-banner {
 		width: 100%;
-		margin-inline: 16px;
 
 		.banner__action {
 			a {
-				display: flex;
+				display: inline-flex;
 				white-space: nowrap;
 			}
 		}
 
-		@include break-large {
-			margin-inline: 26px;
-		}
-
-		@include break-huge {
-			margin-inline: 64px;
-			width: 100%;
-			max-width: 1400px;
-		}
 	}
 
 	.dataviews-filters__view-actions {
@@ -182,6 +184,10 @@
 	table.dataviews-view-table th:last-child,
 	table.dataviews-view-table td:last-child {
 		display: table-cell; /* ensures these cells are always shown */
+	}
+
+	table.dataviews-view-table td:last-child .dataviews-view-table__cell-content-wrapper {
+		justify-content: flex-end;
 	}
 
 	.sites-overview__content {
@@ -535,9 +541,11 @@
 
 		.dataviews-wrapper {
 			.dataviews-pagination {
+				border: 0;
 				margin: 0;
+				padding-left: 0;
+				padding-right: 0;
 				position: relative;
-				width: 100%;
 			}
 
 			.spinner-wrapper {
@@ -555,7 +563,12 @@
 		margin: 0 auto;
 		max-width: 1400px;
 		box-sizing: border-box;
+
+		.dataviews-pagination {
+			width: auto;
+		}
 	}
+
 	div.a4a-layout__viewport {
 		margin: 0 auto;
 		max-width: 1400px;
@@ -564,19 +577,6 @@
 
 	.a4a-layout-column__container {
 		margin: 0 -14px;
-		.dataviews-wrapper {
-			.dataviews-pagination {
-				@include break-large {
-					padding-left: 26px;
-					padding-right: 26px;
-				}
-
-				@include break-huge {
-					padding-left: 64px;
-					padding-right: 64px;
-				}
-			}
-		}
 	}
 }
 
@@ -602,7 +602,7 @@
 			.a4a-layout__viewport {
 				display: flex;
 				margin: 0;
-				padding: 16px;
+				padding: 16px 24px;
 			}
 
 			.a4a-layout__header {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1729282075333529-slack-C048CUFRGFQ

## Proposed Changes

This PR proposed some quick layout improvements to the sites dashboard.

Before:
![SCR-20241020-jrcr](https://github.com/user-attachments/assets/bb892c7b-3b06-4a13-895d-9ecc376bf83c)

After:
![SCR-20241020-jwyd](https://github.com/user-attachments/assets/95d184d9-35a9-4675-abbe-b1e83358dd03)

Not in scope:
- Optimizing alignment when scrollbar is always being shown.
- Making the table full-width for wide resolutions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WordPress.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`
* Ensure that alignments are updated as shown above.
* Also test different resolutions and alignments still make sense.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?