### PR TITLE
Help Center: Check for conversation returning null

### DIFF
--- a/packages/odie-client/src/context/use-load-previous-chat.ts
+++ b/packages/odie-client/src/context/use-load-previous-chat.ts
@@ -34,15 +34,17 @@ export const useLoadPreviousChat = ( {
 					chatId: existingChat?.chat_id,
 					conversationId: selectedConversationId,
 				} )?.then( ( conversation ) => {
-					setSupportProvider( 'zendesk' );
-					setChat( {
-						chat_id: conversation.metadata[ 'odieChatId' ]
-							? Number( conversation.metadata[ 'odieChatId' ] )
-							: null,
-						...existingChat,
-						conversationId: conversation.id,
-						messages: [ ...messages, ...( conversation.messages as Message[] ) ],
-					} );
+					if ( conversation ) {
+						setSupportProvider( 'zendesk' );
+						setChat( {
+							chat_id: conversation.metadata[ 'odieChatId' ]
+								? Number( conversation.metadata[ 'odieChatId' ] )
+								: null,
+							...existingChat,
+							conversationId: conversation.id,
+							messages: [ ...messages, ...( conversation.messages as Message[] ) ],
+						} );
+					}
 					return;
 				} );
 			}

--- a/packages/odie-client/src/context/use-load-previous-chat.ts
+++ b/packages/odie-client/src/context/use-load-previous-chat.ts
@@ -27,7 +27,11 @@ export const useLoadPreviousChat = ( {
 	useEffect( () => {
 		if ( existingChat || selectedConversationId ) {
 			const initialMessage = getOdieInitialMessage( botNameSlug, odieInitialPromptText );
-			const messages = [ initialMessage, ...( existingChat as Chat ).messages ];
+			const messages = [ initialMessage ];
+
+			if ( existingChat ) {
+				messages.push( ...( existingChat as Chat ).messages );
+			}
 
 			if ( isChatLoaded ) {
 				getZendeskConversation( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

`getZendeskConversation` may return null if there are no conversations, causing an error.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To prevent an error for happening.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new user
* Try to access Support via the Help center
* You shouldn't get a white screen

