### PR TITLE
Paid subscriber importer: restructure "action required"

### DIFF
--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -83,7 +83,7 @@ export default function Summary( {
 					<h2>{ __( 'Action required' ) }</h2>
 					{ createInterpolateElement(
 						__(
-							'To prevent any charges from Substack, go to your <substackPaymentsSettingsLink>Substack Payments Settings</substackPaymentsSettingsLink>, select "Pause billing" and click "<strong>Pause indefinitely</strong>".'
+							'To prevent double-charging your subscribers, go to your <substackPaymentsSettingsLink>Substack Payments Settings</substackPaymentsSettingsLink>, click <strong>"Pause"</strong> under "Pause subscription billing". In the pop-up, chosoe "<strong>Pause indefinitely</strong>".'
 						),
 						{
 							strong: <strong />,
@@ -97,11 +97,14 @@ export default function Summary( {
 							),
 						}
 					) }
-					<img
-						src={ pauseSubstackBillingImg }
-						alt={ __( 'Pause Substack billing' ) }
-						className="pause-billing"
-					/>
+					<details>
+						<summary>{ __( 'Show me how' ) }</summary>
+						<img
+							src={ pauseSubstackBillingImg }
+							alt={ __( 'Pause Substack billing' ) }
+							className="pause-billing"
+						/>
+					</details>
 				</Notice>
 			) }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/95722

**Before**
<img width="893" alt="image" src="https://github.com/user-attachments/assets/4768bfb0-35e2-4ca9-b743-4ecf7087906c">


**After**
<img width="621" alt="image" src="https://github.com/user-attachments/assets/0092bdae-d93a-4344-9f52-25123a7e58b6">


## Proposed Changes

* Update copy
* Add "show me how" toggle around the instructional image
* Add checkbox which allows you to continue to the final summary

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
