### PR TITLE
Audit Upsell: Remove Jetpack AI in Add-Ons

### DIFF
--- a/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
@@ -1,9 +1,7 @@
 import {
-	PRODUCT_JETPACK_AI_MONTHLY,
 	PRODUCT_WPCOM_CUSTOM_DESIGN,
 	PRODUCT_WPCOM_UNLIMITED_THEMES,
 	PRODUCT_1GB_SPACE,
-	WPCOM_FEATURES_AI_ASSISTANT,
 	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 	WPCOM_FEATURES_CUSTOM_DESIGN,
 } from '@automattic/calypso-products';
@@ -16,12 +14,10 @@ import {
 	ADD_ON_100GB_STORAGE,
 	ADD_ON_50GB_STORAGE,
 	ADD_ON_CUSTOM_DESIGN,
-	ADD_ON_JETPACK_AI_MONTHLY,
 	ADD_ON_UNLIMITED_THEMES,
 	STORAGE_LIMIT,
 } from '../constants';
 import customDesignIcon from '../icons/custom-design';
-import jetpackAIIcon from '../icons/jetpack-ai';
 import spaceUpgradeIcon from '../icons/space-upgrade';
 import unlimitedThemesIcon from '../icons/unlimited-themes';
 import isStorageAddonEnabled from '../lib/is-storage-addon-enabled';
@@ -37,7 +33,6 @@ const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 	/*
 	 * TODO: `useAddOnDisplayCost` be refactored instead to return an index of `{ [ slug ]: "display cost" }`
 	 */
-	const displayCostJetpackAIMonthly = useAddOnDisplayCost( PRODUCT_JETPACK_AI_MONTHLY );
 	const displayCostUnlimitedThemes = useAddOnDisplayCost( PRODUCT_WPCOM_UNLIMITED_THEMES );
 	const displayCostCustomDesign = useAddOnDisplayCost( PRODUCT_WPCOM_CUSTOM_DESIGN );
 	const displayCost1GBSpace50 = useAddOnDisplayCost( PRODUCT_1GB_SPACE, 50 );
@@ -52,19 +47,6 @@ const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 	return useMemo(
 		() =>
 			[
-				{
-					addOnSlug: ADD_ON_JETPACK_AI_MONTHLY,
-					productSlug: PRODUCT_JETPACK_AI_MONTHLY,
-					featureSlugs: null,
-					icon: jetpackAIIcon,
-					overrides: null,
-					displayCost: displayCostJetpackAIMonthly,
-					featured: true,
-					description: translate(
-						'Elevate your content with Jetpack AI, your AI assistant in the WordPress Editor. Save time writing with effortless content crafting, tone adjustment, title generation, grammar checks, translation, and more.'
-					),
-					name: undefined,
-				},
 				{
 					addOnSlug: ADD_ON_UNLIMITED_THEMES,
 					productSlug: PRODUCT_WPCOM_UNLIMITED_THEMES,
@@ -127,7 +109,6 @@ const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 			displayCost1GBSpace100,
 			displayCost1GBSpace50,
 			displayCostCustomDesign,
-			displayCostJetpackAIMonthly,
 			displayCostUnlimitedThemes,
 			selectedSiteId,
 			translate,
@@ -157,107 +138,90 @@ const useAddOns = ( {
 
 	return useMemo(
 		() =>
-			activeAddOns
-				.filter( ( addOn ) => {
-					/**
-					 * Remove the Jetpack AI add-on if the site already supports the feature.
-					 * TODO: Potentially another candidate for migrating to `use-add-on-purchase-status`.
-					 * The intention is to have a single source of truth. The add-on can be removed from display
-					 * instead with an appropriate flag, but kept in list of add-ons.
-					 */
-					if (
-						addOn.productSlug === PRODUCT_JETPACK_AI_MONTHLY &&
-						siteFeatures.data?.active?.includes( WPCOM_FEATURES_AI_ASSISTANT )
-					) {
-						return false;
-					}
+			activeAddOns.map( ( addOn ) => {
+				const product = productsList.data?.[ addOn.productSlug ];
+				const name = addOn.name ? addOn.name : product?.name || '';
+				const description = addOn.description ?? ( product?.description || '' );
 
-					return true;
-				} )
-				.map( ( addOn ) => {
-					const product = productsList.data?.[ addOn.productSlug ];
-					const name = addOn.name ? addOn.name : product?.name || '';
-					const description = addOn.description ?? ( product?.description || '' );
-
-					/**
-					 * If siteFeatures, sitePurchases, or productsList are still loading, show the add-on as loading.
-					 * TODO: Potentially another candidate for migrating to `use-add-on-purchase-status`, and attach
-					 * that to the add-on's meta if need to.
-					 */
-					if ( siteFeatures.isLoading || sitePurchases.isLoading || productsList.isLoading ) {
-						return {
-							...addOn,
-							name,
-							description,
-							isLoading: true,
-						};
-					}
-
-					/**
-					 * If the product is not found in the products list, remove the add-on.
-					 * This should signal a wrong slug or a product that doesn't exist i.e. some sort of Bug.
-					 * (not sure if add-on without a connected product is a valid use case)
-					 */
-					if ( ! product ) {
-						return null;
-					}
-
-					/**
-					 * If it's a storage add-on.
-					 */
-					if ( addOn.productSlug === PRODUCT_1GB_SPACE ) {
-						// if storage add-ons are not enabled in the config or disabled via hook prop, remove them
-						if (
-							( 'boolean' === typeof enableStorageAddOns && ! enableStorageAddOns ) ||
-							( ! isStorageAddonEnabled() && 'boolean' !== typeof enableStorageAddOns )
-						) {
-							return null;
-						}
-
-						/**
-						 * If storage add-on is already purchased.
-						 * TODO: Consider migrating this part to `use-add-on-purchase-status` and attach
-						 * that to the add-on's meta if need to. The intention is to have a single source of truth.
-						 */
-						const isStorageAddOnPurchased = Object.values( spaceUpgradesPurchased ?? [] ).some(
-							( purchase ) => purchase.purchaseRenewalQuantity === addOn.quantity
-						);
-						if ( isStorageAddOnPurchased ) {
-							return {
-								...addOn,
-								name,
-								description,
-								purchased: true,
-							};
-						}
-
-						/**
-						 * If the current storage add-on option is greater than the available upgrade.
-						 * TODO: This is also potentially a candidate for `use-add-on-purchase-status`.
-						 */
-						const currentMaxStorage = mediaStorage.data?.maxStorageBytes
-							? mediaStorage.data.maxStorageBytes / Math.pow( 1024, 3 )
-							: 0;
-						const availableStorageUpgrade = STORAGE_LIMIT - currentMaxStorage;
-						if ( ( addOn.quantity ?? 0 ) > availableStorageUpgrade ) {
-							return {
-								...addOn,
-								name,
-								description,
-								exceedsSiteStorageLimits: true,
-							};
-						}
-					}
-
-					/**
-					 * Regular product add-ons.
-					 */
+				/**
+				 * If siteFeatures, sitePurchases, or productsList are still loading, show the add-on as loading.
+				 * TODO: Potentially another candidate for migrating to `use-add-on-purchase-status`, and attach
+				 * that to the add-on's meta if need to.
+				 */
+				if ( siteFeatures.isLoading || sitePurchases.isLoading || productsList.isLoading ) {
 					return {
 						...addOn,
 						name,
 						description,
+						isLoading: true,
 					};
-				} ),
+				}
+
+				/**
+				 * If the product is not found in the products list, remove the add-on.
+				 * This should signal a wrong slug or a product that doesn't exist i.e. some sort of Bug.
+				 * (not sure if add-on without a connected product is a valid use case)
+				 */
+				if ( ! product ) {
+					return null;
+				}
+
+				/**
+				 * If it's a storage add-on.
+				 */
+				if ( addOn.productSlug === PRODUCT_1GB_SPACE ) {
+					// if storage add-ons are not enabled in the config or disabled via hook prop, remove them
+					if (
+						( 'boolean' === typeof enableStorageAddOns && ! enableStorageAddOns ) ||
+						( ! isStorageAddonEnabled() && 'boolean' !== typeof enableStorageAddOns )
+					) {
+						return null;
+					}
+
+					/**
+					 * If storage add-on is already purchased.
+					 * TODO: Consider migrating this part to `use-add-on-purchase-status` and attach
+					 * that to the add-on's meta if need to. The intention is to have a single source of truth.
+					 */
+					const isStorageAddOnPurchased = Object.values( spaceUpgradesPurchased ?? [] ).some(
+						( purchase ) => purchase.purchaseRenewalQuantity === addOn.quantity
+					);
+					if ( isStorageAddOnPurchased ) {
+						return {
+							...addOn,
+							name,
+							description,
+							purchased: true,
+						};
+					}
+
+					/**
+					 * If the current storage add-on option is greater than the available upgrade.
+					 * TODO: This is also potentially a candidate for `use-add-on-purchase-status`.
+					 */
+					const currentMaxStorage = mediaStorage.data?.maxStorageBytes
+						? mediaStorage.data.maxStorageBytes / Math.pow( 1024, 3 )
+						: 0;
+					const availableStorageUpgrade = STORAGE_LIMIT - currentMaxStorage;
+					if ( ( addOn.quantity ?? 0 ) > availableStorageUpgrade ) {
+						return {
+							...addOn,
+							name,
+							description,
+							exceedsSiteStorageLimits: true,
+						};
+					}
+				}
+
+				/**
+				 * Regular product add-ons.
+				 */
+				return {
+					...addOn,
+					name,
+					description,
+				};
+			} ),
 		[
 			activeAddOns,
 			enableStorageAddOns,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

This PR proposes to remove Jetpack AI in the Add-Ons page as proposed in the post pbxlJb-6wX-p2.

| Before | After |
| --- | --- |
| ![Screenshot 2024-10-28 at 3 27 51 PM](https://github.com/user-attachments/assets/ebf009a8-ff92-443d-900a-b4e7364c0ae5) | ![Screenshot 2024-10-28 at 3 27 58 PM](https://github.com/user-attachments/assets/4c861a1a-9f9d-4a6b-9cce-6a7a1944a12f) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WordPress.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/add-ons/${SITE}`.
* Ensure that the Jetpack AI add-on is no longer available.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?