### PR TITLE
Untangling: clean up marketing stub

### DIFF
--- a/client/sites/marketing/business-tools/index.tsx
+++ b/client/sites/marketing/business-tools/index.tsx
@@ -1,3 +1,0 @@
-export default function BusinessTools() {
-	return <div>This is Business Tools page</div>;
-}

--- a/client/sites/marketing/controller.tsx
+++ b/client/sites/marketing/controller.tsx
@@ -1,7 +1,5 @@
 import { __ } from '@wordpress/i18n';
 import makeSidebar, { PanelWithSidebar } from '../components/panel-sidebar';
-import BusinessTools from './business-tools';
-import MarketingTools from './tools';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
 const MarketingSidebar = makeSidebar( {
@@ -25,7 +23,7 @@ export function marketingTools( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
 			<MarketingSidebar selectedItemKey="tools" />
-			<MarketingTools />
+			<div>This is Marketing Tools page</div>
 		</PanelWithSidebar>
 	);
 	next();
@@ -35,7 +33,7 @@ export function businessTools( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
 			<MarketingSidebar selectedItemKey="business-tools" />
-			<BusinessTools />
+			<div>This is Business Tools page</div>
 		</PanelWithSidebar>
 	);
 	next();

--- a/client/sites/marketing/tools/index.tsx
+++ b/client/sites/marketing/tools/index.tsx
@@ -1,3 +1,0 @@
-export default function MarketingTools() {
-	return <div>This is Marketing Tools page</div>;
-}


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/9608

## Proposed Changes

This PR removes `client/sites/marketing/*/index.tsx`, so further commit will correctly show the `index.tsx` are renamed (moved) under the directory, not shown as editing the `index.tsx` file.

## Testing Instructions

- Go to `/sites`, click any site; verify nothing breaks.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
