### PR TITLE
Audit Upsell: Add event tracking to the no purchases upsell

### DIFF
--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -13,6 +14,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getPurchasesBySite, getSubscriptionsBySite } from 'calypso/lib/purchases';
 import { PurchaseListConciergeBanner } from 'calypso/me/purchases/purchases-list/purchase-list-concierge-banner';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
@@ -67,6 +69,7 @@ class PurchasesList extends Component {
 
 	render() {
 		const { purchases, sites, translate, subscriptions } = this.props;
+		const commonEventProps = { context: 'me' };
 		let content;
 
 		if ( this.isDataLoading() ) {
@@ -109,18 +112,26 @@ class PurchasesList extends Component {
 			content = (
 				<>
 					{ this.renderConciergeBanner() }
-
 					<CompactCard className="purchases-list__no-content">
-						<EmptyContent
-							title={ translate( 'Looking to upgrade?' ) }
-							line={ translate(
-								'Our plans give your site the power to thrive. ' +
-									'Find the plan that works for you.'
-							) }
-							action={ translate( 'Upgrade now' ) }
-							actionURL="/plans"
-							illustration={ noSitesIllustration }
-						/>
+						<>
+							<TrackComponentView
+								eventName="calypso_no_purchases_upgrade_nudge_impression"
+								eventProperties={ commonEventProps }
+							/>
+							<EmptyContent
+								title={ translate( 'Looking to upgrade?' ) }
+								line={ translate(
+									'Our plans give your site the power to thrive. ' +
+										'Find the plan that works for you.'
+								) }
+								action={ translate( 'Upgrade now' ) }
+								actionURL="/plans"
+								illustration={ noSitesIllustration }
+								actionCallback={ () => {
+									recordTracksEvent( 'calypso_no_purchases_upgrade_nudge_click', commonEventProps );
+								} }
+							/>
+						</>
 					</CompactCard>
 				</>
 			);

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -1,9 +1,11 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CompactCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import noSitesIllustration from 'calypso/assets/images/illustrations/illustration-nosites.svg';
 import EmptyContent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import JetpackRnaActionCard from 'calypso/components/jetpack/card/jetpack-rna-action-card';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { Purchase } from 'calypso/lib/purchases/types';
 import PurchasesListHeader from 'calypso/me/purchases/purchases-list/purchases-list-header';
@@ -107,6 +109,7 @@ function NoPurchasesMessage() {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const translate = useTranslate();
 	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );
+	const commonEventProps = { context: 'site' };
 
 	let url;
 	if ( ! isJetpackCloud() ) {
@@ -130,13 +133,22 @@ function NoPurchasesMessage() {
 		/>
 	) : (
 		<CompactCard className="subscriptions__list">
-			<EmptyContent
-				title={ translate( 'Looking to upgrade?' ) }
-				line={ translate( 'You have made no purchases for this site.' ) }
-				action={ translate( 'Upgrade now' ) }
-				actionURL={ url }
-				illustration={ noSitesIllustration }
-			/>
+			<>
+				<TrackComponentView
+					eventName="calypso_no_purchases_upgrade_nudge_impression"
+					eventProperties={ commonEventProps }
+				/>
+				<EmptyContent
+					title={ translate( 'Looking to upgrade?' ) }
+					line={ translate( 'You have made no purchases for this site.' ) }
+					action={ translate( 'Upgrade now' ) }
+					actionURL={ url }
+					illustration={ noSitesIllustration }
+					actionCallback={ () => {
+						recordTracksEvent( 'calypso_no_purchases_upgrade_nudge_click', commonEventProps );
+					} }
+				/>
+			</>
 		</CompactCard>
 	);
 }


### PR DESCRIPTION
## Proposed Changes

This PR adds impression and click event tracking to the no purchases upsell screen.
See the upsell for reference:

![Screenshot 2024-10-30 at 12 23 52 PM](https://github.com/user-attachments/assets/9635b255-a223-4d79-8f72-b75292ff7011)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Helps with the upsell auditing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /purchases/subscriptions/:domain with a site that has no purchases.
* Ensure that the event `calypso_no_purchases_upgrade_nudge_impression` is triggered as intended.
* Click on the "Upgrade now" button.
* Ensure that the event `calypso_no_purchases_upgrade_nudge_click` is triggered as intended.
* Try the same for /me/purchases.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
