### PR TITLE
E2E: Update close block button selector

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -4,7 +4,8 @@ import { EditorComponent } from './editor-component';
 
 const sidebarParentSelector = '.block-editor-inserter__main-area';
 const selectors = {
-	closeBlockInserterButton: 'button[aria-label="Close Block Inserter"]',
+	closeBlockInserterButton:
+		'button[aria-label="Close Block Inserter"], button[aria-label="Close block inserter"]',
 	blockSearchInput: `${ sidebarParentSelector } input[type="search"]`,
 	patternResultItem: ( name: string ) => `${ sidebarParentSelector } div[aria-label="${ name }"]`,
 };

--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -4,7 +4,7 @@ import { EditorComponent } from './editor-component';
 
 const sidebarParentSelector = '.block-editor-inserter__main-area';
 const selectors = {
-	closeBlockInserterButton: 'button[aria-label="Close block inserter"]',
+	closeBlockInserterButton: 'button[aria-label="Close Block Inserter"]',
 	blockSearchInput: `${ sidebarParentSelector } input[type="search"]`,
 	patternResultItem: ( name: string ) => `${ sidebarParentSelector } div[aria-label="${ name }"]`,
 };

--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -4,6 +4,8 @@ import { EditorComponent } from './editor-component';
 
 const sidebarParentSelector = '.block-editor-inserter__main-area';
 const selectors = {
+	// This selector was updated to the capitalized label in Gutenberg v19.5.0. Once that is released, we should be able to remove the old selector ("Close block inserter").
+	// See: https://github.com/WordPress/gutenberg/pull/65983
 	closeBlockInserterButton:
 		'button[aria-label="Close Block Inserter"], button[aria-label="Close block inserter"]',
 	blockSearchInput: `${ sidebarParentSelector } input[type="search"]`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1729558813594279-slack-CBTN58FTJ

## Proposed Changes

* Updates the selector used in the EditorSidebarBlockInserterComponent to handle the current markup and the new markup introduced in [Gutenberg v19.5.0-rc.1](https://github.com/WordPress/gutenberg/releases/tag/v19.5.0-rc.1), specifically [this change](https://github.com/WordPress/gutenberg/pull/65983).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This fixes the [mobile e2e tests](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_edge_mobile/13561940?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildDeploymentsSection=false) for Gutenberg edge that were failing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up your test env using [this guide](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/README.md).
* Run the tests on the edge GB version by running `GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test -- [test path-1] [test-path-2]`.  You can find the failing test paths in [this build](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_nightly_mobile/13555123?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildProblemsSection=true&expandBuildChangesSection=true&expandBuildTestsSection=true).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
