### PR TITLE
A4A > Agency Tier: Minor text update to pro agency partner benefits

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
@@ -131,7 +131,7 @@ const getAgencyTierInfo = (
 						"You've influenced at least $5,000 in Automattic revenue and have unlocked these additional benefits:"
 					),
 					benefits: [
-						translate( 'A dedicated partner manager and enjoy priority support access.' ),
+						translate( 'A dedicated partner manager and priority support access.' ),
 						translate(
 							"Advanced sales training sessions at request to sharpen your team's expertise."
 						),


### PR DESCRIPTION
## Proposed Changes

The translation team suggested to remove the text "enjoy" from `A dedicated partner manager and enjoy priority support access.`

## Why are these changes being made?

* To remove the word "enjoy".

## Testing Instructions

* Open the A4A live link
* Use the MC tool to update your agency tier to Pro Agency Partner.
* Go to the overview page and refresh the page.
* Verify the first point has been changed to: `A dedicated partner manager and priority support access.`

<img width="792" alt="Screenshot 2024-10-29 at 4 35 47 PM" src="https://github.com/user-attachments/assets/211af466-583f-4d11-816e-1b530fd06436">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
