### PR TITLE
Cleanup: Remove old unused feature flags

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -166,8 +166,6 @@
 		"performance-profiler/logged-in": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/pro-plan": false,
-		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/multisite-scheduled-updates": true,

--- a/config/development.json
+++ b/config/development.json
@@ -106,7 +106,6 @@
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,
-		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jitms": true,
 		"lasagna": true,
 		"launchpad-updates": true,

--- a/config/development.json
+++ b/config/development.json
@@ -84,7 +84,6 @@
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,
-		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/ai-logo-generator": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-contents-page": true,

--- a/config/development.json
+++ b/config/development.json
@@ -216,7 +216,6 @@
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,
-		"themes/subscription-purchases": true,
 		"themes/text-search-lots": true,
 		"themes/assembler-first": true,
 		"titan/iframe-control-panel": false,

--- a/config/development.json
+++ b/config/development.json
@@ -40,7 +40,6 @@
 		"calypso/ai-assembler": true,
 		"calypso/big-sky": true,
 		"calypso/help-center": true,
-		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,

--- a/config/development.json
+++ b/config/development.json
@@ -175,7 +175,6 @@
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,
 		"press-this": true,
-		"promote-post/widget-i2": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,

--- a/config/development.json
+++ b/config/development.json
@@ -108,7 +108,6 @@
 		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
-		"launchpad-updates": true,
 		"launchpad/navigator": false,
 		"launchpad/new-task-definition-parser": true,
 		"launchpad/new-task-definition-parser/free": true,

--- a/config/development.json
+++ b/config/development.json
@@ -208,7 +208,6 @@
 		"stats/empty-module-v2": true,
 		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
-		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/development.json
+++ b/config/development.json
@@ -166,7 +166,6 @@
 		"performance-profiler/logged-in": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,

--- a/config/development.json
+++ b/config/development.json
@@ -103,7 +103,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": true,
-		"jetpack/simplify-pricing-structure": false,
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -62,7 +62,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
-		"jetpack/simplify-pricing-structure": false,
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -47,7 +47,6 @@
 		"importers/newsletter": false,
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
-		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/ai-logo-generator": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -140,7 +140,6 @@
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,
-		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
 		"themes/assembler-first": true,
 		"two-factor/enhanced-security": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -67,7 +67,6 @@
 		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
-		"launchpad-updates": false,
 		"launchpad/navigator": false,
 		"launchpad/new-task-definition-parser": true,
 		"layout/app-banner": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -18,7 +18,6 @@
 		"calypso/ai-assembler": true,
 		"calypso/big-sky": true,
 		"calypso/help-center": true,
-		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/ebanx-pix": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -105,7 +105,6 @@
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": false,
 		"press-this": true,
-		"promote-post/widget-i2": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -132,7 +132,6 @@
 		"stats/empty-module-v2": true,
 		"stats/new-date-filtering": false,
 		"stats/paid-wpcom-v2": true,
-		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -96,8 +96,6 @@
 		"pattern-assembler/v2": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/pro-plan": false,
-		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/multisite-scheduled-updates": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -96,7 +96,6 @@
 		"pattern-assembler/v2": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -63,7 +63,6 @@
 		"jetpack/manage-sites-v2-menu": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
-		"jetpack/simplify-pricing-structure": false,
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/url-only-connection": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -57,7 +57,6 @@
 		"jetpack/manage-sites-v2-menu": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
-		"jetpack/simplify-pricing-structure": false,
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/streamline-license-purchases": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -58,7 +58,6 @@
 		"jetpack/manage-simple-sites": true,
 		"jetpack/manage-sites-v2-menu": false,
 		"jetpack/server-credentials-advanced-flow": true,
-		"jetpack/simplify-pricing-structure": false,
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/streamline-license-purchases": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -59,7 +59,6 @@
 		"jetpack/pro-dashboard-wpcom-atomic-hosting": true,
 		"jetpack/manage-simple-sites": true,
 		"jetpack/server-credentials-advanced-flow": true,
-		"jetpack/simplify-pricing-structure": false,
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/url-only-connection": true,

--- a/config/production.json
+++ b/config/production.json
@@ -135,8 +135,6 @@
 		"performance-profiler/logged-in": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/pro-plan": false,
-		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/multisite-scheduled-updates": true,

--- a/config/production.json
+++ b/config/production.json
@@ -144,7 +144,6 @@
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": false,
 		"press-this": true,
-		"promote-post/widget-i2": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,

--- a/config/production.json
+++ b/config/production.json
@@ -31,7 +31,6 @@
 		"calypso/big-sky": false,
 		"bilmur-script": true,
 		"calypso/help-center": true,
-		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/ebanx-pix": true,

--- a/config/production.json
+++ b/config/production.json
@@ -184,7 +184,6 @@
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,
-		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
 		"themes/assembler-first": true,
 		"upgrades/redirect-payments": true,

--- a/config/production.json
+++ b/config/production.json
@@ -62,7 +62,6 @@
 		"is_running_in_jetpack_site": false,
 		"is_running_in_woo_site": false,
 		"jetpack/agency-dashboard": true,
-		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/ai-logo-generator": true,
 		"jetpack/api-cache": false,
 		"jetpack/backup-messaging-i3": true,

--- a/config/production.json
+++ b/config/production.json
@@ -79,7 +79,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
-		"jetpack/simplify-pricing-structure": false,
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": false,

--- a/config/production.json
+++ b/config/production.json
@@ -81,7 +81,6 @@
 		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
-		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jitms": true,

--- a/config/production.json
+++ b/config/production.json
@@ -170,7 +170,6 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler/metrics": false,
-		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
 		"stats/empty-module-traffic": true,

--- a/config/production.json
+++ b/config/production.json
@@ -84,7 +84,6 @@
 		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
-		"launchpad-updates": false,
 		"launchpad/navigator": false,
 		"launchpad/new-task-definition-parser": true,
 		"launchpad/new-task-definition-parser/free": true,

--- a/config/production.json
+++ b/config/production.json
@@ -176,7 +176,6 @@
 		"stats/empty-module-v2": true,
 		"stats/new-date-filtering": false,
 		"stats/paid-wpcom-v2": true,
-		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -135,7 +135,6 @@
 		"performance-profiler/logged-in": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,

--- a/config/production.json
+++ b/config/production.json
@@ -82,7 +82,6 @@
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,
-		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jitms": true,
 		"lasagna": true,
 		"launchpad-updates": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -173,7 +173,6 @@
 		"stats/empty-module-v2": true,
 		"stats/new-date-filtering": false,
 		"stats/paid-wpcom-v2": true,
-		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -142,7 +142,6 @@
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,
 		"press-this": true,
-		"promote-post/widget-i2": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -79,7 +79,6 @@
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,
-		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jitms": true,
 		"lasagna": true,
 		"launchpad-updates": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -78,7 +78,6 @@
 		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
-		"jetpack-social/advanced-plan": true,
 		"jetpack/offer-complete-after-activation": false,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jitms": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -81,7 +81,6 @@
 		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
-		"launchpad-updates": false,
 		"launchpad/navigator": false,
 		"launchpad/new-task-definition-parser": true,
 		"launchpad/new-task-definition-parser/free": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -29,7 +29,6 @@
 		"calypso/ai-assembler": true,
 		"calypso/big-sky": true,
 		"calypso/help-center": true,
-		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/ebanx-pix": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -133,7 +133,6 @@
 		"performance-profiler/logged-in": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -76,7 +76,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
-		"jetpack/simplify-pricing-structure": false,
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -59,7 +59,6 @@
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,
-		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/ai-logo-generator": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -133,8 +133,6 @@
 		"performance-profiler/logged-in": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/pro-plan": false,
-		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/multisite-scheduled-updates": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -181,7 +181,6 @@
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,
-		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
 		"themes/assembler-first": true,
 		"two-factor/enhanced-security": true,

--- a/config/test.json
+++ b/config/test.json
@@ -59,7 +59,6 @@
 		"jetpack/plugin-management": false,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
-		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": false,

--- a/config/test.json
+++ b/config/test.json
@@ -98,7 +98,6 @@
 		"p2-enabled": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plugins/ssr-categories": true,

--- a/config/test.json
+++ b/config/test.json
@@ -26,7 +26,6 @@
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
-		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,
 		"checkout/ebanx-pix": true,

--- a/config/test.json
+++ b/config/test.json
@@ -62,7 +62,6 @@
 		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": false,
-		"launchpad-updates": false,
 		"launchpad/navigator": false,
 		"launchpad/new-task-definition-parser": true,
 		"launchpad/new-task-definition-parser/free": true,

--- a/config/test.json
+++ b/config/test.json
@@ -59,7 +59,6 @@
 		"jetpack/plugin-management": false,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
-		"jetpack/simplify-pricing-structure": false,
 		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,

--- a/config/test.json
+++ b/config/test.json
@@ -103,7 +103,6 @@
 		"plugins/ssr-landing": true,
 		"post-list/qr-code-link": false,
 		"press-this": true,
-		"promote-post/widget-i2": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,

--- a/config/test.json
+++ b/config/test.json
@@ -98,8 +98,6 @@
 		"p2-enabled": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/pro-plan": false,
-		"plans/starter-plan": false,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,

--- a/config/test.json
+++ b/config/test.json
@@ -124,7 +124,6 @@
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/new-date-filtering": false,
-		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -83,7 +83,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/offer-complete-after-activation": false,
-		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jitms": true,
 		"lasagna": true,
 		"launchpad-updates": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -28,7 +28,6 @@
 		"calypso/ai-assembler": true,
 		"calypso/big-sky": true,
 		"calypso/help-center": true,
-		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,
 		"checkout/ebanx-pix": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -178,7 +178,6 @@
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,
-		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
 		"themes/assembler-first": true,
 		"two-factor/enhanced-security": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,7 +82,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
-		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jitms": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -85,7 +85,6 @@
 		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
-		"launchpad-updates": false,
 		"launchpad/navigator": false,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,7 +82,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
-		"jetpack/simplify-pricing-structure": false,
 		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,
 		"jetpack/zendesk-chat-for-logged-in-users": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -67,7 +67,6 @@
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,
-		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/ai-logo-generator": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-restore-preflight-checks": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -131,7 +131,6 @@
 		"performance-profiler/logged-in": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -131,8 +131,6 @@
 		"performance-profiler/logged-in": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
-		"plans/pro-plan": false,
-		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/multisite-scheduled-updates": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -170,7 +170,6 @@
 		"stats/empty-module-v2": true,
 		"stats/new-date-filtering": false,
 		"stats/paid-wpcom-v2": true,
-		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -140,7 +140,6 @@
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,
 		"press-this": true,
-		"promote-post/widget-i2": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,


### PR DESCRIPTION
## Proposed Changes

This PR removes old (unused since before 2024) unused feature flags. These flags are only present in the JSON configuration files and are not referenced anywhere in Calypso.

The removed flags are:

- `calypsoify/plugins` - not used since #61901 (2022)
- `jetpack/ai-assistant-request-limit` - not used since #79557 (2023)
- `jetpack/simplify-pricing-structure` - added in #57070 (2021) but never used
- `jetpack-social/advanced-plan` - not used since #73993 (2023)
- `jetpack/zendesk-chat-for-logged-in-users` - not used since #77499 (2023)
- `launchpad-updates` - added in #77328 (2023) but never used
- `plans/personal-plan` - not used since #83443 (2023)
- `plans/pro-plan` - not used since #82894 (2023)
- `plans/starter-plan` - not used since #82894 (2023)
- `promote-post/widget-i2` - not used since #83590 (2023)
- `ssr/log-prefetch-errors` - added in #68775 but never used (2022)
- `stepper-woocommerce-poc` - not used since #72243 (2023)
- `themes/subscription-purchases` - not used since #78043 (2023)

## Why are these changes being made?

Remove obsolete code.

## Testing Instructions

- Code inspection
- Ensure none of these flags are being used in Calypso

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?