### PR TITLE
Logged-in Site Profiler: Fix page selector onBlur state

### DIFF
--- a/client/hosting/performance/components/PageSelector.tsx
+++ b/client/hosting/performance/components/PageSelector.tsx
@@ -4,7 +4,11 @@ import { search } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ComponentProps } from 'react';
 
-export const PageSelector = ( props: ComponentProps< typeof SearchableDropdown > ) => {
+interface PageSelectorProps extends ComponentProps< typeof SearchableDropdown > {
+	onBlur?: ( event: React.FocusEvent< HTMLDivElement > ) => void;
+}
+
+export const PageSelector = ( { onBlur, ...props }: PageSelectorProps ) => {
 	const translate = useTranslate();
 
 	return (
@@ -13,28 +17,32 @@ export const PageSelector = ( props: ComponentProps< typeof SearchableDropdown >
 				{ translate( 'Page' ) }
 			</div>
 			<div className="site-performance__page-selector-container">
-				<SearchableDropdown
-					{ ...props }
-					className="site-performance__page-selector-drowdown"
-					__experimentalRenderItem={ ( { item } ) => {
-						if ( item.value === '-1' ) {
+				<div onBlur={ onBlur } tabIndex={ -1 }>
+					<SearchableDropdown
+						{ ...props }
+						className="site-performance__page-selector-drowdown"
+						__experimentalRenderItem={ ( { item } ) => {
+							if ( item.value === '-1' ) {
+								return (
+									<div className="message">
+										{ translate(
+											'Performance testing is available for the 20 most popular pages.'
+										) }
+									</div>
+								);
+							}
+							if ( item.value === '-2' ) {
+								return <div className="message">{ translate( 'No pages found' ) }</div>;
+							}
 							return (
-								<div className="message">
-									{ translate( 'Performance testing is available for the 20 most popular pages.' ) }
+								<div className="site-performance__page-selector-item" aria-label={ item.label }>
+									<span>{ item.label }</span>
+									<span className="subtitle">{ item.path }</span>
 								</div>
 							);
-						}
-						if ( item.value === '-2' ) {
-							return <div className="message">{ translate( 'No pages found' ) }</div>;
-						}
-						return (
-							<div className="site-performance__page-selector-item" aria-label={ item.label }>
-								<span>{ item.label }</span>
-								<span className="subtitle">{ item.path }</span>
-							</div>
-						);
-					} }
-				/>
+						} }
+					/>
+				</div>
 				<div className="site-performance__page-selector-search-icon">
 					<Icon
 						icon={ search }

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -296,6 +296,12 @@ export const SitePerformance = () => {
 				setNoPagesFound( { query: value, found: false } );
 			} }
 			allowReset={ false }
+			onBlur={ () => {
+				// if no pages found, reset so that the previous selected page is shown
+				if ( ! noPagesFound.found ) {
+					setNoPagesFound( { query: '', found: true } );
+				}
+			} }
 			options={ options }
 			disabled={ disableControls }
 			onChange={ ( page_id ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Minor issue raised by @matt-west p1729243082884319/1729242772.270269-slack-C04H4NY6STW

Closes https://github.com/Automattic/dotcom-forge/issues/9576

## Proposed Changes
When no pages are found in the page selector, if we click away the selector becomes empty, this is not a good experience.

* Reset the page selector value to the previous page when blurred from a `no pages found` state

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the quality of the product.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `sites/performance/siteSlug`
* Search for a non existent page then click away from the selector
* Verify the selector value retains the currently displayed page label


**Before**
p1729243082884319/1729242772.270269-slack-C04H4NY6STW

**After**

https://github.com/user-attachments/assets/58ed3977-cb21-498f-a8a5-b8f0bc4a5c77



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?