### PR TITLE
Stats: Add tool tip to date range picker

### DIFF
--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -65,6 +65,7 @@ const StatsDateControl = ( {
 
 	const moment = useLocalizedMoment();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' );
 
 	// Shared link generation helper.
 	const generateNewLink = ( period: string, startDate: string, endDate: string ) => {
@@ -167,7 +168,9 @@ const StatsDateControl = ( {
 					buttonRef: RefObject< typeof Button >;
 				} ) => {
 					return (
-						<Tooltip text={ translate( 'Filter all data by date' ) }>
+						<Tooltip
+							text={ isNewDateFilteringEnabled ? translate( 'Filter all data by date' ) : '' }
+						>
 							<Button
 								onClick={ () => {
 									const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -170,6 +170,7 @@ const StatsDateControl = ( {
 					return (
 						<Tooltip
 							text={ isNewDateFilteringEnabled ? translate( 'Filter all data by date' ) : '' }
+							placement="bottom-end"
 						>
 							<Button
 								onClick={ () => {

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button, Tooltip } from '@wordpress/components';
 import { Icon, calendar } from '@wordpress/icons';
+import { translate } from 'i18n-calypso';
 import { Moment } from 'moment';
 import qs from 'qs';
 import { RefObject } from 'react';
@@ -166,7 +167,7 @@ const StatsDateControl = ( {
 					buttonRef: RefObject< typeof Button >;
 				} ) => {
 					return (
-						<Tooltip text="Filter all data by date">
+						<Tooltip text={ translate( 'Filter all data by date' ) }>
 							<Button
 								onClick={ () => {
 									const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
 import { Icon, calendar } from '@wordpress/icons';
 import { Moment } from 'moment';
 import qs from 'qs';
@@ -166,17 +166,19 @@ const StatsDateControl = ( {
 					buttonRef: RefObject< typeof Button >;
 				} ) => {
 					return (
-						<Button
-							onClick={ () => {
-								const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-								recordTracksEvent( eventNames[ event_from ][ 'trigger_button' ] );
-								onTriggerClick();
-							} }
-							ref={ buttonRef }
-						>
-							{ getButtonLabel() }
-							<Icon className="gridicon" icon={ calendar } />
-						</Button>
+						<Tooltip text="Filter all data by date">
+							<Button
+								onClick={ () => {
+									const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+									recordTracksEvent( eventNames[ event_from ][ 'trigger_button' ] );
+									onTriggerClick();
+								} }
+								ref={ buttonRef }
+							>
+								{ getButtonLabel() }
+								<Icon className="gridicon" icon={ calendar } />
+							</Button>
+						</Tooltip>
 					);
 				} }
 				rootClass="stats-date-control-picker"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/216

## Proposed Changes

* Add a tooltip to the daterangepicker trigger button

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the header refresh in the Date Filtering for the Traffic Page project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live Branch
* Apply feature flag `stats/new-date-filtering`
* Confirm that the daterange picker button now has a tooltip, which looks like the screenshot

![image](https://github.com/user-attachments/assets/e638dfe0-aa4f-43d3-84b5-f6791909bbbd)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
