### PR TITLE
A4A > Agency Tier: UI enhancements to the celebration modal

### DIFF
--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
@@ -119,7 +119,7 @@ $video-green: #0e5837;
 		.a4a-themed-modal__content {
 			margin: -2px 0;
 			// Make sure to update the BLOCK_PADDING in the index.tsx file when changing the padding
-			padding: 48px 32px;
+			padding: 48px 0 48px 32px;
 			border-radius: 4px 4px 0 0;
 		}
 
@@ -128,6 +128,7 @@ $video-green: #0e5837;
 
 			.components-modal__content.hide-header {
 				border-radius: 0;
+				overflow: hidden;
 			}
 		}
 		.agency-tier-celebration-modal__footer {
@@ -135,6 +136,12 @@ $video-green: #0e5837;
 			inset-block-end: 16px;
 			width: 100%;
 			background: var(--color-text-white);
+			padding-inline: 32px;
+			left: 0;
+
+			.components-button {
+				width: 100%;
+			}
 		}
 
 		&.agency-partner, &.pro-agency-partner {
@@ -149,6 +156,7 @@ $video-green: #0e5837;
 		display: flex;
 		flex-direction: column;
 		padding-block-end: 16px;
+		padding-inline-end: 0;
 	}
 
 	.a4a-themed-modal__sidebar-image-container {
@@ -166,6 +174,7 @@ $video-green: #0e5837;
 			gap: 16px;
 			flex-direction: column;
 			overflow-y: auto;
+			padding-inline-end: 32px;
 
 			.agency-tier-celebration-modal__title {
 				@include a4a-font-heading-xl;


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1370

## Proposed Changes

This PR:

- Updates the CTA on the celebration modal to take full width.
- Updates the scroll to be positioned to the extreme right of the modal.

## Testing Instructions

* Update your agency tier to Pro Agency Partner using the MC tool > Open the A4A live link > Go to the Overview page.
* Verify the scroll on the modal is positioned in the extreme corner:

| Before | After |
|--------|--------|
| <img width="791" alt="Screenshot 2024-10-28 at 5 04 36 PM" src="https://github.com/user-attachments/assets/542eb540-d925-4740-9aeb-2cc021fc6e20">| <img width="791" alt="Screenshot 2024-10-28 at 5 04 15 PM" src="https://github.com/user-attachments/assets/5146547c-70e1-4e8e-93fc-c0aeda6e1ce8"> |

- Switch to mobile view > Verify the button takes full width

| Before | After |
|--------|--------|
| <img width="378" alt="Screenshot 2024-10-28 at 5 08 03 PM" src="https://github.com/user-attachments/assets/da546df0-dafd-4eb6-bb4d-f17f8fd6c4c6">| <img width="378" alt="Screenshot 2024-10-28 at 5 05 10 PM" src="https://github.com/user-attachments/assets/b50a7192-f863-488b-92a4-802624f61a94"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
