### PR TITLE
Performance Profiler: Align the IA badge with the recommendations text

### DIFF
--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -28,7 +28,9 @@ type InsightsSectionProps = {
 const AIBadge = styled.span`
 	padding: 0 8px;
 	margin-left: 8px;
+	margin-top: 2px;
 	width: fit-content;
+	height: fit-content;
 	border-radius: 4px;
 	float: right;
 	font-size: 12px;

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -19,6 +19,8 @@
 	}
 
 	.title {
+		display: flex;
+		align-items: center;
 		font-size: 1rem;
 		font-weight: 500;
 		margin-bottom: 8px;


### PR DESCRIPTION


## Proposed Changes

Align the IA badge with the title text

![CleanShot 2024-10-28 at 16 10 18@2x](https://github.com/user-attachments/assets/0dd50f3f-78f5-4893-848c-cc56e5e1709b)


## Why are these changes being made?

Fixes [Performance Profiler: Generated with AI label looks misaligned](https://github.com/Automattic/dotcom-forge/issues/9547)

## Testing Instructions

* Go to the speed test tool. Ex:  `/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MTA0ODB9.gVaNWDVCln4Dffv9LESjxTrlE8lK_L0sJZzypEKRYZ0`
* Scroll down to the recommendations section
* Check if the text inside the badge is aligned with the title as the image above
