### PR TITLE
A4A > Overview: Update the Pressable card text

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/hosting/pressable-oferring.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/pressable-oferring.tsx
@@ -22,7 +22,7 @@ const PressableOffering = () => {
 		translate( 'Lightning-fast performance.' ),
 		translate( '100% uptime SLA.' ),
 		translate( 'Smart, managed plugin updates.' ),
-		translate( 'Comprehensive WP security with Jetpack.' ),
+		translate( 'Comprehensive WP security & performance with Jetpack Complete included.' ),
 		translate( '24/7 support from WordPress experts.' ),
 	];
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1263

## Proposed Changes

This PR updates the Pressable card on the Overview page.

## Why are these changes being made?

* To add Jetpack Complete to the Pressable card on the Overview page.

## Testing Instructions

* Open the A4A live link
* Go to the overview page > Go to the Pressable card and verify that the 3rd line item is updated to `Comprehensive WP security & performance with Jetpack Complete included.` Verify it is updated according to the [issue](https://github.com/Automattic/automattic-for-agencies-dev/issues/1263).

<img width="877" alt="Screenshot 2024-10-29 at 10 40 28 AM" src="https://github.com/user-attachments/assets/bbeb8c86-52b3-4c83-ae1b-1a9958d464e2">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
