### PR TITLE
Iframe bridge server: Handle the `ENTER` key on commands so they are properly redirected to wp admin

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -38,15 +38,33 @@ function addEditorListener( selector, cb ) {
 	}
 }
 
+const enterOverrides = {};
+let addedEnterListener = false;
 function addCommandsInputListener( selector, cb ) {
-	document.querySelector( 'body.is-iframed' )?.addEventListener( 'keydown', ( e ) => {
-		const isInputActive = document.activeElement?.matches( '.commands-command-menu__header input' );
-		const isCommandSelected = document.querySelector( '[data-selected=true]' )?.matches( selector );
+	enterOverrides[ selector ] = cb;
 
-		if ( e.key === 'Enter' && isInputActive && isCommandSelected ) {
-			cb( e );
-		}
-	} );
+	if ( ! addedEnterListener ) {
+		document.querySelector( 'body.is-iframed' )?.addEventListener( 'keydown', ( e ) => {
+			const isInputActive = document.activeElement?.matches(
+				'.commands-command-menu__header input'
+			);
+			const selectedCommand = document.querySelector( '[data-selected=true]' );
+
+			if ( e.key === 'Enter' && isInputActive && !! selectedCommand ) {
+				const matchingSelector = Object.keys( enterOverrides ).find( ( _selector ) => {
+					return selectedCommand.matches( _selector );
+				} );
+
+				if ( matchingSelector ) {
+					const callback = enterOverrides[ matchingSelector ];
+
+					callback?.( e );
+				}
+			}
+		} );
+
+		addedEnterListener = true;
+	}
 }
 
 /**

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -26,15 +26,15 @@ import {
 const debug = debugFactory( 'wpcom-block-editor:iframe-bridge-server' );
 
 const clickOverrides = {};
-let addedListener = false;
+let addedClickListener = false;
 // Replicates basic '$( el ).on( selector, cb )'.
 function addEditorListener( selector, cb ) {
 	clickOverrides[ selector ] = cb;
-	if ( ! addedListener ) {
+	if ( ! addedClickListener ) {
 		document
 			.querySelector( 'body.is-iframed' )
 			?.addEventListener( 'click', triggerOverrideHandler );
-		addedListener = true;
+		addedClickListener = true;
 	}
 }
 


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/95518 followup

## Proposed Changes

* Make sure that whenever the `ENTER` key is pressed and there's a selected command, the callback associated to it is triggered by adding a map between the command css selector and its callback.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/pull/95518 fixed clicking on the commands, but not pressing `ENTER` when they were selected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch locally on the `wp-calypso` folder
2. Go to the `apps/wpcom-block-editor` folder inside `wp-calypso`
3. Run `yarn dev --sync`, this will add the necessary changes to your sandbox
4. Sandbox `widgets.wp.com`
6. Set up a new Creator site.
7. Sandbox that site as well
8. Navigate to the Pages tab.
9. Select the Default View.
10. Create a new page.
11. Click CMD + K.
12. Type "Single " and use the up/down keys to choose the "Single Posts" command:
![image](https://github.com/user-attachments/assets/ba21e7d0-a129-4c45-9290-2c672d0518a9)
13. Press the `ENTER` key
14. Check that you are redirected to the `Single Posts` template

![image](https://github.com/user-attachments/assets/3ed4f04a-4d89-4b3b-9c67-8e257fb46548)

- Repeat steps 11-14 with the `Patterns` command to check that there's been no regression, you should reach the patterns page:

![image](https://github.com/user-attachments/assets/17e58345-9662-4cdb-b8a5-4f52d9865d4f)
![image](https://github.com/user-attachments/assets/3352c2cc-86c1-4cf2-9b98-165850e51a07)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
