### PR TITLE
e2e: Further fix flaky Twitter test

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
@@ -60,12 +60,12 @@ export class TwitterBlockFlow implements BlockFlow {
 		// In most cases, the iframe will render, so look for that.
 		const iframeTweetLocator = context.page
 			.frameLocator( selectors.publishedTwitterIframe )
-			.locator( `text=${ this.configurationData.expectedTweetText }` );
+			.locator( `text=${ this.configurationData.expectedTweetText }` )
+			.first();
 
 		// However, sometimes only the bare link renders, so we need to check for that fallback.
-		const bareTweetLinkLocator = context.page.locator( selectors.publishedTwitterBareLink );
+		const bareTweetLinkLocator = context.page.locator( selectors.publishedTwitterBareLink ).first();
 
-		const tweetLocator = iframeTweetLocator.or( bareTweetLinkLocator ).first();
-		await tweetLocator.waitFor();
+		await Promise.any( [ iframeTweetLocator.waitFor(), bareTweetLinkLocator.waitFor() ] );
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

PR #95579 attempted to adjust the test to accept both the expected iframe and the fallback link produced when Twitter's API is flaky. Unfortunately the way Playwright interpreted the code is like `iframe > ( tweet or link )` rather than `( iframe > tweet ) or link` as intended, so it's still not finding the link.

Fall back to using `Promise.any()` to combine the two locators instead, like we do in a bunch of other places.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

E2E test is still flaky.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure it works normally, when the tweet is rendered.
* To force the fallback link to test that case, you can edit `wp-includes/class-wp-oembed.php` to add something like this at the top of `private function _fetch_with_format()`
  ```php
  if ( str_contains( $provider_url_with_args, 'twitter' ) ) return false;
  ```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
