### PR TITLE
Theme: load correct fullpage screenshot for partner themes.

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -608,12 +608,21 @@ class ThemeSheet extends Component {
 	 * Render screenshot for either non-wpcom or externally-managed themes.
 	 */
 	renderScreenshot() {
-		const { name: themeName, demoUrl, translate, screenshot } = this.props;
+		const {
+			name: themeName,
+			demoUrl,
+			translate,
+			screenshot,
+			screenshots,
+			isExternallyManagedTheme,
+		} = this.props;
 
+		// Partner themes have their fullpage screenshot in the first position of screenshots.
+		const screenshotFull = isExternallyManagedTheme ? screenshots[ 0 ] : screenshot;
 		const width = 735;
 		// Photon may return null, allow fallbacks
-		const photonSrc = screenshot && photon( screenshot, { width } );
-		const img = screenshot && (
+		const photonSrc = screenshotFull && photon( screenshotFull, { width } );
+		const img = screenshotFull && (
 			<img
 				alt={
 					// translators: %s is the theme name. Eg Twenty Twenty.
@@ -622,8 +631,8 @@ class ThemeSheet extends Component {
 					} )
 				}
 				className="theme__sheet-img"
-				src={ photonSrc || screenshot }
-				srcSet={ photonSrc && `${ photon( screenshot, { width, zoom: 2 } ) } 2x` }
+				src={ photonSrc || screenshotFull }
+				srcSet={ photonSrc && `${ photon( screenshotFull, { width, zoom: 2 } ) } 2x` }
 			/>
 		);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes a regression from https://github.com/Automattic/wp-calypso/pull/95604

## Proposed Changes

* Gets the correct screenshot for Partner themes.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Theme Showcase** 
* Go to Theme Showcase
* Pick a partner theme eg `/theme/organic-stax`
* Make sure it loads the fullpage screenshot

|Before | After|
|-------|------|
|![CleanShot 2024-10-29 at 15 04 35](https://github.com/user-attachments/assets/bb48d1eb-0039-4f33-b3aa-bba24493fe8e)|![CleanShot 2024-10-29 at 14 58 51](https://github.com/user-attachments/assets/1d86b958-2a73-4558-af44-8ff517c088e4)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
