### PR TITLE
A4A: Implement the 'Client relationship' section on the new Migrations page.

### DIFF
--- a/client/a8c-for-agencies/components/page-section/index.tsx
+++ b/client/a8c-for-agencies/components/page-section/index.tsx
@@ -1,4 +1,5 @@
 import { useBreakpoint } from '@automattic/viewport-react';
+import clsx from 'clsx';
 import { TranslateResult } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import { SectionBackground } from './backgrounds';
@@ -6,6 +7,7 @@ import { SectionBackground } from './backgrounds';
 import './style.scss';
 
 export type PageSectionProps = {
+	className?: string;
 	children: ReactNode;
 	heading: TranslateResult;
 	subheading?: TranslateResult;
@@ -15,6 +17,7 @@ export type PageSectionProps = {
 };
 
 export default function PageSection( {
+	className,
 	icon,
 	heading,
 	subheading,
@@ -26,7 +29,7 @@ export default function PageSection( {
 
 	return (
 		<section
-			className="page-section-wrapper"
+			className={ clsx( 'page-section-wrapper', className ) }
 			style={ {
 				backgroundColor: background?.color,
 				backgroundImage: isNarrowView ? undefined : background?.image,

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/index.tsx
@@ -4,6 +4,7 @@ import PageSection, { PageSectionProps } from 'calypso/a8c-for-agencies/componen
 import './style.scss';
 
 type Props = Omit< PageSectionProps, 'children' > & {
+	className?: string;
 	items: {
 		title: string;
 		description: string;
@@ -12,6 +13,7 @@ type Props = Omit< PageSectionProps, 'children' > & {
 };
 
 export default function HostingBenefitsSection( {
+	className,
 	icon,
 	heading,
 	subheading,
@@ -21,6 +23,7 @@ export default function HostingBenefitsSection( {
 }: Props ) {
 	return (
 		<PageSection
+			className={ className }
 			icon={ icon }
 			heading={ heading }
 			subheading={ subheading }

--- a/client/a8c-for-agencies/sections/migrations/migrations-overview-v2/sections/migrations-client-relationship.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview-v2/sections/migrations-client-relationship.tsx
@@ -1,14 +1,41 @@
 import { useTranslate } from 'i18n-calypso';
-import PageSection from 'calypso/a8c-for-agencies/components/page-section';
+import HostingBenefitsSection from 'calypso/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section';
 
 export default function MigrationsClientRelationship() {
 	const translate = useTranslate();
 	return (
-		<PageSection
+		<HostingBenefitsSection
 			heading={ translate( 'Improve your client relationships with our hosting' ) }
 			description={ translate( 'Our hosting platform is built exclusively for WordPress.' ) }
-		>
-			CLIENT RELATIONSHIP HERE
-		</PageSection>
+			items={ [
+				{
+					title: translate( 'Create trust' ),
+					description: translate(
+						"With over 15 years of experience running hundreds of millions of sites on WordPress.com, including the highest-trafficked sites globally, we've developed a platform we confidently put up against any cloud service."
+					),
+					benefits: [
+						translate( '99.999% Uptime' ),
+						translate( 'High availability with automated scaling' ),
+					],
+				},
+				{
+					title: translate( 'Minimize risk' ),
+					description: translate(
+						'Automattic hosting plans offer exceptional security from day one, with the option to include or sell additional client-facing security features like real-time backups, anti-spam, and malware scanning.'
+					),
+					benefits: [ translate( 'Web Application Firewall' ), translate( 'DDoS protection' ) ],
+				},
+				{
+					title: translate( 'Increase speed' ),
+					description: translate(
+						"We're the only cloud platform team fully dedicated to optimizing WordPress. Your customers will feel the difference."
+					),
+					benefits: [
+						translate( 'Incredibly low page speed index' ),
+						'Automated WordPress edge caching',
+					],
+				},
+			] }
+		/>
 	);
 }

--- a/client/a8c-for-agencies/sections/migrations/migrations-overview-v2/sections/migrations-client-relationship/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview-v2/sections/migrations-client-relationship/index.tsx
@@ -1,10 +1,13 @@
 import { useTranslate } from 'i18n-calypso';
 import HostingBenefitsSection from 'calypso/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section';
 
+import './style.scss';
+
 export default function MigrationsClientRelationship() {
 	const translate = useTranslate();
 	return (
 		<HostingBenefitsSection
+			className="migrations-client-relationship"
 			heading={ translate( 'Improve your client relationships with our hosting' ) }
 			description={ translate( 'Our hosting platform is built exclusively for WordPress.' ) }
 			items={ [

--- a/client/a8c-for-agencies/sections/migrations/migrations-overview-v2/sections/migrations-client-relationship/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview-v2/sections/migrations-client-relationship/style.scss
@@ -1,0 +1,3 @@
+.migrations-client-relationship .hosting-benefits-card {
+	border-color: var( --color-primary-5 );
+}


### PR DESCRIPTION
This PR implements the **'Client relationship'** section on the new Migrations page.

<img width="1430" alt="Screenshot 2024-10-29 at 7 56 45 PM" src="https://github.com/user-attachments/assets/a52ff2f7-c467-4765-8abe-f182b1c9f80f">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1378

## Proposed Changes

* Utilize the current `HostingBenefitSection` component for this section. I refrained from relocating it to global components, as it appears to be tailored specifically for Hosting, making it logical to keep it within the Marketplace section.

## Why are these changes being made?

* This is part of the new Migrations page project.

## Testing Instructions

* Use the A4A live link and go to the `/migrations` page.
* Confirm you see the **Client Relationship** section.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
