### PR TITLE
localizeUrl: Update wp-login rule to support Romanian and Vietnamese

### DIFF
--- a/packages/i18n-utils/src/locales.ts
+++ b/packages/i18n-utils/src/locales.ts
@@ -135,3 +135,5 @@ export const jetpackComLocales: Locale[] = [
 	'zh-cn',
 	'zh-tw',
 ];
+
+export const wpLoginLocales: Locale[] = [ ...magnificentNonEnLocales, 'ro', 'vi' ];

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -13,6 +13,7 @@ import {
 	magnificentNonEnLocales,
 	localesForPricePlans,
 	jetpackComLocales,
+	wpLoginLocales,
 	Locale,
 } from './locales';
 
@@ -128,7 +129,7 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com/pricing/': prefixLocalizedUrlPath( localesForPricePlans ),
 	'wordpress.com/tos/': prefixLocalizedUrlPath( magnificentNonEnLocales ),
 	'wordpress.com/wp-admin/': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
-	'wordpress.com/wp-login.php': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
+	'wordpress.com/wp-login.php': setLocalizedUrlHost( 'wordpress.com', wpLoginLocales ),
 	'jetpack.com': prefixLocalizedUrlPath( jetpackComLocales ),
 	'cloud.jetpack.com': prefixLocalizedUrlPath( jetpackComLocales ),
 	'en.support.wordpress.com': setLocalizedWpComPath( '/support', supportSiteLocales ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 877-gh-Automattic/i18n-issues

## Proposed Changes

* Update `localizeUrl` utility to support Romanian and Vietnamese for the [wp-login URLs](https://wordpress.com/wp-login.php?action=lostpassword).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The wp-login screens are well translated in Romanian and Vietnamese and therefore we'd like to enable the localization of these URLs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/log-in/ro` and `/log-in/vi` and confirm the "Lost Password" button links to https://ro.wordpress.com/wp-login.php?action=lostpassword and https://vi.wordpress.com/wp-login.php?action=lostpassword respectively.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
