### PR TITLE
Remove sites actions button justification override

### DIFF
--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -186,10 +186,6 @@
 		display: table-cell; /* ensures these cells are always shown */
 	}
 
-	table.dataviews-view-table td:last-child .dataviews-view-table__cell-content-wrapper {
-		justify-content: flex-end;
-	}
-
 	.sites-overview__content {
 		margin-top: 0;
 	}


### PR DESCRIPTION
Related to # https://github.com/Automattic/wp-calypso/pull/95536

## Proposed Changes

* Removes the `justify-content: flex-end` from the actions ellipsis button on the /sites dashboard

Before

![Screenshot 2024-10-29 at 15-43-52 Sites — WordPress com](https://github.com/user-attachments/assets/3238474c-bda4-4caa-b93d-561f5b27d170)


After

![Screenshot 2024-10-29 at 15-45-42 Sites — WordPress com](https://github.com/user-attachments/assets/07f6f1ac-58d4-4841-8b59-ad2bd1a958dd)
