### PR TITLE
A4A > Agency Tiers: Add event tracking

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/download-link.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/download-link.tsx
@@ -1,10 +1,11 @@
 import { JetpackLogo } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-// import JetpackLogo from 'calypso/assets/images/a8c-for-agencies/product-logos/jetpack.svg';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/product-logos/pressable.svg';
 import WooLogo from 'calypso/assets/images/a8c-for-agencies/product-logos/woo.svg';
 import WordPressogo from 'calypso/assets/images/a8c-for-agencies/product-logos/wordpress.svg';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { DirectoryApplicationType } from '../../partner-directory/types';
 import type { AgencyTier } from '../types';
 
@@ -16,6 +17,7 @@ function DownloadLink( {
 	currentAgencyTier: AgencyTier;
 } ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const productData: Record<
 		string,
@@ -82,7 +84,17 @@ function DownloadLink( {
 	}
 
 	return (
-		<Button href={ data.href }>
+		<Button
+			href={ data.href }
+			onClick={ () => {
+				dispatch(
+					recordTracksEvent( 'calypso_a8c_agency_tier_badges_download_modal_download_click', {
+						product,
+						agency_tier: currentAgencyTier,
+					} )
+				);
+			} }
+		>
 			{ data.icon }
 			{ data.name }
 		</Button>

--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
@@ -5,14 +5,16 @@ import { useState } from 'react';
 import A4AThemedModal from 'calypso/a8c-for-agencies/components/a4a-themed-modal';
 import AgencyTierLevels from 'calypso/assets/images/a8c-for-agencies/agency-tier/agency-tier-levels.svg';
 import { preventWidows } from 'calypso/lib/formatting';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import DownloadLink from './download-link';
 
 import './style.scss';
 
 export default function DownloadBadges() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const agency = useSelector( getActiveAgency );
 
@@ -27,6 +29,12 @@ export default function DownloadBadges() {
 
 	const handleOnClose = () => {
 		setShowDownloadModal( false );
+		dispatch( recordTracksEvent( 'calypso_a8c_agency_tier_badges_download_modal_close' ) );
+	};
+
+	const handleDownloadBadgeClick = () => {
+		setShowDownloadModal( true );
+		dispatch( recordTracksEvent( 'calypso_a8c_agency_tier_badges_download_modal_open' ) );
 	};
 
 	if ( ! partnerDirectorties.length || ! currentAgencyTier ) {
@@ -38,7 +46,7 @@ export default function DownloadBadges() {
 			<Button
 				className="agency-tier-download-badge__button"
 				variant="secondary"
-				onClick={ () => setShowDownloadModal( true ) }
+				onClick={ handleDownloadBadgeClick }
 			>
 				{ translate( 'Download your badges' ) }
 				<Icon icon={ download } size={ 18 } />

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -11,8 +11,9 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import DownloadBadges from '../../download-badges';
 import getAgencyTierInfo from '../../lib/get-agency-tier-info';
 import getTierBenefits from '../../lib/get-tier-benefits';
@@ -22,6 +23,7 @@ import './style.scss';
 
 export default function AgencyTierOverview() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const agency = useSelector( getActiveAgency );
 
@@ -77,7 +79,20 @@ export default function AgencyTierOverview() {
 									<div>{ currentAgencyTierInfo.subtitle }</div>
 									{ translate( '{{a}}Learn more{{/a}} ↗', {
 										components: {
-											a: <a target="_blank" href={ learnMoreLink } rel="noopener noreferrer" />,
+											a: (
+												<a
+													target="_blank"
+													href={ learnMoreLink }
+													onClick={ () => {
+														dispatch(
+															recordTracksEvent( 'calypso_a4a_agency_tier_badge_learn_more_click', {
+																agency_tier: currentAgencyTier,
+															} )
+														);
+													} }
+													rel="noopener noreferrer"
+												/>
+											),
 										},
 									} ) }
 								</div>

--- a/client/a8c-for-agencies/sections/agency-tier/tier-permission-error/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/tier-permission-error/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -9,14 +10,22 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import AgencyTierLevels from 'calypso/assets/images/a8c-for-agencies/agency-tier/agency-tier-levels.svg';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getTierPermissionData from '../lib/get-tier-permission-data';
 
 import './style.scss';
 
 export default function TierPermissionError( { section }: { section: string } ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const { title, content } = getTierPermissionData( section, translate );
+
+	// Record the view event
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_agency_tier_permission_error_view', { section } ) );
+	}, [ dispatch, section ] );
 
 	return (
 		<Layout className="agency-tier-permission-error__layout" title={ title } wide>
@@ -43,7 +52,17 @@ export default function TierPermissionError( { section }: { section: string } ) 
 						<div className="agency-tier-permission-error__content-description">
 							{ content.description }
 						</div>
-						<Button href={ content.buttonProps.href } variant="primary">
+						<Button
+							href={ content.buttonProps.href }
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_agency_tier_permission_error_button_click', {
+										section,
+									} )
+								);
+							} }
+							variant="primary"
+						>
 							{ content.buttonProps.text }
 						</Button>
 					</div>

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal.tsx
@@ -7,6 +7,7 @@ import A4AThemedModal from 'calypso/a8c-for-agencies/components/a4a-themed-modal
 import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import type { AgencyTierInfo } from 'calypso/a8c-for-agencies/sections/agency-tier/types';
@@ -57,6 +58,20 @@ export default function AgencyTierCelebrationModal( {
 		};
 	}, [] );
 
+	// Record the event when the modal is shown
+	useEffect( () => {
+		if (
+			agencyTierInfo?.celebrationModal &&
+			celebrationModalShowForCurrentType !== currentAgencyTier
+		) {
+			dispatch(
+				recordTracksEvent( 'calypso_a8c_agency_tier_celebration_modal_shown', {
+					agency_tier: currentAgencyTier,
+				} )
+			);
+		}
+	}, [ agencyTierInfo, celebrationModalShowForCurrentType, currentAgencyTier, dispatch ] );
+
 	if (
 		! agencyTierInfo?.celebrationModal ||
 		celebrationModalShowForCurrentType === currentAgencyTier
@@ -66,6 +81,21 @@ export default function AgencyTierCelebrationModal( {
 
 	const handleOnClose = () => {
 		dispatch( savePreference( PREFERENCE_NAME, currentAgencyTier ?? '' ) );
+		dispatch(
+			recordTracksEvent( 'calypso_a8c_agency_tier_celebration_modal_dismiss', {
+				agency_tier: currentAgencyTier,
+			} )
+		);
+	};
+
+	const handleClickExploreBenefits = () => {
+		// Save the preference to prevent the modal from showing again
+		dispatch( savePreference( PREFERENCE_NAME, currentAgencyTier ?? '' ) );
+		dispatch(
+			recordTracksEvent( 'calypso_a8c_agency_tier_celebration_modal_explore_benefits_click', {
+				agency_tier: currentAgencyTier,
+			} )
+		);
 	};
 
 	const { title, description, extraDescription, benefits, video, image } =
@@ -109,7 +139,11 @@ export default function AgencyTierCelebrationModal( {
 				></div>
 			</div>
 			<div className="agency-tier-celebration-modal__footer">
-				<Button variant="primary" onClick={ handleOnClose } href={ A4A_AGENCY_TIER_LINK }>
+				<Button
+					variant="primary"
+					onClick={ handleClickExploreBenefits }
+					href={ A4A_AGENCY_TIER_LINK }
+				>
 					{ translate( 'Explore your benefits' ) }
 				</Button>
 			</div>

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
@@ -6,14 +6,16 @@ import { useTranslate } from 'i18n-calypso';
 import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import getAgencyTierInfo from 'calypso/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info';
 import { preventWidows } from 'calypso/lib/formatting';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AgencyTierCelebrationModal from './celebration-modal';
 
 import './style.scss';
 
 export default function OverviewSidebarAgencyTier() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const agency = useSelector( getActiveAgency );
 
@@ -58,7 +60,16 @@ export default function OverviewSidebarAgencyTier() {
 								{ currentAgencyTierInfo.description }
 							</div>
 						) }
-						<Button href={ A4A_AGENCY_TIER_LINK }>
+						<Button
+							href={ A4A_AGENCY_TIER_LINK }
+							onClick={ () =>
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_agency_tier_explore_tiers_and_benefits_click', {
+										agency_tier: currentAgencyTier,
+									} )
+								)
+							}
+						>
 							<Icon icon={ arrowRight } size={ 18 } />
 							{ translate( 'Explore tiers and benefits' ) }
 						</Button>


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1357

## Proposed Changes

This PR adds event tracking to agency tier changes.

## Why are these changes being made?

* To be able to track the events for the changes made for Agency Tier.

## Testing Instructions

- Open the A4A live link > Open the network tab on the browser dev tool > Filter `Img` and `a8c-for-agencies-development` text.

<img width="835" alt="Screenshot 2024-10-25 at 1 53 16 PM" src="https://github.com/user-attachments/assets/f0fdb22e-57e8-48e4-be15-10b44e65f713">

- Verify the below tracking events are being captured along with the props mentioned:

1) Widget on the overview page > Click the `Explore tiers and benefits` button 

<img width="437" alt="Screenshot 2024-10-25 at 2 04 56 PM" src="https://github.com/user-attachments/assets/7c239717-9e28-4848-aecf-13a88451fce2">

```
Event: calypso_a4a_agency_tier_explore_tiers_and_benefits_click
Props: agency_tier
```

2) Change the agency tier using the MC tool for the celebration to be shown

<img width="786" alt="Screenshot 2024-10-25 at 2 05 22 PM" src="https://github.com/user-attachments/assets/c28567df-4776-41cb-ba3d-83a1b279d3e6">

- When the modal is shown

```
Event: calypso_a8c_agency_tier_celebration_modal_shown
Props: agency_tier
```

- Click the `Explore your benefits` button

```
Event: calypso_a8c_agency_tier_celebration_modal_explore_benefits_click
Props: agency_tier
```

- Dismiss modal

```
Event: calypso_a8c_agency_tier_celebration_modal_dismiss
Props: agency_tier
```
3) Go to the Agency Tier Page:

- Click the `Learn more` button on the badge:

<img width="889" alt="Screenshot 2024-10-25 at 2 05 38 PM" src="https://github.com/user-attachments/assets/f204111a-3bf5-4c18-bb36-f9885d6b546b">

```
Event: calypso_a4a_agency_tier_badge_learn_more_click
Props: agency_tier
```

4) Click the `Download your badges` button (Only for Agency & Pro Agency)

- Button click

```
Event: calypso_a8c_agency_tier_badges_download_modal_open
```

5) Download badges (Only for Agency & Pro Agency)

<img width="795" alt="Screenshot 2024-10-25 at 2 06 07 PM" src="https://github.com/user-attachments/assets/857a9ae5-883a-46d7-b2ee-de81a3136b4a">

```
Event: calypso_a8c_agency_tier_badges_download_modal_download_click
Props: product, agency_tier: pro-agency-partner
```

6) Switch the tier type to Emerging partner or no tier > Go to Partner Directory

<img width="811" alt="Screenshot 2024-10-25 at 12 50 25 PM" src="https://github.com/user-attachments/assets/a6812393-4c4b-4862-8e90-92217f2088f5">

- When the error view is shown

```
Event: calypso_agency_tier_permission_error_view
Props: section
```

- Learn more button click

```
Event: calypso_agency_tier_permission_error_button_click
Props: section
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
