### PR TITLE
Domains: Hide cancel and transfer options for 100-year domains

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -21,6 +21,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import FormButton from 'calypso/components/forms/form-button';
 import HeaderCakeBack from 'calypso/components/header-cake/back';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { getSelectedDomain } from 'calypso/lib/domains';
 import {
 	getName,
 	purchaseType,
@@ -43,6 +44,7 @@ import {
 	hasLoadedUserPurchasesFromServer,
 	getIncludedDomainPurchase,
 } from 'calypso/state/purchases/selectors';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
 import CancelPurchaseButton from './button';
 import CancelPurchaseDomainOptions from './domain-options';
@@ -280,6 +282,11 @@ class CancelPurchase extends Component {
 			);
 		}
 
+		if ( this.props.isHundredYearDomain ) {
+			this.redirect();
+			return null;
+		}
+
 		const { purchase, isJetpackPurchase } = this.props;
 		const purchaseName = getName( purchase );
 		const plan = getPlan( purchase?.productSlug );
@@ -408,6 +415,12 @@ export default connect( ( state, props ) => {
 		purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) );
 	const purchases = purchase && getSitePurchases( state, purchase.siteId );
 	const productsList = getProductsList( state );
+
+	const domains = purchase && getDomainsBySiteId( state, purchase.siteId );
+	const selectedDomainName = purchase && getName( purchase );
+	const selectedDomain =
+		domains && selectedDomainName && getSelectedDomain( { domains, selectedDomainName } );
+
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
@@ -417,5 +430,6 @@ export default connect( ( state, props ) => {
 		productsList,
 		includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
 		site: getSite( state, purchase ? purchase.siteId : null ),
+		isHundredYearDomain: selectedDomain?.isHundredYearDomain,
 	};
 } )( localize( withLocalizedMoment( CancelPurchase ) ) );

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -862,6 +862,16 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
+		// If it's a 100-year domain, don't show the cancel button
+		if ( isDomainRegistration( purchase ) ) {
+			const domain = this.props.domainsDetails?.[ purchase.siteId ]?.find(
+				( domain ) => domain.domain === purchase.meta
+			);
+			if ( domain?.isHundredYearDomain ) {
+				return null;
+			}
+		}
+
 		const onClick = ( event: { preventDefault: () => void } ) => {
 			recordTracksEvent( 'calypso_purchases_manage_purchase_cancel_click', {
 				product_slug: purchase.productSlug,

--- a/client/my-sites/domains/domain-management/components/domain/hundred-year-domain-not-transferrable-notice.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/hundred-year-domain-not-transferrable-notice.jsx
@@ -1,0 +1,12 @@
+import { useTranslate } from 'i18n-calypso';
+import Notice from 'calypso/components/notice';
+
+const HundredYearDomainNotTransferrableNotice = () => {
+	const translate = useTranslate();
+
+	const text = translate( 'This is a 100-year domain and cannot be transferred.' );
+
+	return <Notice text={ text } status="is-warning" showDismiss={ false } />;
+};
+
+export default HundredYearDomainNotTransferrableNotice;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -762,8 +762,12 @@ const Settings = ( {
 				{ ! domain.isGravatarDomain && (
 					<DomainEmailInfoCard selectedSite={ selectedSite } domain={ domain } />
 				) }
-				<DomainTransferInfoCard selectedSite={ selectedSite } domain={ domain } />
-				<DomainDeleteInfoCard selectedSite={ selectedSite } domain={ domain } />
+				{ ! domain.isHundredYearDomain && (
+					<DomainTransferInfoCard selectedSite={ selectedSite } domain={ domain } />
+				) }
+				{ ! domain.isHundredYearDomain && (
+					<DomainDeleteInfoCard selectedSite={ selectedSite } domain={ domain } />
+				) }
 				<DomainDisconnectCard selectedSite={ selectedSite } domain={ domain } />
 			</>
 		);

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -20,6 +20,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, getTopLevelOfTld, isMappedDomain } from 'calypso/lib/domains';
 import wpcom from 'calypso/lib/wp';
 import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
+import HundredYearDomainNotTransferrableNotice from 'calypso/my-sites/domains/domain-management/components/domain/hundred-year-domain-not-transferrable-notice';
 import InfoNotice from 'calypso/my-sites/domains/domain-management/components/domain/info-notice';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import NonTransferrableDomainNotice from 'calypso/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice';
@@ -401,6 +402,10 @@ const TransferPage = ( props: TransferPageProps ) => {
 					showDismiss={ false }
 				/>
 			);
+		}
+
+		if ( domain.isHundredYearDomain ) {
+			return <HundredYearDomainNotTransferrableNotice />;
 		}
 
 		if ( ! domain.currentUserIsOwner ) {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
@@ -18,6 +18,7 @@ import { getSelectedDomain } from 'calypso/lib/domains';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
+import HundredYearDomainNotTransferrableNotice from 'calypso/my-sites/domains/domain-management/components/domain/hundred-year-domain-not-transferrable-notice';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import NonTransferrableDomainNotice from 'calypso/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice';
@@ -163,6 +164,10 @@ export default function TransferDomainToAnyUser( {
 		selectedDomain && ( hasTitanMailWithUs( selectedDomain ) || hasGSuiteWithUs( selectedDomain ) );
 
 	const renderForm = () => {
+		if ( selectedDomain?.isHundredYearDomain ) {
+			return <HundredYearDomainNotTransferrableNotice />;
+		}
+
 		if ( ! selectedDomain?.currentUserCanManage ) {
 			return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
 		}

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -10,6 +10,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isMappedDomain } from 'calypso/lib/domains';
 import wpcom from 'calypso/lib/wp';
 import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
+import HundredYearDomainNotTransferrableNotice from 'calypso/my-sites/domains/domain-management/components/domain/hundred-year-domain-not-transferrable-notice';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import NonTransferrableDomainNotice from 'calypso/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice';
@@ -208,6 +209,10 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		const { children, ...propsWithoutChildren } = this.props;
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard { ...propsWithoutChildren } />;
+		}
+
+		if ( domain?.isHundredYearDomain ) {
+			return <HundredYearDomainNotTransferrableNotice />;
 		}
 
 		if ( aftermarketAuction ) {


### PR DESCRIPTION
## Proposed Changes

This PR hides the cancel and transfer possibilities for 100-year domains. Also, if the user accesses transfer or cancelation URLs directly, they should not be able to do anything.

### Screenshots

| Page | Before | After |
| --- | --- | --- |
| Domain management | ![Markup on 2024-10-29 at 16:30:18](https://github.com/user-attachments/assets/bc96918f-cc9d-4920-9478-e79e93548aa5) | ![Screenshot 2024-10-30 at 15 50 40](https://github.com/user-attachments/assets/74c41a43-d4fe-44e4-b916-a2353aa3a890) |
| Domain transfer | ![Screenshot 2024-10-30 at 15 47 34](https://github.com/user-attachments/assets/3303cc4f-2cbb-4e01-9c42-6193d4e29bcc) | ![Screenshot 2024-10-30 at 15 49 55](https://github.com/user-attachments/assets/b4a364f4-54b4-45f2-a519-1ebaca148845) |
| Transfer domain to another user |  ![Screenshot 2024-10-30 at 15 48 13](https://github.com/user-attachments/assets/cfa76e05-5a0f-4dd2-aba6-11de8574292f) |  ![Screenshot 2024-10-30 at 15 38 13](https://github.com/user-attachments/assets/0ddccfec-2803-49a1-bc2a-2c9634beee65) |
| Transfer domain to another site | ![Screenshot 2024-10-30 at 15 48 59](https://github.com/user-attachments/assets/9db2d979-082f-498e-817d-6bfd4f4edb91) | ![Screenshot 2024-10-30 at 15 38 06](https://github.com/user-attachments/assets/39639e01-1e94-46b6-875b-340c0df6fb32) |
| Purchase management | ![Screenshot 2024-10-30 at 16 09 54](https://github.com/user-attachments/assets/7953e103-1585-41c0-9c53-f1c0b3eeb90d) | ![Screenshot 2024-10-30 at 16 10 04](https://github.com/user-attachments/assets/e14d1d29-f36b-4cd1-8827-fac292d4235d) |
| Purchase cancelation | ![Screenshot 2024-10-30 at 16 10 11](https://github.com/user-attachments/assets/8b75d394-c4f6-4184-8c5c-a6ea63e4882f) | None - should redirect to purchase management page |

## Why are these changes being made?

We don't want to let users turn off auto-renewal or cancel these domains since they'll be handled in a different way from regular domains.

This is part of the 100-year domains project - checkout (pcYYhz-2nI-p2).

## Testing Instructions

Note: If D165092-code was not deployed yet, please review it first as it's easier to do so before this PR is merged.

- Open the live Calypso link or build this branch locally
- Open the domain management page for a 100-year domain and ensure there are no links to transfer or cancel it
- Open the purchase management page for a 100-year domain and ensure there's no link to cancel it
- Visit the internal domain transfer URLs and ensure you can do nothing and only the 100-year domain notice is shown, like in the screenshots
  - Transfer domain: `/domains/manage/all/:domain/transfer/:site`
  - Transfer domain to another user: `/domains/manage/all/:domain/transfer/any-user/:site`
  - Transfer domain to another site: `/domains/manage/all/:domain/transfer/other-site/:site`
- Visit the purchase cancelation page URL and ensure you are redirected to the purchase management page
  - `/purchases/subscriptions/:site/:domain_registration_subscription_id/cancel`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?