### PR TITLE
A4A: Add more error indicators.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -175,7 +175,7 @@ export const JetpackSitesDataViews = ( {
 								isLoading={ isLoading }
 								isDevSite={ item.isDevSite }
 								onSiteTitleClick={ openSitePreviewPane }
-								errors={ getSiteErrors( item.error ) }
+								errors={ getSiteErrors( item ) }
 							/>
 						</div>
 					);

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -52,6 +52,7 @@
 
 	li {
 		@include a4a-font-body-sm($font-weight: 500);
+		text-align: start;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.ts
@@ -6,39 +6,46 @@ export default function useGetSiteErrors() {
 	const translate = useTranslate();
 
 	return useCallback(
-		( site?: SiteData ): SiteError[] => {
+		( data?: SiteData ): SiteError[] => {
 			const errors: SiteError[] = [];
-			if ( site?.error?.status === 'failed' ) {
+			if ( data?.error?.status === 'failed' ) {
 				errors.push( { severity: 'high', message: translate( 'Connectivity issue' ) } );
 			}
 
-			if ( site?.scan?.status === 'failed' ) {
+			if ( data?.scan?.status === 'failed' ) {
 				errors.push( {
 					severity: 'medium',
 					message: translate( '%(count)s threat found', '%(count)s threats found', {
-						count: site.scan.threats,
+						count: data.scan.threats,
 						args: {
-							count: site.scan.threats,
+							count: data.scan.threats,
 						},
 						comment: '%(count) here is the number of threats found',
 					} ),
 				} );
 			}
 
-			if ( site?.plugin?.status === 'warning' ) {
+			if ( data?.plugin?.status === 'warning' ) {
 				errors.push( {
 					severity: 'medium',
 					message: translate(
 						'%(count)s plugin requires update',
 						'%(count)s plugins require updates',
 						{
-							count: site.plugin.updates,
+							count: data.plugin.updates,
 							args: {
-								count: site.plugin.updates,
+								count: data.plugin.updates,
 							},
 							comment: '%(count) here is the number of plugins that require updates',
 						}
 					),
+				} );
+			}
+
+			if ( data?.site?.value?.is_simple ) {
+				errors.push( {
+					severity: 'medium',
+					message: translate( 'We are provisioning your site' ),
 				} );
 			}
 

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.ts
@@ -1,18 +1,48 @@
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import { ErrorNode, SiteError } from '../../types';
+import { SiteData, SiteError } from '../../types';
 
 export default function useGetSiteErrors() {
 	const translate = useTranslate();
 
 	return useCallback(
-		( error?: ErrorNode ): SiteError[] => {
-			if ( error?.status === 'failed' ) {
-				// FIXME: For the time being we only have one error type and that is network issue.
-				return [ { severity: 'high', message: translate( 'Connectivity issue' ) } ];
+		( site?: SiteData ): SiteError[] => {
+			const errors: SiteError[] = [];
+			if ( site?.error?.status === 'failed' ) {
+				errors.push( { severity: 'high', message: translate( 'Connectivity issue' ) } );
 			}
 
-			return [];
+			if ( site?.scan?.status === 'failed' ) {
+				errors.push( {
+					severity: 'medium',
+					message: translate( '%(count)s threat found', '%(count)s threats found', {
+						count: site.scan.threats,
+						args: {
+							count: site.scan.threats,
+						},
+						comment: '%(count) here is the number of threats found',
+					} ),
+				} );
+			}
+
+			if ( site?.plugin?.status === 'warning' ) {
+				errors.push( {
+					severity: 'medium',
+					message: translate(
+						'%(count)s plugin requires update',
+						'%(count)s plugins require updates',
+						{
+							count: site.plugin.updates,
+							args: {
+								count: site.plugin.updates,
+							},
+							comment: '%(count) here is the number of plugins that require updates',
+						}
+					),
+				} );
+			}
+
+			return errors;
 		},
 		[ translate ]
 	);

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.tsx
@@ -43,9 +43,23 @@ export default function useGetSiteErrors() {
 			}
 
 			if ( data?.site?.value?.is_simple ) {
+				const siteSlug = data?.site?.value?.url?.replace( /(^\w+:|^)\/\//, '' );
+				const wpOverviewUrl = `https://wordpress.com/overview/${ siteSlug }`;
+
 				errors.push( {
 					severity: 'medium',
-					message: translate( 'We are provisioning your site' ),
+					message: translate( 'We are provisioning your site {{a}}Set up your site{{/a}}', {
+						components: {
+							a: (
+								<a
+									href={ wpOverviewUrl }
+									target="_blank"
+									rel="noreferrer"
+									onClick={ ( e ) => e.stopPropagation() }
+								/>
+							),
+						},
+					} ),
 				} );
 			}
 

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field-error-indicator.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field-error-indicator.tsx
@@ -23,8 +23,6 @@ export default function SiteDataFieldErrorIndicator( { errors }: Props ) {
 			ref={ popoverContext }
 			onMouseEnter={ () => setIsPopoverVisible( true ) }
 			onMouseLeave={ () => setIsPopoverVisible( false ) }
-			onMouseDown={ () => setIsPopoverVisible( true ) }
-			onMouseUp={ () => setIsPopoverVisible( false ) }
 			onTouchStart={ () => setIsPopoverVisible( true ) }
 			onTouchEnd={ () => setIsPopoverVisible( false ) }
 			role="button"

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -1,3 +1,4 @@
+import { TranslateResult } from 'i18n-calypso';
 import { ReactNode, SetStateAction, Dispatch } from 'react';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { Site } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
@@ -45,5 +46,5 @@ export interface SitesDashboardContextInterface {
 
 export type SiteError = {
 	severity: 'high' | 'medium' | 'low';
-	message: string;
+	message: TranslateResult;
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -32,10 +32,11 @@ export default function SiteStatusContent( {
 	// Disable clicks/hover when there is a site error &
 	// when the row is not monitor and monitor status is down
 	// since monitor is clickable when site is down.
-	const disabledStatus = siteError || ( type !== 'monitor' && siteDown );
+	const disabledStatus =
+		siteError || ( type !== 'monitor' && siteDown ) || rows.site.value.is_simple;
 
-	// Disable selection and toggle when there is a site error or site is down
-	const hasAnyError = !! ( siteError || siteDown );
+	// Disable selection and toggle when there is a site error, site is down or site is simple provisioning
+	const hasAnyError = !! ( siteError || siteDown || rows.site.value.is_simple );
 
 	if ( type === 'site' ) {
 		return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -112,6 +112,7 @@ export interface Site {
 	hosting_provider_guess: string;
 	has_paid_agency_monitor: boolean;
 	is_atomic: boolean;
+	is_simple: boolean;
 	has_pending_boost_one_time_score: boolean;
 	has_vulnerable_plugins: boolean;
 	latest_scan_has_threats_found: boolean;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -112,7 +112,7 @@ export interface Site {
 	hosting_provider_guess: string;
 	has_paid_agency_monitor: boolean;
 	is_atomic: boolean;
-	is_simple: boolean;
+	is_simple?: boolean;
 	has_pending_boost_one_time_score: boolean;
 	has_vulnerable_plugins: boolean;
 	latest_scan_has_threats_found: boolean;


### PR DESCRIPTION
This PR adds more errors in the error indicator.

<img width="382" alt="Screenshot 2024-10-25 at 6 16 21 PM" src="https://github.com/user-attachments/assets/69c6cb48-9e97-42c6-95f3-5675fc916c87">

<img width="569" alt="Screenshot 2024-10-25 at 3 53 58 PM" src="https://github.com/user-attachments/assets/6f80662d-c141-4213-8679-167aa1a88dbb">



Depends on https://github.com/Automattic/wp-calypso/pull/95654
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1018

## Proposed Changes

* Add more errors in the Indicator list.
   * Threat founds
   * Plugin updates
   * Simple site provisioning

## Why are these changes being made?

* 

## Testing Instructions

* Apply D161280-code patch
* Use the A4A live link and go to the `/sites` page.
* Test that the error indicator supports the threat founds and plugin updates.
* Provision of a WPCOM site.
* Confirm that the indicator also displays a warning that the site is provisioning.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?