### PR TITLE
Stats: Add new date filtering feature flag

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -243,6 +243,7 @@ class StatsSite extends Component {
 			supportUserFeedback,
 		} = this.props;
 		const isNewStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
+		const isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' );
 		let defaultPeriod = PAST_SEVEN_DAYS;
 
 		const shouldShowUpsells = isOdysseyStats && ! isAtomic;
@@ -376,6 +377,14 @@ class StatsSite extends Component {
 					isOdysseyStats={ isOdysseyStats }
 					statsPurchaseSuccess={ context.query.statsPurchaseSuccess }
 				/>
+				{ isNewDateFilteringEnabled && (
+					<div
+						className="stats-new-date-filtering-callout"
+						style={ { background: 'antiquewhite', maring: '24px', padding: '24px' } }
+					>
+						<p>New date filtering enabled.</p>
+					</div>
+				) }
 				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>

--- a/config/client.json
+++ b/config/client.json
@@ -24,6 +24,7 @@
 	"signup_url",
 	"stats/empty-module-traffic",
 	"stats/empty-module-v2",
+	"stats/new-date-filtering",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -218,6 +218,7 @@
 		"ssr/prefetch-timebox": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
+		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -141,6 +141,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
+		"stats/new-date-filtering": false,
 		"stats/paid-wpcom-v2": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/production.json
+++ b/config/production.json
@@ -187,6 +187,7 @@
 		"ssr/sample-log-cache-misses": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
+		"stats/new-date-filtering": false,
 		"stats/paid-wpcom-v2": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -183,6 +183,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
+		"stats/new-date-filtering": false,
 		"stats/paid-wpcom-v2": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/test.json
+++ b/config/test.json
@@ -131,6 +131,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
+		"stats/new-date-filtering": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -180,6 +180,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
+		"stats/new-date-filtering": false,
 		"stats/paid-wpcom-v2": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/212

## Proposed Changes

Adds the `stats/new-date-filtering` feature flag to the project and a callout for visually testing flag.

- Enabled by default in "development" environment.
- Disabled in all other environments.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Kick-off for the new date filtering project.

pejTkB-1zs-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link.
* Visit the Stats → Traffic page and confirm it loads normally.
* Manually enable the feature flag: `?flags=stats/new-date-filtering`
* Confirm the temp callout is visible.
* Disable the flag: `?flags=-stats/new-date-filtering`
* Confirm the temp callout is no longer visible.

<img width="751" alt="SCR-20241021-lavx" src="https://github.com/user-attachments/assets/a95d4925-a992-4843-aae9-728069219d80">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?