### PR TITLE
A4A > Checkout: Update referral checkout summary notice 

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -99,9 +99,11 @@ export default function NoticeSummary( { type }: Props ) {
 			case 'request-client-payment':
 				return [
 					translate(
-						"Your client will be sent an invoice where they will be asked to create a WordPress.com account to pay for these products. Once paid, you'll be able to manage these products on behalf of the client."
+						'Your client will be sent an invoice asking them to create a WordPress.com account to pay for these products. They will be invoiced at the start of each month until they choose to cancel. Depending on how many days are left in the month, your client may be charged less than the total above for their first invoice.'
 					),
-					translate( 'The client can cancel their products at any time.' ),
+					translate(
+						'Once paid, you can manage these products on behalf of your client. The client can cancel their products at any time.'
+					),
 				];
 
 			case 'request-payment-method':


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1212
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1241

## Proposed Changes

This PR: 
- Updates the referral checkout summary notice.
- Change the disclaimer for the referral cart lifespan from 12 to 48 hours.

## Why are these changes being made?

* Explain the initial billing process in case of Referrals.

## Testing Instructions

* Open the A4A live link
* Go to Marketplace > Toggle the refer mode on > Add a few products > Go to checkout
* Verify the notice on the right side that displays the checkout summary is updated as per the [issue](https://github.com/Automattic/automattic-for-agencies-dev/issues/1212).
* Verify that the disclaimer is updated for the referral cart lifespan, which is from 12 hours to 48 hours.


<img width="572" alt="Screenshot 2024-10-29 at 12 30 12 PM" src="https://github.com/user-attachments/assets/5f70de52-2f61-4b9a-8ca7-ff08608bed85">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
