### PR TITLE
Update e2e test to select Instagram Embed

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -21,7 +21,7 @@ export class InstagramBlockFlow implements BlockFlow {
 	}
 
 	blockSidebarName = 'Instagram Embed';
-	blockEditorSelector = '[aria-label="Block: Embed"]:has-text("Instagram URL")';
+	blockEditorSelector = '[aria-label="Block: Embed"]:has-text("Instagram Embed URL")';
 
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -21,7 +21,10 @@ export class InstagramBlockFlow implements BlockFlow {
 	}
 
 	blockSidebarName = 'Instagram Embed';
-	blockEditorSelector = '[aria-label="Block: Embed"]:has-text("Instagram Embed URL")';
+	blockTestFallBackName = 'Instagram';
+	blockEditorSelector =
+		'[aria-label="Block: Embed"]:has-text("Instagram Embed URL"), [aria-label="Block: Embed"]:has-text("Instagram URL")';
+	noSearch = false;
 
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -21,9 +21,7 @@ export class InstagramBlockFlow implements BlockFlow {
 	}
 
 	blockSidebarName = 'Instagram Embed';
-	blockTestFallBackName = 'Instagram';
 	blockEditorSelector = '[aria-label="Block: Embed"]:has-text("Instagram URL")';
-	noSearch = false;
 
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/39970

## Proposed Changes

* We've updated the embed variation names of Instagram and Facebook blocks on Jetpack. Now we also need to update the tests to use the new name of the block.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match changes in jetpack and fix failing e2e tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_jetpack_atomic_build_smoke_e2e_desktop#all-projects test should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
