### PR TITLE
Logged-In Plans Page: Show discounted prices when coupon is applied

### DIFF
--- a/packages/data-stores/src/plans/hooks/use-current-plan.ts
+++ b/packages/data-stores/src/plans/hooks/use-current-plan.ts
@@ -7,7 +7,8 @@ interface Props {
 }
 
 const useCurrentPlan = ( { siteId }: Props ): SitePlan | undefined => {
-	const sitePlans = useSitePlans( { siteId } );
+	// TODO: Determine if we should pass through a coupon here
+	const sitePlans = useSitePlans( { coupon: undefined, siteId } );
 
 	return useMemo(
 		() =>

--- a/packages/data-stores/src/plans/hooks/use-current-plan.ts
+++ b/packages/data-stores/src/plans/hooks/use-current-plan.ts
@@ -7,7 +7,6 @@ interface Props {
 }
 
 const useCurrentPlan = ( { siteId }: Props ): SitePlan | undefined => {
-	// TODO: Determine if we should pass through a coupon here
 	const sitePlans = useSitePlans( { coupon: undefined, siteId } );
 
 	return useMemo(

--- a/packages/data-stores/src/plans/hooks/use-intro-offers.ts
+++ b/packages/data-stores/src/plans/hooks/use-intro-offers.ts
@@ -20,7 +20,8 @@ interface Props {
  * or `undefined` if we haven't observed any metadata yet
  */
 const useIntroOffers = ( { siteId, coupon }: Props ): IntroOffersIndex | undefined => {
-	const sitePlans = useSitePlans( { siteId } );
+	// TODO: Determine if we should pass through a coupon here
+	const sitePlans = useSitePlans( { coupon: undefined, siteId } );
 	const plans = usePlans( { coupon } );
 
 	return useMemo( () => {

--- a/packages/data-stores/src/plans/hooks/use-intro-offers.ts
+++ b/packages/data-stores/src/plans/hooks/use-intro-offers.ts
@@ -20,7 +20,6 @@ interface Props {
  * or `undefined` if we haven't observed any metadata yet
  */
 const useIntroOffers = ( { siteId, coupon }: Props ): IntroOffersIndex | undefined => {
-	// TODO: Determine if we should pass through a coupon here
 	const sitePlans = useSitePlans( { coupon: undefined, siteId } );
 	const plans = usePlans( { coupon } );
 

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -83,7 +83,7 @@ const usePricingMetaForGridPlans = ( {
 	// plans - should have a definition for all plans, being the main source of API data
 	const plans = Plans.usePlans( { coupon } );
 	// sitePlans - unclear if all plans are included
-	const sitePlans = Plans.useSitePlans( { siteId } );
+	const sitePlans = Plans.useSitePlans( { coupon, siteId } );
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
 	const introOffers = Plans.useIntroOffers( { siteId, coupon } );
 	const purchasedPlan = Purchases.useSitePurchaseById( {

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -232,23 +232,48 @@ const usePricingMetaForGridPlans = ( {
 						sitePlan?.pricing?.costOverrides?.[ 0 ]?.overrideCode ===
 							COST_OVERRIDE_REASONS.RECENT_PLAN_PRORATION
 					) {
-						return [
-							planSlug,
-							{
-								originalPrice,
-								discountedPrice: {
-									monthly: null,
-									full: null,
-								},
-								currencyCode: sitePlan?.pricing?.currencyCode,
-								...( sitePlan?.pricing.introOffer && {
-									introOffer: {
-										...sitePlan?.pricing.introOffer,
-										rawPrice: introOfferPrice,
+						// TODO: Reconsider approach with hasSaleCoupon flag
+						return sitePlan?.pricing?.hasSaleCoupon
+							? [
+									planSlug,
+									{
+										originalPrice,
+										discountedPrice: {
+											monthly: getTotalPrice(
+												sitePlan?.pricing.discountedPrice.monthly,
+												storageAddOnPriceMonthly
+											),
+											full: getTotalPrice(
+												sitePlan?.pricing.discountedPrice.full,
+												storageAddOnPriceYearly
+											),
+										},
+										currencyCode: sitePlan?.pricing?.currencyCode,
+										...( sitePlan?.pricing.introOffer && {
+											introOffer: {
+												...sitePlan?.pricing.introOffer,
+												rawPrice: introOfferPrice,
+											},
+										} ),
 									},
-								} ),
-							},
-						];
+							  ]
+							: [
+									planSlug,
+									{
+										originalPrice,
+										discountedPrice: {
+											monthly: null,
+											full: null,
+										},
+										currencyCode: sitePlan?.pricing?.currencyCode,
+										...( sitePlan?.pricing.introOffer && {
+											introOffer: {
+												...sitePlan?.pricing.introOffer,
+												rawPrice: introOfferPrice,
+											},
+										} ),
+									},
+							  ];
 					}
 
 					const discountedPrice = {

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -227,53 +227,32 @@ const usePricingMetaForGridPlans = ( {
 					};
 
 					// Do not return discounted prices if discount is due to plan proration
+					// If there is, however, a sale coupon, show the discounted price
+					// without proration. This isn't ideal, but is intentional. Because of
+					// this, the price will differ between the plans grid and checkout screen.
 					if (
+						! sitePlan?.pricing?.hasSaleCoupon &&
 						! withProratedDiscounts &&
 						sitePlan?.pricing?.costOverrides?.[ 0 ]?.overrideCode ===
 							COST_OVERRIDE_REASONS.RECENT_PLAN_PRORATION
 					) {
-						// TODO: Reconsider approach with hasSaleCoupon flag
-						return sitePlan?.pricing?.hasSaleCoupon
-							? [
-									planSlug,
-									{
-										originalPrice,
-										discountedPrice: {
-											monthly: getTotalPrice(
-												sitePlan?.pricing.discountedPrice.monthly,
-												storageAddOnPriceMonthly
-											),
-											full: getTotalPrice(
-												sitePlan?.pricing.discountedPrice.full,
-												storageAddOnPriceYearly
-											),
-										},
-										currencyCode: sitePlan?.pricing?.currencyCode,
-										...( sitePlan?.pricing.introOffer && {
-											introOffer: {
-												...sitePlan?.pricing.introOffer,
-												rawPrice: introOfferPrice,
-											},
-										} ),
+						return [
+							planSlug,
+							{
+								originalPrice,
+								discountedPrice: {
+									monthly: null,
+									full: null,
+								},
+								currencyCode: sitePlan?.pricing?.currencyCode,
+								...( sitePlan?.pricing.introOffer && {
+									introOffer: {
+										...sitePlan?.pricing.introOffer,
+										rawPrice: introOfferPrice,
 									},
-							  ]
-							: [
-									planSlug,
-									{
-										originalPrice,
-										discountedPrice: {
-											monthly: null,
-											full: null,
-										},
-										currencyCode: sitePlan?.pricing?.currencyCode,
-										...( sitePlan?.pricing.introOffer && {
-											introOffer: {
-												...sitePlan?.pricing.introOffer,
-												rawPrice: introOfferPrice,
-											},
-										} ),
-									},
-							  ];
+								} ),
+							},
+						];
 					}
 
 					const discountedPrice = {

--- a/packages/data-stores/src/plans/queries/lib/use-query-keys-factory.ts
+++ b/packages/data-stores/src/plans/queries/lib/use-query-keys-factory.ts
@@ -1,5 +1,10 @@
 const useQueryKeysFactory = () => ( {
-	sitePlans: ( siteId?: string | number | null ) => [ 'site-plans', siteId ],
+	// TODO: Verify that this is the correct convention for query keys
+	sitePlans: ( coupon?: string, siteId?: string | number | null ) => [
+		'site-plans',
+		siteId,
+		coupon,
+	],
 	plans: ( coupon?: string ) => [ 'plans', coupon ],
 } );
 

--- a/packages/data-stores/src/plans/queries/lib/use-query-keys-factory.ts
+++ b/packages/data-stores/src/plans/queries/lib/use-query-keys-factory.ts
@@ -1,5 +1,4 @@
 const useQueryKeysFactory = () => ( {
-	// TODO: Verify that this is the correct convention for query keys
 	sitePlans: ( coupon?: string, siteId?: string | number | null ) => [
 		'site-plans',
 		siteId,

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -14,6 +14,10 @@ interface PricedAPISitePlansIndex {
 }
 
 interface Props {
+	/**
+	 * `coupon` required on purpose to mitigate risk with not passing something through when we should
+	 */
+	coupon: string | undefined;
 	siteId: string | number | null | undefined;
 }
 
@@ -22,15 +26,18 @@ interface Props {
  * - Plans from `/sites/[siteId]/plans`, unlike `/plans`, are returned indexed by product_id, and do not include that in the plan's payload.
  * - UI works with product/plan slugs everywhere, so returned index is transformed to be keyed by product_slug
  */
-function useSitePlans( { siteId }: Props ): UseQueryResult< SitePlansIndex > {
+function useSitePlans( { coupon, siteId }: Props ): UseQueryResult< SitePlansIndex > {
 	const queryKeys = useQueryKeysFactory();
+	const params = new URLSearchParams();
+	coupon && params.append( 'coupon_code', coupon );
 
 	return useQuery( {
-		queryKey: queryKeys.sitePlans( siteId ),
+		queryKey: queryKeys.sitePlans( coupon, siteId ),
 		queryFn: async (): Promise< SitePlansIndex > => {
 			const data: PricedAPISitePlansIndex = await wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId as string ) }/plans`,
 				apiVersion: '1.3',
+				query: params.toString(),
 			} );
 
 			return Object.fromEntries(

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -15,7 +15,8 @@ interface PricedAPISitePlansIndex {
 
 interface Props {
 	/**
-	 * `coupon` required on purpose to mitigate risk with not passing something through when we should
+	 * To match the use-plans hook, `coupon` is required on purpose to mitigate risk of not passing
+	 * something through when we should
 	 */
 	coupon: string | undefined;
 	siteId: string | number | null | undefined;

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -59,6 +59,7 @@ function useSitePlans( { coupon, siteId }: Props ): UseQueryResult< SitePlansInd
 							hasRedeemedDomainCredit: plan?.has_redeemed_domain_credit,
 							purchaseId: plan.id ? Number( plan.id ) : undefined,
 							pricing: {
+								hasSaleCoupon: plan.has_sale_coupon,
 								currencyCode: plan.currency_code,
 								introOffer: unpackIntroOffer( plan ),
 								costOverrides: unpackCostOverrides( plan ),

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -120,6 +120,7 @@ export interface PlanPricing {
 }
 
 export interface SitePlanPricing extends Omit< PlanPricing, 'billPeriod' > {
+	hasSaleCoupon?: boolean;
 	costOverrides?: CostOverride[];
 }
 
@@ -269,6 +270,7 @@ export interface PricedAPIPlan extends PricedAPIPlanPricing, PricedAPIPlanIntrod
 export interface PricedAPISitePlan
 	extends PricedAPISitePlanPricing,
 		PricedAPIPlanIntroductoryOffer {
+	has_sale_coupon?: boolean;
 	/* product_id: number; // not included in the plan's payload */
 	product_slug: StorePlanSlug;
 	current_plan?: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95702

## Proposed Changes

* Use coupon query param when fetching site specific plans pricing

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Both `/start/plans/?coupon=COUPON_CODE` and `/pricing/?coupon=COUPON_CODE` apply the coupon discount to the plan price. 
* For consistency and a better UX, we should carry over the functionality into the Calypso admin page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


- Patch this phab diff D164653-code
- Sandbox public api
- Check out PR
- Spin up local calypso instance
- Navigate to plans page `/plans/:siteSlug?coupon=xyz` Ex. /plans/testsite.wordpress.com?coupon=federate25
- Verify that the page shows discounted values in the plans grid header pricing and billing timeframes

<img width="1703" alt="Screenshot 2024-10-30 at 12 12 15 PM" src="https://github.com/user-attachments/assets/2ee61e61-607c-4665-91bf-7c212a17b66c">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?