### PR TITLE
A4A: Add the migration page v2 feature flag.

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/controller.tsx
+++ b/client/a8c-for-agencies/sections/migrations/controller.tsx
@@ -1,13 +1,15 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import MainSidebar from '../../components/sidebar-menu/main';
 import MigrationsOverview from './migrations-overview';
+import MigrationsOverviewV2 from './migrations-overview-v2';
 
 export const migrationsContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Migrations" path={ context.path } />
-			<MigrationsOverview />
+			{ isEnabled( 'a4a-migrations-page-v2' ) ? <MigrationsOverviewV2 /> : <MigrationsOverview /> }
 		</>
 	);
 	context.secondary = <MainSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/migrations/migrations-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview-v2/index.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export default function MigrationsOverviewV2() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const title = translate( 'Migrations' );
+
+	const onMigrateSitesClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_migrations_migrate_sites_button_click' ) );
+	}, [ dispatch ] );
+
+	return (
+		<Layout className="migrations-overview-v2" title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title }</Title>
+					<Actions>
+						<Button
+							variant="primary"
+							onClick={ onMigrateSitesClick }
+							href={ CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT }
+						>
+							{ translate( 'Migrate your sites' ) }
+						</Button>
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>Migrations Overview V2</LayoutBody>
+		</Layout>
+	);
+}

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -42,6 +42,7 @@
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": true,
+		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -35,6 +35,7 @@
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": true,
+		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true
 	},
 	"enable_all_sections": false,


### PR DESCRIPTION
This PR introduces the migration page v2 feature flag. To make testing easier, it also includes a new empty page where we will develop the updated migration page.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1371

## Proposed Changes

* Add the 'a4a-migrations-page-v2' feature flag.
* Add the 'migrations-overview-v2' component where our new implementation will reside. If the feature flag is enabled, this component is loaded in the migrations page.

## Why are these changes being made?

* This unblock multiple tickets that relies with the new feature flag.

## Testing Instructions

* Use the A4A live link and go to the `/migrations` page.
* Confirm that you see the new empty page.
   <img width="1726" alt="Screenshot 2024-10-28 at 8 20 11 PM" src="https://github.com/user-attachments/assets/c48bd085-3d4a-4c4c-99d1-ef5b724b6d02">
* Now disable the feature flag by going to the URL: `/migrations?flags=-a4a-migrations-page-v2`
* Confirm that you see the current migrations page.
   <img width="1148" alt="Screenshot 2024-10-28 at 8 26 54 PM" src="https://github.com/user-attachments/assets/2340a0eb-8c07-4e76-a9b0-25b6570236cd">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
