### PR TITLE
Fix /start/plans: Special currencies not showing coupon-discounted price

### DIFF
--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -73,7 +73,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 					/>
 					<PlanPrice
 						currencyCode={ currencyCode }
-						rawPrice={ discountedPrice.monthly }
+						rawPrice={ discountedPrice.monthly || introOffer.rawPrice.monthly }
 						displayPerMonthNotation={ false }
 						isLargeCurrency
 						isSmallestUnit

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -73,7 +73,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 					/>
 					<PlanPrice
 						currencyCode={ currencyCode }
-						rawPrice={ introOffer.rawPrice.monthly }
+						rawPrice={ discountedPrice.monthly }
 						displayPerMonthNotation={ false }
 						isLargeCurrency
 						isSmallestUnit

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -73,7 +73,11 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 					/>
 					<PlanPrice
 						currencyCode={ currencyCode }
-						rawPrice={ discountedPrice.monthly || introOffer.rawPrice.monthly }
+						rawPrice={
+							typeof discountedPrice.monthly === 'number'
+								? discountedPrice.monthly
+								: introOffer.rawPrice.monthly
+						}
 						displayPerMonthNotation={ false }
 						isLargeCurrency
 						isSmallestUnit

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -108,9 +108,12 @@ export default function usePlanBillingDescription( {
 	 *   2. We only expose month & year based intervals for now (so no need to introduce more translations just yet)
 	 */
 	if ( introOffer?.intervalCount && introOffer.intervalUnit && ! introOffer.isOfferComplete ) {
+		const discountedPriceFull =
+			typeof discountedPrice?.full === 'number' ? discountedPrice.full : introOffer?.rawPrice?.full;
+
 		const introOfferFullTermText =
-			currencyCode && ( discountedPrice?.full || introOffer.rawPrice )
-				? formatCurrency( discountedPrice?.full || introOffer.rawPrice.full, currencyCode, {
+			currencyCode && typeof discountedPriceFull === 'number'
+				? formatCurrency( discountedPriceFull, currencyCode, {
 						stripZeros: true,
 						isSmallestUnit: true,
 				  } )

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -109,8 +109,8 @@ export default function usePlanBillingDescription( {
 	 */
 	if ( introOffer?.intervalCount && introOffer.intervalUnit && ! introOffer.isOfferComplete ) {
 		const introOfferFullTermText =
-			currencyCode && introOffer.rawPrice
-				? formatCurrency( introOffer.rawPrice.full, currencyCode, {
+			currencyCode && ( discountedPrice?.full || introOffer.rawPrice )
+				? formatCurrency( discountedPrice?.full || introOffer.rawPrice.full, currencyCode, {
 						stripZeros: true,
 						isSmallestUnit: true,
 				  } )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#3500

## Proposed Changes

* Changes allow the discountPrice to be use before into price. This is needed because coupon discount is applied after intro price.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is needed for special discounted currencies such as INR, MXN and PHP which come with a intro offer. Applying a coupon discount on top is ignored by the frontend.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set you account to one of the special currencies (INR, MXN or PHP)
* Go to `/start/plans`
* The plan prices should only include the intro offer (20%)
<img width="320" alt="Screenshot 2024-10-24 at 10 14 22" src="https://github.com/user-attachments/assets/6fc7ff14-1312-4974-bc62-d704ace09f39">


* Go to `/start/plans?coupon=COUPON_CODE`
* The Plan prices should show the correct discounted prices, (20% and another 50% on top from the coupon) 
<img width="320" alt="Screenshot 2024-10-25 at 09 02 21" src="https://github.com/user-attachments/assets/85f228d3-7d41-4e1e-b632-4b7931d18856">


* Prices should should match the checkout prices
<img width="320" alt="Screenshot 2024-10-24 at 12 59 11" src="https://github.com/user-attachments/assets/6962bc69-409b-47c6-b5bd-807dee2c7858">


* Switching to USD should only apply the coupon discount 
<img width="320" alt="Screenshot 2024-10-24 at 12 55 59" src="https://github.com/user-attachments/assets/a4f78597-c647-46c2-8b03-1d3abf8c7e8d">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
