### PR TITLE
Batch process plugins api call in parallel

### DIFF
--- a/client/components/data/query-all-jetpack-sites-plugins/index.tsx
+++ b/client/components/data/query-all-jetpack-sites-plugins/index.tsx
@@ -1,7 +1,13 @@
-import { useEffect } from 'react';
-import { useDispatch } from 'calypso/state';
-import { fetchAllPlugins } from 'calypso/state/plugins/installed/actions';
+import { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { PLUGINS_ALL_REQUEST_SUCCESS } from 'calypso/state/action-types';
+import {
+	fetchAllPlugins,
+	fetchBatchPlugins,
+	receiveAllSitesPlugins,
+} from 'calypso/state/plugins/installed/actions';
 import { isRequestingForAllSites } from 'calypso/state/plugins/installed/selectors';
+import getSites from 'calypso/state/selectors/get-sites';
 import type { CalypsoDispatch } from 'calypso/state/types';
 import type { AppState } from 'calypso/types';
 
@@ -17,6 +23,43 @@ export default function QueryAllJetpackSitesPlugins() {
 	useEffect( () => {
 		dispatch( request() );
 	}, [ dispatch ] );
+
+	return null;
+}
+
+const requestBatches =
+	( batches: number[][] ) => async ( dispatch: CalypsoDispatch, getState: AppState ) => {
+		if ( ! isRequestingForAllSites( getState() ) ) {
+			const fetchPromises = batches.map( ( batch ) => dispatch( fetchBatchPlugins( batch ) ) );
+			const sites = await Promise.all( fetchPromises );
+
+			dispatch( { type: PLUGINS_ALL_REQUEST_SUCCESS } );
+			const allSites = Object.assign( {}, ...sites.map( ( obj: { sites: [] } ) => obj.sites ) );
+			dispatch( receiveAllSitesPlugins( allSites ) );
+		}
+	};
+
+export function QueryBatchJetpackSitesPlugins( { batchSize = 500 }: { batchSize?: number } ) {
+	const dispatch = useDispatch();
+	const siteIds = useSelector( ( state ) => getSites( state ) )
+		.filter( ( site ) => site?.is_wpcom_atomic )
+		.map( ( site ) => site?.ID )
+		.filter( ( id ): id is number => id !== undefined );
+
+	const batches = useMemo( () => {
+		const result: number[][] = [];
+		for ( let i = 0; i < siteIds.length; i += batchSize ) {
+			result.push( siteIds?.slice( i, i + batchSize ) );
+		}
+		return result;
+	}, [ batchSize ] );
+
+	useEffect( () => {
+		if ( batches.length === 0 ) {
+			return;
+		}
+		dispatch( requestBatches( batches ) );
+	}, [ dispatch, batches ] );
 
 	return null;
 }

--- a/client/components/data/query-plugins/index.tsx
+++ b/client/components/data/query-plugins/index.tsx
@@ -1,14 +1,26 @@
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import QueryAllJetpackSitesPlugins from '../query-all-jetpack-sites-plugins';
+import QueryAllJetpackSitesPlugins, {
+	QueryBatchJetpackSitesPlugins,
+} from '../query-all-jetpack-sites-plugins';
 import QueryJetpackPlugins from '../query-jetpack-plugins';
 
-export default function QueryPlugins( { siteId }: { siteId?: number } ) {
+export default function QueryPlugins( {
+	siteId,
+	inBatches = false,
+}: {
+	siteId?: number;
+	inBatches?: boolean;
+} ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	// Sites plugins can only be retrieved by logged in users
 	if ( isLoggedIn === false ) {
 		return false;
+	}
+
+	if ( inBatches ) {
+		return <QueryBatchJetpackSitesPlugins />;
 	}
 
 	return siteId ? <QueryJetpackPlugins siteIds={ [ siteId ] } /> : <QueryAllJetpackSitesPlugins />;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -470,7 +470,7 @@ export class PluginsMain extends Component {
 		return (
 			<>
 				<DocumentHead title={ pageTitle } />
-				<QueryPlugins siteId={ selectedSite?.ID } />
+				<QueryPlugins siteId={ selectedSite?.ID } inBatches />
 				{ this.props.siteIds && 1 === this.props.siteIds.length ? (
 					<QuerySiteFeatures siteIds={ this.props.siteIds } />
 				) : (

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -670,3 +670,11 @@ export function fetchAllPlugins() {
 			.catch( receivePluginsDispatchFail );
 	};
 }
+
+export function fetchBatchPlugins( batch ) {
+	return ( dispatch ) => {
+		dispatch( { type: PLUGINS_ALL_REQUEST } );
+
+		return wpcom.req.post( `/me/sites/plugins`, { sites: batch } );
+	};
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Draft diff with api changes D165096-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?