### PR TITLE
DIFM Landing: add FAQ for content guidelines

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -16,7 +16,7 @@ import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState, useCallback } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -24,6 +24,7 @@ import FoldableFAQComponent from 'calypso/components/foldable-faq';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
+import { CHARACTER_LIMIT } from 'calypso/signup/steps/website-content/section-types/constants';
 import { useSelector } from 'calypso/state';
 import {
 	getProductBySlug,
@@ -670,7 +671,93 @@ export default function DIFMLanding( {
 								) }
 							</p>
 						</FoldableFAQ>
-						<FoldableFAQ id="faq-9" question={ translate( 'Can I use my existing domain name?' ) }>
+						<FoldableFAQ id="faq-9" question={ translate( 'What are the content guidelines?' ) }>
+							<p>
+								{ translate(
+									'{{strong}}Fresh Content Only:{{/strong}} Please provide original content rather than requesting migrations or content from existing pages, external websites, or files.',
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									"{{strong}}Timely Submission:{{/strong}} Submit your content {{strong}}within %(refundPeriodDays)d days{{/strong}} of purchase to keep things on track. If we don't receive it in time, we'll use AI-generated text and stock images based on your search terms to bring your site to life.",
+									{
+										components: {
+											strong: <strong />,
+										},
+										args: {
+											refundPeriodDays: 14,
+										},
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									'{{strong}}Bite-sized Content:{{/strong}} Keep each page under %s characters. Longer content will be trimmed using AI to ensure everything looks great.',
+									{
+										components: {
+											strong: <strong />,
+										},
+										args: [ numberFormat( CHARACTER_LIMIT, {} ) ],
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									"{{strong}}Design Approach:{{/strong}} We follow established design guidelines while customizing your site to reflect your brand. With your logo, colors, and style preferences, we'll create a professional site that captures your essence using our curated design elements.",
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									"{{strong}}Stay Connected:{{/strong}} After you submit your content, we'll review it. If everything meets our guidelines, we'll notify you when your site is ready for launch. If adjustments are needed, we'll reach out.",
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									"{{strong}}Perfect As-Is:{{/strong}} We aim to get it right the first time! While revisions aren't included, you can always make updates later using the WordPress editor.",
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									"{{strong}}Plugin Potential:{{/strong}} The initial setup doesn't include every feature, but it's a great starting point. Add options like appointments, courses, property listings, memberships, payments, animations, and more after we finish your site. Our Happiness Engineers can make recommendations based on your plan.",
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									"{{strong}}Custom Requests:{{/strong}} We focus on attractive and functional designs, but we can't accommodate very specific layout requests or exact matches to designs. For fully custom solutions or pixel-perfect recreations, we can connect you with an expert WordPress agency partner, with projects starting at $5,000.",
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
+							</p>
+						</FoldableFAQ>
+						<FoldableFAQ id="faq-10" question={ translate( 'Can I use my existing domain name?' ) }>
 							<p>
 								{ translate(
 									'Yes, our support team will help you connect your existing domain name to your site after the build is complete.'
@@ -678,7 +765,7 @@ export default function DIFMLanding( {
 							</p>
 						</FoldableFAQ>
 						{ ! isStoreFlow && (
-							<FoldableFAQ id="faq-10" question={ translate( 'Can I have a store set up?' ) }>
+							<FoldableFAQ id="faq-11" question={ translate( 'Can I have a store set up?' ) }>
 								<>
 									<p>
 										{ translate(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdh1Xd-2Ue-p2

## Proposed Changes

* Adds a new FAQ section on the DIFM landing page for content guidelines.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pdh1Xd-2Ue-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`.
* Confirm that there is a FAQ section titled "What are the content guidelines" and the answer matches the screenshot below:

<img width="1289" alt="image" src="https://github.com/user-attachments/assets/f84fdf1e-5f41-4bf9-8f73-e3aa662e1ca8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?