### PR TITLE
Performance Profiler: Update LLM react query to provide more context to bot

### DIFF
--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -99,16 +99,10 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 	const translate = useTranslate();
 
 	const { insight, fullPageScreenshot, onClick, index, isWpcom, hash } = props;
-	// Creates a list of URLs from the insight details to be used as context for the LLM query.
-	const insightDetailsContext = insight?.details?.items?.reduce( ( context, item ) => {
-		context += `* '${ item.url }' `;
-		return context;
-	}, '' );
 
 	const [ retrieveInsight, setRetrieveInsight ] = useState( false );
 	const { data: llmAnswer, isLoading: isLoadingLlmAnswer } = useSupportChatLLMQuery(
-		insight.title ?? '',
-		insightDetailsContext ?? '',
+		insight,
 		hash,
 		isWpcom,
 		isEnabled( 'performance-profiler/llm' ) && retrieveInsight

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -12,8 +12,6 @@ export const useSupportChatLLMQuery = (
 	is_wpcom: boolean,
 	enable: boolean
 ) => {
-	const question = `I need to fix the following issue to improve the performance of my WordPress site: ${ insight.title }.`;
-
 	return useQuery( {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps
 		queryKey: [ 'support', 'chat', insight.title, is_wpcom ],
@@ -24,10 +22,8 @@ export const useSupportChatLLMQuery = (
 					apiNamespace: 'wpcom/v2',
 				},
 				{
-					message: question,
-					is_wpcom,
 					audit_context: insight,
-					audit_id: insight.id,
+					is_wpcom,
 				}
 			),
 		meta: {

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -22,7 +22,7 @@ export const useSupportChatLLMQuery = (
 					apiNamespace: 'wpcom/v2',
 				},
 				{
-					audit_context: insight,
+					insight,
 					is_wpcom,
 				}
 			),

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
 import wp from 'calypso/lib/wp';
 
 function mapResult( response: WPComSupportQueryResponse ) {
@@ -6,41 +7,34 @@ function mapResult( response: WPComSupportQueryResponse ) {
 }
 
 export const useSupportChatLLMQuery = (
-	title: string,
-	context: string,
+	insight: PerformanceMetricsItemQueryResponse,
 	hash: string,
 	is_wpcom: boolean,
 	enable: boolean
 ) => {
-	const question = `I need to fix the following issue to improve the performance of my WordPress site: ${ title }.`;
-	const howToAnswer =
-		'Answer me in two topics in bold: "Why is this important?" and "How to fix this?".';
-	const contextToInclude = `Use each of the following context: ${ context }. Visit any links provided for more information.`;
-	const suggestionsToInclude =
-		'Add if the issue can be fixed automatically with a WordPress setting, an editor block setting, or a plugin. Prefer Automattic owned plugins. Add relevant links. Provide code snippets as a last resort.';
-	const wpcomOrSelfHostedSuggestions = ! is_wpcom
-		? 'Do not show suggestions that work only in WordPress.com. Do not show any references to documentation or support forums related to WordPress.com.'
-		: 'Provide suggestions that work only in WordPress.com. Use WordPress.com documentation if availabble.';
-	const otherDirectives =
-		'Do not suggest doing additional tests to identify the issue. Do not suggest any other tool/website/service for doing another test except WordPress Speed Test (https://wordpress.com/speed-test). Do not mention Lighthouse reports or any other tool. Rarely suggest subscribing to weekly emails feature of the Performance Profiler tool to monitor changes. Do not ask follow-up questions or offer further assistance or ask for any feedback.';
-	const message = `${ question } ${ howToAnswer } ${ contextToInclude } ${ suggestionsToInclude } ${ wpcomOrSelfHostedSuggestions } ${ otherDirectives }`;
+	const question = `I need to fix the following issue to improve the performance of my WordPress site: ${ insight.title }.`;
 
 	return useQuery( {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps
-		queryKey: [ 'support', 'chat', title, is_wpcom ],
+		queryKey: [ 'support', 'chat', insight.title, is_wpcom ],
 		queryFn: () =>
 			wp.req.post(
 				{
 					path: `/odie/assistant/performance-profiler?hash=${ hash }`,
 					apiNamespace: 'wpcom/v2',
 				},
-				{ message, is_wpcom }
+				{
+					message: question,
+					is_wpcom,
+					audit_context: insight,
+					audit_id: insight.id,
+				}
 			),
 		meta: {
 			persist: false,
 		},
 		select: mapResult,
-		enabled: !! title && enable,
+		enabled: !! insight.title && enable,
 		retry: false,
 		refetchOnWindowFocus: false,
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9074

## Proposed Changes

* Remove existing prompt message from frontend
* Pass the entire audit object to the backend for further processing

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We wanted to personalize the bot responses. The prompt will be prepared on the backend using audit details. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions given in D163195-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?