### PR TITLE
Render a placeholder in plans column 

### DIFF
--- a/client/sites-dashboard/components/sites-site-plan.tsx
+++ b/client/sites-dashboard/components/sites-site-plan.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import JetpackLogo from 'calypso/components/jetpack-logo';
-import { isNotAtomicJetpack, isTrialSite } from '../utils';
+import { isDisconnectedJetpackAndNotAtomic, isNotAtomicJetpack, isTrialSite } from '../utils';
 import { PlanRenewNag } from './sites-plan-renew-nag';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -32,6 +32,7 @@ const STAGING_PLAN_LABEL = 'Staging';
 export const SitePlan = ( { site, userId }: SitePlanProps ) => {
 	const isWpcomStagingSite = site?.is_wpcom_staging_site ?? false;
 	const trialSite = isTrialSite( site );
+	const isSiteDisconnectedJetpackAndNotAtomic = isDisconnectedJetpackAndNotAtomic( site );
 
 	return (
 		<SitePlanContainer>
@@ -56,7 +57,10 @@ export const SitePlan = ( { site, userId }: SitePlanProps ) => {
 							/>
 						</PlanRenewNagContainer>
 					) : (
-						site.plan?.product_name_short
+						<>
+							{ ! isSiteDisconnectedJetpackAndNotAtomic && site.plan?.product_name_short }
+							{ isSiteDisconnectedJetpackAndNotAtomic && '-' }
+						</>
 					) }
 				</>
 			) : (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9490

## Proposed Changes

* Render a dash `-` in the plan column for non WordPress.com sites that have Jetpack disabled

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of WordPress.com quality works

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a Pressable or [jurassic ninja](https://jurassic.ninja/) site
* Deactivate Jetpack and install [A4A Client](https://wordpress.org/plugins/automattic-for-agencies-client/) plugin 
* Activate and connect the plugin so that your site shows up in `/sites` dashboard
* Verify the plans column has `-` instead of `Free`

![image](https://github.com/user-attachments/assets/0b13a5df-ec7c-4c69-b266-7058c362e4cf)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
