### PR TITLE
A4A > Agency Tier: Implement an agency tier celebration modal

### DIFF
--- a/client/a8c-for-agencies/components/a4a-themed-modal/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-themed-modal/index.tsx
@@ -12,6 +12,7 @@ type Props = {
 	onClose?: () => void;
 	modalImage?: string;
 	dismissable?: boolean;
+	modalVideo?: ReactNode;
 };
 
 export default function A4AThemedModal( {
@@ -20,6 +21,7 @@ export default function A4AThemedModal( {
 	onClose = () => {},
 	modalImage,
 	dismissable,
+	modalVideo,
 }: Props ) {
 	return (
 		<Modal
@@ -29,7 +31,10 @@ export default function A4AThemedModal( {
 		>
 			<div className="a4a-themed-modal__wrapper">
 				<div className="a4a-themed-modal__sidebar-image-container">
-					<img className="a4a-themed-modal__sidebar-image" src={ modalImage } alt="" />
+					{ modalImage && (
+						<img className="a4a-themed-modal__sidebar-image" src={ modalImage } alt="" />
+					) }
+					{ modalVideo }
 				</div>
 				<div className="a4a-themed-modal__content">
 					{ dismissable && (

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
@@ -2,16 +2,7 @@ import AgencyPartnerLogo from 'calypso/assets/images/a8c-for-agencies/agency-tie
 import EmergingPartnerLogo from 'calypso/assets/images/a8c-for-agencies/agency-tier/emerging-partner-logo-small.svg';
 import ProAgencyPartnerLogo from 'calypso/assets/images/a8c-for-agencies/agency-tier/pro-agency-partner-logo-small.svg';
 import { preventWidows } from 'calypso/lib/formatting';
-
-interface AgencyTierInfo {
-	title: string;
-	fullTitle: string;
-	subtitle: string;
-	description: string;
-	logo: string;
-	includedTiers: string[];
-	emptyStateMessage?: string;
-}
+import type { AgencyTierInfo } from '../types';
 
 const getAgencyTierInfo = (
 	agencyTier: 'emerging-partner' | 'agency-partner' | 'pro-agency-partner',
@@ -25,6 +16,13 @@ const getAgencyTierInfo = (
 		logo: '',
 		includedTiers: [] as string[],
 		emptyStateMessage: '',
+		celebrationModal: {
+			title: '',
+			description: '',
+			extraDescription: undefined,
+			benefits: [],
+			video: '',
+		},
 	};
 	switch ( agencyTier ) {
 		case 'emerging-partner':
@@ -54,6 +52,24 @@ const getAgencyTierInfo = (
 						components: { b: <b /> },
 					}
 				),
+				celebrationModal: {
+					title: translate( 'Welcome to Automattic for Agencies!' ),
+					description: translate(
+						"You're just starting your journey with us. Your tier and associated benefits will change over time as you invest in or refer clients to Automattic products."
+					),
+					extraDescription: translate( 'As an Automattic for Agencies member, you can:' ),
+					benefits: [
+						translate( 'Enjoy special bulk discounts on our marketplace curated for partners.' ),
+						translate( 'Boost your income by earning commissions on client referrals.' ),
+						translate( 'Manage all your client sites effortlessly in one convenient location.' ),
+						translate(
+							'Access immediate help from our WordPress experts through our support tools.'
+						),
+						translate( 'Enhance your skills with product training and marketing materials.' ),
+					],
+					video:
+						'https://automattic.com/wp-content/uploads/2024/10/emerging_partner_tier_celebration.mp4',
+				},
 			};
 			break;
 		case 'agency-partner':
@@ -80,6 +96,19 @@ const getAgencyTierInfo = (
 				),
 				logo: AgencyPartnerLogo,
 				includedTiers: [ 'emerging-partner', 'agency-partner' ],
+				celebrationModal: {
+					title: translate( "Congratulations! You've reached the Partner tier!" ),
+					description: translate(
+						"You've reached at least $1,200 in influenced revenue and have unlocked these additional benefits:"
+					),
+					benefits: [
+						translate( 'Inclusion in agency directories.' ),
+						translate( 'A free WordPress.com and Pressable site.' ),
+						translate( 'Early access to new Automattic products and features.' ),
+					],
+					video:
+						'https://automattic.com/wp-content/uploads/2024/10/agency_partner_tier_celebration-2.mp4',
+				},
 			};
 			break;
 		case 'pro-agency-partner':
@@ -100,6 +129,24 @@ const getAgencyTierInfo = (
 				),
 				logo: ProAgencyPartnerLogo,
 				includedTiers: [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ],
+				celebrationModal: {
+					title: translate( "Congratulations, you've reached the Pro Partner tier!" ),
+					description: translate(
+						"You've influenced at least $5,000 in Automattic revenue and have unlocked these additional benefits:"
+					),
+					benefits: [
+						translate( 'A dedicated partner manager and enjoy priority support access.' ),
+						translate(
+							"Advanced sales training sessions at request to sharpen your team's expertise."
+						),
+						translate( "Access to pre-qualified leads provided by Automattic's sales teams." ),
+						translate( "Access to pre-qualified leads provided by Automattic's sales teams." ),
+						translate( 'Co-marketing opportunities.' ),
+						translate( 'Access to the Automattic for Agencies advisory board.' ),
+					],
+					video:
+						'https://automattic.com/wp-content/uploads/2024/10/agency_pro_partner_tier_celebration-2.mp4',
+				},
 			};
 	}
 	return { id: agencyTier, ...tierInfo };

--- a/client/a8c-for-agencies/sections/agency-tier/types.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/types.ts
@@ -1,0 +1,16 @@
+export interface AgencyTierInfo {
+	title: string;
+	fullTitle: string;
+	subtitle: string;
+	description: string;
+	logo: string;
+	includedTiers: string[];
+	emptyStateMessage?: string;
+	celebrationModal: {
+		title: string;
+		description: string;
+		extraDescription?: string;
+		benefits: string[];
+		video: string;
+	};
+}

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal.tsx
@@ -1,0 +1,67 @@
+import { Button } from '@wordpress/components';
+import { clsx } from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import A4AThemedModal from 'calypso/a8c-for-agencies/components/a4a-themed-modal';
+import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch, useSelector } from 'calypso/state';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import type { AgencyTierInfo } from 'calypso/a8c-for-agencies/sections/agency-tier/types';
+
+// Style is imported from the parent component
+
+const PREFERENCE_NAME = 'a4a-agency-tier-celebration-modal-dismissed-type';
+
+export default function AgencyTierCelebrationModal( {
+	agencyTierInfo,
+	currentAgencyTier,
+}: {
+	agencyTierInfo?: AgencyTierInfo | null;
+	currentAgencyTier?: string | null;
+} ) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const celebrationModalShowForCurrentType = useSelector( ( state ) =>
+		getPreference( state, PREFERENCE_NAME )
+	);
+
+	if ( ! agencyTierInfo || celebrationModalShowForCurrentType === currentAgencyTier ) {
+		return null;
+	}
+
+	const handleOnClose = () => {
+		dispatch( savePreference( PREFERENCE_NAME, currentAgencyTier ?? '' ) );
+	};
+
+	const { title, description, extraDescription, benefits, video } = agencyTierInfo.celebrationModal;
+
+	return (
+		<A4AThemedModal
+			className={ clsx( 'agency-tier-celebration-modal', currentAgencyTier ) }
+			modalVideo={ <video src={ video } preload="auto" width={ 470 } loop muted autoPlay /> }
+			onClose={ handleOnClose }
+			dismissable
+		>
+			<div className="agency-tier-celebration-modal__content">
+				<div className="agency-tier-celebration-modal__title">{ title }</div>
+				<div className="agency-tier-celebration-modal__description">{ description }</div>
+				{ extraDescription && (
+					<div className="agency-tier-celebration-modal__extra-description">
+						{ extraDescription }
+					</div>
+				) }
+				<ul className="agency-tier-celebration-modal__benefits">
+					{ benefits.map( ( benefit ) => (
+						<li key={ benefit }>{ benefit }</li>
+					) ) }
+				</ul>
+			</div>
+			<div className="agency-tier-celebration-modal__footer">
+				<Button variant="primary" onClick={ handleOnClose } href={ A4A_AGENCY_TIER_LINK }>
+					{ translate( 'Explore your benefits' ) }
+				</Button>
+			</div>
+		</A4AThemedModal>
+	);
+}

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
@@ -7,6 +7,7 @@ import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sideba
 import getAgencyTierInfo from 'calypso/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import AgencyTierCelebrationModal from './celebration-modal';
 
 import './style.scss';
 
@@ -15,58 +16,65 @@ export default function OverviewSidebarAgencyTier() {
 
 	const agency = useSelector( getActiveAgency );
 
-	const currentAgencyTierInfo = agency?.tier?.id
-		? getAgencyTierInfo( agency.tier.id, translate )
+	const currentAgencyTier = agency?.tier?.id;
+	const currentAgencyTierInfo = currentAgencyTier
+		? getAgencyTierInfo( currentAgencyTier, translate )
 		: null;
 
 	const defaultAgencyTierInfo = getAgencyTierInfo( 'emerging-partner', translate );
 
 	return (
-		<Card className="agency-tier__card">
-			<FoldableCard
-				className="foldable-nav"
-				header={ translate( 'Your Agency Tier' ) }
-				expanded
-				compact
-				iconSize={ 18 }
-			>
-				<div className="agency-tier__bottom-content">
-					<div
-						className={ clsx( 'agency-tier__current-agency-tier-header', {
-							'is-default': ! currentAgencyTierInfo,
-						} ) }
-					>
-						{ currentAgencyTierInfo ? (
-							<>
-								<span className="agency-tier__current-agency-tier-icon">
-									<img src={ currentAgencyTierInfo.logo } alt={ currentAgencyTierInfo.id } />
-								</span>
-								<span className="agency-tier__current-agency-tier-title">
-									{ currentAgencyTierInfo.title }
-								</span>
-							</>
-						) : (
-							<>
-								<span className="agency-tier__current-agency-tier-icon">
-									<img src={ defaultAgencyTierInfo.logo } alt={ defaultAgencyTierInfo.id } />
-								</span>
-								<span className="agency-tier__current-agency-tier-title">
-									{ defaultAgencyTierInfo.emptyStateMessage }
-								</span>
-							</>
-						) }
-					</div>
-					{ currentAgencyTierInfo && (
-						<div className="agency-tier__current-agency-tier-description">
-							{ currentAgencyTierInfo.description }
+		<>
+			<AgencyTierCelebrationModal
+				agencyTierInfo={ currentAgencyTierInfo }
+				currentAgencyTier={ currentAgencyTier }
+			/>
+			<Card className="agency-tier__card">
+				<FoldableCard
+					className="foldable-nav"
+					header={ translate( 'Your Agency Tier' ) }
+					expanded
+					compact
+					iconSize={ 18 }
+				>
+					<div className="agency-tier__bottom-content">
+						<div
+							className={ clsx( 'agency-tier__current-agency-tier-header', {
+								'is-default': ! currentAgencyTierInfo,
+							} ) }
+						>
+							{ currentAgencyTierInfo ? (
+								<>
+									<span className="agency-tier__current-agency-tier-icon">
+										<img src={ currentAgencyTierInfo.logo } alt={ currentAgencyTierInfo.id } />
+									</span>
+									<span className="agency-tier__current-agency-tier-title">
+										{ currentAgencyTierInfo.title }
+									</span>
+								</>
+							) : (
+								<>
+									<span className="agency-tier__current-agency-tier-icon">
+										<img src={ defaultAgencyTierInfo.logo } alt={ defaultAgencyTierInfo.id } />
+									</span>
+									<span className="agency-tier__current-agency-tier-title">
+										{ defaultAgencyTierInfo.emptyStateMessage }
+									</span>
+								</>
+							) }
 						</div>
-					) }
-					<Button href={ A4A_AGENCY_TIER_LINK }>
-						<Icon icon={ arrowRight } size={ 18 } />
-						{ translate( 'Explore tiers and benefits' ) }
-					</Button>
-				</div>
-			</FoldableCard>
-		</Card>
+						{ currentAgencyTierInfo && (
+							<div className="agency-tier__current-agency-tier-description">
+								{ currentAgencyTierInfo.description }
+							</div>
+						) }
+						<Button href={ A4A_AGENCY_TIER_LINK }>
+							<Icon icon={ arrowRight } size={ 18 } />
+							{ translate( 'Explore tiers and benefits' ) }
+						</Button>
+					</div>
+				</FoldableCard>
+			</Card>
+		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
@@ -1,3 +1,7 @@
+$video-pink: #f4b1ff;
+$video-blue: #002d3e;
+$video-green: #0e5837;
+
 .agency-tier__card {
 	padding: 8px;
 	border-radius: 4px;
@@ -70,5 +74,83 @@
 	&:hover {
 		background: none;
 		box-shadow: none;
+	}
+}
+
+.agency-tier-celebration-modal {
+	&.emerging-partner {
+
+		&.a4a-themed-modal .components-modal__content.hide-header {
+			background: $video-pink;
+		}
+	}
+
+	&.agency-partner {
+
+		&.a4a-themed-modal .components-modal__content.hide-header {
+			background: $video-blue;
+		}
+	}
+
+	&.pro-agency-partner {
+		&.a4a-themed-modal .components-modal__content.hide-header {
+			background: $video-green;
+		}
+	}
+
+	&.a4a-themed-modal .components-modal__content.hide-header {
+		padding: 0;
+	}
+
+	.a4a-themed-modal__content {
+		margin: 8px;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		padding-bottom: 16px;
+		max-height: 450px;
+	}
+
+	.a4a-themed-modal__sidebar-image-container {
+		min-width: 50%;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+
+	.agency-tier-celebration-modal__content {
+		display: flex;
+		gap: 16px;
+		flex-direction: column;
+		max-height: 360px;
+		overflow: scroll;
+		margin-block-end: 16px;
+
+		.agency-tier-celebration-modal__title {
+			@include a4a-font-heading-xl;
+		}
+
+		.agency-tier-celebration-modal__description,
+		.agency-tier-celebration-modal__extra-description {
+			@include a4a-font-body-md;
+		}
+
+		.agency-tier-celebration-modal__benefits {
+			display: grid;
+			gap: 4px;
+			margin: 0 0 0 0.8rem;
+			list-style-image: url(calypso/assets/images/a8c-for-agencies/agency-tier/check-icon.svg);
+
+			li {
+				@include a4a-font-body-md;
+				padding-inline-start: 8px;
+				margin-inline-start: 4px;
+			}
+		}
+
+		a.components-button {
+			margin-block-start: 8px;
+			width: fit-content;
+		}
 	}
 }

--- a/client/assets/images/a8c-for-agencies/agency-tier/check-icon.svg
+++ b/client/assets/images/a8c-for-agencies/agency-tier/check-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="13" height="11" viewBox="0 0 13 11" fill="none">
+<path d="M11.3979 1.7168L4.83125 8.28343L2 5.45218" stroke="#5AB7E8" stroke-width="3" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1252

## Proposed Changes

This PR implements an agency tier celebration modal.

## Why are these changes being made?

* To let the user know about their agency tier upgrade. 

NOTE: 

- Mobile view and scroll indicator for overflowing content will be implemented in another PR.
- Dismissing the banner or clicking on the `Explore your benefits` should hide the banner permanently until the next tier is reached.

## Testing Instructions

* Remove your agency tier if it is already set from the MC tool > Go to the Overview page using the A4A live link> Verify no modal is shown. 

* Update your agency tier to **Emerging Partner** using the MC tool > Refresh the UI & verify the screen looks as shown below. Clicking on the `Explore your benefits` button should take you to /agency-tier. 

https://github.com/user-attachments/assets/9a4ae076-55df-4486-99f9-883f9f63f18b

<img width="790" alt="Screenshot 2024-10-21 at 10 41 10 AM" src="https://github.com/user-attachments/assets/5233f6ec-22b8-4269-be70-f5776aa9dd6f">

* Change the agency tier to **Agency Partner** > Refresh the UI and verify the screen looks as shown below:

https://github.com/user-attachments/assets/b10b4fb9-dbef-432e-8cef-3180eb09ebf7

<img width="790" alt="Screenshot 2024-10-21 at 10 42 13 AM" src="https://github.com/user-attachments/assets/af02b5f7-99b8-4fb9-a75a-245262309a70">

* Change the agency tier to **Pro Agency Partner** > Refresh the UI and verify the screen looks as shown below:

https://github.com/user-attachments/assets/bb67a142-749a-444b-9082-7e2351b67aec

<img width="790" alt="Screenshot 2024-10-21 at 10 42 42 AM" src="https://github.com/user-attachments/assets/0daf090f-e0bd-4385-9fe3-533756ebdc99">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
