### PR TITLE
Domain Purchase Flow: Email solution comparison link opens externally

### DIFF
--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -5,10 +5,11 @@ import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import { ExternalLink } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { stringify } from 'qs';
-import { useEffect, useState } from 'react';
+import { createElement, useEffect, useState } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
@@ -215,20 +216,20 @@ const EmailProvidersStackedComparison = ( {
 		/>,
 	];
 
-	const comparisonComponents = {
-		a: (
-			<a
-				href={ getEmailInDepthComparisonPath(
-					selectedSite?.slug ?? '',
-					selectedDomainName,
-					currentRoute,
-					source,
-					selectedIntervalLength
-				) }
-				onClick={ handleCompareClick }
-			/>
-		),
-	};
+	const comparisonComponents = ( isExternal: boolean ) => ( {
+		a: createElement( isExternal ? ExternalLink : 'a', {
+			href: getEmailInDepthComparisonPath(
+				selectedSite?.slug ?? '',
+				selectedDomainName,
+				currentRoute,
+				source,
+				selectedIntervalLength
+			),
+			onClick: handleCompareClick,
+			// The `children` will be replaced when the element is passed to `translate()`; the empty prop here is only to satisfy the type checker.
+			children: null,
+		} ),
+	} );
 
 	return (
 		<Main
@@ -266,11 +267,11 @@ const EmailProvidersStackedComparison = ( {
 						? translate(
 								'Build an online presence and build your brand with one of these options ({{a}}see how they compare{{/a}}).',
 								{
-									components: comparisonComponents,
+									components: comparisonComponents( true ),
 								}
 						  )
 						: translate( 'Not sure where to start? {{a}}See how they compare{{/a}}.', {
-								components: comparisonComponents,
+								components: comparisonComponents( false ),
 						  } ) }
 				</div>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #95812

## Proposed Changes

* Use `<ExternalLink>` to open the detailed email provider comparison in a new tab
   * But only when the user is in a domain purchase flow.

**Adding a new domain**
![CleanShot 2024-10-30 at 10 23 35@2x](https://github.com/user-attachments/assets/688ade92-2bb4-47f8-8d99-9ee20773d98d)


**Adding email to existing domain** (i.e. no change)
![CleanShot 2024-10-30 at 10 23 42@2x](https://github.com/user-attachments/assets/a1994ea3-ef39-4971-bd0a-a91f8044ecb6)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We don't usually open Calypso links in a new tab, but an exception is warranted here. When the user is purchasing a domain they're in the middle of a purchase flow, and we would prefer to keep them in that flow.

The same comparison link exists at `/email/{{ site slug }}` when the site already has a custom domain. In this case the user isn't in the middle of a flow, and so the exception doesn't hold in this situation. So it hasn't been updated to an external link here.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* **The domain purchase flow**
   * `/domains/manage/{{ site slug }}`
   * Click **Add new domain**
   * Search and select any old domain
   * On the **Add a professional email address...** screen confirm the **see how they compare** link opens in a new tab
   * Confirm it has the external link icon
* **The existing domain screen**
   * Test a site that has an existing custom domain
   * `/email/{{ site slug }}`
   * Confirm the **See how they compare** link opens in the same tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~
