### PR TITLE
A4A: UX improvement on the Site error indicator.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -73,6 +73,11 @@ export const JetpackSitesDataViews = ( {
 				return;
 			}
 
+			if ( site.is_simple ) {
+				// We don't want to open the site preview pane for simple sites.
+				return;
+			}
+
 			setDataViewsState( ( prevState: DataViewsState ) => ( {
 				...prevState,
 				selectedItem: site,
@@ -373,7 +378,7 @@ export const JetpackSitesDataViews = ( {
 								{ ( ! item.site.value.sticker?.includes( 'migration-in-progress' ) ||
 									isNotProduction ) && (
 									<>
-										{ ! item.site.error && (
+										{ ! item.site.error && ! item.site.value.is_simple && (
 											<SiteActions
 												isLargeScreen={ isLargeScreen }
 												isDevSite={ isDevSite }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -56,6 +56,11 @@
 	}
 }
 
+.sites-dataviews__site-error-popover-content {
+	@include a4a-font-body-sm($font-weight: 500);
+	margin: 16px;
+}
+
 .preview-hidden {
 	@media (min-width: 2040px) {
 		.sites-dataviews__site-name {

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.tsx
@@ -49,7 +49,7 @@ export default function useGetSiteErrors() {
 				errors.push( {
 					severity: 'medium',
 					message: translate(
-						'We are still provisioning your site. In the meantime, you can {{a}}set up your site{{/a}}',
+						'We are still provisioning your site. In the meantime, you can {{a}}set up your site{{/a}}.',
 						{
 							components: {
 								a: (

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.tsx
@@ -48,18 +48,21 @@ export default function useGetSiteErrors() {
 
 				errors.push( {
 					severity: 'medium',
-					message: translate( 'We are provisioning your site {{a}}Set up your site{{/a}}', {
-						components: {
-							a: (
-								<a
-									href={ wpOverviewUrl }
-									target="_blank"
-									rel="noreferrer"
-									onClick={ ( e ) => e.stopPropagation() }
-								/>
-							),
-						},
-					} ),
+					message: translate(
+						'We are still provisioning your site. In the meantime, you can {{a}}set up your site{{/a}}',
+						{
+							components: {
+								a: (
+									<a
+										href={ wpOverviewUrl }
+										target="_blank"
+										rel="noreferrer"
+										onClick={ ( e ) => e.stopPropagation() }
+									/>
+								),
+							},
+						}
+					),
 				} );
 			}
 

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field-error-indicator.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field-error-indicator.tsx
@@ -37,16 +37,22 @@ export default function SiteDataFieldErrorIndicator( { errors }: Props ) {
 					context={ popoverContext.current }
 					isVisible={ isPopoverVisible }
 				>
-					<ul className="sites-dataviews__site-error-popover-list">
-						{ errors.map( ( error, index ) => (
-							<li
-								key={ index }
-								className={ `sites-dataviews__site-error-item is-${ error.severity }` }
-							>
-								{ error.message }
-							</li>
-						) ) }
-					</ul>
+					{ errors.length > 1 ? (
+						<ul className="sites-dataviews__site-error-popover-list">
+							{ errors.map( ( error, index ) => (
+								<li
+									key={ index }
+									className={ `sites-dataviews__site-error-item is-${ error.severity }` }
+								>
+									{ error.message }
+								</li>
+							) ) }
+						</ul>
+					) : (
+						<div className="sites-dataviews__site-error-popover-content">
+							{ errors[ 0 ].message }
+						</div>
+					) }
 				</Popover>
 			) }
 		</div>


### PR DESCRIPTION
This PR introduces several enhancements to the Site error indicator.

Follow up PR: https://github.com/Automattic/wp-calypso/pull/95708

## Proposed Changes

* The indicator will no longer render a list if there is only one error.

| Before | After |
|--------|--------|
| <img width="215" alt="Screenshot 2024-10-29 at 6 43 32 PM" src="https://github.com/user-attachments/assets/e7205ecd-17d7-4c68-adf3-1110d9cd602f"> | <img width="200" alt="Screenshot 2024-10-29 at 6 43 17 PM" src="https://github.com/user-attachments/assets/49d97a89-23fd-482c-b4cf-a6eacce17983"> | 

* We updated the copy for the site that is under-provisioning.

| Before | After |
|--------|--------|
| ![Screenshot 2024-10-25 at 6 16 21 PM (1)](https://github.com/user-attachments/assets/1bd48516-ac3a-4987-904d-e0b821474004) | <img width="521" alt="Screenshot 2024-10-29 at 6 44 50 PM" src="https://github.com/user-attachments/assets/d45fb8db-290e-4892-b7a0-382c2e31496c"> | 

* We also now hide the actions menu for provisioning sites and have also disabled the preview panel.
<img width="2241" alt="Screenshot 2024-10-29 at 6 41 15 PM" src="https://github.com/user-attachments/assets/6ed4c624-1b89-406b-be7f-3c50507c03ff">

## Why are these changes being made?

* This improves user experience with the site error indicator.

## Testing Instructions

* Apply D161280-code patch
* Use the A4A live link and go to the `/sites` page.
* Spin up a WPCOM site.
* Confirm that the above points are working as expected.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
