### PR TITLE
A4A > Overview: Fix the growth accelerator overflow issue

### DIFF
--- a/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/style.scss
@@ -23,16 +23,20 @@
 .overview__growth-accelerator-footer {
 	display: flex;
 	gap: 16px;
+	flex-direction: row;
+	flex-wrap: wrap;
 }
 
 .components-button.is-primary.overview__growth-accelerator-footer-schedule-call {
 	display: flex;
 	flex-direction: row;
 	gap: 8px;
+	flex: 1 1 auto;
 }
 
 .components-button.is-link.overview__growth-accelerator-footer-not-interested {
 	color: var(--color-text);
+	flex: 1 1 auto;
 
 	&:visited,
 	&:focus,


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1262

## Proposed Changes

This PR fixes the growth accelerator overflow issue

## Why are these changes being made?

* To fix the growth accelerator overflow issue

NOTE: you might have to clear the preferences: `a4a_growth_accelerator_requested` & `a4a_growth_accelerator_dismissed`

## Testing Instructions

* Open the A4A live link
* Go to the overview page and verify the growth accelerator scheduling card looks good on all the screens. You can compare this to production to reproduce the issue.

Large screen:

<img width="1368" alt="Screenshot 2024-10-29 at 1 14 55 PM" src="https://github.com/user-attachments/assets/6d08d2e9-35ad-4e5a-8ced-02be2141485f">

Tablet: 

<img width="764" alt="Screenshot 2024-10-29 at 1 01 03 PM" src="https://github.com/user-attachments/assets/17d4ba19-2971-4b84-a0ad-09d1e53f1d99">

Mobile: 

<img width="373" alt="Screenshot 2024-10-29 at 1 00 32 PM" src="https://github.com/user-attachments/assets/8fe78460-fee6-459c-bf16-625bd589d4a0">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
