### PR TITLE
Migration Flow: Fix multiple stickers being added simultaneously when navigating to the "DIY" option

### DIFF
--- a/client/data/site-migration/use-update-migration-status.ts
+++ b/client/data/site-migration/use-update-migration-status.ts
@@ -20,7 +20,11 @@ export const useUpdateMigrationStatus = () => {
 			} ),
 	} );
 
-	const { mutate: updateMigrationStatusMutate, ...updateStatusMutationRest } = updateStatusMutation;
+	const {
+		mutate: updateMigrationStatusMutate,
+		mutateAsync: updateMigrationStatusMutateAsync,
+		...updateStatusMutationRest
+	} = updateStatusMutation;
 
 	const updateMigrationStatus = useCallback(
 		( targetBlogId: SiteId, statusSticker: string ) =>
@@ -28,5 +32,11 @@ export const useUpdateMigrationStatus = () => {
 		[ updateMigrationStatusMutate ]
 	);
 
-	return { updateMigrationStatus, updateStatusMutationRest };
+	const updateMigrationStatusAsync = useCallback(
+		( targetBlogId: SiteId, statusSticker: string ) =>
+			updateMigrationStatusMutateAsync( { targetBlogId, statusSticker } ),
+		[ updateMigrationStatusMutateAsync ]
+	);
+
+	return { updateMigrationStatus, updateMigrationStatusAsync, updateStatusMutationRest };
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,6 +1,6 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import { FC, useMemo } from 'react';
+import { FC, useMemo, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -63,9 +63,20 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 		urlData
 	);
 
-	const { setPendingMigration, isLoading } = usePendingMigrationStatus( {
+	const { setPendingMigration, isLoading: isUpdatingMigrationStatus } = usePendingMigrationStatus( {
 		onSubmit: navigation.submit,
 	} );
+
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const handleClick = async ( value: string ) => {
+		setIsSubmitting( true );
+
+		try {
+			await setPendingMigration( value );
+		} finally {
+			setIsSubmitting( false );
+		}
+	};
 
 	const hostingProviderSlug = hostingProviderData?.hosting_provider?.slug;
 	const shouldDisplayHostIdentificationMessage =
@@ -73,20 +84,21 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 		hostingProviderSlug !== 'unknown' &&
 		hostingProviderSlug !== 'automattic';
 
-	const stepContent = isLoading ? (
-		<LoadingEllipsis className="how-to-migrate__loader" />
-	) : (
-		<div className="how-to-migrate__list">
-			{ options.map( ( option, i ) => (
-				<FlowCard
-					key={ i }
-					title={ option.label }
-					text={ option.description }
-					onClick={ () => setPendingMigration( option.value ) }
-				/>
-			) ) }
-		</div>
-	);
+	const stepContent =
+		isSubmitting || isUpdatingMigrationStatus ? (
+			<LoadingEllipsis className="how-to-migrate__loader" />
+		) : (
+			<div className="how-to-migrate__list">
+				{ options.map( ( option, i ) => (
+					<FlowCard
+						key={ i }
+						title={ option.label }
+						text={ option.description }
+						onClick={ () => handleClick( option.value ) }
+					/>
+				) ) }
+			</div>
+		);
 
 	const platformText = shouldDisplayHostIdentificationMessage
 		? translate( 'Your WordPress site is hosted with %(hostingProviderName)s.', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { FC, useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
@@ -62,7 +63,9 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 		urlData
 	);
 
-	const { setPendingMigration } = usePendingMigrationStatus( { onSubmit: navigation.submit } );
+	const { setPendingMigration, isLoading } = usePendingMigrationStatus( {
+		onSubmit: navigation.submit,
+	} );
 
 	const hostingProviderSlug = hostingProviderData?.hosting_provider?.slug;
 	const shouldDisplayHostIdentificationMessage =
@@ -72,16 +75,20 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 
 	const stepContent = (
 		<>
-			<div className="how-to-migrate__list">
-				{ options.map( ( option, i ) => (
-					<FlowCard
-						key={ i }
-						title={ option.label }
-						text={ option.description }
-						onClick={ () => setPendingMigration( option.value ) }
-					/>
-				) ) }
-			</div>
+			{ isLoading ? (
+				<LoadingEllipsis className="how-to-migrate__loader" />
+			) : (
+				<div className="how-to-migrate__list">
+					{ options.map( ( option, i ) => (
+						<FlowCard
+							key={ i }
+							title={ option.label }
+							text={ option.description }
+							onClick={ () => setPendingMigration( option.value ) }
+						/>
+					) ) }
+				</div>
+			) }
 		</>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -73,23 +73,19 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 		hostingProviderSlug !== 'unknown' &&
 		hostingProviderSlug !== 'automattic';
 
-	const stepContent = (
-		<>
-			{ isLoading ? (
-				<LoadingEllipsis className="how-to-migrate__loader" />
-			) : (
-				<div className="how-to-migrate__list">
-					{ options.map( ( option, i ) => (
-						<FlowCard
-							key={ i }
-							title={ option.label }
-							text={ option.description }
-							onClick={ () => setPendingMigration( option.value ) }
-						/>
-					) ) }
-				</div>
-			) }
-		</>
+	const stepContent = isLoading ? (
+		<LoadingEllipsis className="how-to-migrate__loader" />
+	) : (
+		<div className="how-to-migrate__list">
+			{ options.map( ( option, i ) => (
+				<FlowCard
+					key={ i }
+					title={ option.label }
+					text={ option.description }
+					onClick={ () => setPendingMigration( option.value ) }
+				/>
+			) ) }
+		</div>
 	);
 
 	const platformText = shouldDisplayHostIdentificationMessage

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
@@ -43,4 +43,9 @@
 	.how-to-migrate__description {
 		color: var(--studio-gray-60);
 	}
+
+	.how-to-migrate__loader {
+		display: block;
+		margin: 0 auto;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
@@ -47,6 +47,8 @@ describe( 'SiteMigrationHowToMigrate', () => {
 		mockUpdateMigrationStatus = jest.fn();
 		( useUpdateMigrationStatus as jest.Mock ).mockReturnValue( {
 			updateMigrationStatus: mockUpdateMigrationStatus,
+			updateMigrationStatusAsync: mockUpdateMigrationStatus,
+			updateStatusMutationRest: {},
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { useUpdateMigrationStatus } from 'calypso/data/site-migration/use-update-migration-status';
 import { RenderStepOptions, mockStepProps, renderStep } from '../../test/helpers';
@@ -58,11 +58,14 @@ describe( 'SiteMigrationHowToMigrate', () => {
 		expect( mockUpdateMigrationStatus ).toHaveBeenCalledWith( siteId, 'migration-pending' );
 	} );
 
-	it( 'should call updateMigrationStatus with correct value for DIFM option', () => {
+	it( 'should call updateMigrationStatus with correct value for DIFM option', async () => {
 		const { getByText } = render( { navigation: { submit: mockSubmit } } );
 
 		const optionButton = getByText( 'Do it for me' );
-		fireEvent.click( optionButton );
+
+		await act( async () => {
+			await fireEvent.click( optionButton );
+		} );
 
 		// Check the last call value
 		const lastCallValue =
@@ -70,11 +73,14 @@ describe( 'SiteMigrationHowToMigrate', () => {
 		expect( lastCallValue ).toBe( 'migration-pending-difm' );
 	} );
 
-	it( 'should call updateMigrationStatus with correct value for DIY option', () => {
+	it( 'should call updateMigrationStatus with correct value for DIY option', async () => {
 		const { getByText } = render( { navigation: { submit: mockSubmit } } );
 
 		const optionButton = getByText( "I'll do it myself" );
-		fireEvent.click( optionButton );
+
+		await act( async () => {
+			await fireEvent.click( optionButton );
+		} );
 
 		// Check the last call value
 		const lastCallValue =
@@ -82,20 +88,26 @@ describe( 'SiteMigrationHowToMigrate', () => {
 		expect( lastCallValue ).toBe( 'migration-pending-diy' );
 	} );
 
-	it( 'should call submit with correct value when DIFM option is clicked', () => {
+	it( 'should call submit with correct value when DIFM option is clicked', async () => {
 		const { getByText } = render( { navigation: { submit: mockSubmit } } );
 
 		const optionButton = getByText( 'Do it for me' );
-		fireEvent.click( optionButton );
+
+		await act( async () => {
+			await fireEvent.click( optionButton );
+		} );
 
 		expect( mockSubmit ).toHaveBeenCalledWith( { destination: 'upgrade', how: 'difm' } );
 	} );
 
-	it( 'should call submit with correct value for DIY option', () => {
+	it( 'should call submit with correct value for DIY option', async () => {
 		const { getByText } = render( { navigation: { submit: mockSubmit } } );
 
 		const optionButton = getByText( "I'll do it myself" );
-		fireEvent.click( optionButton );
+
+		await act( async () => {
+			await fireEvent.click( optionButton );
+		} );
 
 		expect( mockSubmit ).toHaveBeenCalledWith( { destination: 'upgrade', how: 'myself' } );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/use-pending-migration-status.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/use-pending-migration-status.ts
@@ -18,7 +18,11 @@ const usePendingMigrationStatus = ( { onSubmit }: PendingMigrationStatusProps ) 
 		? true
 		: false;
 
-	const { updateMigrationStatus } = useUpdateMigrationStatus();
+	const {
+		updateMigrationStatus,
+		updateMigrationStatusAsync,
+		updateStatusMutationRest: { isPending: isLoading },
+	} = useUpdateMigrationStatus();
 
 	// Register pending migration status when loading the step.
 	useEffect( () => {
@@ -27,11 +31,11 @@ const usePendingMigrationStatus = ( { onSubmit }: PendingMigrationStatusProps ) 
 		}
 	}, [ siteId, updateMigrationStatus ] );
 
-	const setPendingMigration = ( how: string ) => {
+	const setPendingMigration = async ( how: string ) => {
 		const destination = canInstallPlugins ? 'migrate' : 'upgrade';
 		if ( siteId ) {
 			const parsedHow = how === HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF ? 'diy' : how;
-			updateMigrationStatus( siteId, `migration-pending-${ parsedHow }` );
+			await updateMigrationStatusAsync( siteId, `migration-pending-${ parsedHow }` );
 		}
 
 		if ( onSubmit ) {
@@ -39,7 +43,7 @@ const usePendingMigrationStatus = ( { onSubmit }: PendingMigrationStatusProps ) 
 		}
 	};
 
-	return { setPendingMigration };
+	return { setPendingMigration, isLoading };
 };
 
 export default usePendingMigrationStatus;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/use-pending-migration-status.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/use-pending-migration-status.ts
@@ -21,8 +21,13 @@ const usePendingMigrationStatus = ( { onSubmit }: PendingMigrationStatusProps ) 
 	const {
 		updateMigrationStatus,
 		updateMigrationStatusAsync,
-		updateStatusMutationRest: { isPending: isLoading },
+		updateStatusMutationRest: {
+			isIdle: isMigrationStatusUpdateIdle,
+			isPending: isMigrationStatusUpdatePending,
+		},
 	} = useUpdateMigrationStatus();
+
+	const isLoading = isMigrationStatusUpdateIdle || isMigrationStatusUpdatePending;
 
 	// Register pending migration status when loading the step.
 	useEffect( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #95560

## Proposed Changes

* This fixes a race condition causing multiple stickers to be added when the "I'll do it myself" option is selected. The problem is explained in detail [here](https://github.com/Automattic/wp-calypso/issues/95560).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need only one migration sticker to be present at all times.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/setup/migration`.
- Select "WordPress" and the "I'll do it myself" option.
- Check the blog stickers for the site (you can check it in the Blog RC), and make sure that only the`migration-started-diy` sticker is present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
