### PR TITLE
Developer Features: Fix spacing on Popular features heading

### DIFF
--- a/client/me/developer/features/style.scss
+++ b/client/me/developer/features/style.scss
@@ -4,12 +4,12 @@
 @import "@automattic/components/src/styles/typography";
 
 .developer-features-sub-title {
-	margin-bottom: 16px;
+	padding-bottom: 16px;
 	font-weight: 500;
 	color: $studio-gray-60;
 
 	@media (max-width: $break-large) {
-		margin: 0 32px 16px;
+		padding: 0 32px 16px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #95544

## Proposed Changes

* Adjust CSS to ensure spacing below the "Popular features" header is correct.


| Before | After |
|--------|--------|
| <img width="423" alt="Screenshot 2024-10-21 at 11 05 44" src="https://github.com/user-attachments/assets/30c8e4ca-2000-4a8f-9c2c-7b2719f6f86d"> | <img width="430" alt="Screenshot 2024-10-21 at 11 05 27" src="https://github.com/user-attachments/assets/40db9b85-accf-4279-96ea-73ec2814a60e"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixing quality issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the PR
* Go to `/me/developers`
