### PR TITLE
Credential Form: Show error message on the correct language + cleanup

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
@@ -1,5 +1,5 @@
 import { FormLabel } from '@automattic/components';
-import { useHasEnTranslation, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { Controller } from 'react-hook-form';
 import getValidationMessage from 'calypso/blocks/import/capture/url-validation-message-helper';
@@ -10,7 +10,6 @@ import { ErrorMessage } from './error-message';
 
 export const SiteAddressField: React.FC< CredentialsFormFieldProps > = ( { control, errors } ) => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 	const hasEnTranslation = useHasEnTranslation();
 
 	const validateSiteAddress = ( siteAddress: string ) => {
@@ -26,9 +25,7 @@ export const SiteAddressField: React.FC< CredentialsFormFieldProps > = ( { contr
 
 	return (
 		<div className="site-migration-credentials__form-field">
-			<FormLabel htmlFor="from_url">
-				{ isEnglishLocale ? translate( 'Current site address' ) : translate( 'Site address' ) }
-			</FormLabel>
+			<FormLabel htmlFor="from_url">{ translate( 'Current site address' ) }</FormLabel>
 			<Controller
 				control={ control }
 				name="from_url"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-form-error-mapping.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-form-error-mapping.ts
@@ -1,4 +1,3 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import { FieldErrors } from 'react-hook-form';
@@ -19,7 +18,6 @@ export const useFormErrorMapping = (
 	siteInfo?: UrlData | undefined
 ): FieldErrors< CredentialsFormData > | undefined => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	const fieldMapping: Record< string, { type: string; message: string } | null > = useMemo(
 		() => ( {
@@ -32,7 +30,7 @@ export const useFormErrorMapping = (
 	);
 
 	const getCredentialsErrorMessage = useCallback(
-		( errorCode: any ) => {
+		( errorCode: number | undefined ) => {
 			switch ( errorCode ) {
 				case 404:
 					return {
@@ -79,7 +77,6 @@ export const useFormErrorMapping = (
 					},
 				};
 			}
-			return undefined;
 		},
 		[ translate ]
 	);
@@ -96,10 +93,7 @@ export const useFormErrorMapping = (
 				};
 			}
 
-			if (
-				isEnglishLocale &&
-				code === 'automated_migration_tools_login_and_get_cookies_test_failed'
-			) {
+			if ( code === 'automated_migration_tools_login_and_get_cookies_test_failed' ) {
 				return {
 					root: {
 						type: 'special',
@@ -128,7 +122,7 @@ export const useFormErrorMapping = (
 				{} as Record< string, { type: string; message: string } >
 			);
 		},
-		[ getTranslatedMessage, translate, getCredentialsErrorMessage, isEnglishLocale ]
+		[ getTranslatedMessage, translate, getCredentialsErrorMessage ]
 	);
 
 	return useMemo( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-request-automated-migration.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-request-automated-migration.tsx
@@ -1,3 +1,4 @@
+import { useLocale } from '@automattic/i18n-utils';
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import { ApiError, CredentialsFormData } from '../types';
@@ -19,10 +20,11 @@ interface AutomatedMigration {
 
 const requestAutomatedMigration = async (
 	siteSlug: string,
-	payload: AutomatedMigration
+	payload: AutomatedMigration,
+	locale: string
 ): Promise< AutomatedMigrationAPIResponse > => {
 	return wpcomRequest( {
-		path: `sites/${ siteSlug }/automated-migration`,
+		path: `sites/${ siteSlug }/automated-migration?_locale=${ locale }`,
 		apiNamespace: 'wpcom/v2/',
 		apiVersion: '2',
 		method: 'POST',
@@ -34,6 +36,7 @@ export const useRequestAutomatedMigration = (
 	siteSlug?: string | null,
 	options: UseMutationOptions< AutomatedMigrationAPIResponse, ApiError, CredentialsFormData > = {}
 ) => {
+	const locale = useLocale();
 	return useMutation< AutomatedMigrationAPIResponse, ApiError, CredentialsFormData >( {
 		mutationFn: ( {
 			from_url,
@@ -70,7 +73,7 @@ export const useRequestAutomatedMigration = (
 				};
 			}
 
-			return requestAutomatedMigration( siteSlug, body );
+			return requestAutomatedMigration( siteSlug, body, locale );
 		},
 		...options,
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -1,4 +1,3 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { UrlData } from 'calypso/blocks/import/types';
@@ -27,7 +26,6 @@ const getAction = ( siteInfo?: UrlData ) => {
 
 const SiteMigrationCredentials: Step = function ( { navigation } ) {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	const handleSubmit = ( siteInfo?: UrlData | undefined ) => {
 		const action = getAction( siteInfo );
@@ -42,13 +40,7 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 
 	return (
 		<>
-			<DocumentHead
-				title={
-					isEnglishLocale
-						? translate( 'Tell us about your WordPress site' )
-						: translate( 'Tell us about your site' )
-				}
-			/>
+			<DocumentHead title={ translate( 'Tell us about your WordPress site' ) } />
 			<StepContainer
 				stepName="site-migration-credentials"
 				flowName="site-migration"
@@ -59,20 +51,10 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 				formattedHeader={
 					<FormattedHeader
 						id="site-migration-credentials-header"
-						headerText={
-							isEnglishLocale
-								? translate( 'Tell us about your WordPress site' )
-								: translate( 'Tell us about your site' )
-						}
-						subHeaderText={
-							isEnglishLocale
-								? translate(
-										'Please share the following details to access your site and start your migration to WordPress.com.'
-								  )
-								: translate(
-										'Please share the following details to access your site and start your migration.'
-								  )
-						}
+						headerText={ translate( 'Tell us about your WordPress site' ) }
+						subHeaderText={ translate(
+							'Please share the following details to access your site and start your migration to WordPress.com.'
+						) }
 						align="center"
 					/>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -63,7 +63,7 @@ const fillNoteField = async () => {
 };
 
 const requestPayload = {
-	path: 'sites/site-url.wordpress.com/automated-migration',
+	path: 'sites/site-url.wordpress.com/automated-migration?_locale=en',
 	apiNamespace: 'wpcom/v2/',
 	apiVersion: '2',
 	method: 'POST',
@@ -120,7 +120,7 @@ describe( 'SiteMigrationCredentials', () => {
 		await userEvent.click( continueButton() );
 
 		expect( wpcomRequest ).toHaveBeenCalledWith( {
-			path: 'sites/site-url.wordpress.com/automated-migration',
+			path: 'sites/site-url.wordpress.com/automated-migration?_locale=en',
 			apiNamespace: 'wpcom/v2/',
 			apiVersion: '2',
 			method: 'POST',
@@ -164,7 +164,7 @@ describe( 'SiteMigrationCredentials', () => {
 		await userEvent.click( continueButton() );
 
 		expect( wpcomRequest ).toHaveBeenCalledWith( {
-			path: 'sites/site-url.wordpress.com/automated-migration',
+			path: 'sites/site-url.wordpress.com/automated-migration?_locale=en',
 			apiNamespace: 'wpcom/v2/',
 			apiVersion: '2',
 			method: 'POST',
@@ -199,7 +199,7 @@ describe( 'SiteMigrationCredentials', () => {
 
 		//TODO: Ideally we should use nock to mock the request, but it is not working with the current implementation due to wpcomRequest usage that is well captured by nock.
 		expect( wpcomRequest ).toHaveBeenCalledWith( {
-			path: 'sites/site-url.wordpress.com/automated-migration',
+			path: 'sites/site-url.wordpress.com/automated-migration?_locale=en',
 			apiNamespace: 'wpcom/v2/',
 			apiVersion: '2',
 			method: 'POST',


### PR DESCRIPTION
Fix  #95625 and continue the work started on Remove English-based verifications #95552

## Proposed Changes
* Remove all locale checking from the credential step
* Add _locale flag to the ticket creation request

## Context
This  [comment](https://github.com/Automattic/wp-calypso/pull/95552#pullrequestreview-2387978031)  highlighted we are not showing an error message on the user language. I initially thought the reason was the missing _locale flag, but actually, I [found another English ](https://github.com/Automattic/wp-calypso/compare/update/remove-english-checkings?expand=1#diff-382f42f81c8c6345dcc99cb07d5d3b7498000569987df98536685a295289f9d4L99)checking that was making the UI show errors directly from the backend.

Now, the UI is showing correct error messages.

 
## Testing Instructions
* Select any locale (excluding en) in your WordPress account
* Access any of the migration flows 
* Go to the `Do it for me` 
* Follow all steps until you reach the credential form
* Set a valid WordPress site 
* Set invalids credentials
* Check if the error messages are using the correct language.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
