### PR TITLE
Reader Onboarding: Do not render if user registered before Oct 1 2024

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,6 +1,6 @@
-import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
+import { useState } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -13,7 +13,8 @@ import FollowingIntro from './intro';
 import './style.scss';
 
 function FollowingStream( { ...props } ) {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	const [ readerOnboardingIsRendered, setReaderOnboardingIsRendered ] = useState( false );
+	// config.isEnabled( 'reader/onboarding' )
 	return (
 		<>
 			<Stream
@@ -29,13 +30,13 @@ function FollowingStream( { ...props } ) {
 						'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,
 					} ) }
 				/>
-				{ ! config.isEnabled( 'reader/onboarding' ) && <FollowingIntro /> }
-				{ config.isEnabled( 'reader/onboarding' ) && <ReaderOnboarding /> }
+
+				<ReaderOnboarding onRender={ setReaderOnboardingIsRendered } />
+				{ ! readerOnboardingIsRendered && <FollowingIntro /> }
 			</Stream>
 			<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
 		</>
 	);
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
 export default SuggestionProvider( withDimensions( FollowingStream ) );

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -14,7 +14,7 @@ import './style.scss';
 
 function FollowingStream( { ...props } ) {
 	const [ readerOnboardingIsRendered, setReaderOnboardingIsRendered ] = useState( false );
-	// config.isEnabled( 'reader/onboarding' )
+
 	return (
 		<>
 			<Stream

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -24,24 +24,19 @@ const ReaderOnboarding = ( { onRender }: { onRender?: ( shown: boolean ) => void
 	const preferencesLoaded = useSelector( hasReceivedRemotePreferences );
 	const userRegistrationDate = useSelector( getCurrentUserDate );
 
-	// Don't render anything if the feature flag is disabled.
-	if ( ! config.isEnabled( 'reader/onboarding' ) ) {
+	const shouldShowOnboarding =
+		config.isEnabled( 'reader/onboarding' ) &&
+		preferencesLoaded &&
+		! hasCompletedOnboarding &&
+		userRegistrationDate &&
+		new Date( userRegistrationDate ) >= new Date( '2024-10-01T00:00:00Z' );
+
+	// Notify the parent component if onboarding will render.
+	onRender?.( shouldShowOnboarding );
+
+	if ( ! shouldShowOnboarding ) {
 		return null;
 	}
-
-	// Don't render anything until preferences are loaded or if onboarding is completed.
-	if ( ! preferencesLoaded || hasCompletedOnboarding ) {
-		return null;
-	}
-
-	// Don't render anything if userRegistrationDate is missing or if user registered before Oct 1, 2024
-	const cutoffDate = new Date( '2024-10-01T00:00:00Z' );
-	if ( ! userRegistrationDate || new Date( userRegistrationDate ) < cutoffDate ) {
-		return null;
-	}
-
-	// Notify the parent component that onboarding will render.
-	onRender?.( true );
 
 	const handleInterestsContinue = () => {
 		setIsInterestsModalOpen( false );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/197

## Proposed Changes

* This PR add a check for user registration. It will not render onboarding if the user registered before Oct 1, 2024.
* It moves the check for the feature flag inside the `ReaderOnboarding` component
* It adds a prop to `ReaderOnboarding` called `onRender` that alerts the parent component if the `ReaderOnboarding` component will render.
* Using the new `onRender` prop state, we can conditionally show the `FollowingIntro` component on /read

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The date check is part of the project criteria
* Adding the `onRender` state property allows us to keep the "gatekeeping" logic inside the `ReaderOnboarding` component so the parent component doesn't need to know the rules for displaying the component. That will allow us to easily reuse the `ReaderOnboarding` component in other places without duplicating the display rules everywhere it is used.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso Live and an account created before Oct 1 2024
* Go to /read - The onboarding banner should NOT show up because the feature flag is missing
* Go to /read?flags=reader/onboarding - The onboarding banner should NOT show up because your user account is older than Oct 1 2024
* Create a new account or use an account created after Oct 1 2024
* Using Calypso Live
* Go to /read - The onboarding banner should NOT appear because the feature flag is missing AND you should see the "Welcome!" banner
* Go to /read?flags=reader/onboarding - The onboarding banner SHOULD appear because the feature flag is there and your account is newer than Oct 1 2024. The "Welcome!" banner should NOT appear because the onboarding banner takes precedence.
* Still on /read?flags=reader/onboarding complete both onboarding tasks. The Reader Onboarding banner should disappear, and the "Welcome!" banner should take its place.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
