### PR TITLE
Remove nowrap

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -402,7 +402,6 @@
 
 .reader-post-card__byline-secondary-item {
 	// Add extra margin to give space for the bullet that may exist between items.
-	white-space: nowrap;
 	margin-right: 12px;
 	&:last-of-type {
 		margin-right: 0;


### PR DESCRIPTION
## Description

In manually reviewing a bunch of blogs I discovered this little bug where `white-space: nowrap` was being applied to the byline causing the formatting to be misaligned on some sites with a really long byline.

## Before

![before](https://github.com/user-attachments/assets/989e12ee-c327-465a-8de4-e08c80f9bb27)

## After

![after](https://github.com/user-attachments/assets/abd40702-e90a-4cc8-b5fa-9c20deb933eb)

## Testing

- Apply this PR
- Head to `/read/feeds/46075821`