### PR TITLE
Untangling: fix focus style on panel sidebar

### DIFF
--- a/client/sites/components/panel-sidebar/style.scss
+++ b/client/sites/components/panel-sidebar/style.scss
@@ -18,18 +18,31 @@
 	list-style: none;
 }
 
-.panel-sidebar-tab {
+.components-button.panel-sidebar-tab {
 	border-radius: 4px;
 	width: 100%;
-	margin: 2px 0;
 	padding: 8px;
 	height: 40px;
 	color: var(--studio-gray-100);
 	white-space: nowrap;
 	font-size: $font-body-small;
 
-	&:visited, &:focus {
+	&:visited, &:hover:not(:disabled):not([aria-disabled="true"]) {
 		color: var(--studio-gray-100);
+	}
+
+	&:active, &:focus {
+		outline: none;
+		box-shadow: none;
+
+		.accessible-focus & {
+			box-shadow: inset 0 0 0 2px var(--color-primary-light) !important;
+		}
+	}
+
+	&:hover {
+		background-color: #f7f7f7;
+		border-radius: 4px;
 	}
 
 	&--active {

--- a/client/sites/components/panel-sidebar/style.scss
+++ b/client/sites/components/panel-sidebar/style.scss
@@ -22,6 +22,7 @@
 	border-radius: 4px;
 	width: 100%;
 	padding: 8px;
+	margin-bottom: 2px;
 	height: 40px;
 	color: var(--studio-gray-100);
 	white-space: nowrap;


### PR DESCRIPTION

Related to https://github.com/Automattic/wp-calypso/pull/95927#pullrequestreview-2406985882

## Proposed Changes

This PR removes the unnecessary margin (see linked comment above), by fixing the hover/focus styling of the sidebar items.

I "invented" the hover background color. We can refine the color later.

For the keyboard focus style, I copied from here: 

https://github.com/Automattic/wp-calypso/blob/fc74e34e0216373e7a75c72075d1437d16e5b0d1/client/components/section-nav/item.scss#L70-L72

### With mouse

https://github.com/user-attachments/assets/41686f2c-89a6-481d-9faa-fd0618b9fb71

### With Tab key (keyboard)


https://github.com/user-attachments/assets/cbf49a7b-c00c-44c8-a8a7-14954b811d74



## Why are these changes being made?

We want to get rid of excessive margin.

## Testing Instructions

1. Go to /sites
2. Click any site
3. Click Settings tab
4. Loop through the subtabs using mouse and keyboard as explained above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
