### PR TITLE
My Sites: Fix header path capitalization

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -112,6 +112,7 @@ class Sites extends Component {
 		}
 
 		let path = this.getPath();
+		const initialPath = path;
 
 		const { translate } = this.props;
 
@@ -207,11 +208,13 @@ class Sites extends Component {
 				path = translate( 'Add-ons' );
 				break;
 		}
+		// We don't have a translated path, capitalize the provided path.
+		const capitalize = initialPath === path;
 
 		return translate( 'Select a site to open {{strong}}%(path)s{{/strong}}', {
 			args: { path },
 			components: {
-				strong: <strong />,
+				strong: <strong className={ clsx( { 'strong--capitalize': capitalize } ) } />,
 			},
 		} );
 	}

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -20,7 +20,7 @@
 	margin-top: 55px;
 	margin-bottom: 24px;
 
-	strong {
+	.strong--capitalize {
 		text-transform: capitalize;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR updates the path capitalization logic in the Site Selector to capitalize the path only if we do not have a custom string/translation for the specific path. 

Before:

![image](https://github.com/user-attachments/assets/07dc484f-9965-4b2e-93e7-d0477ed97592)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To ensure `text-transform: capitalize`  is only applied when we do not have a translation for the path. 
For some locales, the path translation might contain multiple words with specific capitalization which needs to be preserved.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch your account language to `de`. 
* Visit wordpress.com/import (make sure you have at least 2 sites, so the Site selector is displayed). 
* Confirm that the `path ` is now correctly capitalized. 

![image](https://github.com/user-attachments/assets/35287617-c36f-40df-98bd-021893c846cb)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
