### PR TITLE
Refactor color processing for monitoring charts.

### DIFF
--- a/client/hosting/monitoring/components/site-monitoring.tsx
+++ b/client/hosting/monitoring/components/site-monitoring.tsx
@@ -1,6 +1,5 @@
 import colorStudio from '@automattic/color-studio';
 import { useI18n } from '@wordpress/react-i18n';
-import chroma from 'chroma-js';
 import { translate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -232,7 +231,14 @@ export interface HTTPCodeSerie {
 }
 
 function colorToAlpha( color: keyof typeof colorStudio.colors, alpha: number ) {
-	return chroma( colorStudio.colors[ color ] ).alpha( alpha ).hex();
+	const hex = colorStudio.colors[ color ];
+
+	const bigint = parseInt( hex.slice( 1 ), 16 );
+	const r = ( bigint >> 16 ) & 255;
+	const g = ( bigint >> 8 ) & 255;
+	const b = bigint & 255;
+
+	return `rgba(${ r }, ${ g }, ${ b }, ${ alpha })`;
 }
 
 const seriesDefaultProps = {

--- a/client/hosting/monitoring/components/site-monitoring.tsx
+++ b/client/hosting/monitoring/components/site-monitoring.tsx
@@ -231,6 +231,10 @@ export interface HTTPCodeSerie {
 }
 
 function colorToAlpha( color: keyof typeof colorStudio.colors, alpha: number ) {
+	if ( alpha < 0 || alpha >= 1 ) {
+		return colorStudio.colors[ color ];
+	}
+
 	const hex = colorStudio.colors[ color ];
 
 	const bigint = parseInt( hex.slice( 1 ), 16 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/95550

## Proposed Changes

Based on @sejas’s [feedback](https://github.com/Automattic/wp-calypso/pull/95550#pullrequestreview-2388028001) I’ve made some updates to how we generate colors for the monitoring charts.

* Remove `chroma-js` to reduce the added page weight.
* Introduce our own function for transforming colors.