### PR TITLE
Prevent green leaking to global scope

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
@@ -89,10 +89,6 @@ td.plugin-common-table__actions {
 	}
 }
 
-.components-form-toggle.is-checked .components-form-toggle__track {
-	background-color: var(--studio-jetpack-green-50);
-}
-
 .plugin-common-table__plugin-icon {
 	width: 32px;
 	height: 32px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/86946#issuecomment-2429644580

## Proposed Changes

* Removes green from the autoupdates toggle as it was leaking to the global scope.

![Screenshot 2024-10-23 at 10-19-49 Elementor Plugin ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/3ae75745-ec0b-450c-b2a1-317414e23e33)

## Testing Instructions

(See issue for video/screenshots of the issue)

* Visit settings page, confirm toggles are blue or matching your color scheme.
* Navigate to a plugin page
* Navigate back to a settings page, confirm the toggles are still blue
