### PR TITLE
Revert "Reader: Ensure URL Scheme in Subscription List Component"

### DIFF
--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -96,7 +96,6 @@ class ConnectedSubscriptionListItem extends Component {
 export default compose(
 	connect( ( state, ownProps ) => ( {
 		isFollowing: isFollowingSelector( state, { feedId: ownProps.feedId, blogId: ownProps.siteId } ),
-		url: ownProps.url.match( /^https?:\/\// ) ? ownProps.url : `http://${ ownProps.url }`,
 	} ) ),
 	connectSite
 )( ConnectedSubscriptionListItem );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#95676 to fix Reader > Search loading a blank screen.