### PR TITLE
A4A > Agency Tier: Update the emerging partner celebration modal copy

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
@@ -55,23 +55,14 @@ const getAgencyTierInfo = (
 				logo: EmergingPartnerLogo,
 				includedTiers: [ 'emerging-partner' ],
 				celebrationModal: {
-					title: translate( 'Welcome to Automattic for Agencies!' ),
+					title: translate( 'You made your first purchase, your account is now activated!' ),
 					description: translate(
-						"You're just starting your journey with us. Your tier and associated benefits will change over time as you invest in or refer clients to Automattic products."
+						'Progress towards the Agency Partner tier and access extra benefits with additional purchases and referrals.'
 					),
-					extraDescription: translate( 'As an Automattic for Agencies member, you can:' ),
-					benefits: [
-						translate( 'Enjoy special bulk discounts on our marketplace curated for partners.' ),
-						translate( 'Boost your income by earning commissions on client referrals.' ),
-						translate( 'Manage all your client sites effortlessly in one convenient location.' ),
-						translate(
-							'Access immediate help from our WordPress experts through our support tools.'
-						),
-						translate( 'Enhance your skills with product training and marketing materials.' ),
-					],
 					video:
 						'https://automattic.com/wp-content/uploads/2024/10/emerging_partner_tier_celebration.mp4',
 					image: EmergingPartnerBackground,
+					cta: translate( 'Learn about Tiers' ),
 				},
 			};
 			break;
@@ -112,6 +103,7 @@ const getAgencyTierInfo = (
 					video:
 						'https://automattic.com/wp-content/uploads/2024/10/agency_partner_tier_celebration-2.mp4',
 					image: AgencyPartnerBackground,
+					cta: translate( 'Explore your benefits' ),
 				},
 			};
 			break;
@@ -150,6 +142,7 @@ const getAgencyTierInfo = (
 					video:
 						'https://automattic.com/wp-content/uploads/2024/10/agency_pro_partner_tier_celebration-2.mp4',
 					image: ProAgencyPartnerBackground,
+					cta: translate( 'Explore your benefits' ),
 				},
 			};
 	}

--- a/client/a8c-for-agencies/sections/agency-tier/types.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/types.ts
@@ -10,8 +10,9 @@ export interface AgencyTierInfo {
 		title: string;
 		description: string;
 		extraDescription?: string;
-		benefits: string[];
+		benefits?: string[];
 		video: string;
 		image: string;
+		cta: string;
 	};
 }

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal.tsx
@@ -1,7 +1,6 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
 import { clsx } from 'clsx';
-import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import A4AThemedModal from 'calypso/a8c-for-agencies/components/a4a-themed-modal';
 import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -30,7 +29,6 @@ export default function AgencyTierCelebrationModal( {
 	currentAgencyTier?: string | null;
 } ) {
 	const dispatch = useDispatch();
-	const translate = useTranslate();
 	const isNarrowView = useBreakpoint( '<660px' );
 
 	const celebrationModalShowForCurrentType = useSelector( ( state ) =>
@@ -115,7 +113,7 @@ export default function AgencyTierCelebrationModal( {
 		);
 	};
 
-	const { title, description, extraDescription, benefits, video, image } =
+	const { title, description, extraDescription, benefits, video, image, cta } =
 		agencyTierInfo.celebrationModal;
 
 	return (
@@ -143,11 +141,13 @@ export default function AgencyTierCelebrationModal( {
 							{ preventWidows( extraDescription ) }
 						</div>
 					) }
-					<ul className="agency-tier-celebration-modal__benefits">
-						{ benefits.map( ( benefit ) => (
-							<li key={ benefit }>{ preventWidows( benefit ) }</li>
-						) ) }
-					</ul>
+					{ benefits && (
+						<ul className="agency-tier-celebration-modal__benefits">
+							{ benefits.map( ( benefit ) => (
+								<li key={ benefit }>{ preventWidows( benefit ) }</li>
+							) ) }
+						</ul>
+					) }
 				</div>
 				<div
 					className={ clsx( 'agency-tier-celebration-modal__scroll-indicator', {
@@ -161,7 +161,7 @@ export default function AgencyTierCelebrationModal( {
 					onClick={ handleClickExploreBenefits }
 					href={ A4A_AGENCY_TIER_LINK }
 				>
-					{ translate( 'Explore your benefits' ) }
+					{ cta }
 				</Button>
 			</div>
 		</A4AThemedModal>

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
@@ -169,6 +169,7 @@ $video-green: #0e5837;
 
 			.agency-tier-celebration-modal__title {
 				@include a4a-font-heading-xl;
+				text-wrap: balance;
 			}
 
 			.agency-tier-celebration-modal__description,


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1369

## Proposed Changes

This PR updates the emerging partner celebration modal copy. 

## Why are these changes being made?

* To update emerging partner celebration modal copy.

## Testing Instructions

* Update your agency tier to Emerging Partner using the MC tool > Open the A4A live link > Go to the Overview page.
* Verify the celebration modal is displayed as shown below:

<img width="818" alt="Screenshot 2024-10-28 at 10 40 38 AM" src="https://github.com/user-attachments/assets/df8ff29c-b587-44ba-be26-c10c95a8ffad">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
