### PR TITLE
Theme: Determine whether a theme is a FSE theme only by the block_theme attribute

### DIFF
--- a/client/my-sites/themes/is-full-site-editing-theme.ts
+++ b/client/my-sites/themes/is-full-site-editing-theme.ts
@@ -1,10 +1,5 @@
 import { Theme } from 'calypso/types';
 
 export function isFullSiteEditingTheme( theme: Theme | null ): boolean {
-	if ( theme?.block_theme ) {
-		return true;
-	}
-
-	const features = theme?.taxonomies?.theme_feature;
-	return features?.some( ( feature ) => feature.slug === 'full-site-editing' ) ?? false;
+	return theme?.block_theme;
 }

--- a/client/my-sites/themes/is-full-site-editing-theme.ts
+++ b/client/my-sites/themes/is-full-site-editing-theme.ts
@@ -1,5 +1,5 @@
 import { Theme } from 'calypso/types';
 
 export function isFullSiteEditingTheme( theme: Theme | null ): boolean {
-	return theme?.block_theme;
+	return !! theme?.block_theme;
 }

--- a/client/state/themes/selectors/is-full-site-editing-theme.ts
+++ b/client/state/themes/selectors/is-full-site-editing-theme.ts
@@ -19,5 +19,5 @@ export function isFullSiteEditingTheme(
 		return false;
 	}
 
-	return theme.block_theme;
+	return !! theme.block_theme;
 }

--- a/client/state/themes/selectors/is-full-site-editing-theme.ts
+++ b/client/state/themes/selectors/is-full-site-editing-theme.ts
@@ -1,5 +1,4 @@
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
-import { getThemeTaxonomySlugs } from 'calypso/state/themes/utils';
 import type { AppState } from 'calypso/types';
 
 import 'calypso/state/themes/init';
@@ -20,11 +19,5 @@ export function isFullSiteEditingTheme(
 		return false;
 	}
 
-	if ( theme.block_theme ) {
-		return true;
-	}
-
-	const themeFeatures = getThemeTaxonomySlugs( theme, 'theme_feature' );
-
-	return themeFeatures.includes( 'full-site-editing' );
+	return theme.block_theme;
 }

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -111,6 +111,7 @@ const sidekick = {
 
 const appleton = {
 	id: 'appleton',
+	block_theme: true,
 	taxonomies: {
 		theme_feature: [ { slug: 'full-site-editing' } ],
 	},
@@ -118,6 +119,7 @@ const appleton = {
 
 const pendant = {
 	id: 'pendant',
+	block_theme: true,
 	taxonomies: {
 		theme_feature: [ { slug: 'full-site-editing' } ],
 	},
@@ -126,6 +128,7 @@ const pendant = {
 const nokul = {
 	id: 'nokul',
 	theme_type: 'managed-external',
+	block_theme: true,
 	taxonomies: {
 		theme_feature: [ { slug: 'full-site-editing' } ],
 	},


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/95571

## Proposed Changes

* This is a follow-up PR of https://github.com/Automattic/wp-calypso/pull/95571 and we don't want to rely on the `full-site-editing` tag anymore. As a result, this PR proposes to determine whether a theme is a FSE theme **ONLY** by the block_theme attribute

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /theme/impressionist/<your_site>
- Make sure you can see the "Preview & Customize" button
- Check other block themes
- Make sure the “Preview & Customize” button is still there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
