### PR TITLE
Thank You Page: update blue to blueberry

### DIFF
--- a/client/components/thank-you-v2/footer/style.scss
+++ b/client/components/thank-you-v2/footer/style.scss
@@ -62,6 +62,6 @@
 		font-size: $font-body-small;
 		line-height: 20px;
 		font-weight: 500;
-		color: var(--studio-blue-50);
+		color: var(--studio-wordpress-blue);
 	}
 }

--- a/client/components/thank-you-v2/header/style.scss
+++ b/client/components/thank-you-v2/header/style.scss
@@ -37,7 +37,7 @@
 	letter-spacing: -0.1px;
 
 	.button-plain {
-		color: var(--studio-blue-50);
+		color: var(--studio-wordpress-blue);
 		cursor: pointer;
 	}
 

--- a/client/components/thank-you-v2/style.scss
+++ b/client/components/thank-you-v2/style.scss
@@ -3,8 +3,8 @@
 @import "@automattic/typography/styles/variables";
 
 .thank-you {
-	--color-accent: var(--studio-blue-50);
-	--color-accent-60: var(--studio-blue-60);
+	--color-accent: var(--studio-wordpress-blue);
+	--color-accent-60: var(--studio-wordpress-blue-60);
 
 	display: flex;
 	flex-direction: column;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -28,7 +28,7 @@ const ContactContainer = styled.div`
 		font-size: 14px;
 
 		span {
-			color: var( --color-accent );
+			color: var( --studio-wordpress-blue );
 		}
 
 		&:hover {


### PR DESCRIPTION
Fixes #95868

## Proposed Changes

<img width="1383" alt="Screen Shot 2024-10-30 at 17 36 46" src="https://github.com/user-attachments/assets/360cafc0-a5a9-48b6-baeb-9fd0eb1edd1a">

* Update the color in a few areas of the Thank You page.

## Why are these changes being made?

We have changed the color of our blue on WordPress.com and there are a few places that it is still incorrect. The checkout success page is one of them.

## Testing Instructions

1. Using the live link you can go through the checkout process for any item. Make sure you see no incorrect blues.
2. After paying for the product you should land on a success "Thank You" page. Verify the action buttons and any links are the correct color `#3858e9`