### PR TITLE
Reader Onboarding: Append recommendations instead of replacing them.

### DIFF
--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -257,7 +257,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 								) ) }
 							</div>
 						) }
-						{ combinedRecommendations.length > 6 && currentPage < maxPages && (
+						{ currentPage < maxPages && (
 							<Button
 								className="subscribe-modal__load-more-button"
 								onClick={ handleLoadMore }

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -62,6 +62,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 	const [ selectedSite, setSelectedSite ] = useState< CardData | null >( null );
 	const dispatch = useDispatch();
 	const currentLocale = getLocaleSlug();
+	const SITES_PER_PAGE = 6;
 
 	const { data: apiRecommendedSites = [], isLoading } = useQuery( {
 		queryKey: [ 'reader-onboarding-recommended-sites', followedTagSlugs, currentLocale ],
@@ -148,11 +149,11 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		return sortedRecommendations.slice( 0, 18 );
 	}, [ followedTagSlugs, apiRecommendedSites, isLoading, currentLocale ] );
 
-	const maxPages = Math.ceil( combinedRecommendations.length / 6 ) - 1; // -1 because pages are 0-based.
+	const maxPages = Math.ceil( combinedRecommendations.length / SITES_PER_PAGE ) - 1; // -1 because pages are 0-based.
 
 	const displayedRecommendations = useMemo( () => {
 		// Show all items up to the current page.
-		return combinedRecommendations.slice( 0, ( currentPage + 1 ) * 6 );
+		return combinedRecommendations.slice( 0, ( currentPage + 1 ) * SITES_PER_PAGE );
 	}, [ combinedRecommendations, currentPage ] );
 
 	const handleLoadMore = useCallback( () => {

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -148,20 +148,17 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		return sortedRecommendations.slice( 0, 18 );
 	}, [ followedTagSlugs, apiRecommendedSites, isLoading, currentLocale ] );
 
+	const maxPages = Math.ceil( combinedRecommendations.length / 6 ) - 1; // -1 because pages are 0-based.
+
 	const displayedRecommendations = useMemo( () => {
-		const startIndex = currentPage * 6;
-		return combinedRecommendations.slice( startIndex, startIndex + 6 );
+		// Show all items up to the current page.
+		return combinedRecommendations.slice( 0, ( currentPage + 1 ) * 6 );
 	}, [ combinedRecommendations, currentPage ] );
 
 	const handleLoadMore = useCallback( () => {
-		const maxPages = Math.ceil( combinedRecommendations.length / 6 ) - 1; // -1 because pages are 0-based.
-		setCurrentPage( ( prevPage ) => ( prevPage < maxPages ? prevPage + 1 : 0 ) );
-	}, [ combinedRecommendations.length ] );
-
-	const loadMoreText =
-		currentPage === Math.ceil( combinedRecommendations.length / 6 ) - 1
-			? __( 'Start over' )
-			: __( 'Load more recommendations' );
+		// Only increment the page if we haven't reached the end.
+		setCurrentPage( ( prevPage ) => ( prevPage < maxPages ? prevPage + 1 : prevPage ) );
+	}, [ maxPages ] );
 
 	const headerActions = (
 		<>
@@ -260,13 +257,13 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 								) ) }
 							</div>
 						) }
-						{ combinedRecommendations.length > 6 && (
+						{ combinedRecommendations.length > 6 && currentPage < maxPages && (
 							<Button
 								className="subscribe-modal__load-more-button"
 								onClick={ handleLoadMore }
 								variant="link"
 							>
-								{ loadMoreText }
+								{ __( 'Load more recommendations' ) }
 							</Button>
 						) }
 						<Button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/200

## Proposed Changes

* Append pages of recommendations instead of replacing them.
* Show "Load more recommendations" only when there's another page of recommendations to append.


https://github.com/user-attachments/assets/6c5a6534-c70d-4a19-ba6b-740fe9d34f1a



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the Reader Onboarding user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read as a new user with a verified email.
* Start Reader Onboarding by clicking "Select some of your interests."
* Select at least two interests and click Continue.
* You should see 6 sites to subscribe to.
* Scroll down and click "Load more recommendations". You should see 6 more sites.
* Keep loading more until the button disappears.
* Verify that you can still see and subscribe to sites at the beginning of the list.
* Verify that you can click "Continue" again to complete onboarding.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
