### PR TITLE
Reader Onboarding: Update blog preview placeholder style

### DIFF
--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -1,6 +1,19 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
+body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-placeholder {
+	padding: 16px 24px 12px 24px;
+
+	.reader__post-title {
+		margin-top: 0;
+	}
+
+	&::after,
+	.reader__post-footer {
+		display: none;
+	}
+}
+
 .subscribe-modal {
 	&__title {
 		font-family: Recoleta, sans-serif;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95772

## Proposed Changes

* This PR updates the preview column placeholder to be closer to the actual content.


Before | After
--|--
<img width="632" alt="Screenshot 2024-10-30 at 4 48 23 PM" src="https://github.com/user-attachments/assets/85eda367-de35-491e-8b34-9a69498620a7">  | <img width="632" alt="Screenshot 2024-10-30 at 5 29 55 PM" src="https://github.com/user-attachments/assets/256f8371-3fb0-4985-952b-04b2ec813b1a">






## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Adding polish to Reader Onboarding.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/onboarding on a new account with a verified email
* Select some tags and preview some blogs in the Discover modal.
* As you scroll, you'll see the placeholder boxes as the new content loads.
* TIP: Using web developer tools, in the network tab, you can throttle your network speed to "offline," so when you scroll, the placeholder boxes will stay on the screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
