### PR TITLE
Fix colours in migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
@@ -43,6 +43,10 @@ $blueberry-color: #3858e9;
 		// !important needed here to override unrelated styles from "steps-repository/importer-migrate-message/style.scss"
 		// that are affecting this component in some instances
 		margin-bottom: 0 !important;
+
+		.badge--info-blue {
+			background-color: $blueberry-color;
+		}
 	}
 
 	.flow-question__description {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -1,4 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
+$blueberry-color: #3858e9;
+$blueberry-hover: #2145e6;
 
 .site-migration-credentials {
 	#site-migration-credentials-header {
@@ -33,8 +35,14 @@
 			background: var(--color-border-subtle);
 		}
 		.action-buttons__next {
+			background-color: $blueberry-color;
 			width: 100%;
 			margin-top: 1em;
+
+			&:hover {
+				background-color: $blueberry-hover;
+				border-color: $blueberry-hover;
+			}
 		}
 		.site-migration-credentials__form-fields-row {
 			display: flex;
@@ -75,6 +83,10 @@
 			}
 			.form-radio {
 				margin: 0;
+
+				&:checked::before {
+					background-color: $blueberry-color;
+				}
 			}
 		}
 		.site-migration-credentials__form-note {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -1,4 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
+$blueberry-color: #3858e9;
+$blueberry-hover: #2145e6;
 
 .import__capture-container {
 	max-width: 368px;
@@ -37,6 +39,12 @@
 
 	button[type="submit"] {
 		width: 100%;
+		background-color: $blueberry-color;
+
+		&:hover {
+			background-color: $blueberry-hover !important;
+			border-color: $blueberry-hover !important;
+		}
 	}
 
 	.form-setting-explanation {


### PR DESCRIPTION
## Proposed Changes

This PR takes the quick and easy route to update the colours in the migration flow. I've applied localized changes in the style sheets. The right way to do it would be to update the colours in the main components so that these updates are distributed across Calypso. @sixhours discussed doing this the quick way first and then circling back to do it the right way after. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I made updates to the following screens:

![image](https://github.com/user-attachments/assets/c5901635-370a-4153-90ef-5e0b2c4caeee)

![image](https://github.com/user-attachments/assets/28e6d917-ead3-423f-a8ef-c90c92e1a469)

![image](https://github.com/user-attachments/assets/77ee813b-14d7-4211-8651-6e3215bd2e2d)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go through the migration flow and pick DIFM option.
