### PR TITLE
Tailored Flows: Remove redirect to launchpad for removed flows

### DIFF
--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -17,7 +17,7 @@ const REMOVED_TAILORED_FLOWS = [
 ];
 
 export const isRemovedFlow = ( flowToCheck ) =>
-	REMOVED_TAILORED_FLOWS.find( ( { flow } ) => flow === flowToCheck );
+	!! REMOVED_TAILORED_FLOWS.find( ( { flow } ) => flow === flowToCheck );
 
 // Regex pattern for the optional language code in the format xx or xx-yy
 const langPattern = '(?:/([a-z]{2}(?:-[a-z]{2})?))?/?$';

--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -1,12 +1,12 @@
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 // Flows to redirect
-const redirectRoutes = [
-	{ from: '/setup/blog/', to: '/start:lang?' },
-	{ from: '/setup/free/', to: '/start/free:lang?' },
-	{ from: '/setup/link-in-bio/', to: '/start:lang?' },
-	{ from: '/setup/videopress/', to: '/start:lang?' },
-	{ from: '/setup/sensei/', to: ':lang?/plugins/sensei-pro/' },
+export const REMOVED_TAILORED_FLOWS = [
+	{ flow: 'blog', to: '/start:lang?' },
+	{ flow: 'free', to: '/start/free:lang?' },
+	{ flow: 'link-in-bio', to: '/start:lang?' },
+	{ flow: 'videopress', to: '/start:lang?' },
+	{ flow: 'sensei', to: ':lang?/plugins/sensei-pro/' },
 ];
 
 // Regex pattern for the optional language code in the format xx or xx-yy
@@ -18,7 +18,9 @@ const redirectPathIfNecessary = ( pathname: string, search: string ) => {
 	pathname = pathname.endsWith( '/' ) ? pathname : pathname + '/';
 
 	// Find the matching redirect route
-	const route = redirectRoutes.find( ( redirect ) => pathname.startsWith( redirect.from ) );
+	const route = REMOVED_TAILORED_FLOWS.find( ( { flow } ) =>
+		pathname.startsWith( `/setup/${ flow }/` )
+	);
 
 	// If no route is found we don't redirect and return false
 	if ( ! route ) {

--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -8,13 +8,16 @@ import {
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 // Flows to redirect
-export const REMOVED_TAILORED_FLOWS = [
+const REMOVED_TAILORED_FLOWS = [
 	{ flow: BLOG_FLOW, to: '/start:lang?' },
 	{ flow: FREE_FLOW, to: '/start/free:lang?' },
 	{ flow: LINK_IN_BIO_FLOW, to: '/start:lang?' },
 	{ flow: VIDEOPRESS_FLOW, to: '/start:lang?' },
 	{ flow: SENSEI_FLOW, to: ':lang?/plugins/sensei-pro/' },
 ];
+
+export const isRemovedFlow = ( flowToCheck ) =>
+	REMOVED_TAILORED_FLOWS.find( ( { flow } ) => flow === flowToCheck );
 
 // Regex pattern for the optional language code in the format xx or xx-yy
 const langPattern = '(?:/([a-z]{2}(?:-[a-z]{2})?))?/?$';

--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -1,12 +1,19 @@
+import {
+	BLOG_FLOW,
+	FREE_FLOW,
+	LINK_IN_BIO_FLOW,
+	VIDEOPRESS_FLOW,
+	SENSEI_FLOW,
+} from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 // Flows to redirect
 export const REMOVED_TAILORED_FLOWS = [
-	{ flow: 'blog', to: '/start:lang?' },
-	{ flow: 'free', to: '/start/free:lang?' },
-	{ flow: 'link-in-bio', to: '/start:lang?' },
-	{ flow: 'videopress', to: '/start:lang?' },
-	{ flow: 'sensei', to: ':lang?/plugins/sensei-pro/' },
+	{ flow: BLOG_FLOW, to: '/start:lang?' },
+	{ flow: FREE_FLOW, to: '/start/free:lang?' },
+	{ flow: LINK_IN_BIO_FLOW, to: '/start:lang?' },
+	{ flow: VIDEOPRESS_FLOW, to: '/start:lang?' },
+	{ flow: SENSEI_FLOW, to: ':lang?/plugins/sensei-pro/' },
 ];
 
 // Regex pattern for the optional language code in the format xx or xx-yy

--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -16,7 +16,7 @@ const REMOVED_TAILORED_FLOWS = [
 	{ flow: SENSEI_FLOW, to: ':lang?/plugins/sensei-pro/' },
 ];
 
-export const isRemovedFlow = ( flowToCheck ) =>
+export const isRemovedFlow = ( flowToCheck: string ) =>
 	!! REMOVED_TAILORED_FLOWS.find( ( { flow } ) => flow === flowToCheck );
 
 // Regex pattern for the optional language code in the format xx or xx-yy

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
+import { REMOVED_TAILORED_FLOWS } from 'calypso/landing/stepper/utils/flow-redirect-handler';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
@@ -67,7 +68,8 @@ export async function maybeRedirect( context, next ) {
 			checklist: launchpadChecklist,
 		} = await fetchLaunchpad( slug );
 
-		const shouldShowLaunchpad = true;
+		const isRemovedFlow = REMOVED_TAILORED_FLOWS.find( ( { flow } ) => flow === siteIntentOption );
+		const shouldShowLaunchpad = ! isRemovedFlow;
 
 		if (
 			shouldShowLaunchpad &&

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
-import { REMOVED_TAILORED_FLOWS } from 'calypso/landing/stepper/utils/flow-redirect-handler';
+import { isRemovedFlow } from 'calypso/landing/stepper/utils/flow-redirect-handler';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
@@ -68,8 +68,7 @@ export async function maybeRedirect( context, next ) {
 			checklist: launchpadChecklist,
 		} = await fetchLaunchpad( slug );
 
-		const isRemovedFlow = REMOVED_TAILORED_FLOWS.find( ( { flow } ) => flow === siteIntentOption );
-		const shouldShowLaunchpad = ! isRemovedFlow;
+		const shouldShowLaunchpad = ! isRemovedFlow( siteIntentOption );
 
 		if (
 			shouldShowLaunchpad &&


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/95667

## Proposed Changes

Prevents the redirection from `/home/:site` to `/setup/:flow/launchpad` if the site was created with one of the flows we have removed as part of https://github.com/Automattic/dotcom-forge/issues/8999.

**Before**

https://github.com/user-attachments/assets/2fbd2be4-b4af-47f6-8911-3f313927d8cd

**After**


https://github.com/user-attachments/assets/701d4e90-5ea0-4952-b498-3340ae2d78c2




## Why are these changes being made?

Because unlaunched sites created with a removed tailored flow were getting a broken experience

## Testing Instructions

- If you don't have a site created with one of the removed tailored flows, run this on your sandbox:

```
update_blog_option( <SITE_ID>, 'site_intent', 'free' );
```

- Make sure the site is unlaunched and has not skipped/completed the launchpad
- Use the Calypso live link below
- Go to `/sites`
- Pick the site and click on the "My Home" button
- Make sure you stay on My Home and are not redirected to `/setup/:flow/launchpad`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
