### PR TITLE
Stats: Date Filtering: Date range block for header refresh

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -404,6 +404,7 @@ class StatsSite extends Component {
 							activeLegend={ this.state.activeLegend }
 							onChangeLegend={ this.onChangeLegend }
 							isWithNewDateFiltering // @TODO:remove this prop once we release new date filtering
+							isWithNewDateControl
 							slug={ slug }
 							dateRange={ customChartRange }
 						>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -389,35 +389,67 @@ class StatsSite extends Component {
 					// @TODO: remove highlight section completely once flag is released
 					<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				) }
+				{ isNewDateFilteringEnabled && (
+					// moves date range block into new location
+					<StatsPeriodHeader>
+						<StatsPeriodNavigation
+							date={ date }
+							period={ period }
+							url={ `/stats/${ period }/${ slug }` }
+							queryParams={ context.query }
+							pathTemplate={ pathTemplate }
+							charts={ CHARTS }
+							availableLegend={ this.getAvailableLegend() }
+							activeTab={ getActiveTab( this.props.chartTab ) }
+							activeLegend={ this.state.activeLegend }
+							onChangeLegend={ this.onChangeLegend }
+							isWithNewDateFiltering // @TODO:remove this prop once we release new date filtering
+							slug={ slug }
+							dateRange={ customChartRange }
+						>
+							{ ' ' }
+							<DatePicker
+								period={ period }
+								date={ date }
+								query={ query }
+								statsType="statsTopPosts"
+								showQueryDate
+								isShort
+							/>
+						</StatsPeriodNavigation>
+					</StatsPeriodHeader>
+				) }
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>
-						<StatsPeriodHeader>
-							<StatsPeriodNavigation
-								date={ date }
-								period={ period }
-								url={ `/stats/${ period }/${ slug }` }
-								queryParams={ context.query }
-								pathTemplate={ pathTemplate }
-								charts={ CHARTS }
-								availableLegend={ this.getAvailableLegend() }
-								activeTab={ getActiveTab( this.props.chartTab ) }
-								activeLegend={ this.state.activeLegend }
-								onChangeLegend={ this.onChangeLegend }
-								isWithNewDateControl
-								slug={ slug }
-								dateRange={ customChartRange }
-							>
-								{ ' ' }
-								<DatePicker
-									period={ period }
+						{ ! isNewDateFilteringEnabled && (
+							<StatsPeriodHeader>
+								<StatsPeriodNavigation
 									date={ date }
-									query={ query }
-									statsType="statsTopPosts"
-									showQueryDate
-									isShort
-								/>
-							</StatsPeriodNavigation>
-						</StatsPeriodHeader>
+									period={ period }
+									url={ `/stats/${ period }/${ slug }` }
+									queryParams={ context.query }
+									pathTemplate={ pathTemplate }
+									charts={ CHARTS }
+									availableLegend={ this.getAvailableLegend() }
+									activeTab={ getActiveTab( this.props.chartTab ) }
+									activeLegend={ this.state.activeLegend }
+									onChangeLegend={ this.onChangeLegend }
+									isWithNewDateControl
+									slug={ slug }
+									dateRange={ customChartRange }
+								>
+									{ ' ' }
+									<DatePicker
+										period={ period }
+										date={ date }
+										query={ query }
+										statsType="statsTopPosts"
+										showQueryDate
+										isShort
+									/>
+								</StatsPeriodNavigation>
+							</StatsPeriodHeader>
+						) }
 
 						<ChartTabs
 							activeTab={ getActiveTab( this.props.chartTab ) }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -405,6 +405,7 @@ class StatsSite extends Component {
 							onChangeLegend={ this.onChangeLegend }
 							isWithNewDateFiltering // @TODO:remove this prop once we release new date filtering
 							isWithNewDateControl
+							showArrows
 							slug={ slug }
 							dateRange={ customChartRange }
 						>
@@ -436,6 +437,7 @@ class StatsSite extends Component {
 									activeLegend={ this.state.activeLegend }
 									onChangeLegend={ this.onChangeLegend }
 									isWithNewDateControl
+									showArrows
 									slug={ slug }
 									dateRange={ customChartRange }
 								>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -464,7 +464,7 @@ class StatsSite extends Component {
 							chartTab={ this.props.chartTab }
 							customQuantity={ customChartQuantity }
 							customRange={ customChartRange }
-							hideLegend
+							hideLegend={ ! isNewDateFilteringEnabled } // if isNewDateFilteringEnabled then we want to show the legend down in the chart instead of in the Period Header
 						/>
 					</>
 

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -17,10 +17,6 @@
 	.stats-period-navigation {
 		@include section-header-with-siblings;
 
-		@media (max-width: $break-medium) {
-			padding: 0 16px;
-		}
-
 	 // this new selector removes padding only for the date filtering design
 		&.stats-period-navigation__is-with-new-date-filtering {
 			padding: 0;
@@ -39,6 +35,10 @@
 			margin: 0 0 24px 0;
 			padding: 0;
 		}
+	}
+
+	@media (max-width: $break-medium) {
+		padding: 0 16px;
 	}
 
 	@media (max-width: $break-mobile) {

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -17,7 +17,11 @@
 	.stats-period-navigation {
 		@include section-header-with-siblings;
 
-		// this new selectorremoves padding only for the date filtering design
+		@media (max-width: $break-medium) {
+			padding: 0 16px;
+		}
+
+	 // this new selector removes padding only for the date filtering design
 		&.stats-period-navigation__is-with-new-date-filtering {
 			padding: 0;
 

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -16,6 +16,15 @@
 
 	.stats-period-navigation {
 		@include section-header-with-siblings;
+
+		// this new selectorremoves padding only for the date filtering design
+		&.stats-period-navigation__is-with-new-date-filtering {
+			padding: 0;
+
+			@media (max-width: $break-medium) {
+				padding: 0 16px;
+			}
+		}
 	}
 
 	@include navigation-segment-control-buttons;
@@ -26,10 +35,6 @@
 			margin: 0 0 24px 0;
 			padding: 0;
 		}
-	}
-
-	@media (max-width: $break-medium) {
-		padding: 0 16px;
 	}
 
 	@media (max-width: $break-mobile) {

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -211,6 +211,35 @@ class StatsPeriodNavigation extends PureComponent {
 			>
 				<div className="stats-period-navigation__children">{ children }</div>
 				{ isWithNewDateFiltering ? (
+					<div className="stats-period-navigation__period-control">
+						{ showArrows && (
+							<NavigationArrows
+								disableNextArrow={ disableNextArrow || isToday }
+								disablePreviousArrow={ disablePreviousArrow }
+								onClickNext={ this.handleArrowNext }
+								onClickPrevious={ this.handleArrowPrevious }
+							/>
+						) }
+
+						<div className="stats-period-navigation__date-control">
+							<StatsDateControl
+								slug={ slug }
+								queryParams={ queryParams }
+								dateRange={ dateRange }
+								shortcutList={ shortcutList }
+								onGatedHandler={ this.onGatedHandler }
+								overlay={
+									gateDateControl && (
+										<StatsCardUpsell
+											className="stats-module__upsell"
+											statType={ STATS_FEATURE_DATE_CONTROL }
+											siteId={ siteId }
+										/>
+									)
+								}
+							/>
+						</div>
+					</div>
 				) : (
 					<div className="stats-period-navigation__date-control">
 						<StatsDateControl

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -210,17 +210,20 @@ class StatsPeriodNavigation extends PureComponent {
 				} ) }
 			>
 				<div className="stats-period-navigation__children">{ children }</div>
-				{ isWithNewDateFiltering ? (
-					<div className="stats-period-navigation__period-control">
-						{ showArrows && (
-							<NavigationArrows
-								disableNextArrow={ disableNextArrow || isToday }
-								disablePreviousArrow={ disablePreviousArrow }
-								onClickNext={ this.handleArrowNext }
-								onClickPrevious={ this.handleArrowPrevious }
-							/>
-						) }
 
+				{ /* Legacy view: Show only navigation arrows when not using new date control */ }
+				{ ! isWithNewDateControl && showArrows && (
+					<NavigationArrows
+						disableNextArrow={ disableNextArrow || isToday }
+						disablePreviousArrow={ disablePreviousArrow }
+						onClickNext={ this.handleArrowNext }
+						onClickPrevious={ this.handleArrowPrevious }
+					/>
+				) }
+
+				{ /* New filtering view: Shows date control in a simplified layout */ }
+				{ isWithNewDateControl && isWithNewDateFiltering && (
+					<div className="stats-period-navigation__period-control">
 						<div className="stats-period-navigation__date-control">
 							<StatsDateControl
 								slug={ slug }
@@ -240,7 +243,10 @@ class StatsPeriodNavigation extends PureComponent {
 							/>
 						</div>
 					</div>
-				) : (
+				) }
+
+				{ /* Standard date control view: Shows date control with old layout and additional controls (Legend, IntervalDropdown) */ }
+				{ isWithNewDateControl && ! isWithNewDateFiltering && (
 					<div className="stats-period-navigation__date-control">
 						<StatsDateControl
 							slug={ slug }
@@ -266,14 +272,6 @@ class StatsPeriodNavigation extends PureComponent {
 									availableCharts={ this.props.availableLegend }
 									clickHandler={ this.onLegendClick }
 									tabs={ this.props.charts }
-								/>
-							) }
-							{ showArrows && (
-								<NavigationArrows
-									disableNextArrow={ disableNextArrow || isToday }
-									disablePreviousArrow={ disablePreviousArrow }
-									onClickNext={ this.handleArrowNext }
-									onClickPrevious={ this.handleArrowPrevious }
 								/>
 							) }
 							<IntervalDropdown

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -46,6 +46,7 @@ class StatsPeriodNavigation extends PureComponent {
 		startDate: PropTypes.bool,
 		endDate: PropTypes.bool,
 		isWithNewDateControl: PropTypes.bool,
+		isWithNewDateFiltering: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -57,6 +58,7 @@ class StatsPeriodNavigation extends PureComponent {
 		startDate: false,
 		endDate: false,
 		isWithNewDateControl: false,
+		isWithNewDateFiltering: false,
 	};
 
 	handleArrowEvent = ( arrow, href ) => {
@@ -190,6 +192,7 @@ class StatsPeriodNavigation extends PureComponent {
 			queryParams,
 			slug,
 			isWithNewDateControl,
+			isWithNewDateFiltering,
 			dateRange,
 			shortcutList,
 			gateDateControl,
@@ -206,7 +209,8 @@ class StatsPeriodNavigation extends PureComponent {
 				} ) }
 			>
 				<div className="stats-period-navigation__children">{ children }</div>
-				{ isWithNewDateControl ? (
+				{ isWithNewDateFiltering ? (
+				) : (
 					<div className="stats-period-navigation__date-control">
 						<StatsDateControl
 							slug={ slug }
@@ -251,17 +255,6 @@ class StatsPeriodNavigation extends PureComponent {
 							/>
 						</div>
 					</div>
-				) : (
-					<>
-						{ showArrows && (
-							<NavigationArrows
-								disableNextArrow={ disableNextArrow || isToday }
-								disablePreviousArrow={ disablePreviousArrow }
-								onClickNext={ this.handleArrowNext }
-								onClickPrevious={ this.handleArrowPrevious }
-							/>
-						) }
-					</>
 				) }
 			</div>
 		);

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -224,6 +224,14 @@ class StatsPeriodNavigation extends PureComponent {
 				{ /* New filtering view: Shows date control in a simplified layout */ }
 				{ isWithNewDateControl && isWithNewDateFiltering && (
 					<div className="stats-period-navigation__period-control">
+						{ showArrows && (
+							<NavigationArrows
+								disableNextArrow={ disableNextArrow || isToday }
+								disablePreviousArrow={ disablePreviousArrow }
+								onClickNext={ this.handleArrowNext }
+								onClickPrevious={ this.handleArrowPrevious }
+							/>
+						) }
 						<div className="stats-period-navigation__date-control">
 							<StatsDateControl
 								slug={ slug }
@@ -245,7 +253,7 @@ class StatsPeriodNavigation extends PureComponent {
 					</div>
 				) }
 
-				{ /* Standard date control view: Shows date control with old layout and additional controls (Legend, IntervalDropdown) */ }
+				{ /* Standard new date control view: Shows date control with additional controls (Legend, IntervalDropdown) */ }
 				{ isWithNewDateControl && ! isWithNewDateFiltering && (
 					<div className="stats-period-navigation__date-control">
 						<StatsDateControl
@@ -272,6 +280,14 @@ class StatsPeriodNavigation extends PureComponent {
 									availableCharts={ this.props.availableLegend }
 									clickHandler={ this.onLegendClick }
 									tabs={ this.props.charts }
+								/>
+							) }
+							{ showArrows && (
+								<NavigationArrows
+									disableNextArrow={ disableNextArrow || isToday }
+									disablePreviousArrow={ disablePreviousArrow }
+									onClickNext={ this.handleArrowNext }
+									onClickPrevious={ this.handleArrowPrevious }
 								/>
 							) }
 							<IntervalDropdown

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -223,7 +223,7 @@ class StatsPeriodNavigation extends PureComponent {
 
 				{ /* New filtering view: Shows date control in a simplified layout */ }
 				{ isWithNewDateControl && isWithNewDateFiltering && (
-					<div className="stats-period-navigation__period-control">
+					<div className="stats-period-navigation__date-range-control">
 						{ showArrows && (
 							<NavigationArrows
 								disableNextArrow={ disableNextArrow || isToday }
@@ -272,7 +272,7 @@ class StatsPeriodNavigation extends PureComponent {
 								)
 							}
 						/>
-						<div className="stats-period-navigation__period-control">
+						<div className="stats-period-navigation__date-range-control">
 							{ this.props.activeTab && (
 								<Legend
 									activeCharts={ this.props.activeLegend }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -206,6 +206,7 @@ class StatsPeriodNavigation extends PureComponent {
 			<div
 				className={ clsx( 'stats-period-navigation', {
 					'stats-period-navigation__is-with-new-date-control': isWithNewDateControl,
+					'stats-period-navigation__is-with-new-date-filtering': isWithNewDateFiltering,
 				} ) }
 			>
 				<div className="stats-period-navigation__children">{ children }</div>

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -272,7 +272,7 @@ class StatsPeriodNavigation extends PureComponent {
 								)
 							}
 						/>
-						<div className="stats-period-navigation__date-range-control">
+						<div className="stats-period-navigation__period-control">
 							{ this.props.activeTab && (
 								<Legend
 									activeCharts={ this.props.activeLegend }

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -53,7 +53,7 @@
 		justify-content: flex-end;
 	}
 
-	.stats-period-navigation__period-control {
+	.stats-period-navigation__date-range-control {
 		display:flex;
 		flex-direction: row;
 		gap: 20px;

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -46,6 +46,20 @@
 	}
 }
 
+// Styling specific to the new Date Filtering traffic page project
+.stats-period-navigation.stats-period-navigation__is-with-new-date-filtering {
+
+	.stats-navigation-arrows {
+		justify-content: flex-end;
+	}
+
+	.stats-period-navigation__period-control {
+		display:flex;
+		flex-direction: row;
+		gap: 20px;
+	  }
+}
+
 .stats-period-navigation.stats-period-navigation__is-with-new-date-control {
 	padding: 0;
 	align-items: flex-start;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/215

## Proposed Changes

* Creates a new date range block containing just the date title, navigation arrows, and datepicker drop down. 
* Note: background color staying white for now, while a decision on final style is decided in design thread

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Past of the Date Filtering for the Traffic Page header refresh

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live Branch
* Apply feature flag `stats/new-date-filtering`
* Confirm that new date range block layout is showing like in the screenshot
* Confirm the chart legend is now displaying down in the chart
* Test on other display sizes 

 ![Image](https://github.com/user-attachments/assets/3263744d-689b-45fe-86a0-315b1c699a38)  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
