### PR TITLE
Reader Onboarding: Hide onboarding unless user email is verified

### DIFF
--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -8,7 +8,10 @@ import { READER_ONBOARDING_PREFERENCE_KEY } from 'calypso/reader/onboarding/cons
 import InterestsModal from 'calypso/reader/onboarding/interests-modal';
 import SubscribeModal from 'calypso/reader/onboarding/subscribe-modal';
 import { useSelector } from 'calypso/state';
-import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
+import {
+	getCurrentUserDate,
+	isCurrentUserEmailVerified,
+} from 'calypso/state/current-user/selectors';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 
@@ -23,12 +26,14 @@ const ReaderOnboarding = ( { onRender }: { onRender?: ( shown: boolean ) => void
 	);
 	const preferencesLoaded = useSelector( hasReceivedRemotePreferences );
 	const userRegistrationDate = useSelector( getCurrentUserDate );
+	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
 
 	const shouldShowOnboarding =
 		config.isEnabled( 'reader/onboarding' ) &&
 		preferencesLoaded &&
 		! hasCompletedOnboarding &&
 		userRegistrationDate &&
+		isEmailVerified &&
 		new Date( userRegistrationDate ) >= new Date( '2024-10-01T00:00:00Z' );
 
 	// Notify the parent component if onboarding will render.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/loop#203

## Proposed Changes

* Hides onboarding UI if user email is not verified

New User Unverified
![41828da31b5d91ad2da91bdfd742362d](https://github.com/user-attachments/assets/5825bf23-cce3-4613-b563-7b7f66f9f122)

Same User Verified
![4c028dc76fd14a47e25d8f81df72c6ea](https://github.com/user-attachments/assets/66c9a04d-b664-42c1-9efb-966c9c093d44)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX for Reader Onboarding

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new user and do not verify email
* Navigate to `/read?flags=reader/onboarding`
* *Should not see onboarding UI*
* Verify email
* Navigate to `/read?flags=reader/onboarding`
* *Should see onboarding UI*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
