### PR TITLE
BackupScheduleSetting: Add tracking events

### DIFF
--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -51,9 +51,16 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 
 	if ( useSplitButton ) {
 		const secondaryActions = [
-			needsCredentials && <CredentialsPrompt siteSlug={ siteSlug } />,
-			isSuccessfulBackup && <ViewFilesButton siteSlug={ siteSlug } rewindId={ rewindId } />,
-			<DownloadButton siteId={ siteId } siteSlug={ siteSlug } rewindId={ rewindId } />,
+			needsCredentials && <CredentialsPrompt key="credentials-prompt" siteSlug={ siteSlug } />,
+			isSuccessfulBackup && (
+				<ViewFilesButton key="view-files-button" siteSlug={ siteSlug } rewindId={ rewindId } />
+			),
+			<DownloadButton
+				key="download-button"
+				siteId={ siteId }
+				siteSlug={ siteSlug }
+				rewindId={ rewindId }
+			/>,
 		];
 
 		return (

--- a/client/components/jetpack/backup-schedule-setting/index.tsx
+++ b/client/components/jetpack/backup-schedule-setting/index.tsx
@@ -7,6 +7,7 @@ import useScheduledTimeMutation from 'calypso/data/jetpack-backup/use-scheduled-
 import useScheduledTimeQuery from 'calypso/data/jetpack-backup/use-scheduled-time-query';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
@@ -53,12 +54,20 @@ const BackupScheduleSetting: FunctionComponent = () => {
 	const { isFetching: isScheduledTimeQueryFetching, data } = useScheduledTimeQuery( siteId );
 	const { isPending: isScheduledTimeMutationLoading, mutate: scheduledTimeMutate } =
 		useScheduledTimeMutation( {
-			onSuccess: () => {
+			onSuccess: ( data, variables ) => {
+				const { scheduledHour } = variables;
+
 				queryClient.invalidateQueries( { queryKey: [ 'jetpack-backup-scheduled-time', siteId ] } );
 				dispatch(
 					successNotice( translate( 'Daily backup time successfully changed.' ), {
 						duration: 5000,
 						isPersistent: true,
+					} )
+				);
+
+				dispatch(
+					recordTracksEvent( 'calypso_jetpack_backup_schedule_update', {
+						scheduled_hour: scheduledHour,
 					} )
 				);
 			},

--- a/client/components/jetpack/daily-backup-status/status-card/parts/next-scheduled-backup.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/parts/next-scheduled-backup.tsx
@@ -3,7 +3,8 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useNextBackupSchedule } from 'calypso/components/jetpack/backup-schedule-setting/hooks';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 type Props = {
@@ -11,6 +12,7 @@ type Props = {
 };
 
 const NextScheduledBackup: FunctionComponent< Props > = ( { siteId } ) => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
@@ -28,6 +30,10 @@ const NextScheduledBackup: FunctionComponent< Props > = ( { siteId } ) => {
 		return null;
 	}
 
+	const onModifyClick = () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_schedule_modify_click' ) );
+	};
+
 	return (
 		<div className="status-card__scheduled-backup">
 			<span className="scheduled-backup__message">
@@ -43,6 +49,7 @@ const NextScheduledBackup: FunctionComponent< Props > = ( { siteId } ) => {
 			<a
 				href={ `${ settingsPath( siteSlug ) }#backup-schedule` }
 				className="scheduled-backup__action"
+				onClick={ onModifyClick }
 			>
 				{ ' ' }
 				{ translate( 'Modify' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/674

## Proposed Changes

* Add `calypso_jetpack_backup_schedule_modify_click` track event when user clicks on `Modify` link on the `Latest backup` section.
* Add `calypso_jetpack_backup_schedule_update` track event when user updates the backup schedule setting.

Other minor change:
* Fix missing “key” prop for element in array(react/ jsx-key) on `SingleSiteActionsButton` component that was introduced in https://github.com/Automattic/wp-calypso/pull/95638.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to track feature usage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!TIP]
> You could use this extension to make it easier: p7H4VZ-4cf-p2

* Spin up a Jetpack Cloud live branch.
* Pick a site with Jetpack VaultPress Backup.
* Navigate to the Backup page.
* Click on `Modify` link next to the `Next full backup`.
  * Validate the event `calypso_jetpack_backup_schedule_modify_click` was triggered by checking that there is a t.gif request with said event.
  ![CleanShot 2024-10-24 at 18 16 03@2x](https://github.com/user-attachments/assets/a0718570-2838-4f09-bd1d-201fa25f06d4)
  ![CleanShot 2024-10-24 at 18 22 42@2x](https://github.com/user-attachments/assets/94dd0c35-2ae9-4848-ad43-e54afd4c81cc)

* Try updating your site backup schedule.
  * When it succeeds, validate the event `calypso_jetpack_backup_schedule_update` was triggered by checking that there is a t.gif request with said event, including a prop `schedule_hour` with the UTC time updated.
  ![CleanShot 2024-10-24 at 18 23 15@2x](https://github.com/user-attachments/assets/b293b511-915f-48a7-ad38-19dc03cce3d5)
  ![CleanShot 2024-10-24 at 18 21 55@2x](https://github.com/user-attachments/assets/a4ea9948-9f68-47af-b1ef-5e539612098f)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
