### PR TITLE
JITM: Fix jitm id on dismiss

### DIFF
--- a/apps/odyssey-stats/src/app.scss
+++ b/apps/odyssey-stats/src/app.scss
@@ -85,6 +85,7 @@
 		padding: 0.5em 1.5em;
 		font-size: 1rem;
 		line-height: 1.375;
+		align-content: center;
 
 		&:focus {
 			box-shadow: none;

--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -73,7 +73,7 @@ function renderTemplate( template, props ) {
 }
 
 function getEventHandlers( props, dispatch ) {
-	const { jitm, currentSite, messagePath, searchQuery, onClick } = props;
+	const { jitm, currentSite, searchQuery, onClick } = props;
 	const tracks = jitm.tracks || {};
 	const eventProps = {
 		id: jitm.id,
@@ -98,7 +98,7 @@ function getEventHandlers( props, dispatch ) {
 				recordTracksEvent( tracks.dismiss.name, { ...tracks.dismiss.props, ...eventProps } )
 			);
 		}
-		dispatch( dismissJITM( currentSite.ID, messagePath, jitm.featureClass ) );
+		dispatch( dismissJITM( currentSite.ID, jitm.id, jitm.featureClass ) );
 	};
 
 	handlers.onClick = () => {


### PR DESCRIPTION
Related to p1730239948195999/1728892827.347349-slack-C01264051NE

## Proposed Changes

* Dismiss JITM accepts a JITM ID not its messagePath

## Why are these changes being made?

* bugfix

## Testing Instructions

* Follow instruction https://github.com/Automattic/wp-calypso/pull/95273
* Ensure when dismissing the notice
* `id` is the ID of the JITM

<img width="459" alt="image" src="https://github.com/user-attachments/assets/f197cb06-a140-43c0-9e06-9ff3abbcabff">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?