### PR TITLE
Reader Onboarding: Update the subscriptions list behind the modal

### DIFF
--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -70,6 +70,7 @@ class ConnectedSubscriptionListItem extends Component {
 			disableSuggestedFollows,
 			onItemClick,
 			isSelected,
+			onFollowToggle,
 		} = this.props;
 
 		return (
@@ -88,6 +89,7 @@ class ConnectedSubscriptionListItem extends Component {
 				disableSuggestedFollows={ disableSuggestedFollows }
 				onItemClick={ onItemClick }
 				isSelected={ isSelected }
+				onFollowToggle={ onFollowToggle }
 			/>
 		);
 	}

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -47,6 +47,7 @@ function ReaderSubscriptionListItem( {
 	disableSuggestedFollows,
 	onItemClick,
 	isSelected,
+	onFollowToggle,
 } ) {
 	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
@@ -220,7 +221,7 @@ function ReaderSubscriptionListItem( {
 					feedId={ feedId }
 					siteId={ siteId }
 					railcar={ railcar }
-					onFollowToggle={ openSuggestedFollowsModal }
+					onFollowToggle={ onFollowToggle || openSuggestedFollowsModal }
 				/>
 				{ isFollowing && showNotificationSettings && (
 					<ReaderSiteNotificationSettings siteId={ siteId } />

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -221,7 +221,7 @@ function ReaderSubscriptionListItem( {
 					feedId={ feedId }
 					siteId={ siteId }
 					railcar={ railcar }
-					onFollowToggle={ onFollowToggle || openSuggestedFollowsModal }
+					onFollowToggle={ disableSuggestedFollows ? onFollowToggle : openSuggestedFollowsModal }
 				/>
 				{ isFollowing && showNotificationSettings && (
 					<ReaderSiteNotificationSettings siteId={ siteId } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/204

## Proposed Changes

* Pass a `handleFollowToggle` function from the subscribe modal, that re-requests follows to update the "Subscriptions" list.


https://github.com/user-attachments/assets/1d9b69db-75e0-4408-b21a-f1e42485ee3e



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the Reader Onboarding user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As a new user with a verified email, go to /read?flags=reader/onboarding
* Click "Select some of your interests" to begin onboarding, choose interests, and click Continue.
* On the next step, Subscribe to a site. Hit cancel or continue.
* Check that the "Subscriptions" list on the right includes the site.
* Clear your onboarding completed preference and go back to the "Discover and subscribe to sites you'll love" step.
* Unsubscribe from the site. Hit cancel or continue.
* Check that the site is no longer listed in Subscriptions.

Known existing issue: the Subscribe/Subscribed button is slightly glitchy.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
