### PR TITLE
A4A > Agency Tier: Fix the celebration modal overflow logic on mobile screens.

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
@@ -144,7 +144,6 @@ const getAgencyTierInfo = (
 							"Advanced sales training sessions at request to sharpen your team's expertise."
 						),
 						translate( "Access to pre-qualified leads provided by Automattic's sales teams." ),
-						translate( "Access to pre-qualified leads provided by Automattic's sales teams." ),
 						translate( 'Co-marketing opportunities.' ),
 						translate( 'Access to the Automattic for Agencies advisory board.' ),
 					],

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal.tsx
@@ -14,6 +14,12 @@ import type { AgencyTierInfo } from 'calypso/a8c-for-agencies/sections/agency-ti
 
 // Style is imported from the parent component
 
+// Make sure to update the CSS values if you change the block padding or image height
+const BLOCK_PADDING = 98; // 48px * 2
+const IMAGE_HEIGHT = 260;
+const MARGIN_BLOCK_END = 20;
+const DEFAULT_MAX_HEIGHT = 300;
+
 const PREFERENCE_NAME = 'a4a-agency-tier-celebration-modal-dismissed-type';
 
 export default function AgencyTierCelebrationModal( {
@@ -39,9 +45,20 @@ export default function AgencyTierCelebrationModal( {
 
 		const checkVerticalOverflow = () => {
 			if ( currentRef ) {
-				const { scrollTop, scrollHeight, clientHeight } = currentRef;
+				const { scrollTop, scrollHeight } = currentRef;
+
+				const modalHeight =
+					document.querySelector( '.agency-tier-celebration-modal' )?.clientHeight ?? 0;
+
+				const maxHeight = isNarrowView
+					? modalHeight - ( IMAGE_HEIGHT + BLOCK_PADDING + MARGIN_BLOCK_END )
+					: DEFAULT_MAX_HEIGHT;
+
+				currentRef.style.maxHeight = `${ maxHeight }px`;
+				currentRef.style.marginBlockEnd = `${ MARGIN_BLOCK_END }px`;
+
 				// Determine if the user is at the bottom of the list (allow some leeway with a small threshold)
-				if ( scrollHeight > clientHeight && scrollTop < scrollHeight - clientHeight - 1 ) {
+				if ( scrollHeight > maxHeight && scrollTop < scrollHeight - maxHeight - 1 ) {
 					setIsOverflowing( true );
 				} else {
 					setIsOverflowing( false );
@@ -56,7 +73,7 @@ export default function AgencyTierCelebrationModal( {
 		return () => {
 			currentRef?.removeEventListener( 'scroll', checkVerticalOverflow );
 		};
-	}, [] );
+	}, [ isNarrowView ] );
 
 	// Record the event when the modal is shown
 	useEffect( () => {

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
@@ -79,6 +79,10 @@ $video-green: #0e5837;
 }
 
 .agency-tier-celebration-modal {
+	&.a4a-themed-modal .components-modal__content.hide-header {
+		padding: 0;
+	}
+
 	&.emerging-partner {
 
 		&.a4a-themed-modal .components-modal__content.hide-header {
@@ -99,10 +103,6 @@ $video-green: #0e5837;
 		}
 	}
 
-	&.a4a-themed-modal .components-modal__content.hide-header {
-		padding: 0;
-	}
-
 	&.is-narrow-view {
 		display: block;
 		border-radius: 0;
@@ -111,20 +111,25 @@ $video-green: #0e5837;
 			flex-direction: column;
 		}
 
+		.a4a-themed-modal__sidebar-image {
+			// Make sure to update the IMAGE_HEIGHT in the index.tsx file when changing the height
+			height: 260px;
+		}
+
 		.a4a-themed-modal__content {
 			margin: -2px 0;
+			// Make sure to update the BLOCK_PADDING in the index.tsx file when changing the padding
 			padding: 48px 32px;
 			border-radius: 4px 4px 0 0;
 		}
 
-		.agency-tier-celebration-modal__content-wrapper .agency-tier-celebration-modal__content {
-			max-height: 250px;
-		}
+		&.a4a-themed-modal {
+			min-height: 100vh;
 
-		&.a4a-themed-modal .components-modal__content.hide-header {
-			border-radius: 0;
+			.components-modal__content.hide-header {
+				border-radius: 0;
+			}
 		}
-
 		.agency-tier-celebration-modal__footer {
 			position: absolute;
 			inset-block-end: 16px;
@@ -144,7 +149,6 @@ $video-green: #0e5837;
 		display: flex;
 		flex-direction: column;
 		padding-block-end: 16px;
-		max-height: 450px;
 	}
 
 	.a4a-themed-modal__sidebar-image-container {
@@ -161,8 +165,6 @@ $video-green: #0e5837;
 			display: flex;
 			gap: 16px;
 			flex-direction: column;
-			max-height: 310px;
-			margin-block-end: 16px;
 			overflow-y: auto;
 
 			.agency-tier-celebration-modal__title {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1367

## Proposed Changes

This PR fixes the celebration modal UI on mobile devices.

## Why are these changes being made?

* To fix the celebration modal UI on mobile devices.

## Testing Instructions

1) Update your agency tier to Emerging Partner using the MC tool > Open the A4A live link > Go to the Overview page.
2) Switch to mobile view using the dev tool > Use different mobile views and verify that all devices look good. Also, verify that the tablet view and desktop view look good. You should see a faded horizontal div when the content is overflowing, which disappears when scrolled to the bottom.

<img width="273" alt="Screenshot 2024-10-28 at 8 49 25 AM" src="https://github.com/user-attachments/assets/7a6e4632-7f67-429e-9ac5-55c6dffc7297">

<img width="374" alt="Screenshot 2024-10-28 at 8 49 08 AM" src="https://github.com/user-attachments/assets/120fca9e-e4c2-4b21-b517-48e21d77dbf1">

3) Update your agency tier to Agency Partner using the MC tool > Refresh the overview page > Repeat step 2 and verify everything works as expected.

4) Update your agency tier to Pro Agency Partner using the MC tool > Refresh the overview page > Repeat step 2 and verify everything works as expected.

<img width="865" alt="Screenshot 2024-10-28 at 9 15 52 AM" src="https://github.com/user-attachments/assets/5c10fe4d-aabb-44cb-9bf2-cb39446f64d6">

<img width="812" alt="Screenshot 2024-10-28 at 9 16 52 AM" src="https://github.com/user-attachments/assets/19379070-f56e-45a8-8ec2-05ab89efb450">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
