### PR TITLE
Avoid getTheme call when slug is null

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -45,6 +45,13 @@ export const usePreviewingTheme = () => {
 	const previewingThemeSlug = usePreviewingThemeSlug();
 	const { previewingThemeName } = useSelect(
 		( select ) => {
+			// Avoid calling getTheme with null - fetches all site /themes (10s~)
+			if ( ! previewingThemeSlug ) {
+				return {
+					previewingThemeSlug,
+					previewingThemeName: undefined,
+				};
+			}
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const previewingTheme = ( select( 'core' ) as any ).getTheme( previewingThemeSlug );
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -1,13 +1,20 @@
 import { useSelect } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { registerPlugin } from '@wordpress/plugins';
+import { usePreviewingThemeSlug } from './hooks/use-previewing-theme';
 import LivePreviewNoticePlugin from './live-preview-notice-plugin';
 
 const LivePreviewPlugin = () => {
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
+	const previewingThemeSlug = usePreviewingThemeSlug();
 
 	// Do nothing outside the Site Editor context.
 	if ( ! siteEditorStore ) {
+		return null;
+	}
+
+	// Don't render unless the user is previewing a theme.
+	if ( ! previewingThemeSlug ) {
 		return null;
 	}
 


### PR DESCRIPTION
Related to # p55Cj4-3EI-p2

## Proposed Changes

Prevents unnecessary call to wp/v2/sites/:site/themes

## Why are these changes being made?

When there is no theme being previewed and theme slug was undefined the `getTheme` call was makes a fallback call to get all themes instead of just the one theme. This call takes 10s on dotcom and was blocking the site editor from rendering.

## Testing Instructions

Confirm only one theme call is made on site editor load:

* Sandbox widgets.wp.com
* Have sandbox aliased to wpcom-sandbox and `yarn dev --sync` or
* `install-plugin.sh wpcom-block-editor update/themes-preview`
* Using a simple site, visit https://testingcalypso1.wordpress.com/wp-admin/site-editor.php?canvas=edit
* Confirm only one call to wp/v2/sites/*/themes is made and it contains the status=active param.

Also confirm live preview still renders correctly:
* https://wordpress.com/theme/hola/testingcalypso1.wordpress.com
* Click Preview & Customize
* Confirm site editor loads normally
* Confirm this notice is still being shown:

![Screenshot(81)](https://github.com/user-attachments/assets/03766dcc-bd77-449b-9784-aadfc33ecea5)

Before

![Screenshot_2024-10-22_11-44-25](https://github.com/user-attachments/assets/2dff840b-92e4-47b4-a80f-120ef089e525)

After

![Screenshot_2024-10-22_11-42-27](https://github.com/user-attachments/assets/879b8599-2eb7-49e2-b537-bd04ef8ab402)
