### PR TITLE
Performance Profiler: Display CRUX overall score when available

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -151,6 +151,7 @@ export type PerformanceMetricsHistory = {
 
 export type PerformanceReport = {
 	audits: Record< string, PerformanceMetricsItemQueryResponse >;
+	crux_score: number;
 	performance: number;
 	overall_score: number;
 	fullPageScreenshot: FullPageScreenshot;

--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -38,6 +38,7 @@ export const PerformanceProfilerDashboardContent = ( {
 	onRecommendationsFilterChange,
 }: PerformanceProfilerDashboardContentProps ) => {
 	const {
+		crux_score,
 		overall_score,
 		fcp,
 		lcp,
@@ -59,7 +60,7 @@ export const PerformanceProfilerDashboardContent = ( {
 				{ ! overallScoreIsTab && (
 					<div className="top-section">
 						<PerformanceScore
-							value={ overall_score * 100 }
+							value={ crux_score ? crux_score * 100 : overall_score * 100 }
 							recommendationsQuantity={ Object.keys( audits ).length }
 							recommendationsRef={ insightsRef }
 						/>


### PR DESCRIPTION

## Proposed Changes

Display CRUX overall scores when available, currently only the calculated overall score is displayed.

## Why are these changes being made?

Related to [Investigate inconsistent CrUX score](https://github.com/Automattic/dotcom-forge/issues/9516)

## Testing Instructions

* Go to `/speed-test-tool?url=https%3A%2F%2Fwww.sportshunter.gr%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MTA0MTR9.puUdWIf1E2IxV5HqTsftsuHOJHnlnkn5x4z0aSER9Ds&tab=mobile`
* Check if the Performance score is displayed as `41`

![CleanShot 2024-10-30 at 16 45 05@2x](https://github.com/user-attachments/assets/22401f5c-81dc-466a-ac93-bc04d1106b22)

* Go to `http://calypso.localhost:3000/speed-test-tool?url=https%3A%2F%2Fwberredotestingchaos.wpcomstaging.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MTA1MzN9.y63U0ryYf2Mn36lsrpKqJ1ZH-8vPCuoKsePjuIPe6XI`
* Check if the Performance Score is displayed even when no Crux data is available.