### PR TITLE
Help Center: Save elapsed time from HE and user's response

### DIFF
--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -5,6 +5,7 @@ import { useSelect } from '@wordpress/data';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { broadcastChatClearance, useSetOdieStorage, useOdieBroadcastWithCallbacks } from '../data';
 import { isOdieAllowedBot } from '../utils';
+import { getHelpCenterZendeskConversationStarted } from '../utils/storage-utils';
 import { getOdieInitialMessage } from './get-odie-initial-message';
 import { useLoadPreviousChat } from './use-load-previous-chat';
 import type {
@@ -51,6 +52,7 @@ type OdieAssistantContextInterface = {
 	sendNudge: ( nudge: Nudge ) => void;
 	selectedSiteId?: number | null;
 	selectedConversationId?: string | null;
+	waitAnswerToFirstMessageFromHumanSupport: boolean;
 	setChat: ( chat: SetStateAction< Chat > ) => void;
 	setMessageLikedStatus: ( message: Message, liked: boolean ) => void;
 	setLastMessageInView?: ( lastMessageInView: boolean ) => void;
@@ -63,6 +65,9 @@ type OdieAssistantContextInterface = {
 	chatStatus: 'loading' | 'loaded' | 'sending' | 'dislike' | 'transfer';
 	setChatStatus: ( chatStatus: 'loading' | 'loaded' | 'sending' | 'dislike' | 'transfer' ) => void;
 	version?: string | null;
+	setWaitAnswerToFirstMessageFromHumanSupport: (
+		waitAnswerToFirstMessageFromHumanSupport: boolean
+	) => void;
 };
 
 const defaultContextInterfaceValues = {
@@ -85,6 +90,7 @@ const defaultContextInterfaceValues = {
 	lastMessageRef: null,
 	odieClientId: '',
 	currentUser: { display_name: 'Me' },
+	waitAnswerToFirstMessageFromHumanSupport: false,
 	sendNudge: noop,
 	setChat: noop,
 	setMessageLikedStatus: noop,
@@ -97,6 +103,7 @@ const defaultContextInterfaceValues = {
 	setChatStatus: noop,
 	chatStatus: 'loading' as 'loading' | 'loaded' | 'sending',
 	updateMessage: noop,
+	setWaitAnswerToFirstMessageFromHumanSupport: noop,
 };
 
 // Create a default new context
@@ -147,6 +154,8 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 	const [ isVisible, setIsVisible ] = useState( false );
 	const [ isNudging, setIsNudging ] = useState( false );
 	const [ lastNudge, setLastNudge ] = useState< Nudge | null >( null );
+	const [ waitAnswerToFirstMessageFromHumanSupport, setWaitAnswerToFirstMessageFromHumanSupport ] =
+		useState( getHelpCenterZendeskConversationStarted() !== null );
 	const [ scrollToLastMessage, setScrollToLastMessage ] =
 		useState< ScrollToLastMessageType | null >( null );
 
@@ -297,6 +306,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 				odieClientId,
 				selectedSiteId,
 				selectedConversationId,
+				waitAnswerToFirstMessageFromHumanSupport,
 				sendNudge: setLastNudge,
 				setChat,
 				setMessageLikedStatus,
@@ -312,6 +322,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 				isUserEligibleForPaidSupport,
 				chatStatus,
 				setChatStatus,
+				setWaitAnswerToFirstMessageFromHumanSupport,
 			} }
 		>
 			{ children }

--- a/packages/odie-client/src/query/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/query/use-create-zendesk-conversation.ts
@@ -1,10 +1,18 @@
 import { useUpdateZendeskUserFields } from '@automattic/zendesk-client';
 import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../context';
+import { setHelpCenterZendeskConversationStarted } from '../utils';
 
 export const useCreateZendeskConversation = (): ( () => Promise< void > ) => {
-	const { setSupportProvider, selectedSiteId, addMessage, setChat, setChatStatus, chat } =
-		useOdieAssistantContext();
+	const {
+		setSupportProvider,
+		selectedSiteId,
+		addMessage,
+		setChat,
+		setChatStatus,
+		setWaitAnswerToFirstMessageFromHumanSupport,
+		chat,
+	} = useOdieAssistantContext();
 	const { isPending: isSubmittingZendeskUserFields, mutateAsync: submitUserFields } =
 		useUpdateZendeskUserFields();
 	const chatId = Number( chat.chat_id ) || 0;
@@ -37,6 +45,8 @@ export const useCreateZendeskConversation = (): ( () => Promise< void > ) => {
 			Smooch.createConversation( { metadata: { odieChatId: chatId } } ).then( ( conversation ) => {
 				setSupportProvider( 'zendesk' );
 				setChatStatus( 'loaded' );
+				setHelpCenterZendeskConversationStarted();
+				setWaitAnswerToFirstMessageFromHumanSupport( true );
 				setChat( ( prevChat ) => {
 					return {
 						...prevChat,

--- a/packages/odie-client/src/query/use-odie-chat.ts
+++ b/packages/odie-client/src/query/use-odie-chat.ts
@@ -48,6 +48,7 @@ export const useOdieChat = (
 			const chatResponse: Chat = {
 				chat_id: response.chat_id,
 				messages: response.messages || [],
+				wpcom_user_id: response.wpcom_user_id,
 				// Add any other fields that are part of the Chat type
 			};
 

--- a/packages/odie-client/src/query/use-send-chat-message.ts
+++ b/packages/odie-client/src/query/use-send-chat-message.ts
@@ -1,6 +1,7 @@
 import { useCallback } from '@wordpress/element';
 import { useOdieAssistantContext } from '../context';
 import { broadcastOdieMessage } from '../data';
+import { getHelpCenterZendeskConversationStartedElapsedTime } from '../utils/storage-utils';
 import { useSendOdieMessage } from './use-send-odie-message';
 import { useSendZendeskMessage } from './use-send-zendesk-message';
 import type { Message } from '../types/';
@@ -9,8 +10,15 @@ import type { Message } from '../types/';
  * This is the gate that manages which message provider to use.
  */
 export const useSendChatMessage = () => {
-	const { supportProvider, shouldUseHelpCenterExperience, addMessage, odieClientId } =
-		useOdieAssistantContext();
+	const {
+		supportProvider,
+		shouldUseHelpCenterExperience,
+		addMessage,
+		odieClientId,
+		waitAnswerToFirstMessageFromHumanSupport,
+		setWaitAnswerToFirstMessageFromHumanSupport,
+		trackEvent,
+	} = useOdieAssistantContext();
 
 	const { mutateAsync: sendOdieMessage } = useSendOdieMessage();
 	const sendZendeskMessage = useSendZendeskMessage();
@@ -22,6 +30,20 @@ export const useSendChatMessage = () => {
 			broadcastOdieMessage( message, odieClientId );
 
 			if ( shouldUseHelpCenterExperience && supportProvider === 'zendesk' ) {
+				if (
+					message.role === 'user' &&
+					message.type === 'message' &&
+					waitAnswerToFirstMessageFromHumanSupport
+				) {
+					//track the time it took to send the first message for the user
+					const elapsedTime = getHelpCenterZendeskConversationStartedElapsedTime();
+					if ( elapsedTime ) {
+						trackEvent( 'first_answer_to_human_support', {
+							elapsed_time: elapsedTime,
+						} );
+					}
+					setWaitAnswerToFirstMessageFromHumanSupport( false );
+				}
 				return sendZendeskMessage( message );
 			}
 
@@ -34,6 +56,9 @@ export const useSendChatMessage = () => {
 			sendZendeskMessage,
 			addMessage,
 			odieClientId,
+			waitAnswerToFirstMessageFromHumanSupport,
+			setWaitAnswerToFirstMessageFromHumanSupport,
+			trackEvent,
 		]
 	);
 

--- a/packages/odie-client/src/query/use-send-chat-message.ts
+++ b/packages/odie-client/src/query/use-send-chat-message.ts
@@ -18,6 +18,7 @@ export const useSendChatMessage = () => {
 		waitAnswerToFirstMessageFromHumanSupport,
 		setWaitAnswerToFirstMessageFromHumanSupport,
 		trackEvent,
+		chat,
 	} = useOdieAssistantContext();
 
 	const { mutateAsync: sendOdieMessage } = useSendOdieMessage();
@@ -41,6 +42,7 @@ export const useSendChatMessage = () => {
 						trackEvent( 'first_answer_to_human_support', {
 							elapsed_time: elapsedTime,
 							role: message.role,
+							user_id: chat?.wpcom_user_id,
 						} );
 					}
 					setWaitAnswerToFirstMessageFromHumanSupport( false );
@@ -60,6 +62,7 @@ export const useSendChatMessage = () => {
 			waitAnswerToFirstMessageFromHumanSupport,
 			setWaitAnswerToFirstMessageFromHumanSupport,
 			trackEvent,
+			chat?.wpcom_user_id,
 		]
 	);
 

--- a/packages/odie-client/src/query/use-send-chat-message.ts
+++ b/packages/odie-client/src/query/use-send-chat-message.ts
@@ -40,6 +40,7 @@ export const useSendChatMessage = () => {
 					if ( elapsedTime ) {
 						trackEvent( 'first_answer_to_human_support', {
 							elapsed_time: elapsedTime,
+							role: message.role,
 						} );
 					}
 					setWaitAnswerToFirstMessageFromHumanSupport( false );

--- a/packages/odie-client/src/types/index.ts
+++ b/packages/odie-client/src/types/index.ts
@@ -103,6 +103,7 @@ export type Message = {
 export type Chat = {
 	conversationId?: string;
 	chat_id?: number | null;
+	wpcom_user_id?: number | null;
 	messages: Message[];
 };
 

--- a/packages/odie-client/src/utils/index.ts
+++ b/packages/odie-client/src/utils/index.ts
@@ -2,3 +2,7 @@ export { zendeskMessageConverter } from './zendesk-message-converter';
 export { isOdieAllowedBot } from './is-odie-allowed-bot';
 export { generateUUID } from './generate-uuid';
 export { useZendeskMessageListener } from './use-zendesk-message-listener';
+export {
+	setHelpCenterZendeskConversationStarted,
+	getHelpCenterZendeskConversationStartedElapsedTime,
+} from './storage-utils';

--- a/packages/odie-client/src/utils/storage-utils.ts
+++ b/packages/odie-client/src/utils/storage-utils.ts
@@ -1,0 +1,37 @@
+function ignoreFatalsForSessionStorage( callback: () => unknown ) {
+	try {
+		return callback();
+	} catch {
+		// Do nothing.
+		return undefined;
+	}
+}
+
+export const setHelpCenterZendeskConversationStarted = () =>
+	ignoreFatalsForSessionStorage(
+		() =>
+			sessionStorage?.setItem(
+				'help_center_zendesk_conversation_started',
+				performance.now().toString()
+			)
+	);
+export const getHelpCenterZendeskConversationStarted = () =>
+	ignoreFatalsForSessionStorage(
+		() => sessionStorage?.getItem( 'help_center_zendesk_conversation_started' )
+	);
+export const clearHelpCenterZendeskConversationStarted = () =>
+	ignoreFatalsForSessionStorage(
+		() => sessionStorage?.removeItem( 'help_center_zendesk_conversation_started' )
+	);
+
+export const getHelpCenterZendeskConversationStartedElapsedTime = () => {
+	const startTime = getHelpCenterZendeskConversationStarted();
+
+	if ( startTime == null ) {
+		return null;
+	}
+
+	clearHelpCenterZendeskConversationStarted();
+
+	return Math.floor( performance.now() - ( startTime as number ) );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9259

## Proposed Changes

Trigger a new event, `calypso_odie_first_answer_to_human_support`, when the user answers to the first message received by human support (an happiness engineer).

<img width="528" alt="image" src="https://github.com/user-attachments/assets/a8b8fd27-9d25-41f8-b4f1-1296ec7daabc">

`elapsed_time` will be the time passed.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To look at the rate of users who request human support and reply within X minutes to the first message they receive from an HE. More context in the issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Live link.
- Add `?flags=help-center-experience` to the URL to trigger the new Support experience.
- Start a new chat with Wapuu and ask to talk to an human.
- When clicking Get Support, check in Application tab in devtools that a `help_center_zendesk_conversation_started` has been created
- Wait for HE to answer and then send a message.
- `help_center_zendesk_conversation_started` should be removed and an event `calypso_odie_first_answer_to_human_support` triggered, with an `elapsed_time` property.
- Send another message and check that this doesn't happen again.
- Send a message to the user from the Happiness Engineer, then send another message from the user: it shouldn't happen again.

