### PR TITLE
Add documentation about how chat being toggled off generates e2e test failures

### DIFF
--- a/test/e2e/specs/help-center/help-center__calypso.ts
+++ b/test/e2e/specs/help-center/help-center__calypso.ts
@@ -142,7 +142,10 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )( 'Help Center in Calyp
 			expect( await helpCenterLocator.locator( '#odie-messages-container' ).count() ).toBeTruthy();
 		} );
 
-		it( 'get forwarded to a human', async () => {
+		// It's rare that chat is disabled so I'm opting to add a message to the test
+		// description about muting the test instead of working around the failure
+		// mode some other way. If this becomes tedious to maintain, please revisit and fix.
+		it( 'get forwarded to a human. Note: This test fails when chat is disabled. Search "WP.com contact via email" in #dotcom-support to confirm. Mute the test for the duration.', async () => {
 			await helpCenterComponent.startAIChat( 'talk to human' );
 
 			const contactSupportButton = helpCenterComponent.getContactSupportButton();


### PR DESCRIPTION
Note: Hold off shipping until the current test is unmuted (2024-10-24), I'm assuming the test text is what we use to ID the test.

Related to p1729555214894249-slack-C03TY6J1A

## Proposed Changes

* Updates test description with a note to check the #dotcom-support channel on failure and temporarily mute the test if required.

## Why are these changes being made?

* This should only really be happening once or twice a year. If it's more frequent we can either disable the test or make it fall back to accepting the contact via email option as a pass (this is displayed instead, see screenshot). I left a similar note about this in the comments.

![Screenshot_2024-10-23_10-07-05](https://github.com/user-attachments/assets/9825c557-01b4-47ad-b6cb-f7460ef0f6ab)


## Testing Instructions

* e2e
