### PR TITLE
Reader curated tech list: Swap urls and names to fix entries

### DIFF
--- a/client/reader/onboarding/curated-blogs/technology.tsx
+++ b/client/reader/onboarding/curated-blogs/technology.tsx
@@ -99,8 +99,8 @@ export const technologyBlogs: CuratedBlogsList = {
 		{
 			feed_ID: 117374,
 			site_ID: 15451510,
-			site_URL: 'Reflections on Technology',
-			site_name: 'richardcoyne.com',
+			site_URL: 'richardcoyne.com',
+			site_name: 'Reflections on Technology, Media & Culture',
 		},
 		{
 			feed_ID: 68503995,
@@ -119,8 +119,8 @@ export const technologyBlogs: CuratedBlogsList = {
 		{
 			feed_ID: 47166615,
 			site_ID: 0,
-			site_URL: 'Design Milk',
-			site_name: 'design-milk.com',
+			site_URL: 'design-milk.com',
+			site_name: 'Design Milk',
 		},
 		{
 			feed_ID: 143967848,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/95568

## Proposed Changes

* Swap the URLs and names so that the Subscribe button works for those sites.
* This PR won't work without https://github.com/Automattic/wp-calypso/pull/95676

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See pe7F0s-2eo-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso Live, go to /read?flags=reader/onboarding
* You can clear the preference flag to make the banner reappear by using the DEV tools found in the bottom right of the screen.
* Click "Select some of your interests" and pick Software and Tech News.
* Click to subscribe to richardcoyne.com. It should succeed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?