### PR TITLE
i18n: Localize the suggested timezone option in Site Settings

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -35,6 +35,7 @@ import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import SiteSettingPrivacy from 'calypso/my-sites/site-settings/site-setting-privacy';
+import getTimezonesLabels from 'calypso/state/selectors/get-timezones-labels';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -364,7 +365,7 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	Timezone() {
-		const { fields, isRequestingSettings, translate } = this.props;
+		const { fields, isRequestingSettings, translate, timezonesLabels } = this.props;
 		const guessedTimezone = guessTimezone();
 		const setGuessedTimezone = this.onTimezoneSelect.bind( this, guessedTimezone );
 
@@ -388,7 +389,7 @@ export class SiteSettingsFormGeneral extends Component {
 							'You might want to follow our guess: {{button}}Select %(timezoneName)s{{/button}}',
 							{
 								args: {
-									timezoneName: guessedTimezone,
+									timezoneName: timezonesLabels[ guessedTimezone ] ?? guessedTimezone,
 								},
 								components: {
 									button: (
@@ -730,6 +731,7 @@ const connectComponent = connect( ( state ) => {
 		isLaunchable:
 			! getIsSiteOnECommerceTrial( state, siteId ) && ! getIsSiteOnMigrationTrial( state, siteId ),
 		isSimple: isSimpleSite( state, siteId ),
+		timezonesLabels: getTimezonesLabels( state ),
 	};
 } );
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -389,7 +389,7 @@ export class SiteSettingsFormGeneral extends Component {
 							'You might want to follow our guess: {{button}}Select %(timezoneName)s{{/button}}',
 							{
 								args: {
-									timezoneName: timezonesLabels[ guessedTimezone ] ?? guessedTimezone,
+									timezoneName: timezonesLabels?.[ guessedTimezone ] ?? guessedTimezone,
 								},
 								components: {
 									button: (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 884-gh-Automattic/i18n-issues

## Proposed Changes

* Use the localized timezone labels from the store to display the suggested timezone in the Site Settings.

![wczfcZyiwrT0AKpf](https://github.com/user-attachments/assets/755e43d6-c6f4-4e14-93c1-74158f5ef94e)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, the Site Settings displays the suggested timezone as a IANA formatted timezone. With the changes from this PR, the guessed timezone will match the localized timezone labels in the select dropdown.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change UI to a Mag-16 language.
* Navigate to `/settings/general/`.
* Confirm the suggested timezone is now using a localized label fetched from the API.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
