### PR TITLE
Site Creation: adds partnerBundle to the options.

### DIFF
--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -38,14 +38,8 @@ const entrepreneurFlow: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
 
-		const { setPluginsToVerify, setPartnerBundle } = useDispatch( ONBOARD_STORE );
+		const { setPluginsToVerify } = useDispatch( ONBOARD_STORE );
 		setPluginsToVerify( [ 'woocommerce' ] );
-
-		const params = new URLSearchParams( window.location.search );
-		const partnerBundle = params.get( 'partnerBundle' );
-		if ( partnerBundle ) {
-			setPartnerBundle( partnerBundle );
-		}
 
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -230,7 +230,8 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			siteUrl,
 			domainItem,
 			sourceSlug,
-			siteIntent
+			siteIntent,
+			partnerBundle ?? undefined
 		);
 
 		if ( preselectedThemeSlug && site?.siteSlug ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -227,11 +227,11 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			useThemeHeadstart,
 			username,
 			mergedDomainCartItems,
+			partnerBundle,
 			siteUrl,
 			domainItem,
 			sourceSlug,
-			siteIntent,
-			partnerBundle ?? undefined
+			siteIntent
 		);
 
 		if ( preselectedThemeSlug && site?.siteSlug ) {

--- a/client/landing/stepper/hooks/use-save-query-params.ts
+++ b/client/landing/stepper/hooks/use-save-query-params.ts
@@ -11,8 +11,9 @@ import { useQuery } from './use-query';
  */
 export function useSaveQueryParams() {
 	const urlQueryParams = useQuery();
-	const { setCouponCode, setStorageAddonSlug, setEcommerceFlowRecurType } =
+	const { setCouponCode, setStorageAddonSlug, setEcommerceFlowRecurType, setPartnerBundle } =
 		useDispatch( ONBOARD_STORE );
+
 	urlQueryParams.forEach( ( value, key ) => {
 		switch ( key ) {
 			case 'coupon':
@@ -27,6 +28,12 @@ export function useSaveQueryParams() {
 				// This stores a storage addon, supplied as a query param by landing pages when
 				// an addon is selected in the pricing grid.
 				value && setStorageAddonSlug( value );
+				break;
+
+			case 'partnerBundle':
+				// This stores a partner bundle string, supplied as a query param in landing pages
+				// related to a partner partnership.
+				value && setPartnerBundle( value );
 				break;
 
 			case 'recur':

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -28,9 +28,9 @@ interface GetNewSiteParams {
 	useThemeHeadstart: boolean;
 	siteVisibility: Site.Visibility;
 	username: string;
+	partnerBundle: string | null;
 	sourceSlug?: string;
 	siteIntent?: string;
-	partnerBundle?: string;
 }
 
 type NewSiteParams = {
@@ -152,11 +152,11 @@ export const createSiteWithCart = async (
 	useThemeHeadstart: boolean,
 	username: string,
 	domainCartItems: MinimalRequestCartProduct[],
+	partnerBundle: string | null,
 	storedSiteUrl?: string,
 	domainItem?: DomainSuggestion,
 	sourceSlug?: string,
-	siteIntent?: string,
-	partnerBundle?: string
+	siteIntent?: string
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -200,7 +200,6 @@ export const createSiteWithCart = async (
 			options: {
 				...newSiteParams.options,
 				has_segmentation_survey: hasSegmentationSurvey,
-				site_partner_bundle: partnerBundle,
 				...( hasSegmentationSurvey && segmentationSurveyAnswersAnonId
 					? { segmentation_survey_answers_anon_id: segmentationSurveyAnswersAnonId }
 					: {} ),

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -30,6 +30,7 @@ interface GetNewSiteParams {
 	username: string;
 	sourceSlug?: string;
 	siteIntent?: string;
+	partnerBundle?: string;
 }
 
 type NewSiteParams = {
@@ -108,6 +109,7 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 		siteVisibility,
 		sourceSlug,
 		siteIntent,
+		partnerBundle,
 	} = params;
 
 	// We will use the default annotation instead of theme annotation as fallback,
@@ -131,6 +133,7 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 			...( siteAccentColor && { site_accent_color: siteAccentColor } ),
 			...( themeSlugWithRepo && { theme: themeSlugWithRepo } ),
 			...( siteIntent && { site_intent: siteIntent } ),
+			...( partnerBundle && { site_partner_bundle: partnerBundle } ),
 		},
 		validate: false,
 	};
@@ -152,7 +155,8 @@ export const createSiteWithCart = async (
 	storedSiteUrl?: string,
 	domainItem?: DomainSuggestion,
 	sourceSlug?: string,
-	siteIntent?: string
+	siteIntent?: string,
+	partnerBundle?: string
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );
@@ -169,6 +173,7 @@ export const createSiteWithCart = async (
 		username,
 		sourceSlug,
 		siteIntent,
+		partnerBundle,
 	} );
 
 	// if ( isEmpty( bearerToken ) && 'onboarding-registrationless' === flowToCheck ) {
@@ -195,6 +200,7 @@ export const createSiteWithCart = async (
 			options: {
 				...newSiteParams.options,
 				has_segmentation_survey: hasSegmentationSurvey,
+				site_partner_bundle: partnerBundle,
 				...( hasSegmentationSurvey && segmentationSurveyAnswersAnonId
 					? { segmentation_survey_answers_anon_id: segmentationSurveyAnswersAnonId }
 					: {} ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9480

## Proposed Changes

* For any stepper flow, captures `partnerBundle` from the query parameter
* Passes it to the site creation api call

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/setup/new-hosted-site?partnerBundle=myNewShinyBundle` 
* Check the created site options for `site_partner_bundle === myNewShinyBundle` by running in `wpsh` `gpr select * from wp_BLOGID_options where option_name = 'site_partner_bundle';`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
