### PR TITLE
Domains card on my home: fix up styling

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -39,17 +39,20 @@ body .customer-home__layout .domain-upsell__card {
 
 	.domain-upsell-subtitle {
 		margin-bottom: 12px;
+		font-size: $font-body;
+		color: var(--color-text-subtle);
 	}
 
 	.domain-upsell-description {
 		font-size: rem(14px);
 		font-style: italic;
+		color: var(--color-text-subtle);
 	}
 
 	.domain-upsell-actions {
 		display: flex;
 		flex-direction: column;
-		justify-content: right;
+		justify-content: left;
 		padding: 28px 0 0;
 		gap: 16px;
 		@media (min-width: ($break-large + 1)) {

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -53,7 +53,7 @@ body .customer-home__layout .domain-upsell__card {
 		display: flex;
 		flex-direction: column;
 		justify-content: left;
-		padding: 28px 0 0;
+		padding: 24px 0 0;
 		gap: 16px;
 		@media (min-width: ($break-large + 1)) {
 			flex-direction: row-reverse;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9579

## Proposed Changes

This PR adjusts the styling on the Domains card on `My Home` page to be consistent with styling of other cards.

**Before**

<img width="614" alt="Screenshot 2024-10-29 at 2 50 02 PM" src="https://github.com/user-attachments/assets/cb8dd85e-a250-4434-bae2-695202ab22a2">

**After**

<img width="603" alt="Screenshot 2024-10-29 at 3 54 53 PM" src="https://github.com/user-attachments/assets/14ae053b-b16c-4127-8759-c3af32ebf3b6">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site with Business plan but do not purchase a domain
* Navigate to Calypso Live link below
* Navigate to `home/{yourBusinessSite}`
* Scroll down to the card that says "That perfect domain is waiting"
* Observe that the actions buttons on the domains card are shifted to the left
* Observe that the text styling is changed to the one indicated in Figma: NNfIg8OP1Xx0kumwkd2if8-fi-0_1

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?