### PR TITLE
Stepper: Update primary button/toggle/checkbox/component color

### DIFF
--- a/client/blocks/import/style/components.scss
+++ b/client/blocks/import/style/components.scss
@@ -132,7 +132,6 @@
 
 		.action-buttons__next.is-primary {
 			border: none;
-			background: #117ac9;
 		}
 	}
 }

--- a/client/components/theme-upgrade-modal/style.scss
+++ b/client/components/theme-upgrade-modal/style.scss
@@ -3,9 +3,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-$design-button-primary-color: var(--color-primary);
-$design-button-primary-hover-color: var(--color-primary-60);
-
 .theme-upgrade-modal {
 	display: flex;
 	flex-direction: column;
@@ -202,15 +199,7 @@ $design-button-primary-hover-color: var(--color-primary-60);
 			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05) !important;
 
 			&.is-primary {
-				background: $design-button-primary-color;
-				border-color: $design-button-primary-color;
 				width: 100%;
-
-				&:hover,
-				&:focus {
-					background: $design-button-primary-hover-color;
-					border-color: $design-button-primary-hover-color;
-				}
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -193,8 +193,8 @@ button {
 		&:disabled,
 		&.disabled {
 			color: #fff;
-			background-color: var(--studio-blue-20);
-			border-color: var(--studio-blue-20);
+			background-color: var(--studio-wordpress-blue-20);
+			border-color: var(--studio-wordpress-blue-20);
 		}
 	}
 
@@ -209,11 +209,11 @@ button {
 
 	// WordPress.org components no longer use blue-50 as the primary color.
 	// This changes the primary color to blue-50 to conform to the WordPress.com colors.
-	--color-accent: var(--studio-blue-50);
-	--color-accent-60: var(--studio-blue-60);
-	--wp-components-color-accent-darker-10: var(--studio-blue-60);
-	--wp-components-color-accent-darker-20: var(--studio-blue-70);
-	--wp-components-color-accent: var(--studio-blue-50);
+	--color-accent: var(--studio-wordpress-blue-50);
+	--color-accent-60: var(--studio-wordpress-blue-60);
+	--wp-components-color-accent-darker-10: var(--studio-wordpress-blue-60);
+	--wp-components-color-accent-darker-20: var(--studio-wordpress-blue-70);
+	--wp-components-color-accent: var(--studio-wordpress-blue-50);
 
 }
 
@@ -313,29 +313,29 @@ button {
 					outline: none;
 
 					svg {
-						fill: var(--studio-blue-50);
+						fill: var(--studio-wordpress-blue-50);
 					}
 
 					span {
 						font-size: $font-body-extra-small;
 
 						&.add {
-							color: var(--studio-blue-50);
+							color: var(--studio-wordpress-blue-50);
 						}
 
 						&.replace {
-							color: var(--studio-blue-50);
+							color: var(--studio-wordpress-blue-50);
 						}
 					}
 				}
 				&:focus {
-					background-color: var(--studio-blue-50);
+					background-color: var(--studio-wordpress-blue-50);
 					box-shadow: none;
 					svg {
 						fill: #fff;
 					}
 					span {
-						color: var(--studio-blue-50);
+						color: var(--studio-wordpress-blue-50);
 					}
 				}
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -1,6 +1,5 @@
 @import "@wordpress/base-styles/breakpoints";
 $blueberry-color: #3858e9;
-$blueberry-hover: #2145e6;
 
 .site-migration-credentials {
 	#site-migration-credentials-header {
@@ -35,14 +34,8 @@ $blueberry-hover: #2145e6;
 			background: var(--color-border-subtle);
 		}
 		.action-buttons__next {
-			background-color: $blueberry-color;
 			width: 100%;
 			margin-top: 1em;
-
-			&:hover {
-				background-color: $blueberry-hover;
-				border-color: $blueberry-hover;
-			}
 		}
 		.site-migration-credentials__form-fields-row {
 			display: flex;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -1,6 +1,4 @@
 @import "@wordpress/base-styles/breakpoints";
-$blueberry-color: #3858e9;
-$blueberry-hover: #2145e6;
 
 .import__capture-container {
 	max-width: 368px;
@@ -39,12 +37,6 @@ $blueberry-hover: #2145e6;
 
 	button[type="submit"] {
 		width: 100%;
-		background-color: $blueberry-color;
-
-		&:hover {
-			background-color: $blueberry-hover !important;
-			border-color: $blueberry-hover !important;
-		}
 	}
 
 	.form-setting-explanation {

--- a/packages/onboarding/src/step-navigation-link/style.scss
+++ b/packages/onboarding/src/step-navigation-link/style.scss
@@ -28,9 +28,6 @@ $font-body-small: 14px !default;
 	&.is-primary {
 		border-radius: 4px;
 		box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
-		background-color: #117ac9;
-		border-color: #117ac9;
-		color: var(--color-text-inverted);
 		padding: 8px 14px;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Use `--studio-wordpress-blue-50` rather than `--studio-blue-50` for the primary accent color throughout Stepper.

**Before**
<img width="1408" alt="Screenshot 2024-10-22 at 3 42 51 PM" src="https://github.com/user-attachments/assets/bc03ccba-b49b-4df5-902c-e56ceaf824eb">
<img width="1413" alt="Screenshot 2024-10-22 at 3 42 17 PM" src="https://github.com/user-attachments/assets/80b70688-0748-4207-8cbd-2f893df4d9d0">

**After**
<img width="1410" alt="Screenshot 2024-10-22 at 3 43 02 PM" src="https://github.com/user-attachments/assets/5dc444e4-c680-4334-8184-0e2c5f614670">
<img width="1412" alt="Screenshot 2024-10-22 at 3 41 51 PM" src="https://github.com/user-attachments/assets/6ddfe5cf-791e-418f-a9ff-646034b88d46">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're inconsistent about color usage across Calypso right now; our primary color has changed from `--studio-blue-50` to `--studio-wordpress-blue-50`. This attempts to bring Stepper's global styles into alignment and removes some of the lower-level overrides. There are probably some I've missed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the steps *after* domains & plans at `/start` and ensure you don't see any visual bugs.
* The blue value on primary buttons should map to HEX value `#3858e9`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
