### PR TITLE
Keyring connections: Add "google_photos_picker" and hide "google_photos" based on feature flag

### DIFF
--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -181,6 +181,17 @@ class SharingServiceDescription extends Component {
 					comment: 'Description for Google Photos when no accounts are connected',
 				} );
 			},
+			google_photos_picker: function () {
+				if ( this.props.numberOfConnections > 0 ) {
+					return this.props.translate( 'Access photos stored in your Google Photos library.', {
+						comment: 'Description for Google Photos when one or more accounts are connected',
+					} );
+				}
+
+				return this.props.translate( 'Access photos stored in your Google Photos library', {
+					comment: 'Description for Google Photos when no accounts are connected',
+				} );
+			},
 			google_drive: function () {
 				if ( this.props.numberOfConnections > 0 ) {
 					return this.props.translate( 'Create and access files in your Google Drive', {

--- a/client/my-sites/marketing/connections/service-examples.jsx
+++ b/client/my-sites/marketing/connections/service-examples.jsx
@@ -40,6 +40,7 @@ const SERVICES_WITH_EXAMPLES = [
 	'twitter',
 	'threads',
 	'google_photos',
+	'google_photos_picker',
 	'google-drive',
 	'mailchimp',
 	'p2_slack',
@@ -64,6 +65,28 @@ class SharingServiceExamples extends Component {
 		site: Object.freeze( {} ),
 		hasJetpack: false,
 	};
+
+	getGooglePhotosExample() {
+		return [
+			{
+				image: {
+					src: '/calypso/images/sharing/connections-google-photos.png',
+					alt: this.props.translate(
+						'Connect to use photos stored in your Google Photos library directly inside the editor',
+						{ textOnly: true }
+					),
+				},
+				label: this.props.translate(
+					'{{strong}}Connect{{/strong}} to use photos stored in your Google Photos library directly inside the editor.',
+					{
+						components: {
+							strong: <strong />,
+						},
+					}
+				),
+			},
+		];
+	}
 
 	getSharingButtonsLink() {
 		if ( this.props.site ) {
@@ -99,25 +122,11 @@ class SharingServiceExamples extends Component {
 	}
 
 	google_photos() {
-		return [
-			{
-				image: {
-					src: '/calypso/images/sharing/connections-google-photos.png',
-					alt: this.props.translate(
-						'Connect to use photos stored in your Google Photos library directly inside the editor',
-						{ textOnly: true }
-					),
-				},
-				label: this.props.translate(
-					'{{strong}}Connect{{/strong}} to use photos stored in your Google Photos library directly inside the editor.',
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				),
-			},
-		];
+		return this.getGooglePhotosExample();
+	}
+
+	google_photos_picker() {
+		return this.getGooglePhotosExample();
 	}
 
 	google_drive() {

--- a/client/my-sites/marketing/connections/services/index.js
+++ b/client/my-sites/marketing/connections/services/index.js
@@ -1,5 +1,6 @@
 export { default as instagram_basic_display } from './instagram';
 export { default as google_photos } from './google-photos';
+export { default as google_photos_picker } from './google-photos';
 export { default as google_drive } from './google-drive';
 export { default as google_my_business } from './google-my-business';
 export { default as facebook } from './facebook';
@@ -23,6 +24,7 @@ const services = new Set( [
 	'mastodon',
 	'instagram_basic_display',
 	'google_photos',
+	'google_photos_picker',
 	'google_drive',
 	'google_my_business',
 	'mailchimp',

--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -53,6 +53,7 @@ export function getKeyringServiceByName( state, name ) {
  */
 export function getEligibleKeyringServices( state, siteId, type ) {
 	const services = getKeyringServicesByType( state, type );
+	const googlePhotosPickerEnabled = config.isEnabled( 'google-photos-picker' );
 
 	if ( ! siteId ) {
 		return services;
@@ -110,6 +111,16 @@ export function getEligibleKeyringServices( state, siteId, type ) {
 		// Omit Eventbrite as the API that is used by Eventbrite plugin was disabled 20/02/2020
 		if ( service.ID === 'eventbrite' ) {
 			return false;
+		}
+
+		// Omit Google Photos if the Google Photos Picker is enabled
+		if ( service.ID === 'google_photos' ) {
+			return ! googlePhotosPickerEnabled;
+		}
+
+		// Omit Google Photos Picker if it's not enabled
+		if ( service.ID === 'google_photos_picker' ) {
+			return googlePhotosPickerEnabled;
 		}
 
 		// Omit the GitHub deployment app so it doesn't appear in the list of "other" services


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Register keyring "google_photo_picker" service
* Show the same "Example" below the service following the existing setup
* Switch between "Google Photos" and "Google Photos Picker" services

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Apply D164673 on your sandbox
* Go to `/marketing/connections/{SITE_SLUG}`
* Check if there is a "Google Photos" service
* Provide `?flags=google-photos-picker` query param
* Check if there is "Google Photos Picker" service
* Try to connect/disconnect

<img width="1566" alt="Screenshot 2024-10-29 at 18 26 01" src="https://github.com/user-attachments/assets/70c5f688-c50f-4b0e-8cbd-1389c90817dd">

<img width="1562" alt="Screenshot 2024-10-29 at 18 26 18" src="https://github.com/user-attachments/assets/47e5538d-7ce7-4890-ab77-0a846336e553">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
