### PR TITLE
100-year domain flow: remove hardcoded price from domain search results

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -270,12 +270,11 @@ class DomainProductPrice extends Component {
 
 	/**
 	 * Used to render the price of 100-year domains, which are a one time purchase
-	 * TODO: Replace hardcoded value by 100-eyar domain product price when we have it
 	 */
 	renderOneTimePrice() {
 		return (
 			<div className="domain-product-price domain-product-single-price">
-				<span>$2,000</span>
+				<span>{ this.props.price }</span>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -1,6 +1,7 @@
 import { Badge, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { HUNDRED_YEAR_DOMAIN_FLOW } from '@automattic/onboarding';
 import { HTTPS_SSL } from '@automattic/urls';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -482,6 +483,9 @@ const mapStateToProps = ( state, props ) => {
 				stripZeros,
 			} );
 		}
+	} else if ( HUNDRED_YEAR_DOMAIN_FLOW === flowName ) {
+		productCost = props.suggestion.cost;
+		renewCost = props.suggestion.renew_cost;
 	} else {
 		productCost = getDomainPrice( productSlug, productsList, currentUserCurrencyCode, stripZeros );
 		// Renew cost is the same as the product cost for non-premium domains

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -213,17 +213,12 @@ function InfoColumn( {
 		( select ) => select( ProductsList.store ).getProductBySlug( PLAN_100_YEARS )?.currency_code,
 		[]
 	);
-	let displayCost =
+	const displayCost =
 		productPrice &&
 		currencyCode &&
 		formatCurrency( productPrice, currencyCode, {
 			stripZeros: true,
 		} );
-
-	// TODO: Replace hardcoded value by 100-eyar domain product price when we have it
-	if ( flowName === HUNDRED_YEAR_DOMAIN_FLOW ) {
-		displayCost = '$2,000';
-	}
 
 	const planTitle =
 		flowName === HUNDRED_YEAR_PLAN_FLOW ? getPlan( PLAN_100_YEARS )?.getTitle() : '100-Year Domain';
@@ -261,7 +256,9 @@ function InfoColumn( {
 							<Gridicon icon="info-outline" size={ 16 } />
 						</>
 					</LearnMore>
-					<Price className={ ! displayCost ? 'is-price-loading' : '' }>{ displayCost }</Price>
+					{ flowName !== HUNDRED_YEAR_DOMAIN_FLOW && (
+						<Price className={ ! displayCost ? 'is-price-loading' : '' }>{ displayCost }</Price>
+					) }
 				</Info>
 			</InfoColumnContainer>
 		</>


### PR DESCRIPTION
## Proposed Changes

This PR updates the 100-year domain flow, removing the hardcoded price in the domain search result. The price is now returned directly from the suggestion endpoint. It also remove the price in the left sidebar copy.

This is part of the 100-year domains project - checkout (pcYYhz-2nI-p2).

## Testing Instructions
This PR depends on D164729-code.

Apply the PR locally (or use the Calypso live link) and visit the 100-year domain flow. Search for a domain and verify that the price it's showed correctly in the suggestions results.

<img width="1620" alt="Screenshot 2024-10-31 alle 12 02 46" src="https://github.com/user-attachments/assets/bf4135b9-7b2a-4da0-9202-b4ae427ef50b">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?