### PR TITLE
Add new styles for wapuu loading

### DIFF
--- a/packages/odie-client/src/assets/wapuu-thinking_new.svg
+++ b/packages/odie-client/src/assets/wapuu-thinking_new.svg
@@ -1,0 +1,18 @@
+<svg width="88" height="44" viewBox="0 0 88 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 8C0 3.58172 3.58172 0 8 0H80C84.4183 0 88 3.58172 88 8V36C88 40.4183 84.4183 44 80 44H0V8Z" fill="#FFD200"/>
+    <!--Circle 1 with animation-->
+    <circle cx="22" cy="22" r="6" fill="black">
+      <animate id="shrink" attributeName="r" from="6" to="3" dur="320ms" begin="0s;grow.end" fill="freeze" calcMode="spline" keySplines="0.42 0 0.58 1"/>
+      <animate id="grow" attributeName="r" from="3" to="6" dur="320ms" begin="shrink3.begin" fill="freeze" calcMode="spline" keySplines="0.42 0 0.58 1"/>
+    </circle>
+    <!--Circle 2 with animation-->
+    <circle cx="46" cy="22" r="4" fill="black">
+      <animate id="grow2" attributeName="r" from="3" to="6" dur="320ms" begin="0s;shrink.begin" fill="freeze" calcMode="spline" keySplines="0.42 0 0.58 1"/>
+      <animate id="shrink2" attributeName="r" from="6" to="3" dur="320ms" begin="grow2.end" fill="freeze" calcMode="spline" keySplines="0.42 0 0.58 1"/>
+    </circle>
+    <!--Circle 3 with animation-->
+    <circle cx="68" cy="22" r="4" fill="black">
+      <animate id="grow3" attributeName="r" from="3" to="6" dur="320ms" begin="shrink2.begin" fill="freeze" calcMode="spline" keySplines="0.42 0 0.58 1"/>
+      <animate id="shrink3" attributeName="r" from="6" to="3" dur="320ms" begin="grow3.end" fill="freeze" calcMode="spline" keySplines="0.42 0 0.58 1"/>
+    </circle>
+</svg>

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -586,3 +586,7 @@ $custom-border-corner-size: 16px;
     color: var(--studio-gray-50);
     font-size: 0.75rem;
 }
+
+.odie-chatbox-thinking-icon {
+	margin-left: 8px;
+}

--- a/packages/odie-client/src/components/message/thinking-placeholder.tsx
+++ b/packages/odie-client/src/components/message/thinking-placeholder.tsx
@@ -1,20 +1,37 @@
 import { __ } from '@wordpress/i18n';
+import { WapuuAvatar } from '../../assets';
 import WapuuAvatarSquared from '../../assets/wapuu-squared-avatar.svg';
 import WapuuThinking from '../../assets/wapuu-thinking.svg';
+import WapuuThinkingNew from '../../assets/wapuu-thinking_new.svg';
+import { useOdieAssistantContext } from '../../context';
 
 export const ThinkingPlaceholder = () => {
+	const { shouldUseHelpCenterExperience } = useOdieAssistantContext();
 	return (
 		<div className="message-header bot">
-			<img
-				src={ WapuuAvatarSquared }
-				alt={ __( 'AI profile picture', __i18n_text_domain__ ) }
-				className="odie-chatbox-message-avatar thinking"
-			/>
-			<img
-				src={ WapuuThinking }
-				alt={ __( 'Loading state, awaiting response from AI', __i18n_text_domain__ ) }
-				className="odie-chatbox-thinking-icon"
-			/>
+			{ shouldUseHelpCenterExperience ? (
+				<>
+					<WapuuAvatar className="odie-chatbox-message-avatar" />
+					<img
+						src={ WapuuThinkingNew }
+						alt={ __( 'Loading state, awaiting response from AI', __i18n_text_domain__ ) }
+						className="odie-chatbox-thinking-icon"
+					/>
+				</>
+			) : (
+				<>
+					<img
+						src={ WapuuAvatarSquared }
+						alt={ __( 'AI profile picture', __i18n_text_domain__ ) }
+						className="odie-chatbox-message-avatar thinking"
+					/>
+					<img
+						src={ WapuuThinking }
+						alt={ __( 'Loading state, awaiting response from AI', __i18n_text_domain__ ) }
+						className="odie-chatbox-thinking-icon"
+					/>
+				</>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9592
Fixes https://github.com/Automattic/dotcom-forge/issues/9592

## Proposed Changes

* Change Wapuu avatar and loading message style

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Match the new designs CMvR9P4FontAbv2b0TNMzj-fi-282_51381

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using live link
* Add the flag `?flags=help-center-experience` in the URL
* Make sure the wapuu loading is the same as the one in the design
* Check without the flag, it should be the same as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?