### PR TITLE
Reader Onboarding: Hide onboarding when user clicks final "Continue" button

### DIFF
--- a/client/reader/onboarding/constants.tsx
+++ b/client/reader/onboarding/constants.tsx
@@ -1,0 +1,1 @@
+export const READER_ONBOARDING_PREFERENCE_KEY = 'has_completed_reader_onboarding';

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -3,12 +3,12 @@ import { CircularProgressBar } from '@automattic/components';
 import { Checklist, ChecklistItem, Task } from '@automattic/launchpad';
 import { translate } from 'i18n-calypso';
 import React, { useState } from 'react';
+import { READER_ONBOARDING_PREFERENCE_KEY } from 'calypso/reader/onboarding/constants';
 import InterestsModal from 'calypso/reader/onboarding/interests-modal';
 import SubscribeModal from 'calypso/reader/onboarding/subscribe-modal';
 import { useSelector } from 'calypso/state';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
-import { READER_ONBOARDING_PREFERENCE_KEY } from './constants';
 
 import './style.scss';
 

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -3,16 +3,28 @@ import { CircularProgressBar } from '@automattic/components';
 import { Checklist, ChecklistItem, Task } from '@automattic/launchpad';
 import { translate } from 'i18n-calypso';
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
+import InterestsModal from 'calypso/reader/onboarding/interests-modal';
+import SubscribeModal from 'calypso/reader/onboarding/subscribe-modal';
+import { useSelector } from 'calypso/state';
+import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
-import InterestsModal from './interests-modal';
-import SubscribeModal from './subscribe-modal';
+import { READER_ONBOARDING_PREFERENCE_KEY } from './constants';
+
 import './style.scss';
 
 const ReaderOnboarding = () => {
 	const [ isInterestsModalOpen, setIsInterestsModalOpen ] = useState( false );
 	const [ isDiscoverModalOpen, setIsDiscoverModalOpen ] = useState( false );
 	const followedTags = useSelector( getReaderFollowedTags );
+	const hasCompletedOnboarding = useSelector( ( state ) =>
+		getPreference( state, READER_ONBOARDING_PREFERENCE_KEY )
+	);
+	const preferencesLoaded = useSelector( hasReceivedRemotePreferences );
+
+	// Don't render anything until preferences are loaded or if onboarding is completed.
+	if ( ! preferencesLoaded || hasCompletedOnboarding ) {
+		return null;
+	}
 
 	const handleInterestsContinue = () => {
 		setIsInterestsModalOpen( false );

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -6,11 +6,13 @@ import React, { useMemo, useState, ComponentType, useEffect, useCallback } from 
 import { connect, useSelector } from 'react-redux';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import wpcom from 'calypso/lib/wp';
+import { READER_ONBOARDING_PREFERENCE_KEY } from 'calypso/reader/onboarding/constants';
+import { curatedBlogs } from 'calypso/reader/onboarding/curated-blogs';
 import Stream from 'calypso/reader/stream';
 import { useDispatch } from 'calypso/state';
+import { savePreference } from 'calypso/state/preferences/actions';
 import { requestPage } from 'calypso/state/reader/streams/actions';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
-import { curatedBlogs } from '../curated-blogs';
 
 import './style.scss';
 
@@ -134,7 +136,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		} );
 
 		return finalRec;
-	}, [ followedTagSlugs, apiRecommendedSites ] );
+	}, [ followedTagSlugs, apiRecommendedSites, dispatch ] );
 
 	const displayedRecommendations = useMemo( () => {
 		const startIndex = currentPage * 6;
@@ -181,6 +183,11 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 			.replace( /^(https?:\/\/)?(www\.)?/, '' ) // Remove protocol and www
 			.replace( /\/$/, '' ); // Remove trailing slash
 	};
+
+	const handleContinue = useCallback( () => {
+		dispatch( savePreference( READER_ONBOARDING_PREFERENCE_KEY, true ) );
+		onClose();
+	}, [ dispatch, onClose ] );
 
 	return (
 		isOpen && (
@@ -232,7 +239,10 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 								{ loadMoreText }
 							</Button>
 						) }
-						<Button className="subscribe-modal__continue-button is-primary" onClick={ onClose }>
+						<Button
+							className="subscribe-modal__continue-button is-primary"
+							onClick={ handleContinue }
+						>
 							{ __( 'Continue' ) }
 						</Button>
 					</div>
@@ -265,4 +275,4 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 	);
 };
 
-export default connect( null, { requestPage } )( SubscribeModal );
+export default connect( null, { requestPage, savePreference } )( SubscribeModal );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/188

## Proposed Changes

* This PR introduces a Calypso preference that is used to hide the Reader Onboarding banner once it's been completed.

Video demo in Slack here:  p1729546767804849/1729546570.928729-slack-C03NLNTPZ2T

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Push the reader onboarding project forward.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/onboarding
* Complete the onboarding process.
* The final "Continue" click will hide the reader onboarding forever
* Open a new private window and login as your user. Go to /read?flags=reader/onboarding and see that the Reader onboarding banner is still hidden.

You can clear the preference flag to make the banner reappear by using the DEV tools found in the bottom right of the screen.


<img width="914" alt="Screenshot 2024-10-21 at 5 10 55 PM" src="https://github.com/user-attachments/assets/4f8abe01-0a83-41a4-9b19-d4b4c268e487">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?