### PR TITLE
A4A > Agency Tier: Fetch updated tier after first purchase to display the celebration modal

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
@@ -8,7 +8,9 @@ import {
 	A4A_SITES_LINK_NEEDS_SETUP,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { fetchAgencies } from 'calypso/state/a8c-for-agencies/agency/actions';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setPurchasedLicense, resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -88,6 +90,8 @@ function useIssueAndAssignLicenses(
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
+	const agency = useSelector( getActiveAgency );
+
 	const products = useProductsQuery();
 
 	const { isReady: isIssueReady, issueLicenses } = useIssueLicenses( {
@@ -127,6 +131,11 @@ function useIssueAndAssignLicenses(
 
 			// We have issued the licenses successfully so we can now call onSuccess callback regardless if it was able to assign it.
 			options.onSuccess?.();
+
+			// Refresh the list of agencies if we don't have the tier to get the updated tier
+			if ( ! agency?.tier ) {
+				dispatch( fetchAgencies() );
+			}
 
 			const issuedKeys = issuedLicenses
 				.map( ( item ) => item.licenses.map( ( lic ) => lic.license_key ) )
@@ -209,6 +218,7 @@ function useIssueAndAssignLicenses(
 		selectedSite?.domain,
 		products?.data,
 		translate,
+		agency?.tier,
 	] );
 }
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1388

## Proposed Changes

This PR fetches the agency to get the updated tier info after the first purchase to display the celebration modal.

## Why are these changes being made?

* To show the celebration modal soon after the purchase without refreshing the page.

## Testing Instructions

* Update your agency tier to "No Tier" using the MC tool > Open the A4A live link
* Go to Marketplace > Add WordPress.com hosting > Complete the purchase
* Go to the overview page and verify that the celebration modal is shown as soon as you land on the page without having to refresh the page.

<img width="795" alt="Screenshot 2024-10-29 at 8 21 50 AM" src="https://github.com/user-attachments/assets/9282d585-89f9-452b-9637-61da089ffeab">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
