### PR TITLE
SMP: Make the item preview content with sidebar responsive

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -40,6 +40,7 @@ export default function ItemPreviewPane( {
 	addTourDetails,
 	itemPreviewPaneHeaderExtraProps,
 	hideNavIfSingleTab,
+	enforceTabsView,
 }: PreviewPaneProps ) {
 	const [ navRef, setNavRef ] = useState< HTMLElement | null >( null );
 
@@ -96,6 +97,7 @@ export default function ItemPreviewPane( {
 				<SectionNav
 					className={ clsx( 'preview-pane__navigation', { 'is-hidden': shouldHideNav } ) }
 					selectedText={ selectedFeature.tab.label }
+					enforceTabsView={ enforceTabsView }
 				>
 					{ navItems && navItems.length > 0 ? (
 						<NavTabs hasHorizontalScroll>{ navItems }</NavTabs>

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/style.scss
@@ -114,7 +114,9 @@
 
 @media (max-width: 480px) {
 	.section-nav {
-		box-shadow: 0 0 0 1px #fff !important;
+		&:not(.enforce-tabs-view) {
+			box-shadow: 0 0 0 1px #fff !important;
+		}
 	}
 
 	.section-nav.is-open {

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/style.scss
@@ -65,43 +65,45 @@
 		}
 
 		@media (max-width: 480px) {
-			.section-nav-group {
-				margin-top: 0;
-			}
-			.section-nav-tabs__list {
-				margin: 0 24px;
-				padding: 0 !important;
-				border: 1px solid var(--color-neutral-10) !important;
-			}
-
-			.section-nav__mobile-header {
-				margin: 16px auto 0 auto;
-				width: 90%;
-				border: 1px solid var(--color-neutral-10) !important;
-				border-radius: 2px;
-				justify-content: space-between;
-			}
-
-			.section-nav-tab__link {
-				color: var(--color-neutral-70);
-				font-weight: 400;
-			}
-
-			.section-nav-tab {
-				.section-nav-tab__link {
-					&:hover {
-						color: var(--color-accent);
-						background-color: var(--color-neutral-5);
-					}
+			&:not(.enforce-tabs-view) {
+				.section-nav-group {
+					margin-top: 0;
+				}
+				.section-nav-tabs__list {
+					margin: 0 24px;
+					padding: 0 !important;
+					border: 1px solid var(--color-neutral-10) !important;
 				}
 
-				&.is-selected {
-					.section-nav-tab__link {
-						color: #fff;
+				.section-nav__mobile-header {
+					margin: 16px auto 0 auto;
+					width: 90%;
+					border: 1px solid var(--color-neutral-10) !important;
+					border-radius: 2px;
+					justify-content: space-between;
+				}
 
+				.section-nav-tab__link {
+					color: var(--color-neutral-70);
+					font-weight: 400;
+				}
+
+				.section-nav-tab {
+					.section-nav-tab__link {
 						&:hover {
+							color: var(--color-accent);
+							background-color: var(--color-neutral-5);
+						}
+					}
+
+					&.is-selected {
+						.section-nav-tab__link {
 							color: #fff;
-							background-color: var(--color-accent-60);
+
+							&:hover {
+								color: #fff;
+								background-color: var(--color-accent-60);
+							}
 						}
 					}
 				}

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
@@ -41,6 +41,7 @@ export interface PreviewPaneProps {
 	addTourDetails?: { id: string; tourId: string };
 	itemPreviewPaneHeaderExtraProps?: ItemPreviewPaneHeaderExtraProps;
 	hideNavIfSingleTab?: boolean;
+	enforceTabsView?: boolean;
 }
 
 export interface ItemPreviewPaneHeaderExtraProps {

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -20,6 +20,7 @@ class SectionNav extends Component {
 		allowDropdown: PropTypes.bool,
 		variation: PropTypes.string,
 		children: PropTypes.node,
+		enforceTabsView: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -81,6 +82,7 @@ class SectionNav extends Component {
 			'section-nav-updated': this.props.applyUpdatedStyles,
 			'has-pinned-items': this.hasPinnedSearch || this.props.hasPinnedItems,
 			minimal: 'minimal' === this.props.variation,
+			'enforce-tabs-view': this.props.enforceTabsView,
 		} );
 
 		return (
@@ -115,6 +117,11 @@ class SectionNav extends Component {
 			// Propagate 'selectedCount' to NavItem component
 			if ( child.type === NavTabs && this.props.selectedCount ) {
 				extraProps.selectedCount = this.props.selectedCount;
+			}
+
+			// Propagate 'enforceTabsView' to NavItem component
+			if ( child.type === NavTabs && this.props.enforceTabsView ) {
+				extraProps.enforceTabsView = this.props.enforceTabsView;
 			}
 
 			if ( child.type === Search ) {

--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -6,7 +6,7 @@
 }
 
 .section-nav-tab {
-	@include breakpoint-deprecated( ">480px" ) {
+	@mixin tabs-view-styles {
 		width: auto;
 		flex: none;
 		border-bottom: 2px solid transparent;
@@ -20,6 +20,14 @@
 		&:hover:not(.is-selected) {
 			border-bottom-color: var(--color-primary-0);
 		}
+	}
+
+	.enforce-tabs-view & {
+		@include tabs-view-styles;
+	}
+
+	@include breakpoint-deprecated( ">480px" ) {
+		@include tabs-view-styles;
 	}
 }
 
@@ -98,7 +106,7 @@
 		}
 	}
 
-	@include breakpoint-deprecated( ">480px" ) {
+	@mixin tabs-view-styles {
 		display: block;
 		width: auto;
 		padding: 16px 16px 14px;
@@ -108,24 +116,48 @@
 		&:visited {
 			color: var(--color-primary);
 		}
+	}
 
-		.is-selected & {
-			color: var(--color-neutral-70);
-			background-color: transparent;
+	@mixin tabs-view-selected-styles {
+		color: var(--color-neutral-70);
+		background-color: transparent;
 
-			&::after {
-				display: none;
-			}
+		&::after {
+			display: none;
 		}
 
-		.notouch .is-selected & {
+		.notouch & {
 			&:hover {
 				color: var(--color-neutral-70);
 			}
 		}
+	}
+
+	@mixin tabs-view-minimal-styles {
+		color: var(--color-neutral-70);
+	}
+
+	.enforce-tabs-view & {
+		@include tabs-view-styles;
+	}
+
+	.enforce-tabs-view .is-selected & {
+		@include tabs-view-selected-styles;
+	}
+
+	.enforce-tabs-view.minimal & {
+		@include tabs-view-minimal-styles;
+	}
+
+	@include breakpoint-deprecated( ">480px" ) {
+		@include tabs-view-styles;
+
+		.is-selected & {
+			@include tabs-view-selected-styles;
+		}
 
 		.minimal & {
-			color: var(--color-neutral-70);
+			@include tabs-view-minimal-styles;
 		}
 	}
 }
@@ -136,10 +168,18 @@
 	width: 0;
 	color: inherit;
 
-	@include breakpoint-deprecated( ">480px" ) {
+	@mixin tabs-view-styles {
 		display: inline;
 		flex: none;
 		width: auto;
+	}
+
+	.enforce-tabs-view & {
+		@include tabs-view-styles;
+	}
+
+	@include breakpoint-deprecated( ">480px" ) {
+		@include tabs-view-styles;
 	}
 }
 .section-nav-updated.section-nav {

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -75,8 +75,16 @@
 		}
 	}
 
-	@include breakpoint-deprecated( ">480px" ) {
+	@mixin tabs-view-styles {
 		display: none;
+	}
+
+	.enforce-tabs-view & {
+		@include tabs-view-styles;
+	}
+
+	@include breakpoint-deprecated( ">480px" ) {
+		@include tabs-view-styles;
 	}
 }
 
@@ -108,7 +116,7 @@
 		}
 	}
 
-	@include breakpoint-deprecated( ">480px" ) {
+	@mixin tabs-view-styles {
 		display: flex;
 		align-items: center;
 
@@ -116,6 +124,14 @@
 			width: 0;
 			flex: 1 0 auto;
 		}
+	}
+
+	.enforce-tabs-view & {
+		@include tabs-view-styles;
+	}
+
+	@include breakpoint-deprecated( ">480px" ) {
+		@include tabs-view-styles;
 	}
 }
 
@@ -138,7 +154,7 @@
 		}
 	}
 
-	@include breakpoint-deprecated( ">480px" ) {
+	@mixin tabs-view-styles {
 		margin-top: 0;
 		padding-top: 0;
 		border-top: none;
@@ -148,13 +164,28 @@
 			width: 0;
 			flex: 1 0 auto;
 		}
+	}
 
+	.enforce-tabs-view & {
+		@include tabs-view-styles;
+	}
+
+	@include breakpoint-deprecated( ">480px" ) {
+		@include tabs-view-styles;
 	}
 }
 
-@include breakpoint-deprecated( ">480px" ) {
-	.section-nav-group.has-horizontal-scroll {
+.section-nav-group.has-horizontal-scroll {
+	@mixin tabs-view-styles {
 		overflow-x: auto;
+	}
+
+	.enforce-tabs-view & {
+		@include tabs-view-styles;
+	}
+
+	@include breakpoint-deprecated( ">480px" ) {
+		@include tabs-view-styles;
 	}
 }
 

--- a/client/components/section-nav/tabs.scss
+++ b/client/components/section-nav/tabs.scss
@@ -1,7 +1,15 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 
+.section-nav-group {
+	&.enforce-tabs-view {
+		display: block;
+		border-top: none;
+		margin-block-start: 0;
+	}
+}
+
 .section-nav-tabs {
-	@include breakpoint-deprecated( ">480px" ) {
+	@mixin tabs-view-styles {
 		width: 0;
 		flex: 1 0 auto;
 
@@ -12,13 +20,21 @@
 			margin: 8px;
 		}
 	}
+
+	.enforce-tabs-view & {
+		@include tabs-view-styles;
+	}
+
+	@include breakpoint-deprecated( ">480px" ) {
+		@include tabs-view-styles;
+	}
 }
 
 .section-nav-tabs__list {
 	margin: 0;
 	list-style: none;
 
-	@include breakpoint-deprecated( ">480px" ) {
+	@mixin tabs-view-styles {
 		display: flex;
 		width: 100%;
 		overflow: hidden;
@@ -27,16 +43,52 @@
 			display: none;
 		}
 	}
-}
 
-.enforce-tabs-view {
-	&.section-nav-group {
-		display: block;
-		border-top: none;
-		margin-block-start: 0;
+	.enforce-tabs-view & {
+		@include tabs-view-styles;
 	}
 
+	@include breakpoint-deprecated( ">480px" ) {
+		@include tabs-view-styles;
+	}
+}
+
+/**
+ * Overflow styles
+ */
+.section-nav-tabs:not(.is-dropdown) {
 	.section-nav-tabs__list {
-		display: flex;
+		--direction-start: left;
+		--direction-end: right;
+		&:dir( rtl ) {
+			--direction-start: right;
+			--direction-end: left;
+		}
+
+		--fade-width: 4rem;
+		--fade-gradient-base: transparent 0%, #000 var( --fade-width );
+		--fade-gradient-composed: var( --fade-gradient-base ), #000 60%, transparent 50%;
+
+		&.is-overflowing-first {
+			mask-image: linear-gradient(
+				to var( --direction-end ),
+				var( --fade-gradient-base )
+			);
+		}
+
+		&.is-overflowing-last {
+			mask-image: linear-gradient(
+				to var( --direction-start ),
+				var( --fade-gradient-base )
+			);
+		}
+
+		&.is-overflowing-first.is-overflowing-last {
+			mask-image: linear-gradient(
+					to right,
+					var( --fade-gradient-composed )
+				),
+				linear-gradient( to left, var( --fade-gradient-composed ) );
+		}
 	}
 }

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -14,6 +14,16 @@ jest.mock( 'calypso/lib/analytics/ga', () => ( {
 	recordEvent: () => {},
 } ) );
 
+window.IntersectionObserver = jest.fn( () => ( {
+	observe: jest.fn(),
+	disconnect: jest.fn(),
+	root: null,
+	rootMargin: '',
+	thresholds: [],
+	takeRecords: jest.fn(),
+	unobserve: jest.fn(),
+} ) );
+
 function createComponent( component, props, children ) {
 	const renderer = new ShallowRenderer();
 

--- a/client/my-sites/site-settings/site-setting-privacy/form.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/form.tsx
@@ -237,7 +237,7 @@ const SiteSettingPrivacyForm = ( {
 									disabled={ isRequestingSettings || discourageSearchChecked }
 									onClick={ () => recordEvent( 'Clicked Partnership Radio Button' ) }
 								/>
-								<span>
+								<span style={ { overflowWrap: 'anywhere' } }>
 									{ translate( 'Prevent third-party sharing for %(siteName)s', {
 										args: {
 											siteName: siteSlug || '',

--- a/client/sites/components/panel-sidebar/index.tsx
+++ b/client/sites/components/panel-sidebar/index.tsx
@@ -1,6 +1,11 @@
+import { SelectDropdown } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import { Children, isValidElement } from 'react';
+import { navigate } from 'calypso/lib/navigate';
+import type { ReactNode, ReactElement } from 'react';
+
 import './style.scss';
 
 export function SidebarItem( { href, children }: { href: string; children: ReactNode } ) {
@@ -21,7 +26,37 @@ export function SidebarItem( { href, children }: { href: string; children: React
 }
 
 export function Sidebar( { children }: { children: ReactNode } ) {
-	return <ul className="panel-sidebar">{ children }</ul>;
+	const isDesktop = useViewportMatch( 'mobile', '>=' );
+	const activeElement = Children.toArray( children ).find(
+		( child ) => isValidElement( child ) && window.location.pathname.startsWith( child.props.href )
+	) as ReactElement;
+
+	if ( isDesktop ) {
+		return (
+			<ul className="panel-sidebar">{ children }</ul>
+		);
+	}
+
+	return (
+		<SelectDropdown
+			className="panel-sidebar panel-sidebar-dropdown"
+			selectedText={ activeElement?.props?.children }
+		>
+			{ Children.toArray( children )
+				.filter( ( child ) => child && isValidElement( child ) )
+				.map( ( child, index ) => {
+					const { href, ...childProps } = ( child as ReactElement ).props;
+					return (
+						<SelectDropdown.Item
+							{ ...childProps }
+							key={ index }
+							selected={ window.location.pathname.startsWith( href ) }
+							onClick={ () => navigate( href ) }
+						/>
+					);
+				} ) }
+		</SelectDropdown>
+	);
 }
 
 export function PanelWithSidebar( { children }: { children: ReactNode } ) {

--- a/client/sites/components/panel-sidebar/index.tsx
+++ b/client/sites/components/panel-sidebar/index.tsx
@@ -26,15 +26,13 @@ export function SidebarItem( { href, children }: { href: string; children: React
 }
 
 export function Sidebar( { children }: { children: ReactNode } ) {
-	const isDesktop = useViewportMatch( 'mobile', '>=' );
+	const isDesktop = useViewportMatch( 'small', '>=' );
 	const activeElement = Children.toArray( children ).find(
 		( child ) => isValidElement( child ) && window.location.pathname.startsWith( child.props.href )
 	) as ReactElement;
 
 	if ( isDesktop ) {
-		return (
-			<ul className="panel-sidebar">{ children }</ul>
-		);
+		return <ul className="panel-sidebar">{ children }</ul>;
 	}
 
 	return (

--- a/client/sites/components/panel-sidebar/style.scss
+++ b/client/sites/components/panel-sidebar/style.scss
@@ -13,7 +13,7 @@
 		margin-bottom: 16px;
 	}
 
-	@include break-mobile {
+	@include break-small {
 		flex-direction: row;
 		align-items: flex-start;
 	}
@@ -29,7 +29,7 @@
 	background: #fff;
 	z-index: 1;
 
-	@include break-mobile {
+	@include break-small {
 		top: 0;
 		min-width: 160px;
 		padding: 0;

--- a/client/sites/components/panel-sidebar/style.scss
+++ b/client/sites/components/panel-sidebar/style.scss
@@ -24,7 +24,7 @@
 	top: -24px;
 	flex-shrink: 0;
 	padding: 24px 24px 20px;
-	margin: -24px -24px -19px;
+	margin: -23px -24px -19px;
 	list-style: none;
 	background: #fff;
 	z-index: 1;

--- a/client/sites/components/panel-sidebar/style.scss
+++ b/client/sites/components/panel-sidebar/style.scss
@@ -5,6 +5,7 @@
 .panel-with-sidebar {
 	display: flex;
 	gap: 20px;
+	align-items: flex-start;
 
 	.navigation-header {
 		margin-bottom: 16px;
@@ -12,8 +13,10 @@
 }
 
 .panel-sidebar {
-	margin: 0;
+	position: sticky;
+	top: 0;
 	min-width: 160px;
+	margin: 0;
 	flex-shrink: 0;
 	list-style: none;
 }

--- a/client/sites/components/panel-sidebar/style.scss
+++ b/client/sites/components/panel-sidebar/style.scss
@@ -1,24 +1,40 @@
 
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 @import "~@automattic/color-studio/dist/color-variables";
 @import "~@automattic/typography/styles/variables";
 
 .panel-with-sidebar {
 	display: flex;
 	gap: 20px;
-	align-items: flex-start;
+	flex-direction: column;
 
 	.navigation-header {
 		margin-bottom: 16px;
+	}
+
+	@include break-mobile {
+		flex-direction: row;
+		align-items: flex-start;
 	}
 }
 
 .panel-sidebar {
 	position: sticky;
-	top: 0;
-	min-width: 160px;
-	margin: 0;
+	top: -24px;
 	flex-shrink: 0;
+	padding: 24px 24px 20px;
+	margin: -24px -24px -19px;
 	list-style: none;
+	background: #fff;
+	z-index: 1;
+
+	@include break-mobile {
+		top: 0;
+		min-width: 160px;
+		padding: 0;
+		margin: 0;
+	}
 }
 
 .panel-sidebar-tab {
@@ -39,5 +55,11 @@
 		background-color: #f0f0f0;
 		font-weight: 600;
 		border-radius: 4px;
+	}
+}
+
+.panel-sidebar-dropdown {
+	.select-dropdown__container {
+		display: block;
 	}
 }

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -233,6 +233,7 @@ const DotcomPreviewPane = ( {
 			closeItemPreviewPane={ closeSitePreviewPane }
 			features={ features }
 			className={ site.is_wpcom_staging_site ? 'is-staging-site' : '' }
+			enforceTabsView
 			itemPreviewPaneHeaderExtraProps={ {
 				externalIconSize: 16,
 				siteIconFallback: isMigrationPending ? 'migration' : 'first-grapheme',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9609

## Proposed Changes

* Make the sidebar sticky on scroll on both desktop and mobile
* Make the first level tab on mobile still a tab instead of the dropdown. It would be better to replace it with the [TabList](https://wordpress.github.io/gutenberg/?path=/story/components-tabs--size-and-overflow-playground) component from Gutenberg in the future
* Make the second level tab on mobile the dropdown

**Desktop**

<img width="300" src="https://github.com/user-attachments/assets/8ad916de-068b-493c-a608-73204695f3d6" />

**Mobile**

<img width="300" src="https://github.com/user-attachments/assets/f5193f2e-3c52-49b1-9695-cfc4cba420b3" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Pick any site to open the SMP
* Make sure the first-level tabs won't become dropdown on mobile
* Click any tab that has second-level tabs, e.g.: Marketing, Settings
* Make sure the second-level tabs always sticky on scroll
* Make sure the second-level tabs become the dropdown on mobile

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
