### PR TITLE
Untangling: Add skeleton Advanced Tools tab and subtabs

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -575,6 +575,12 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'site-tools',
+		paths: [ '/sites/tools' ],
+		module: 'calypso/sites/tools',
+		group: 'sites',
+	},
+	{
 		name: 'site-marketing',
 		paths: [ '/sites/marketing' ],
 		module: 'calypso/sites/marketing',

--- a/client/sites/components/site-preview-pane/constants.ts
+++ b/client/sites/components/site-preview-pane/constants.ts
@@ -10,6 +10,13 @@ export const DOTCOM_SITE_PERFORMANCE = 'dotcom-site-performance';
 
 export const MARKETING_TOOLS = 'marketing-tools';
 
+export const TOOLS_STAGING_SITE = 'tools-staging-site';
+export const TOOLS_DEPLOYMENTS = 'tools-deployments';
+export const TOOLS_MONITORING = 'tools-monitoring';
+export const TOOLS_LOGS = 'tools-logs';
+export const TOOLS_SFTP_SSH = 'tools-sftp-ssh';
+export const TOOLS_DATABASE = 'tools-database';
+
 export const SETTINGS_SITE = 'settings-site';
 export const SETTINGS_ADMINISTRATION = 'settings-administration';
 export const SETTINGS_AGENCY = 'settings-agency';
@@ -29,6 +36,12 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 
 	// New Information Architecture
 	[ MARKETING_TOOLS ]: 'sites/marketing/tools/:site',
+	[ TOOLS_STAGING_SITE ]: 'sites/tools/staging-site/:site',
+	[ TOOLS_DEPLOYMENTS ]: 'sites/tools/deployments/:site',
+	[ TOOLS_MONITORING ]: 'sites/tools/monitoring/:site',
+	[ TOOLS_LOGS ]: 'sites/tools/logs/:site',
+	[ TOOLS_SFTP_SSH ]: 'sites/tools/sftp-ssh/:site',
+	[ TOOLS_DATABASE ]: 'sites/tools/database/:site',
 	[ SETTINGS_SITE ]: 'sites/settings/site/:site',
 	[ SETTINGS_ADMINISTRATION ]: 'sites/settings/administration/:site',
 	[ SETTINGS_AGENCY ]: 'sites/settings/agency/:site',

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -27,6 +27,12 @@ import {
 	SETTINGS_AGENCY,
 	SETTINGS_CACHES,
 	SETTINGS_WEB_SERVER,
+	TOOLS_SFTP_SSH,
+	TOOLS_STAGING_SITE,
+	TOOLS_DEPLOYMENTS,
+	TOOLS_MONITORING,
+	TOOLS_DATABASE,
+	TOOLS_LOGS,
 } from './constants';
 import PreviewPaneHeaderButtons from './preview-pane-header-buttons';
 import SiteEnvironmentSwitcher from './site-environment-switcher';
@@ -115,6 +121,18 @@ const DotcomPreviewPane = ( {
 				label: __( 'Marketing' ),
 				enabled: config.isEnabled( 'untangling/hosting-menu' ),
 				featureIds: [ MARKETING_TOOLS ],
+			},
+			{
+				label: __( 'Advanced Tools' ),
+				enabled: isActiveAtomicSite && config.isEnabled( 'untangling/hosting-menu' ),
+				featureIds: [
+					TOOLS_STAGING_SITE,
+					TOOLS_DEPLOYMENTS,
+					TOOLS_MONITORING,
+					TOOLS_LOGS,
+					TOOLS_SFTP_SSH,
+					TOOLS_DATABASE,
+				],
 			},
 			{
 				label: __( 'Settings' ),

--- a/client/sites/tools/controller.tsx
+++ b/client/sites/tools/controller.tsx
@@ -1,0 +1,84 @@
+import { __ } from '@wordpress/i18n';
+import { useSelector } from 'react-redux';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { SidebarItem, Sidebar, PanelWithSidebar } from '../components/panel-sidebar';
+import type { Context as PageJSContext } from '@automattic/calypso-router';
+
+export function ToolsSidebar() {
+	const slug = useSelector( getSelectedSiteSlug );
+
+	return (
+		<Sidebar>
+			<SidebarItem href={ `/sites/tools/staging-site/${ slug }` }>
+				{ __( 'Staging site' ) }
+			</SidebarItem>
+			<SidebarItem href={ `/sites/tools/deployments/${ slug }` }>
+				{ __( 'Deployments' ) }
+			</SidebarItem>
+			<SidebarItem href={ `/sites/tools/monitoring/${ slug }` }>{ __( 'Monitoring' ) }</SidebarItem>
+			<SidebarItem href={ `/sites/tools/logs/${ slug }` }>{ __( 'Logs' ) }</SidebarItem>
+			<SidebarItem href={ `/sites/tools/sftp-ssh/${ slug }` }>{ __( 'SFTP/SSH' ) }</SidebarItem>
+			<SidebarItem href={ `/sites/tools/database/${ slug }` }>{ __( 'Database' ) }</SidebarItem>
+		</Sidebar>
+	);
+}
+
+export function stagingSite( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<PanelWithSidebar>
+			<ToolsSidebar />
+			<p>Staging site</p>
+		</PanelWithSidebar>
+	);
+	next();
+}
+
+export function deployments( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<PanelWithSidebar>
+			<ToolsSidebar />
+			<p>Deployments</p>
+		</PanelWithSidebar>
+	);
+	next();
+}
+
+export function monitoring( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<PanelWithSidebar>
+			<ToolsSidebar />
+			<p>Monitoring</p>
+		</PanelWithSidebar>
+	);
+	next();
+}
+
+export function logs( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<PanelWithSidebar>
+			<ToolsSidebar />
+			<p>Logs</p>
+		</PanelWithSidebar>
+	);
+	next();
+}
+
+export function sftpSsh( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<PanelWithSidebar>
+			<ToolsSidebar />
+			<p>SFTP/SSH</p>
+		</PanelWithSidebar>
+	);
+	next();
+}
+
+export function database( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<PanelWithSidebar>
+			<ToolsSidebar />
+			<p>Database</p>
+		</PanelWithSidebar>
+	);
+	next();
+}

--- a/client/sites/tools/index.tsx
+++ b/client/sites/tools/index.tsx
@@ -1,0 +1,81 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { siteSelection, navigation, sites } from 'calypso/my-sites/controller';
+import {
+	TOOLS_DEPLOYMENTS,
+	TOOLS_MONITORING,
+	TOOLS_LOGS,
+	TOOLS_STAGING_SITE,
+	TOOLS_SFTP_SSH,
+	TOOLS_DATABASE,
+} from 'calypso/sites/components/site-preview-pane/constants';
+import { siteDashboard } from 'calypso/sites/controller';
+import { stagingSite, deployments, monitoring, logs, sftpSsh, database } from './controller';
+
+export default function () {
+	page( '/sites/tools/staging-site', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/sites/tools/staging-site/:site',
+		siteSelection,
+		navigation,
+		stagingSite,
+		siteDashboard( TOOLS_STAGING_SITE ),
+		makeLayout,
+		clientRender
+	);
+
+	page( '/sites/tools/deployments', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/sites/tools/deployments/:site',
+		siteSelection,
+		navigation,
+		deployments,
+		siteDashboard( TOOLS_DEPLOYMENTS ),
+		makeLayout,
+		clientRender
+	);
+
+	page( '/sites/tools/monitoring', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/sites/tools/monitoring/:site',
+		siteSelection,
+		navigation,
+		monitoring,
+		siteDashboard( TOOLS_MONITORING ),
+		makeLayout,
+		clientRender
+	);
+
+	page( '/sites/tools/logs', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/sites/tools/logs/:site',
+		siteSelection,
+		navigation,
+		logs,
+		siteDashboard( TOOLS_LOGS ),
+		makeLayout,
+		clientRender
+	);
+
+	page( '/sites/tools/sftp-ssh', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/sites/tools/sftp-ssh/:site',
+		siteSelection,
+		navigation,
+		sftpSsh,
+		siteDashboard( TOOLS_SFTP_SSH ),
+		makeLayout,
+		clientRender
+	);
+
+	page( '/sites/tools/database', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/sites/tools/database/:site',
+		siteSelection,
+		navigation,
+		database,
+		siteDashboard( TOOLS_DATABASE ),
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -20,6 +20,7 @@ const SITE_DASHBOARD_ROUTES = {
 
 	// New Information Architecture
 	'site-marketing': '/sites/marketing',
+	'site-tools': '/sites/tools',
 	'site-settings': '/sites/settings',
 };
 


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/9615

## Proposed Changes

This PR adds a skeleton `Advanced Tools` tab with its subtabs containig placeholder pages:

<img width="1098" alt="image" src="https://github.com/user-attachments/assets/6d29d16b-1654-419e-ab74-02715a5e5ac1">

This is so that we can work on the subtabs in parallel.

## Why are these changes being made?

pbxlJb-6ye-p2

## Testing Instructions

1. Go to `/sites`, open an Atomic site:
   - Verify that you can see Advanced Tools tab
   - Verify you can click through the subtabs
1. Go to `/sites`, open a Simple site:
   - Verify that you DO NOT see Advanced Tools tab
1. Go to `/sites?flags=-untangling/hosting-menu`, click any Atomic & Simple sites:
   - Verify that you DO NOT see Advanced Tools tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?