### PR TITLE
Performance Profiler: remove style and css prop

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-accordion/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-accordion/index.tsx
@@ -37,7 +37,7 @@ const CardHeader = ( props: HeaderProps ) => {
 				<span className="core-web-vitals-accordion__header-text-name">{ displayName }</span>
 
 				{ isPerformanceScoreSelected ? (
-					<div className="metric-tab-bar__tab-metric" style={ { marginTop: '6px' } }>
+					<div className="metric-tab-bar__tab-metric performance-score accordion">
 						<CircularPerformanceScore score={ metricValue } size={ isActive ? 72 : 48 } />
 					</div>
 				) : (

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -110,11 +110,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 		<div className="core-web-vitals-display__details">
 			<div className="core-web-vitals-display__description">
 				<div className="core-web-vitals-display__description-container">
-					<div
-						css={ {
-							flex: 1,
-						} }
-					>
+					<div className="header">
 						{ ! isMobile && (
 							<span className="core-web-vitals-display__description-subheading">
 								{ displayName }
@@ -124,12 +120,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 						{ ! isMobile && (
 							<div className={ `core-web-vitals-display__metric ${ statusClass }` }>
 								{ isPerformanceScoreSelected ? (
-									<div
-										className="metric-tab-bar__tab-metric"
-										css={ {
-											marginTop: '16px',
-										} }
-									>
+									<div className="metric-tab-bar__tab-metric performance-score tab">
 										<CircularPerformanceScore score={ value } size={ 72 } />
 									</div>
 								) : (
@@ -146,13 +137,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 						recommendationsQuantity={ numberOfAuditsForMetric }
 					/>
 				</div>
-				<p
-					style={ {
-						marginTop: 0,
-						marginBottom: '24px',
-						maxWidth: '496px',
-					} }
-				>
+				<p>
 					{ metricValuations[ activeTab ].explanation }
 					&nbsp;
 					{ isPerformanceScoreSelected ? (

--- a/client/performance-profiler/components/core-web-vitals-display/style.scss
+++ b/client/performance-profiler/components/core-web-vitals-display/style.scss
@@ -33,9 +33,10 @@ $blueberry-color: #3858e9;
 }
 
 .core-web-vitals-display__description p {
-	margin-top: 15px;
+	margin-top: 0;
+	margin-bottom: 24px;
+	max-width: 496px;
 	line-height: 24px;
-	margin-bottom: 32px;
 }
 
 .core-web-vitals-display__description a {
@@ -124,6 +125,10 @@ $blueberry-color: #3858e9;
 	display: flex;
 	gap: 24px;
 
+	.header {
+		flex: 1;
+	}
+
 	@media (max-width: $break-large) {
 		flex-direction: column;
 		gap: 0;
@@ -162,5 +167,15 @@ $blueberry-color: #3858e9;
 	@media (max-width: $break-mobile) {
 		flex-direction: column;
 		gap: 8px;
+	}
+}
+
+.metric-tab-bar__tab-metric.performance-score {
+	&.tab {
+		margin-top: 16px;
+	}
+
+	&.accordion {
+		margin-top: 6px;
 	}
 }

--- a/client/performance-profiler/components/metric-tab-bar/index.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/index.tsx
@@ -36,14 +36,7 @@ const MetricTabBar = ( props: Props ) => {
 					onClick={ () => handleTabClick( 'overall' ) }
 				>
 					<div className="metric-tab-bar__tab-text">
-						<div
-							className="metric-tab-bar__tab-header"
-							css={ {
-								marginBottom: '6px',
-							} }
-						>
-							{ translate( 'Performance Score' ) }
-						</div>
+						<div className="metric-tab-bar__tab-header">{ translate( 'Performance Score' ) }</div>
 						<div className="metric-tab-bar__tab-metric">
 							<CircularPerformanceScore score={ props.overall } size={ 48 } />
 						</div>

--- a/client/performance-profiler/components/metric-tab-bar/style.scss
+++ b/client/performance-profiler/components/metric-tab-bar/style.scss
@@ -73,6 +73,7 @@ $blueberry-color: #3858e9;
 	font-family: $font-sf-pro-display;
 	font-size: $font-body-small;
 	font-weight: 500;
+	margin-bottom: 6px;
 }
 .metric-tab-bar__tab-metric {
 	font-family: $font-sf-pro-display;

--- a/client/performance-profiler/components/screenshot-thumbnail.tsx
+++ b/client/performance-profiler/components/screenshot-thumbnail.tsx
@@ -24,6 +24,10 @@ const UnavailableScreenshot = styled.div`
 	height: 100%;
 `;
 
+const ScreenShot = styled.img`
+	max-height: 100%;
+`;
+
 export const ScreenshotThumbnail = ( props: {
 	src: string | undefined;
 	alt: string;
@@ -36,7 +40,7 @@ export const ScreenshotThumbnail = ( props: {
 			{ src === undefined ? (
 				<UnavailableScreenshot>{ translate( 'Screenshot unavailable' ) }</UnavailableScreenshot>
 			) : (
-				<img style={ { maxHeight: '100%' } } src={ src } alt={ alt } { ...rest } />
+				<ScreenShot src={ src } alt={ alt } { ...rest } />
 			) }
 		</Container>
 	);

--- a/client/performance-profiler/components/status-section/index.tsx
+++ b/client/performance-profiler/components/status-section/index.tsx
@@ -51,7 +51,7 @@ export const StatusSection = ( props: StatusSectionProps ) => {
 										/* eslint-disable-next-line jsx-a11y/anchor-is-valid */
 										<Button
 											variant="link"
-											style={ { textDecoration: 'none' } }
+											className="button"
 											role="button"
 											tabIndex={ 0 }
 											onClick={ () => {
@@ -76,7 +76,7 @@ export const StatusSection = ( props: StatusSectionProps ) => {
 											/* eslint-disable-next-line jsx-a11y/anchor-is-valid */
 											<Button
 												variant="link"
-												style={ { textDecoration: 'none' } }
+												className="button"
 												role="button"
 												tabIndex={ 0 }
 												onClick={ () => {

--- a/client/performance-profiler/components/status-section/style.scss
+++ b/client/performance-profiler/components/status-section/style.scss
@@ -47,4 +47,8 @@
 		align-items: center;
 		margin-bottom: 24px;
 	}
+
+	.button {
+		text-decoration: none;
+	}
 }


### PR DESCRIPTION


## Proposed Changes

* Update the components to stop using the `style` and `css` prop when appropriate
  * Most of the cases where handled adding a `className` and putting the styling on a `scss` file
  * One case was handled creating a styled component
* In cases where calculations where being made the style property was kept  

## Why are these changes being made?

Fixes [Performance Profiler: Remove all style props](https://github.com/Automattic/dotcom-forge/issues/9455)

## Testing Instructions

There shouldn't have any visual changes and the Logged in and out performance profiler should still be working as in `trunk`