### PR TITLE
Remove dummy `SiteOptionsStepRouter` component

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -18,7 +18,7 @@ import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import type { StepProps } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 
-export const SiteOptions = ( { navigation }: Pick< StepProps, 'navigation' > ) => {
+const SiteOptions = ( { navigation }: Pick< StepProps, 'navigation' > ) => {
 	const { currentSiteTitle, currentTagline } = useSelect(
 		( select ) => ( {
 			currentSiteTitle: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle(),
@@ -174,3 +174,5 @@ export const SiteOptions = ( { navigation }: Pick< StepProps, 'navigation' > ) =
 		</>
 	);
 };
+
+export default SiteOptions;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -1,9 +1,0 @@
-import { SiteOptions } from './site-options';
-import type { Step } from '../../types';
-import './style.scss';
-
-const SiteOptionsStepRouter: Step = function SiteOptionsStepRouter( { navigation } ) {
-	return <SiteOptions navigation={ navigation } />;
-};
-
-export default SiteOptionsStepRouter;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/9333

## Proposed Changes

* After the changes made on https://github.com/Automattic/wp-calypso/pull/95763 and https://github.com/Automattic/wp-calypso/pull/95751, the `SiteOptionsStepRouter` component is no longer necessary, since it just imports and returns the `SiteOptions` component. In this PR, I'm removing it and moving the `SiteOptions` component to the index file instead.

## Testing Instructions

* Open the live preview
* Go to `/start`
* Choose a domain
* Choose the free plan
* Choose `sell online` as your goal
* Check that you see the store name option screen

![image](https://github.com/user-attachments/assets/58672f2f-50ce-4b01-aa92-a680380f4a52)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
