### PR TITLE
e2e: Remove broken OpenTable test

### DIFF
--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -5,7 +5,7 @@
 import {
 	BlockFlow,
 	PayWithPaypalBlockFlow,
-	OpenTableFlow,
+	// OpenTableFlow,
 	DonationsFormFlow,
 	AdFlow,
 	envVariables,
@@ -21,9 +21,11 @@ const blockFlows: BlockFlow[] = [
 		price: 900,
 		email: 'test@wordpress.com',
 	} ),
-	new OpenTableFlow( {
-		restaurant: 'Miku Restaurant - Vancouver',
-	} ),
+	// Skip OpenTable block test for now, block is broken due to upstream API changes.
+	// https://github.com/Automattic/jetpack/issues/39410
+	// new OpenTableFlow( {
+	// 	restaurant: 'Miku Restaurant - Vancouver',
+	// } ),
 	new DonationsFormFlow(
 		{
 			frequency: 'Yearly',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The test has been broken for some time now, since upstream has changed the private API we had been using. Time to disable it, so as not to accidentally hide failures in anything that gets tested after it.

See https://github.com/Automattic/jetpack/issues/39410 for details.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See above

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `test/e2e/specs/blocks/blocks__jetpack-earn.ts` against various sites, see that it completes successfully.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
