### PR TITLE
Social: Remove defaulting to Twitter in share log

### DIFF
--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Dialog, Gridicon } from '@automattic/components';
+import { Icon, linkOff } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
@@ -64,7 +65,11 @@ class PublicizeActionsList extends PureComponent {
 			<div className="post-share__footer-items" key={ index }>
 				<div className="post-share__footer-item">
 					<div className="post-share__handle">
-						<SocialLogo icon={ service === 'google_plus' ? 'google-plus' : service } />
+						{ service ? (
+							<SocialLogo icon={ service === 'google_plus' ? 'google-plus' : service } />
+						) : (
+							<Icon icon={ linkOff } />
+						) }
 						<span className="post-share__handle-value">{ connectionName }</span>
 					</div>
 					<div className="post-share__timestamp">

--- a/client/state/selectors/utils/index.js
+++ b/client/state/selectors/utils/index.js
@@ -22,7 +22,7 @@ export function enrichPublicizeActionsWithConnections( state, postShareActions )
 				connectionName: connection?.external_display,
 				message,
 				result,
-				service: connection?.service ?? 'twitter',
+				service: connection?.service,
 				date: share_date,
 				status,
 				url,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/jetpack-reach/issues/649
## Proposed Changes

* Removed defaulting to `twitter` if there is no icon
* Added an unlink icon if we cannot retrieve the service icon

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/posts/<your_site>`
* Reshare a published post to a connection
* Remove that connection
* In the log it should have a Twitter icon on trunk, but a disconnected icon with this PR

![CleanShot 2024-10-24 at 16 40 11 png](https://github.com/user-attachments/assets/0dce1346-7507-472c-a468-6ea054f10262)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
