### PR TITLE
Theme: Treat the block-based theme as a FSE theme

### DIFF
--- a/client/my-sites/themes/is-full-site-editing-theme.ts
+++ b/client/my-sites/themes/is-full-site-editing-theme.ts
@@ -1,6 +1,10 @@
 import { Theme } from 'calypso/types';
 
 export function isFullSiteEditingTheme( theme: Theme | null ): boolean {
+	if ( theme?.block_theme ) {
+		return true;
+	}
+
 	const features = theme?.taxonomies?.theme_feature;
 	return features?.some( ( feature ) => feature.slug === 'full-site-editing' ) ?? false;
 }

--- a/client/state/themes/selectors/is-full-site-editing-theme.ts
+++ b/client/state/themes/selectors/is-full-site-editing-theme.ts
@@ -20,6 +20,10 @@ export function isFullSiteEditingTheme(
 		return false;
 	}
 
+	if ( theme.block_theme ) {
+		return true;
+	}
+
 	const themeFeatures = getThemeTaxonomySlugs( theme, 'theme_feature' );
 
 	return themeFeatures.includes( 'full-site-editing' );

--- a/client/types.ts
+++ b/client/types.ts
@@ -24,6 +24,7 @@ export interface Theme {
 	author: string;
 	author_uri: string;
 	cost: ThemeCost;
+	block_theme?: boolean;
 	date_launched: string;
 	date_updated: string;
 	demo_uri?: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92198

## Proposed Changes

* A FSE theme is a theme that contains the `full-site-editing` tag or it's a block-based theme. As a result, this PR proposes to check whether the theme is a block-based theme

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/theme/impressionist/<your_site>`
* Make sure you can see the "Preview & Customize" button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
