### PR TITLE
Reader: Check that URL exists before updating it

### DIFF
--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -94,8 +94,19 @@ class ConnectedSubscriptionListItem extends Component {
 }
 
 export default compose(
-	connect( ( state, ownProps ) => ( {
-		isFollowing: isFollowingSelector( state, { feedId: ownProps.feedId, blogId: ownProps.siteId } ),
-	} ) ),
+	connect( ( state, ownProps ) => {
+		let url = '';
+		if ( ownProps.url ) {
+			url = ownProps.url.match( /^https?:\/\// ) ? ownProps.url : `http://${ ownProps.url }`;
+		}
+
+		return {
+			isFollowing: isFollowingSelector( state, {
+				feedId: ownProps.feedId,
+				blogId: ownProps.siteId,
+			} ),
+			url: url,
+		};
+	} ),
 	connectSite
 )( ConnectedSubscriptionListItem );

--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -93,20 +93,20 @@ class ConnectedSubscriptionListItem extends Component {
 	}
 }
 
-export default compose(
-	connect( ( state, ownProps ) => {
-		let url = '';
-		if ( ownProps.url ) {
-			url = ownProps.url.match( /^https?:\/\// ) ? ownProps.url : `http://${ ownProps.url }`;
-		}
+const normalizeUrl = ( url ) => {
+	if ( ! url ) {
+		return '';
+	}
+	return url.match( /^https?:\/\// ) ? url : `http://${ url }`;
+};
 
-		return {
-			isFollowing: isFollowingSelector( state, {
-				feedId: ownProps.feedId,
-				blogId: ownProps.siteId,
-			} ),
-			url: url,
-		};
-	} ),
+export default compose(
+	connect( ( state, ownProps ) => ( {
+		isFollowing: isFollowingSelector( state, {
+			feedId: ownProps.feedId ?? null,
+			blogId: ownProps.siteId ?? null,
+		} ),
+		url: normalizeUrl( ownProps.url ?? '' ),
+	} ) ),
 	connectSite
 )( ConnectedSubscriptionListItem );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/95676

## Proposed Changes

* Followup to https://github.com/Automattic/wp-calypso/pull/95676
* This PR checks if the URL exists before updating it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Patches an issue https://github.com/Automattic/wp-calypso/pull/95676

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read/search and make sure you can search for a term
* Check that the test instructions on https://github.com/Automattic/wp-calypso/pull/95676 work

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
