### PR TITLE
Stast: Add track view floating panel follow up

### DIFF
--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -26,6 +26,7 @@ const TRACKS_EVENT_LEAVE_REVIEW_FROM_PANEL =
 const TRACKS_EVENT_SEND_FEEDBACK_FROM_PANEL =
 	'stats_feedback_action_open_form_modal_from_floating_panel';
 const TRACKS_EVENT_DISMISS_FLOATING_PANEL = 'stats_feedback_action_dismiss_floating_panel';
+const TRACKS_EVENT_VIEW_FLOATING_PANEL = 'stats_feedback_action_view_floating_panel';
 
 const FEEDBACK_PANEL_PRESENTATION_DELAY = 3000;
 const FEEDBACK_LEAVE_REVIEW_URL = 'https://wordpress.org/support/plugin/jetpack/reviews/';
@@ -196,6 +197,7 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		if ( ! isPending && ! isError && shouldShowFeedbackPanel ) {
 			setTimeout( () => {
 				setIsFloatingPanelOpen( true );
+				trackStatsAnalyticsEvent( TRACKS_EVENT_VIEW_FLOATING_PANEL );
 			}, FEEDBACK_PANEL_PRESENTATION_DELAY );
 		}
 	}, [ isPending, isError, shouldShowFeedbackPanel ] );

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -194,13 +194,13 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		useNoticeVisibilityHooks( siteId );
 
 	useEffect( () => {
-		if ( ! isPending && ! isError && shouldShowFeedbackPanel ) {
+		if ( ! isPending && ! isError && shouldShowFeedbackPanel && supportCommercialUse ) {
 			setTimeout( () => {
 				setIsFloatingPanelOpen( true );
 				trackStatsAnalyticsEvent( TRACKS_EVENT_VIEW_FLOATING_PANEL );
 			}, FEEDBACK_PANEL_PRESENTATION_DELAY );
 		}
-	}, [ isPending, isError, shouldShowFeedbackPanel ] );
+	}, [ isPending, isError, shouldShowFeedbackPanel, supportCommercialUse ] );
 
 	const dismissPanelWithDelay = () => {
 		// Allows the animation to run first.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Follow up for https://github.com/Automattic/wp-calypso/pull/95775

## Why are these changes being made?

* The panel flag is set to true even when it's not shown, so we need to fix it

## Testing Instructions

* Open a website without commercial subscription
* Ensure no event is sent similar to  `https://pixel.wp.com/t.gif?_en=jetpack_odyssey_stats_feedback_action_view_floating_panel&_ui=jetpack%3AaGLz1mflg0nQxV3UkZonlkih&_ut=anon&_ts=1730149951111&_tz=-13&_lg=en&_pf=MacIntel&_ht=982&_wd=1512&_sx=0&_sy=0&_dl=https%3A%2F%2Ftropic-of-horses.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dstats%23!%2Fstats%2Fday%2F238474157%3Fpage%3Dstats&_dr=&_rt=1730149951114&_=_`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
