### PR TITLE
Theme: Fix Preview & Customize button for themes belonging to both wpcom and wporg

### DIFF
--- a/client/state/themes/selectors/get-is-live-preview-supported.ts
+++ b/client/state/themes/selectors/get-is-live-preview-supported.ts
@@ -4,6 +4,7 @@ import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
 import { AppState } from 'calypso/types';
 import {
+	isWpcomTheme,
 	isWporgTheme,
 	isThemeActive,
 	isFullSiteEditingTheme,
@@ -142,7 +143,7 @@ export const getIsLivePreviewSupported = ( state: AppState, themeId: string, sit
 		 * Disable Live Preview for wporg themes,
 		 * since Simple sites do NOT have wporg themes installed.
 		 */
-		if ( isWporgTheme( state, themeId ) ) {
+		if ( ! isWpcomTheme( state, themeId ) && isWporgTheme( state, themeId ) ) {
 			return false;
 		}
 

--- a/client/state/themes/selectors/is-wpcom-theme.js
+++ b/client/state/themes/selectors/is-wpcom-theme.js
@@ -4,8 +4,8 @@ import 'calypso/state/themes/init';
 
 /**
  * Whether a theme is present in the WordPress.com Theme Directory
- * @param  {Object}  state   Global state tree
- * @param  {number}  themeId Theme ID
+ * @param  {Object}         state   Global state tree
+ * @param  {string|number}  themeId Theme ID
  * @returns {boolean}         Whether theme is in WP.com theme directory
  */
 export function isWpcomTheme( state, themeId ) {

--- a/client/state/themes/selectors/is-wporg-theme.js
+++ b/client/state/themes/selectors/is-wporg-theme.js
@@ -4,8 +4,8 @@ import 'calypso/state/themes/init';
 
 /**
  * Whether a theme is present in the WordPress.org Theme Directory
- * @param  {Object}  state   Global state tree
- * @param  {string}  themeId Theme ID
+ * @param  {Object}         state   Global state tree
+ * @param  {string|number}  themeId Theme ID
  * @returns {boolean}         Whether theme is in WP.org theme directory
  */
 export function isWporgTheme( state, themeId ) {


### PR DESCRIPTION
…

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92198

## Proposed Changes

* The "Preview & Customize" button didn't show because the theme is wporg theme. As a result, this PR proposed to check whether the theme is wpcom theme as well

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/2915197b-9c59-4e11-999a-e76b4439283b) | ![image](https://github.com/user-attachments/assets/8c177f3c-96a7-471a-879a-1c2c2072e7bf) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Search for "Twenty Twenty Four" and select
* Make sure you can see the "Preview & Customize" button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
