### PR TITLE
A4A > Agency Tier: Display only approved directories when downloading the badge

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -137,7 +137,8 @@ const useMainMenuItems = ( path: string ) => {
 						},
 				  ]
 				: [] ),
-			...( config.isEnabled( 'a4a-partner-directory' )
+			...( config.isEnabled( 'a4a-partner-directory' ) ||
+			config.isEnabled( 'a8c-for-agencies-agency-tier' )
 				? [
 						{
 							icon: commentAuthorAvatar,

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -138,8 +138,24 @@ export const isPathAllowedForTier = ( pathname: string, agency: Agency | null ) 
 		return false;
 	}
 
+	// featureConditions is used to check if the user has access to a specific feature
+	// Add the feature name and the condition to enable it according to MEMBER_TIER_ACCESSIBLE_PATHS
+	const featureConditions = {
+		a4a_feature_partner_directory: agency?.partner_directory.allowed,
+	};
+
+	const featuresSet = new Set( agency?.tier?.features || [] );
+
+	// Check if the user has extra capabilities
+	for ( const [ feature, condition ] of Object.entries( featureConditions ) ) {
+		if ( condition ) {
+			featuresSet.add( feature );
+		}
+	}
+
+	const features = Array.from( featuresSet );
+
 	// Check if the user has the required capability to access the current path
-	const features = agency?.tier?.features;
 	if ( features ) {
 		const permissions = MEMBER_TIER_ACCESSIBLE_PATHS?.[ pathname ];
 		if ( permissions ) {

--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
@@ -16,10 +16,7 @@ export default function DownloadBadges() {
 
 	const agency = useSelector( getActiveAgency );
 
-	const partnerDirectorties =
-		agency?.profile?.partner_directory_application?.directories.map(
-			( { directory } ) => directory
-		) ?? [];
+	const partnerDirectorties = agency?.partner_directory?.directories ?? [];
 
 	const currentAgencyTier = agency?.tier?.id;
 

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-permission-data.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-permission-data.tsx
@@ -23,7 +23,7 @@ const getTierPermissionData = (
 					translate( 'Access this benefit when you become an Agency Partner.' )
 				),
 				description: translate(
-					"Agency Partners and Pro Agency Partners can apply to be included in Automatic's directory listings."
+					"Agency Partners and Pro Agency Partners can apply to be included in Automattic's directory listings."
 				),
 				buttonProps: {
 					text: translate( 'Learn more' ),

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -103,7 +104,7 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 	}
 
 	// Check if the Partner Directory is allowed for the agency
-	if ( ! agency?.partner_directory_allowed ) {
+	if ( ! agency?.partner_directory.allowed && ! isEnabled( 'a8c-for-agencies-agency-tier' ) ) {
 		// Redirect user to the Overview page
 		page.redirect( A4A_OVERVIEW_LINK );
 		return;

--- a/client/state/a8c-for-agencies/agency/actions.ts
+++ b/client/state/a8c-for-agencies/agency/actions.ts
@@ -57,7 +57,7 @@ export function receiveAgencies( agencies: Agency[] ): AgencyThunkAction {
 			dispatch( setActiveAgency( newAgency ) );
 
 			// Enable the Partner Directory section
-			if ( ! config.isEnabled( 'a4a-partner-directory' ) && newAgency.partner_directory_allowed ) {
+			if ( ! config.isEnabled( 'a4a-partner-directory' ) && newAgency.partner_directory.allowed ) {
 				config.enable( 'a4a-partner-directory' );
 			}
 		}

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -71,7 +71,10 @@ export interface Agency {
 			is_published?: boolean;
 		};
 	};
-	partner_directory_allowed: boolean;
+	partner_directory: {
+		allowed: boolean;
+		directories: 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable'[];
+	};
 	user: {
 		role: 'a4a_administrator' | 'a4a_manager';
 		capabilities: string[];

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -1,5 +1,6 @@
 import { Action, AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
+import { DirectoryApplicationType } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
 import type { AgencyTier } from 'calypso/a8c-for-agencies/sections/agency-tier/types';
 
 export interface APIError {
@@ -62,7 +63,7 @@ export interface Agency {
 			status?: 'pending' | 'in-progress' | 'completed';
 			directories: {
 				status: 'pending' | 'approved' | 'rejected' | 'closed';
-				directory: 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable';
+				directory: DirectoryApplicationType;
 				urls: string[];
 				note: string;
 				is_published?: boolean;
@@ -73,7 +74,7 @@ export interface Agency {
 	};
 	partner_directory: {
 		allowed: boolean;
-		directories: 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable'[];
+		directories: DirectoryApplicationType[];
 	};
 	user: {
 		role: 'a4a_administrator' | 'a4a_manager';


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/95647

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1332

## Proposed Changes

This PR shows only approved directories for downloading the badges.

## Why are these changes being made?

* To display only approved directories when downloading the tier badges. 

## Testing Instructions

* Open the A4A live link
* Use the Partner Directory MC tool and reject all your directories. Go to the Agency MC tool and set the agency tier to Agency or Pro Agency.
* Go to the Agency Tier page > Verify the `Download your badges` is not shown.
* Approve a few directories and set the visibility to "shown" using the eye icon and refresh the UI. To be on the safer side, only do this for the Jetpack directory.
* On the UI,  verify that the `Download your badges` is shown > Click the button and verify the approved directories are displayed to be downloaded as shown below:

<img width="789" alt="Screenshot 2024-10-25 at 4 53 01 PM" src="https://github.com/user-attachments/assets/07716514-f243-4f04-8e44-714a129b1f46">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
