### PR TITLE
E2E: Accept tweet bare link fallback and bump full E2E deploy timeout

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -303,8 +303,8 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 			defaultE2eFailureConditions()
 			// These are long-running tests, and we have to scale back the parallelization too.
 			// Let's give them some more breathing room.
-			// This number is arbitrary, but tests in mid-2024 tend to run longer than 25 minutes.
-			executionTimeoutMin = 31
+			// This number is arbitrary, but tests in mid-2024 tend to run longer than 30 minutes.
+			executionTimeoutMin = 51
 		}
 	});
 }

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
@@ -60,13 +60,12 @@ export class TwitterBlockFlow implements BlockFlow {
 		// In most cases, the iframe will render, so look for that.
 		const iframeTweetLocator = context.page
 			.frameLocator( selectors.publishedTwitterIframe )
-			.locator( `text=${ this.configurationData.expectedTweetText }` )
-			.first(); // May not be specific enough to match only one (and that's okay).
+			.locator( `text=${ this.configurationData.expectedTweetText }` );
 
 		// However, sometimes only the bare link renders, so we need to check for that fallback.
-		const bareTweetLinkLocator = context.page.locator( selectors.publishedTwitterBareLink ).first();
+		const bareTweetLinkLocator = context.page.locator( selectors.publishedTwitterBareLink );
 
-		const tweetLocator = iframeTweetLocator.or( bareTweetLinkLocator );
+		const tweetLocator = iframeTweetLocator.or( bareTweetLinkLocator ).first();
 		await tweetLocator.waitFor();
 	}
 }

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
@@ -47,7 +47,7 @@ export class TwitterBlockFlow implements BlockFlow {
 
 		// We should make sure the actual Iframe loads, because it takes a second.
 		const twitterIframeLocator = editorCanvas.locator( selectors.editorTwitterIframe );
-		await twitterIframeLocator.waitFor();
+		await twitterIframeLocator.waitFor( { timeout: 20000 } );
 	}
 
 	/**
@@ -60,6 +60,6 @@ export class TwitterBlockFlow implements BlockFlow {
 			.frameLocator( selectors.publishedTwitterIframe )
 			.locator( `text=${ this.configurationData.expectedTweetText }` )
 			.first(); // May not be specific enough to match only one (and that's okay).
-		await expectedTweetLocator.waitFor();
+		await expectedTweetLocator.waitFor( { timeout: 20000 } );
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

The X iframe doesn't always render in the published page, causing frequent alerts. This PR allows the tweet bare link to be detected as a fallback. More discussion here:

p1729602835809629-slack-C034JEXD1RD

Recent alerts:
p1729485496456049-slack-C034JEXD1RD
p1729501651187269-slack-C034JEXD1RD
p1729519948875869-slack-C034JEXD1RD
p1729521318691029-slack-C034JEXD1RD
p1729529955580059-slack-C034JEXD1RD
p1729548378365819-slack-C034JEXD1RD
p1729576910822409-slack-C034JEXD1RD

This also bumps the execution timeout for the full E2E deploy tests.