### PR TITLE
Autofollow is enabled by default, add an option to disable it

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -243,19 +243,21 @@ class NotificationSubscriptions extends Component {
 
 						{ isAutomattician && (
 							<FormFieldset>
-								<FormLegend>Auto-follow P2 posts upon commenting (Automatticians only)</FormLegend>
+								<FormLegend>
+									Disable auto-follow P2 posts upon commenting (Automatticians only)
+								</FormLegend>
 								<FormLabel>
 									<FormCheckbox
-										checked={ this.props.getSetting( 'p2_autofollow_on_comment' ) }
+										checked={ this.props.getSetting( 'p2_disable_autofollow_on_comment' ) }
 										disabled={ this.props.getDisabledState() }
-										id="p2_autofollow_on_comment"
-										name="p2_autofollow_on_comment"
+										id="p2_disable_autofollow_on_comment"
+										name="p2_disable_autofollow_on_comment"
 										onChange={ this.props.toggleSetting }
-										onClick={ this.handleCheckboxEvent( 'Auto-follow P2 Upon Comment' ) }
+										onClick={ this.handleCheckboxEvent( 'Disable auto-follow P2 Upon Comment' ) }
 									/>
 									<span>
-										Automatically subscribe to notifications for a P2 post whenever you leave a
-										comment on it.
+										Don't automatically subscribe to notifications for a P2 post whenever you leave
+										a comment on it.
 									</span>
 								</FormLabel>
 							</FormFieldset>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95583

## Proposed Changes

* Reverse the option from enabling to disabling

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* After shipping the feature, it became popular fast internally, so we make it enabled by default.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the setting and post a comment on a p2. It should not automatically start following the p2 post.
* Disable the setting and post a comment on a p2. It should automatically start following the p2 post.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
