### PR TITLE
Update community translator field to use toggle

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -12,9 +12,7 @@ import TransitionGroup from 'react-transition-group/TransitionGroup';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
-import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLegend from 'calypso/components/forms/form-legend';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -27,7 +25,6 @@ import SectionHeader from 'calypso/components/section-header';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { withGeoLocation } from 'calypso/data/geo/with-geolocation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { ENABLE_TRANSLATOR_KEY } from 'calypso/lib/i18n-utils/constants';
 import { onboardingUrl } from 'calypso/lib/paths';
 import { protectForm } from 'calypso/lib/protect-form';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
@@ -56,6 +53,7 @@ import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import AccountSettingsCloseLink from './close-link';
 import ToggleSitesAsLandingPage from './toggle-sites-as-landing-page';
+import ToggleUseCommunityTranslator from './toggle-use-community-translator';
 
 import './style.scss';
 
@@ -300,42 +298,6 @@ class Account extends Component {
 		}
 
 		return true;
-	}
-
-	communityTranslator() {
-		if ( ! this.shouldDisplayCommunityTranslator() ) {
-			return;
-		}
-		const { translate } = this.props;
-		return (
-			<FormFieldset>
-				<FormLegend>{ translate( 'Community Translator' ) }</FormLegend>
-				<FormLabel htmlFor={ ENABLE_TRANSLATOR_KEY }>
-					<FormCheckbox
-						checked={ this.getUserSetting( ENABLE_TRANSLATOR_KEY ) }
-						onChange={ this.updateCommunityTranslatorSetting }
-						disabled={ this.getDisabledState( INTERFACE_FORM_NAME ) }
-						id={ ENABLE_TRANSLATOR_KEY }
-						name={ ENABLE_TRANSLATOR_KEY }
-						onClick={ this.getCheckboxHandler( 'Community Translator' ) }
-					/>
-					<span>
-						{ translate( 'Enable the in-page translator where available. {{a}}Learn more{{/a}}', {
-							components: {
-								a: (
-									<a
-										target="_blank"
-										rel="noopener noreferrer"
-										href="https://translate.wordpress.com/community-translator/"
-										onClick={ this.getClickHandler( 'Community Translator Learn More Link' ) }
-									/>
-								),
-							},
-						} ) }
-					</span>
-				</FormLabel>
-			</FormFieldset>
-		);
 	}
 
 	thankTranslationContributors() {
@@ -993,7 +955,14 @@ class Account extends Component {
 							{ this.thankTranslationContributors() }
 						</FormFieldset>
 
-						{ this.props.canDisplayCommunityTranslator && this.communityTranslator() }
+						{ this.props.canDisplayCommunityTranslator && (
+							<FormFieldset className="account__settings-admin-home">
+								<FormLabel id="account__default_landing_page">
+									{ translate( 'Community Translator' ) }
+								</FormLabel>
+								<ToggleUseCommunityTranslator />
+							</FormFieldset>
+						) }
 
 						<FormFieldset className="account__settings-admin-home">
 							<FormLabel id="account__default_landing_page">

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -370,15 +370,6 @@ class Account extends Component {
 		return () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
 	}
 
-	getCheckboxHandler( checkboxName ) {
-		return ( event ) => {
-			const action = 'Clicked ' + checkboxName + ' checkbox';
-			const value = event.target.checked ? 1 : 0;
-
-			this.props.recordGoogleEvent( 'Me', action, 'checked', value );
-		};
-	}
-
 	handleUsernameChangeBlogRadio = ( event ) => {
 		this.props.recordGoogleEvent(
 			'Me',

--- a/client/me/account/toggle-use-community-translator.tsx
+++ b/client/me/account/toggle-use-community-translator.tsx
@@ -1,0 +1,49 @@
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { ENABLE_TRANSLATOR_KEY } from 'calypso/lib/i18n-utils/constants';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { saveUserSettings } from 'calypso/state/user-settings/actions';
+import { isUpdatingUserSettings } from 'calypso/state/user-settings/selectors';
+
+function ToggleUseCommunityTranslator() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const enableTranslator = useSelector( ( state ) =>
+		getUserSetting( state, ENABLE_TRANSLATOR_KEY )
+	);
+
+	const isSaving = useSelector( isUpdatingUserSettings );
+
+	const handleToggle = ( isChecked: boolean ) => {
+		dispatch( saveUserSettings( { [ ENABLE_TRANSLATOR_KEY ]: isChecked } ) );
+	};
+
+	const handleLearnMoreClick = () => {
+		dispatch( recordGoogleEvent( 'Me', 'Clicked on Community Translator Learn More Link' ) );
+	};
+
+	return (
+		<div>
+			<ToggleControl
+				checked={ !! enableTranslator }
+				onChange={ handleToggle }
+				disabled={ isSaving }
+				label={ translate( 'Enable the in-page translator where available. {{a}}Learn more{{/a}}', {
+					components: {
+						a: (
+							<a
+								target="_blank"
+								rel="noopener noreferrer"
+								href="https://translate.wordpress.com/community-translator/"
+								onClick={ handleLearnMoreClick }
+							/>
+						),
+					},
+				} ) }
+			/>
+		</div>
+	);
+}
+export default ToggleUseCommunityTranslator;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/95581

## Proposed Changes
![image](https://github.com/user-attachments/assets/872cc1cd-5b5e-4f12-8229-69f0949cd230)

The Community translator option under Interface Settings currently uses a checkbox, whereas the Admin home field underneath uses a toggle. We should standardize so that both of these fields use a toggle.

| Before | After |
|--------|-------|
|     ![image](https://github.com/user-attachments/assets/45b40c4c-8aae-4f77-948e-4b9cfbc0ed3f)   | ![image](https://github.com/user-attachments/assets/4d0df987-1b3c-4db4-9f26-3f81af094d1b)    |


## Testing Instructions

- Apply the branch locally or use the live preview link.
- Go to Account Settings (/me/account).
- If you are not seeing the `Community translator` field, try switching to another idiom. There is some logic that compares browser local with account idiom to hide the field if translation is not possible or relevant.
- Toggle on or off the field. Reload the page to double check if value persisted.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
