### PR TITLE
Reader Onboarding: Add society curated blogs

### DIFF
--- a/client/reader/onboarding/curated-blogs/society.tsx
+++ b/client/reader/onboarding/curated-blogs/society.tsx
@@ -198,7 +198,42 @@ export const societyBlogs: CuratedBlogsList = {
 		},
 	],
 	history: [
-		// Add history blogs...
+		{
+			feed_ID: 144373922,
+			site_ID: 218674381,
+			site_URL: 'https://historyfacts.com/',
+			site_name: 'History Facts',
+		},
+		{
+			feed_ID: 111739841,
+			site_ID: 181957101,
+			site_URL: 'https://livinglondonhistory.com/',
+			site_name: 'History Facts',
+		},
+		{
+			feed_ID: 158014293,
+			site_ID: 190492275,
+			site_URL: 'https://prologue.blogs.archives.gov/',
+			site_name: 'Pieces of History',
+		},
+		{
+			feed_ID: 158014293,
+			site_ID: 190492275,
+			site_URL: 'https://prologue.blogs.archives.gov/',
+			site_name: 'Pieces of History',
+		},
+		{
+			feed_ID: 9002220,
+			site_ID: 9563068,
+			site_URL: 'http://www.thehistoryblog.com/',
+			site_name: 'The History Blog',
+		},
+		{
+			feed_ID: 95253203,
+			site_ID: 161773962,
+			site_URL: 'https://acoup.blog/',
+			site_name: 'A Collection of Unmitigated Pedantry',
+		},
 	],
 	society: [
 		// Add society blogs...

--- a/client/reader/onboarding/curated-blogs/society.tsx
+++ b/client/reader/onboarding/curated-blogs/society.tsx
@@ -312,6 +312,41 @@ export const societyBlogs: CuratedBlogsList = {
 		},
 	],
 	philosophy: [
-		// Add philosophy blogs...
+		{
+			feed_ID: 75755245,
+			site_ID: 62276702,
+			site_URL: 'https://1000wordphilosophy.com/',
+			site_name: '1000-Word Philosophy: An Introductory Anthology ',
+		},
+		{
+			feed_ID: 76484859,
+			site_ID: 83006194,
+			site_URL: 'https://www.lse.ac.uk/philosophy/',
+			site_name: 'Philosophy, Logic and Scientific Method',
+		},
+		{
+			feed_ID: 59963902,
+			site_ID: 44180183,
+			site_URL: 'https://jamesbishopblog.com/',
+			site_name: "Bishop's Encyclopedia of Religion, Society and Philosophy ",
+		},
+		{
+			feed_ID: 45806376,
+			site_ID: 75932265,
+			site_URL: 'https://dailynous.com/',
+			site_name: 'Daily Nous',
+		},
+		{
+			feed_ID: 25217327,
+			site_ID: 0,
+			site_URL: 'https://philosophynow.org/',
+			site_name: 'Philosophy Now',
+		},
+		{
+			feed_ID: 76453290,
+			site_ID: 0,
+			site_URL: 'https://partiallyexaminedlife.com/',
+			site_name: 'The Partially Examined Life Philosophy Podcast',
+		},
 	],
 };

--- a/client/reader/onboarding/curated-blogs/society.tsx
+++ b/client/reader/onboarding/curated-blogs/society.tsx
@@ -20,12 +20,112 @@ export const societyBlogs: CuratedBlogsList = {
 			site_URL: 'http://www.shakeuplearning.com/',
 			site_name: 'Educators Technology',
 		},
+		{
+			feed_ID: 69814417,
+			site_ID: 39960713,
+			site_URL: 'https://www.teachertoolkit.co.uk/',
+			site_name: 'TeacherToolkit',
+		},
+		{
+			feed_ID: 19068123,
+			site_ID: 64463434,
+			site_URL: 'https://jenniefitzkee.com/',
+			site_name: "A Teacher's Reflections",
+		},
+		{
+			feed_ID: 22002764,
+			site_ID: 60068710,
+			site_URL: 'https://www.coolcatteacher.com/',
+			site_name: 'Cool Cat Teacher Blog',
+		},
 	],
 	nature: [
-		// Add nature blogs...
+		{
+			feed_ID: 93708735,
+			site_ID: 158320507,
+			site_URL: 'https://scubahanknyc.com/',
+			site_name: 'Scuba Hank NYC',
+		},
+		{
+			feed_ID: 47864083,
+			site_ID: 43646855,
+			site_URL: 'https://stevecreek.com/',
+			site_name: 'Steve Creek Wildlife Photography',
+		},
+		{
+			feed_ID: 136146583,
+			site_ID: 159711569,
+			site_URL: 'https://elpasozoo.home.blog/',
+			site_name: 'Conservation Education',
+		},
+		{
+			feed_ID: 79041338,
+			site_ID: 142325617,
+			site_URL: 'https://nationalparkswitht.com/',
+			site_name: 'National Parks With T',
+		},
+		{
+			feed_ID: 17239565,
+			site_ID: 62426488,
+			site_URL: 'https://backyardbirdnerd.com/',
+			site_name: 'Backyard Bird Nerd',
+		},
+		{
+			feed_ID: 155668618,
+			site_ID: 48819432,
+			site_URL: 'https://scotlandsnature.wordpress.com/',
+			site_name: "Scotland's Nature",
+		},
 	],
 	future: [
-		// Add future-focused blogs...
+		{
+			feed_ID: 66308872,
+			site_ID: 101450901,
+			site_URL: 'https://futurism.com/',
+			site_name: 'Futurism',
+		},
+		{
+			feed_ID: 16857803,
+			site_ID: 4183809,
+			site_URL: 'https://singularityhub.com/',
+			site_name: 'Singularity Hub',
+		},
+		{
+			feed_ID: 64152258,
+			site_ID: 127277856,
+			site_URL: 'http://www.nextbigfuture.com/',
+			site_name: 'NextBigFuture.com',
+		},
+		{
+			feed_ID: 77891657,
+			site_ID: 136066274,
+			site_URL: 'https://www.fanaticalfuturist.com/',
+			site_name: 'Matthew Griffin | Keynote Speaker & Master Futurist',
+		},
+		{
+			feed_ID: 77936565,
+			site_ID: 141327587,
+			site_URL: 'https://bryanalexander.org/',
+			site_name: 'Bryan Alexander',
+		},
+		{
+			feed_ID: 388033,
+			site_ID: 1011537,
+			site_URL: 'https://thenextwavefutures.wordpress.com/',
+			site_name: 'the next wave',
+		},
+		{
+			feed_ID: 46138681,
+			site_ID: 16638040,
+			site_URL: 'https://frankdiana.net/',
+			site_name: 'Reimagining the Future',
+		},
+		{
+			feed_ID: 1430889,
+			site_ID: 8522080,
+			site_URL: 'https://lucept.com/',
+			site_name: 'Lucept',
+		},
 	],
 	politics: [
 		// Add politics blogs...

--- a/client/reader/onboarding/curated-blogs/society.tsx
+++ b/client/reader/onboarding/curated-blogs/society.tsx
@@ -97,12 +97,6 @@ export const societyBlogs: CuratedBlogsList = {
 			site_name: 'NextBigFuture.com',
 		},
 		{
-			feed_ID: 77891657,
-			site_ID: 136066274,
-			site_URL: 'https://www.fanaticalfuturist.com/',
-			site_name: 'Matthew Griffin | Keynote Speaker & Master Futurist',
-		},
-		{
 			feed_ID: 77936565,
 			site_ID: 141327587,
 			site_URL: 'https://bryanalexander.org/',
@@ -128,7 +122,42 @@ export const societyBlogs: CuratedBlogsList = {
 		},
 	],
 	politics: [
-		// Add politics blogs...
+		{
+			feed_ID: 144806355,
+			site_ID: 205851186,
+			site_URL: 'https://www.worldpoliticsreview.com/',
+			site_name: 'World Politics Review',
+		},
+		{
+			feed_ID: 163680501,
+			site_ID: 204171482,
+			site_URL: 'https://arcmag.org',
+			site_name: 'Arc: Religion, Politics, Et Cetera',
+		},
+		{
+			feed_ID: 4860866,
+			site_ID: 0,
+			site_URL: 'https://politicalwire.com/',
+			site_name: 'Political Wire',
+		},
+		{
+			feed_ID: 119663676,
+			site_ID: 0,
+			site_URL: 'https://www.politics.co.uk/',
+			site_name: 'Politics.co.uk',
+		},
+		{
+			feed_ID: 5055404,
+			site_ID: 0,
+			site_URL: 'https://www.politico.com/',
+			site_name: 'Politico',
+		},
+		{
+			feed_ID: 17459859,
+			site_ID: 0,
+			site_URL: 'https://www.factcheck.org/',
+			site_name: 'FactCheck.org',
+		},
 	],
 	'climate-change': [
 		// Add climate change blogs...

--- a/client/reader/onboarding/curated-blogs/society.tsx
+++ b/client/reader/onboarding/curated-blogs/society.tsx
@@ -236,10 +236,80 @@ export const societyBlogs: CuratedBlogsList = {
 		},
 	],
 	society: [
-		// Add society blogs...
+		{
+			feed_ID: 48416491,
+			site_ID: 0,
+			site_URL: 'https://www.theatlantic.com/',
+			site_name: 'The Atlantic',
+		},
+		{
+			feed_ID: 163685502,
+			site_ID: 0,
+			site_URL: 'https://www.vox.com/',
+			site_name: 'Vox',
+		},
+		{
+			feed_ID: 110082608,
+			site_ID: 177241961,
+			site_URL: 'https://blog.ted.com/',
+			site_name: 'TED Blog',
+		},
+		{
+			feed_ID: 14625,
+			site_ID: 0,
+			site_URL: 'https://www.newyorker.com/',
+			site_name: 'The New Yorker',
+		},
+		{
+			feed_ID: 66598595,
+			site_ID: 0,
+			site_URL: 'https://www.theroot.com/',
+			site_name: 'The Root',
+		},
+		{
+			feed_ID: 13683185,
+			site_ID: 0,
+			site_URL: 'https://www.theguardian.com/us',
+			site_name: 'The Guardian',
+		},
 	],
 	culture: [
-		// Add culture blogs...
+		{
+			feed_ID: 142614162,
+			site_ID: 118955609,
+			site_URL: 'https://hyperallergic.com/',
+			site_name: 'Hyperallergic',
+		},
+		{
+			feed_ID: 5767946,
+			site_ID: 3521287,
+			site_URL: 'https://www.themarginalian.org/',
+			site_name: 'The Marginalian',
+		},
+		{
+			feed_ID: 10359,
+			site_ID: 0,
+			site_URL: 'https://pitchfork.com/',
+			site_name: 'Pitchfork',
+		},
+		{
+			feed_ID: 8949493,
+			site_ID: 0,
+			site_URL: 'https://www.dazeddigital.com/rss',
+			site_name: 'Dazed',
+		},
+		{
+			feed_ID: 6645964,
+			site_ID: 0,
+			site_URL: 'https://www.openculture.com/',
+			site_name: 'Open Culture',
+		},
+		{
+			feed_ID: 19592473,
+			site_ID: 0,
+			site_URL: 'https://www.messynessychic.com/',
+			site_name: 'Messy Nessy Chic',
+		},
 	],
 	philosophy: [
 		// Add philosophy blogs...

--- a/client/reader/onboarding/curated-blogs/society.tsx
+++ b/client/reader/onboarding/curated-blogs/society.tsx
@@ -239,13 +239,13 @@ export const societyBlogs: CuratedBlogsList = {
 		{
 			feed_ID: 48416491,
 			site_ID: 0,
-			site_URL: 'https://www.theatlantic.com/',
+			site_URL: 'http://www.theatlantic.com/feed/all',
 			site_name: 'The Atlantic',
 		},
 		{
 			feed_ID: 163685502,
 			site_ID: 0,
-			site_URL: 'https://www.vox.com/',
+			site_URL: 'http://www.vox.com/rss/index.xml',
 			site_name: 'Vox',
 		},
 		{
@@ -257,25 +257,25 @@ export const societyBlogs: CuratedBlogsList = {
 		{
 			feed_ID: 14625,
 			site_ID: 0,
-			site_URL: 'https://www.newyorker.com/',
+			site_URL: 'http://www.newyorker.com/feed/rss',
 			site_name: 'The New Yorker',
 		},
 		{
 			feed_ID: 66598595,
 			site_ID: 0,
-			site_URL: 'https://www.theroot.com/',
+			site_URL: 'http://www.theroot.com/rss',
 			site_name: 'The Root',
 		},
 		{
-			feed_ID: 13683185,
+			feed_ID: 38049686,
 			site_ID: 0,
-			site_URL: 'https://www.theguardian.com/us',
+			site_URL: 'http://www.theguardian.com/us/rss',
 			site_name: 'The Guardian',
 		},
 	],
 	culture: [
 		{
-			feed_ID: 142614162,
+			feed_ID: 55747131,
 			site_ID: 118955609,
 			site_URL: 'https://hyperallergic.com/',
 			site_name: 'Hyperallergic',
@@ -289,7 +289,7 @@ export const societyBlogs: CuratedBlogsList = {
 		{
 			feed_ID: 10359,
 			site_ID: 0,
-			site_URL: 'https://pitchfork.com/',
+			site_URL: 'http://pitchfork.com/feed/rss',
 			site_name: 'Pitchfork',
 		},
 		{
@@ -305,10 +305,10 @@ export const societyBlogs: CuratedBlogsList = {
 			site_name: 'Open Culture',
 		},
 		{
-			feed_ID: 19592473,
+			feed_ID: 56317607,
 			site_ID: 0,
-			site_URL: 'https://www.messynessychic.com/',
-			site_name: 'Messy Nessy Chic',
+			site_URL: 'http://www.juxtapoz.com/news/?format=feed&type=rss',
+			site_name: 'Juxtapoz Magazine',
 		},
 	],
 	philosophy: [
@@ -319,10 +319,10 @@ export const societyBlogs: CuratedBlogsList = {
 			site_name: '1000-Word Philosophy: An Introductory Anthology ',
 		},
 		{
-			feed_ID: 76484859,
-			site_ID: 83006194,
-			site_URL: 'https://www.lse.ac.uk/philosophy/',
-			site_name: 'Philosophy, Logic and Scientific Method',
+			feed_ID: 19103724,
+			site_ID: 0,
+			site_URL: 'http://aeon.co/feed.rss',
+			site_name: 'Aeon | a world of ideas',
 		},
 		{
 			feed_ID: 59963902,
@@ -339,7 +339,7 @@ export const societyBlogs: CuratedBlogsList = {
 		{
 			feed_ID: 25217327,
 			site_ID: 0,
-			site_URL: 'https://philosophynow.org/',
+			site_URL: 'http://philosophynow.org/rss',
 			site_name: 'Philosophy Now',
 		},
 		{

--- a/client/reader/onboarding/curated-blogs/society.tsx
+++ b/client/reader/onboarding/curated-blogs/society.tsx
@@ -187,13 +187,13 @@ export const societyBlogs: CuratedBlogsList = {
 		{
 			feed_ID: 40967167,
 			site_ID: 0,
-			site_URL: 'https://www.carbonbrief.org/',
+			site_URL: 'http://www.carbonbrief.org/feed',
 			site_name: 'Carbon Brief',
 		},
 		{
 			feed_ID: 42326459,
 			site_ID: 0,
-			site_URL: 'https://skepticalscience.com/',
+			site_URL: 'http://skepticalscience.com/feed.xml',
 			site_name: 'Skeptical Science',
 		},
 	],

--- a/client/reader/onboarding/curated-blogs/society.tsx
+++ b/client/reader/onboarding/curated-blogs/society.tsx
@@ -149,7 +149,7 @@ export const societyBlogs: CuratedBlogsList = {
 		{
 			feed_ID: 5055404,
 			site_ID: 0,
-			site_URL: 'https://www.politico.com/',
+			site_URL: 'http://www.politico.com/rss/politicopicks.xml',
 			site_name: 'Politico',
 		},
 		{
@@ -160,7 +160,42 @@ export const societyBlogs: CuratedBlogsList = {
 		},
 	],
 	'climate-change': [
-		// Add climate change blogs...
+		{
+			feed_ID: 154160739,
+			site_ID: 228474941,
+			site_URL: 'https://insideclimatenews.org/',
+			site_name: 'Inside Climate News ',
+		},
+		{
+			feed_ID: 107813600,
+			site_ID: 185804187,
+			site_URL: 'https://yaleclimateconnections.org/',
+			site_name: 'Yale Climate Connections',
+		},
+		{
+			feed_ID: 163683192,
+			site_ID: 0,
+			site_URL: 'https://www.ipcc.ch/',
+			site_name: 'IPCC',
+		},
+		{
+			feed_ID: 48632660,
+			site_ID: 162117108,
+			site_URL: 'https://climatefeedback.org/',
+			site_name: 'Climate Feedback ',
+		},
+		{
+			feed_ID: 40967167,
+			site_ID: 0,
+			site_URL: 'https://www.carbonbrief.org/',
+			site_name: 'Carbon Brief',
+		},
+		{
+			feed_ID: 42326459,
+			site_ID: 0,
+			site_URL: 'https://skepticalscience.com/',
+			site_name: 'Skeptical Science',
+		},
 	],
 	history: [
 		// Add history blogs...

--- a/client/reader/onboarding/curated-blogs/society.tsx
+++ b/client/reader/onboarding/curated-blogs/society.tsx
@@ -2,7 +2,24 @@ import { CuratedBlogsList } from './index';
 
 export const societyBlogs: CuratedBlogsList = {
 	education: [
-		// Add more education blogs...
+		{
+			feed_ID: 155447430,
+			site_ID: 202092965,
+			site_URL: 'https://world-education-blog.org',
+			site_name: 'World Education Blog',
+		},
+		{
+			feed_ID: 161689814,
+			site_ID: 223822458,
+			site_URL: 'https://www.educatorstechnology.com/',
+			site_name: 'Educators Technology',
+		},
+		{
+			feed_ID: 78449659,
+			site_ID: 102727187,
+			site_URL: 'http://www.shakeuplearning.com/',
+			site_name: 'Educators Technology',
+		},
 	],
 	nature: [
 		// Add nature blogs...


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9441

## Proposed Changes

* Add curated "society" blogs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve Reader Onboarding

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load up the curated list and click on all of them

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
