### PR TITLE
Social: Fix broken calypso sharing experience when toggling off connections

### DIFF
--- a/client/blocks/post-share/connection.jsx
+++ b/client/blocks/post-share/connection.jsx
@@ -20,10 +20,9 @@ function hasRoundIcon( service ) {
 }
 
 const PostShareConnection = ( { connection, isActive, onToggle } ) => {
-	const { external_display, external_profile_picture, keyring_connection_ID, service, status } =
-		connection;
+	const { external_display, external_profile_picture, ID, service, status } = connection;
 
-	const toggle = () => onToggle( keyring_connection_ID );
+	const toggle = () => onToggle( ID );
 
 	const classes = clsx( {
 		'post-share__service': true,
@@ -32,7 +31,7 @@ const PostShareConnection = ( { connection, isActive, onToggle } ) => {
 		'is-broken': status === 'broken',
 	} );
 
-	const id = `post-share__label-${ keyring_connection_ID }`;
+	const id = `post-share__label-${ ID }`;
 
 	const accountImageStyle = {};
 	if ( external_profile_picture ) {

--- a/client/blocks/post-share/connections-list.jsx
+++ b/client/blocks/post-share/connections-list.jsx
@@ -38,7 +38,7 @@ class ConnectionsList extends PureComponent {
 			<div className="post-share__connections">
 				{ connections.map( ( connection ) => (
 					<Connection
-						key={ connection.keyring_connection_ID }
+						key={ connection.ID }
 						{ ...{
 							connection,
 							onToggle,

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -136,8 +136,8 @@ class PostShare extends Component {
 		this.setState( { scheduledDate: date } );
 	};
 
-	skipConnection( { keyring_connection_ID } ) {
-		return this.state.skipped.indexOf( keyring_connection_ID ) === -1;
+	skipConnection( { ID } ) {
+		return this.state.skipped.indexOf( ID ) === -1;
 	}
 
 	isConnectionActive = ( connection ) =>
@@ -173,7 +173,7 @@ class PostShare extends Component {
 	sharePost = () => {
 		const { postId, siteId, connections, isJetpack } = this.props;
 		const servicesToPublish = connections.filter(
-			( connection ) => this.state.skipped.indexOf( connection.keyring_connection_ID ) === -1
+			( connection ) => this.state.skipped.indexOf( connection.ID ) === -1
 		);
 		//Let's prepare array of service stats for tracks.
 		const numberOfAccountsPerService = servicesToPublish.reduce(
@@ -376,7 +376,7 @@ class PostShare extends Component {
 			<div>
 				{ brokenConnections.map( ( connection ) => (
 					<Notice
-						key={ connection.keyring_connection_ID }
+						key={ connection.ID }
 						status="is-warning"
 						showDismiss={ false }
 						text={ translate( 'There is an issue connecting to %s.', { args: connection.label } ) }
@@ -388,13 +388,13 @@ class PostShare extends Component {
 				) ) }
 				{ invalidConnections.map( ( connection ) => (
 					<Notice
-						key={ connection.keyring_connection_ID }
+						key={ connection.ID }
 						status="is-error"
 						showDismiss={ false }
 						text={
 							connection.service === 'facebook'
 								? translate( 'Connections to Facebook profiles ceased to work on August 1st.' )
-								: translate( 'Connections to %s have a permenant issue which prevents sharing.', {
+								: translate( 'Connections to %s have a permanent issue which prevents sharing.', {
 										args: connection.label,
 								  } )
 						}


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
When two Facebook pages belonging to the same Facebook account are connected, toggling off one connection, toggles the other as well. The calypso connection screen still used the old keyring token id checks. This PR fixes it.

Related to #

## Proposed Changes

* Updated the logic to skip sharing/toggling off connections to use the publicize connection id, instead of the keyring token_id. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Toggling off sharing is broken in the calypso sharing screen. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a WPCOM site, buy the WordPress premium plan, so you have the resharing feature.
* Connect Jetpack Social connections. Make sure you have at least 2 facebook pages connected and 1 non Facebook connection.
* Go to wordpress.com/posts/site/your-site-wordpress.com
* Share just to one Facebook page, while the other is toggled off. If you try doing the same on trunk, you will see that, toggling off one Facebook page toggles off the other as well.

Before

![CleanShot 2024-10-21 at 14 09 45](https://github.com/user-attachments/assets/2a68a166-2cbf-4034-8fa4-208374e715e2)

After

Only the selected connection will be toggled off. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
