### PR TITLE
Add missing page tracks

### DIFF
--- a/client/hosting/overview/components/hosting-overview.tsx
+++ b/client/hosting/overview/components/hosting-overview.tsx
@@ -5,6 +5,7 @@ import ActiveDomainsCard from 'calypso/hosting/overview/components/active-domain
 import PlanCard from 'calypso/hosting/overview/components/plan-card';
 import QuickActionsCard from 'calypso/hosting/overview/components/quick-actions-card';
 import SiteBackupCard from 'calypso/hosting/overview/components/site-backup-card';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import {
 	isNotAtomicJetpack,
 	isMigrationInProgress,
@@ -43,6 +44,7 @@ const HostingOverview: FC = () => {
 
 	return (
 		<div className="hosting-overview">
+			<PageViewTracker path="/overview/:site" title="Site Overview" />
 			<NavigationHeader
 				className="hosting-overview__navigation-header"
 				title={ translate( 'Overview' ) }

--- a/client/hosting/staging-site/controller.js
+++ b/client/hosting/staging-site/controller.js
@@ -1,7 +1,12 @@
-import { createElement } from 'react';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import StagingSite from './components/staging-site';
 
 export function renderStagingSite( context, next ) {
-	context.primary = createElement( StagingSite );
+	context.primary = (
+		<>
+			<PageViewTracker path="/staging-site/:site" title="Staging Site" />
+			<StagingSite />
+		</>
+	);
 	next();
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/9586

## Proposed Changes

* Add missing `calypso_page_view` stats for "Overview" and "Staging Site" tabs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/Automattic/dotcom-forge/issues/9529

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `http://calypso.localhost:3000/overview/_BLOG_`
* Visit `http://calypso.localhost:3000/staging-site/_BLOG_`
* Ensure on Tracks Vigilante that `/overview/:site` and `/staging-site/:site` `calypso_page_view` track is generated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?