### PR TITLE
Domains: Create 100-Year domain transfer flow

### DIFF
--- a/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
@@ -1,10 +1,14 @@
 import { HUNDRED_YEAR_DOMAIN_TRANSFER } from '@automattic/onboarding';
+import { translate } from 'i18n-calypso';
 import domainTransfer from './domain-transfer';
 import { Flow } from './internals/types';
 
 const hundredYearDomainTransfer: Flow = {
 	...domainTransfer,
 	variantSlug: HUNDRED_YEAR_DOMAIN_TRANSFER,
+	get title() {
+		return translate( '100-Year Domain' );
+	},
 
 	useSideEffect( _currentStep, navigate ) {
 		// Always skip the "intro" step as we don't need it for the 100-year domain transfer flow.

--- a/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
@@ -1,7 +1,14 @@
 import { HUNDRED_YEAR_DOMAIN_TRANSFER } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
+import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
+import { setSignupCompleteFlowName, setSignupCompleteSlug } from 'calypso/signup/storageUtils';
 import domainTransfer from './domain-transfer';
-import { Flow } from './internals/types';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	Flow,
+	ProvidedDependencies,
+} from './internals/types';
 
 const hundredYearDomainTransfer: Flow = {
 	...domainTransfer,
@@ -16,7 +23,53 @@ const hundredYearDomainTransfer: Flow = {
 	useSteps() {
 		const transferSteps = domainTransfer.useSteps();
 		const domainsStepIndex = transferSteps.findIndex( ( step ) => step.slug === 'domains' );
-		return transferSteps.slice( domainsStepIndex );
+		return [
+			transferSteps[ domainsStepIndex ],
+			...stepsWithRequiredLogin( transferSteps.slice( domainsStepIndex ) ),
+		];
+	},
+
+	// Always allow the user to proceed with the transfer, as we assert that the user is logged in later.
+	useAssertConditions(): AssertConditionResult {
+		return { state: AssertConditionState.SUCCESS };
+	},
+
+	useStepNavigation( _currentStepSlug, navigate ) {
+		const flowName = this.name;
+
+		const submit = async ( providedDependencies: ProvidedDependencies = {} ) => {
+			switch ( _currentStepSlug ) {
+				case 'domains': {
+					// go to processing step without pushing it to history
+					// so the back button would go back to domains step
+					return navigate( 'processing', undefined );
+				}
+				case 'processing': {
+					setSignupCompleteSlug( providedDependencies?.siteSlug );
+					setSignupCompleteFlowName( flowName );
+
+					// Delay to keep the "Setting up your legacy..." page showing for 2 seconds
+					// since there's nothing to actually process in that step
+					await new Promise( ( resolve ) => setTimeout( resolve, 2000 ) );
+
+					const checkoutBackURL = new URL(
+						'/setup/hundred-year-domain-transfer',
+						window.location.href
+					);
+
+					// use replace instead of assign to remove the processing URL from history
+					return window.location.replace(
+						`/checkout/no-site?signup=0&isDomainOnly=1&checkoutBackUrl=${ encodeURIComponent(
+							checkoutBackURL.href
+						) }`
+					);
+				}
+				default:
+					return;
+			}
+		};
+
+		return { submit };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
@@ -1,0 +1,19 @@
+import { HUNDRED_YEAR_DOMAIN_TRANSFER } from '@automattic/onboarding';
+import domainTransfer from './domain-transfer';
+import { Flow } from './internals/types';
+
+const hundredYearDomainTransfer: Flow = {
+	...domainTransfer,
+	variantSlug: HUNDRED_YEAR_DOMAIN_TRANSFER,
+
+	useSideEffect( _currentStep, navigate ) {
+		// Always skip the "intro" step as we don't need it for the 100-year domain transfer flow.
+		// It doesn't make sense to show it as it contains additional cluttering information that
+		// doesn't matter specifically for the 100-year domain context - they'll come from a different entry point also.
+		if ( _currentStep === 'intro' ) {
+			navigate( 'domains' );
+		}
+	},
+};
+
+export default hundredYearDomainTransfer;

--- a/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
@@ -10,13 +10,13 @@ const hundredYearDomainTransfer: Flow = {
 		return translate( '100-Year Domain' );
 	},
 
-	useSideEffect( _currentStep, navigate ) {
-		// Always skip the "intro" step as we don't need it for the 100-year domain transfer flow.
-		// It doesn't make sense to show it as it contains additional cluttering information that
-		// doesn't matter specifically for the 100-year domain context - they'll come from a different entry point also.
-		if ( _currentStep === 'intro' ) {
-			navigate( 'domains' );
-		}
+	// Always start on the "domains" step, as we don't need what comes before it for the 100-year domain transfer flow.
+	// It doesn't make sense to show it as it contains additional cluttering information that doesn't matter
+	// specifically under the 100-year domain context - they'll also come from a different entry point.
+	useSteps() {
+		const transferSteps = domainTransfer.useSteps();
+		const domainsStepIndex = transferSteps.findIndex( ( step ) => step.slug === 'domains' );
+		return transferSteps.slice( domainsStepIndex );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FormInputValidation, FormLabel, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { GOOGLE_TRANSFER } from '@automattic/onboarding';
+import { GOOGLE_TRANSFER, HUNDRED_YEAR_DOMAIN_TRANSFER } from '@automattic/onboarding';
 import { Button, Icon } from '@wordpress/components';
 import { check, closeSmall } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -110,6 +110,7 @@ export function DomainCodePair( {
 
 	const validation = useValidationMessage( domain, auth, hasDuplicates );
 	const isGoogleDomainsTransferFlow = GOOGLE_TRANSFER === variantSlug;
+	const isHundredYearDomainsTransferFlow = HUNDRED_YEAR_DOMAIN_TRANSFER === variantSlug;
 	const userCurrencyCode = useSelector( getCurrentUserCurrencyCode ) || 'USD';
 
 	const {
@@ -195,9 +196,13 @@ export function DomainCodePair( {
 				} ) }
 				position="right"
 			>
-				{ __(
-					'Unique code proving ownership, needed for secure domain transfer between registrars.'
-				) }
+				{ isHundredYearDomainsTransferFlow
+					? __(
+							'Your secret key to unlock the domain transfer. Get yours from your current domain provider.'
+					  )
+					: __(
+							'Unique code proving ownership, needed for secure domain transfer between registrars.'
+					  ) }
 				<div>
 					<Button
 						href={ localizeUrl(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -108,9 +108,11 @@ export function DomainCodePair( {
 }: Props ) {
 	const { __ } = useI18n();
 
-	const validation = useValidationMessage( domain, auth, hasDuplicates );
-	const isGoogleDomainsTransferFlow = GOOGLE_TRANSFER === variantSlug;
 	const isHundredYearDomainsTransferFlow = HUNDRED_YEAR_DOMAIN_TRANSFER === variantSlug;
+	const validation = useValidationMessage( domain, auth, hasDuplicates, {
+		is_hundred_year_domain: isHundredYearDomainsTransferFlow,
+	} );
+	const isGoogleDomainsTransferFlow = GOOGLE_TRANSFER === variantSlug;
 	const userCurrencyCode = useSelector( getCurrentUserCurrencyCode ) || 'USD';
 
 	const {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -110,7 +110,7 @@ export function DomainCodePair( {
 
 	const isHundredYearDomainsTransferFlow = HUNDRED_YEAR_DOMAIN_TRANSFER === variantSlug;
 	const validation = useValidationMessage( domain, auth, hasDuplicates, {
-		vendor: isHundredYearDomainsTransferFlow ? '100-year-domains' : null,
+		vendor: isHundredYearDomainsTransferFlow ? '100-year-domains' : undefined,
 	} );
 	const isGoogleDomainsTransferFlow = GOOGLE_TRANSFER === variantSlug;
 	const userCurrencyCode = useSelector( getCurrentUserCurrencyCode ) || 'USD';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -110,7 +110,7 @@ export function DomainCodePair( {
 
 	const isHundredYearDomainsTransferFlow = HUNDRED_YEAR_DOMAIN_TRANSFER === variantSlug;
 	const validation = useValidationMessage( domain, auth, hasDuplicates, {
-		is_hundred_year_domain: isHundredYearDomainsTransferFlow,
+		vendor: isHundredYearDomainsTransferFlow ? '100-year-domains' : null,
 	} );
 	const isGoogleDomainsTransferFlow = GOOGLE_TRANSFER === variantSlug;
 	const userCurrencyCode = useSelector( getCurrentUserCurrencyCode ) || 'USD';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
 import { DomainTransferData, DomainTransferForm } from '@automattic/data-stores';
 import formatCurrency from '@automattic/format-currency';
-import { useDataLossWarning } from '@automattic/onboarding';
+import { HUNDRED_YEAR_DOMAIN_TRANSFER, useDataLossWarning } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
@@ -90,6 +90,8 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 	const hasAnyDomains = Object.values( domainsState ).some(
 		( { domain, auth } ) => domain.trim() || auth.trim()
 	);
+
+	const isHundredYearTransfer = variantSlug === HUNDRED_YEAR_DOMAIN_TRANSFER;
 
 	useDataLossWarning( hasAnyDomains && enabledDataLossWarning );
 
@@ -258,7 +260,7 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 				/>
 			) ) }
 			<Button className="bulk-domain-transfer__add-domain" icon={ plus } onClick={ addDomain }>
-				{ __( 'Add more' ) }
+				{ isHundredYearTransfer ? __( 'Add another domain' ) : __( 'Add more' ) }
 			</Button>
 			<div className="bulk-domain-transfer__cta-container">
 				<Button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -112,6 +112,7 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 						auth_code: auth,
 						signup: false,
 						import_dns_records: true,
+						is_hundred_year_domain: isHundredYearTransfer,
 					},
 				} )
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -114,6 +114,7 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 						import_dns_records: true,
 						is_hundred_year_domain: isHundredYearTransfer,
 					},
+					volume: isHundredYearTransfer ? 100 : 1,
 				} )
 			);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -1,12 +1,13 @@
 import { MaterialIcon } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
-import { GOOGLE_TRANSFER } from '@automattic/onboarding';
+import { GOOGLE_TRANSFER, HUNDRED_YEAR_DOMAIN_TRANSFER } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import ChatButton from 'calypso/components/chat-button';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import TransferDomains from './domains';
 import type { Step } from '../../types';
 
@@ -22,10 +23,14 @@ const Intro: Step = function Intro( { navigation, flow, variantSlug } ) {
 	};
 
 	const isGoogleDomainsTransferFlow = GOOGLE_TRANSFER === variantSlug;
+	const isHundredYearDomainsTransferFlow = HUNDRED_YEAR_DOMAIN_TRANSFER === variantSlug;
+
+	const Container = isHundredYearDomainsTransferFlow ? HundredYearPlanStepWrapper : StepContainer;
 
 	return (
-		<StepContainer
+		<Container
 			flowName={ flow }
+			variantSlug={ variantSlug }
 			stepName="domains"
 			goBack={ goBack }
 			isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -28,6 +28,22 @@ const Intro: Step = function Intro( { navigation, flow, variantSlug } ) {
 
 	const Container = isHundredYearDomainsTransferFlow ? HundredYearPlanStepWrapper : StepContainer;
 
+	const headerText = isHundredYearDomainsTransferFlow
+		? __( 'Transfer your Domain' )
+		: __( 'Add your domains' );
+
+	const regularFlowsSubheaderText = isGoogleDomainsTransferFlow
+		? __( 'Enter your domain names and transfer codes below.' )
+		: __( 'Enter your domain names and authorization codes below.' );
+
+	const hundredYearFlowsSubheaderText = __(
+		'Start building your legacy. Secure your domain for the next 100 years.'
+	);
+
+	const subHeaderText = isHundredYearDomainsTransferFlow
+		? hundredYearFlowsSubheaderText
+		: regularFlowsSubheaderText;
+
 	return (
 		<Container
 			flowName={ flow }
@@ -40,14 +56,10 @@ const Intro: Step = function Intro( { navigation, flow, variantSlug } ) {
 			formattedHeader={
 				<FormattedHeader
 					id="domain-transfer-header"
-					headerText={ __( 'Add your domains' ) }
+					headerText={ headerText }
 					subHeaderText={
 						<>
-							<span>
-								{ isGoogleDomainsTransferFlow
-									? __( 'Enter your domain names and transfer codes below.' )
-									: __( 'Enter your domain names and authorization codes below.' ) }
-							</span>
+							<span>{ subHeaderText }</span>
 						</>
 					}
 					align="center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -8,6 +8,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
+import { WIDE_BREAKPOINT } from '../hundred-year-plan-step-wrapper/constants';
 import TransferDomains from './domains';
 import type { Step } from '../../types';
 
@@ -31,6 +32,7 @@ const Intro: Step = function Intro( { navigation, flow, variantSlug } ) {
 		<Container
 			flowName={ flow }
 			variantSlug={ variantSlug }
+			mobileBreakpoint={ WIDE_BREAKPOINT }
 			stepName="domains"
 			goBack={ goBack }
 			isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -11,6 +11,24 @@
 	align-items: center;
 	gap: 30px;
 
+	&.hundred-year-domain-transfer {
+
+		&.step-route {
+			gap: 0;
+			width: 100%;
+			margin: 0;
+			max-width: none;
+		}
+
+		.domains {
+			.step-container__header {
+				@media (max-width: $break-wide) {
+					margin-top: 32px;
+				}
+			}
+		}
+	}
+
 	button:disabled {
 		pointer-events: none;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -27,6 +27,21 @@
 				}
 			}
 		}
+
+		.bulk-domain-transfer__cta-container {
+			display: flex;
+			justify-content: center;
+			margin-bottom: 32px;
+
+			.bulk-domain-transfer__cta {
+				height: 48px;
+				width: 240px;
+
+				@media (max-width: $break-medium) {
+					width: 100%;
+				}
+			}
+		}
 	}
 
 	button:disabled {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -4,7 +4,16 @@ import { useDebounce } from 'use-debounce';
 import { useIsDomainCodeValid } from 'calypso/landing/stepper/hooks/use-is-domain-code-valid';
 import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
 
-export function useValidationMessage( domain: string, auth: string, hasDuplicates: boolean ) {
+export type DomainValidationOptions = {
+	is_hundred_year_domain?: boolean;
+};
+
+export function useValidationMessage(
+	domain: string,
+	auth: string,
+	hasDuplicates: boolean,
+	options: DomainValidationOptions = {}
+) {
 	const { __ } = useI18n();
 
 	const [ domainDebounced ] = useDebounce( domain, 500 );
@@ -25,6 +34,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		{
 			domain: domainDebounced,
 			auth: authDebounced,
+			options,
 		},
 		{
 			enabled: Boolean( passedLocalValidation ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -5,7 +5,7 @@ import { useIsDomainCodeValid } from 'calypso/landing/stepper/hooks/use-is-domai
 import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
 
 export type DomainValidationOptions = {
-	is_hundred_year_domain?: boolean;
+	vendor?: string;
 };
 
 export function useValidationMessage(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/constants.ts
@@ -1,1 +1,2 @@
 export const SMALL_BREAKPOINT = 960;
+export const WIDE_BREAKPOINT = 1280;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -26,6 +26,7 @@ type Props = {
 	stepName: string;
 	flowName: string;
 	variantSlug?: string;
+	mobileBreakpoint?: number;
 	stepContent: ReactElement;
 	justifyStepContent?: string;
 	formattedHeader?: ReactElement;
@@ -294,9 +295,10 @@ function HundredYearPlanStepWrapper( props: Props ) {
 		justifyStepContent,
 		hideInfoColumn,
 		variantSlug,
+		mobileBreakpoint,
 	} = props;
 
-	const isMobile = useBreakpoint( `<${ SMALL_BREAKPOINT }px` );
+	const isMobile = useBreakpoint( `<${ mobileBreakpoint ?? SMALL_BREAKPOINT }px` );
 	const [ isOpen, setOpen ] = useState( false );
 	const openModal = () => setOpen( true );
 	const closeModal = () => setOpen( false );
@@ -323,8 +325,10 @@ function HundredYearPlanStepWrapper( props: Props ) {
 							</InfoColumnWrapper>
 						) }
 						<FlexWrapper justifyStepContent={ justifyStepContent }>
-							<div className="step-container__header">{ formattedHeader }</div>
-							{ stepContent }
+							<div className="hundred-year-plan-step-wrapper__step-container">
+								<div className="step-container__header">{ formattedHeader }</div>
+								{ stepContent }
+							</div>
 						</FlexWrapper>
 					</Container>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -5,6 +5,7 @@ import { formatCurrency } from '@automattic/format-currency';
 import {
 	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
+	HUNDRED_YEAR_DOMAIN_TRANSFER,
 	StepContainer,
 } from '@automattic/onboarding';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -21,10 +22,10 @@ import HundredYearPlanLogo from './hundred-year-plan-logo';
 import InfoModal from './info-modal';
 
 import './style.scss';
-
 type Props = {
 	stepName: string;
 	flowName: string;
+	variantSlug?: string;
 	stepContent: ReactElement;
 	justifyStepContent?: string;
 	formattedHeader?: ReactElement;
@@ -210,10 +211,12 @@ function InfoColumn( {
 	isMobile,
 	openModal,
 	flowName,
+	variantSlug,
 }: {
 	isMobile: boolean;
 	openModal: () => void;
 	flowName: string;
+	variantSlug?: string;
 } ) {
 	const translate = useTranslate();
 
@@ -225,12 +228,17 @@ function InfoColumn( {
 		( select ) => select( ProductsList.store ).getProductBySlug( PLAN_100_YEARS )?.currency_code,
 		[]
 	);
-	const displayCost =
+	let displayCost =
 		productPrice &&
 		currencyCode &&
 		formatCurrency( productPrice, currencyCode, {
 			stripZeros: true,
 		} );
+
+	// TODO: Replace hardcoded value/checks by 100-year domain product price when we have it
+	if ( variantSlug === HUNDRED_YEAR_DOMAIN_TRANSFER || flowName === HUNDRED_YEAR_DOMAIN_FLOW ) {
+		displayCost = '$2,000';
+	}
 
 	const planTitle =
 		flowName === HUNDRED_YEAR_PLAN_FLOW ? getPlan( PLAN_100_YEARS )?.getTitle() : '100-Year Domain';
@@ -278,8 +286,15 @@ function InfoColumn( {
 }
 
 function HundredYearPlanStepWrapper( props: Props ) {
-	const { stepContent, stepName, flowName, formattedHeader, justifyStepContent, hideInfoColumn } =
-		props;
+	const {
+		stepContent,
+		stepName,
+		flowName,
+		formattedHeader,
+		justifyStepContent,
+		hideInfoColumn,
+		variantSlug,
+	} = props;
 
 	const isMobile = useBreakpoint( `<${ SMALL_BREAKPOINT }px` );
 	const [ isOpen, setOpen ] = useState( false );
@@ -304,7 +319,7 @@ function HundredYearPlanStepWrapper( props: Props ) {
 						{ isOpen && <InfoModal flowName={ flowName } onClose={ closeModal } /> }
 						{ ! hideInfoColumn && (
 							<InfoColumnWrapper isMobile={ isMobile } flowName={ flowName }>
-								<InfoColumn isMobile={ isMobile } openModal={ openModal } flowName={ flowName } />
+								<InfoColumn isMobile={ isMobile } openModal={ openModal } flowName={ flowName } variantSlug={ variantSlug } />
 							</InfoColumnWrapper>
 						) }
 						<FlexWrapper justifyStepContent={ justifyStepContent }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -5,7 +5,6 @@ import { formatCurrency } from '@automattic/format-currency';
 import {
 	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
-	HUNDRED_YEAR_DOMAIN_TRANSFER,
 	StepContainer,
 } from '@automattic/onboarding';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -212,12 +211,10 @@ function InfoColumn( {
 	isMobile,
 	openModal,
 	flowName,
-	variantSlug,
 }: {
 	isMobile: boolean;
 	openModal: () => void;
 	flowName: string;
-	variantSlug?: string;
 } ) {
 	const translate = useTranslate();
 
@@ -229,17 +226,12 @@ function InfoColumn( {
 		( select ) => select( ProductsList.store ).getProductBySlug( PLAN_100_YEARS )?.currency_code,
 		[]
 	);
-	let displayCost =
+	const displayCost =
 		productPrice &&
 		currencyCode &&
 		formatCurrency( productPrice, currencyCode, {
 			stripZeros: true,
 		} );
-
-	// TODO: Replace hardcoded value/checks by 100-year domain product price when we have it
-	if ( variantSlug === HUNDRED_YEAR_DOMAIN_TRANSFER || flowName === HUNDRED_YEAR_DOMAIN_FLOW ) {
-		displayCost = '$2,000';
-	}
 
 	const planTitle =
 		flowName === HUNDRED_YEAR_PLAN_FLOW ? getPlan( PLAN_100_YEARS )?.getTitle() : '100-Year Domain';
@@ -294,7 +286,6 @@ function HundredYearPlanStepWrapper( props: Props ) {
 		formattedHeader,
 		justifyStepContent,
 		hideInfoColumn,
-		variantSlug,
 		mobileBreakpoint,
 	} = props;
 
@@ -321,7 +312,7 @@ function HundredYearPlanStepWrapper( props: Props ) {
 						{ isOpen && <InfoModal flowName={ flowName } onClose={ closeModal } /> }
 						{ ! hideInfoColumn && (
 							<InfoColumnWrapper isMobile={ isMobile } flowName={ flowName }>
-								<InfoColumn isMobile={ isMobile } openModal={ openModal } flowName={ flowName } variantSlug={ variantSlug } />
+								<InfoColumn isMobile={ isMobile } openModal={ openModal } flowName={ flowName } />
 							</InfoColumnWrapper>
 						) }
 						<FlexWrapper justifyStepContent={ justifyStepContent }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -4,6 +4,7 @@ import { ProductsList } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import {
 	HUNDRED_YEAR_DOMAIN_FLOW,
+	HUNDRED_YEAR_DOMAIN_TRANSFER,
 	HUNDRED_YEAR_PLAN_FLOW,
 	StepContainer,
 } from '@automattic/onboarding';
@@ -211,10 +212,12 @@ function InfoColumn( {
 	isMobile,
 	openModal,
 	flowName,
+	variantSlug,
 }: {
 	isMobile: boolean;
 	openModal: () => void;
 	flowName: string;
+	variantSlug?: string;
 } ) {
 	const translate = useTranslate();
 
@@ -269,9 +272,10 @@ function InfoColumn( {
 							<Gridicon icon="info-outline" size={ 16 } />
 						</>
 					</LearnMore>
-					{ flowName !== HUNDRED_YEAR_DOMAIN_FLOW && (
-						<Price className={ ! displayCost ? 'is-price-loading' : '' }>{ displayCost }</Price>
-					) }
+					{ flowName !== HUNDRED_YEAR_DOMAIN_FLOW &&
+						variantSlug !== HUNDRED_YEAR_DOMAIN_TRANSFER && (
+							<Price className={ ! displayCost ? 'is-price-loading' : '' }>{ displayCost }</Price>
+						) }
 				</Info>
 			</InfoColumnContainer>
 		</>
@@ -286,6 +290,7 @@ function HundredYearPlanStepWrapper( props: Props ) {
 		formattedHeader,
 		justifyStepContent,
 		hideInfoColumn,
+		variantSlug,
 		mobileBreakpoint,
 	} = props;
 
@@ -312,7 +317,12 @@ function HundredYearPlanStepWrapper( props: Props ) {
 						{ isOpen && <InfoModal flowName={ flowName } onClose={ closeModal } /> }
 						{ ! hideInfoColumn && (
 							<InfoColumnWrapper isMobile={ isMobile } flowName={ flowName }>
-								<InfoColumn isMobile={ isMobile } openModal={ openModal } flowName={ flowName } />
+								<InfoColumn
+									isMobile={ isMobile }
+									openModal={ openModal }
+									flowName={ flowName }
+									variantSlug={ variantSlug }
+								/>
 							</InfoColumnWrapper>
 						) }
 						<FlexWrapper justifyStepContent={ justifyStepContent }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
@@ -1,6 +1,7 @@
 @import "@automattic/onboarding/styles/mixins";
 
 .hundred-year-plan,
+.hundred-year-domain-transfer,
 .hundred-year-domain {
 	height: 100%;
 	padding: 0;
@@ -9,8 +10,16 @@
 	}
 }
 
+/**
+ * A different selector (not `.step-container.${flowName}`) is needed for the 100-year domain transfer
+ * since it's just a variation of the `domain-transfer` flow, and variations aren't accounted for
+ * in the StepContainer component. Then, we need to use a parent selector (which at the time of writing,
+ * uses the name, variant and step of the flow) to target this flow within these styles.
+ */
 .step-container.hundred-year-plan.hundred-year-plan,
-.step-container.hundred-year-domain.hundred-year-domain {
+.step-container.hundred-year-domain.hundred-year-domain,
+.hundred-year-domain-transfer>.step-container.domain-transfer,
+{
 	max-width: none;
 	height: 100%;
 	padding: 0;
@@ -32,6 +41,24 @@
 		.is-price-loading {
 			@include onboarding-placeholder;
 			width: 100px;
+		}
+	}
+
+	&.step-container.domain-transfer {
+		margin-top: 0;
+		width: 100%;
+
+		.hundred-year-plan-step-wrapper__step-container {
+			max-width: $break-large;
+			box-sizing: border-box;
+			padding: 0 20px;
+		}
+
+		.hundred-year-plan-step-wrapper__info-column-container {
+			.is-price-loading {
+				@include onboarding-placeholder;
+				width: 100px;
+			}
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -9,6 +9,7 @@ import {
 	isTransferringHostedSiteCreationFlow,
 	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
+	HUNDRED_YEAR_DOMAIN_TRANSFER,
 	isAnyHostingFlow,
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
@@ -187,7 +188,10 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		return <TailoredFlowPreCheckoutScreen flowName={ flowName } />;
 	}
 
-	if ( [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( flowName ) ) {
+	if (
+		[ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( flowName ) ||
+		props.variantSlug === HUNDRED_YEAR_DOMAIN_TRANSFER
+	) {
 		return <HundredYearPlanFlowProcessingScreen />;
 	}
 

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -8,6 +8,7 @@ import {
 	IMPORT_HOSTED_SITE_FLOW,
 	DOMAIN_TRANSFER,
 	GOOGLE_TRANSFER,
+	HUNDRED_YEAR_DOMAIN_TRANSFER,
 	REBLOGGING_FLOW,
 	MIGRATION_FLOW,
 	SITE_MIGRATION_FLOW,
@@ -149,6 +150,10 @@ const hundredYearDomainFlow: Record< string, () => Promise< { default: Flow } > 
 		? {
 				[ HUNDRED_YEAR_DOMAIN_FLOW ]: () =>
 					import( /* webpackChunkName: "hundred-year-domain" */ './hundred-year-domain' ),
+				[ HUNDRED_YEAR_DOMAIN_TRANSFER ]: () =>
+					import(
+						/* webpackChunkName: "hundred-year-domain-transfer" */ './hundred-year-domain-transfer'
+					),
 		  }
 		: {};
 

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -1,6 +1,7 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import sha256 from 'hash.js/lib/hash/sha/256';
 import wpcomRequest from 'wpcom-proxy-request';
+import { DomainValidationOptions } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 
 const VERSION = 2;
@@ -39,7 +40,11 @@ type DomainLockResponse = {
 	cannot_transfer_due_to_unsupported_premium_tld?: boolean;
 };
 
-type DomainCodePair = { domain: string; auth: string };
+type DomainCodePair = {
+	domain: string;
+	auth: string;
+	options?: DomainValidationOptions;
+};
 
 export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) {
 	return useQuery( {
@@ -84,6 +89,11 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 					query: `auth_code=${ encodeURIComponent( pair.auth ) }`,
 				} ).catch( () => ( { success: false } ) );
 
+				// TODO: Replace hardcoded value/checks by 100-year domain product price when we have it.
+				// We'll also n to pass it to the backend (/is-available) also, so it can return the proper value
+				// and we don't rely on hacks such as this one.
+				const price = pair.options?.is_hundred_year_domain ? 2000 : availability.raw_price;
+
 				return {
 					domain: pair.domain,
 					registered: true,
@@ -91,7 +101,7 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 					auth_code_valid: response.success,
 					status: availability.status,
 					transferrability: availability.transferrability,
-					raw_price: availability.raw_price,
+					raw_price: price,
 					sale_cost: availability.sale_cost,
 					currency_code: availability.currency_code,
 					cannot_transfer_due_to_unsupported_premium_tld:

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -99,9 +99,6 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 					query: `auth_code=${ encodeURIComponent( pair.auth ) }`,
 				} ).catch( () => ( { success: false } ) );
 
-				// TODO: Replace hardcoded value/checks by 100-year domain product price when we have it.
-				const price = pair.options?.is_hundred_year_domain ? 2000 : availability.raw_price;
-
 				return {
 					domain: pair.domain,
 					registered: true,
@@ -109,7 +106,7 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 					auth_code_valid: response.success,
 					status: availability.status,
 					transferrability: availability.transferrability,
-					raw_price: price,
+					raw_price: availability.raw_price,
 					sale_cost: availability.sale_cost,
 					currency_code: availability.currency_code,
 					cannot_transfer_due_to_unsupported_premium_tld:

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -357,10 +357,12 @@ export function domainTransfer( properties: {
 	domain: string;
 	source?: string;
 	extra?: RequestCartProductExtra;
+	volume?: number;
 } ): MinimalRequestCartProduct {
 	return {
 		...domainItem( domainProductSlugs.TRANSFER_IN, properties.domain, properties.source ),
 		...( properties.extra ? { extra: properties.extra } : {} ),
+		...( properties.volume ? { volume: properties.volume } : {} ),
 	};
 }
 

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -34,6 +34,7 @@ export const UPDATE_DESIGN_FLOW = 'update-design';
 export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
 export const DOMAIN_TRANSFER = 'domain-transfer';
 export const GOOGLE_TRANSFER = 'google-transfer';
+export const HUNDRED_YEAR_DOMAIN_TRANSFER = 'hundred-year-domain-transfer';
 export const HUNDRED_YEAR_DOMAIN_FLOW = 'hundred-year-domain';
 export const HUNDRED_YEAR_PLAN_FLOW = 'hundred-year-plan';
 export const BLOG_FLOW = 'blog';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/nomado-issues#1169.

Depends on 170244-ghe-Automattic/wpcom.

## Proposed Changes
Enable the 100-year domain flow for transfers. This is an effort related to this project: pcYYhz-2mw-p2.

## Why are these changes being made?
We need a new flow for the 100-year domain transfers - this PR follows the design guidelines for it described here: S4C3G9FpO6TxBQfmT2Sp1h-fi-8901_1185.
## Testing Instructions
- Enable Store Sandbox;
- Go to `/setup/hundred-year-domain-transfer`:
  - Ensure the page loads properly;
  - Ensure there's no `/intro` step, as opposed to the regular bulk transfer flow - you should be redirected to the next step, `/domains`.
- Try using a domain you have the auth code for, and that's unlocked, and ensure it can be used in the flow - either that or hack the back end to allow you to move forward, this patch should help: 36c22-pb/#diff - please note that **YOU SHOULDN'T COMPLETE THE PURCHASE** in this case.
- Ensure the auth code check and lock check for the domain step of the flow work properly;
- Ensure the retrieved price looks correct - should be the price for a 100-year domain/transfer, and not the one for a regular transfer;
- Click "Transfer" and proceed to the next screen - ensure it displays the proper "processing" screen, with specific designs to 100-year related products (the background video) - same as in the design files;
- Ensure the checkout page looks good and has the correct information - pricing, terms, etc;

## Preview

https://github.com/user-attachments/assets/62e41085-b93d-4f7f-b5c9-5ae8487ae718

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?