### PR TITLE
Audit Upsell: Remove Purchases empty state upsell

### DIFF
--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -3,11 +3,9 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import noSitesIllustration from 'calypso/assets/images/illustrations/illustration-nosites.svg';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import EmptyContent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
@@ -109,18 +107,8 @@ class PurchasesList extends Component {
 			content = (
 				<>
 					{ this.renderConciergeBanner() }
-
 					<CompactCard className="purchases-list__no-content">
-						<EmptyContent
-							title={ translate( 'Looking to upgrade?' ) }
-							line={ translate(
-								'Our plans give your site the power to thrive. ' +
-									'Find the plan that works for you.'
-							) }
-							action={ translate( 'Upgrade now' ) }
-							actionURL="/plans"
-							illustration={ noSitesIllustration }
-						/>
+						{ translate( 'You have made no purchases.' ) }
 					</CompactCard>
 				</>
 			);

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -1,7 +1,5 @@
 import { CompactCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import noSitesIllustration from 'calypso/assets/images/illustrations/illustration-nosites.svg';
-import EmptyContent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import JetpackRnaActionCard from 'calypso/components/jetpack/card/jetpack-rna-action-card';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -108,10 +106,16 @@ function NoPurchasesMessage() {
 	const translate = useTranslate();
 	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );
 
-	let url;
 	if ( ! isJetpackCloud() ) {
-		url = selectedSite ? `/plans/${ selectedSite.slug }` : '/plans';
-	} else if ( hasJetpackPartnerAccess ) {
+		return (
+			<CompactCard className="subscriptions__list">
+				{ translate( 'You have made no purchases for this site.' ) }
+			</CompactCard>
+		);
+	}
+
+	let url;
+	if ( hasJetpackPartnerAccess ) {
 		url = selectedSiteId
 			? `/partner-portal/issue-license?site_id=${ selectedSiteId }`
 			: '/partner-portal/issue-license';
@@ -119,7 +123,7 @@ function NoPurchasesMessage() {
 		url = selectedSite ? `/pricing/${ selectedSite.slug }` : '/pricing';
 	}
 
-	return isJetpackCloud() ? (
+	return (
 		<JetpackRnaActionCard
 			headerText={ translate( 'You don’t have any active subscriptions for this site.' ) }
 			subHeaderText={ translate(
@@ -128,15 +132,5 @@ function NoPurchasesMessage() {
 			ctaButtonLabel={ translate( 'View products' ) }
 			ctaButtonURL={ url }
 		/>
-	) : (
-		<CompactCard className="subscriptions__list">
-			<EmptyContent
-				title={ translate( 'Looking to upgrade?' ) }
-				line={ translate( 'You have made no purchases for this site.' ) }
-				action={ translate( 'Upgrade now' ) }
-				actionURL={ url }
-				illustration={ noSitesIllustration }
-			/>
-		</CompactCard>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

This PR proposes to remove the empty state upsell nudge in the Purchases page as proposed in the post pbxlJb-6wX-p2.

| Before | After |
| --- | --- |
| ![Screenshot 2024-10-28 at 4 36 48 PM](https://github.com/user-attachments/assets/cf0f424d-c906-4f80-81e1-44017a904ca1) | ![Screenshot 2024-10-28 at 4 36 43 PM](https://github.com/user-attachments/assets/7676963a-7543-4507-b3bc-9dc59b34fae5) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WordPress.com.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/purchases/subscriptions/${SITE}` using a free plan site.
* Ensure that the empty state is updated as shown above.
* Also test `/me/purchases` with an account that has made no purchases.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
