### PR TITLE
Passwordless Core Profiler Auth - text-align to center and update the btn copy

### DIFF
--- a/client/blocks/authentication/social/social-tos.jsx
+++ b/client/blocks/authentication/social/social-tos.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -30,6 +31,46 @@ function getToSComponent( content ) {
 
 function SocialAuthToS( props ) {
 	if ( props.isWooPasswordless ) {
+		if ( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
+			const termsOfServiceLink = (
+				<a
+					href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+					className="jetpack-connect__sso-actions-modal-link"
+					onClick={ () => {
+						this.props.recordTracksEvent( 'calypso_jpc_disclaimer_tos_link_click', {
+							...this.props,
+						} );
+					} }
+				/>
+			);
+			const syncDataLink = (
+				<a
+					href={ localizeUrl( 'https://jetpack.com/support/what-data-does-jetpack-sync/' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+					className="jetpack-connect__sso-actions-modal-link"
+					onClick={ () => {
+						this.props.recordTracksEvent( 'calypso_jpc_disclaimer_sync_data_link_click', {
+							...this.props,
+						} );
+					} }
+				/>
+			);
+
+			return getToSComponent(
+				props.translate(
+					'By clicking any of the options above, you agree to our {{termsOfServiceLink}}Terms of Service{{/termsOfServiceLink}} and to {{syncDataLink}}sync your site’s data{{/syncDataLink}} with us.',
+					{
+						components: {
+							termsOfServiceLink,
+							syncDataLink,
+						},
+					}
+				)
+			);
+		}
 		return getToSComponent(
 			props.translate(
 				'By continuing with any of the options above, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -793,21 +793,15 @@ export class JetpackAuthorize extends Component {
 			return translate( 'Return to your site' );
 		}
 
-if (this.isWooPasswordlessJPC()) {
-    if (config.isEnabled('woocommerce/core-profiler-passwordless-auth')) {
-        return translate('Connect to WordPress.com');
-    } else {
-        return translate('Connect your account');
-    }
-}
-			if ( this.isWooPasswordlessJPC() ) {
+		if ( this.isWooPasswordlessJPC() ) {
+			if ( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
 				return translate( 'Connect to WordPress.com' );
 			}
-		} else {
-			// eslint-disable-next-line no-lonely-if
-			if ( this.isWooPasswordlessJPC() ) {
-				return translate( 'Connect your account' );
-			}
+			return translate( 'Connect your account' );
+		}
+		// eslint-disable-next-line no-lonely-if
+		if ( this.isWooPasswordlessJPC() ) {
+			return translate( 'Connect your account' );
 		}
 
 		if ( ! this.retryingAuth ) {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -793,8 +793,15 @@ export class JetpackAuthorize extends Component {
 			return translate( 'Return to your site' );
 		}
 
-		if ( this.isWooPasswordlessJPC() ) {
-			return translate( 'Connect your account' );
+		if ( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
+			if ( this.isWooPasswordlessJPC() ) {
+				return translate( 'Connect to WordPress.com' );
+			}
+		} else {
+			// eslint-disable-next-line no-lonely-if
+			if ( this.isWooPasswordlessJPC() ) {
+				return translate( 'Connect your account' );
+			}
 		}
 
 		if ( ! this.retryingAuth ) {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -793,7 +793,13 @@ export class JetpackAuthorize extends Component {
 			return translate( 'Return to your site' );
 		}
 
-		if ( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
+if (this.isWooPasswordlessJPC()) {
+    if (config.isEnabled('woocommerce/core-profiler-passwordless-auth')) {
+        return translate('Connect to WordPress.com');
+    } else {
+        return translate('Connect your account');
+    }
+}
 			if ( this.isWooPasswordlessJPC() ) {
 				return translate( 'Connect to WordPress.com' );
 			}

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -70,7 +70,7 @@ class JetpackConnectDisclaimer extends PureComponent {
 			);
 
 			text = translate(
-				'By clicking Connect your account, you agree to our {{termsOfServiceLink}}Terms of Service{{/termsOfServiceLink}} and to {{syncDataLink}}sync your site’s data{{/syncDataLink}} with us.',
+				'By clicking Connect to WordPress.com, you agree to our {{termsOfServiceLink}}Terms of Service{{/termsOfServiceLink}} and to {{syncDataLink}}sync your site’s data{{/syncDataLink}} with us.',
 				{
 					components: {
 						termsOfServiceLink,

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1221,7 +1221,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		.jetpack-connect__tos-link {
 			margin: 24px auto;
-			text-align: left;
+			text-align: center;
 			a {
 				line-height: inherit;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR centers the disclaimer copy on the authorization page and updates the connect btn text to `Connect to WordPress.com`
![Screenshot 2024-10-28 at 10 42 21 AM](https://github.com/user-attachments/assets/dbb5267c-15d4-4428-a9be-cc537bf35964)
![Screenshot 2024-10-29 at 12 22 53 PM](https://github.com/user-attachments/assets/a9defbf9-7c60-4810-a417-b5c338038ebb)




Figma: Y5pUYSJPsGEud1vknUZhi8-fi-3182_10667


## Proposed Changes

* Center align the disclaimer copy
* Update the connect btn copy

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To reflect the latest design change

## Testing Instructions

1. Checkout this branch and run `yarn start`
2. Once the site is ready, visit this [link](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=236381464&redirect_uri=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D32ab4c9508%26redirect%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A2ca8ea2582da1c066074563a12cc8b22&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=13.7&secret=QFoaAXaOIPZTr9p6Z5Hqf6RWkCboPylJ&blogname=Noisily+Fortunate+Toucan&site_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&home_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&site_icon&site_lang=en_US&site_created=2024-08-26+19%3A40%3A51&allow_site_connection=1&calypso_env=production&source&_as=search-term&_ak=jetpack&from=woocommerce-core-profiler&installed_ext_success=1&_ui=254662545&_ut=wpcom%3Auser_id&purchase_nonce=lbtPaOlO&_wp_nonce=69744335dc&redirect_after_auth=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja)
3. Confirm the button copy is `Connect your account`
4. Quit `yarn start` command and open `config/development.json`
5. Enable `woocommerce/core-profiler-passwordless-auth` feature flag.
6. Run `yarn start`
7. Go back to the link and refresh the page
8. Confirm the new changes.
9. Copy the URL and open it in an incognito session.
10. Confirm the changes for the `Connect your account` page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?