### PR TITLE
Post-migration purchase experience: Add "View sites dashboard" button to migration message screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
+import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Icon, globe, group, shield, backup, scheduled } from '@wordpress/icons';
@@ -157,6 +158,21 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 		? __( "We'll take it from here!" )
 		: __( 'Let us take it from here!' );
 
+	const sitesDashboardButton = (
+		<div className="migration-message__cta-wrapper">
+			<Button
+				className="migration-message__cta"
+				href="/sites"
+				variant="primary"
+				onClick={ () =>
+					recordTracksEvent( 'calypso_migration_message_view_sites_dashboard_click' )
+				}
+			>
+				{ __( 'View sites dashboard' ) }
+			</Button>
+		</div>
+	);
+
 	return (
 		<StepContainer
 			stepName="migration-message"
@@ -199,6 +215,7 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 							<FlowCard key={ index } title={ title } text={ text } onClick={ onClick } />
 						) ) }
 					</div>
+					{ sitesDashboardButton }
 				</>
 			}
 			recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -18,15 +18,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { UserData } from 'calypso/lib/user/user';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import FlowCard from '../components/flow-card';
-import { redirect } from '../import/util';
 import { useSubmitMigrationTicket } from './hooks/use-submit-migration-ticket';
-
-interface ActionsProps {
-	title: string;
-	text: string;
-	onClick: () => void;
-}
 
 interface WhatToExpectProps {
 	icon: JSX.Element;
@@ -86,7 +78,6 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ shouldPreventTicketCreation, config, fromUrl, siteSlug ] );
 	let whatToExpect: WhatToExpectProps[] = [];
-	let actions: ActionsProps[] = [];
 
 	if (
 		shouldPreventTicketCreation &&
@@ -102,20 +93,8 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 			{
 				icon: scheduled,
 				text: __(
-					`You'll get an update on the progress of your migration within 2–3 business days.`
+					`We'll send you an update within 2–3 business days. You can also check the progress of your migration from your Sites dashboard.`
 				),
-			},
-		];
-		actions = [
-			{
-				title: __( 'Explore features' ),
-				text: __( 'Discover the features available on WordPress.com' ),
-				onClick: () => redirect( `/home/${ siteSlug }` ),
-			},
-			{
-				title: __( 'Learn about WordPress.com' ),
-				text: __( 'Access guides and tutorials to better understand how to use WordPress.com.' ),
-				onClick: () => redirect( '/support' ),
 			},
 		];
 	} else {
@@ -133,18 +112,6 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 			{
 				icon: group,
 				text: __( `We'll create a copy of your live site, allowing you to compare the two.` ),
-			},
-		];
-		actions = [
-			{
-				title: __( 'Let me explore' ),
-				text: __( 'Discover more features and options available on WordPress.com on your own.' ),
-				onClick: () => redirect( `/home/${ siteSlug }` ),
-			},
-			{
-				title: __( 'Help me learn' ),
-				text: __( 'Access guides and tutorials to better understand how to use WordPress.com.' ),
-				onClick: () => redirect( '/support' ),
 			},
 		];
 	}
@@ -210,11 +177,6 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 							{ text }
 						</div>
 					) ) }
-					<div className="migration-message__actions">
-						{ actions.map( ( { title, text, onClick }, index ) => (
-							<FlowCard key={ index } title={ title } text={ text } onClick={ onClick } />
-						) ) }
-					</div>
 					{ sitesDashboardButton }
 				</>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -168,7 +168,7 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 					recordTracksEvent( 'calypso_migration_message_view_sites_dashboard_click' )
 				}
 			>
-				{ __( 'View sites dashboard' ) }
+				{ __( 'View Sites dashboard' ) }
 			</Button>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
@@ -71,4 +71,13 @@
 			}
 		}
 	}
+
+	.migration-message__cta-wrapper {
+		display: flex;
+		justify-content: center;
+	}
+
+	.migration-message__cta {
+		margin-top: 20px;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #95404

## Proposed Changes

* Add a "View Sites dashboard" button at the bottom of the migration message screen during onboarding.
* Update copy for the timing.
* Remove the explore and learn action cards.

<img width="1360" alt="Screenshot 2024-10-28 at 3 42 25 PM" src="https://github.com/user-attachments/assets/0ff38fbc-4e8e-4a34-b93a-5d5989bdbd4e">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Switch to this PR
* Navigate to `/setup/site-migration/migrateMessage?siteId=12345&siteSlug=yourtestsite.wordpress.com&preventTicketCreation=true`
* Note the presence of the button at the bottom of the page
* Clicking the button should take you to `/sites`
* Upon clicking the button, you should see a Tracks event fire in Tracks Vigilante or the console (run `localStorage.debug="calypso:analytics*"` in the console and refresh the page):

<img width="1070" alt="Screenshot 2024-10-28 at 1 25 56 PM" src="https://github.com/user-attachments/assets/961460e9-177e-4686-85a2-c61c59943b81">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
