### PR TITLE
Stats: Data Filtering for Traffic Page: Hides the highlight section

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -385,8 +385,8 @@ class StatsSite extends Component {
 						<p>New date filtering enabled.</p>
 					</div>
 				) }
-				// TODO: remove highlight section completely once flag is released
 				{ ! isNewDateFilteringEnabled && (
+					// @TODO: remove highlight section completely once flag is released
 					<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				) }
 				<div id="my-stats-content" className={ wrapperClass }>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -385,7 +385,10 @@ class StatsSite extends Component {
 						<p>New date filtering enabled.</p>
 					</div>
 				) }
-				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
+				// TODO: remove highlight section completely once flag is released
+				{ ! isNewDateFilteringEnabled && (
+					<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
+				) }
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>
 						<StatsPeriodHeader>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/210

## Proposed Changes

* This PR hides the Highlights section from the traffic page if the feature flag is applied. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is an intermediary step, and the section will be completely removed once the Data Filtering project is released. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live Branch
* Apply feature flag `stats/new-date-filtering`
* Check the traffic page highlights card section is no longer displayed

![image](https://github.com/user-attachments/assets/8d8ed616-3e9e-472a-b804-6c20202458c7)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
