### PR TITLE
Calypso Admin Plans Page: Allow `coupon` query param

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -32,6 +32,12 @@ export function plans( context, next ) {
 		return productSelect( '/plans' )( context, next );
 	}
 
+	// Emails rely on the `discount` query param to auto-apply coupons
+	// from the Calypso admin plans page. The `/start` onboarding flow
+	// plans page, however, relies on the `coupon` query param for the
+	// same purpose. We handle both coupon and discount here for the time
+	// being to avoid confusion. We'll probably consolidate to just `coupon`
+	// in the future.
 	const withDiscount = context.query.coupon || context.query.discount;
 
 	context.primary = (

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -32,6 +32,8 @@ export function plans( context, next ) {
 		return productSelect( '/plans' )( context, next );
 	}
 
+	const withDiscount = context.query.coupon || context.query.discount;
+
 	context.primary = (
 		<Plans
 			context={ context }
@@ -39,7 +41,7 @@ export function plans( context, next ) {
 			customerType={ context.query.customerType }
 			selectedFeature={ context.query.feature }
 			selectedPlan={ context.query.plan }
-			withDiscount={ context.query.discount }
+			withDiscount={ withDiscount }
 			discountEndDate={ context.query.ts }
 			redirectTo={ context.query.redirect_to }
 			redirectToAddDomainFlow={


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pau2Xa-6sB-p2#comment-16318

## Proposed Changes

* Handle the `coupon` query param on the Calypso admin `/plans` page in the same way that we handle the `discount` query param

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `/start` onboarding flow accepts the `coupon` query param. The plans page accepts the `discount` query param. Both serve the same function.
* It's unusual and unexpected to have two different query params, so we add support for the `coupon` query param in the plans page as well.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the Calypso admin `/plans/:site?discount=HCHOSEN100PER` page for a site with a free plan
* Click on the Personal Plan upgrade CTA
* Verify that you are redirected to checkout with the coupon applied
* Repeat for `/plans/:site?coupon=HCHOSEN100PER`
* Verify that you are redirected to checkout with the coupon applied

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?