### PR TITLE
Reader Onboarding - Ship to users by removing the `reader/onboarding` flag

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { useState } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -9,12 +8,10 @@ import ReaderOnboarding from 'calypso/reader/onboarding';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import Stream, { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
 import ReaderListFollowedSites from 'calypso/reader/stream/reader-list-followed-sites';
-import FollowingIntro from './intro';
+
 import './style.scss';
 
 function FollowingStream( { ...props } ) {
-	const [ readerOnboardingIsRendered, setReaderOnboardingIsRendered ] = useState( false );
-
 	return (
 		<>
 			<Stream
@@ -31,8 +28,7 @@ function FollowingStream( { ...props } ) {
 					} ) }
 				/>
 
-				<ReaderOnboarding onRender={ setReaderOnboardingIsRendered } />
-				{ ! readerOnboardingIsRendered && <FollowingIntro /> }
+				<ReaderOnboarding />
 			</Stream>
 			<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
 		</>

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
 import { CircularProgressBar } from '@automattic/components';
 import { Checklist, ChecklistItem, Task } from '@automattic/launchpad';
 import { translate } from 'i18n-calypso';
@@ -32,7 +31,6 @@ const ReaderOnboarding = ( { onRender }: { onRender?: ( shown: boolean ) => void
 	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
 
 	const shouldShowOnboarding =
-		config.isEnabled( 'reader/onboarding' ) &&
 		preferencesLoaded &&
 		! hasCompletedOnboarding &&
 		userRegistrationDate &&

--- a/config/development.json
+++ b/config/development.json
@@ -195,7 +195,6 @@
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,
-		"reader/onboarding": true,
 		"readymade-templates/showcase": true,
 		"redirect-fallback-browsers": false,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR removes the `reader/onboarding` flag, effectively launching Reader Onboarding to end users.
* It also removes the `FollowingIntro` "Welcome!" banner.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To launch v1 of Reader Onboarding

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live and go to /read (note the lack of a feature flag in the URL) on a new account with a verified email.
* You should see Reader Onboarding.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
