### PR TITLE
`SitePreview`: Remove unnecessary props

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/site-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/site-preview/index.tsx
@@ -11,7 +11,6 @@ import './style.scss';
 
 interface Props {
 	siteSlug: string | null;
-	isUnsupportedPlan?: boolean;
 	defaultDevice?: Device;
 	showDeviceSwitcher?: boolean;
 	enableInteractions?: boolean;
@@ -19,7 +18,6 @@ interface Props {
 
 const SitePreview = ( {
 	siteSlug = '',
-	isUnsupportedPlan,
 	defaultDevice = DEVICE_TYPES.COMPUTER,
 	showDeviceSwitcher = false,
 	enableInteractions = false,
@@ -33,14 +31,10 @@ const SitePreview = ( {
 		DEVICE_TYPES.PHONE,
 	];
 
-	const previewUrl = ! isUnsupportedPlan && siteSlug ? `https://${ siteSlug }` : null;
-	const loadingMessage = ! isUnsupportedPlan
-		? translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
-				components: { strong: <strong /> },
-		  } )
-		: translate( '{{strong}}Site preview not available.{{/strong}} Plan upgrade is required.', {
-				components: { strong: <strong /> },
-		  } );
+	const previewUrl = siteSlug ? `https://${ siteSlug }` : null;
+	const loadingMessage = translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
+		components: { strong: <strong /> },
+	} );
 
 	const { shareCode, isPreviewLinksLoading, isCreatingSitePreviewLinks } =
 		useSitePreviewShareCode();

--- a/client/landing/stepper/declarative-flow/internals/components/site-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/site-preview/index.tsx
@@ -13,14 +13,12 @@ interface Props {
 	siteSlug: string | null;
 	defaultDevice?: Device;
 	showDeviceSwitcher?: boolean;
-	enableInteractions?: boolean;
 }
 
 const SitePreview = ( {
 	siteSlug = '',
 	defaultDevice = DEVICE_TYPES.COMPUTER,
 	showDeviceSwitcher = false,
-	enableInteractions = false,
 }: Props ) => {
 	const translate = useTranslate();
 	const site = useSite();
@@ -52,7 +50,7 @@ const SitePreview = ( {
 			hide_banners: true,
 			// hide cookies popup
 			preview: true,
-			do_preview_no_interactions: ! enableInteractions,
+			do_preview_no_interactions: true,
 			...( globalStylesInUse && { 'preview-global-styles': true } ),
 		} );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -40,7 +40,6 @@ const LaunchpadSitePreview = ( { siteSlug, flow }: Props ) => {
 			siteSlug={ siteSlug }
 			defaultDevice={ getSitePreviewDefaultDevice( flow ) }
 			showDeviceSwitcher
-			enableInteractions={ false }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -38,7 +38,6 @@ const LaunchpadSitePreview = ( { siteSlug, flow }: Props ) => {
 	return (
 		<SitePreview
 			siteSlug={ siteSlug }
-			isUnsupportedPlan={ false }
 			defaultDevice={ getSitePreviewDefaultDevice( flow ) }
 			showDeviceSwitcher
 			enableInteractions={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/components/readymade-template-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/components/readymade-template-preview/index.tsx
@@ -23,7 +23,7 @@ const ReadymadeTemplatePreview: React.FC< RTPreviewProps > = ( {
 		);
 	}
 
-	return siteSlug ? <SitePreview siteSlug={ siteSlug } enableInteractions={ false } /> : null;
+	return siteSlug ? <SitePreview siteSlug={ siteSlug } /> : null;
 };
 
 export default ReadymadeTemplatePreview;


### PR DESCRIPTION
## Proposed Changes

* After the changes made on https://github.com/Automattic/wp-calypso/pull/95763 and https://github.com/Automattic/wp-calypso/pull/95751, the `isUnsupportedPlan` and `enableInteractions` are not needed on the `SitePreview` component, since they are always set to `false`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just check the code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
