### PR TITLE
Remove english based verifications

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -1,4 +1,3 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
@@ -21,14 +20,13 @@ interface CredentialsFormProps {
 
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip } ) => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 	const { control, errors, accessMethod, isBusy, submitHandler, canBypassVerification } =
 		useCredentialsForm( onSubmit );
 
 	const queryError = useQuery().get( 'error' ) || null;
 
 	let errorMessage;
-	if ( isEnglishLocale && errors.root && errors.root.type !== 'manual' && errors.root.message ) {
+	if ( errors.root && errors.root.type !== 'manual' && errors.root.message ) {
 		errorMessage = errors.root.message;
 	} else if ( queryError === 'ticket-creation' ) {
 		errorMessage = translate(
@@ -37,10 +35,10 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 	}
 
 	const getContinueButtonText = () => {
-		if ( isEnglishLocale && isBusy && ! canBypassVerification ) {
+		if ( isBusy && ! canBypassVerification ) {
 			return translate( 'Verifying credentials' );
 		}
-		if ( isEnglishLocale && canBypassVerification ) {
+		if ( canBypassVerification ) {
 			return translate( 'Continue anyways' );
 		}
 
@@ -92,9 +90,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 					onClick={ onSkip }
 					type="button"
 				>
-					{ isEnglishLocale
-						? translate( 'I need help, please contact me' )
-						: translate( 'Skip, I need help providing access' ) }
+					{ translate( 'I need help, please contact me' ) }
 				</button>
 			</div>
 		</form>


### PR DESCRIPTION


## Proposed Changes
*  Remove translation verification since the phrases are already available in all languages.

## Testing Instructions
- Access the screen using any of the supported languages and check if you can see any message in English (visual inspection is also ok).

<img width="844" alt="image" src="https://github.com/user-attachments/assets/524f0488-48ee-429d-a5bc-b9dfc34cd25b">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
