### PR TITLE
Add missing overview tracking events

### DIFF
--- a/client/components/hosting-card/index.tsx
+++ b/client/components/hosting-card/index.tsx
@@ -27,6 +27,7 @@ interface HostingCardLinkButtonProps {
 	to: string;
 	children: string | ReactNode;
 	hideOnMobile?: boolean;
+	onClick?: () => void;
 }
 
 interface HostingCardGridProps {
@@ -67,6 +68,7 @@ export function HostingCardLinkButton( {
 	to,
 	children,
 	hideOnMobile,
+	onClick,
 }: HostingCardLinkButtonProps ) {
 	return (
 		<Button
@@ -75,6 +77,7 @@ export function HostingCardLinkButton( {
 			} ) }
 			plain
 			href={ to }
+			onClick={ onClick }
 		>
 			{ children }
 		</Button>

--- a/client/hosting/overview/components/active-domains-card.tsx
+++ b/client/hosting/overview/components/active-domains-card.tsx
@@ -10,6 +10,7 @@ import {
 	HostingCardHeading,
 	HostingCardLinkButton,
 } from 'calypso/components/hosting-card';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
 import { filterOutWpcomDomains } from 'calypso/my-sites/domains/domain-management/list/utils';
 import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils';
@@ -52,10 +53,18 @@ const ActiveDomainsCard: FC = () => {
 				<HostingCardLinkButton
 					to={ `/domains/add/${ site?.slug }?redirect_to=${ window.location.pathname }` }
 					hideOnMobile
+					onClick={ () =>
+						dispatch( recordTracksEvent( 'calypso_overview_add_domain_button_click' ) )
+					}
 				>
 					{ translate( 'Add new domain' ) }
 				</HostingCardLinkButton>
-				<HostingCardLinkButton to={ `/domains/manage/${ site?.slug }` }>
+				<HostingCardLinkButton
+					to={ `/domains/manage/${ site?.slug }` }
+					onClick={ () =>
+						dispatch( recordTracksEvent( 'calypso_overview_manage_domains_button_click' ) )
+					}
+				>
 					{ translate( 'Manage domains' ) }
 				</HostingCardLinkButton>
 			</HostingCardHeading>

--- a/client/hosting/overview/components/active-domains-card.tsx
+++ b/client/hosting/overview/components/active-domains-card.tsx
@@ -10,11 +10,11 @@ import {
 	HostingCardHeading,
 	HostingCardLinkButton,
 } from 'calypso/components/hosting-card';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
 import { filterOutWpcomDomains } from 'calypso/my-sites/domains/domain-management/list/utils';
 import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils';
 import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import {

--- a/client/hosting/overview/components/plan-card.tsx
+++ b/client/hosting/overview/components/plan-card.tsx
@@ -304,6 +304,9 @@ const PlanCard = () => {
 										a: isA4A ? (
 											<a
 												href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }
+												onClick={ () => {
+													recordTracksEvent( 'calypso_overview_agency_managed_site_click' );
+												} }
 											></a>
 										) : (
 											<strong></strong>

--- a/client/hosting/overview/components/quick-actions-card.tsx
+++ b/client/hosting/overview/components/quick-actions-card.tsx
@@ -9,6 +9,7 @@ import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { WriteIcon } from 'calypso/layout/masterbar/write-icon';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
+import { useDispatch } from 'calypso/state';
 import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import getPluginInstallUrl from 'calypso/state/selectors/get-plugin-install-url';
@@ -26,10 +27,13 @@ interface ActionProps {
 }
 export const Action: FC< ActionProps > = ( { icon, href, text, commandName, onClick } ) => {
 	const isDisabled = ! href && ! onClick;
+	const dispatch = useDispatch();
 	const clickAction = () => {
-		recordTracksEvent( 'calypso_hosting_command_palette_navigate', {
-			command: commandName,
-		} );
+		dispatch(
+			recordTracksEvent( 'calypso_hosting_command_palette_navigate', {
+				command: commandName,
+			} )
+		);
 
 		onClick?.();
 	};

--- a/client/hosting/overview/components/quick-actions-card.tsx
+++ b/client/hosting/overview/components/quick-actions-card.tsx
@@ -20,7 +20,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 interface ActionProps {
 	onClick?: () => void;
-	commandName: string;
+	commandName?: string;
 	icon: ReactNode;
 	href?: string;
 	text: string;
@@ -29,11 +29,13 @@ export const Action: FC< ActionProps > = ( { icon, href, text, commandName, onCl
 	const isDisabled = ! href && ! onClick;
 	const dispatch = useDispatch();
 	const clickAction = () => {
-		dispatch(
-			recordTracksEvent( 'calypso_hosting_command_palette_navigate', {
-				command: commandName,
-			} )
-		);
+		if ( commandName ) {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_command_palette_navigate', {
+					command: commandName,
+				} )
+			);
+		}
 
 		onClick?.();
 	};

--- a/client/hosting/overview/components/quick-actions-card.tsx
+++ b/client/hosting/overview/components/quick-actions-card.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { chevronRightSmall, Icon } from '@wordpress/icons';
@@ -18,17 +19,26 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 interface ActionProps {
 	onClick?: () => void;
+	commandName: string;
 	icon: ReactNode;
 	href?: string;
 	text: string;
 }
-export const Action: FC< ActionProps > = ( { icon, href, text, onClick } ) => {
+export const Action: FC< ActionProps > = ( { icon, href, text, commandName, onClick } ) => {
 	const isDisabled = ! href && ! onClick;
+	const clickAction = () => {
+		recordTracksEvent( 'calypso_hosting_command_palette_navigate', {
+			command: commandName,
+		} );
+
+		onClick?.();
+	};
+
 	return (
 		<li className="hosting-overview__action">
 			<Button
 				className="hosting-overview__action-button"
-				onClick={ onClick }
+				onClick={ clickAction }
 				plain
 				href={ href }
 				disabled={ isDisabled }
@@ -95,6 +105,7 @@ const QuickActionsCard: FC = () => {
 					icon={ <SidebarCustomIcon icon="dashicons-wordpress-alt hosting-overview__dashicon" /> }
 					href={ adminUrl }
 					text={ adminLabel }
+					commandName="openSiteDashboard"
 				/>
 				<Action
 					icon={
@@ -102,24 +113,33 @@ const QuickActionsCard: FC = () => {
 					}
 					href={ siteEditorUrl }
 					text={ translate( 'Edit site' ) }
+					commandName="openSiteEditor"
 				/>
-				<Action icon={ <WriteIcon /> } href={ editorUrl } text={ translate( 'Write post' ) } />
+				<Action
+					icon={ <WriteIcon /> }
+					href={ editorUrl }
+					text={ translate( 'Write post' ) }
+					commandName="addNewPost"
+				/>
 				<Action
 					icon={
 						<SidebarCustomIcon icon="dashicons-admin-appearance hosting-overview__dashicon" />
 					}
 					href={ themeInstallUrl }
 					text={ translate( 'Change theme' ) }
+					commandName="installTheme"
 				/>
 				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-admin-plugins hosting-overview__dashicon" /> }
 					href={ pluginInstallUrl }
 					text={ translate( 'Install plugins' ) }
+					commandName="installPlugin"
 				/>
 				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-chart-bar hosting-overview__dashicon" /> }
 					href={ statsUrl }
 					text={ translate( 'See Jetpack Stats' ) }
+					commandName="openJetpackStats"
 				/>
 			</ul>
 		</HostingCard>

--- a/client/hosting/overview/components/quick-actions-card.tsx
+++ b/client/hosting/overview/components/quick-actions-card.tsx
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { chevronRightSmall, Icon } from '@wordpress/icons';
@@ -10,6 +9,7 @@ import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query'
 import { WriteIcon } from 'calypso/layout/masterbar/write-icon';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import getPluginInstallUrl from 'calypso/state/selectors/get-plugin-install-url';

--- a/client/hosting/overview/components/site-backup-card/index.js
+++ b/client/hosting/overview/components/site-backup-card/index.js
@@ -120,6 +120,9 @@ const SiteBackupCard = ( { lastGoodBackup, requestBackups, siteId, siteSlug } ) 
 								? `https://cloud.jetpack.com/backup/${ siteSlug }`
 								: `/backup/${ siteSlug }`
 						}
+						onClick={ () =>
+							dispatch( recordTracksEvent( 'calypso_overview_backups_see_all_click' ) )
+						}
 					>
 						{ translate( 'See all backups' ) }
 					</HostingCardLinkButton>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9587

## Proposed Changes

Add these new tracks
* `calypso_overview_add_domain_button_click`
* `calypso_overview_manage_domains_button_click`
* `calypso_overview_agency_managed_site_click`
* `calypso_hosting_command_palette_navigate`
* `calypso_overview_backups_see_all_click`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
See https://github.com/Automattic/dotcom-forge/issues/9529

## Testing Instructions

1. Visit `http://calypso.localhost:3000/overview/_BLOG_`
2. Click all links and buttons found in this issue https://github.com/Automattic/dotcom-forge/issues/9587
3. Ensure on Tracks Vigilante that all the tracks are generated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?