### PR TITLE
[Odie] Remove undefined when chatId is undefined from the URL

### DIFF
--- a/packages/odie-client/src/query/use-send-odie-message.ts
+++ b/packages/odie-client/src/query/use-send-odie-message.ts
@@ -24,15 +24,16 @@ export const useSendOdieMessage = () => {
 
 	return useMutation< Chat, Error, Message >( {
 		mutationFn: async ( message: Message ): Promise< Chat > => {
+			const chatIdSegment = chatId ? `/${ chatId }` : '';
 			const response = canAccessWpcomApis()
 				? await wpcomRequest( {
 						method: 'POST',
-						path: `/odie/chat/${ botNameSlug }/${ chatId }`,
+						path: `/odie/chat/${ botNameSlug }${ chatIdSegment }`,
 						apiNamespace: 'wpcom/v2',
 						body: { message: message.content, version, context: { selectedSiteId } },
 				  } )
 				: await apiFetch( {
-						path: `/help-center/odie/chat/${ botNameSlug }/${ chatId }`,
+						path: `/help-center/odie/chat/${ botNameSlug }${ chatIdSegment }`,
 						method: 'POST',
 						data: { message: message.content, version, context: { selectedSiteId } },
 				  } );


### PR DESCRIPTION
HapOps has discovered that new chats are failing. It happens due to send undefined in the url.

## Proposed Changes

Identidy if chatId is undefined, then adjust the url without it

## Why are these changes being made?

New users are not having live chat and being redirected directly to forums :( 

## Testing Instructions

- Create a new WordPress user
- Start a new conversation
- It should not fail :) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
