### PR TITLE
Substack importer: copy updates for summary step

### DIFF
--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -1,8 +1,9 @@
 import { Card, ConfettiAnimation } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { ExternalLink, Notice } from '@wordpress/components';
+import { useReducedMotion } from '@wordpress/compose';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import pauseSubstackBillingImg from 'calypso/assets/images/importer/pause-substack-billing.png';
@@ -46,7 +47,7 @@ export default function Summary( {
 }: SummaryProps ) {
 	const { __ } = useI18n();
 	const { resetPaidNewsletter } = useResetMutation();
-	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+	const prefersReducedMotion = useReducedMotion();
 
 	const onButtonClick = () => resetPaidNewsletter( selectedSite.ID, engine, 'content' );
 	const paidSubscribersCount = parseInt(
@@ -66,6 +67,16 @@ export default function Summary( {
 		<Card>
 			{ showConfetti && <ConfettiAnimation trigger={ ! prefersReducedMotion } /> }
 			<h2>{ getStepTitle( importerStatus ) }</h2>
+
+			{ importerStatus === 'done' && (
+				<p>
+					{ sprintf(
+						// translators: %s is the site name
+						__( 'This is what you’ve succesfully imported to %s:' ),
+						selectedSite.slug
+					) }
+				</p>
+			) }
 
 			{ steps.content.content && (
 				<ContentSummary stepContent={ steps.content.content } status={ steps.content.status } />

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -1,70 +1,8 @@
 import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { Icon, post } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { ContentStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
-
-function getSummaryCopy( postsNumber: number, pagesNumber: number, attachmentsNumber: number ) {
-	if ( postsNumber > 0 && pagesNumber > 0 && attachmentsNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } posts</strong>, <strong>{ pagesNumber } pages</strong>{ ' ' }
-				and
-				<strong>{ attachmentsNumber } media</strong>.
-			</>
-		);
-	}
-
-	if ( postsNumber > 0 && pagesNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } posts</strong> and{ ' ' }
-				<strong>{ pagesNumber } pages</strong>.
-			</>
-		);
-	}
-
-	if ( postsNumber > 0 && attachmentsNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } posts</strong> and{ ' ' }
-				<strong>{ attachmentsNumber } media</strong>.
-			</>
-		);
-	}
-
-	if ( pagesNumber > 0 && attachmentsNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber }</strong> pages and{ ' ' }
-				<strong>{ attachmentsNumber } media</strong>.
-			</>
-		);
-	}
-
-	if ( postsNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } posts</strong>.
-			</>
-		);
-	}
-
-	if ( pagesNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } pages</strong>.
-			</>
-		);
-	}
-
-	if ( attachmentsNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } media</strong>.
-			</>
-		);
-	}
-}
 
 interface ContentSummaryProps {
 	stepContent: ContentStepContent;
@@ -72,7 +10,7 @@ interface ContentSummaryProps {
 }
 
 export default function ContentSummary( { status, stepContent }: ContentSummaryProps ) {
-	const { __ } = useI18n();
+	const { __, _n } = useI18n();
 	if ( status === 'skipped' ) {
 		return (
 			<div className="summary__content">
@@ -102,17 +40,44 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 
 	if ( status === 'done' ) {
 		const progress = stepContent.progress;
+		const postsNumber = progress.post.completed;
+		const pagesNumber = progress.page.completed;
+		const attachmentsNumber = progress.attachment.completed;
 
 		return (
 			<div className="summary__content">
-				<p>
-					<Icon icon={ post } />
-					{ getSummaryCopy(
-						progress.post.completed,
-						progress.page.completed,
-						progress.attachment.completed
+				<ul>
+					{ postsNumber > 0 && (
+						<li>
+							<Icon icon={ post } />
+							{ sprintf(
+								// translators: %d is the post count
+								_n( '%d post', '%d posts', postsNumber ),
+								postsNumber
+							) }
+						</li>
 					) }
-				</p>
+					{ pagesNumber > 0 && (
+						<li>
+							<Icon icon={ post } />
+							{ sprintf(
+								// translators: %d is the page count
+								_n( '%d page', '%d pages', pagesNumber ),
+								pagesNumber
+							) }
+						</li>
+					) }
+					{ attachmentsNumber > 0 && (
+						<li>
+							<Icon icon={ post } />
+							{ sprintf(
+								// translators: %d is the media count
+								_n( '%d media', '%d media', attachmentsNumber ),
+								attachmentsNumber
+							) }
+						</li>
+					) }
+				</ul>
 			</div>
 		);
 	}

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,5 +1,7 @@
 import { ProgressBar } from '@wordpress/components';
-import { Icon, people, atSymbol, payment, info, warning } from '@wordpress/icons';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
+import { Icon, people, info, payment, atSymbol } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
@@ -9,12 +11,15 @@ interface SubscriberSummaryProps {
 }
 
 export default function SubscriberSummary( { stepContent, status }: SubscriberSummaryProps ) {
-	const { __ } = useI18n();
+	const { __, _n } = useI18n();
 	if ( status === 'skipped' ) {
 		return (
 			<div className="summary__content">
 				<p>
-					<Icon icon={ atSymbol } /> You <strong>skipped</strong> subscriber importing.
+					<Icon icon={ atSymbol } />
+					{ createInterpolateElement( __( 'You <strong>skipped</strong> subscriber importing.' ), {
+						strong: <strong />,
+					} ) }
 				</p>
 			</div>
 		);
@@ -56,44 +61,127 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 			<>
 				<div className="summary__content">
 					<p>
-						<Icon icon={ atSymbol } /> We imported { subscribedCount } subscribers, where:
+						<Icon icon={ atSymbol } />{ ' ' }
+						{ sprintf(
+							// translators: %d is the subscriber count
+							_n( '%d subscriber, where:', '%d subscribers, where:', subscribedCount ),
+							subscribedCount
+						) }
 					</p>
 				</div>
 				<div className="summary__content summary__content-indent">
 					{ !! addedFree && (
 						<p>
 							<Icon icon={ people } />
-							<strong>{ addedFree }</strong> free subscribers.
+							{ createInterpolateElement(
+								sprintf(
+									// translators: %d is the subscriber count
+									_n(
+										'<strong>%d</strong> is free subscriber',
+										'<strong>%d</strong> are free subscribers',
+										addedFree
+									),
+									addedFree
+								),
+								{
+									strong: <strong />,
+								}
+							) }
 						</p>
 					) }
 					{ !! addedPaid && (
 						<p>
 							<Icon icon={ payment } />
-							<strong>{ addedPaid }</strong> paid subscribers added.
+							{ createInterpolateElement(
+								sprintf(
+									// translators: %d is the subscriber count
+									_n(
+										'<strong>%d</strong> is paid subscriber',
+										'<strong>%d</strong> are paid subscribers',
+										addedPaid
+									),
+									addedPaid
+								),
+								{
+									strong: <strong />,
+								}
+							) }
 						</p>
 					) }
 					{ !! existingFree && (
 						<p>
-							<Icon icon={ info } />
-							<strong>{ existingFree }</strong> existing subscribers.
+							<Icon icon={ people } />
+							{ createInterpolateElement(
+								sprintf(
+									// translators: %d is the subscriber count
+									_n(
+										'<strong>%d</strong> is existing free subscriber',
+										'<strong>%d</strong> are existing free subscribers',
+										existingFree
+									),
+									existingFree
+								),
+								{
+									strong: <strong />,
+								}
+							) }
 						</p>
 					) }
 					{ !! existingPaid && (
 						<p>
-							<Icon icon={ info } />
-							<strong>{ existingPaid }</strong> existing paid subscribers.
+							<Icon icon={ payment } />
+							{ createInterpolateElement(
+								sprintf(
+									// translators: %d is the subscriber count
+									_n(
+										'<strong>%d</strong> is existing paid subscriber',
+										'<strong>%d</strong> are existing paid subscribers',
+										existingPaid
+									),
+									existingPaid
+								),
+								{
+									strong: <strong />,
+								}
+							) }
 						</p>
 					) }
 					{ !! failedFree && (
 						<p>
-							<Icon icon={ warning } />
-							<strong>{ failedFree }</strong> error in the email format.
+							<Icon icon={ info } />
+							{ createInterpolateElement(
+								sprintf(
+									// translators: %d is the subscriber count
+									_n(
+										'<strong>%d</strong> free subscriber was not imported because they had error in the email format',
+										'<strong>%d</strong> free subscribers were not imported because they had error in the email format',
+										failedFree
+									),
+									failedFree
+								),
+								{
+									strong: <strong />,
+								}
+							) }
 						</p>
 					) }
 					{ !! failedPaid && (
 						<p>
-							<Icon icon={ warning } />
-							<strong>{ failedPaid }</strong> error in the email format.
+							<Icon icon={ info } />
+							{ createInterpolateElement(
+								sprintf(
+									// translators: %d is the subscriber count
+									_n(
+										'<strong>%d</strong> paid subscriber was not imported because they had error in the email format',
+										'<strong>%d</strong> paid subscribers were not imported because they had error in the email format',
+										failedFree
+									),
+									failedFree
+								),
+								{
+									strong: <strong />,
+								}
+							) }
 						</p>
 					) }
 				</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

<img width="895" alt="image" src="https://github.com/user-attachments/assets/e62ac387-23fb-4750-8f16-8a7090d0b118">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
