### PR TITLE
Sites Dashboard: Add migration status to site header

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SiteFaviconFallback } from 'calypso/a8c-for-agencies/components/items-dashboard/site-favicon';
 
 export interface FeaturePreviewInterface {
 	id: string;
@@ -44,7 +45,7 @@ export interface PreviewPaneProps {
 
 export interface ItemPreviewPaneHeaderExtraProps {
 	externalIconSize?: number;
-	siteIconFallback?: 'color' | 'wordpress-logo' | 'first-grapheme';
+	siteIconFallback?: SiteFaviconFallback;
 	headerButtons?: React.ComponentType< {
 		focusRef: React.RefObject< HTMLButtonElement >;
 		itemData: ItemData;

--- a/client/a8c-for-agencies/components/items-dashboard/site-favicon/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/site-favicon/index.tsx
@@ -9,12 +9,14 @@ import { getSite } from 'calypso/state/sites/selectors';
 
 import './style.scss';
 
+export type SiteFaviconFallback = 'color' | 'wordpress-logo' | 'first-grapheme' | 'migration';
+
 interface SiteFaviconProps {
 	blogId?: number;
 	color?: string;
 	size?: number;
 	className?: string;
-	fallback?: 'color' | 'wordpress-logo' | 'first-grapheme' | 'migration';
+	fallback?: SiteFaviconFallback;
 }
 
 const SiteFavicon = ( {

--- a/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -197,10 +197,15 @@ const DotcomPreviewPane = ( {
 				externalIconSize: 16,
 				siteIconFallback: isMigrationPending ? 'migration' : 'first-grapheme',
 				headerButtons: PreviewPaneHeaderButtons,
-				subtitleExtra: () =>
-					( site.is_wpcom_staging_site || isStagingStatusFinished ) && (
-						<SiteEnvironmentSwitcher onChange={ changeSitePreviewPane } site={ site } />
-					),
+				subtitleExtra: () => {
+					if ( isMigrationPending ) {
+						return <SiteStatus site={ site } />;
+					}
+
+					if ( site.is_wpcom_staging_site || isStagingStatusFinished ) {
+						return <SiteEnvironmentSwitcher onChange={ changeSitePreviewPane } site={ site } />;
+					}
+				},
 			} }
 		/>
 	);

--- a/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/hosting/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -5,7 +5,9 @@ import { useI18n } from '@wordpress/react-i18n';
 import React, { useMemo, useEffect } from 'react';
 import ItemPreviewPane from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import HostingFeaturesIcon from 'calypso/hosting/hosting-features/components/hosting-features-icon';
+import { SiteStatus } from 'calypso/hosting/sites/components/sites-dataviews/sites-site-status';
 import { useStagingSite } from 'calypso/hosting/staging-site/hooks/use-staging-site';
+import { getMigrationStatus } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
 import { getStagingSiteStatus } from 'calypso/state/staging-site/selectors';
@@ -56,6 +58,7 @@ const DotcomPreviewPane = ( {
 	const isAtomicSite = !! site.is_wpcom_atomic || !! site.is_wpcom_staging_site;
 	const isSimpleSite = ! site.jetpack && ! site.is_wpcom_atomic;
 	const isPlanExpired = !! site.plan?.expired;
+	const isMigrationPending = getMigrationStatus( site ) === 'pending';
 
 	const features: FeaturePreviewInterface[] = useMemo( () => {
 		const isActiveAtomicSite = isAtomicSite && ! isPlanExpired;
@@ -141,7 +144,7 @@ const DotcomPreviewPane = ( {
 	] );
 
 	const itemData: ItemData = {
-		title: site.title,
+		title: isMigrationPending ? __( 'Incoming Migration' ) : site.title,
 		subtitle: site.slug,
 		url: site.URL,
 		blogId: site.ID,
@@ -192,7 +195,7 @@ const DotcomPreviewPane = ( {
 			className={ site.is_wpcom_staging_site ? 'is-staging-site' : '' }
 			itemPreviewPaneHeaderExtraProps={ {
 				externalIconSize: 16,
-				siteIconFallback: 'first-grapheme',
+				siteIconFallback: isMigrationPending ? 'migration' : 'first-grapheme',
 				headerButtons: PreviewPaneHeaderButtons,
 				subtitleExtra: () =>
 					( site.is_wpcom_staging_site || isStagingStatusFinished ) && (

--- a/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -19,7 +19,7 @@ import { ThumbnailLink } from 'calypso/sites-dashboard/components/thumbnail-link
 import {
 	displaySiteUrl,
 	isNotAtomicJetpack,
-	isMigrationInProgress,
+	getMigrationStatus,
 	isStagingSite,
 	isDisconnectedJetpackAndNotAtomic,
 } from 'calypso/sites-dashboard/utils';
@@ -86,8 +86,8 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 		event.preventDefault();
 	};
 
-	const isMigrating = isMigrationInProgress( site );
-	const siteTitle = isMigrating ? translate( 'Incoming Migration' ) : site.title;
+	const isMigrationPending = getMigrationStatus( site ) === 'pending';
+	const siteTitle = isMigrationPending ? translate( 'Incoming Migration' ) : site.title;
 
 	return (
 		<div className="sites-dataviews__site">
@@ -110,7 +110,7 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 							<SiteFavicon
 								className="sites-site-favicon"
 								blogId={ site.ID }
-								fallback={ isMigrating ? 'migration' : 'first-grapheme' }
+								fallback={ isMigrationPending ? 'migration' : 'first-grapheme' }
 								size={ 56 }
 							/>
 						</ThumbnailLink>

--- a/client/hosting/sites/components/sites-dataviews/sites-site-status.tsx
+++ b/client/hosting/sites/components/sites-dataviews/sites-site-status.tsx
@@ -13,7 +13,7 @@ import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpt
 import { SiteLaunchNag } from 'calypso/sites-dashboard/components/sites-site-launch-nag';
 import TransferNoticeWrapper from 'calypso/sites-dashboard/components/sites-transfer-notice-wrapper';
 import { WithAtomicTransfer } from 'calypso/sites-dashboard/components/with-atomic-transfer';
-import { MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
+import { getMigrationStatus, MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
@@ -120,13 +120,12 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 		);
 	}
 
-	const isMigrationPeding =
-		site.site_migration?.migration_status?.startsWith( 'migration-pending' );
-	const statusElement = isMigrationPeding ? (
-		<span className="sites-dataviews__migration-pending-status">{ translatedStatus }</span>
-	) : (
-		translatedStatus
-	);
+	const statusElement =
+		getMigrationStatus( site ) === 'pending' ? (
+			<span className="sites-dataviews__migration-pending-status">{ translatedStatus }</span>
+		) : (
+			translatedStatus
+		);
 
 	return (
 		<WithAtomicTransfer site={ site }>

--- a/client/hosting/sites/components/sites-dataviews/style.scss
+++ b/client/hosting/sites/components/sites-dataviews/style.scss
@@ -145,6 +145,7 @@
 .sites-dataviews__migration-pending-status {
 	display: inline-block;
 	padding: 0 10px;
+	font-size: rem(12px);
 	border-radius: 4px;
 	background-color: var(--color-warning-20);
 	line-height: 20px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of #95589
Based on #95497

## Proposed Changes

* When the migration status is "pending", updates the site title to "Incoming Migration", changes to icon, and adds the "migration pending" status in the site header.
* Fixes the site title being updated to "Incoming Migration" when the migration status is "started". In the design, it's updated only when the status is "pending".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a blog with the "pending" migration status.
* Go to `/sites`, click on the blog, and make sure the site heading has the "Incoming Migration" title, custom icon, and the "migration pending" status added to it.

<img width="609" alt="image" src="https://github.com/user-attachments/assets/12932fe3-8362-416b-b31c-798c685209ca">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
