### PR TITLE
Help Center: Add feedback user response for thumbs down option

### DIFF
--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { ForwardedRef, forwardRef } from 'react';
 import Markdown from 'react-markdown';
@@ -6,6 +7,7 @@ import CustomALink from './custom-a-link';
 import DislikeFeedbackMessage from './dislike-feedback-message';
 import ErrorMessage from './error-message';
 import Sources from './sources';
+import { ThumbsDownIcon } from './thumbs-icons';
 import { uriTransformer } from './uri-transformer';
 import { UserMessage } from './user-message';
 import { MessageIndicators } from '.';
@@ -38,6 +40,7 @@ export const MessageContent = forwardRef<
 			isLastMessage && 'odie-chatbox-message-last'
 		);
 
+		const shouldUseHelpCenterExperience = config.isEnabled( 'help-center-experience' );
 		return (
 			<div
 				className="odie-chatbox-message-sources-container"
@@ -70,6 +73,11 @@ export const MessageContent = forwardRef<
 					{ message.type === 'dislike-feedback' && <DislikeFeedbackMessage /> }
 				</div>
 				<Sources message={ message } />
+				{ shouldUseHelpCenterExperience && message.liked === false && (
+					<div className="odie-chatbox-message-feedback-response">
+						<ThumbsDownIcon />
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -484,6 +484,19 @@ $custom-border-corner-size: 16px;
 	.odie-chatbox-message-sources {
 		margin: 12px;
 	}
+	
+	.odie-chatbox-message-feedback-response {
+		border-radius: 2px;
+		background: var(--color-primary);
+		width: 46px;
+		height: 40px;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		fill: #fff;
+		float: right;
+		margin: 16px;
+	}
 
 	&:nth-last-child(2) {
 		.foldable-card {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95626
Fixes https://github.com/Automattic/wp-calypso/issues/95626

## Proposed Changes

* Adds a thumbs-down icon as a "user response" when the user selects the thumbs-down feedback option.

<img src="https://github.com/user-attachments/assets/e47de90c-9199-4e89-a4a8-44c136e6ccac" alt="Help Center feedback response" width="450" height="850"></img>


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Enable the `help-center-experience` flag (query param: `flags=help-center-experience`).
* Open the Help Center and click the "Still need help?" button.
* Send a message and click on the thumbs-down icon for the AI response.
* Verify the thumbs down icon appears underneath the AI response.
