### PR TITLE
Add p2 autofollow setting to /me/settings endpoint

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -243,11 +243,7 @@ class NotificationSubscriptions extends Component {
 
 						{ isAutomattician && (
 							<FormFieldset>
-								<FormLegend>
-									{ this.props.translate(
-										'Auto-follow P2 posts upon commenting (Automatticians only)'
-									) }
-								</FormLegend>
+								<FormLegend>Auto-follow P2 posts upon commenting (Automatticians only)</FormLegend>
 								<FormLabel>
 									<FormCheckbox
 										checked={ this.props.getSetting( 'p2_autofollow_on_comment' ) }
@@ -258,9 +254,8 @@ class NotificationSubscriptions extends Component {
 										onClick={ this.handleCheckboxEvent( 'Auto-follow P2 Upon Comment' ) }
 									/>
 									<span>
-										{ this.props.translate(
-											'Automatically subscribe to notifications for a P2 post whenever you leave a comment on it.'
-										) }
+										Automatically subscribe to notifications for a P2 post whenever you leave a
+										comment on it.
 									</span>
 								</FormLabel>
 							</FormFieldset>


### PR DESCRIPTION
Related to D164349-code, p1729592555312909-slack-C010KDAPG49.

## Proposed Changes

* Add UI support for the `p2_autofollow_on_comment` flag

## Why are these changes being made?

* To support the "auto-subscribe upon comment" feature, we need to have this flag and it should default to false, in order not to potentially disturb any existing workflows by sending too many notifications.

## Testing Instructions

* Switch your branch to D164349-code on your sandbox (make sure to sandbox public-api.wordpress.com)
* Switch to this branch in your dev environment
* Visit http://wordpress.com/me/notifications/subscriptions first to sign in with your pass key.
* Next, open http://calypso.localhost:3000/me/notifications/subscriptions with both an automattician and a non-automattician account
    - Non-automattician: Should not see any new option flags.
    - Automattician: Should see the `Auto-follow P2 posts upon commenting` option. Make sure that data can be saved, and read.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
