### PR TITLE
Jetpack Start: Remove references to 'agency_beta'

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -874,7 +874,7 @@ export function isAgencyPartnerType( partnerType: string ) {
 		return false;
 	}
 
-	return [ 'agency', 'agency_beta', 'a4a_agency' ].includes( partnerType );
+	return [ 'agency', 'a4a_agency' ].includes( partnerType );
 }
 
 export function purchaseType( purchase: Purchase ) {

--- a/client/state/partner-portal/partner/selectors.ts
+++ b/client/state/partner-portal/partner/selectors.ts
@@ -59,11 +59,7 @@ export function hasJetpackPartnerAccess( state: PartnerPortalStore ): boolean {
 
 export function isAgencyUser( state: PartnerPortalStore | IAppState ): boolean {
 	const currentUser = getCurrentUser( state );
-	return (
-		( currentUser?.jetpack_partner_types?.includes( 'agency' ) ||
-			currentUser?.jetpack_partner_types?.includes( 'agency_beta' ) ) ??
-		false
-	);
+	return currentUser?.jetpack_partner_types?.includes( 'agency' ) ?? false;
 }
 
 export function isA4AUser( state: PartnerPortalStore | IAppState ): boolean {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1348

## Proposed Changes

* Remove references to the agency beta partner type.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The agency beta partner type does not exist.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
