### PR TITLE
Staging Sites: Synchronize data toggle labels are out of alignment

### DIFF
--- a/client/hosting/staging-site/components/staging-site-card/sync-options-panel.tsx
+++ b/client/hosting/staging-site/components/staging-site-card/sync-options-panel.tsx
@@ -23,7 +23,6 @@ const DangerousItemsTitle = styled.p( {
 
 const ToggleControlWithHelpMargin = styled( ToggleControl )( {
 	'.components-base-control__help': {
-		marginLeft: '44px',
 		marginTop: 0,
 	},
 	label: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9470

## Proposed Changes

This PR removes the extra margin by the data synchronization toggle labels. Before:

<img width="985" alt="Screenshot 2024-10-21 at 11 34 01 AM" src="https://github.com/user-attachments/assets/076c0d12-8751-4ec8-8284-3898880c83b5">

After:

<img width="952" alt="Screenshot 2024-10-21 at 11 33 33 AM" src="https://github.com/user-attachments/assets/882f5d72-4c88-4f3e-9fcb-cde03b91bf1c">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to a Calypso live link or pull the changes from this branch
* Ensure that you have an Atomic site and a corresponding staging site
* Navigate to `https://wordpress.com/staging-site/{yourAtomicSite}`
* Click on `Staging to production` option
* Observe that the sub-labels under `Media uploads` and `wp-content files and directories` are aligned with the parent label

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
