### PR TITLE
A4A > Agency Tier: Minor UI enhancements

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -33,7 +33,8 @@ export default function AgencyTierOverview() {
 		? getAgencyTierInfo( currentAgencyTier, translate )
 		: null;
 
-	const learnMoreLink = ''; // TODO: Add link
+	const learnMoreLink =
+		'https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits/';
 
 	const ALL_TIERS: AgencyTier[] = [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ];
 

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
@@ -142,7 +142,6 @@ $video-green: #0e5837;
 		margin: 8px;
 		display: flex;
 		flex-direction: column;
-		justify-content: space-between;
 		padding-block-end: 16px;
 		max-height: 450px;
 	}


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1352
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1355

## Proposed Changes

This PR:

- Does a minor UI enhancement. 
- Updates the learn more link for the agency tier.

## Why are these changes being made?

* UI enhancement and update the link

## Testing Instructions

* Open the A4A live link
* Change the agency tier to Agency Partner using the MC tool > On the overview page, verify the `Explore your benefits button` on the  celebration modal is aligned right after the list as shown below

| Before | After |
|--------|--------|
| <img width="789" alt="Screenshot 2024-10-24 at 4 55 58 PM" src="https://github.com/user-attachments/assets/97ccc2f1-a93f-4d32-a860-aba34d955434">| <img width="789" alt="Screenshot 2024-10-24 at 4 56 08 PM" src="https://github.com/user-attachments/assets/fb339c78-1674-4b84-88e2-7dab671e75f4"> |

* Go to the Agency Tier page > Click the Learn more link on the top badge below and verify this link (https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits/) open in a new tab

<img width="892" alt="Screenshot 2024-10-24 at 5 05 18 PM" src="https://github.com/user-attachments/assets/ad8ec29a-85d0-40a3-80dd-8eeb6bebdbbe">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
