### PR TITLE
Tailored onboarding: Add a domain step to new-hosted-site flow

### DIFF
--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -65,6 +65,7 @@ const hosting: Flow = {
 
 		const query = useQuery();
 		const queryParams = Object.fromEntries( query );
+		const plan = queryParams.plan;
 		const flowName = this.name;
 
 		const goBack = () => {
@@ -83,6 +84,9 @@ const hosting: Flow = {
 
 			switch ( _currentStepSlug ) {
 				case 'domains': {
+					if ( plan ) {
+						return navigate( 'createSite', { plan } );
+					}
 					return navigate( 'plans' );
 				}
 				case 'plans': {

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -1,8 +1,8 @@
 import { isFreeHostingTrial } from '@automattic/calypso-products';
 import { NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { addQueryArgs, getQueryArgs } from '@wordpress/url';
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { addQueryArgs } from '@wordpress/url';
+import { useEffect, useLayoutEffect } from 'react';
 import { recordFreeHostingTrialStarted } from 'calypso/lib/analytics/ad-tracking/ad-track-trial-start';
 import {
 	setSignupCompleteSlug,
@@ -33,7 +33,7 @@ const hosting: Flow = {
 				? [
 						{
 							slug: 'domains',
-							asyncComponent: () => import( './internals/steps-repository/unified-domains' ),
+							asyncComponent: () => import( './internals/steps-repository/domains' ),
 						},
 				  ]
 				: [] ),
@@ -53,34 +53,15 @@ const hosting: Flow = {
 		];
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
-		const {
-			setDomain,
-			setDomainCartItem,
-			setDomainCartItems,
-			setPlanCartItem,
-			setSiteUrl,
-			setSignupDomainOrigin,
-			resetCouponCode,
-		} = useDispatch( ONBOARD_STORE );
-
-		const { planCartItem, signupDomainOrigin } = useSelect(
-			( select: ( key: string ) => OnboardSelect ) => ( {
-				domainCartItem: select( ONBOARD_STORE ).getDomainCartItem(),
-				planCartItem: select( ONBOARD_STORE ).getPlanCartItem(),
-				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
-			} ),
+		const { setPlanCartItem, resetCouponCode } = useDispatch( ONBOARD_STORE );
+		const planCartItem = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 			[]
 		);
-
 		const couponCode = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getCouponCode(),
 			[]
 		);
-
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const [ _redirectedToUseMyDomain, setRedirectedToUseMyDomain ] = useState( false );
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const [ _useMyDomainQueryParams, setUseMyDomainTracksEventProps ] = useState( {} );
 
 		const query = useQuery();
 		const queryParams = Object.fromEntries( query );
@@ -101,38 +82,9 @@ const hosting: Flow = {
 			}
 
 			switch ( _currentStepSlug ) {
-				case 'domains':
-					setSiteUrl( providedDependencies.siteUrl );
-					setDomain( providedDependencies.suggestion );
-					setDomainCartItem( providedDependencies.domainItem );
-					setDomainCartItems( providedDependencies.domainCart );
-					setSignupDomainOrigin( providedDependencies.signupDomainOrigin );
-
-					if ( providedDependencies.navigateToUseMyDomain ) {
-						const currentQueryArgs = getQueryArgs( window.location.href );
-						currentQueryArgs.step = 'domain-input';
-
-						setRedirectedToUseMyDomain( true );
-						let useMyDomainURL = addQueryArgs( `/use-my-domain`, currentQueryArgs );
-
-						const lastQueryParam = ( providedDependencies?.domainForm as { lastQuery?: string } )
-							?.lastQuery;
-
-						if ( lastQueryParam !== undefined ) {
-							currentQueryArgs.initialQuery = lastQueryParam;
-							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
-						}
-
-						setUseMyDomainTracksEventProps( {
-							site_url: providedDependencies.siteUrl,
-							signup_domain_origin: signupDomainOrigin,
-							domain_item: providedDependencies.domainItem,
-						} );
-						return navigate( useMyDomainURL );
-					}
-
-					setRedirectedToUseMyDomain( false );
+				case 'domains': {
 					return navigate( 'plans' );
+				}
 				case 'plans': {
 					const productSlug = ( providedDependencies.plan as MinimalRequestCartProduct )
 						.product_slug;

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -22,14 +22,19 @@ import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import './internals/new-hosted-site-flow.scss';
 
+function useShowDomainStep(): boolean {
+	const query = useQuery();
+	const showDomainStepValue = query.get( 'showDomainStep' );
+	return showDomainStepValue !== null && showDomainStepValue.toLowerCase() !== 'false';
+}
+
 const hosting: Flow = {
 	name: NEW_HOSTED_SITE_FLOW,
 	isSignupFlow: true,
 	useSteps() {
-		const query = useQuery();
-		const isPatnerBundle = query.has( 'partnerBundle' );
+		const showDomainStep = useShowDomainStep();
 		return [
-			...( isPatnerBundle
+			...( showDomainStep
 				? [
 						{
 							slug: 'domains',
@@ -67,10 +72,14 @@ const hosting: Flow = {
 		const queryParams = Object.fromEntries( query );
 		const plan = queryParams.plan;
 		const flowName = this.name;
+		const showDomainStep = useShowDomainStep();
 
 		const goBack = () => {
 			if ( _currentStepSlug === 'plans' ) {
-				return window.location.assign( '/sites?hosting-flow=true' );
+				if ( ! showDomainStep ) {
+					return window.location.assign( '/sites?hosting-flow=true' );
+				}
+				return navigate( 'domains' );
 			}
 			if ( _currentStepSlug === 'trialAcknowledge' ) {
 				navigate( 'plans' );
@@ -84,6 +93,7 @@ const hosting: Flow = {
 
 			switch ( _currentStepSlug ) {
 				case 'domains': {
+					// If the plan is already supplied as a query param, add it to cart, and skip plans step
 					if ( plan && isDotComPlan( { product_slug: plan } ) ) {
 						setPlanCartItem( {
 							product_slug: plan,

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -24,8 +24,7 @@ import './internals/new-hosted-site-flow.scss';
 
 function useShowDomainStep(): boolean {
 	const query = useQuery();
-	const showDomainStepValue = query.get( 'showDomainStep' );
-	return showDomainStepValue !== null && showDomainStepValue.toLowerCase() !== 'false';
+	return query.has( 'showDomainStep' );
 }
 
 const hosting: Flow = {

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -1,8 +1,8 @@
 import { isFreeHostingTrial } from '@automattic/calypso-products';
 import { NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
-import { useEffect, useLayoutEffect } from 'react';
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { recordFreeHostingTrialStarted } from 'calypso/lib/analytics/ad-tracking/ad-track-trial-start';
 import {
 	setSignupCompleteSlug,
@@ -53,15 +53,34 @@ const hosting: Flow = {
 		];
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
-		const { setPlanCartItem, resetCouponCode } = useDispatch( ONBOARD_STORE );
-		const planCartItem = useSelect(
-			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
+		const {
+			setDomain,
+			setDomainCartItem,
+			setDomainCartItems,
+			setPlanCartItem,
+			setSiteUrl,
+			setSignupDomainOrigin,
+			resetCouponCode,
+		} = useDispatch( ONBOARD_STORE );
+
+		const { planCartItem, signupDomainOrigin } = useSelect(
+			( select: ( key: string ) => OnboardSelect ) => ( {
+				domainCartItem: select( ONBOARD_STORE ).getDomainCartItem(),
+				planCartItem: select( ONBOARD_STORE ).getPlanCartItem(),
+				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
+			} ),
 			[]
 		);
+
 		const couponCode = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getCouponCode(),
 			[]
 		);
+
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const [ _redirectedToUseMyDomain, setRedirectedToUseMyDomain ] = useState( false );
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const [ _useMyDomainQueryParams, setUseMyDomainTracksEventProps ] = useState( {} );
 
 		const query = useQuery();
 		const queryParams = Object.fromEntries( query );
@@ -82,6 +101,38 @@ const hosting: Flow = {
 			}
 
 			switch ( _currentStepSlug ) {
+				case 'domains':
+					setSiteUrl( providedDependencies.siteUrl );
+					setDomain( providedDependencies.suggestion );
+					setDomainCartItem( providedDependencies.domainItem );
+					setDomainCartItems( providedDependencies.domainCart );
+					setSignupDomainOrigin( providedDependencies.signupDomainOrigin );
+
+					if ( providedDependencies.navigateToUseMyDomain ) {
+						const currentQueryArgs = getQueryArgs( window.location.href );
+						currentQueryArgs.step = 'domain-input';
+
+						setRedirectedToUseMyDomain( true );
+						let useMyDomainURL = addQueryArgs( `/use-my-domain`, currentQueryArgs );
+
+						const lastQueryParam = ( providedDependencies?.domainForm as { lastQuery?: string } )
+							?.lastQuery;
+
+						if ( lastQueryParam !== undefined ) {
+							currentQueryArgs.initialQuery = lastQueryParam;
+							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
+						}
+
+						setUseMyDomainTracksEventProps( {
+							site_url: providedDependencies.siteUrl,
+							signup_domain_origin: signupDomainOrigin,
+							domain_item: providedDependencies.domainItem,
+						} );
+						return navigate( useMyDomainURL );
+					}
+
+					setRedirectedToUseMyDomain( false );
+					return navigate( 'plans' );
 				case 'plans': {
 					const productSlug = ( providedDependencies.plan as MinimalRequestCartProduct )
 						.product_slug;

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -26,7 +26,17 @@ const hosting: Flow = {
 	name: NEW_HOSTED_SITE_FLOW,
 	isSignupFlow: true,
 	useSteps() {
+		const query = useQuery();
+		const isPatnerBundle = query.has( 'partnerBundle' );
 		return [
+			...( isPatnerBundle
+				? [
+						{
+							slug: 'domains',
+							asyncComponent: () => import( './internals/steps-repository/unified-domains' ),
+						},
+				  ]
+				: [] ),
 			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },
 			{
 				slug: 'trialAcknowledge',

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -76,10 +76,10 @@ const hosting: Flow = {
 
 		const goBack = () => {
 			if ( _currentStepSlug === 'plans' ) {
-				if ( ! showDomainStep ) {
-					return window.location.assign( '/sites?hosting-flow=true' );
+				if ( showDomainStep ) {
+					return navigate( 'domains' );
 				}
-				return navigate( 'domains' );
+				return window.location.assign( '/sites?hosting-flow=true' );
 			}
 			if ( _currentStepSlug === 'trialAcknowledge' ) {
 				navigate( 'plans' );

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -1,4 +1,4 @@
-import { isFreeHostingTrial } from '@automattic/calypso-products';
+import { isFreeHostingTrial, isDotComPlan } from '@automattic/calypso-products';
 import { NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -84,8 +84,7 @@ const hosting: Flow = {
 
 			switch ( _currentStepSlug ) {
 				case 'domains': {
-					// TODO: This needs validation to ensure the plan is valid.
-					if ( plan ) {
+					if ( plan && isDotComPlan( { product_slug: plan } ) ) {
 						setPlanCartItem( {
 							product_slug: plan,
 						} );

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -84,8 +84,12 @@ const hosting: Flow = {
 
 			switch ( _currentStepSlug ) {
 				case 'domains': {
+					// TODO: This needs validation to ensure the plan is valid.
 					if ( plan ) {
-						return navigate( 'createSite', { plan } );
+						setPlanCartItem( {
+							product_slug: plan,
+						} );
+						return navigate( 'createSite' );
 					}
 					return navigate( 'plans' );
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9448

Further context: 
- peRNfl-14g-p2#comment-1399
- p1729842141508079/1729787350.512219-slack-C02JPCHEKDY

## Proposed Changes

* Add a conditional step to `new-hosted-site` flow that will display the `domains` step if the `showDomainStep` query param exists
* Creates the site and adds a plan to the cart if the `plan` query param exists

https://github.com/user-attachments/assets/8826ca76-4c60-41f9-b25e-75dbd62211f9

## Why are these changes being made?




<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To create a proper flow for the user during the affiliate onboarding as per peRNfl-14g-p2#comment-1399
 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Navigate to the `new-hosted-site` flow adding  `partnerBundle`, `showDomainStep` and the `plan` query params, for example `/setup/new-hosted-site?partnerBundle=myNewAmazingBundle&plan=business-bundle&showDomainStep` or `/setup/new-hosted-site?partnerBundle=myNewAmazingBundle&plan=ecommerce-bundle&showDomainStep`
* Select a domain and click next
* Check the site is created and the checkout screen displays with the correct plan added



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?