### PR TITLE
Checkout: Prevent fatal in sidebar features list for unlisted product

### DIFF
--- a/client/my-sites/checkout/src/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/src/lib/get-plan-features.ts
@@ -13,6 +13,7 @@ import {
 	applyTestFiltersToPlansList,
 	FEATURE_CUSTOM_DOMAIN,
 	getFeatureByKey,
+	getPlan,
 } from '@automattic/calypso-products';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
@@ -36,6 +37,11 @@ export default function getPlanFeatures(
 	const isMonthlyPlan = isMonthly( productSlug );
 
 	if ( showPricingGridFeatures ) {
+		const plan = getPlan( productSlug );
+		if ( ! plan ) {
+			return [];
+		}
+
 		const planObject = applyTestFiltersToPlansList( productSlug, undefined );
 
 		if ( ! planObject ) {


### PR DESCRIPTION
## Background

The checkout sidebar's `CheckoutSummaryPlanFeatures` component lists the features for a plan by calling `getPlanFeatures()`, which in turn calls `applyTestFiltersToPlansList()`, which calls `getPlan()`. That last function checks a large hard-coded list of plans in calypso for a list of features. However, there are certain plans which are not included in that hard-coded list (eg: `wpcom-enterprise`). For those plans, the call to `getPlan()` fails, which causes `applyTestFiltersToPlansList()` [to throw an error](https://github.com/Automattic/wp-calypso/blob/efe93c9c860d3cfd4bbc7b083fbb30a581acc176/packages/calypso-products/src/main.ts#L709-L711). This error then breaks the rendering of `CheckoutSummaryPlanFeatures` and shows a React error boundary to the user in the checkout sidebar.

## Proposed Changes

In this PR, we alter `getPlanFeatures()` so that it checks the hard-coded list of plans (using `getPlan()`) _before_ calling `applyTestFiltersToPlansList()`, and skips that call if the plan does not have an entry. That appears to be the intent of the function anyway, since [there is already a guard](https://github.com/Automattic/wp-calypso/blob/da267fa3552e2aae99e2500f3fd6702f6ea86449/client/my-sites/checkout/src/lib/get-plan-features.ts#L47-L49) for a falsy result of `applyTestFiltersToPlansList()` (even though I don't think that function can return a falsy result).

Before             |  After
:-------------------------:|:-------------------------:
<img width="1095" alt="Screenshot 2024-10-29 at 12 01 32 PM" src="https://github.com/user-attachments/assets/ae3a2315-bc47-4d2f-bea4-3d800d4954e8"> | <img width="1095" alt="Screenshot 2024-10-29 at 12 01 05 PM" src="https://github.com/user-attachments/assets/9a7e9b0a-50f8-4834-8c31-19e69eef485b">

Fixes https://github.com/Automattic/wp-calypso/issues/86420

## Testing Instructions

- Visit `/checkout/wpcom-enterprise` and select a site that has no active plan.
- Verify that the checkout sidebar does not show an error.