### PR TITLE
A4A > Marketplace: Open Pressable support when the Contact us button is clicked

### DIFF
--- a/client/a8c-for-agencies/components/a4a-contact-support-widget/get-default-product.ts
+++ b/client/a8c-for-agencies/components/a4a-contact-support-widget/get-default-product.ts
@@ -1,0 +1,12 @@
+import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from '../sidebar-menu/lib/constants';
+
+// This map is used to determine the product when the user is on a specific page to preselect the product in the form.
+const pathToProductMap: Record< string, string > = {
+	[ A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK ]: 'pressable',
+};
+
+export default function getDefaultProduct(): string {
+	const product = pathToProductMap?.[ window.location.pathname ];
+
+	return product || '';
+}

--- a/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
@@ -3,8 +3,10 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import MigrationContactSupportForm from '../a4a-migration-offer-v2/migration-contact-support-form';
 import UserContactSupportModalForm from '../user-contact-support-modal-form';
+import getDefaultProduct from './get-default-product';
 
 export const CONTACT_URL_HASH_FRAGMENT = '#contact-support';
+export const CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT = '#contact-support-a4a';
 export const CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT = '#contact-support-migration-offer';
 
 export default function A4AContactSupportWidget() {
@@ -12,6 +14,7 @@ export default function A4AContactSupportWidget() {
 
 	const hashSupportFormHash =
 		window.location.hash === CONTACT_URL_HASH_FRAGMENT ||
+		window.location.hash === CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT ||
 		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
 
 	const [ showUserSupportForm, setShowUserSupportForm ] = useState( hashSupportFormHash );
@@ -35,6 +38,9 @@ export default function A4AContactSupportWidget() {
 		'\n\n' +
 		translate( '[your message here]' );
 
+	const defaultProduct =
+		window.location.hash === CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT ? getDefaultProduct() : '';
+
 	return isNewHostingPage &&
 		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT ? (
 		<MigrationContactSupportForm show={ showUserSupportForm } onClose={ onCloseUserSupportForm } />
@@ -47,6 +53,7 @@ export default function A4AContactSupportWidget() {
 					? migrationOfferDefaultMessage
 					: undefined
 			}
+			defaultProduct={ defaultProduct }
 		/>
 	);
 }

--- a/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
@@ -12,12 +12,12 @@ export const CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT = '#contact-support-m
 export default function A4AContactSupportWidget() {
 	const translate = useTranslate();
 
-	const hashSupportFormHash =
+	const supportFormHash =
 		window.location.hash === CONTACT_URL_HASH_FRAGMENT ||
 		window.location.hash === CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT ||
 		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
 
-	const [ showUserSupportForm, setShowUserSupportForm ] = useState( hashSupportFormHash );
+	const [ showUserSupportForm, setShowUserSupportForm ] = useState( supportFormHash );
 
 	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
 
@@ -28,7 +28,7 @@ export default function A4AContactSupportWidget() {
 	}, [] );
 
 	// We need make sure to set this to true when we have the support form hash fragment.
-	if ( hashSupportFormHash && ! showUserSupportForm ) {
+	if ( supportFormHash && ! showUserSupportForm ) {
 		setShowUserSupportForm( true );
 	}
 

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -21,6 +21,7 @@ type Props = {
 	show: boolean;
 	onClose?: () => void;
 	defaultMessage?: string;
+	defaultProduct?: string;
 };
 
 const DEFAULT_MESSAGE_VALUE = '';
@@ -30,6 +31,7 @@ export default function UserContactSupportModalForm( {
 	show,
 	onClose,
 	defaultMessage = DEFAULT_MESSAGE_VALUE,
+	defaultProduct = DEFAULT_PRODUCT_VALUE,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -39,7 +41,7 @@ export default function UserContactSupportModalForm( {
 
 	const [ name, setName ] = useState( user?.display_name );
 	const [ email, setEmail ] = useState( user?.email );
-	const [ product, setProduct ] = useState( DEFAULT_PRODUCT_VALUE );
+	const [ product, setProduct ] = useState( defaultProduct );
 	const [ pressableContactType, setPressableContactType ] = useState( 'sales' );
 	const [ site, setSite ] = useState( '' );
 	const [ message, setMessage ] = useState( defaultMessage );
@@ -53,8 +55,8 @@ export default function UserContactSupportModalForm( {
 
 	const resetForm = useCallback( () => {
 		setMessage( defaultMessage );
-		setProduct( DEFAULT_PRODUCT_VALUE );
-	}, [ defaultMessage ] );
+		setProduct( defaultProduct );
+	}, [ defaultMessage, defaultProduct ] );
 
 	const onModalClose = useCallback( () => {
 		onClose?.();

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -5,7 +5,7 @@ import formatCurrency from '@automattic/format-currency';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
-import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
+import { CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
 import { useDispatch, useSelector } from 'calypso/state';
 import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -175,7 +175,7 @@ export default function PlanSelectionDetails( {
 						</div>
 						<Button
 							className="pressable-overview-plan-selection__details-card-cta-button"
-							href={ CONTACT_URL_HASH_FRAGMENT }
+							href={ CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT }
 							primary
 						>
 							{ translate( 'Contact support' ) } <Icon icon={ external } size={ 16 } />
@@ -243,8 +243,7 @@ export default function PlanSelectionDetails( {
 							<Button
 								className="pressable-overview-plan-selection__details-card-cta-button"
 								onClick={ onContactUs }
-								href={ PRESSABLE_CONTACT_LINK }
-								target="_blank"
+								href={ CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT }
 								primary
 							>
 								{ translate( 'Contact us' ) } <Icon icon={ external } size={ 16 } />


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1265

## Proposed Changes

This PR:

- Updates the contact form to support the default product.
- Updates the `Contact us` button for the custom plan to open the support form modal.
- Updates the `Contact us` button for referral to open the support form modal with Pressable pre-selected as product.

## Why are these changes being made?

* To make it easy for the users to contact specific product support
* To allow agencies to contact us directly instead of redirecting. 

## Testing Instructions

* Open the A4A live link
* Go to Marketplace > Toggle the Refer mode on > Click the `Contact` us button on the Pressable tab > Verify that the modal is shown with the Pressable product pre-selected. 
* Toggle the Refer mode off > On the Pressable tab, drag the plan selector to the end for the custom plan > Click the `Contact` us button > Verify that the modal is shown with the Pressable product pre-selected. 
* Click the `Contact sales & support` button on the left navbar from the Pressable tab and verify that `Automattic for Agencies` is pre-selected instead of Pressable.

<img width="840" alt="Screenshot 2024-10-29 at 3 18 50 PM" src="https://github.com/user-attachments/assets/d2800960-3370-4eee-9662-f7b3916f76c1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
