### PR TITLE
Update checkout help text link

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -26,6 +26,14 @@ const ContactContainer = styled.div`
 		text-decoration: underline;
 		line-height: 20px;
 		font-size: 14px;
+
+		span {
+			color: var( --studio-wordpress-blue-50 );
+		}
+
+		&:hover {
+			text-decoration: none;
+		}
 	}
 	.gridicon {
 		display: block;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -28,7 +28,7 @@ const ContactContainer = styled.div`
 		font-size: 14px;
 
 		span {
-			color: var( --studio-wordpress-blue-50 );
+			color: var( --color-accent );
 		}
 
 		&:hover {


### PR DESCRIPTION
## Proposed Changes

This PR updates the help link text colour in checkout to match the blues for all the other links.

**Before**
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/89d9f17a-aff4-4f47-a265-b320aa4c925e">


**After**
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/b1e3f434-0afe-4c73-8af8-bf560e61c5e4">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit checkout, check the support link in the top right to see if it matches the blues throughout the rest of the screen.


