### PR TITLE
Reader Onboarding: Add more Tracks events

### DIFF
--- a/client/reader/onboarding/constants.tsx
+++ b/client/reader/onboarding/constants.tsx
@@ -1,1 +1,2 @@
 export const READER_ONBOARDING_PREFERENCE_KEY = 'has_completed_reader_onboarding';
+export const READER_ONBOARDING_TRACKS_EVENT_PREFIX = 'calypso_reader_onboarding_';

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -64,7 +64,6 @@ const ReaderOnboarding = ( { onRender }: { onRender?: ( shown: boolean ) => void
 		setIsDiscoverModalOpen( false );
 	};
 
-	// Navigation handlers
 	const handleInterestsContinue = () => {
 		recordTracksEvent( 'calypso_reader_onboarding_interests_modal_continue' );
 		closeInterestsModal();

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -4,7 +4,10 @@ import { CircularProgressBar } from '@automattic/components';
 import { Checklist, ChecklistItem, Task } from '@automattic/launchpad';
 import { translate } from 'i18n-calypso';
 import React, { useState } from 'react';
-import { READER_ONBOARDING_PREFERENCE_KEY } from 'calypso/reader/onboarding/constants';
+import {
+	READER_ONBOARDING_PREFERENCE_KEY,
+	READER_ONBOARDING_TRACKS_EVENT_PREFIX,
+} from 'calypso/reader/onboarding/constants';
 import InterestsModal from 'calypso/reader/onboarding/interests-modal';
 import SubscribeModal from 'calypso/reader/onboarding/subscribe-modal';
 import { useSelector } from 'calypso/state';
@@ -43,35 +46,35 @@ const ReaderOnboarding = ( { onRender }: { onRender?: ( shown: boolean ) => void
 		return null;
 	}
 
-	// Modal state handlers with tracking
+	// Modal state handlers with tracking.
 	const openInterestsModal = () => {
-		recordTracksEvent( 'calypso_reader_onboarding_interests_modal_open' );
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_open` );
 		setIsInterestsModalOpen( true );
 	};
 
 	const closeInterestsModal = () => {
-		recordTracksEvent( 'calypso_reader_onboarding_interests_modal_close' );
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_close` );
 		setIsInterestsModalOpen( false );
 	};
 
 	const openDiscoverModal = () => {
-		recordTracksEvent( 'calypso_reader_onboarding_discover_modal_open' );
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }discover_modal_open` );
 		setIsDiscoverModalOpen( true );
 	};
 
 	const closeDiscoverModal = () => {
-		recordTracksEvent( 'calypso_reader_onboarding_discover_modal_close' );
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }discover_modal_close` );
 		setIsDiscoverModalOpen( false );
 	};
 
 	const handleInterestsContinue = () => {
-		recordTracksEvent( 'calypso_reader_onboarding_interests_modal_continue' );
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_continue` );
 		closeInterestsModal();
 		openDiscoverModal();
 	};
 
 	const itemClickHandler = ( task: Task ) => {
-		recordTracksEvent( 'calypso_reader_onboarding_task_click', {
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }task_click`, {
 			task: task.id,
 		} );
 		task?.actionDispatch?.();

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -3,7 +3,7 @@ import config from '@automattic/calypso-config';
 import { CircularProgressBar } from '@automattic/components';
 import { Checklist, ChecklistItem, Task } from '@automattic/launchpad';
 import { translate } from 'i18n-calypso';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
 	READER_ONBOARDING_PREFERENCE_KEY,
 	READER_ONBOARDING_TRACKS_EVENT_PREFIX,
@@ -38,6 +38,13 @@ const ReaderOnboarding = ( { onRender }: { onRender?: ( shown: boolean ) => void
 		userRegistrationDate &&
 		isEmailVerified &&
 		new Date( userRegistrationDate ) >= new Date( '2024-10-01T00:00:00Z' );
+
+	// Track if user viewed Reader Onboarding.
+	useEffect( () => {
+		if ( shouldShowOnboarding ) {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }viewed` );
+		}
+	}, [ shouldShowOnboarding ] );
 
 	// Notify the parent component if onboarding will render.
 	onRender?.( shouldShowOnboarding );

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -43,9 +43,32 @@ const ReaderOnboarding = ( { onRender }: { onRender?: ( shown: boolean ) => void
 		return null;
 	}
 
-	const handleInterestsContinue = () => {
+	// Modal state handlers with tracking
+	const openInterestsModal = () => {
+		recordTracksEvent( 'calypso_reader_onboarding_interests_modal_open' );
+		setIsInterestsModalOpen( true );
+	};
+
+	const closeInterestsModal = () => {
+		recordTracksEvent( 'calypso_reader_onboarding_interests_modal_close' );
 		setIsInterestsModalOpen( false );
+	};
+
+	const openDiscoverModal = () => {
+		recordTracksEvent( 'calypso_reader_onboarding_discover_modal_open' );
 		setIsDiscoverModalOpen( true );
+	};
+
+	const closeDiscoverModal = () => {
+		recordTracksEvent( 'calypso_reader_onboarding_discover_modal_close' );
+		setIsDiscoverModalOpen( false );
+	};
+
+	// Navigation handlers
+	const handleInterestsContinue = () => {
+		recordTracksEvent( 'calypso_reader_onboarding_interests_modal_continue' );
+		closeInterestsModal();
+		openDiscoverModal();
 	};
 
 	const itemClickHandler = ( task: Task ) => {
@@ -61,14 +84,14 @@ const ReaderOnboarding = ( { onRender }: { onRender?: ( shown: boolean ) => void
 		{
 			id: 'select-interests',
 			title: translate( 'Select some of your interests' ),
-			actionDispatch: () => setIsInterestsModalOpen( true ),
+			actionDispatch: openInterestsModal,
 			completed: taskOneCompleted,
 			disabled: false,
 		},
 		{
 			id: 'discover-sites',
 			title: translate( "Discover and subscribe to sites you'll love" ),
-			actionDispatch: () => setIsDiscoverModalOpen( true ),
+			actionDispatch: openDiscoverModal,
 			completed: false,
 			disabled: ! taskOneCompleted,
 		},
@@ -102,13 +125,10 @@ const ReaderOnboarding = ( { onRender }: { onRender?: ( shown: boolean ) => void
 
 			<InterestsModal
 				isOpen={ isInterestsModalOpen }
-				onClose={ () => setIsInterestsModalOpen( false ) }
+				onClose={ closeInterestsModal }
 				onContinue={ handleInterestsContinue }
 			/>
-			<SubscribeModal
-				isOpen={ isDiscoverModalOpen }
-				onClose={ () => setIsDiscoverModalOpen( false ) }
-			/>
+			<SubscribeModal isOpen={ isDiscoverModalOpen } onClose={ closeDiscoverModal } />
 		</>
 	);
 };

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -4,6 +4,7 @@ import { Modal, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { READER_ONBOARDING_TRACKS_EVENT_PREFIX } from 'calypso/reader/onboarding/constants';
 import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 
@@ -47,17 +48,20 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 		if ( checked ) {
 			dispatch( requestFollowTag( tag ) );
 			setFollowedTags( ( currentTags ) => [ ...currentTags, tag ] );
-			recordTracksEvent( 'calypso_reader_onboarding_interests_modal_tag_followed', {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_tag_followed`, {
 				tag,
 				total_followed: followedTags.length + 1,
 			} );
 		} else {
 			dispatch( requestUnfollowTag( tag ) );
 			setFollowedTags( ( currentTags ) => currentTags.filter( ( t ) => t !== tag ) );
-			recordTracksEvent( 'calypso_reader_onboarding_interests_modal_tag_unfollowed', {
-				tag,
-				total_followed: followedTags.length - 1,
-			} );
+			recordTracksEvent(
+				`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_tag_unfollowed`,
+				{
+					tag,
+					total_followed: followedTags.length - 1,
+				}
+			);
 		}
 	};
 

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { SelectCardCheckbox } from '@automattic/onboarding';
 import { Modal, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -46,9 +47,17 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 		if ( checked ) {
 			dispatch( requestFollowTag( tag ) );
 			setFollowedTags( ( currentTags ) => [ ...currentTags, tag ] );
+			recordTracksEvent( 'calypso_reader_onboarding_interests_modal_tag_followed', {
+				tag,
+				total_followed: followedTags.length + 1,
+			} );
 		} else {
 			dispatch( requestUnfollowTag( tag ) );
 			setFollowedTags( ( currentTags ) => currentTags.filter( ( t ) => t !== tag ) );
+			recordTracksEvent( 'calypso_reader_onboarding_interests_modal_tag_unfollowed', {
+				tag,
+				total_followed: followedTags.length - 1,
+			} );
 		}
 	};
 

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -161,9 +161,12 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 	}, [ combinedRecommendations, currentPage ] );
 
 	const handleLoadMore = useCallback( () => {
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }clicked_load_more`, {
+			page: currentPage,
+		} );
 		// Only increment the page if we haven't reached the end.
 		setCurrentPage( ( prevPage ) => ( prevPage < maxPages ? prevPage + 1 : prevPage ) );
-	}, [ maxPages ] );
+	}, [ maxPages, currentPage ] );
 
 	const headerActions = (
 		<>

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -9,7 +9,10 @@ import { useSelector } from 'react-redux';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import wpcom from 'calypso/lib/wp';
 import { trackScrollPage } from 'calypso/reader/controller-helper';
-import { READER_ONBOARDING_PREFERENCE_KEY } from 'calypso/reader/onboarding/constants';
+import {
+	READER_ONBOARDING_PREFERENCE_KEY,
+	READER_ONBOARDING_TRACKS_EVENT_PREFIX,
+} from 'calypso/reader/onboarding/constants';
 import { curatedBlogs } from 'calypso/reader/onboarding/curated-blogs';
 import Stream from 'calypso/reader/stream';
 import { useDispatch } from 'calypso/state';
@@ -215,7 +218,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 
 	const handleContinue = useCallback( () => {
 		dispatch( savePreference( READER_ONBOARDING_PREFERENCE_KEY, true ) );
-		recordTracksEvent( 'calypso_reader_onboarding_completed' );
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed` );
 		onClose();
 	}, [ dispatch, onClose ] );
 

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { LoadingPlaceholder } from '@automattic/components';
 import { useQuery } from '@tanstack/react-query';
 import { Modal, Button } from '@wordpress/components';
@@ -214,6 +215,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 
 	const handleContinue = useCallback( () => {
 		dispatch( savePreference( READER_ONBOARDING_PREFERENCE_KEY, true ) );
+		recordTracksEvent( 'calypso_reader_onboarding_completed' );
 		onClose();
 	}, [ dispatch, onClose ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/198

## Proposed Changes

* Adds Tracks events when modals open and close (by any means).
* Adds Tracks even when the user clicks "Continue" from the Interests modal.
* Adds Tracks event when `tags` are un/followed from the Interests modal.
* Adds Tracks event when the "Continue" button is clicked in the Discover modal and the Reader Onboarding is marked completed.
* Adds Tracks event when the Reader Onboarding component renders (is viewed).
* Adds Tracks event when the user click "Load more recommendations" in the Discover modal.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So we can track the effectiveness and engagement of Reader Onboarding.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/onboarding (on a new user account)
* In your browser web developer tools console, type and run this command `localStorage.setItem( 'debug', 'calypso:analytics*' );` Refresh your browser window.
* Now you will see Tracks data in the browser's console "debug" log. (see picture below)
* You can "filter" with the prefix used in this PR `calypso_reader_onboarding_`
* Now try to trigger our Tracks events by clicking our "task links", opening and closing our modals, follow and unfollow `tags`, and finally click the "Continue" buttons.
* Note: an event already exists when you subscribe or unsubscribe from a blog in the Discover modal. We get that for free from the component we're reusing.
* Any Tracks events we're missing that you can think of?


<img width="1727" alt="Screenshot 2024-10-29 at 12 01 16 PM" src="https://github.com/user-attachments/assets/53489fed-b0d2-40da-b83d-16f8a4abf72a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
