### PR TITLE
Redirect Flows: We now redirect without using the Stepper framework

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,20 +1,12 @@
-import {
-	isWooExpressFlow,
-	SENSEI_FLOW,
-	VIDEOPRESS_FLOW,
-	LINK_IN_BIO_FLOW,
-	FREE_FLOW,
-	BLOG_FLOW,
-} from '@automattic/onboarding';
+import { isWooExpressFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { lazy, useEffect } from 'react';
 import Modal from 'react-modal';
 import { generatePath, useParams } from 'react-router';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import AsyncCheckoutModal from 'calypso/my-sites/checkout/modal/async';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -41,46 +33,6 @@ const lazyCache = new WeakMap<
 	} >,
 	React.ComponentType< StepProps >
 >();
-
-const redirects = [
-	{ flow: BLOG_FLOW, to: '/start/:lang?' },
-	{ flow: FREE_FLOW, to: '/start/free/:lang?' },
-	{ flow: LINK_IN_BIO_FLOW, to: '/start/:lang?' },
-	{ flow: VIDEOPRESS_FLOW, to: '/start/:lang?' },
-	{ flow: SENSEI_FLOW, to: '/plugins/sensei-pro/' },
-];
-
-type RedirectHandlerProps = {
-	redirectTo: string;
-	flow: string;
-};
-
-// Custom component to run code when the route matches
-const RedirectHandler: React.FC< RedirectHandlerProps > = ( { redirectTo, flow } ) => {
-	const location = useLocation();
-	const { lang } = useParams< { lang?: string } >();
-
-	// If lang exists, prepend it for the SENSEI flow
-	if ( flow === SENSEI_FLOW && lang ) {
-		redirectTo = `/${ lang }${ redirectTo }`;
-	}
-
-	// Generate the redirection URL
-	const redirectUrl = generatePath( redirectTo, { lang: lang || null } ) + location.search;
-
-	// Track the redirect event
-	recordTracksEvent( 'calypso_tailored_flows_redirect', {
-		redirectFrom: `/setup/${ flow }`,
-		redirectFromUrl: `/setup${ location.pathname + location.search }`,
-		redirectTo: redirectUrl,
-		referrer: document.referrer,
-	} );
-
-	// Perform the actual redirection
-	window.location.href = redirectUrl;
-
-	return null;
-};
 
 function flowStepComponent( flowStep: StepperStep | undefined ) {
 	if ( ! flowStep ) {
@@ -246,24 +198,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 			<DocumentHead title={ getDocumentHeadTitle() } />
 
 			<Routes>
-				{ redirects.map( ( redirect ) => (
-					<>
-						{ /* Step-based routes */ }
-						{ flowSteps.map( ( step ) => (
-							<Route
-								key={ `${ redirect.flow }_step_${ step.slug }` }
-								path={ `${ redirect.flow }/${ step.slug }/:lang?` }
-								element={ <RedirectHandler redirectTo={ redirect.to } flow={ redirect.flow } /> }
-							/>
-						) ) }
-						{ /* Lang-based routes */ }
-						<Route
-							key={ `${ redirect.flow }_lang` }
-							path={ `${ redirect.flow }/:lang?` }
-							element={ <RedirectHandler redirectTo={ redirect.to } flow={ redirect.flow } /> }
-						/>
-					</>
-				) ) }
 				{ flowSteps.map( ( step ) => (
 					<Route
 						key={ step.slug }

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -42,6 +42,7 @@ import availableFlows from './declarative-flow/registered-flows';
 import { USER_STORE } from './stores';
 import { setupWpDataDebug } from './utils/devtools';
 import { enhanceFlowWithAuth } from './utils/enhanceFlowWithAuth';
+import redirectPathIfNecessary from './utils/flow-redirect-handler';
 import { startStepperPerformanceTracking } from './utils/performance-tracking';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
 import type { Flow } from './declarative-flow/internals/types';
@@ -99,6 +100,13 @@ const initializeHotJar = ( flowName: string ) => {
 };
 
 window.AppBoot = async () => {
+	const { pathname, search } = window.location;
+
+	// Before proceeding we redirect the user if necessary.
+	if ( redirectPathIfNecessary( pathname, search ) ) {
+		return null;
+	}
+
 	const flowName = getFlowFromURL();
 
 	if ( ! flowName ) {

--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -2,11 +2,11 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 // Flows to redirect
 const redirectRoutes = [
-	{ flow: '/setup/blog', to: '/start:lang?' },
-	{ flow: '/setup/free', to: '/start/free:lang?' },
-	{ flow: '/setup/link-in-bio', to: '/start:lang?' },
-	{ flow: '/setup/videopress', to: '/start:lang?' },
-	{ flow: '/setup/sensei', to: ':lang?/plugins/sensei-pro/' },
+	{ flow: '/setup/blog/', to: '/start:lang?' },
+	{ flow: '/setup/free/', to: '/start/free:lang?' },
+	{ flow: '/setup/link-in-bio/', to: '/start:lang?' },
+	{ flow: '/setup/videopress/', to: '/start:lang?' },
+	{ flow: '/setup/sensei/', to: ':lang?/plugins/sensei-pro/' },
 ];
 
 // Regex pattern for the optional language code in the format xx or xx-yy
@@ -14,6 +14,9 @@ const langPattern = '(?:/([a-z]{2}(?:-[a-z]{2})?))?/?$';
 
 // Test against a location pathname and build a redirect URL
 const redirectPathIfNecessary = ( pathname: string, search: string ) => {
+	// Add trailing slash to pathname if not present
+	pathname = pathname.endsWith( '/' ) ? pathname : pathname + '/';
+
 	// Find the matching redirect route
 	const route = redirectRoutes.find( ( redirect ) => pathname.startsWith( redirect.flow ) );
 

--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -2,11 +2,11 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 // Flows to redirect
 const redirectRoutes = [
-	{ flow: '/setup/blog/', to: '/start:lang?' },
-	{ flow: '/setup/free/', to: '/start/free:lang?' },
-	{ flow: '/setup/link-in-bio/', to: '/start:lang?' },
-	{ flow: '/setup/videopress/', to: '/start:lang?' },
-	{ flow: '/setup/sensei/', to: ':lang?/plugins/sensei-pro/' },
+	{ from: '/setup/blog/', to: '/start:lang?' },
+	{ from: '/setup/free/', to: '/start/free:lang?' },
+	{ from: '/setup/link-in-bio/', to: '/start:lang?' },
+	{ from: '/setup/videopress/', to: '/start:lang?' },
+	{ from: '/setup/sensei/', to: ':lang?/plugins/sensei-pro/' },
 ];
 
 // Regex pattern for the optional language code in the format xx or xx-yy
@@ -18,7 +18,7 @@ const redirectPathIfNecessary = ( pathname: string, search: string ) => {
 	pathname = pathname.endsWith( '/' ) ? pathname : pathname + '/';
 
 	// Find the matching redirect route
-	const route = redirectRoutes.find( ( redirect ) => pathname.startsWith( redirect.flow ) );
+	const route = redirectRoutes.find( ( redirect ) => pathname.startsWith( redirect.from ) );
 
 	// If no route is found we don't redirect and return false
 	if ( ! route ) {
@@ -37,7 +37,7 @@ const redirectPathIfNecessary = ( pathname: string, search: string ) => {
 	// Track the redirect event
 	recordTracksEvent( 'calypso_tailored_flows_redirect', {
 		redirectFromUrl: location.pathname + location.search,
-		redirectTo: finalUrl,
+		redirectToUrl: finalUrl,
 		referrer: document.referrer,
 	} );
 

--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -2,66 +2,46 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 // Flows to redirect
 const redirectRoutes = [
-	{ flow: '/setup/blog/', to: '/start:lang?' },
-	{ flow: '/setup/free/', to: '/start/free:lang?' },
-	{ flow: '/setup/link-in-bio/', to: '/start:lang?' },
-	{ flow: '/setup/videopress/', to: '/start:lang?' },
-	{ flow: '/setup/sensei/', to: ':lang?/plugins/sensei-pro/' },
+	{ flow: '/setup/blog', to: '/start:lang?' },
+	{ flow: '/setup/free', to: '/start/free:lang?' },
+	{ flow: '/setup/link-in-bio', to: '/start:lang?' },
+	{ flow: '/setup/videopress', to: '/start:lang?' },
+	{ flow: '/setup/sensei', to: ':lang?/plugins/sensei-pro/' },
 ];
-
-// Sub-flow parts to match
-const subFlows = [
-	'freeSetup',
-	'processing',
-	'create-site',
-	'launchpad',
-	'designSetup',
-	'pattern-assembler',
-	'error',
-];
-
-// Build the regex pattern to match
-const routePaths = redirectRoutes.map( ( route ) => route.flow.replace( /\/$/, '' ) ); // Removing trailing slash
-
-// Join the subFlows with '|' to create an "OR" regex pattern, making it optional
-const flowsPattern = `(?:/(${ subFlows.join( '|' ) }))?`;
 
 // Regex pattern for the optional language code in the format xx or xx-yy
-const langPattern = '(?:/([a-z]{2}(?:-[a-z]{2})?))?';
-
-// Build the complete regex to match the routes
-const regex = new RegExp( `^(${ routePaths.join( '|' ) })${ flowsPattern }${ langPattern }/?$` );
+const langPattern = '(?:/([a-z]{2}(?:-[a-z]{2})?))?/?$';
 
 // Test against a location pathname and build a redirect URL
 const redirectPathIfNecessary = ( pathname: string, search: string ) => {
 	// Find the matching redirect route
-	const match = pathname.match( regex );
-	if ( match ) {
-		const [ , baseRoute, , lang ] = match;
+	const route = redirectRoutes.find( ( redirect ) => pathname.startsWith( redirect.flow ) );
 
-		// Find the corresponding redirect rule
-		const route = redirectRoutes.find( ( route ) => route.flow === `${ baseRoute }/` );
-		if ( route ) {
-			// Replace the ":lang?" placeholder in the "to" field with the matched language or empty string if not present
-			const redirectUrl = route.to.replace( ':lang?', lang ? `/${ lang }` : '' );
-
-			// Construct the final URL with search parameters if present
-			const finalUrl = `${ redirectUrl }${ search }`;
-
-			// Track the redirect event
-			recordTracksEvent( 'calypso_tailored_flows_redirect', {
-				redirectFromUrl: location.pathname + location.search,
-				redirectTo: finalUrl,
-				referrer: document.referrer,
-			} );
-
-			// Perform the actual redirection
-			window.location.href = finalUrl;
-
-			return true;
-		}
+	// If no route is found we don't redirect and return false
+	if ( ! route ) {
+		return false;
 	}
-	return false;
+
+	// Find the language code in the pathname if present
+	const [ , lang ] = pathname.match( langPattern ) ?? [];
+
+	// Replace the ":lang?" placeholder in the "to" field with the matched language or empty string if not present
+	const redirectUrl = route.to.replace( ':lang?', lang ? `/${ lang }` : '' );
+
+	// Construct the final URL with search parameters if present
+	const finalUrl = `${ redirectUrl }${ search }`;
+
+	// Track the redirect event
+	recordTracksEvent( 'calypso_tailored_flows_redirect', {
+		redirectFromUrl: location.pathname + location.search,
+		redirectTo: finalUrl,
+		referrer: document.referrer,
+	} );
+
+	// Perform the actual redirection
+	window.location.href = finalUrl;
+
+	return true;
 };
 
 export default redirectPathIfNecessary;

--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -1,0 +1,67 @@
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+// Flows to redirect
+const redirectRoutes = [
+	{ flow: '/setup/blog/', to: '/start:lang?' },
+	{ flow: '/setup/free/', to: '/start/free:lang?' },
+	{ flow: '/setup/link-in-bio/', to: '/start:lang?' },
+	{ flow: '/setup/videopress/', to: '/start:lang?' },
+	{ flow: '/setup/sensei/', to: ':lang?/plugins/sensei-pro/' },
+];
+
+// Sub-flow parts to match
+const subFlows = [
+	'freeSetup',
+	'processing',
+	'create-site',
+	'launchpad',
+	'designSetup',
+	'pattern-assembler',
+	'error',
+];
+
+// Build the regex pattern to match
+const routePaths = redirectRoutes.map( ( route ) => route.flow.replace( /\/$/, '' ) ); // Removing trailing slash
+
+// Join the subFlows with '|' to create an "OR" regex pattern, making it optional
+const flowsPattern = `(?:/(${ subFlows.join( '|' ) }))?`;
+
+// Regex pattern for the optional language code in the format xx or xx-yy
+const langPattern = '(?:/([a-z]{2}(?:-[a-z]{2})?))?';
+
+// Build the complete regex to match the routes
+const regex = new RegExp( `^(${ routePaths.join( '|' ) })${ flowsPattern }${ langPattern }/?$` );
+
+// Test against a location pathname and build a redirect URL
+const redirectPathIfNecessary = ( pathname: string, search: string ) => {
+	// Find the matching redirect route
+	const match = pathname.match( regex );
+	if ( match ) {
+		const [ , baseRoute, , lang ] = match;
+
+		// Find the corresponding redirect rule
+		const route = redirectRoutes.find( ( route ) => route.flow === `${ baseRoute }/` );
+		if ( route ) {
+			// Replace the ":lang?" placeholder in the "to" field with the matched language or empty string if not present
+			const redirectUrl = route.to.replace( ':lang?', lang ? `/${ lang }` : '' );
+
+			// Construct the final URL with search parameters if present
+			const finalUrl = `${ redirectUrl }${ search }`;
+
+			// Track the redirect event
+			recordTracksEvent( 'calypso_tailored_flows_redirect', {
+				redirectFromUrl: location.pathname + location.search,
+				redirectTo: finalUrl,
+				referrer: document.referrer,
+			} );
+
+			// Perform the actual redirection
+			window.location.href = finalUrl;
+
+			return true;
+		}
+	}
+	return false;
+};
+
+export default redirectPathIfNecessary;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/9452

## Proposed Changes

* We now have a redirect framework outside the stepper framework so that we can remove flows and continue to redirect.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to migrate the redirection from the main framework because it relies on the flows existing in order to redirect and we want to delete the code for some existing flows while keeping the redirections.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link and visit:
  * `/setup/blog`
  * `/setup/link-in-bio`
  * `/setup/videopress`
* They should redirect to `/start/`
* Check t.gif for `calypso_tailored_flows_redirect` events
* After some time, check these events on Tracks.
* Visit:
  * `/setup/free`
* It should redirect to `/start/free/`
* also use /es at the end or any other language
* Visit:
  * `/setup/sensei`
* You should land on `/plugins/sensei-pro`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
