### PR TITLE
Logged-in Performance Profiler:Add additional track events

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -9,6 +9,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
 import { useUrlPerformanceInsightsQuery } from 'calypso/data/site-profiler/use-url-performance-insights';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
 import { useDispatch, useSelector } from 'calypso/state';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getRequest from 'calypso/state/selectors/get-request';
@@ -303,7 +304,8 @@ export const SitePerformance = () => {
 			onChange={ ( page_id ) => {
 				const url = new URL( window.location.href );
 				recordTracksEvent( 'calypso_performance_profiler_page_selector_change', {
-					page: pages.find( ( page ) => page.value === page_id )?.label ?? '/',
+					is_home: page_id === '0',
+					version: profilerVersion(),
 				} );
 				if ( page_id ) {
 					setCurrentPageUserSelection( pages.find( ( page ) => page.value === page_id ) );

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -249,12 +249,12 @@ export const SitePerformance = () => {
 
 	const onLaunchSiteClick = () => {
 		if ( site?.is_a4a_dev_site ) {
-			recordTracksEvent( 'calypso_performance_profiler_prepare_launch_click' );
+			recordTracksEvent( 'calypso_performance_profiler_prepare_launch_cta_click' );
 			page( `/settings/general/${ site.slug }` );
 			return;
 		}
 		dispatch( launchSite( siteId! ) );
-		recordTracksEvent( 'calypso_performance_profiler_launch_site_click' );
+		recordTracksEvent( 'calypso_performance_profiler_launch_site_cta_click' );
 	};
 
 	const isMobile = useMobileBreakpoint();
@@ -303,7 +303,7 @@ export const SitePerformance = () => {
 			onChange={ ( page_id ) => {
 				const url = new URL( window.location.href );
 				recordTracksEvent( 'calypso_performance_profiler_page_selector_change', {
-					page: pages.find( ( page ) => page.value === page_id ).label ?? '/',
+					page: pages.find( ( page ) => page.value === page_id )?.label ?? '/',
 				} );
 				if ( page_id ) {
 					setCurrentPageUserSelection( pages.find( ( page ) => page.value === page_id ) );

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -300,7 +300,9 @@ export const SitePerformance = () => {
 			disabled={ disableControls }
 			onChange={ ( page_id ) => {
 				const url = new URL( window.location.href );
-
+				recordTracksEvent( 'calypso_performance_profiler_page_selector_change', {
+					page: page_id,
+				} );
 				if ( page_id ) {
 					setCurrentPageUserSelection( pages.find( ( page ) => page.value === page_id ) );
 					url.searchParams.set( 'page_id', page_id );

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -249,10 +249,12 @@ export const SitePerformance = () => {
 
 	const onLaunchSiteClick = () => {
 		if ( site?.is_a4a_dev_site ) {
+			recordTracksEvent( 'calypso_performance_profiler_prepare_launch_click' );
 			page( `/settings/general/${ site.slug }` );
 			return;
 		}
 		dispatch( launchSite( siteId! ) );
+		recordTracksEvent( 'calypso_performance_profiler_launch_site_click' );
 	};
 
 	const isMobile = useMobileBreakpoint();
@@ -301,7 +303,7 @@ export const SitePerformance = () => {
 			onChange={ ( page_id ) => {
 				const url = new URL( window.location.href );
 				recordTracksEvent( 'calypso_performance_profiler_page_selector_change', {
-					page: page_id,
+					page: pages.find( ( page ) => page.value === page_id ).label ?? '/',
 				} );
 				if ( page_id ) {
 					setCurrentPageUserSelection( pages.find( ( page ) => page.value === page_id ) );

--- a/client/performance-profiler/components/core-web-vitals-accordion/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-accordion/index.tsx
@@ -9,7 +9,7 @@ import {
 	mapThresholdsToStatus,
 	displayValue,
 } from 'calypso/performance-profiler/utils/metrics';
-
+import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
 import './styles.scss';
 
 type Props = Record< Metrics, number > & {
@@ -61,6 +61,7 @@ export const CoreWebVitalsAccordion = ( props: Props ) => {
 		} else {
 			recordTracksEvent( 'calypso_performance_profiler_metric_tab_click', {
 				tab: key,
+				version: profilerVersion(),
 			} );
 			setActiveTab( key as Metrics );
 		}

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -11,6 +11,7 @@ import {
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { MetricsInsight } from 'calypso/performance-profiler/components/metrics-insight';
 import { filterRecommendations, metricsNames } from 'calypso/performance-profiler/utils/metrics';
+import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
 import { updateQueryParams } from 'calypso/performance-profiler/utils/query-params';
 import './style.scss';
 
@@ -139,6 +140,7 @@ export const InsightsSection = forwardRef(
 							recordTracksEvent( 'calypso_performance_profiler_insight_click', {
 								url: props.url,
 								key,
+								version: profilerVersion(),
 							} )
 						}
 					/>

--- a/client/performance-profiler/components/metric-tab-bar/index.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/index.tsx
@@ -8,6 +8,7 @@ import {
 	mapThresholdsToStatus,
 	displayValue,
 } from 'calypso/performance-profiler/utils/metrics';
+import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
 import { StatusIndicator } from '../status-indicator';
 import './style.scss';
 
@@ -23,7 +24,10 @@ const MetricTabBar = ( props: Props ) => {
 
 	const handleTabClick = ( tab: Metrics ) => {
 		setActiveTab( tab );
-		recordTracksEvent( 'calypso_performance_profiler_metric_tab_click', { tab } );
+		recordTracksEvent( 'calypso_performance_profiler_metric_tab_click', {
+			tab,
+			version: profilerVersion(),
+		} );
 	};
 
 	return (

--- a/client/performance-profiler/components/status-section/index.tsx
+++ b/client/performance-profiler/components/status-section/index.tsx
@@ -2,7 +2,9 @@ import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { Metrics } from 'calypso/data/site-profiler/types';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { Valuation } from 'calypso/performance-profiler/types/performance-metrics';
+import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
 
 import './style.scss';
 
@@ -39,6 +41,12 @@ export const StatusSection = ( props: StatusSectionProps ) => {
 		good: translate( 'Excellent' ),
 	}[ status ];
 
+	const recordRecommendationsClickEvent = ( filter = 'all' ) =>
+		recordTracksEvent( 'calypso_performance_profiler_recommendations_link_click', {
+			filter,
+			version: profilerVersion(),
+		} );
+
 	return (
 		<div className="status-section">
 			<div className={ clsx( 'status-badge', { [ status ]: true } ) }>{ statusText }</div>
@@ -55,6 +63,7 @@ export const StatusSection = ( props: StatusSectionProps ) => {
 											role="button"
 											tabIndex={ 0 }
 											onClick={ () => {
+												recordRecommendationsClickEvent();
 												onRecommendationsFilterChange?.( '' );
 												recommendationsRef?.current?.scrollIntoView( {
 													behavior: 'smooth',
@@ -80,6 +89,7 @@ export const StatusSection = ( props: StatusSectionProps ) => {
 												role="button"
 												tabIndex={ 0 }
 												onClick={ () => {
+													recordRecommendationsClickEvent( activeTab ?? '' );
 													onRecommendationsFilterChange?.( activeTab ?? '' );
 													recommendationsRef?.current?.scrollIntoView( {
 														behavior: 'smooth',

--- a/client/performance-profiler/components/status-section/index.tsx
+++ b/client/performance-profiler/components/status-section/index.tsx
@@ -41,7 +41,7 @@ export const StatusSection = ( props: StatusSectionProps ) => {
 		good: translate( 'Excellent' ),
 	}[ status ];
 
-	const recordRecommendationsClickEvent = ( filter = 'all' ) =>
+	const recordRecommendationsClickEvent = ( filter: string ) =>
 		recordTracksEvent( 'calypso_performance_profiler_recommendations_link_click', {
 			filter,
 			version: profilerVersion(),
@@ -63,7 +63,7 @@ export const StatusSection = ( props: StatusSectionProps ) => {
 											role="button"
 											tabIndex={ 0 }
 											onClick={ () => {
-												recordRecommendationsClickEvent();
+												recordRecommendationsClickEvent( 'all' );
 												onRecommendationsFilterChange?.( '' );
 												recommendationsRef?.current?.scrollIntoView( {
 													behavior: 'smooth',

--- a/client/performance-profiler/utils/profiler-version.ts
+++ b/client/performance-profiler/utils/profiler-version.ts
@@ -1,2 +1,8 @@
-export const profilerVersion = () =>
-	window.location.pathname.includes( '/sites/performance/' ) ? 'logged-in' : 'logged-out';
+export const profilerVersion = () => {
+	if ( window.location.pathname.includes( '/sites/performance/' ) ) {
+		return 'logged-in';
+	} else if ( window.location.pathname.includes( '/speed-test-tool' ) ) {
+		return 'logged-out';
+	}
+	return 'unknown';
+};

--- a/client/performance-profiler/utils/profiler-version.ts
+++ b/client/performance-profiler/utils/profiler-version.ts
@@ -1,0 +1,2 @@
+export const profilerVersion = () =>
+	window.location.pathname.includes( '/sites/performance/' ) ? 'logged-in' : 'logged-out';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9065

## Proposed Changes
This relates to this comment pdKhl6-4fl-p2#comment-7548
* Add additional track events 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To add more points of analytics 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In your console run `localStorage.setItem( 'debug', 'calypso:analytics*' );`
* Verify the track events are being fired for both logged-in and logged-out versions

![image](https://github.com/user-attachments/assets/2f938573-72a5-4141-adb7-c90a2da6749e)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?