### PR TITLE
Untangling: show unsupported notice for Settings -> Administration for staging sites

### DIFF
--- a/client/sites/components/panel-sidebar/index.tsx
+++ b/client/sites/components/panel-sidebar/index.tsx
@@ -8,8 +8,20 @@ import type { ReactNode, ReactElement } from 'react';
 
 import './style.scss';
 
-export function SidebarItem( { href, children }: { href: string; children: ReactNode } ) {
+export function SidebarItem( {
+	enabled = true,
+	href,
+	children,
+}: {
+	enabled?: boolean;
+	href: string;
+	children: ReactNode;
+} ) {
 	const isActive = window.location.pathname.startsWith( href );
+
+	if ( ! enabled && ! isActive ) {
+		return null;
+	}
 
 	return (
 		<li>

--- a/client/sites/settings/administration/index.jsx
+++ b/client/sites/settings/administration/index.jsx
@@ -1,41 +1,16 @@
-import { CompactCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import SiteTools from '../../../my-sites/site-settings/site-tools';
 import { SOURCE_SETTINGS_ADMINISTRATION } from '../../../my-sites/site-settings/site-tools/utils';
 
 export default function AdministrationSettings() {
 	const translate = useTranslate();
-	const isWpcomStagingSite = useSelector( ( state ) =>
-		isSiteWpcomStaging( state, getSelectedSiteId( state ) )
-	);
-	const slug = useSelector( getSelectedSiteSlug );
 
 	return (
 		<div className="administration-settings">
-			{ ! isWpcomStagingSite && (
-				<SiteTools
-					headerTitle={ translate( 'Administration' ) }
-					source={ SOURCE_SETTINGS_ADMINISTRATION }
-				/>
-			) }
-			{ isWpcomStagingSite && (
-				<div>
-					<SettingsSectionHeader title={ translate( 'Administration' ) } />
-					<CompactCard>
-						<p>
-							{ translate( 'Manage staging sites from the {{a}}staging dashboard{{/a}}.', {
-								components: {
-									a: <a href={ `/staging-site/${ slug }` } />,
-								},
-							} ) }
-						</p>
-					</CompactCard>
-				</div>
-			) }
+			<SiteTools
+				headerTitle={ translate( 'Administration' ) }
+				source={ SOURCE_SETTINGS_ADMINISTRATION }
+			/>
 		</div>
 	);
 }

--- a/client/sites/settings/administration/index.tsx
+++ b/client/sites/settings/administration/index.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import NavigationHeader from 'calypso/components/navigation-header';
 import SiteTools from 'calypso/my-sites/site-settings/site-tools';
 import { SOURCE_SETTINGS_ADMINISTRATION } from 'calypso/my-sites/site-settings/site-tools/utils';
 
@@ -7,10 +8,8 @@ export default function AdministrationSettings() {
 
 	return (
 		<div className="administration-settings">
-			<SiteTools
-				headerTitle={ translate( 'Administration' ) }
-				source={ SOURCE_SETTINGS_ADMINISTRATION }
-			/>
+			<NavigationHeader title={ translate( 'Administration' ) } />
+			<SiteTools source={ SOURCE_SETTINGS_ADMINISTRATION } />
 		</div>
 	);
 }

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -1,8 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
+import Notice from 'calypso/components/notice';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SidebarItem, Sidebar, PanelWithSidebar } from '../components/panel-sidebar';
 import AdministrationSettings from './administration';
 import AgencySettings from './agency';
@@ -18,17 +19,23 @@ export function SettingsSidebar() {
 	return (
 		<Sidebar>
 			<SidebarItem href={ `/sites/settings/site/${ slug }` }>{ __( 'Site' ) }</SidebarItem>
-			{ ! isWpcomStaging && (
-				<SidebarItem href={ `/sites/settings/administration/${ slug }` }>
-					{ __( 'Administration' ) }
-				</SidebarItem>
-			) }
+			<SidebarItem enabled={ ! isWpcomStaging } href={ `/sites/settings/administration/${ slug }` }>
+				{ __( 'Administration' ) }
+			</SidebarItem>
 			<SidebarItem href={ `/sites/settings/agency/${ slug }` }>{ __( 'Agency' ) }</SidebarItem>
 			<SidebarItem href={ `/sites/settings/caches/${ slug }` }>{ __( 'Caches' ) }</SidebarItem>
 			<SidebarItem href={ `/sites/settings/web-server/${ slug }` }>
 				{ __( 'Web Server' ) }
 			</SidebarItem>
 		</Sidebar>
+	);
+}
+
+function SettingsNotSupportedNotice( { message }: { message: string } ) {
+	return (
+		<Notice showDismiss={ false } status="is-warning">
+			{ message }
+		</Notice>
 	);
 }
 
@@ -43,10 +50,19 @@ export function siteSettings( context: PageJSContext, next: () => void ) {
 }
 
 export function administrationSettings( context: PageJSContext, next: () => void ) {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+
 	context.primary = (
 		<PanelWithSidebar>
 			<SettingsSidebar />
-			<AdministrationSettings />
+			{ ! isSiteWpcomStaging( state, siteId ) ? (
+				<AdministrationSettings />
+			) : (
+				<SettingsNotSupportedNotice
+					message={ __( 'This setting is not supported for staging sites.' ) }
+				/>
+			) }
 		</PanelWithSidebar>
 	);
 	next();


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/95934#discussion_r1823828706

## Proposed Changes

This PR shows a "site unsupported" notice in Settings -> Administration when we're on a staging sites. The sidebar item will be shown as active as well.

<img width="837" alt="image" src="https://github.com/user-attachments/assets/c37c59d0-9ab7-43a4-bff4-ff7526df33a5">


## Testing Instructions

1. Go to /sites, click a non-staging site, click Settings.
   - Verify you can see and click Administration subtab.
1. Now click any staging site in the site list sidebar.
   - Verify you can still see the Administration subtab.
   - Verify that you see the site not supported notice.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
