### PR TITLE
Theme: Fix the 3rd party themes cannot be previewed

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -604,6 +604,12 @@ class ThemeSheet extends Component {
 		return isAtomic && isPremium && ! canUserUploadThemes && ! hasUnlimitedPremiumThemes;
 	}
 
+	getFullLengthScreenshot() {
+		// Results are being returned with photon params like `?w=…`. This makes the photon
+		// module abort and return null. Strip query string.
+		return this.props.screenshots?.[ 0 ]?.replace( /\?.*/, '' ) ?? null;
+	}
+
 	/**
 	 * Render screenshot for either non-wpcom or externally-managed themes.
 	 */
@@ -613,12 +619,11 @@ class ThemeSheet extends Component {
 			demoUrl,
 			translate,
 			screenshot,
-			screenshots,
 			isExternallyManagedTheme,
 		} = this.props;
 
 		// Partner themes have their fullpage screenshot in the first position of screenshots.
-		const screenshotFull = isExternallyManagedTheme ? screenshots[ 0 ] : screenshot;
+		const screenshotFull = isExternallyManagedTheme ? this.getFullLengthScreenshot() : screenshot;
 		const width = 735;
 		// Photon may return null, allow fallbacks
 		const photonSrc = screenshotFull && photon( screenshotFull, { width } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1730265360413609-slack-CRWCHQGUB, https://github.com/Automattic/wp-calypso/pull/95810

## Proposed Changes

* The `screenshots` property might be undefined if people go to the Theme Showcase and then preview any 3rd party theme.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Filter by the Partner theme
* Preview any of the Partner themes
* Make sure the Theme Details page displays correctly instead of the error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?