### PR TITLE
Site Settings: Use an info notices when changing the admin style and global edge cache

### DIFF
--- a/client/data/hosting/use-cache.ts
+++ b/client/data/hosting/use-cache.ts
@@ -10,7 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
 import wp from 'calypso/lib/wp';
 import { useDispatch } from 'calypso/state';
-import { successNotice, errorNotice, plainNotice } from 'calypso/state/notices/actions';
+import { successNotice, errorNotice, infoNotice } from 'calypso/state/notices/actions';
 
 export const EDGE_CACHE_ENABLE_DISABLE_NOTICE_ID = 'edge-cache-enable-disable-notice';
 export const USE_EDGE_CACHE_QUERY_KEY = 'edge-cache-key';
@@ -130,9 +130,11 @@ export const useSetEdgeCacheMutation = (
 	const setEdgeCache = useCallback(
 		( siteId: number | null, active: boolean ) => {
 			dispatch(
-				plainNotice( active ? __( 'Enabling edge cache…' ) : __( 'Disabling edge cache…' ), {
+				infoNotice( active ? __( 'Enabling edge cache…' ) : __( 'Disabling edge cache…' ), {
 					duration: 5000,
 					id: EDGE_CACHE_ENABLE_DISABLE_NOTICE_ID,
+					isLoading: true,
+					icon: 'ellipsis',
 				} )
 			);
 

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -56,6 +56,8 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting = false } ) => {
 				infoNotice( translate( 'Changing admin interface style…' ), {
 					id: changeLoadingNoticeId,
 					showDismiss: false,
+					isLoading: true,
+					icon: 'sync',
 				} )
 			);
 		},

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -16,7 +16,7 @@ import { useSelector } from 'calypso/state';
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import {
 	errorNotice,
-	plainNotice,
+	infoNotice,
 	removeNotice,
 	successNotice,
 } from 'calypso/state/notices/actions';
@@ -53,7 +53,7 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting = false } ) => {
 		onMutate: () => {
 			removeAllNotices();
 			dispatch(
-				plainNotice( translate( 'Changing admin interface style…' ), {
+				infoNotice( translate( 'Changing admin interface style…' ), {
 					id: changeLoadingNoticeId,
 					showDismiss: false,
 				} )

--- a/client/state/notices/types.ts
+++ b/client/state/notices/types.ts
@@ -25,6 +25,8 @@ export interface BaseNoticeOptions {
 	displayOnNextPage?: boolean;
 	duration?: null | number;
 	href?: string;
+	icon?: string;
+	isLoading?: boolean;
 	isPersistent?: boolean;
 	onClick?: () => void;
 	showDismiss?: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9472

## Proposed Changes

* Use an `infoNotice` in a loading state when changing the admin style or toggle global edge cache.

Before: 

<img width="381" alt="Screenshot 2024-10-21 at 11 32 17" src="https://github.com/user-attachments/assets/0e43aaba-da35-4f03-a758-99568a423ace">

After: 

https://github.com/user-attachments/assets/e1815540-3ccf-4f52-a9c2-1394cb386ecf 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that we’re displaying the blue banner that is used for informational notices.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Admin style**

* Ensure your site is using the Default admin style.
* Go to Settings → General.
* Change the admin style to Classic style and save.
* The notice shown in the top right corner should have a blue background behind the icon.

**Global edge cache**

* Go to Server Settings
* Switch the Global edge cache toggle
* Note that an info notice is displayed in the loading state
