### PR TITLE
Add new Site Settings

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -581,6 +581,12 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'site-settings',
+		paths: [ '/sites/settings' ],
+		module: 'calypso/sites/settings',
+		group: 'sites',
+	},
+	{
 		name: 'backup',
 		paths: [ '/backup' ],
 		module: 'calypso/my-sites/backup',

--- a/client/sites/components/site-preview-pane/constants.ts
+++ b/client/sites/components/site-preview-pane/constants.ts
@@ -10,11 +10,12 @@ export const DOTCOM_SITE_PERFORMANCE = 'dotcom-site-performance';
 
 export const SITE_MARKETING_TOOLS = 'site-marketing-tools';
 export const SITE_MARKETING_BUSINESS_TOOLS = 'site-marketing-business-tools';
-export const SETTINGS_SITE = 'site-settings';
-export const SETTINGS_ADMINISTRATION = 'site-administration';
-export const SETTINGS_AGENCY = 'site-agency';
-export const SETTINGS_CACHES = 'site-caches';
-export const SETTINGS_WEB_SERVER = 'site-web-server';
+
+export const SETTINGS_SITE = 'settings-site';
+export const SETTINGS_ADMINISTRATION = 'settings-administration';
+export const SETTINGS_AGENCY = 'settings-agency';
+export const SETTINGS_CACHES = 'settings-caches';
+export const SETTINGS_WEB_SERVER = 'settings-web-server';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOTCOM_OVERVIEW ]: 'overview/:site',

--- a/client/sites/components/site-preview-pane/constants.ts
+++ b/client/sites/components/site-preview-pane/constants.ts
@@ -10,8 +10,11 @@ export const DOTCOM_SITE_PERFORMANCE = 'dotcom-site-performance';
 
 export const SITE_MARKETING_TOOLS = 'site-marketing-tools';
 export const SITE_MARKETING_BUSINESS_TOOLS = 'site-marketing-business-tools';
-export const SITE_SETTINGS = 'site-settings';
-export const SITE_ADMINISTRATION = 'site-administration';
+export const SETTINGS_SITE = 'site-settings';
+export const SETTINGS_ADMINISTRATION = 'site-administration';
+export const SETTINGS_AGENCY = 'site-agency';
+export const SETTINGS_CACHES = 'site-caches';
+export const SETTINGS_WEB_SERVER = 'site-web-server';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOTCOM_OVERVIEW ]: 'overview/:site',
@@ -27,6 +30,9 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	// New Information Architecture
 	[ SITE_MARKETING_TOOLS ]: 'sites/marketing/tools/:site',
 	[ SITE_MARKETING_BUSINESS_TOOLS ]: 'sites/marketing/business-tools/:site',
-	[ SITE_SETTINGS ]: 'sites/settings/:site',
-	[ SITE_ADMINISTRATION ]: 'sites/administration/:site',
+	[ SETTINGS_SITE ]: 'sites/settings/site/:site',
+	[ SETTINGS_ADMINISTRATION ]: 'sites/settings/administration/:site',
+	[ SETTINGS_AGENCY ]: 'sites/settings/agency/:site',
+	[ SETTINGS_CACHES ]: 'sites/settings/caches/:site',
+	[ SETTINGS_WEB_SERVER ]: 'sites/settings/web-server/:site',
 };

--- a/client/sites/components/site-preview-pane/constants.ts
+++ b/client/sites/components/site-preview-pane/constants.ts
@@ -10,6 +10,8 @@ export const DOTCOM_SITE_PERFORMANCE = 'dotcom-site-performance';
 
 export const SITE_MARKETING_TOOLS = 'site-marketing-tools';
 export const SITE_MARKETING_BUSINESS_TOOLS = 'site-marketing-business-tools';
+export const SITE_SETTINGS = 'site-settings';
+export const SITE_ADMINISTRATION = 'site-administration';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOTCOM_OVERVIEW ]: 'overview/:site',
@@ -25,4 +27,6 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	// New Information Architecture
 	[ SITE_MARKETING_TOOLS ]: 'sites/marketing/tools/:site',
 	[ SITE_MARKETING_BUSINESS_TOOLS ]: 'sites/marketing/business-tools/:site',
+	[ SITE_SETTINGS ]: 'sites/settings/:site',
+	[ SITE_ADMINISTRATION ]: 'sites/administration/:site',
 };

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -23,6 +23,8 @@ import {
 	DOTCOM_STAGING_SITE,
 	SITE_MARKETING_TOOLS,
 	SITE_MARKETING_BUSINESS_TOOLS,
+	SITE_SETTINGS,
+	SITE_ADMINISTRATION,
 } from './constants';
 import PreviewPaneHeaderButtons from './preview-pane-header-buttons';
 import SiteEnvironmentSwitcher from './site-environment-switcher';
@@ -111,6 +113,11 @@ const DotcomPreviewPane = ( {
 				label: __( 'Marketing' ),
 				enabled: config.isEnabled( 'untangling/hosting-menu' ),
 				featureIds: [ SITE_MARKETING_TOOLS, SITE_MARKETING_BUSINESS_TOOLS ],
+			},
+			{
+				label: __( 'Settings' ),
+				enabled: config.isEnabled( 'untangling/hosting-menu' ),
+				featureIds: [ SITE_SETTINGS, SITE_ADMINISTRATION ],
 			},
 			{
 				label: hasEnTranslation( 'Server Settings' )

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -23,8 +23,11 @@ import {
 	DOTCOM_STAGING_SITE,
 	SITE_MARKETING_TOOLS,
 	SITE_MARKETING_BUSINESS_TOOLS,
-	SITE_SETTINGS,
-	SITE_ADMINISTRATION,
+	SETTINGS_SITE,
+	SETTINGS_ADMINISTRATION,
+	SETTINGS_AGENCY,
+	SETTINGS_CACHES,
+	SETTINGS_WEB_SERVER,
 } from './constants';
 import PreviewPaneHeaderButtons from './preview-pane-header-buttons';
 import SiteEnvironmentSwitcher from './site-environment-switcher';
@@ -117,7 +120,13 @@ const DotcomPreviewPane = ( {
 			{
 				label: __( 'Settings' ),
 				enabled: config.isEnabled( 'untangling/hosting-menu' ),
-				featureIds: [ SITE_SETTINGS, SITE_ADMINISTRATION ],
+				featureIds: [
+					SETTINGS_SITE,
+					SETTINGS_ADMINISTRATION,
+					SETTINGS_AGENCY,
+					SETTINGS_CACHES,
+					SETTINGS_WEB_SERVER,
+				],
 			},
 			{
 				label: hasEnTranslation( 'Server Settings' )

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -6,7 +6,7 @@ import type { Context as PageJSContext } from '@automattic/calypso-router';
 const SettingsSidebar = makeSidebar( {
 	items: [
 		{
-			key: 'settings',
+			key: 'site',
 			get label() {
 				return __( 'Site' );
 			},
@@ -17,13 +17,31 @@ const SettingsSidebar = makeSidebar( {
 				return __( 'Administration' );
 			},
 		},
+		{
+			key: 'agency',
+			get label() {
+				return __( 'Agency' );
+			},
+		},
+		{
+			key: 'caches',
+			get label() {
+				return __( 'Caches' );
+			},
+		},
+		{
+			key: 'web-server',
+			get label() {
+				return __( 'Web Server' );
+			},
+		},
 	],
 } );
 
 export function siteSettings( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
-			<SettingsSidebar selectedItemKey="settings" />
+			<SettingsSidebar selectedItemKey="site" />
 			<WpcomSiteTools />
 		</PanelWithSidebar>
 	);

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -39,3 +39,33 @@ export function administrationSettings( context: PageJSContext, next: () => void
 	);
 	next();
 }
+
+export function agencySettings( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<PanelWithSidebar>
+			<SettingsSidebar selectedItemKey="agency" />
+			<WpcomSiteTools />
+		</PanelWithSidebar>
+	);
+	next();
+}
+
+export function cachesSettings( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<PanelWithSidebar>
+			<SettingsSidebar selectedItemKey="caches" />
+			<WpcomSiteTools />
+		</PanelWithSidebar>
+	);
+	next();
+}
+
+export function webServerSettings( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<PanelWithSidebar>
+			<SettingsSidebar selectedItemKey="web-server" />
+			<WpcomSiteTools />
+		</PanelWithSidebar>
+	);
+	next();
+}

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import WpcomSiteTools from 'calypso/my-sites/site-settings/wpcom-site-tools';
 import makeSidebar, { PanelWithSidebar } from '../components/panel-sidebar';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
@@ -42,7 +41,7 @@ export function siteSettings( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
 			<SettingsSidebar selectedItemKey="site" />
-			<WpcomSiteTools />
+			<p>Site settings</p>
 		</PanelWithSidebar>
 	);
 	next();
@@ -52,7 +51,7 @@ export function administrationSettings( context: PageJSContext, next: () => void
 	context.primary = (
 		<PanelWithSidebar>
 			<SettingsSidebar selectedItemKey="administration" />
-			<WpcomSiteTools />
+			<p>Administration settings</p>
 		</PanelWithSidebar>
 	);
 	next();
@@ -62,7 +61,7 @@ export function agencySettings( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
 			<SettingsSidebar selectedItemKey="agency" />
-			<WpcomSiteTools />
+			<p>Agency settings</p>
 		</PanelWithSidebar>
 	);
 	next();
@@ -72,7 +71,7 @@ export function cachesSettings( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
 			<SettingsSidebar selectedItemKey="caches" />
-			<WpcomSiteTools />
+			<p>Caches settings</p>
 		</PanelWithSidebar>
 	);
 	next();
@@ -82,7 +81,7 @@ export function webServerSettings( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
 			<SettingsSidebar selectedItemKey="web-server" />
-			<WpcomSiteTools />
+			<p>Web server settings</p>
 		</PanelWithSidebar>
 	);
 	next();

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -1,0 +1,41 @@
+import { __ } from '@wordpress/i18n';
+import WpcomSiteTools from 'calypso/my-sites/site-settings/wpcom-site-tools';
+import makeSidebar, { PanelWithSidebar } from '../components/panel-sidebar';
+import type { Context as PageJSContext } from '@automattic/calypso-router';
+
+const SettingsSidebar = makeSidebar( {
+	items: [
+		{
+			key: 'settings',
+			get label() {
+				return __( 'Site' );
+			},
+		},
+		{
+			key: 'administration',
+			get label() {
+				return __( 'Administration' );
+			},
+		},
+	],
+} );
+
+export function siteSettings( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<PanelWithSidebar>
+			<SettingsSidebar selectedItemKey="settings" />
+			<WpcomSiteTools />
+		</PanelWithSidebar>
+	);
+	next();
+}
+
+export function administrationSettings( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<PanelWithSidebar>
+			<SettingsSidebar selectedItemKey="administration" />
+			<WpcomSiteTools />
+		</PanelWithSidebar>
+	);
+	next();
+}

--- a/client/sites/settings/index.tsx
+++ b/client/sites/settings/index.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
+import { siteSelection, navigation, sites } from 'calypso/my-sites/controller';
 import {
 	SETTINGS_SITE,
 	SETTINGS_ADMINISTRATION,
@@ -18,7 +18,7 @@ import {
 } from './controller';
 
 export default function () {
-	page( '/sites/settings', siteSelection, sites, makeLayout, clientRender );
+	page( '/sites/settings/site', siteSelection, sites, makeLayout, clientRender );
 	page(
 		'/sites/settings/site/:site',
 		siteSelection,
@@ -29,6 +29,7 @@ export default function () {
 		clientRender
 	);
 
+	page( '/sites/settings/administration', siteSelection, sites, makeLayout, clientRender );
 	page(
 		'/sites/settings/administration/:site',
 		siteSelection,
@@ -39,6 +40,7 @@ export default function () {
 		clientRender
 	);
 
+	page( '/sites/settings/agency', siteSelection, sites, makeLayout, clientRender );
 	page(
 		'/sites/settings/agency/:site',
 		siteSelection,
@@ -48,6 +50,8 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	page( '/sites/settings/caches', siteSelection, sites, makeLayout, clientRender );
 	page(
 		'/sites/settings/caches/:site',
 		siteSelection,
@@ -57,6 +61,8 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	page( '/sites/settings/web-server', siteSelection, sites, makeLayout, clientRender );
 	page(
 		'/sites/settings/web-server/:site',
 		siteSelection,

--- a/client/sites/settings/index.tsx
+++ b/client/sites/settings/index.tsx
@@ -2,31 +2,67 @@ import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import {
-	SITE_SETTINGS,
-	SITE_ADMINISTRATION,
+	SETTINGS_SITE,
+	SETTINGS_ADMINISTRATION,
+	SETTINGS_AGENCY,
+	SETTINGS_CACHES,
+	SETTINGS_WEB_SERVER,
 } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
-import { siteSettings, administrationSettings } from './controller';
+import {
+	siteSettings,
+	administrationSettings,
+	agencySettings,
+	cachesSettings,
+	webServerSettings,
+} from './controller';
 
 export default function () {
 	page( '/sites/settings', siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/sites/settings/:site',
+		'/sites/settings/site/:site',
 		siteSelection,
 		navigation,
 		siteSettings,
-		siteDashboard( SITE_SETTINGS ),
+		siteDashboard( SETTINGS_SITE ),
 		makeLayout,
 		clientRender
 	);
 
-	page( '/sites/administration', siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/sites/administration/:site',
+		'/sites/settings/administration/:site',
 		siteSelection,
 		navigation,
 		administrationSettings,
-		siteDashboard( SITE_ADMINISTRATION ),
+		siteDashboard( SETTINGS_ADMINISTRATION ),
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/sites/settings/agency/:site',
+		siteSelection,
+		navigation,
+		agencySettings,
+		siteDashboard( SETTINGS_AGENCY ),
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/sites/settings/caches/:site',
+		siteSelection,
+		navigation,
+		cachesSettings,
+		siteDashboard( SETTINGS_CACHES ),
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/sites/settings/web-server/:site',
+		siteSelection,
+		navigation,
+		webServerSettings,
+		siteDashboard( SETTINGS_WEB_SERVER ),
 		makeLayout,
 		clientRender
 	);

--- a/client/sites/settings/index.tsx
+++ b/client/sites/settings/index.tsx
@@ -1,0 +1,33 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
+import {
+	SITE_SETTINGS,
+	SITE_ADMINISTRATION,
+} from 'calypso/sites/components/site-preview-pane/constants';
+import { siteDashboard } from 'calypso/sites/controller';
+import { siteSettings, administrationSettings } from './controller';
+
+export default function () {
+	page( '/sites/settings', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/sites/settings/:site',
+		siteSelection,
+		navigation,
+		siteSettings,
+		siteDashboard( SITE_SETTINGS ),
+		makeLayout,
+		clientRender
+	);
+
+	page( '/sites/administration', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/sites/administration/:site',
+		siteSelection,
+		navigation,
+		administrationSettings,
+		siteDashboard( SITE_ADMINISTRATION ),
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -20,6 +20,7 @@ const SITE_DASHBOARD_ROUTES = {
 
 	// New Information Architecture
 	'site-marketing': '/sites/marketing',
+	'site-settings': '/sites/settings',
 };
 
 function isInSection( sectionName: string, sectionNames: string[] ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9607

## Proposed Changes

![Screenshot 2024-10-30 at 14-24-26 Site Tools ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/09f7d8e4-a06c-4a72-8112-89c4baa1eba6)

## Testing Instructions

* Visit the new settings page, confirm it's populated:
* http://calypso.localhost:3000/sites/settings/site
* Disable the feature flag, ensure the Settings tab isn't shown:
* calypso.localhost:3000/overview?flags=-untangling/hosting-menu
