### PR TITLE
A4A > Agency Tier: Implement tier permission check

### DIFF
--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -126,3 +126,26 @@ export const isPathAllowed = ( pathname: string, agency: Agency | null ) => {
 
 	return false;
 };
+
+const MEMBER_TIER_ACCESSIBLE_PATHS: Record< string, string[] > = {
+	[ A4A_PARTNER_DIRECTORY_DASHBOARD_LINK ]: [ 'a4a_feature_partner_directory' ],
+	[ A4A_PARTNER_DIRECTORY_AGENCY_DETAILS_LINK ]: [ 'a4a_feature_partner_directory' ],
+	[ A4A_PARTNER_DIRECTORY_AGENCY_EXPERTISE_LINK ]: [ 'a4a_feature_partner_directory' ],
+};
+
+export const isPathAllowedForTier = ( pathname: string, agency: Agency | null ) => {
+	if ( ! agency ) {
+		return false;
+	}
+
+	// Check if the user has the required capability to access the current path
+	const features = agency?.tier?.features;
+	if ( features ) {
+		const permissions = MEMBER_TIER_ACCESSIBLE_PATHS?.[ pathname ];
+		if ( permissions ) {
+			return features.some( ( capability: string ) => permissions?.includes( capability ) );
+		}
+	}
+
+	return false;
+};

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-permission-data.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-permission-data.tsx
@@ -1,0 +1,37 @@
+import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+
+const getTierPermissionData = (
+	section: string,
+	translate: ( key: string, args?: Record< string, unknown > ) => string
+) => {
+	const content: Record<
+		string,
+		{
+			title: string;
+			content: {
+				heading: string;
+				description: string;
+				buttonProps: { text: string; href: string };
+			};
+		}
+	> = {
+		'a8c-for-agencies-partner-directory': {
+			title: translate( 'Partner Directory' ),
+			content: {
+				heading: translate(
+					"Reach the next tier to be showcased in Automattic's partner directories."
+				),
+				description: translate(
+					"Agency Partners and Pro Agency Partners get to be included in Automatic's directories. Pro Agency Partners also get co-marketing opportunities."
+				),
+				buttonProps: {
+					text: translate( 'Learn more' ),
+					href: A4A_AGENCY_TIER_LINK,
+				},
+			},
+		},
+	};
+	return content?.[ section ];
+};
+
+export default getTierPermissionData;

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-permission-data.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-permission-data.tsx
@@ -1,4 +1,5 @@
 import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { preventWidows } from 'calypso/lib/formatting';
 
 const getTierPermissionData = (
 	section: string,
@@ -18,8 +19,8 @@ const getTierPermissionData = (
 		'a8c-for-agencies-partner-directory': {
 			title: translate( 'Partner Directory' ),
 			content: {
-				heading: translate(
-					"Reach the next tier to be showcased in Automattic's partner directories."
+				heading: preventWidows(
+					translate( "Reach the next tier to be showcased in Automattic's partner directories." )
 				),
 				description: translate(
 					"Agency Partners and Pro Agency Partners get to be included in Automatic's directories. Pro Agency Partners also get co-marketing opportunities."

--- a/client/a8c-for-agencies/sections/agency-tier/tier-permission-error/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/tier-permission-error/index.tsx
@@ -1,0 +1,54 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import AgencyTierLevels from 'calypso/assets/images/a8c-for-agencies/agency-tier/agency-tier-levels.svg';
+import getTierPermissionData from '../lib/get-tier-permission-data';
+
+import './style.scss';
+
+export default function TierPermissionError( { section }: { section: string } ) {
+	const translate = useTranslate();
+
+	const { title, content } = getTierPermissionData( section, translate );
+
+	return (
+		<Layout className="agency-tier-permission-error__layout" title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title } </Title>
+					<Actions>
+						<MobileSidebarNavigation />
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<div className="agency-tier-permission-error__content">
+					<div className="agency-tier-permission-error__content-image">
+						<img
+							className="agency-tier-permission-error__content-image"
+							alt="agency-tier-levels"
+							src={ AgencyTierLevels }
+						/>
+					</div>
+					<div className="agency-tier-permission-error__content-text">
+						<div className="agency-tier-permission-error__content-heading">{ content.heading }</div>
+						<div className="agency-tier-permission-error__content-description">
+							{ content.description }
+						</div>
+						<Button href={ content.buttonProps.href } variant="primary">
+							{ content.buttonProps.text }
+						</Button>
+					</div>
+				</div>
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/agency-tier/tier-permission-error/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/tier-permission-error/style.scss
@@ -1,0 +1,82 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.agency-tier-permission-error__layout {
+	.a4a-layout__container {
+		height: 100%;
+	}
+	.a4a-layout__body {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		height: 100%;
+	}
+}
+
+.agency-tier-permission-error__content {
+	display: flex;
+	flex-direction: column;
+	max-width: 700px;
+	background-color: var(--color-neutral-0);
+	border-radius: 12px; /* stylelint-disable-line scales/radii */
+
+	@include break-large {
+		flex-direction: row;
+		height: 350px;
+	}
+
+	@include break-wide {
+		height: unset;
+	}
+
+
+	.agency-tier-permission-error__content-image {
+		display: none;
+
+		@include break-large {
+			display: block;
+			min-width: 250px;
+			height: 350px;
+		}
+
+		@include break-wide {
+			min-width: 350px;
+			height: unset;
+		}
+
+		img {
+			border-radius: 12px 0 0 12px; /* stylelint-disable-line scales/radii */
+		}
+	}
+
+	.agency-tier-permission-error__content-text {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		padding: 72px 32px 48px;
+		margin: 8px;
+		background-color: var(--color-text-white);
+		border-radius: 8px; /* stylelint-disable-line scales/radii */
+
+		@include break-large {
+			margin-inline-start: 0;
+			padding: 32px;
+		}
+
+		@include break-wide {
+			padding: 72px 32px 48px;
+		}
+	}
+
+	.agency-tier-permission-error__content-heading {
+		@include a4a-font-heading-xl;
+	}
+
+	.agency-tier-permission-error__content-description {
+		@include a4a-font-body-md;
+	}
+
+	a.components-button {
+		width: fit-content;
+	}
+}

--- a/client/a8c-for-agencies/sections/agency-tier/tier-permission-error/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/tier-permission-error/style.scss
@@ -16,7 +16,7 @@
 .agency-tier-permission-error__content {
 	display: flex;
 	flex-direction: column;
-	max-width: 700px;
+	max-width: 750px;
 	background-color: var(--color-neutral-0);
 	border-radius: 12px; /* stylelint-disable-line scales/radii */
 
@@ -36,7 +36,7 @@
 		@include break-large {
 			display: block;
 			min-width: 250px;
-			height: 350px;
+			height: 375px;
 		}
 
 		@include break-wide {

--- a/client/a8c-for-agencies/sections/partner-directory/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/index.tsx
@@ -1,6 +1,9 @@
 import page from '@automattic/calypso-router';
 import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import {
+	requireAccessContext,
+	requireTierAccessContext,
+} from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { PARTNER_DIRECTORY_DASHBOARD_SLUG } from './constants';
 import { partnerDirectoryDashboardContext } from './controller';
@@ -15,6 +18,7 @@ export default function () {
 		`${ A4A_PARTNER_DIRECTORY_LINK }/:section?`,
 		requireAccessContext,
 		partnerDirectoryDashboardContext,
+		requireTierAccessContext,
 		makeLayout,
 		clientRender
 	);

--- a/client/assets/images/a8c-for-agencies/agency-tier/agency-tier-levels.svg
+++ b/client/assets/images/a8c-for-agencies/agency-tier/agency-tier-levels.svg
@@ -1,0 +1,28 @@
+<svg width="325" height="456" viewBox="0 0 325 456" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_8783_10722)">
+<g clip-path="url(#clip1_8783_10722)">
+<rect x="-150" y="-9" width="627" height="465" rx="4.45031" fill="#F6F7F7"/>
+<path d="M504.054 -114.322L-166.483 272.812" stroke="#98DBFF" stroke-width="1.5898" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0.04 5.17"/>
+<path d="M504.054 8.07422L-166.483 395.209" stroke="#98DBFF" stroke-width="1.5898" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0.04 5.17"/>
+<path d="M504.054 130.471L-166.483 517.605" stroke="#98DBFF" stroke-width="1.5898" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0.04 5.17"/>
+<path d="M504.056 252.867L-166.483 640.003" stroke="#98DBFF" stroke-width="1.5898" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0.04 5.17"/>
+<path d="M504.054 375.265L-166.483 762.399" stroke="#98DBFF" stroke-width="1.5898" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0.04 5.17"/>
+<path d="M-166.481 -114.322L504.056 272.812" stroke="#98DBFF" stroke-width="1.5898" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0.04 5.17"/>
+<path d="M-166.481 8.07422L504.056 395.209" stroke="#98DBFF" stroke-width="1.5898" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0.04 5.17"/>
+<path d="M-166.481 130.471L504.056 517.605" stroke="#98DBFF" stroke-width="1.5898" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0.04 5.17"/>
+<path d="M-166.483 252.867L504.056 640.003" stroke="#98DBFF" stroke-width="1.5898" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0.04 5.17"/>
+<path d="M-166.481 375.265L504.056 762.399" stroke="#98DBFF" stroke-width="1.5898" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0.04 5.17"/>
+<path d="M59.2932 262.556L167.936 199.868L276.579 262.556L167.936 325.244L59.2932 262.556Z" fill="#104E30"/>
+<path d="M59.2932 225.592L167.936 162.904L276.579 225.592L167.936 288.28L59.2932 225.592Z" fill="#022836"/>
+<path opacity="0.5" d="M59.293 188.129L167.936 125.441L276.578 188.129L167.936 250.818L59.293 188.129Z" fill="#F4B1FF"/>
+</g>
+</g>
+<defs>
+<clipPath id="clip0_8783_10722">
+<rect width="325" height="456" fill="white"/>
+</clipPath>
+<clipPath id="clip1_8783_10722">
+<rect x="-150" y="-9" width="627" height="465" rx="4.45031" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1303

## Proposed Changes

This PR implements a tier permission check, allowing users to view the page only if it is accessible. 

Note: MC tool links are in the issue mentioned above.

## Testing Instructions

* Remove your agency tier if it is already set from the Agency MC tool and enable the Partner Directory for your agency using the Partner Directory MC tool.
* Open the A4A live link > Go to Partner Directory > Verify that the below UI is shown. Clicking on the `Learn more` button should take you to /agency-tier. Verify it looks good on mobile views, too. Screenshots at the bottom.

<img width="1726" alt="Screenshot 2024-10-21 at 3 15 36 PM" src="https://github.com/user-attachments/assets/45ad888a-e083-4d5f-a833-dd37bfc5a159">

* Update your agency tier to **Emerging Partner** using the MC tool > Refresh the UI and verify that the permissions error is displayed as shown above.

* Change the agency tier to **Agency Partner** > Refresh the UI and verify that the permissions error is no longer showing and that you can view the Partner Directory.

* Change the agency tier to **Pro Agency Partner** > Refresh the UI and verify that the permissions error is no longer showing and that you can view the Partner Directory.

Small screens:

<img width="575" alt="Screenshot 2024-10-21 at 3 16 06 PM" src="https://github.com/user-attachments/assets/d6f109a8-e7bf-4dc3-a86d-5407ed417ce7">

<img width="336" alt="Screenshot 2024-10-21 at 3 16 23 PM" src="https://github.com/user-attachments/assets/2761f16f-569a-47e8-be62-eea15fd73075">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
