### PR TITLE
Update sticky state for the plans grid action buttons

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -252,7 +252,7 @@ describe( 'useGenerateActionHook', () => {
 			priceString: '$300',
 		} );
 
-		expect( action.primary.text ).toBe( 'Upgrade – %(priceString)s' );
+		expect( action.primary.text ).toBe( 'Upgrade (%(priceString)s)' );
 	} );
 
 	it( 'should handle upgrade to longer billing period - annual', () => {

--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -252,7 +252,7 @@ describe( 'useGenerateActionHook', () => {
 			priceString: '$300',
 		} );
 
-		expect( action.primary.text ).toBe( 'Upgrade (%(priceString)s)' );
+		expect( action.primary.text ).toBe( 'Upgrade ⋅ %(priceString)s' );
 	} );
 
 	it( 'should handle upgrade to longer billing period - annual', () => {

--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -147,7 +147,7 @@ describe( 'useGenerateActionHook', () => {
 		} );
 
 		// The assertion is okay since we don't actually run the translate function
-		expect( action.primary.text ).toBe( 'Select %(plan)s – %(priceString)s' );
+		expect( action.primary.text ).toBe( 'Select %(plan)s ⋅ %(priceString)s' );
 	} );
 
 	it( 'should handle signup actions for free trial', () => {
@@ -206,7 +206,7 @@ describe( 'useGenerateActionHook', () => {
 		} );
 
 		// The assertion is okay since we don't actually run the translate function
-		expect( action.primary.text ).toBe( 'Get %(plan)s – %(priceString)s' );
+		expect( action.primary.text ).toBe( 'Get %(plan)s ⋅ %(priceString)s' );
 	} );
 
 	it( 'should handle signup actions for plans with sticky buttons and isLargeCurrency as true', () => {

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -462,11 +462,11 @@ function getLoggedInPlansAction( {
 							span: <span className="plan-features-2023-grid__actions-signup-plan-text" />,
 						},
 				  } )
-				: translate( 'Upgrade – %(priceString)s', {
+				: translate( 'Upgrade (%(priceString)s)', {
 						context: 'verb',
 						args: { priceString: priceString ?? '' },
 						comment:
-							'%(priceString)s is the full price including the currency. Eg: Get Upgrade - $10',
+							'%(priceString)s is the full price including the currency. Eg: Get Upgrade ($10)',
 				  } )
 		);
 	}

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -462,7 +462,7 @@ function getLoggedInPlansAction( {
 							span: <span className="plan-features-2023-grid__actions-signup-plan-text" />,
 						},
 				  } )
-				: translate( 'Upgrade (%(priceString)s)', {
+				: translate( 'Upgrade ⋅ %(priceString)s', {
 						context: 'verb',
 						args: { priceString: priceString ?? '' },
 						comment:

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -231,13 +231,13 @@ function getLaunchPageAction( {
 		 * `isStuck` indicates the buttons are fixed/sticky in the grid, and we show the price alongside the plan name.
 		 */
 		return createLaunchPageAction(
-			translate( 'Select %(plan)s – %(priceString)s', {
+			translate( 'Select %(plan)s ⋅ %(priceString)s', {
 				args: {
 					plan: planTitle ?? '',
 					priceString: priceString ?? '',
 				},
 				comment:
-					'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Select Premium - $10',
+					'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Select Premium ⋅ $10',
 			} )
 		);
 	}
@@ -300,18 +300,18 @@ function getSignupAction( {
 							priceString: priceString ?? '',
 						},
 						comment:
-							'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Premium - $10',
+							'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Premium ⋅ $10',
 						components: {
 							span: <span className="plan-features-2023-grid__actions-signup-plan-text" />,
 						},
 				  } )
-				: translate( 'Get %(plan)s – %(priceString)s', {
+				: translate( 'Get %(plan)s ⋅ %(priceString)s', {
 						args: {
 							plan: planTitle ?? '',
 							priceString: priceString ?? '',
 						},
 						comment:
-							'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Premium - $10',
+							'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Premium ⋅ $10',
 				  } )
 		);
 	}
@@ -457,7 +457,7 @@ function getLoggedInPlansAction( {
 							priceString: priceString ?? '',
 						},
 						comment:
-							'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Premium - $10',
+							'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Premium ⋅ $10',
 						components: {
 							span: <span className="plan-features-2023-grid__actions-signup-plan-text" />,
 						},
@@ -466,7 +466,7 @@ function getLoggedInPlansAction( {
 						context: 'verb',
 						args: { priceString: priceString ?? '' },
 						comment:
-							'%(priceString)s is the full price including the currency. Eg: Get Upgrade ($10)',
+							'%(priceString)s is the full price including the currency. Eg: Get Upgrade ⋅ $10',
 				  } )
 		);
 	}

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -603,9 +603,6 @@
 			border: none;
 			background-color: #f9f9f9;
 			box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.04);
-			.plan-features-2023-grid__actions-button {
-				font-size: rem(12px);
-			}
 		}
 	}
 

--- a/packages/plans-grid-next/src/components/sticky-container.tsx
+++ b/packages/plans-grid-next/src/components/sticky-container.tsx
@@ -72,6 +72,10 @@ export function StickyContainer( props: Props ) {
 	const stickyRef = useRef( null );
 	const [ isStuck, setIsStuck ] = useState( false );
 
+	// To account for any differences in the precision of intersectionRect.bottom between browsers,
+	// use a small tolerance to determine if the element is at the bottom of the screen
+	const bottomTolerance = 1;
+
 	/**
 	 * This effect sets the value of `isStuck` state when it detects that
 	 * the element is sticky.
@@ -90,7 +94,9 @@ export function StickyContainer( props: Props ) {
 				if ( entry.intersectionRatio === 0 ) {
 					// The element is out of view
 					setIsStuck( false );
-				} else if ( entry.intersectionRect.bottom === entry.rootBounds?.bottom ) {
+				} else if (
+					Math.abs( entry.intersectionRect.bottom - entry.rootBounds?.bottom ) <= bottomTolerance
+				) {
 					// The element is intersecting, but it is at the bottom of the screen
 					setIsStuck( false );
 				} else {

--- a/packages/plans-grid-next/src/components/sticky-container.tsx
+++ b/packages/plans-grid-next/src/components/sticky-container.tsx
@@ -72,10 +72,6 @@ export function StickyContainer( props: Props ) {
 	const stickyRef = useRef( null );
 	const [ isStuck, setIsStuck ] = useState( false );
 
-	// To account for any differences in the precision of intersectionRect.bottom between browsers,
-	// use a small tolerance to determine if the element is at the bottom of the screen
-	const bottomTolerance = 1;
-
 	/**
 	 * This effect sets the value of `isStuck` state when it detects that
 	 * the element is sticky.
@@ -95,7 +91,8 @@ export function StickyContainer( props: Props ) {
 					// The element is out of view
 					setIsStuck( false );
 				} else if (
-					Math.abs( entry.intersectionRect.bottom - entry.rootBounds?.bottom ) <= bottomTolerance
+					entry.rootBounds?.bottom !== undefined &&
+					entry.boundingClientRect.bottom >= entry.rootBounds?.bottom
 				) {
 					// The element is intersecting, but it is at the bottom of the screen
 					setIsStuck( false );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/82853

## Proposed Changes

* For the plans grid action buttons in sticky state:
  * The button copy now uses parentheses ("Upgrade (€17)") instead of a hyphen ("Upgrade – €17")
  * The button font size is no longer reduced


| Before | After |
| -- | -- |
|![CleanShot 2024-10-21 at 14 54 33@2x](https://github.com/user-attachments/assets/fdb40e96-0876-4307-870d-f0e9d00ff7e3)|![CleanShot 2024-10-21 at 14 53 31@2x](https://github.com/user-attachments/assets/43617e72-98d1-4fc8-8be1-8109785b8bee)|



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The copy "Upgrade – €17" is confusing because the '-' can be interpreted as a minus sign
* The reduced font size is unexpected as the button copy still fits using the larger/original font size

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/plans/:site`
* Scroll down the plans grid until the upgrade buttons enter sticky state
* The button copy should uses parentheses around the amount eg. "Upgrade (€17)" instead of "Upgrade – €17"
* The button font size should not change when entering the sticky state

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
