### PR TITLE
Stats: Chart refresh header component update

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -466,21 +466,40 @@ class StatsSite extends Component {
 							</StatsPeriodHeader>
 						) }
 
-						<ChartTabs
-							activeTab={ getActiveTab( this.props.chartTab ) }
-							activeLegend={ this.state.activeLegend }
-							availableLegend={ this.getAvailableLegend() }
-							onChangeLegend={ this.onChangeLegend }
-							barClick={ this.barClick }
-							switchTab={ this.switchChart }
-							charts={ CHARTS }
-							queryDate={ queryDate }
-							period={ this.props.period }
-							chartTab={ this.props.chartTab }
-							customQuantity={ customChartQuantity }
-							customRange={ customChartRange }
-							hideLegend={ ! isNewDateFilteringEnabled } // if isNewDateFilteringEnabled then we want to show the legend down in the chart instead of in the Period Header
-						/>
+						{ isNewDateFilteringEnabled && ( //adds a new chart instance for the newdatefiltering project
+							<ChartTabs
+								activeTab={ getActiveTab( this.props.chartTab ) }
+								activeLegend={ this.state.activeLegend }
+								availableLegend={ this.getAvailableLegend() }
+								onChangeLegend={ this.onChangeLegend }
+								barClick={ this.barClick }
+								switchTab={ this.switchChart }
+								charts={ CHARTS }
+								queryDate={ queryDate }
+								period={ this.props.period }
+								chartTab={ this.props.chartTab }
+								customQuantity={ customChartQuantity }
+								customRange={ customChartRange }
+								hideLegend={ ! isNewDateFilteringEnabled } // if isNewDateFilteringEnabled then we want to show the legend down in the chart instead of in the Period Header
+							/>
+						) }
+						{ ! isNewDateFilteringEnabled && ( // legacy/old chart @TODO: remove once NewDateFiltering flag is flipped
+							<ChartTabs
+								activeTab={ getActiveTab( this.props.chartTab ) }
+								activeLegend={ this.state.activeLegend }
+								availableLegend={ this.getAvailableLegend() }
+								onChangeLegend={ this.onChangeLegend }
+								barClick={ this.barClick }
+								switchTab={ this.switchChart }
+								charts={ CHARTS }
+								queryDate={ queryDate }
+								period={ this.props.period }
+								chartTab={ this.props.chartTab }
+								customQuantity={ customChartQuantity }
+								customRange={ customChartRange }
+								hideLegend={ ! isNewDateFilteringEnabled } // if isNewDateFilteringEnabled then we want to show the legend down in the chart instead of in the Period Header
+							/>
+						) }
 					</>
 
 					{ ! isOdysseyStats && <MiniCarousel slug={ slug } isSitePrivate={ isSitePrivate } /> }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -480,7 +480,7 @@ class StatsSite extends Component {
 								chartTab={ this.props.chartTab }
 								customQuantity={ customChartQuantity }
 								customRange={ customChartRange }
-								hideLegend={ ! isNewDateFilteringEnabled } // if isNewDateFilteringEnabled then we want to show the legend down in the chart instead of in the Period Header
+								hideLegend={ false } // if isNewDateFilteringEnabled then we want to show the legend down in the chart instead of in the Period Header
 							/>
 						) }
 						{ ! isNewDateFilteringEnabled && ( // legacy/old chart @TODO: remove once NewDateFiltering flag is flipped
@@ -497,7 +497,7 @@ class StatsSite extends Component {
 								chartTab={ this.props.chartTab }
 								customQuantity={ customChartQuantity }
 								customRange={ customChartRange }
-								hideLegend={ ! isNewDateFilteringEnabled } // if isNewDateFilteringEnabled then we want to show the legend down in the chart instead of in the Period Header
+								hideLegend // in the legacy chart the legend is displayed up in the header insdead of in the chart, so we hide it here
 							/>
 						) }
 					</>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -480,7 +480,6 @@ class StatsSite extends Component {
 								chartTab={ this.props.chartTab }
 								customQuantity={ customChartQuantity }
 								customRange={ customChartRange }
-								hideLegend={ false } // if isNewDateFilteringEnabled then we want to show the legend down in the chart instead of in the Period Header
 							/>
 						) }
 						{ ! isNewDateFilteringEnabled && ( // legacy/old chart @TODO: remove once NewDateFiltering flag is flipped

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -480,6 +480,7 @@ class StatsSite extends Component {
 								chartTab={ this.props.chartTab }
 								customQuantity={ customChartQuantity }
 								customRange={ customChartRange }
+								showChartHeader // in the new date filtering enabled experience there is a new chart header to show
 							/>
 						) }
 						{ ! isNewDateFilteringEnabled && ( // legacy/old chart @TODO: remove once NewDateFiltering flag is flipped

--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+import Legend from 'calypso/components/chart/legend';
+
+const ChartHeader = ( {
+	children,
+	showLegend,
+	activeLegend,
+	activeTab,
+	availableLegend,
+	onLegendClick,
+	charts,
+} ) => {
+	return (
+		<div className="stats-chart-tabs__header">
+			{ children }
+			{ showLegend && (
+				<Legend
+					activeCharts={ activeLegend }
+					activeTab={ activeTab }
+					availableCharts={ availableLegend }
+					clickHandler={ onLegendClick }
+					tabs={ charts }
+				/>
+			) }
+		</div>
+	);
+};
+
+ChartHeader.propTypes = {
+	children: PropTypes.node,
+	showLegend: PropTypes.bool,
+	activeLegend: PropTypes.arrayOf( PropTypes.string ),
+	activeTab: PropTypes.object,
+	availableLegend: PropTypes.arrayOf( PropTypes.string ),
+	onLegendClick: PropTypes.func,
+	charts: PropTypes.array,
+};
+
+export default ChartHeader;

--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -11,7 +11,7 @@ const ChartHeader = ( {
 } ) => {
 	return (
 		<div className="stats-chart-tabs__header">
-			<div className="stats-chart-tabs__header-title">{ activeTab?.label || 'Views' }</div>
+			<div className="stats-chart-tabs__header-title">{ activeTab?.label }</div>
 			{ showLegend && (
 				<Legend
 					activeCharts={ activeLegend }

--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types';
 import Legend from 'calypso/components/chart/legend';
 
 const ChartHeader = ( {
-	children,
+	title,
+	controls,
 	showLegend,
 	activeLegend,
 	activeTab,
@@ -12,7 +13,8 @@ const ChartHeader = ( {
 } ) => {
 	return (
 		<div className="stats-chart-tabs__header">
-			{ children }
+			<div className="stats-chart-tabs__header-title">{ title }</div>
+			<div className="stats-chart-tabs__header-controls">{ controls }</div>
 			{ showLegend && (
 				<Legend
 					activeCharts={ activeLegend }
@@ -27,7 +29,8 @@ const ChartHeader = ( {
 };
 
 ChartHeader.propTypes = {
-	children: PropTypes.node,
+	title: PropTypes.node,
+	controls: PropTypes.node,
 	showLegend: PropTypes.bool,
 	activeLegend: PropTypes.arrayOf( PropTypes.string ),
 	activeTab: PropTypes.object,

--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -14,7 +14,6 @@ const ChartHeader = ( {
 	return (
 		<div className="stats-chart-tabs__header">
 			<div className="stats-chart-tabs__header-title">{ title }</div>
-			<div className="stats-chart-tabs__header-controls">{ controls }</div>
 			{ showLegend && (
 				<Legend
 					activeCharts={ activeLegend }
@@ -24,6 +23,7 @@ const ChartHeader = ( {
 					tabs={ charts }
 				/>
 			) }
+			<div className="stats-chart-tabs__header-controls">{ controls }</div>
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -3,7 +3,6 @@ import Legend from 'calypso/components/chart/legend';
 
 const ChartHeader = ( {
 	activeTab,
-	controls,
 	showLegend,
 	activeLegend,
 	availableLegend,
@@ -22,7 +21,6 @@ const ChartHeader = ( {
 					tabs={ charts }
 				/>
 			) }
-			<div className="stats-chart-tabs__header-controls">{ controls }</div>
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -2,18 +2,17 @@ import PropTypes from 'prop-types';
 import Legend from 'calypso/components/chart/legend';
 
 const ChartHeader = ( {
-	title,
+	activeTab,
 	controls,
 	showLegend,
 	activeLegend,
-	activeTab,
 	availableLegend,
 	onLegendClick,
 	charts,
 } ) => {
 	return (
 		<div className="stats-chart-tabs__header">
-			<div className="stats-chart-tabs__header-title">{ title }</div>
+			<div className="stats-chart-tabs__header-title">{ activeTab?.label || 'Views' }</div>
 			{ showLegend && (
 				<Legend
 					activeCharts={ activeLegend }
@@ -29,11 +28,10 @@ const ChartHeader = ( {
 };
 
 ChartHeader.propTypes = {
-	title: PropTypes.node,
+	activeTab: PropTypes.object,
 	controls: PropTypes.node,
 	showLegend: PropTypes.bool,
 	activeLegend: PropTypes.arrayOf( PropTypes.string ),
-	activeTab: PropTypes.object,
 	availableLegend: PropTypes.arrayOf( PropTypes.string ),
 	onLegendClick: PropTypes.func,
 	charts: PropTypes.array,

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -104,7 +104,7 @@ class StatModuleChartTabs extends Component {
 				'has-less-than-three-bars': this.props.chartData.length < 3,
 			},
 		];
-
+		/* pass bars count as `key` to disable transitions between tabs with different column count */
 		return (
 			<div className={ clsx( ...classes ) }>
 				{ showChartHeader && (

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -35,6 +35,7 @@ class StatModuleChartTabs extends Component {
 		activeTab: ChartTabShape,
 		availableLegend: PropTypes.arrayOf( PropTypes.string ),
 		charts: PropTypes.arrayOf( ChartTabShape ),
+		className: PropTypes.string,
 		counts: PropTypes.arrayOf(
 			PropTypes.shape( {
 				comments: PropTypes.number,
@@ -93,9 +94,10 @@ class StatModuleChartTabs extends Component {
 	makeQuery = () => this.props.requestChartCounts( this.props.query );
 
 	render() {
-		const { isActiveTabLoading } = this.props;
+		const { isActiveTabLoading, className } = this.props;
 		const classes = [
 			'is-chart-tabs',
+			className,
 			{
 				'is-loading': isActiveTabLoading,
 				'has-less-than-three-bars': this.props.chartData.length < 3,

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -108,7 +108,7 @@ class StatModuleChartTabs extends Component {
 			<div className={ clsx( ...classes ) }>
 				<ChartHeader
 					title="Title"
-					controls={ <div className="stats-chart-tabs__header-controls-wrapper"></div> }
+					controls={ <div className="stats-chart-tabs__header-controls-wrapper"> Controls </div> }
 					showLegend={ ! hideLegend }
 					activeLegend={ this.props.activeLegend }
 					activeTab={ this.props.activeTab }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -107,15 +107,15 @@ class StatModuleChartTabs extends Component {
 		return (
 			<div className={ clsx( ...classes ) }>
 				<ChartHeader
+					title="Title"
+					controls={ <div className="stats-chart-tabs__header-controls-wrapper"></div> }
 					showLegend={ ! hideLegend }
 					activeLegend={ this.props.activeLegend }
 					activeTab={ this.props.activeTab }
 					availableLegend={ this.props.availableLegend }
 					onLegendClick={ this.onLegendClick }
 					charts={ this.props.charts }
-				>
-					{ /* Add any additional header content here */ }
-				</ChartHeader>
+				></ChartHeader>
 
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
 				<Chart barClick={ this.props.barClick } data={ this.props.chartData } minBarWidth={ 35 }>

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -107,8 +107,6 @@ class StatModuleChartTabs extends Component {
 		return (
 			<div className={ clsx( ...classes ) }>
 				<ChartHeader
-					title="Title"
-					controls={ <div className="stats-chart-tabs__header-controls-wrapper"> Controls </div> }
 					showLegend={ ! hideLegend }
 					activeLegend={ this.props.activeLegend }
 					activeTab={ this.props.activeTab }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Chart from 'calypso/components/chart';
-import Legend from 'calypso/components/chart/legend';
 import { DEFAULT_HEARTBEAT } from 'calypso/components/data/query-site-stats/constants';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
@@ -18,6 +17,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StatsEmptyState from '../stats-empty-state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatTabs from '../stats-tabs';
+import ChartHeader from './chart-header';
 import { buildChartData, getQueryDate } from './utility';
 
 import './style.scss';
@@ -94,7 +94,7 @@ class StatModuleChartTabs extends Component {
 	makeQuery = () => this.props.requestChartCounts( this.props.query );
 
 	render() {
-		const { isActiveTabLoading, className } = this.props;
+		const { isActiveTabLoading, className, hideLegend } = this.props;
 		const classes = [
 			'is-chart-tabs',
 			className,
@@ -104,19 +104,19 @@ class StatModuleChartTabs extends Component {
 			},
 		];
 
-		/* pass bars count as `key` to disable transitions between tabs with different column count */
 		return (
 			<div className={ clsx( ...classes ) }>
-				{ ! this.props.hideLegend && (
-					<Legend
-						activeCharts={ this.props.activeLegend }
-						activeTab={ this.props.activeTab }
-						availableCharts={ this.props.availableLegend }
-						clickHandler={ this.onLegendClick }
-						tabs={ this.props.charts }
-					/>
-				) }
-				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+				<ChartHeader
+					showLegend={ ! hideLegend }
+					activeLegend={ this.props.activeLegend }
+					activeTab={ this.props.activeTab }
+					availableLegend={ this.props.availableLegend }
+					onLegendClick={ this.onLegendClick }
+					charts={ this.props.charts }
+				>
+					{ /* Add any additional header content here */ }
+				</ChartHeader>
+
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
 				<Chart barClick={ this.props.barClick } data={ this.props.chartData } minBarWidth={ 35 }>
 					<StatsEmptyState />

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -50,6 +50,7 @@ class StatModuleChartTabs extends Component {
 		isActiveTabLoading: PropTypes.bool,
 		onChangeLegend: PropTypes.func.isRequired,
 		hideLegend: PropTypes.bool,
+		showChartHeader: PropTypes.bool,
 	};
 
 	intervalId = null;
@@ -94,7 +95,7 @@ class StatModuleChartTabs extends Component {
 	makeQuery = () => this.props.requestChartCounts( this.props.query );
 
 	render() {
-		const { isActiveTabLoading, className, hideLegend } = this.props;
+		const { isActiveTabLoading, className, hideLegend, showChartHeader = false } = this.props;
 		const classes = [
 			'is-chart-tabs',
 			className,
@@ -106,14 +107,16 @@ class StatModuleChartTabs extends Component {
 
 		return (
 			<div className={ clsx( ...classes ) }>
-				<ChartHeader
-					showLegend={ ! hideLegend }
-					activeLegend={ this.props.activeLegend }
-					activeTab={ this.props.activeTab }
-					availableLegend={ this.props.availableLegend }
-					onLegendClick={ this.onLegendClick }
-					charts={ this.props.charts }
-				></ChartHeader>
+				{ showChartHeader && (
+					<ChartHeader
+						showLegend={ ! hideLegend }
+						activeLegend={ this.props.activeLegend }
+						activeTab={ this.props.activeTab }
+						availableLegend={ this.props.availableLegend }
+						onLegendClick={ this.onLegendClick }
+						charts={ this.props.charts }
+					></ChartHeader>
+				) }
 
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
 				<Chart barClick={ this.props.barClick } data={ this.props.chartData } minBarWidth={ 35 }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/249

## Proposed Changes

* This PR adds a new header component for the chart refresh. 
* **NOTE: there is NO styling yet**
* All CSS styling in next PR
* Adding the period drop down selector is in the following PR

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the chart refresh for the new date filtering traffic page. The changes introduce a new ChartHeader component, which is consistent with React's component-based architecture. By separating the header logic into its own component, the code adheres to the common React pattern of modular and reusable components. This approach enhances maintainability and readability. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live Branch
* Ensure that the chart on the traffic page still looks exactly the same as before. 
* Apply feature flag `stats/new-date-filtering`
* Ensure that the chart on the traffic page is now in its own header component, and has an (unstyled) label for the currently selected (active) tab to the left. 

![image](https://github.com/user-attachments/assets/c8a443e5-e5f6-467c-aa27-b9075ed52988)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
