### PR TITLE
Add missing monitoring and logs tracking events

### DIFF
--- a/client/hosting/logs/components/site-logs-toolbar/index.tsx
+++ b/client/hosting/logs/components/site-logs-toolbar/index.tsx
@@ -5,12 +5,13 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useCurrentSiteGmtOffset } from '../../hooks/use-current-site-gmt-offset';
 import { useSiteLogsDownloader } from '../../hooks/use-site-logs-downloader';
 import { buildFilterParam } from '../site-logs';
 import { DateTimePicker } from './date-time-picker';
 import type { Moment } from 'moment';
-
 import './style.scss';
 
 const SiteLogsToolbarDownloadProgress = ( {
@@ -66,6 +67,7 @@ export const SiteLogsToolbar = ( {
 	children,
 }: Props ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const moment = useLocalizedMoment();
 	const { downloadLogs, state } = useSiteLogsDownloader( { roundDateRangeToWholeDays: false } );
 	const siteGmtOffset = useCurrentSiteGmtOffset();
@@ -82,6 +84,14 @@ export const SiteLogsToolbar = ( {
 		}
 		setIsMobileOpen( false );
 		onDateTimeChange( newStart || startDateTime, newEnd || endDateTime );
+	};
+
+	const recordSeverityChange = ( severity: string ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_site_logs_severity_filter', {
+				severity,
+			} )
+		);
 	};
 
 	const severities = [
@@ -170,6 +180,7 @@ export const SiteLogsToolbar = ( {
 								<SelectDropdown.Item
 									key={ option.value }
 									onClick={ () => {
+										recordSeverityChange( option.value );
 										onSeverityChange( option.value );
 										setIsMobileOpen( false );
 									} }

--- a/client/hosting/logs/components/site-logs.tsx
+++ b/client/hosting/logs/components/site-logs.tsx
@@ -7,7 +7,8 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Pagination from 'calypso/components/pagination';
 import { useSiteLogsQuery, FilterType } from 'calypso/data/hosting/use-site-logs-query';
 import { useInterval } from 'calypso/lib/interval';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
 	getDateRangeQueryParam,
@@ -59,6 +60,7 @@ export const SiteLogs = ( {
 	const { __ } = useI18n();
 	const siteId = useSelector( getSelectedSiteId );
 	const moment = useLocalizedMoment();
+	const dispatch = useDispatch();
 
 	const [ autoRefresh, setAutoRefresh ] = useState( false );
 
@@ -128,6 +130,7 @@ export const SiteLogs = ( {
 			updateDateRangeQueryParam( dateRange );
 		}
 
+		dispatch( recordTracksEvent( 'calypso_site_logs_auto_refresh', { enabled: isChecked } ) );
 		setAutoRefresh( isChecked );
 	};
 

--- a/client/hosting/monitoring/components/time-range-picker/index.jsx
+++ b/client/hosting/monitoring/components/time-range-picker/index.jsx
@@ -2,8 +2,9 @@ import { SegmentedControl } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useState } from 'react';
-
 import './style.scss';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export const TIME_RANGE_OPTIONS = {
 	'6-hours': '6-hours',
@@ -32,10 +33,16 @@ export function calculateTimeRange( selectedOption ) {
 
 export const TimeDateChartControls = ( { onTimeRangeChange } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const [ selectedOption, setSelectedOption ] = useState( '24-hours' ); // Default selected option is '1' (24 hours)
 
 	// Event handler to handle changes in the SegmentedControl selection
 	const handleOptionClick = ( newSelectedOption ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_site_monitoring_time_range_change', {
+				time_range: newSelectedOption,
+			} )
+		);
 		setSelectedOption( newSelectedOption );
 
 		// Calculate the time range and pass it back to the parent component


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9588

## Proposed Changes
Add these new tracks
* `calypso_site_logs_severity_filter`
* `calypso_site_logs_auto_refresh`
* `calypso_site_monitoring_time_range_change`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/Automattic/dotcom-forge/issues/9529

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `http://calypso.localhost:3000/site-monitoring/_BLOG_`
* Click all links and buttons found in this issue https://github.com/Automattic/dotcom-forge/issues/9588
* Ensure on Tracks Vigilante that all the tracks are generated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?