### PR TITLE
Domains: Remove unused `domains/kracken-ui/max-characters-filter` feature flag

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -269,7 +269,6 @@ class RegisterDomainStep extends Component {
 
 	getInitialFiltersState() {
 		return {
-			maxCharacters: '',
 			exactSldMatchesOnly: false,
 			tlds: [],
 		};
@@ -532,9 +531,7 @@ class RegisterDomainStep extends Component {
 	}
 
 	renderSearchFilters() {
-		const isKrackenUi =
-			config.isEnabled( 'domains/kracken-ui/exact-match-filter' ) ||
-			config.isEnabled( 'domains/kracken-ui/max-characters-filter' );
+		const isKrackenUi = config.isEnabled( 'domains/kracken-ui/exact-match-filter' );
 		const isRenderingInitialSuggestions =
 			! Array.isArray( this.state.searchResults ) &&
 			! this.state.loadingResults &&

--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -8,22 +8,19 @@ import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormTextInput from 'calypso/components/forms/form-text-input';
 import TokenField from 'calypso/components/token-field';
 import ValidationFieldset from 'calypso/signup/validation-fieldset';
 
-const HANDLED_FILTER_KEYS = [ 'tlds', 'maxCharacters', 'exactSldMatchesOnly' ];
+const HANDLED_FILTER_KEYS = [ 'tlds', 'exactSldMatchesOnly' ];
 
 export class DropdownFilters extends Component {
 	static propTypes = {
 		availableTlds: PropTypes.array,
 		filters: PropTypes.shape( {
-			maxCharacters: PropTypes.string,
 			exactSldMatchesOnly: PropTypes.bool,
 			tlds: PropTypes.array,
 		} ).isRequired,
 		lastFilters: PropTypes.shape( {
-			maxCharacters: PropTypes.string,
 			exactSldMatchesOnly: PropTypes.bool,
 			tlds: PropTypes.array,
 		} ).isRequired,
@@ -41,7 +38,6 @@ export class DropdownFilters extends Component {
 
 	state = {
 		showPopover: false,
-		showOverallValidationError: false,
 	};
 
 	constructor( props ) {
@@ -65,30 +61,8 @@ export class DropdownFilters extends Component {
 	getFiltercounts() {
 		return (
 			( this.props.lastFilters.tlds?.length || 0 ) +
-			( this.props.lastFilters.exactSldMatchesOnly && 1 ) +
-			( this.props.lastFilters.maxCharacters !== '' && 1 )
+			( this.props.lastFilters.exactSldMatchesOnly && 1 )
 		);
-	}
-
-	getMaxCharactersValidationErrors() {
-		const {
-			filters: { maxCharacters },
-			translate,
-		} = this.props;
-		const isValid = /^-?\d*$/.test( maxCharacters );
-		return ! isValid ? [ translate( 'Value must be a whole number' ) ] : null;
-	}
-
-	getOverallValidationErrors() {
-		const isValid = this.getMaxCharactersValidationErrors() === null;
-		const { showOverallValidationError } = this.state;
-		return ! isValid && showOverallValidationError
-			? [ this.props.translate( 'Please correct any errors above' ) ]
-			: null;
-	}
-
-	hasValidationErrors() {
-		return this.getOverallValidationErrors() !== null;
 	}
 
 	updateFilterValues = ( name, value ) => {
@@ -107,18 +81,13 @@ export class DropdownFilters extends Component {
 	};
 
 	handleFiltersReset = () => {
-		this.setState( { showOverallValidationError: false }, () => {
+		this.setState( {}, () => {
 			this.togglePopover( { discardChanges: false } );
-			this.props.onReset( 'tlds', 'maxCharacters', 'exactSldMatchesOnly' );
+			this.props.onReset( 'tlds', 'exactSldMatchesOnly' );
 		} );
 	};
 	handleFiltersSubmit = () => {
-		if ( this.hasValidationErrors() ) {
-			this.setState( { showOverallValidationError: true } );
-			return;
-		}
-
-		this.setState( { showOverallValidationError: false }, () => {
+		this.setState( {}, () => {
 			this.togglePopover( { discardChanges: false } );
 			this.hasFiltersChanged() && this.props.onSubmit();
 		} );
@@ -180,14 +149,13 @@ export class DropdownFilters extends Component {
 
 	renderPopover() {
 		const {
-			filters: { maxCharacters, exactSldMatchesOnly },
+			filters: { exactSldMatchesOnly },
 			popoverId,
 			translate,
 			showTldFilter,
 		} = this.props;
 
 		const isExactMatchFilterEnabled = config.isEnabled( 'domains/kracken-ui/exact-match-filter' );
-		const isLengthFilterEnabled = config.isEnabled( 'domains/kracken-ui/max-characters-filter' );
 
 		return (
 			<Popover
@@ -202,27 +170,6 @@ export class DropdownFilters extends Component {
 				{ ...( isWithinBreakpoint( '>660px' ) && { relativePosition: { left: -238 } } ) }
 				hideArrow
 			>
-				{ isLengthFilterEnabled && (
-					<ValidationFieldset
-						className="search-filters__text-input-fieldset"
-						errorMessages={ this.getMaxCharactersValidationErrors() }
-					>
-						<FormLabel className="search-filters__label" htmlFor="search-filters-max-characters">
-							{ translate( 'Max Characters' ) }:
-						</FormLabel>
-						<FormTextInput
-							className="search-filters__input"
-							id="search-filters-max-characters"
-							min="1"
-							name="maxCharacters"
-							onChange={ this.handleOnChange }
-							placeholder="14"
-							type="number"
-							value={ maxCharacters }
-						/>
-					</ValidationFieldset>
-				) }
-
 				{ showTldFilter && (
 					<ValidationFieldset className="search-filters__tld-filters">
 						<TokenField
@@ -260,10 +207,7 @@ export class DropdownFilters extends Component {
 					) }
 				</FormFieldset>
 
-				<ValidationFieldset
-					className="search-filters__buttons-fieldset"
-					errorMessages={ this.getOverallValidationErrors() }
-				>
+				<ValidationFieldset className="search-filters__buttons-fieldset">
 					<div className="search-filters__buttons">
 						<Button onClick={ this.handleFiltersReset }>{ translate( 'Clear' ) }</Button>
 						<Button primary onClick={ this.handleFiltersSubmit }>

--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -81,16 +81,13 @@ export class DropdownFilters extends Component {
 	};
 
 	handleFiltersReset = () => {
-		this.setState( {}, () => {
-			this.togglePopover( { discardChanges: false } );
-			this.props.onReset( 'tlds', 'exactSldMatchesOnly' );
-		} );
+		this.togglePopover( { discardChanges: false } );
+		this.props.onReset( 'tlds', 'exactSldMatchesOnly' );
 	};
+
 	handleFiltersSubmit = () => {
-		this.setState( {}, () => {
-			this.togglePopover( { discardChanges: false } );
-			this.hasFiltersChanged() && this.props.onSubmit();
-		} );
+		this.togglePopover( { discardChanges: false } );
+		this.hasFiltersChanged() && this.props.onSubmit();
 	};
 
 	hasFiltersChanged() {

--- a/client/components/domains/search-filters/filter-reset-notice.jsx
+++ b/client/components/domains/search-filters/filter-reset-notice.jsx
@@ -8,7 +8,6 @@ export class FilterResetNotice extends Component {
 	static propTypes = {
 		isLoading: PropTypes.bool.isRequired,
 		lastFilters: PropTypes.shape( {
-			maxCharacters: PropTypes.string,
 			exactSldMatchesOnly: PropTypes.bool,
 			tlds: PropTypes.arrayOf( PropTypes.string ),
 		} ).isRequired,
@@ -16,8 +15,8 @@ export class FilterResetNotice extends Component {
 	};
 
 	hasActiveFilters() {
-		const { lastFilters: { exactSldMatchesOnly, maxCharacters, tlds = [] } = {} } = this.props;
-		return exactSldMatchesOnly || maxCharacters !== '' || tlds.length > 0;
+		const { lastFilters: { exactSldMatchesOnly, tlds = [] } = {} } = this.props;
+		return exactSldMatchesOnly || tlds.length > 0;
 	}
 
 	hasTooFewSuggestions() {

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -121,10 +121,6 @@
 	margin-left: 2px;
 }
 
-.search-filters__text-input-fieldset .search-filters__label {
-	margin-bottom: 0.25em;
-}
-
 .search-filters__tld-filters {
 	.token-field__token {
 		margin: 4px 8px 4px 0;

--- a/config/development.json
+++ b/config/development.json
@@ -63,7 +63,6 @@
 		"devdocs/color-scheme-picker": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"domains/kracken-ui/exact-match-filter": true,
-		"domains/kracken-ui/max-characters-filter": false,
 		"domains/kracken-ui/pagination": true,
 		"email-accounts/enabled": true,
 		"external-media": true,


### PR DESCRIPTION
## Proposed Changes

This PR removes the `domains/kracken-ui/max-characters-filter` feature flag which was always `false` and only present in `development.json`. The feature flag was introduced in #24718, where it was split from `domains/kracken-ui/filters`, and then it was disabled in #52874.

That flag gated a max length option when searching for domains. When provided, that option adds a `max_characters` parameter to the suggestion endpoint, which limits the length of the resulting domain name suggestions.

![Markup on 2024-10-18 at 20:27:32](https://github.com/user-attachments/assets/08dff0e5-8536-4382-bc9f-28eaaf0a7fd3)

## Why are these changes being made?

Removing obsolete and dead code.

## Testing Instructions

Since this is only removing dead code, nothing should have changed, but please test:

- Code inspection 
- Go to a domain search page (either in `/start` or searching for a domain for an existing site)
- Use the search filter and ensure it's working normally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?