### PR TITLE
Live Preview: Fix the Save button wasn't overriden correctly

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -5,17 +5,11 @@ import { usePreviewingThemeSlug } from './hooks/use-previewing-theme';
 import LivePreviewNoticePlugin from './live-preview-notice-plugin';
 
 const LivePreviewPlugin = () => {
-	const isReady = useSelect( ( select ) => select( 'core/editor' ).__unstableIsEditorReady() );
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
 	const previewingThemeSlug = usePreviewingThemeSlug();
 
 	// Do nothing outside the Site Editor context.
 	if ( ! siteEditorStore ) {
-		return null;
-	}
-
-	// Don't render until the editor is ready
-	if ( ! isReady ) {
 		return null;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -5,11 +5,17 @@ import { usePreviewingThemeSlug } from './hooks/use-previewing-theme';
 import LivePreviewNoticePlugin from './live-preview-notice-plugin';
 
 const LivePreviewPlugin = () => {
+	const isReady = useSelect( ( select ) => select( 'core/editor' ).__unstableIsEditorReady() );
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
 	const previewingThemeSlug = usePreviewingThemeSlug();
 
 	// Do nothing outside the Site Editor context.
 	if ( ! siteEditorStore ) {
+		return null;
+	}
+
+	// Don't render until the editor is ready
+	if ( ! isReady ) {
 		return null;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
@@ -53,6 +53,7 @@ const LivePreviewNotice: FC< {
 };
 
 const LivePreviewNoticePlugin = () => {
+	const isReady = useSelect( ( select ) => select( 'core/editor' ).__unstableIsEditorReady() );
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
 	const previewingTheme = usePreviewingTheme();
 	const { canPreviewButNeedUpgrade, upgradePlan } = useCanPreviewButNeedUpgrade( previewingTheme );
@@ -72,7 +73,7 @@ const LivePreviewNoticePlugin = () => {
 	if ( canPreviewButNeedUpgrade ) {
 		return (
 			<>
-				<LivePreviewUpgradeButton { ...{ previewingTheme, upgradePlan } } />
+				{ isReady && <LivePreviewUpgradeButton { ...{ previewingTheme, upgradePlan } } /> }
 				<LivePreviewUpgradeNotice { ...{ previewingTheme, dashboardLink } } />
 			</>
 		);

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-button.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-button.tsx
@@ -102,17 +102,21 @@ export const LivePreviewUpgradeButton: FC< {
 			} );
 		};
 
-		if ( canvasMode === 'view' ) {
-			overrideSaveButtonClick( SAVE_HUB_SAVE_BUTTON_SELECTOR );
-			overrideSaveButtonHover( SAVE_HUB_SAVE_BUTTON_SELECTOR );
-		} else if ( canvasMode === 'edit' ) {
-			overrideSaveButtonClick( HEADER_SAVE_BUTTON_SELECTOR );
-			overrideSaveButtonHover( HEADER_SAVE_BUTTON_SELECTOR );
-		}
+		// Delay it to ensure the element is visible.
+		const timeout = window.setTimeout( () => {
+			if ( canvasMode === 'view' ) {
+				overrideSaveButtonClick( SAVE_HUB_SAVE_BUTTON_SELECTOR );
+				overrideSaveButtonHover( SAVE_HUB_SAVE_BUTTON_SELECTOR );
+			} else if ( canvasMode === 'edit' ) {
+				overrideSaveButtonClick( HEADER_SAVE_BUTTON_SELECTOR );
+				overrideSaveButtonHover( HEADER_SAVE_BUTTON_SELECTOR );
+			}
+		}, 0 );
 
 		return () => {
 			resetSaveButton();
 			resetSaveButtonHover();
+			clearTimeout( timeout );
 		};
 	}, [ canvasMode, previewingTheme.id, previewingTheme.type, upgradePlan ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95611

## Proposed Changes

* Fix the error when trying to save/activate changes during the preview.
* The reason is wpcom would redirect to `wordpress.com/checkout/:site/:plan` page if the site didn't have the ability to activate the previewing theme. However, there was CORS issue so the error would show.
* We have a mechanism to override the Save button to open the new tab. However, it didn't work because the button was still not visible when we tried to override it. As a result, this PR made changes to override the button only when the editor is ready.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/3edfdb29-146b-43fe-9707-aab083794d24) | ![image](https://github.com/user-attachments/assets/8012f050-0594-4ecb-a6e7-1b5aa3473a09) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply changes to your site
* Sandbox widgets.wp.com and remember to disable the cache
* Go to Theme Showcase on your free site
* Preview any non-free theme
* Switch to the edit mode
* Make sure you can see the "Upgrade now" button
* Refresh the page
* Make sure you can still see the "Upgrade now" button (there is a little delay...)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
