### PR TITLE
Help Center: Add chat history minimized title

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -149,6 +149,7 @@ const ContentMinimized = ( {
 					<Route path="/post" element={ <ArticleTitle /> } />
 					<Route path="/success" element={ __( 'Message Submitted', __i18n_text_domain__ ) } />
 					<Route path="/odie" element={ __( 'Wapuu', __i18n_text_domain__ ) } />
+					<Route path="/chat-history" element={ __( 'Chat History', __i18n_text_domain__ ) } />
 				</Routes>
 				{ unreadCount > 0 && (
 					<span className="help-center-header__unread-count">{ formattedUnreadCount }</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

| Before | After |
|--------|--------|
| <img width="459" alt="image" src="https://github.com/user-attachments/assets/609df8b6-c1bd-4faa-a6f7-d83935686d46"> | <img width="431" alt="image" src="https://github.com/user-attachments/assets/1b7b88b0-772d-4bd8-9049-31d5a250bae5"> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We were missing the title while in chat history and the help center was minimized.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live link
* Go to Chat History
* Minimize
* You should see the title

