### PR TITLE
White-labeled plugin: Remove feature flag and translation checks for strings

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key-fallback.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key-fallback.tsx
@@ -1,6 +1,4 @@
-import config from '@automattic/calypso-config';
 import { ExternalLink } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordMigrationInstructionsLinkClick } from '../tracking';
@@ -9,17 +7,11 @@ import type { FC } from 'react';
 
 export const StepAddMigrationKeyFallback: FC = () => {
 	const translate = useTranslate();
-	const hasEnTranslation = useHasEnTranslation();
 	const site = useSite();
 	const siteUrl = site?.URL ?? '';
-	const isWhiteLabeledPluginEnabled = config.isEnabled(
-		'migration-flow/enable-white-labeled-plugin'
-	);
-	const migrationKeyLabel = isWhiteLabeledPluginEnabled
-		? 'Migration Key'
-		: 'Migrate Guru Migration Key';
-	const migrateLabel = isWhiteLabeledPluginEnabled ? 'Start migration' : 'Migrate';
-	const pluginName = isWhiteLabeledPluginEnabled ? 'Migrate to WordPress.com' : 'Migrate Guru';
+	const migrationKeyLabel = 'Migration Key';
+	const migrateLabel = 'Start migration';
+	const pluginName = 'Migrate to WordPress.com';
 	const ctaTranslationComponents = {
 		a: (
 			<ExternalLink
@@ -35,23 +27,13 @@ export const StepAddMigrationKeyFallback: FC = () => {
 
 	return (
 		<p>
-			{ hasEnTranslation(
-				'Go to the {{a}}%(pluginName)s page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.'
-			)
-				? translate(
-						'Go to the {{a}}%(pluginName)s page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.',
-						{
-							components: ctaTranslationComponents,
-							args: { pluginName, migrationKeyLabel, migrateLabel },
-						}
-				  )
-				: translate(
-						'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.',
-						{
-							components: ctaTranslationComponents,
-							args: { migrationKeyLabel, migrateLabel },
-						}
-				  ) }
+			{ translate(
+				'Go to the {{a}}%(pluginName)s page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.',
+				{
+					components: ctaTranslationComponents,
+					args: { pluginName, migrationKeyLabel, migrateLabel },
+				}
+			) }
 		</p>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { MigrationKeyInput } from '../migration-key-input';
@@ -11,13 +10,8 @@ interface Props {
 
 export const StepAddMigrationKey: FC< Props > = ( { migrationKey, preparationError } ) => {
 	const translate = useTranslate();
-	const isWhiteLabeledPluginEnabled = config.isEnabled(
-		'migration-flow/enable-white-labeled-plugin'
-	);
-	const migrationKeyLabel = isWhiteLabeledPluginEnabled
-		? 'Migration Key'
-		: 'Migrate Guru Migration Key';
-	const migrateLabel = isWhiteLabeledPluginEnabled ? 'Start migration' : 'Migrate';
+	const migrationKeyLabel = 'Migration Key';
+	const migrateLabel = 'Start migration';
 
 	if ( '' === migrationKey ) {
 		return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-started/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-started/index.tsx
@@ -1,6 +1,4 @@
-import config from '@automattic/calypso-config';
 import { ExternalLink } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -16,10 +14,6 @@ const recordLinkClick = ( linkname: string ) => {
 
 const SiteMigrationStarted: Step = function () {
 	const translate = useTranslate();
-	const hasEnTranslation = useHasEnTranslation();
-	const isWhiteLabeledPluginEnabled = config.isEnabled(
-		'migration-flow/enable-white-labeled-plugin'
-	);
 
 	const stepContent = (
 		<div className="migration-started-card">
@@ -65,10 +59,7 @@ const SiteMigrationStarted: Step = function () {
 						<>
 							{ translate( 'Your migration process has started.' ) }
 							<br />
-							{ isWhiteLabeledPluginEnabled &&
-							hasEnTranslation( "We'll email you when the process is finished." )
-								? translate( "We'll email you when the process is finished." )
-								: translate( 'Migrate Guru will email you when the process is finished.' ) }
+							{ translate( "We'll email you when the process is finished." ) }
 						</>
 					}
 					align="center"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95154

## Proposed Changes

* Remove translation and feature-flag checks for string changes in the migration flow. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because we have translations for all mag 16 languages and the feature flag is no longer necessary.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/start`
* Choose import an existing site at the goals step
* Choose "Migrate site"
* Choose "I'll do it myself"
* Check out.
* Ensure the migration instructions screen still works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
