### PR TITLE
A4A > Agency Tier: minor text fixes

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-benefits.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-benefits.ts
@@ -66,8 +66,8 @@ const getTierBenefits = ( translate: ( key: string ) => string ): Benefit[] => [
 			'Agency dash for streamlined client billing, program and product management, and free agency site on WordPress.com or Pressable*.'
 		),
 		features: [
-			translate( 'Agency partners receive free WordPress.com and Pressable site.' ),
-			translate( 'Pro partners receive free WordPress.com and Pressable site.' ),
+			translate( 'Agency partners receive a free WordPress.com and a Pressable site.' ),
+			translate( 'Pro partners receive a free WordPress.com and a Pressable site.' ),
 		],
 		isComingSoon: true,
 		availableTiers: [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ],

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -98,7 +98,7 @@ export default function AgencyTierOverview() {
 											<div
 												key={ tier }
 												className={ clsx( 'agency-tier-overview__benefit-card-item', {
-													'opacity-50': ! isCurrentTier,
+													'is-opacity-50': ! isCurrentTier,
 												} ) }
 											>
 												<div className="agency-tier-overview__benefit-card-item-icon">

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -643,6 +643,6 @@ html {
 	}
 }
 
-.opacity-50 {
+.is-opacity-50 {
 	opacity: 0.5;
 }


### PR DESCRIPTION
## Proposed Changes

This PR:

- Makes some minor text changes
- Updates the class name to follow the Calypso CSS guidelines. 

## Testing Instructions

* Open A4A live link
* Go to /agency-tier > Verify the text is updated as shown below for the **Tools & Platforms** card

<img width="454" alt="Screenshot 2024-10-21 at 4 36 00 PM" src="https://github.com/user-attachments/assets/ae467f14-2ac4-49ee-b286-33ea446c8424">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
