### PR TITLE
Scrollbar present on wpcom/sites (regardless of window resizing)

### DIFF
--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -574,10 +574,6 @@
 		max-width: 1400px;
 		box-sizing: border-box;
 	}
-
-	.a4a-layout-column__container {
-		margin: 0 -14px;
-	}
 }
 
 // Use flexbox to structure of fly-out panel.


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/95631

## Proposed Changes
![Screen Recording 2024-10-24 at 15 36 56](https://github.com/user-attachments/assets/b770b99b-34f1-4c7c-9b03-b5e97e25f4e8)

The `-14px` margin on `.a4a-layout-column__container` is hiding the scroll bar when the browser window does not have spare space to display overflow content.

| Before | After |
|--------|-------|
|   ![image](https://github.com/user-attachments/assets/974879ba-dad4-4d62-937a-45739505277d)     |  ![image](https://github.com/user-attachments/assets/97b92112-eff7-45ae-b533-86e58ae6c6b7)     |

## Testing Instructions

- Have enough sits so /sites page is scrollable
- Visit http://calypso.localhost:3000/sites
- Resize you window. Scrollbar should be visible on all widths.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
