### PR TITLE
A4A: pressable referrals

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
@@ -1,6 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { JetpackLogo } from '@automattic/components';
 import { layout, blockMeta, shuffle, help, keyboardReturn, tip } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
 import {
 	BackgroundType1,
 	BackgroundType2,
@@ -14,7 +16,9 @@ import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingAdditionalFeaturesSection from '../../../common/hosting-additional-features-section';
 import HostingFeaturesSection from '../../../common/hosting-features-section';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
+import { MarketplaceTypeContext } from '../../../context';
 import PressableOverviewPlanSelection from '../../../pressable-overview/plan-selection';
+import ReferralPressableOverviewPlanSelection from '../../../pressable-overview/plan-selection/referral-mode';
 import CommonHostingBenefits from '../common-hosting-benefits';
 
 import './style.scss';
@@ -25,6 +29,12 @@ type Props = {
 
 export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 	const translate = useTranslate();
+
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+
+	const isReferMode = marketplaceType === 'referral';
+	const isPressableReferralsEnabled = isEnabled( 'a4a-pressable-referrals' );
+	const showReferralMode = isPressableReferralsEnabled && isReferMode;
 
 	const { pressablePlans } = useProductAndPlans( {
 		selectedSite: null,
@@ -37,7 +47,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 
 	return (
 		<div className="premier-agency-hosting">
-			{ isExistingPlanFetched && existingPlan && (
+			{ isExistingPlanFetched && existingPlan && ! showReferralMode && (
 				<section className="pressable-overview-plan-existing">
 					<div className="pressable-overview-plan-existing__details-card">
 						<div className="pressable-overview-plan-existing__header">
@@ -57,7 +67,11 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 					</div>
 				</section>
 			) }
-			<PressableOverviewPlanSelection onAddToCart={ onAddToCart } />
+			{ showReferralMode ? (
+				<ReferralPressableOverviewPlanSelection onAddToCart={ onAddToCart } />
+			) : (
+				<PressableOverviewPlanSelection onAddToCart={ onAddToCart } />
+			) }
 			<HostingAdditionalFeaturesSection
 				icon={ <JetpackLogo size={ 16 } /> }
 				heading={ translate( 'Jetpack Complete included' ) }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/referral-mode/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/referral-mode/index.tsx
@@ -1,0 +1,86 @@
+import { isEnabled } from '@automattic/calypso-config';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import useProductAndPlans from '../../../hooks/use-product-and-plans';
+import usePressableOwnershipType from '../../../hosting-overview/hooks/use-pressable-ownership-type';
+import PlanSelectionDetails from './../details';
+import PlanSelectionFilter from './../filter';
+
+import '../style.scss';
+
+type Props = {
+	onAddToCart: ( plan: APIProductFamilyProduct ) => void;
+};
+
+export default function ReferralPressableOverviewPlanSelection( { onAddToCart }: Props ) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const [ selectedPlan, setSelectedPlan ] = useState< APIProductFamilyProduct | null >( null );
+
+	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
+
+	const onSelectPlan = useCallback(
+		( plan: APIProductFamilyProduct | null ) => {
+			setSelectedPlan( plan );
+		},
+		[ setSelectedPlan ]
+	);
+
+	const { pressablePlans } = useProductAndPlans( {
+		selectedSite: null,
+		productSearchQuery: '',
+	} );
+
+	useEffect( () => {
+		if ( pressablePlans?.length ) {
+			setSelectedPlan( pressablePlans.find( ( plan ) => plan.slug === 'pressable-build' ) ?? null );
+		}
+	}, [ pressablePlans, setSelectedPlan ] );
+
+	const onPlanAddToCart = useCallback( () => {
+		if ( selectedPlan ) {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_select_plan_click', {
+					slug: selectedPlan?.slug,
+				} )
+			);
+			onAddToCart( selectedPlan );
+		}
+	}, [ dispatch, onAddToCart, selectedPlan ] );
+
+	const pressableOwnership = usePressableOwnershipType();
+
+	return (
+		<div
+			className={ clsx( 'pressable-overview-plan-selection', {
+				'is-new-hosting-page': isNewHostingPage,
+				'is-slider-hidden': pressableOwnership === 'regular',
+			} ) }
+		>
+			{ pressableOwnership !== 'regular' && (
+				<>
+					<div className="pressable-overview-plan-selection__upgrade-title">
+						{ translate( 'Choose plan to refer' ) }
+					</div>
+					<PlanSelectionFilter
+						selectedPlan={ selectedPlan }
+						plans={ pressablePlans }
+						onSelectPlan={ onSelectPlan }
+					/>
+				</>
+			) }
+
+			<PlanSelectionDetails
+				selectedPlan={ selectedPlan }
+				onSelectPlan={ onPlanAddToCart }
+				isLoading={ false }
+				pressableOwnership={ pressableOwnership }
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/referral-mode/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/referral-mode/index.tsx
@@ -64,7 +64,7 @@ export default function ReferralPressableOverviewPlanSelection( { onAddToCart }:
 		>
 			{ pressableOwnership !== 'regular' && (
 				<>
-					<div className="pressable-overview-plan-selection__upgrade-title">
+					<div className="pressable-overview-plan-selection__upgrade-title narrow">
 						{ translate( 'Choose plan to refer' ) }
 					</div>
 					<PlanSelectionFilter
@@ -78,7 +78,6 @@ export default function ReferralPressableOverviewPlanSelection( { onAddToCart }:
 			<PlanSelectionDetails
 				selectedPlan={ selectedPlan }
 				onSelectPlan={ onPlanAddToCart }
-				isLoading={ false }
 				pressableOwnership={ pressableOwnership }
 			/>
 		</div>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -253,6 +253,10 @@
 		font-weight: bold;
 		text-align: center;
 		margin-block: 56px 32px;
+
+		&.narrow {
+			margin-block: 16px 32px;
+		}
 	}
 
 	.pressable-overview-plan-selection__details-card {

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -43,7 +43,8 @@
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,
-		"a8c-for-agencies-agency-tier": true
+		"a8c-for-agencies-agency-tier": true,
+		"a4a-pressable-referrals": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -36,7 +36,8 @@
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,
-		"a8c-for-agencies-agency-tier": true
+		"a8c-for-agencies-agency-tier": true,
+		"a4a-pressable-referrals": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -37,7 +37,7 @@
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a4a-pressable-referrals": false
+		"a4a-pressable-referrals": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -34,7 +34,8 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
-		"a4a-dev-sites": true
+		"a4a-dev-sites": true,
+		"a4a-pressable-referrals": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -38,7 +38,8 @@
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": true,
-		"a8c-for-agencies-agency-tier": true
+		"a8c-for-agencies-agency-tier": true,
+		"a4a-pressable-referrals": false
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1327

## Proposed Changes
This PR enables referrals for Pressable products also adding a feature flag to ensure we roll this out when all the backend code is ready.

In order to keep things simple, I've moved the `referral mode` into a separate file in order to avoid multiple conditions inside one class. I believe this will keep the code readable.

Also, new feature flag `a4a-pressable-referrals` added.


https://github.com/user-attachments/assets/b6dc1919-91bd-4fd8-8b1b-3b50145a3eb1



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch to your local machine and spin it up
- Navigate to http://agencies.localhost:3000/marketplace/hosting/pressable. Switch to `referral` mode and check the behavior.
- Additionally, append `?flags=-a4a-pressable-referrals` to the url to check that without feature flag, user will see previous screen with `coming soon` notice.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
