### PR TITLE
CtD Goals Step: Rework SelectCardCheckbox styles

### DIFF
--- a/packages/onboarding/src/select-card-checkbox/index.tsx
+++ b/packages/onboarding/src/select-card-checkbox/index.tsx
@@ -21,13 +21,16 @@ const SelectCardCheckbox = ( {
 
 	return (
 		<div
-			className={ clsx( 'select-card-checkbox__container', className, {
-				'is-checked': checked,
-			} ) }
+			className={ clsx( 'select-card-checkbox__container', className ) }
 			onClick={ () => onChange( ! checked ) }
 			role="presentation"
 		>
-			<CheckboxControl checked={ checked } id={ id } onChange={ onChange } />
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				checked={ checked }
+				id={ id }
+				onChange={ onChange }
+			/>
 			<label className="select-card-checkbox__label" htmlFor={ id }>
 				{ children }
 			</label>

--- a/packages/onboarding/src/select-card-checkbox/style.scss
+++ b/packages/onboarding/src/select-card-checkbox/style.scss
@@ -1,11 +1,16 @@
 .select-card-checkbox__container {
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--color-surface-backdrop, #f6f7f7);
+	background: var(--color-surface-backdrop, #f6f7f7);
 	border-radius: 4px;
-	padding: 17px 25px;
+	padding: 16px;
 	font-size: 0.875rem;
 	cursor: pointer;
 	display: flex;
 	align-items: center;
+
+	.components-checkbox-control {
+		--checkbox-input-margin: 16px;
+	}
 
 	.select-card-checkbox__label {
 		pointer-events: none;
@@ -14,17 +19,16 @@
 		align-items: center;
 	}
 
-	&.is-checked {
-		border: 2px solid #0675c4;
-		background: #f9fbfd;
-		padding: 16px 24px;
+	&:hover {
+		border-color: transparent;
 	}
 
-	.components-base-control__field {
-		margin-bottom: 0;
+	&:hover,
+	&:has(:checked) {
+		background: rgba(var(--color-accent-rgb, #3858e9), 8%);
 	}
 
-	.components-checkbox-control__input[type="checkbox"] {
-		border-color: #a7aaad;
+	&:has(:checked) {
+		border: 1px solid var(--color-accent, #3858e9);
 	}
 }

--- a/packages/onboarding/src/select-card-checkbox/style.scss
+++ b/packages/onboarding/src/select-card-checkbox/style.scss
@@ -1,6 +1,6 @@
 .select-card-checkbox__container {
-	border: 1px solid var(--color-surface-backdrop, #f6f7f7);
-	background: var(--color-surface-backdrop, #f6f7f7);
+	border: 1px solid var(--color-surface-backdrop);
+	background: var(--color-surface-backdrop);
 	border-radius: 4px;
 	padding: 16px;
 	font-size: 0.875rem;
@@ -25,10 +25,10 @@
 
 	&:hover,
 	&:has(:checked) {
-		background: rgba(var(--color-accent-rgb, #3858e9), 8%);
+		background: rgba(var(--color-accent-rgb), 8%);
 	}
 
 	&:has(:checked) {
-		border: 1px solid var(--color-accent, #3858e9);
+		border: 1px solid var(--color-accent);
 	}
 }

--- a/packages/onboarding/src/select-card-checkbox/style.scss
+++ b/packages/onboarding/src/select-card-checkbox/style.scss
@@ -25,7 +25,7 @@
 
 	&:hover,
 	&:has(:checked) {
-		background: rgba(var(--color-accent-rgb), 8%);
+		background: var(--color-accent-5);
 	}
 
 	&:has(:checked) {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/95640.

## Proposed Changes

Updates the styles of the `SelectCardCheckbox` component to conform to the designs.

![image](https://github.com/user-attachments/assets/0140b4ed-0fa4-4cf7-8f1e-071d698d3514)

This component is also used in the Reader's interest modal. I purposefully changed the base component so it looks closer to what we want, design-system wise:

![image](https://github.com/user-attachments/assets/79a56a08-111f-4438-a6e6-9b14b7da3356)

cc @nuriapenya 

## Testing Instructions

Open `http://calypso.localhost:3000/setup/site-setup/goals?siteSlug=%s` and verify the items conform to the designs defined here W9xI27S6Swvw5Ku21EbZvn-fi-5843_21845.