### PR TITLE
Reader: Ensure URL Scheme in Subscription List Component

### DIFF
--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -96,6 +96,7 @@ class ConnectedSubscriptionListItem extends Component {
 export default compose(
 	connect( ( state, ownProps ) => ( {
 		isFollowing: isFollowingSelector( state, { feedId: ownProps.feedId, blogId: ownProps.siteId } ),
+		url: ownProps.url.match( /^https?:\/\// ) ? ownProps.url : `http://${ ownProps.url }`,
 	} ) ),
 	connectSite
 )( ConnectedSubscriptionListItem );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/95624

The curated list URLs do not have 'http://' prefixes which means that the Subscribe API requests fail with the following error;

```
{
    "code": 200,
    "headers": [
        {
            "name": "Content-Type",
            "value": "application\/json"
        }
    ],
    "body": {
        "info": "invalid_url",
        "subscribed": false
    }
}
```

This code change adds logic to ensure that the `url` property in the component always includes a proper URL scheme (i.e., `http://` or `https://`). 

If `ownProps.url` already starts with `http://` or `https://`, it will be left unchanged. However, if the URL doesn't start with a valid scheme, `http://` is prepended to it. This change is applied in the `connect` function, which manages the component's data connection to the state and props.

This ensures that the `url` is always a valid, complete URL when passed to the component.

## Proposed Changes

* Adds `http://` to site URL if missing - this is needed when subscribing to a site

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso Live, go to `/read?flags=reader/onboarding`
* You can clear the preference flag to make the banner reappear by using the DEV tools found in the bottom right of the screen.

<img width="914" alt="Screenshot 2024-10-21 at 5 10 55 PM" src="https://github.com/user-attachments/assets/4f8abe01-0a83-41a4-9b19-d4b4c268e487">
* Click on the `Discover and subscribe to sites you'll love` to open blog suggestions
* Confirm you can subscribe to a blog
* Confirm you can subscribe to a blog on the `/discover` popular blogs (in sidebar)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
