### PR TITLE
refactor(hosting-features): refetching of useSiteTransferStatusQuery should be automatic, instead of manual

### DIFF
--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -6,7 +6,6 @@ import { Spinner } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useRef, useState, useEffect } from 'react';
-import { AnyAction } from 'redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { HostingCard, HostingCardGrid } from 'calypso/components/hosting-card';
 import { HostingHero, HostingHeroButton } from 'calypso/components/hosting-hero';
@@ -14,7 +13,6 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSiteTransferStatusQuery } from 'calypso/landing/stepper/hooks/use-site-transfer/query';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { fetchAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -62,31 +60,13 @@ const HostingFeatures = () => {
 
 	const hasEnTranslation = useHasEnTranslation();
 
-	const { data: siteTransferData, refetch: refetchSiteTransferData } = useSiteTransferStatusQuery(
-		siteId || undefined
-	);
-	// `siteTransferData?.isTransferring` is not a fully reliable indicator by itself, which is why
-	// we also look at `siteTransferData.status`
-	const isTransferInProgress =
+	const { data: siteTransferData } = useSiteTransferStatusQuery( siteId || undefined, {
+		refetchIntervalInBackground: true,
+	} );
+
+	const shouldRenderActivatingCopy =
 		( siteTransferData?.isTransferring || siteTransferData?.status === transferStates.COMPLETED ) &&
 		! isPlanExpired;
-
-	useEffect( () => {
-		if ( ! siteId ) {
-			return;
-		}
-
-		const interval = setInterval( () => {
-			if ( siteTransferData?.status !== transferStates.COMPLETED ) {
-				refetchSiteTransferData();
-			} else {
-				clearInterval( interval );
-				dispatch( fetchAtomicTransfer( siteId ) as unknown as AnyAction );
-			}
-		}, 3000 );
-
-		return () => clearInterval( interval );
-	}, [ siteId, siteTransferData?.status, refetchSiteTransferData, dispatch ] );
 
 	useEffect( () => {
 		if ( isSiteAtomic && ! isPlanExpired ) {
@@ -192,7 +172,7 @@ const HostingFeatures = () => {
 	let title;
 	let description;
 	let buttons;
-	if ( isTransferInProgress ) {
+	if ( shouldRenderActivatingCopy ) {
 		title = translate( 'Activating hosting features' );
 		description = translate(
 			"The hosting features will appear here automatically when they're ready!",
@@ -252,7 +232,7 @@ const HostingFeatures = () => {
 	return (
 		<div className="hosting-features">
 			<HostingHero>
-				{ isTransferInProgress && <Spinner className="hosting-features__content-spinner" /> }
+				{ shouldRenderActivatingCopy && <Spinner className="hosting-features__content-spinner" /> }
 				<h1>{ title }</h1>
 				<p>{ description }</p>
 				{ buttons }

--- a/client/landing/stepper/hooks/use-site-transfer/query.ts
+++ b/client/landing/stepper/hooks/use-site-transfer/query.ts
@@ -52,14 +52,20 @@ export function getSiteTransferStatusQueryKey( siteId: number ) {
 }
 
 const shouldRefetch = ( status: TransferStates | undefined ) => {
-	if ( ! status || status === transferStates.NONE ) {
+	if ( ! status ) {
 		return false;
+	}
+
+	// This condition ensures that when the status is NONE,
+	// we expect it might change in another tab. This allows the UI to reflect any updates dynamically.
+	if ( transferStates.NONE === status ) {
+		return true;
 	}
 
 	return isTransferring( status );
 };
 
-type Options = Pick< UseQueryOptions, 'retry' >;
+type Options = Pick< UseQueryOptions, 'retry' | 'refetchIntervalInBackground' >;
 
 /**
  * Query hook to get the site transfer status, pooling the endpoint.
@@ -83,6 +89,7 @@ export const useSiteTransferStatusQuery = ( siteId: number | undefined, options?
 			};
 		},
 		refetchOnWindowFocus: false,
+		refetchIntervalInBackground: !! options?.refetchIntervalInBackground,
 		refetchInterval: ( { state } ) =>
 			shouldRefetch( state.data?.status ) ? REFETCH_TIME : false,
 		enabled: !! siteId,

--- a/client/landing/stepper/hooks/use-site-transfer/test/index.tsx
+++ b/client/landing/stepper/hooks/use-site-transfer/test/index.tsx
@@ -95,7 +95,7 @@ describe( 'useSiteTransfer', () => {
 			} )
 			.reply( 200, TRANSFER_ACTIVE( siteId ) )
 			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
-			.once()
+			.times( 2 )
 			.reply( 200, TRANSFER_COMPLETED( siteId ) );
 
 		const { result } = render( { siteId } );


### PR DESCRIPTION
## Proposed Changes
It's follow up to [this PR](https://github.com/Automattic/wp-calypso/pull/93789), specifically:
1. [rename isTransferInProgress  to shouldRenderActivatingCopy](https://github.com/Automattic/wp-calypso/pull/93789#discussion_r1728966287)
2. [rewrite manual refetching with internal automatic way](https://github.com/Automattic/wp-calypso/pull/93789#discussion_r1728908295)

## Testing Instructions
### A4A tests
1. Open `https://agencies.automattic.com/`
2. Purchase licences, if you don't have (Left sidebar "Purchase" -> "Issue New License")
3. Click on `Sites` in left sidebar
4. Click on "Needs setup"
5. Click on "Create new site" and proceed
6. Wait till you see the next notification<br /> <img width="531" alt="Screenshot 2024-08-13 at 12 58 24" src="https://github.com/user-attachments/assets/98ea9aab-f607-4998-815a-1c403b9f1020">
7. Copy selected domain on the screenshot above
8. And open new tab with the next URL `http://calypso.localhost:3000/hosting-features/<COPYED_DOMAIN_IN_7TH_STEP>`
9. Assert that you see spinner and copy about "things in progress" <br /><img width="636" alt="Screenshot 2024-08-13 at 13 00 43" src="https://github.com/user-attachments/assets/ae8817f1-da5d-4d06-9c57-3437ea7f5c1b">
10. Wait till it's finished
11. Assert that you are redirected to "Server Settings" tab

### Manually turning on Hosting Features
1. Purchase domain with `Starter` plan
2. Open "Hosting features" tab on "Sites" page (Let's call this tab as `A` during testing)
3. Copy the URL and open a separate tab (Let's call this tab as `B` during testing, we will use it in the end for testing)
4. In tab A, click `Upgrade now` and proceed with upgrading
5. Now let's repeat the 3-rd step to open one more separate tab (Let's call this tab as `C` during testing, we will use it in the end for testing), so that you will have the next tabs `B` and `C`:<br /><img width="2296" alt="Screenshot 2024-07-29 at 16 12 45" src="https://github.com/user-attachments/assets/7ee4bc76-a06c-43dd-b64f-1b8c9c295a7c">
6. Now, in tab `A` click `Activate now` and proceed
7. During activating process, the copy on tabs B and C should be changed to the next (with CTA buttons hidden)<br /><img width="2293" alt="Screenshot 2024-07-29 at 16 15 28" src="https://github.com/user-attachments/assets/00b3e02f-cf04-482e-8ad8-eebbee3d8528">
8. Wait till it's finished
9. Assert that you are redirected to "Overview" tab