### PR TITLE
Stats: Update temp header to be sticky

### DIFF
--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -90,3 +90,17 @@ $sidebar-appearance-break-point: $break-medium;
 		}
 	}
 }
+
+// Override the overflow value to "clip" for Stats.
+// This allows us to implement a sticky header for the Stats page.
+.is-section-stats {
+	& .layout__content {
+		overflow: clip;
+	}
+}
+
+.stats-new-date-filtering-callout {
+	position: sticky;
+	top: 32px;
+	z-index: 20;
+}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -380,7 +380,7 @@ class StatsSite extends Component {
 				{ isNewDateFilteringEnabled && (
 					<div
 						className="stats-new-date-filtering-callout"
-						style={ { background: 'antiquewhite', maring: '24px', padding: '24px' } }
+						style={ { background: 'antiquewhite', padding: '24px' } }
 					>
 						<p>New date filtering enabled.</p>
 					</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/217

## Proposed Changes

Makes the temp callout header sticky.

<img width="754" alt="SCR-20241022-neyy" src="https://github.com/user-attachments/assets/ad0f889c-e42c-402d-a970-35a0a3583d52">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Wanted to test these changes early as it requires a change to the `layout__content` DIV which effects the entire viewport. That way we'll have more time to find any unintended changes to layouts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link.
* Visit the Stats → Traffic page and confirm it loads normally.
* Manually enable the feature flag: `?flags=stats/new-date-filtering`
* Confirm the temp callout is visible.
* Scroll the page and confirm the header sticks to the top of the page.
* Keep an eye out for unintended layout changes.

I've tested this against the default elements and it should work with everything except tooltips (which float above the header) for now. I'm also not seeing any breakage due to the change to `overflow: clip` but that's something we should keep an eye on.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
