### PR TITLE
A4A > Agency Tier: Update Partner Directory permission check

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -137,7 +137,8 @@ const useMainMenuItems = ( path: string ) => {
 						},
 				  ]
 				: [] ),
-			...( config.isEnabled( 'a4a-partner-directory' )
+			...( config.isEnabled( 'a4a-partner-directory' ) ||
+			config.isEnabled( 'a8c-for-agencies-agency-tier' )
 				? [
 						{
 							icon: commentAuthorAvatar,

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -138,8 +138,24 @@ export const isPathAllowedForTier = ( pathname: string, agency: Agency | null ) 
 		return false;
 	}
 
+	// featureConditions is used to check if the user has access to a specific feature
+	// Add the feature name and the condition to enable it according to MEMBER_TIER_ACCESSIBLE_PATHS
+	const featureConditions = {
+		a4a_feature_partner_directory: agency?.partner_directory.allowed,
+	};
+
+	const featuresSet = new Set( agency?.tier?.features || [] );
+
+	// Check if the user has extra capabilities
+	for ( const [ feature, condition ] of Object.entries( featureConditions ) ) {
+		if ( condition ) {
+			featuresSet.add( feature );
+		}
+	}
+
+	const features = Array.from( featuresSet );
+
 	// Check if the user has the required capability to access the current path
-	const features = agency?.tier?.features;
 	if ( features ) {
 		const permissions = MEMBER_TIER_ACCESSIBLE_PATHS?.[ pathname ];
 		if ( permissions ) {

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-permission-data.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-permission-data.tsx
@@ -23,7 +23,7 @@ const getTierPermissionData = (
 					translate( 'Access this benefit when you become an Agency Partner.' )
 				),
 				description: translate(
-					"Agency Partners and Pro Agency Partners can apply to be included in Automatic's directory listings."
+					"Agency Partners and Pro Agency Partners can apply to be included in Automattic's directory listings."
 				),
 				buttonProps: {
 					text: translate( 'Learn more' ),

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -103,7 +104,7 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 	}
 
 	// Check if the Partner Directory is allowed for the agency
-	if ( ! agency?.partner_directory_allowed ) {
+	if ( ! agency?.partner_directory.allowed && ! isEnabled( 'a8c-for-agencies-agency-tier' ) ) {
 		// Redirect user to the Overview page
 		page.redirect( A4A_OVERVIEW_LINK );
 		return;

--- a/client/state/a8c-for-agencies/agency/actions.ts
+++ b/client/state/a8c-for-agencies/agency/actions.ts
@@ -57,7 +57,7 @@ export function receiveAgencies( agencies: Agency[] ): AgencyThunkAction {
 			dispatch( setActiveAgency( newAgency ) );
 
 			// Enable the Partner Directory section
-			if ( ! config.isEnabled( 'a4a-partner-directory' ) && newAgency.partner_directory_allowed ) {
+			if ( ! config.isEnabled( 'a4a-partner-directory' ) && newAgency.partner_directory.allowed ) {
 				config.enable( 'a4a-partner-directory' );
 			}
 		}

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -71,7 +71,10 @@ export interface Agency {
 			is_published?: boolean;
 		};
 	};
-	partner_directory_allowed: boolean;
+	partner_directory: {
+		allowed: boolean;
+		directories: 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable'[];
+	};
 	user: {
 		role: 'a4a_administrator' | 'a4a_manager';
 		capabilities: string[];

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -1,5 +1,6 @@
 import { Action, AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
+import { DirectoryApplicationType } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
 import type { AgencyTier } from 'calypso/a8c-for-agencies/sections/agency-tier/types';
 
 export interface APIError {
@@ -62,7 +63,7 @@ export interface Agency {
 			status?: 'pending' | 'in-progress' | 'completed';
 			directories: {
 				status: 'pending' | 'approved' | 'rejected' | 'closed';
-				directory: 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable';
+				directory: DirectoryApplicationType;
 				urls: string[];
 				note: string;
 				is_published?: boolean;
@@ -73,7 +74,7 @@ export interface Agency {
 	};
 	partner_directory: {
 		allowed: boolean;
-		directories: 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable'[];
+		directories: DirectoryApplicationType[];
 	};
 	user: {
 		role: 'a4a_administrator' | 'a4a_manager';


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1349

## Proposed Changes

This PR updates the Partner Directory permission check by allowing it to be accessible even when it is not allowed for the agency so that we can show the tier permission error message.

## Why are these changes being made?

* To be able to show the tier permission error which is currently not visible if the PD is disabled for the agency.

Note: We are only enabling the route for PD. The onboarding step is still hidden and will be shown only when the PD is enabled for the agency.

## Testing Instructions

* Patch D164505-code
* Update your agency tier to **Emerging Partner** using the MC tool (link in the issue).
* Disable the `Allow Partner Directory` option from the Partner Directory MC tool (link in the issue).
* Open the A4A live link > Append the URL with ?flags=-a8c-for-agencies-agency-tier > Verify that the PD nav item is not shown. 
* Visit PD manually with this URL (/partner-directory/dashboard?flags=-a8c-for-agencies-agency-tier) > Verify you are redirected to the overview page
* Remove the feature flag > Refresh the page > Visit the overview page
* Verify that the onboarding step for PD is not shown:

<img width="893" alt="Screenshot 2024-10-24 at 10 40 25 AM" src="https://github.com/user-attachments/assets/55ccb19c-071f-4315-80c9-040af3794743">

* Go to the Partner Directory page & verify the screen looks as shown below:

<img width="873" alt="Screenshot 2024-10-25 at 12 50 34 PM" src="https://github.com/user-attachments/assets/f738cd53-c6d2-499a-856c-2381b756f74c">

* Change the agency tier to Agency Partner > Refresh the UI, and go to the Overview page > Verify that the onboarding step for PD is shown:

<img width="901" alt="Screenshot 2024-10-24 at 10 40 44 AM" src="https://github.com/user-attachments/assets/b5181c9d-27b8-4c8f-a8a7-fb59e0f5f29b">

* Go to the Partner Directory page & verify that you can now see the Partner Directory page without any permission error

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?