### PR TITLE
Stats: Odyssey Stats: Use Jetpack logo as header

### DIFF
--- a/client/components/jetpack/jetpack-header/style.scss
+++ b/client/components/jetpack/jetpack-header/style.scss
@@ -1,3 +1,7 @@
 .jetpack-header {
 	padding: 12px 0;
 }
+
+.stats .navigation-header:has(.jetpack-header) {
+	padding-bottom: 0;
+  }

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -2,8 +2,8 @@ import styled from '@emotion/styled';
 import clsx from 'clsx';
 import React, { ReactNode } from 'react';
 import Breadcrumb, { Item as TBreadcrumbItem } from 'calypso/components/breadcrumb';
+import FormattedHeader from 'calypso/components/formatted-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
-import FormattedHeader from '../formatted-header';
 
 import './style.scss';
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This small PR updates the import path for FormattedHeader so that it matches the webpack pattern for Odyssey Stats header replace.
*  I want to double check that updating the import path from relative path to an absolute path isn't going to cause any problems for anything else using the component.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the Date Filtering for the Traffic Page stats project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test in Odyssey stats that the Stats header is now replaced with the Jetpack Logo
* Test in Calypso that the original header remains, and is not the Jetpack logo

| Odyssey  | Calypso |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/50187276-0100-4392-ac69-ad7c79558725)  | ![image](https://github.com/user-attachments/assets/e26d0be8-4032-44c6-bc6f-f989ad02d42b)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
