### PR TITLE
Payment Methods: Remove `Bank` field from iDEAL Checkout

### DIFF
--- a/packages/wpcom-checkout/src/payment-methods/ideal.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/ideal.tsx
@@ -116,68 +116,6 @@ function IdealFields() {
 	);
 }
 
-function BankSelector( {
-	id,
-	value,
-	onChange,
-	label,
-	isError,
-	errorMessage,
-	disabled,
-}: {
-	id: string;
-	value: string;
-	onChange: ( newId: string ) => void;
-	label: string;
-	isError: boolean;
-	errorMessage: string | null;
-	disabled?: boolean;
-} ) {
-	const { __ } = useI18n();
-	const bankOptions = getBankOptions( __ );
-	return (
-		<SelectWrapper>
-			<IdealBankLabel htmlFor={ id }>{ label }</IdealBankLabel>
-			<IdealSelect
-				id={ id }
-				value={ value }
-				onChange={ ( event ) => onChange( event.target.value ) }
-				disabled={ disabled }
-			>
-				{ bankOptions.map( ( bank ) => (
-					<BankOption key={ bank.value } value={ bank.value } label={ bank.label } />
-				) ) }
-			</IdealSelect>
-			<ErrorMessage isError={ isError } errorMessage={ errorMessage } />
-		</SelectWrapper>
-	);
-}
-
-function BankOption( { value, label }: { value: string; label: string } ) {
-	return <option value={ value }>{ label }</option>;
-}
-
-function ErrorMessage( {
-	isError,
-	errorMessage,
-}: {
-	isError: boolean;
-	errorMessage: string | null;
-} ) {
-	if ( isError ) {
-		return <Description isError={ isError }>{ errorMessage }</Description>;
-	}
-	return null;
-}
-
-const Description = styled.p< { isError: boolean } >`
-	margin: 8px 0 0;
-	color: ${ ( props ) =>
-		props.isError ? props.theme.colors.error : props.theme.colors.textColorLight };
-	font-style: italic;
-	font-size: 14px;
-`;
-
 const IdealFormWrapper = styled.div`
 	padding: 16px;
 	position: relative;
@@ -202,56 +140,6 @@ const IdealField = styled( Field )`
 
 	:first-of-type {
 		margin-top: 0;
-	}
-`;
-const IdealBankLabel = styled.label`
-	font-size: 14px;
-	font-weight: 600;
-`;
-const IdealSelect = styled.select`
-	background: var( --color-surface,  rgb(255, 255, 255))
-		url( 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==' )
-		no-repeat right 10px center;
-	border-color: var( --color-neutral-10, rgb(195, 196, 199) );
-	color: var( --color-neutral-70, rgb(60, 67, 74) );
-	cursor: pointer;
-	display: inline-block;
-	margin: 8px 0 1em;
-	overflow: hidden;
-	font-size: 1rem;
-    font-weight: 400;
-	line-height: 1.4em;
-	text-overflow: ellipsis;
-	box-sizing: border-box;
-	padding: 7px 32px 9px 14px; // Aligns the text to the 8px baseline grid and adds padding on right to allow for the arrow.
-	-webkit-appearance: none;
-	-moz-appearance: none;
-	appearance: none;
-
-	// IE: Remove the default arrow
-	&::-ms-expand {
-		display: none;
-	}
-
-	// IE: Remove default background and color styles on focus
-	&::-ms-value {
-		background: none;
-		color: var( --color-neutral-70 );
-	}
-
-	// Firefox: Remove the focus outline, see http://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/18853002#18853002
-	&:-moz-focusring {
-		color: transparent;
-		text-shadow: 0 0 0 var( --color-neutral-70 );
-	}
-}
-`;
-
-const SelectWrapper = styled.div`
-	margin-top: 16px;
-
-	select {
-		width: 100%;
 	}
 `;
 
@@ -355,21 +243,4 @@ function IdealLogoSvg( { className }: { className?: string } ) {
 			/>
 		</svg>
 	);
-}
-
-function getBankOptions( __: ReturnType< typeof useI18n >[ '__' ] ) {
-	// Source https://stripe.com/docs/sources/ideal
-	const banks = [
-		{ value: 'abn_amro', label: 'ABN AMRO' },
-		{ value: 'asn_bank', label: 'ASN Bank' },
-		{ value: 'bunq', label: 'Bunq' },
-		{ value: 'ing', label: 'ING' },
-		{ value: 'knab', label: 'Knab' },
-		{ value: 'rabobank', label: 'Rabobank' },
-		{ value: 'regiobank', label: 'RegioBank' },
-		{ value: 'sns_bank', label: 'SNS Bank' },
-		{ value: 'triodos_bank', label: 'Triodos Bank' },
-		{ value: 'van_lanschot', label: 'Van Lanschot' },
-	];
-	return [ { value: '', label: __( 'Please select your bank.' ) }, ...banks ];
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/payments-shilling/issues/3190

## Proposed Changes

* Remove the `Bank` form field from the iDEAL payment form fields ( Available to users with a valid Netherlands billing country and `EUR` currency).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Stripe reached out and let us know it would no longer be required: 
> To streamline the customer experience and to help increase conversion, iDEAL no longer requires merchants to display the bank selector in the checkout. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this branch
* Set user currency to `EUR`
* Add a product to your shopping cart
* Set `Billing Information > Country` to Netherlands and use a valid postal code (example 1011 AH)
* From `Payment Information` click on `Edit` and then select `iDEAL`
* You should only see the `Name` field

<img width="665" alt="Screenshot 2024-10-24 at 10 50 37" src="https://github.com/user-attachments/assets/7df6b4e3-c05b-40d3-9346-6500d8d8e83c">

For complete testing instructions, including a test Checkout, see code-D164607

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
