### PR TITLE
A4A > Agency Tier: Remove the default tier widget

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
@@ -18,7 +18,6 @@ const getAgencyTierInfo = (
 		description: '',
 		logo: '',
 		includedTiers: [] as string[],
-		emptyStateMessage: '',
 		celebrationModal: {
 			title: '',
 			description: '',
@@ -50,12 +49,6 @@ const getAgencyTierInfo = (
 				),
 				logo: EmergingPartnerLogo,
 				includedTiers: [ 'emerging-partner' ],
-				emptyStateMessage: translate(
-					'Make your first purchase to get started as an {{b}}Emerging Partner!{{/b}}',
-					{
-						components: { b: <b /> },
-					}
-				),
 				celebrationModal: {
 					title: translate( 'Welcome to Automattic for Agencies!' ),
 					description: translate(

--- a/client/a8c-for-agencies/sections/agency-tier/types.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/types.ts
@@ -5,7 +5,6 @@ export interface AgencyTierInfo {
 	description: string;
 	logo: string;
 	includedTiers: string[];
-	emptyStateMessage?: string;
 	celebrationModal: {
 		title: string;
 		description: string;

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
@@ -1,7 +1,6 @@
 import { Card, FoldableCard } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, arrowRight } from '@wordpress/icons';
-import { clsx } from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import getAgencyTierInfo from 'calypso/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info';
@@ -17,11 +16,12 @@ export default function OverviewSidebarAgencyTier() {
 	const agency = useSelector( getActiveAgency );
 
 	const currentAgencyTier = agency?.tier?.id;
-	const currentAgencyTierInfo = currentAgencyTier
-		? getAgencyTierInfo( currentAgencyTier, translate )
-		: null;
+	const currentAgencyTierInfo =
+		currentAgencyTier && getAgencyTierInfo( currentAgencyTier, translate );
 
-	const defaultAgencyTierInfo = getAgencyTierInfo( 'emerging-partner', translate );
+	if ( ! currentAgencyTierInfo ) {
+		return null;
+	}
 
 	return (
 		<>
@@ -38,30 +38,13 @@ export default function OverviewSidebarAgencyTier() {
 					iconSize={ 18 }
 				>
 					<div className="agency-tier__bottom-content">
-						<div
-							className={ clsx( 'agency-tier__current-agency-tier-header', {
-								'is-default': ! currentAgencyTierInfo,
-							} ) }
-						>
-							{ currentAgencyTierInfo ? (
-								<>
-									<span className="agency-tier__current-agency-tier-icon">
-										<img src={ currentAgencyTierInfo.logo } alt={ currentAgencyTierInfo.id } />
-									</span>
-									<span className="agency-tier__current-agency-tier-title">
-										{ currentAgencyTierInfo.title }
-									</span>
-								</>
-							) : (
-								<>
-									<span className="agency-tier__current-agency-tier-icon">
-										<img src={ defaultAgencyTierInfo.logo } alt={ defaultAgencyTierInfo.id } />
-									</span>
-									<span className="agency-tier__current-agency-tier-title">
-										{ defaultAgencyTierInfo.emptyStateMessage }
-									</span>
-								</>
-							) }
+						<div className="agency-tier__current-agency-tier-header">
+							<span className="agency-tier__current-agency-tier-icon">
+								<img src={ currentAgencyTierInfo.logo } alt={ currentAgencyTierInfo.id } />
+							</span>
+							<span className="agency-tier__current-agency-tier-title">
+								{ currentAgencyTierInfo.title }
+							</span>
 						</div>
 						{ currentAgencyTierInfo && (
 							<div className="agency-tier__current-agency-tier-description">

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
@@ -35,25 +35,6 @@ $video-green: #0e5837;
 		.agency-tier__current-agency-tier-title {
 			@include a4a-font-heading-lg;
 		}
-
-		&.is-default {
-			margin-inline-start: 14px;
-			padding-block: 36px;
-			gap: 24px;
-
-			.agency-tier__current-agency-tier-icon {
-				display: flex;
-				width: 80px;
-
-				img {
-					transform: scale(1.6);
-				}
-			}
-
-			.agency-tier__current-agency-tier-title {
-				@include a4a-font-body-lg;
-			}
-		}
 	}
 
 	.agency-tier__current-agency-tier-description {


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1338

## Proposed Changes

This PR removes the default tier widget, as an agency will always be set to tier. 

## Why are these changes being made?

* To remove unnecessary/unused code.

## Testing Instructions

* Open the A4A live link
* Remove your agency tier if it is already set from the MC tool > Go to the overview page > Verify no widget is shown on the top right section for agency tier.
* Update your agency tier to **Emerging Partner** using the MC tool > Refresh the UI & verify the screen looks as shown below:

<img width="1728" alt="Screenshot 2024-10-23 at 5 02 40 PM" src="https://github.com/user-attachments/assets/ebed8095-b14b-4ff9-9532-c762a79332e5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
