### PR TITLE
Site Migration: Redirect user to page with better explanation about the case

### DIFF
--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -342,7 +342,7 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 				const siteSlug = getFromPropsOrUrl( 'siteSlug', props ) as string;
 
 				if ( props?.action === 'skip' ) {
-					return navigateWithQueryParams( SITE_MIGRATION_ASSISTED_MIGRATION, [], props );
+					return navigateWithQueryParams( SITE_MIGRATION_SUPPORT_INSTRUCTIONS, [], props );
 				}
 
 				return goToImporter( {

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -534,7 +534,7 @@ describe( `${ flow.name }`, () => {
 				} );
 
 				expect( destination ).toMatchDestination( {
-					step: STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
+					step: STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS,
 					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
 				} );
 			} );


### PR DESCRIPTION
Related to #95296

## Proposed Changes
* As planned, we want to show a more contextualized page when they ask for help after we suggest import their site.


## Testing Instructions
* Go to /setup/migration flow
* Follow all steps until you reach the credentials step
* Set up a site that is not using WordPress (E.g facebook.com)
* Try to submit and then try again by clicking "Continue anyway"
* Check if you can see the new step as the image above (Please pay attention if the subtitle is the same as the screenshot because there is another variation that will be connected to another scenario in a further PR.
* Check the links

![image](https://github.com/user-attachments/assets/1daa1a86-2516-4e9b-81c2-1efcc60cd070)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
