### PR TITLE
Send the vendor string to the domain availability check to support 100 year domain prices

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -785,6 +785,7 @@ class RegisterDomainStep extends Component {
 						{
 							domainName,
 							blogId: get( this.props, 'selectedSite.ID', null ),
+							vendor: this.props.vendor,
 						},
 						( err, availabilityResult ) => {
 							if ( err ) {
@@ -1003,6 +1004,7 @@ class RegisterDomainStep extends Component {
 					domainName: domain,
 					blogId: get( this.props, 'selectedSite.ID', null ),
 					isCartPreCheck: true,
+					vendor: this.props.vendor,
 				},
 				( error, result ) => {
 					const status = get( result, 'status', error );
@@ -1060,7 +1062,11 @@ class RegisterDomainStep extends Component {
 
 		return new Promise( ( resolve ) => {
 			checkDomainAvailability(
-				{ domainName: domain, blogId: get( this.props, 'selectedSite.ID', null ) },
+				{
+					domainName: domain,
+					blogId: get( this.props, 'selectedSite.ID', null ),
+					vendor: this.props.vendor,
+				},
 				( error, result ) => {
 					const timeDiff = Date.now() - timestamp;
 					const status = get( result, 'status', error );

--- a/client/lib/domains/check-domain-availability.js
+++ b/client/lib/domains/check-domain-availability.js
@@ -14,6 +14,7 @@ export function checkDomainAvailability( params, onComplete ) {
 			blog_id: blogId,
 			apiVersion: '1.3',
 			is_cart_pre_check: isCartPreCheck,
+			vendor: params.vendor ?? null,
 		} )
 		.then( ( data ) => {
 			onComplete( null, data );


### PR DESCRIPTION
We need to get the correct price for 100 year domains in the special flow. In order to do that we'll send the vendor string to the availability endpoint and that way we can return the correct price in the availability results

Related to #

## Proposed Changes

* Always send the vendor string as query param to the availability endpoint

## Why are these changes being made?

* We need to get the correct price for 100 year domain registration in the custom 100 year domain flow

## Testing Instructions

* see the testing instructions in D165068-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?