### PR TITLE
`Theme`: Use intersection observer to render a placeholder when not visible

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -26,6 +26,7 @@ import ThemeMoreButton from './more-button';
 import './style.scss';
 
 const THEME_CARD_HEIGHT = 420;
+const VIEWPORT_HEIGHT = `${ 3 * THEME_CARD_HEIGHT }px`;
 
 const noop = () => {};
 
@@ -350,7 +351,7 @@ export class Theme extends Component {
 		}
 
 		return (
-			<InView triggerOnce rootMargin={ `${ THEME_CARD_HEIGHT }px` }>
+			<InView triggerOnce rootMargin={ VIEWPORT_HEIGHT }>
 				{ ( { inView, ref } ) => (
 					<div ref={ ref }>
 						{ inView ? (

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -11,6 +11,7 @@ import { isEmpty, isEqual } from 'lodash';
 import photon from 'photon';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
+import { InView } from 'react-intersection-observer';
 import { connect } from 'react-redux';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { decodeEntities } from 'calypso/lib/formatting';
@@ -23,6 +24,8 @@ import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
 import ThemeMoreButton from './more-button';
 
 import './style.scss';
+
+const THEME_CARD_HEIGHT = 420;
 
 const noop = () => {};
 
@@ -347,27 +350,37 @@ export class Theme extends Component {
 		}
 
 		return (
-			<ThemeCard
-				ref={ this.props.bookmarkRef }
-				name={ name }
-				description={ themeDescription }
-				image={ this.renderScreenshot() }
-				imageClickUrl={ this.props.screenshotClickUrl }
-				imageActionLabel={ this.props.actionLabel }
-				banner={ this.renderUpdateAlert() }
-				badge={ this.renderBadge() }
-				styleVariations={ style_variations }
-				selectedStyleVariation={ selectedStyleVariation }
-				optionsMenu={ this.renderMoreButton() }
-				isActive={ this.props.active }
-				isLoading={ this.props.loading }
-				isSoftLaunched={ this.props.softLaunched }
-				isShowDescriptionOnImageHover={ ! isCustomGeneratedTheme }
-				onClick={ this.setBookmark }
-				onImageClick={ this.onScreenshotClick }
-				onStyleVariationClick={ this.onStyleVariationClick }
-				onStyleVariationMoreClick={ this.onStyleVariationClick }
-			/>
+			<InView triggerOnce rootMargin={ `${ THEME_CARD_HEIGHT }px` }>
+				{ ( { inView, ref } ) => (
+					<div ref={ ref }>
+						{ inView ? (
+							<ThemeCard
+								ref={ this.props.bookmarkRef }
+								name={ name }
+								description={ themeDescription }
+								image={ this.renderScreenshot() }
+								imageClickUrl={ this.props.screenshotClickUrl }
+								imageActionLabel={ this.props.actionLabel }
+								banner={ this.renderUpdateAlert() }
+								badge={ this.renderBadge() }
+								styleVariations={ style_variations }
+								selectedStyleVariation={ selectedStyleVariation }
+								optionsMenu={ this.renderMoreButton() }
+								isActive={ this.props.active }
+								isLoading={ this.props.loading }
+								isSoftLaunched={ this.props.softLaunched }
+								isShowDescriptionOnImageHover={ ! isCustomGeneratedTheme }
+								onClick={ this.setBookmark }
+								onImageClick={ this.onScreenshotClick }
+								onStyleVariationClick={ this.onStyleVariationClick }
+								onStyleVariationMoreClick={ this.onStyleVariationClick }
+							/>
+						) : (
+							this.renderPlaceholder()
+						) }
+					</div>
+				) }
+			</InView>
 		);
 	}
 }

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -1,43 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Theme rendering should match snapshot 1`] = `
-<div
-  class="card theme-card theme-card--is-actionable is-clickable"
-  data-e2e-theme="twenty-seventeen"
->
+<div>
   <div
-    class="theme-card__content"
+    class="card theme-card theme-card--is-actionable is-clickable"
+    data-e2e-theme="twenty-seventeen"
   >
     <div
-      class="theme-card__image-container"
+      class="theme-card__content"
     >
-      <a
-        aria-label="Twenty Seventeen"
-        class="theme-card__image"
-        href="#"
+      <div
+        class="theme-card__image-container"
       >
-        <img
-          alt=""
-          class="theme__img"
-          src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
-          srcset="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
+        <a
+          aria-label="Twenty Seventeen"
+          class="theme-card__image"
+          href="#"
+        >
+          <img
+            alt=""
+            class="theme__img"
+            src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
+            srcset="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
+          />
+        </a>
+      </div>
+      <div
+        class="theme-card__info"
+      >
+        <h2
+          class="theme-card__info-title"
+        >
+          <span>
+            Twenty Seventeen
+          </span>
+        </h2>
+        <components--theme-tier-badge
+          islockedstylevariation="false"
+          themeid="twentyseventeen"
         />
-      </a>
-    </div>
-    <div
-      class="theme-card__info"
-    >
-      <h2
-        class="theme-card__info-title"
-      >
-        <span>
-          Twenty Seventeen
-        </span>
-      </h2>
-      <components--theme-tier-badge
-        islockedstylevariation="false"
-        themeid="twentyseventeen"
-      />
+      </div>
     </div>
   </div>
 </div>

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -114,4 +114,26 @@ describe( 'Theme', () => {
 			expect( container.getElementsByClassName( 'theme__update-alert' ).length ).toBe( 1 );
 		} );
 	} );
+
+	describe( 'In view', () => {
+		it( 'should render a placeholder when the component is not visible', () => {
+			const { container } = render( <Theme { ...props } /> );
+
+			mockAllIsIntersecting( false );
+
+			expect( container.firstChild.firstChild ).toHaveClass( 'is-placeholder' );
+		} );
+
+		it( 'should render the component when it is visible', () => {
+			render( <Theme { ...props } /> );
+
+			mockAllIsIntersecting( false );
+
+			expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
+
+			mockAllIsIntersecting( true );
+
+			expect( screen.getByRole( 'presentation' ) ).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -2,8 +2,9 @@
  * @jest-environment jsdom
  */
 import { parse } from 'url';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
 import { Theme } from '../';
 
 jest.mock( 'calypso/components/popover-menu', () => 'components--popover--menu' );
@@ -24,20 +25,31 @@ describe( 'Theme', () => {
 	};
 
 	describe( 'rendering', () => {
-		test( 'should render an element with a className of "theme"', () => {
+		test( 'should render an element with a className of "theme"', async () => {
 			const { container } = render( <Theme { ...props } /> );
-			expect( container.firstChild ).toHaveClass( 'theme-card--is-actionable' );
+
+			mockAllIsIntersecting( true );
+
+			await waitFor( () => {
+				expect( container.firstChild.firstChild ).toHaveClass( 'theme-card--is-actionable' );
+			} );
 			expect( container.getElementsByTagName( 'h2' )[ 0 ] ).toHaveTextContent( 'Twenty Seventeen' );
 		} );
 
 		test( 'should render a screenshot', () => {
 			render( <Theme { ...props } /> );
+
+			mockAllIsIntersecting( true );
+
 			const img = screen.getByRole( 'presentation' );
 			expect( img ).toHaveAttribute( 'src', expect.stringContaining( '/screenshot.png' ) );
 		} );
 
 		test( 'should include photon parameters', () => {
 			render( <Theme { ...props } /> );
+
+			mockAllIsIntersecting( true );
+
 			const img = screen.getByRole( 'presentation' );
 			const { query } = parse( img.getAttribute( 'src' ), true );
 
@@ -50,6 +62,8 @@ describe( 'Theme', () => {
 			const onScreenshotClick = jest.fn();
 			render( <Theme { ...props } onScreenshotClick={ onScreenshotClick } index={ 1 } /> );
 
+			mockAllIsIntersecting( true );
+
 			const img = screen.getByRole( 'presentation' );
 			await userEvent.click( img );
 			expect( onScreenshotClick ).toHaveBeenCalledTimes( 1 );
@@ -59,11 +73,16 @@ describe( 'Theme', () => {
 		test( 'should not show a price when there is none', () => {
 			const { container } = render( <Theme { ...props } /> );
 
+			mockAllIsIntersecting( true );
+
 			expect( container.getElementsByClassName( 'price' ) ).toHaveLength( 0 );
 		} );
 
 		test( 'should match snapshot', () => {
 			const { container } = render( <Theme { ...props } /> );
+
+			mockAllIsIntersecting( true );
+
 			expect( container.firstChild ).toMatchSnapshot();
 		} );
 	} );
@@ -72,6 +91,8 @@ describe( 'Theme', () => {
 		test( 'should render an element with an is-placeholder class', () => {
 			const theme = { id: 'placeholder-1', name: 'Loading' };
 			const { container } = render( <Theme { ...props } theme={ theme } isPlaceholder /> );
+
+			mockAllIsIntersecting( true );
 
 			expect( container.firstChild ).toHaveClass( 'is-placeholder' );
 		} );
@@ -87,6 +108,9 @@ describe( 'Theme', () => {
 				},
 			};
 			const { container } = render( <Theme { ...updateThemeProps } /> );
+
+			mockAllIsIntersecting( true );
+
 			expect( container.getElementsByClassName( 'theme__update-alert' ).length ).toBe( 1 );
 		} );
 	} );

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -3,6 +3,7 @@
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
 import { setStore } from 'calypso/state/redux-store';
@@ -116,6 +117,8 @@ describe( 'logged-out', () => {
 		);
 		render( <TestComponent store={ store } /> );
 
+		mockAllIsIntersecting( true );
+
 		await waitFor( () => {
 			expect( screen.getByText( 'No themes match your search' ) ).toBeInTheDocument();
 		} );
@@ -133,6 +136,8 @@ describe( 'logged-out', () => {
 			)
 		);
 		render( <TestComponent store={ store } /> );
+
+		mockAllIsIntersecting( true );
 
 		await waitFor( () => {
 			themes.forEach( ( theme ) => {
@@ -153,6 +158,8 @@ describe( 'logged-out', () => {
 			error: 'Error',
 		} );
 		render( <TestComponent store={ store } /> );
+
+		mockAllIsIntersecting( true );
 
 		await waitFor( () => {
 			expect( screen.queryByText( 'No themes match your search' ) ).toBeInTheDocument();

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -12,6 +12,7 @@ const selectors = {
 	// Transitions
 	spinner: '.themes__content > .spinner',
 	placeholder: '.themes-list .is-placeholder',
+	actionableTheme: '.theme-card--is-actionable',
 
 	// Search
 	showAllThemesButton: 'text=Show all themes',
@@ -42,7 +43,7 @@ export class ThemesPage {
 	private async pageSettled(): Promise< void > {
 		await Promise.all( [
 			this.page.waitForSelector( selectors.spinner, { state: 'hidden' } ),
-			this.page.waitForSelector( selectors.placeholder, { state: 'hidden' } ),
+			this.page.locator( selectors.actionableTheme ).first().waitFor(),
 		] );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -59,7 +59,10 @@ export class ThemesPage {
 		const searchInput = await this.page.waitForSelector( selectors.searchInput );
 		await searchInput.fill( keyword );
 		await Promise.all( [ this.page.waitForNavigation(), searchInput.press( 'Enter' ) ] );
-		await this.page.waitForSelector( selectors.placeholder, { state: 'detached' } );
+		// wait for the loadin placeholders to appear after search is triggered
+		await this.page.waitForSelector( selectors.placeholder, { state: 'attached' } );
+		// wait for an actionable theme to appear, meaning the search results are shown
+		await this.page.locator( selectors.actionableTheme ).first().waitFor();
 	}
 
 	/**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95248

## Proposed Changes

* Update the `theme` component so it's lazy loaded when it's visible or within the next viewport height.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `/themes` page loads ~34MB of theme screenshots on page load, because it's rendering 100 themes for each page. This is too much, and lazy loading the component allows us to reduce that to ~5MB.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On the `Files changed` tab, enable the `Hide whitespace` option so the diff is more readable

* Open the live preview while logged out
* Open the dev tools, go to the network tab, filter by `.png`
* Go to `/themes`
* Check that only 8 theme screenshots are loaded (could be more, depending on the screen size), resulting in way less image data transferred (`5.1MB`) than what's happening on prod (`33.6MB`):
* Scroll down, check that the theme images are loaded 
* Repeat the previous steps on the logged in theme showcase

|Before|After|
|---|---|
|![Untitled](https://github.com/user-attachments/assets/af9dcf72-ef82-43d0-ab57-27c64be6a161)|![Untitled](https://github.com/user-attachments/assets/0c5bfe75-3396-4c0a-979e-e949ee1194e0)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
