### PR TITLE
Design Selection Onboarding: Can overwrite design variations with the default variation

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -33,7 +33,7 @@ import type {
 } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
 import type { RequestTemplate } from '../templates';
-import type { Design, DesignOptions } from '@automattic/design-picker/src/types'; // Import from a specific file directly to avoid the circular dependencies
+import type { Design, DesignOptions, StyleVariation } from '@automattic/design-picker/src/types'; // Import from a specific file directly to avoid the circular dependencies
 
 export function createActions( clientCreds: WpcomClientCredentials ) {
 	const fetchSite = () => ( {
@@ -223,7 +223,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 	function* setGlobalStyles(
 		siteIdOrSlug: number | string,
 		stylesheet: string,
-		globalStyles: GlobalStyles,
+		globalStyles: GlobalStyles | StyleVariation,
 		activatedTheme?: ActiveTheme
 	) {
 		// only update if there settings or styles to update
@@ -404,14 +404,13 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 					variation.title.split( ' ' ).join( '-' ).toLowerCase() === styleVariation?.slug
 			);
 
-			if ( currentVariation ) {
-				yield* setGlobalStyles(
-					siteSlug,
-					activatedTheme.stylesheet,
-					currentVariation,
-					activatedTheme
-				);
-			}
+			// the default style is not in variations, so we set it as a fallback here
+			yield* setGlobalStyles(
+				siteSlug,
+				activatedTheme.stylesheet,
+				currentVariation || styleVariation,
+				activatedTheme
+			);
 		}
 
 		if ( globalStyles ) {

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '@automattic/global-styles';
 import { __ } from '@wordpress/i18n';
 import { SiteGoal } from '../onboard';
 import { wpcomRequest } from '../wpcom-request-controls';
@@ -249,6 +250,28 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		}
 	}
 
+	function* resetGlobalStyles(
+		siteIdOrSlug: number | string,
+		stylesheet: string,
+		activatedTheme?: ActiveTheme
+	) {
+		const globalStylesId: number =
+			activatedTheme?.global_styles_id || ( yield getGlobalStylesId( siteIdOrSlug, stylesheet ) );
+
+		const updatedGlobalStyles: GlobalStyles = yield wpcomRequest( {
+			path: `/sites/${ encodeURIComponent( siteIdOrSlug ) }/global-styles/${ globalStylesId }`,
+			apiNamespace: 'wp/v2',
+			method: 'POST',
+			body: {
+				id: globalStylesId,
+				settings: {},
+				styles: {},
+			},
+		} );
+
+		return updatedGlobalStyles;
+	}
+
 	function* getGlobalStylesId( siteIdOrSlug: number | string, stylesheet: string ) {
 		const theme: ActiveTheme = yield wpcomRequest( {
 			path: `/sites/${ encodeURIComponent( siteIdOrSlug ) }/themes/${ stylesheet }`,
@@ -392,8 +415,11 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			method: 'POST',
 		} );
 
+		if ( styleVariation?.slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG ) {
+			yield* resetGlobalStyles( siteSlug, activatedTheme.stylesheet, activatedTheme );
+		}
 		// @todo Always use the global styles for consistency
-		if ( styleVariation?.slug ) {
+		else if ( styleVariation?.slug ) {
 			const variations: GlobalStyles[] = yield* getGlobalStylesVariations(
 				siteSlug,
 				activatedTheme.stylesheet

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -33,7 +33,7 @@ import type {
 } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
 import type { RequestTemplate } from '../templates';
-import type { Design, DesignOptions, StyleVariation } from '@automattic/design-picker/src/types'; // Import from a specific file directly to avoid the circular dependencies
+import type { Design, DesignOptions } from '@automattic/design-picker/src/types'; // Import from a specific file directly to avoid the circular dependencies
 
 export function createActions( clientCreds: WpcomClientCredentials ) {
 	const fetchSite = () => ( {
@@ -223,7 +223,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 	function* setGlobalStyles(
 		siteIdOrSlug: number | string,
 		stylesheet: string,
-		globalStyles: GlobalStyles | StyleVariation,
+		globalStyles: GlobalStyles,
 		activatedTheme?: ActiveTheme
 	) {
 		// only update if there settings or styles to update
@@ -404,13 +404,14 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 					variation.title.split( ' ' ).join( '-' ).toLowerCase() === styleVariation?.slug
 			);
 
-			// the default style is not in variations, so we set it as a fallback here
-			yield* setGlobalStyles(
-				siteSlug,
-				activatedTheme.stylesheet,
-				currentVariation || styleVariation,
-				activatedTheme
-			);
+			if ( currentVariation ) {
+				yield* setGlobalStyles(
+					siteSlug,
+					activatedTheme.stylesheet,
+					currentVariation,
+					activatedTheme
+				);
+			}
 		}
 
 		if ( globalStyles ) {

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '@automattic/global-styles';
+import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '@automattic/global-styles/src/constants';
 import { __ } from '@wordpress/i18n';
 import { SiteGoal } from '../onboard';
 import { wpcomRequest } from '../wpcom-request-controls';

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -437,17 +437,47 @@ describe( 'Site Actions', () => {
 			recipe: mockedRecipe,
 		};
 		const mockedStyleVariation = {
+			title: 'Parrot',
+			slug: 'parrot',
+			settings: {
+				color: {
+					palette: {
+						theme: [
+							{
+								color: '#FF0000',
+								name: 'Red',
+								slug: 'red',
+							},
+						],
+					},
+				},
+			},
+			styles: {
+				spacing: {
+					blockGap: '0.5rem',
+				},
+			},
+		};
+		const mockedDefaultVariation = {
 			title: 'Default',
 			slug: 'default',
 			settings: {
 				color: {
 					palette: {
-						theme: [],
+						theme: [
+							{
+								color: '#880000',
+								name: 'Red',
+								slug: 'red',
+							},
+						],
 					},
 				},
 			},
 			styles: {
-				color: {},
+				spacing: {
+					blockGap: '1rem',
+				},
 			},
 		};
 
@@ -516,6 +546,36 @@ describe( 'Site Actions', () => {
 					id: mockedGlobalStylesId,
 					settings: mockedStyleVariation.settings,
 					styles: mockedStyleVariation.styles,
+				} )
+			);
+		} );
+
+		it( 'should call global styles API to reset styles when user selects default variation', () => {
+			const { setDesignOnSite } = createActions( mockedClientCredentials );
+			const generator = setDesignOnSite( siteSlug, mockedDesign, {
+				styleVariation: mockedDefaultVariation,
+			} );
+
+			// 1st iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
+			expect( generator.next().value ).toEqual(
+				createMockedThemeSwitchApiRequest( {
+					theme: 'zoologist',
+				} )
+			);
+
+			// 2nd iteration: WP_COM_REQUEST to /sites/${ siteSlug }/global-styles/${ globalStylesId } is fired
+			expect(
+				generator.next( {
+					stylesheet: mockedDesign.recipe.stylesheet,
+					global_styles_id: mockedGlobalStylesId,
+				} ).value
+			).toEqual(
+				createMockedSetGlobalStylesApiRequest( mockedGlobalStylesId, {
+					id: mockedGlobalStylesId,
+					// Resetting styles means these values are empty, regrdless of the base styles
+					// specified in the `mockedDefaultVariation` object.
+					settings: {},
+					styles: {},
 				} )
 			);
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95578
Fixes #96219

## Proposed Changes

It's now possible to remove custom style variations using the design selection step.

* Adds `resetGlobalStyles` action to the sites data store, which wipes any user style variations from the current theme
* Use `resetGlobalStyles` in the `setDesignOnSite` action, so that setting the "default" variation clears all style variations
* Unit tests
  * Fix existing `setDesignOnSite` test which was meant to test the behaviour of a non-default style variation
  * Add test for resetting style variation

**Note** `resetGlobalStyles` is destructive! If the user has set custom styles of their own then re-choosing the default variation will destroy them.

**Note 2** this PR only fixes the ability, it doesn't fix issues relating to the ability to easily choose a different variation in the style picker, or issues with the `remove your premium` styles help link raised in #95568. It should keep this PR focused.

## Implementation Details

The `Your site contains premium styles ...` message appears based on this logic:
https://github.com/Automattic/jetpack/blob/be9762ce4b728bc537009746987f4c55d1d821cb/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php#L353

For the message to disappear the styles need to be cleared; setting custom styles that happen to match the theme's defaults will not be enough. And if you watch the network traffic in the site editor when setting a style variation back to "Default", you will see the network request removes all custom styles.

The list of variations in design selector comes from the `/wpcom/v2/starter-designs/{{ theme slug }}` endpoint, which includes a "Default" variation which includes a lot of style information. It appears to be all the theme's default style values. However when saving the variation we `POST` to the `/wp/v2/sites/{{ site slug }}/global-styles/{{ post id }}` endpoint, and this Core API is different from the Starter Designs API used to populate the UI. IMO that's why we're filtering our list of style variations against the Core list of style variations before we save anything.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This partially addresses the usability issue raised in #95578. After choosing a premium design variation, the launchpad informs the user they will need a non-free plan.
![image](https://github.com/user-attachments/assets/77f5067b-a1c9-463f-854c-4ea3dbce7d54)

The might expect to be able to use the launchpad to navigate back to design selection and choose a different variation would remove the non-free plan requirement. However the design selector doesn't currently have the ability to go back to a non-default variation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/start` and continue to the theme selection step.
2. Choose a free theme and select a premium style.
3. Click Continue and then click "Decide later" in the upsell dialog.
4. In the Launchpad, click "Select a design" to go back.
5. Choose the same theme, select the default style, and click Continue. (the large thumbnail might not be clickable, you may need to click on the circles which represent each of the style variations)
6. Check that the default style is applied and that the "Choose a plan" step in the launchpad doesn't ship the "Upgrade plan" badge

Note that this PR changes the `setDesignOnSite()` action, which is also used by the Newsletter flow. So it's worth trying that to:
1. Create a new site using `/setup/newsletter` flow
2. Confirm the correct theme is set

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~
