### PR TITLE
Stats: Fix purchase page for site-less flow

### DIFF
--- a/client/my-sites/stats/pages/purchase/controller.tsx
+++ b/client/my-sites/stats/pages/purchase/controller.tsx
@@ -4,7 +4,8 @@ import type { Context } from '@automattic/calypso-router';
 
 function purchase( context: Context, next: () => void ) {
 	context.primary = (
-		// DO NOT WRAP WITH <StatsPageLoader /> or you will get an infinite loop
+		// DO NOT WRAP WITH <StatsPageLoader />
+		// Or the site-less purchase flow will not work because there is no permission to access Stats.
 		<AsyncLoad
 			require="calypso/my-sites/stats/pages/purchase"
 			placeholder={ PageLoading }

--- a/client/my-sites/stats/pages/purchase/controller.tsx
+++ b/client/my-sites/stats/pages/purchase/controller.tsx
@@ -1,17 +1,15 @@
 import AsyncLoad from 'calypso/components/async-load';
-import StatsPageLoader from '../../stats-page-loader';
 import PageLoading from '../shared/page-loading';
 import type { Context } from '@automattic/calypso-router';
 
 function purchase( context: Context, next: () => void ) {
 	context.primary = (
-		<StatsPageLoader>
-			<AsyncLoad
-				require="calypso/my-sites/stats/pages/purchase"
-				placeholder={ PageLoading }
-				query={ context.query }
-			/>
-		</StatsPageLoader>
+		// DO NOT WRAP WITH <StatsPageLoader /> or you will get an infinite loop
+		<AsyncLoad
+			require="calypso/my-sites/stats/pages/purchase"
+			placeholder={ PageLoading }
+			query={ context.query }
+		/>
 	);
 	next();
 }

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo } from 'react';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
@@ -198,6 +199,9 @@ const StatsPurchasePage = ( {
 						/>
 					</>
 				) }
+
+				{ /* Only query site purchases on Calypso via existing data component */ }
+				<QuerySitePurchases siteId={ siteId } />
 				<QueryProductsList type="jetpack" />
 				{ isLoading && (
 					<div className="stats-purchase-page__loader">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1729743194369679-slack-C1T3N5AMR

## Proposed Changes

* Revert [the change](https://github.com/Automattic/wp-calypso/pull/95507/commits/7a982901896b926b155abcd28653661e2e9cebe2) of wrapping `StatsPurchasePage` with `StatsPageLoader` where we check site access permissions because it would forbid site-less purchases.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The site-less Stats purchase flow was not accessible because of the permission check in `StatsPageLoader`. The purchase page should be open to visiting without selected sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to the Stats purchase page without selected sites: `/stats/purchase`.
* Ensure the purchase page displays.

<img width="1596" alt="截圖 2024-10-24 下午1 01 38" src="https://github.com/user-attachments/assets/9b0b51fd-1493-48e0-a873-d3addc5e3765">

* Click the `Get Stats to grow my site` button to purchase the license.
* Ensure the redirecting checkout page is running for a site-less purchase flow: `https://wordpress.com/checkout/jetpack/jetpack_stats_yearly`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?