### PR TITLE
Bulk Plugin Management: Add plugin management to the global plugins sidebar

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -141,7 +141,7 @@ export class PluginsMain extends Component {
 				href: `/plugins/${ selectedSiteSlug || '' }`,
 			},
 			{
-				label: this.props.translate( 'Installed Plugins' ),
+				label: this.props.translate( 'Manage Plugins' ),
 				href: `/plugins/manage/${ selectedSiteSlug || '' }`,
 			},
 		] );
@@ -377,7 +377,7 @@ export class PluginsMain extends Component {
 
 		const installedPluginsList = showInstalledPluginList && (
 			<PluginsList
-				header={ this.props.translate( 'Installed Plugins' ) }
+				header={ this.props.translate( 'Manage Plugins' ) }
 				plugins={ currentPlugins }
 				isPlaceholder={ this.shouldShowPluginListPlaceholders() }
 				isLoading={ this.props.requestingPluginsForSites }
@@ -453,7 +453,7 @@ export class PluginsMain extends Component {
 		if ( isJetpackCloud ) {
 			pageTitle = this.props.translate( 'Plugins', { textOnly: true } );
 		} else {
-			pageTitle = this.props.translate( 'Installed Plugins', { textOnly: true } );
+			pageTitle = this.props.translate( 'Manage Plugins', { textOnly: true } );
 		}
 
 		const { title, count } = this.getSelectedText();

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { settings } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import GlobalSidebar from 'calypso/layout/global-sidebar';
@@ -50,7 +51,7 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 						label={ translate( 'Manage Plugins' ) }
 						tooltip={ isCollapsed && translate( 'Manage Plugins' ) }
 						selected={ path.startsWith( '/plugins/manage' ) }
-						customIcon={ <SidebarIconCalendar /> }
+						icon={ settings }
 					/>
 				) }
 				<SidebarItem

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import GlobalSidebar from 'calypso/layout/global-sidebar';
@@ -13,6 +14,7 @@ interface Props {
 }
 const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 	const translate = useTranslate();
+	const isBulkPluginManagementEnabled = config.isEnabled( 'bulk-plugin-management' ) || false;
 
 	return (
 		<GlobalSidebar
@@ -34,10 +36,23 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 					label={ translate( 'Marketplace' ) }
 					tooltip={ isCollapsed && translate( 'Marketplace' ) }
 					selected={
-						path.startsWith( '/plugins' ) && ! path.startsWith( '/plugins/scheduled-updates' )
+						path.startsWith( '/plugins' ) &&
+						! path.startsWith( '/plugins/scheduled-updates' ) &&
+						! path.startsWith( '/plugins/manage' )
 					}
 					customIcon={ <SidebarIconPlugins /> }
 				/>
+
+				{ isBulkPluginManagementEnabled && (
+					<SidebarItem
+						className="sidebar__menu-item--plugins"
+						link="/plugins/manage"
+						label={ translate( 'Manage Plugins' ) }
+						tooltip={ isCollapsed && translate( 'Manage Plugins' ) }
+						selected={ path.startsWith( '/plugins/manage' ) }
+						customIcon={ <SidebarIconCalendar /> }
+					/>
+				) }
 				<SidebarItem
 					className="sidebar__menu-item--plugins"
 					link="/plugins/scheduled-updates"

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -16,6 +16,7 @@ interface Props {
 const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 	const translate = useTranslate();
 	const isBulkPluginManagementEnabled = config.isEnabled( 'bulk-plugin-management' ) || false;
+	const managePluginsPattern = /^\/plugins\/(manage|active|inactive|updates)/;
 
 	return (
 		<GlobalSidebar
@@ -39,7 +40,7 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 					selected={
 						path.startsWith( '/plugins' ) &&
 						! path.startsWith( '/plugins/scheduled-updates' ) &&
-						! path.startsWith( '/plugins/manage' )
+						! managePluginsPattern.test( path )
 					}
 					customIcon={ <SidebarIconPlugins /> }
 				/>
@@ -50,7 +51,7 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 						link="/plugins/manage"
 						label={ translate( 'Manage Plugins' ) }
 						tooltip={ isCollapsed && translate( 'Manage Plugins' ) }
-						selected={ path.startsWith( '/plugins/manage' ) }
+						selected={ managePluginsPattern.test( path ) }
 						icon={ settings }
 					/>
 				) }

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -1,7 +1,9 @@
 import config from '@automattic/calypso-config';
+import { SyntheticEvent } from '@wordpress/element';
 import { settings } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import GlobalSidebar from 'calypso/layout/global-sidebar';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
@@ -13,10 +15,16 @@ interface Props {
 	path: string;
 	isCollapsed: boolean;
 }
+const managePluginsPattern = /^\/plugins\/(manage|active|inactive|updates)/;
+
 const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 	const translate = useTranslate();
 	const isBulkPluginManagementEnabled = config.isEnabled( 'bulk-plugin-management' ) || false;
-	const managePluginsPattern = /^\/plugins\/(manage|active|inactive|updates)/;
+
+	const [ previousPath, setPreviousPath ] = useState( path );
+	const isManagedPluginSelected =
+		managePluginsPattern.test( path ) ||
+		( path.startsWith( '/plugins/' ) && managePluginsPattern.test( previousPath ) );
 
 	return (
 		<GlobalSidebar
@@ -37,10 +45,11 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 					link="/plugins"
 					label={ translate( 'Marketplace' ) }
 					tooltip={ isCollapsed && translate( 'Marketplace' ) }
+					onNavigate={ ( _e: SyntheticEvent, link: string ) => setPreviousPath( link ) }
 					selected={
 						path.startsWith( '/plugins' ) &&
 						! path.startsWith( '/plugins/scheduled-updates' ) &&
-						! managePluginsPattern.test( path )
+						! isManagedPluginSelected
 					}
 					customIcon={ <SidebarIconPlugins /> }
 				/>
@@ -51,8 +60,9 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 						link="/plugins/manage"
 						label={ translate( 'Manage Plugins' ) }
 						tooltip={ isCollapsed && translate( 'Manage Plugins' ) }
-						selected={ managePluginsPattern.test( path ) }
+						selected={ isManagedPluginSelected }
 						icon={ settings }
+						onNavigate={ ( _e: SyntheticEvent, link: string ) => setPreviousPath( link ) }
 					/>
 				) }
 				<SidebarItem


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9366

## Proposed Changes

* Adds the plugin management to the sidebar and gate behind feature flag

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the plugins management feature available in the plugins sidebar.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*Go to `/plugins`
*You should see the `Manage Plugins` sidebar menu
* click and the `/plugins/manage` page should be loaded.


![image](https://github.com/user-attachments/assets/dc5e55e6-024c-4517-8c9d-ea8082640a57)
 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
