### PR TITLE
Remove center justification on panel content

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-content/style.scss
@@ -6,5 +6,4 @@
 	overflow-y: auto;
 	overflow-x: hidden;
 	display: flex;
-	justify-content: center;
 }


### PR DESCRIPTION
Related to #

## Proposed Changes

Pulling page content left due to the addition of a new sidebar navigation component within the content.

Before

![Screenshot 2024-10-30 at 15-54-11 Sites ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/8689811d-32b0-42d9-82a9-0aa2675e8e1c)
![Screenshot 2024-10-30 at 15-53-57 Sites ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/cf5ee449-2d7f-4b3a-a43f-6947e3a0b841)


After

![Screenshot 2024-10-30 at 15-53-44 Sites ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/721db65d-fa94-434b-a1ec-3c27da9b7308)
![Screenshot 2024-10-30 at 15-53-32 Sites ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/cd5dd03e-eaf8-46f0-b067-3e584b8bdf9d)

A4A Before
![Screenshot 2024-10-31 at 09-29-06 Boost — Automattic For Agencies](https://github.com/user-attachments/assets/d4f59689-2efa-4959-b2bf-b6ffb8eceb8a)

A4A After
![Screenshot 2024-10-31 at 09-28-47 Boost — Automattic For Agencies](https://github.com/user-attachments/assets/64dff62d-44da-4d18-9455-78c03099b94e)


