### PR TITLE
Stepper: Skip domains step-submit event if use-your-domain

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -122,7 +122,11 @@ export default function DomainsStep( props: StepProps ) {
 				saveSignupStep={ updateSignupStepState }
 				submitSignupStep={ updateSignupStepState }
 				goToNextStep={ ( state: ProvidedDependencies ) => {
-					props.navigation.submit?.( { ...( mostRecentStateRef.current ?? {} ), ...state } );
+					props.navigation.submit?.( {
+						...( mostRecentStateRef.current ?? {} ),
+						...state,
+						shouldSkipSubmitTracking: state?.navigateToUseMyDomain ? true : false,
+					} );
 				} }
 				step={ stepState }
 				flowName={ props.flow }

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -132,6 +132,8 @@ const onboarding: Flow = {
 						return navigate( destination );
 					}
 
+					// We trigger the event here, because we skip it in the domains step if
+					// the user chose use-my-domain
 					recordStepNavigation( {
 						event: STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
 						flow: this.name,

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -9,8 +9,10 @@ import {
 	setSignupCompleteFlowName,
 	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
+import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../constants';
 import { ONBOARD_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
+import { recordStepNavigation } from './internals/analytics/record-step-navigation';
 import { Flow, ProvidedDependencies } from './internals/types';
 
 const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => {
@@ -65,22 +67,18 @@ const onboarding: Flow = {
 			setSignupDomainOrigin,
 		} = useDispatch( ONBOARD_STORE );
 
-		const { planCartItem } = useSelect(
+		const { planCartItem, signupDomainOrigin } = useSelect(
 			( select: ( key: string ) => OnboardSelect ) => ( {
 				domainCartItem: select( ONBOARD_STORE ).getDomainCartItem(),
 				planCartItem: select( ONBOARD_STORE ).getPlanCartItem(),
+				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
 			} ),
 			[]
 		);
 
-		const { signupDomainOrigin } = useSelect( ( select ) => {
-			return {
-				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
-			};
-		}, [] );
-
 		const [ redirectedToUseMyDomain, setRedirectedToUseMyDomain ] = useState( false );
 		const [ useMyDomainQueryParams, setUseMyDomainQueryParams ] = useState( {} );
+		const [ useMyDomainTracksEventProps, setUseMyDomainTracksEventProps ] = useState( {} );
 
 		clearUseMyDomainsQueryParams( currentStepSlug );
 
@@ -107,6 +105,12 @@ const onboarding: Flow = {
 							currentQueryArgs.initialQuery = lastQueryParam;
 							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
 						}
+
+						setUseMyDomainTracksEventProps( {
+							site_url: providedDependencies.siteUrl,
+							signup_domain_origin: signupDomainOrigin,
+							domain_item: providedDependencies.domainItem,
+						} );
 						return navigate( useMyDomainURL );
 					}
 
@@ -115,6 +119,11 @@ const onboarding: Flow = {
 				case 'use-my-domain':
 					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
 					if ( providedDependencies?.mode && providedDependencies?.domain ) {
+						setUseMyDomainTracksEventProps( {
+							...useMyDomainTracksEventProps,
+							signup_domain_origin: SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN,
+							site_url: providedDependencies.domain,
+						} );
 						const destination = addQueryArgs( '/use-my-domain', {
 							...getQueryArgs( window.location.href ),
 							step: providedDependencies.mode,
@@ -122,6 +131,15 @@ const onboarding: Flow = {
 						} );
 						return navigate( destination );
 					}
+
+					recordStepNavigation( {
+						event: STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
+						flow: this.name,
+						intent: '',
+						step: 'domains',
+						providedDependencies: useMyDomainTracksEventProps,
+					} );
+
 					setUseMyDomainQueryParams( getQueryArgs( window.location.href ) );
 					return navigate( 'plans' );
 				case 'plans': {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/95607

STILL MISSING: `calypso_signup_actions_complete_step`

## Proposed Changes

We don't want to trigger Domains `calypso_signup_actions_submit_step` when users click on "Use a Domain I Own".
We want to delay the event until after the use-my-domain part is completed and we submit to reach Plans.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Now users that go to use-my-domain but do not complete it trigger calypso_signup_actions_submit_step anyway, and that's not correct.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding`
* Go to "Use a Domain I Own" and check that `calypso_signup_actions_submit_step` is not fired with step:domain.
* Check that it is triggered when completing that part and reaching plans
* Go back to Domains and choose a domain. Submitting should trigger `calypso_signup_actions_submit_step`