### PR TITLE
Explain what Partner Themes are on badged tooltip.

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -5,6 +5,7 @@ import {
 	PLAN_ECOMMERCE,
 } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
@@ -122,6 +123,27 @@ export default function ThemeTierPartnerBadge() {
 		</>
 	);
 
+	const partnerTooltipContent = (
+		<>
+			<div data-testid="upsell-message">
+				{ translate(
+					'{{a}}Partner themes{{/a}} are developed by third-party creators who have made their themes available to purchase and install directly through your WordPress.com dashboard.',
+					{
+						components: {
+							a: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/support/themes/partner-themes/' ) }
+									target="_blank"
+									rel="noreferrer"
+								></a>
+							),
+						},
+					}
+				) }
+			</div>
+		</>
+	);
+
 	return (
 		<>
 			{ showUpgradeBadge && ( ! isPartnerThemePurchased || ! isThemeAllowed ) && (
@@ -145,7 +167,9 @@ export default function ThemeTierPartnerBadge() {
 				isClickable={ false }
 				labelText={ translate( 'Partner' ) }
 				shouldHideIcon
-				shouldHideTooltip
+				tooltipClassName="theme-tier-badge-tooltip"
+				tooltipContent={ partnerTooltipContent }
+				tooltipPosition="top"
 			/>
 		</>
 	);


### PR DESCRIPTION
Related to  https://github.com/Automattic/wp-calypso/issues/85247

## Proposed Changes
![image](https://github.com/user-attachments/assets/63053b12-b06b-47c8-9ec0-ebedaaf8e4e1)

---

![image](https://github.com/user-attachments/assets/eb5f5e92-bc4f-4742-8890-3c9d4982d88a)

In the Themes Showcase, it's currently a little hard to tell what "Partner" themes really mean.
The tooltip above should help.

## Testing Instructions

- On dashboard, access Appearance -> Theme
- Scroll until finding a Partner theme.
- Hovering over Partner badge, should display the tooltip.
- The link should point to [Partner themes](https://wordpress.com/support/themes/partner-themes/) help center. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
