### PR TITLE
Plugin Details: Avoid prefetch unlisted plugins

### DIFF
--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -12,6 +12,7 @@ import { getPlugin as getWporgPluginSelector } from 'calypso/state/plugins/wporg
 import { receiveProductsList } from 'calypso/state/products-list/actions';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
 import { getCategories } from './categories/use-categories';
+import { UNLISTED_PLUGINS } from './constants';
 import { getCategoryForPluginsBrowser } from './controller';
 
 const PREFETCH_TIMEOUT = 2000;
@@ -181,6 +182,11 @@ export async function fetchPlugin( context, next ) {
 
 	if ( ! context.isServerSide ) {
 		return next();
+	}
+
+	const pluginSlug = decodeURIComponent( context.params.plugin );
+	if ( UNLISTED_PLUGINS.includes( pluginSlug ) ) {
+		return next( 'route' );
 	}
 
 	const options = {


### PR DESCRIPTION

## Proposed Changes

* Avoid prefetch of unlisted plugins
* Avoid render alternate links for unlisted plugins

## Why are these changes being made?

p1729195801390409-slack-C02JPCHEKDY

## Testing Instructions

* Go to `/plugins/wp-fusion-lite`
* Look for `alternate` on the rendered elements
* You should find ZERO results


| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-10-21 at 11 08 25@2x](https://github.com/user-attachments/assets/7e4cc567-e8cc-41d6-b42a-91cdf45e56cb)|![CleanShot 2024-10-21 at 10 59 20@2x](https://github.com/user-attachments/assets/85512cac-b30b-4d8c-ac4f-07343dfccf93)|
