### PR TITLE
Social: Fix Bluesky custom domain handle not being accepted

### DIFF
--- a/client/my-sites/marketing/connections/bluesky.tsx
+++ b/client/my-sites/marketing/connections/bluesky.tsx
@@ -15,18 +15,18 @@ interface Props {
 
 /**
  * Example valid handles:
+ * - domain.tld
  * - username.bsky.social
  * - user-name.bsky.social
- * - my_domain.com.bsky.social
- * - my-domain.com.my-own-server.com
+ * - my-domain.com
  * @param {string} handle - Handle to validate
  * @returns {boolean} - Whether the handle is valid
  */
 function isValidBlueskyHandle( handle: string ) {
 	const parts = handle.split( '.' ).filter( Boolean );
 
-	// A valid handle should have at least 3 parts - username, domain, and tld
-	if ( parts.length < 3 ) {
+	// A valid handle should have at least 2 parts - domain, and tld
+	if ( parts.length < 2 ) {
 		return false;
 	}
 

--- a/client/my-sites/marketing/connections/bluesky.tsx
+++ b/client/my-sites/marketing/connections/bluesky.tsx
@@ -33,6 +33,15 @@ function isValidBlueskyHandle( handle: string ) {
 	return parts.every( ( part ) => /^[a-z0-9_-]+$/i.test( part ) );
 }
 
+/**
+ * Remove any leading "@" and trim the handle
+ * @param {string} handle - Handle to cleanup
+ * @returns {string} - Cleaned up handle
+ */
+function cleanUpHandle( handle: string ) {
+	return handle.replaceAll( /@/g, '' ).trim();
+}
+
 const isAlreadyConnected = ( connections: Array< Connection >, handle: string ) => {
 	return connections.some( ( { external_name } ) => external_name === handle );
 };
@@ -53,7 +62,7 @@ export const Bluesky: React.FC< Props > = ( {
 	useEffect( () => {
 		const handle = formRef.current?.elements.namedItem( 'handle' ) as HTMLInputElement;
 
-		if ( ! isConnecting && isAlreadyConnected( connections, handle.value ) ) {
+		if ( ! isConnecting && isAlreadyConnected( connections, cleanUpHandle( handle.value ) ) ) {
 			formRef.current?.reset();
 		}
 	}, [ isConnecting, connections ] ); // eslint-disable-line react-hooks/exhaustive-deps
@@ -68,7 +77,7 @@ export const Bluesky: React.FC< Props > = ( {
 		const formData = new FormData( e.target as HTMLFormElement );
 
 		// Let us make the user's life easier by removing the leading "@" if they added it
-		const handle = ( formData.get( 'handle' )?.toString().trim() || '' ).replace( /^@/, '' );
+		const handle = cleanUpHandle( formData.get( 'handle' )?.toString().trim() || '' );
 		const app_password = formData.get( 'app_password' )?.toString().trim() || '';
 
 		if ( isAlreadyConnected( connections, handle ) ) {

--- a/client/my-sites/marketing/connections/bluesky.tsx
+++ b/client/my-sites/marketing/connections/bluesky.tsx
@@ -73,6 +73,7 @@ export const Bluesky: React.FC< Props > = ( {
 	const handleSubmit = ( e: FormEvent< HTMLFormElement > ) => {
 		e.preventDefault();
 		e.stopPropagation();
+		setError( '' );
 
 		const formData = new FormData( e.target as HTMLFormElement );
 


### PR DESCRIPTION
A user reported that they tried to connect a Bluesky account where they have used a custom domain as their handle but it didn't allow them to connect saying, `"Please enter a valid handle."`

## Proposed Changes

* Update the handle validation for Bluesky to accept custom domains
* Mark the account already connected if handle is prefixed with @, it means that the form will get cleared once connected if the user enters the handle prefixed with @, which was not the case before this PR
* Clear error on submission, which means that the error message will not remain their forever if the user corrects the handle.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix a bug that a user reported.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Goto `/marketing/connections/:site`
* Enter a simple domain name in Bluesky handle input
* Confirm that the submission opens the connect window
* Enter an invalid handle, "invalid-handle"
* Confirm that submission shows the error
* Now correct the handle and submit again
* Confirm that the error is cleared and the connect screen opens

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

<img width="660" alt="image" src="https://github.com/user-attachments/assets/5a1a4425-ea57-48ca-a7c8-2d81aa87b2d0">
