### PR TITLE
Pricing grid: allow Personal and Premium addons and refactor code

### DIFF
--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
@@ -22,6 +22,7 @@ type StorageDropdownOptionProps = {
 	storageSlug: AddOns.StorageAddOnSlug | WPComPlanStorageFeatureSlug;
 	isLargeCurrency?: boolean;
 	priceOnSeparateLine?: boolean;
+	productSlug: WPComPlanStorageFeatureSlug | null;
 };
 
 const getStorageOptionPrice = (
@@ -35,12 +36,13 @@ const getStorageOptionPrice = (
 const StorageDropdownOption = ( {
 	price,
 	storageSlug,
+	productSlug,
 	isLargeCurrency = false,
 	priceOnSeparateLine,
 }: StorageDropdownOptionProps ) => {
 	const translate = useTranslate();
 	const { siteId } = usePlansGridContext();
-	const title = useStorageStringFromFeature( { storageSlug, siteId } ) ?? '';
+	const title = useStorageStringFromFeature( { productSlug, storageSlug, siteId } ) ?? '';
 
 	return (
 		<>
@@ -79,6 +81,7 @@ const StorageDropdown = ( {
 	const { gridPlansIndex, siteId } = usePlansGridContext();
 	const {
 		pricing: { currencyCode },
+		features: { storageFeature: productStorageFeature },
 	} = gridPlansIndex[ planSlug ];
 	const { setSelectedStorageOptionForPlan } = useDispatch( WpcomPlansUI.store );
 	const storageAddOns = AddOns.useStorageAddOns( { siteId } );
@@ -110,11 +113,14 @@ const StorageDropdown = ( {
 		}
 	}, [] );
 
+	const featureProductSlug = productStorageFeature?.getSlug() as WPComPlanStorageFeatureSlug;
+
 	const selectControlOptions = availableStorageOptions?.map( ( slug ) => {
 		return {
 			key: slug,
 			name: (
 				<StorageDropdownOption
+					productSlug={ featureProductSlug !== slug ? featureProductSlug : null }
 					price={ getStorageOptionPrice( storageAddOns, slug ) }
 					storageSlug={ slug }
 				/>
@@ -129,6 +135,9 @@ const StorageDropdown = ( {
 		name: (
 			<StorageDropdownOption
 				price={ selectedOptionPrice }
+				productSlug={
+					productStorageFeature !== selectedStorageOptionForPlan ? featureProductSlug : null
+				}
 				storageSlug={ selectedStorageOptionForPlan }
 				isLargeCurrency={ isLargeCurrency }
 				priceOnSeparateLine={ priceOnSeparateLine }

--- a/packages/plans-grid-next/src/components/shared/storage/constants.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/constants.ts
@@ -1,3 +1,13 @@
-import { PLAN_BUSINESS, PLAN_ECOMMERCE } from '@automattic/calypso-products';
+import {
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	PLAN_PREMIUM,
+	PLAN_PERSONAL,
+} from '@automattic/calypso-products';
 
-export const ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE = [ PLAN_BUSINESS, PLAN_ECOMMERCE ];
+export const ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE = [
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+];

--- a/packages/plans-grid-next/src/components/shared/storage/hooks/use-storage-string-from-feature.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/hooks/use-storage-string-from-feature.ts
@@ -36,13 +36,13 @@ const getIntegerVolume = (
 			 * Displayed string is: purchased storage + default 50GB storage + Add-On
 			 * TODO: the default 50GB should be coming from plan context, not hardcoded here
 			 */
-			return 100;
+			return 50;
 		case AddOns.ADD_ON_100GB_STORAGE:
 			/**
 			 * Displayed string is: purchased storage + default 50GB storage + Add-On
 			 * TODO: the default 50GB should be coming from plan context, not hardcoded here
 			 */
-			return 150;
+			return 100;
 		default:
 			return 0;
 	}
@@ -51,15 +51,19 @@ const getIntegerVolume = (
 const useStorageStringFromFeature = ( {
 	storageSlug,
 	siteId,
+	productSlug = null,
 }: {
 	storageSlug?: AddOns.StorageAddOnSlug | WPComPlanStorageFeatureSlug;
 	siteId?: null | number | string;
+	productSlug?: null | WPComPlanStorageFeatureSlug;
 } ) => {
 	const translate = useTranslate();
 	const spaceUpgradesPurchased = Purchases.useSitePurchasesByProductSlug( {
 		siteId,
 		productSlug: PRODUCT_1GB_SPACE,
 	} );
+	const defaultSpace = productSlug ? getIntegerVolume( productSlug ) : 0;
+
 	const purchasedQuantityTotal = spaceUpgradesPurchased
 		? Object.values( spaceUpgradesPurchased ).reduce( ( total, current ) => {
 				return total + current.purchaseRenewalQuantity;
@@ -68,7 +72,7 @@ const useStorageStringFromFeature = ( {
 
 	return translate( '%(quantity)d GB', {
 		args: {
-			quantity: purchasedQuantityTotal + getIntegerVolume( storageSlug ),
+			quantity: defaultSpace + purchasedQuantityTotal + getIntegerVolume( storageSlug ),
 		},
 	} );
 };


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add the storage addons for Personal and Premium plans

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Refactors the code to rely on the actual default space instead of hardcoding the values for Business and eCommerce
* Adds the dropdowns for Premium and Personal plans
* Makes it more consistent with the Addons page where users can purchase the addons on Personal and Premium

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link and go to /plans
* Make sure you can purchase addons from /plans

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
