### PR TITLE
Logged-in Performance Profiler: Open learn more link in new browser tab

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -164,7 +164,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 							{ translate( 'See calculator ↗' ) }
 						</a>
 					) : (
-						<a href={ `https://web.dev/articles/${ activeTab }` }>
+						<a href={ `https://web.dev/articles/${ activeTab }` } target="_blank" rel="noreferrer">
 							{ translate( 'Learn more ↗' ) }
 						</a>
 					) }

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -164,7 +164,11 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 							{ translate( 'See calculator ↗' ) }
 						</a>
 					) : (
-						<a href={ `https://web.dev/articles/${ activeTab }` } target="_blank" rel="noreferrer">
+						<a
+							href={ `https://web.dev/articles/${ encodeURIComponent( activeTab ) }` }
+							target="_blank"
+							rel="noreferrer"
+						>
 							{ translate( 'Learn more ↗' ) }
 						</a>
 					) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related tofeeback in this comment pdKhl6-4fl-p2#comment-7548

## Proposed Changes

* Allow core web vitals learn more link to open in a new browser tab.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `sites/performance/site` 
* Click learn more link of the selected metric
* It should open in a new browser tab

![image](https://github.com/user-attachments/assets/4862d31c-24dc-4938-a2fe-6bd0ac18c938)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?