### PR TITLE
[Odie] Disable handler while chat is either loading or sending

### DIFF
--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -22,7 +22,7 @@ export const OdieSendMessageButton = ( {
 	const shouldBeDisabled = chatStatus === 'loading' || chatStatus === 'sending';
 
 	const sendMessageHandler = useCallback( async () => {
-		if ( inputRef.current?.value.trim() === '' ) {
+		if ( inputRef.current?.value.trim() === '' || shouldBeDisabled ) {
 			return;
 		}
 		const messageString = inputRef.current?.value;


### PR DESCRIPTION
## Proposed Changes

- User is able to send messages pressing enter/intro key, while prior message is being processed 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We need to stop user sending messages as the LLM process them sequentially, and might interfer with our resolution metrics.

## Testing Instructions

Open a Wapuu chat
Write a message
Immediatelly write another one and press ENTER key (KEYBOARD)
Assert that message is not sent by any mean

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
