### PR TITLE
A4A > Marketplace: Fix download product for products with longer slugs

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/index.tsx
@@ -41,7 +41,8 @@ export default function DownloadProductsForm() {
 		jetpackKeys.map( ( licenseKey: string ) => {
 			const productSlug = getProductSlugFromLicenseKey( licenseKey );
 			const product =
-				allProducts && allProducts.find( ( product ) => product.slug === productSlug );
+				allProducts &&
+				allProducts.find( ( product ) => productSlug && product.slug.startsWith( productSlug ) );
 
 			return (
 				<li key={ licenseKey }>
@@ -73,7 +74,9 @@ export default function DownloadProductsForm() {
 
 		const invalidKeys = licenseKeys.split( ',' ).filter( ( key ) => {
 			const productSlug = getProductSlugFromLicenseKey( key );
-			return ! allProducts.find( ( product ) => product.slug === productSlug );
+			return ! allProducts.find(
+				( product ) => productSlug && product.slug.startsWith( productSlug )
+			);
 		} );
 
 		if ( invalidKeys.length ) {

--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/woo-product-download.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/woo-product-download.tsx
@@ -18,7 +18,8 @@ export default function WooProductDownload( { licenseKey, allProducts }: WooProd
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const productSlug = licenseKey.split( '_' )[ 0 ];
-	const product = allProducts && allProducts.find( ( product ) => product.slug === productSlug );
+	const product =
+		allProducts && allProducts.find( ( product ) => product.slug.startsWith( productSlug ) );
 	const downloadUrl = useLicenseDownloadUrlMutation( licenseKey );
 
 	const { mutate, status, error, data } = downloadUrl;


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1351

## Proposed Changes

This PR fixes the download product functionality for products with longer slugs.

## Why are these changes being made?

* To fix the redirect issue when a product is assigned to a site that can be downloaded. 

## Testing Instructions

* Open A4A live link.
* Go to /marketplace/products > Add a couple of products: All Products for Woo Subscriptions & AutomateWoo - Birthdays Add-on > Purchase them
* Assign both to a site one by one > Verify that you are redirected to /marketplace/download-products and the product is listed as expected. 

<img width="1728" alt="Screenshot 2024-10-28 at 2 28 51 PM" src="https://github.com/user-attachments/assets/5d8e76fc-d0fe-415a-80c7-6e9842865f1f">

<img width="1728" alt="Screenshot 2024-10-28 at 2 29 12 PM" src="https://github.com/user-attachments/assets/76dfdd1f-c4bd-4a3f-b46e-598d9110ebf3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
