### PR TITLE
A4A > Add Site: Update text & order of the "Add site" menu

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -11,6 +11,7 @@ import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketp
 import usePaymentMethod from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method';
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import A4ALogo from '../a4a-logo';
@@ -130,17 +131,6 @@ export default function AddNewSiteButton( {
 					{ translate( 'Add existing sites' ).toUpperCase() }
 				</div>
 				{ menuItem( {
-					icon: <WordPressLogo />,
-					heading: translate( 'Via WordPress.com' ),
-					description: translate( 'Add sites bought on{{nbsp/}}WordPress.com', {
-						components: { nbsp: <>&nbsp;</> },
-						comment: 'nbsp is a non-breaking space character',
-					} ),
-					buttonProps: {
-						onClick: handleImportFromWPCOM,
-					},
-				} ) }
-				{ menuItem( {
 					icon: <A4ALogo />,
 					heading: translate( 'Via the Automattic plugin' ),
 					description: translate( 'Connect with the Automattic for Agencies{{nbsp/}}plugin', {
@@ -155,9 +145,22 @@ export default function AddNewSiteButton( {
 					},
 				} ) }
 				{ menuItem( {
+					icon: <WordPressLogo />,
+					heading: translate( 'Via WordPress.com' ),
+					description: translate( 'Add sites already connected to{{nbsp/}}WordPress.com', {
+						components: { nbsp: <>&nbsp;</> },
+						comment: 'nbsp is a non-breaking space character',
+					} ),
+					buttonProps: {
+						onClick: handleImportFromWPCOM,
+					},
+				} ) }
+				{ menuItem( {
 					icon: <JetpackLogo />,
 					heading: translate( 'Via Jetpack' ),
-					description: translate( 'Import one or more Jetpack connected sites' ),
+					description: preventWidows(
+						translate( 'Add a site by remotely installing the Jetpack plugin' )
+					),
 					buttonProps: {
 						onClick: () => {
 							setShowJetpackConnectionModal( true );

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -133,10 +133,9 @@ export default function AddNewSiteButton( {
 				{ menuItem( {
 					icon: <A4ALogo />,
 					heading: translate( 'Via the Automattic plugin' ),
-					description: translate( 'Connect with the Automattic for Agencies{{nbsp/}}plugin', {
-						components: { nbsp: <>&nbsp;</> },
-						comment: 'nbsp is a non-breaking space character',
-					} ),
+					description: preventWidows(
+						translate( 'Connect with the Automattic for Agencies plugin' )
+					),
 					buttonProps: {
 						onClick: () => {
 							setShowA4AConnectionModal( true );
@@ -147,10 +146,7 @@ export default function AddNewSiteButton( {
 				{ menuItem( {
 					icon: <WordPressLogo />,
 					heading: translate( 'Via WordPress.com' ),
-					description: translate( 'Add sites already connected to{{nbsp/}}WordPress.com', {
-						components: { nbsp: <>&nbsp;</> },
-						comment: 'nbsp is a non-breaking space character',
-					} ),
+					description: preventWidows( translate( 'Add sites already connected to WordPress.com' ) ),
 					buttonProps: {
 						onClick: handleImportFromWPCOM,
 					},


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1247

## Proposed Changes

This PR updates the text order of the "Add site" menu.

## Testing Instructions

- Open the A4A live link
- Click the Add sites button on the top right of the overview page and verify the text and order is updated according to the [issue](https://github.com/Automattic/automattic-for-agencies-dev/issues/1247)


| Before | After |
|--------|--------|
| <img width="975" alt="Screenshot 2024-10-29 at 10 49 26 AM" src="https://github.com/user-attachments/assets/cfd8f6b6-6dac-4bac-94af-152547f3d4c0">| <img width="975" alt="Screenshot 2024-10-29 at 10 52 19 AM" src="https://github.com/user-attachments/assets/6390b6a3-be4b-4cc8-9833-627511377c26"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
