### PR TITLE
Reader Onboarding: Update tags debouncing to prevent hypothetical "stuck" processing tags

### DIFF
--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -85,10 +85,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 			attempts++;
 
 			// Get the current followed tags from the state.
-			const currentFollowedTags = getReaderFollowedTags( reduxStore.getState() );
-			if ( ! currentFollowedTags ) {
-				return;
-			}
+			const currentFollowedTags = getReaderFollowedTags( reduxStore.getState() ) || [];
 			const stateTagSlugs = currentFollowedTags.map( ( t: Tag ) => t.slug );
 
 			// Check if the tag is now being followed or unfollowed.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/95901 and https://github.com/Automattic/loop/issues/206

## Proposed Changes

* This PR makes a small change to tags debouncing where if followed tags are empty, we return an empty array and continue with the debouncing logic, instead of returning early and potentially leaving tags "stuck" in a processing state.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Defensive programming.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as https://github.com/Automattic/wp-calypso/pull/95901

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
