### PR TITLE
Add missing staging site tracking events

### DIFF
--- a/client/sites/components/site-preview-pane/site-environment-switcher.tsx
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.tsx
@@ -5,8 +5,9 @@ import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import SitesProductionBadge from 'calypso/sites-dashboard/components/sites-production-badge';
 import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
-
 import './site-environment-switcher.scss';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface SiteEnvironmentSwitcherProps {
 	onChange: ( siteId: number ) => void;
@@ -18,6 +19,7 @@ export default function SiteEnvironmentSwitcher( {
 	site,
 }: SiteEnvironmentSwitcherProps ) {
 	const { __ } = useI18n();
+	const dispatch = useDispatch();
 
 	if (
 		! site.is_wpcom_staging_site &&
@@ -38,11 +40,12 @@ export default function SiteEnvironmentSwitcher( {
 		? site.options?.wpcom_staging_blog_ids?.[ 0 ]
 		: undefined;
 
-	const setEnvironment = ( siteIdToChange: number | undefined ) => {
+	const setEnvironment = ( type: string, siteIdToChange: number | undefined ) => {
 		if ( siteIdToChange === site.ID ) {
 			return;
 		}
 
+		dispatch( recordTracksEvent( 'calypso_sites_environment_switched', { type } ) );
 		onChange( siteIdToChange as number );
 	};
 
@@ -62,12 +65,12 @@ export default function SiteEnvironmentSwitcher( {
 			controls={ [
 				{
 					title: __( 'Production' ),
-					onClick: () => setEnvironment( productionSiteId ),
+					onClick: () => setEnvironment( 'production', productionSiteId ),
 					isActive: ! site.is_wpcom_staging_site,
 				},
 				{
 					title: __( 'Staging' ),
-					onClick: () => setEnvironment( stagingSiteId ),
+					onClick: () => setEnvironment( 'staging', stagingSiteId ),
 					isActive: site.is_wpcom_staging_site,
 				},
 			] }

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -132,27 +132,6 @@ export const ManageStagingSiteCardContent = ( {
 				<Button
 					primary
 					onClick={ () => {
-						showSitesPage( `/overview/${ urlToSlug( stagingSite.url ) }` );
-						dispatch( recordTracksEvent( 'calypso_hosting_staging_site_manage' ) );
-						navigate(
-							`/overview/${ urlToSlug( stagingSite.url ) }?search=${ urlToSlug(
-								productionSiteUrl as string
-							) }`,
-							false,
-							true
-						);
-					} }
-					disabled={ isButtonDisabled }
-				>
-					<span>{ translate( 'Manage staging site' ) }</span>
-				</Button>
-			);
-		};
-		const ManageStagingSiteButton = () => {
-			return (
-				<Button
-					primary
-					onClick={ () => {
 						dispatch( recordTracksEvent( 'calypso_hosting_staging_site_manage' ) );
 						showSitesPage( `/overview/${ urlToSlug( stagingSite.url ) }` );
 					} }

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -7,7 +7,8 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import { urlToSlug } from 'calypso/lib/url';
 import { showSitesPage } from 'calypso/sites/components/sites-dashboard';
 import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
 import { StagingSite } from '../../../hooks/use-staging-site';
 import { ConfirmationModal } from '../confirmation-modal';
@@ -104,6 +105,7 @@ export const ManageStagingSiteCardContent = ( {
 	{
 		const translate = useTranslate();
 		const productionSiteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
+		const dispatch = useDispatch();
 
 		const ConfirmationDeleteButton = () => {
 			return (
@@ -130,6 +132,28 @@ export const ManageStagingSiteCardContent = ( {
 				<Button
 					primary
 					onClick={ () => {
+						showSitesPage( `/overview/${ urlToSlug( stagingSite.url ) }` );
+						dispatch( recordTracksEvent( 'calypso_hosting_staging_site_manage' ) );
+						navigate(
+							`/overview/${ urlToSlug( stagingSite.url ) }?search=${ urlToSlug(
+								productionSiteUrl as string
+							) }`,
+							false,
+							true
+						);
+					} }
+					disabled={ isButtonDisabled }
+				>
+					<span>{ translate( 'Manage staging site' ) }</span>
+				</Button>
+			);
+		};
+		const ManageStagingSiteButton = () => {
+			return (
+				<Button
+					primary
+					onClick={ () => {
+						dispatch( recordTracksEvent( 'calypso_hosting_staging_site_manage' ) );
 						showSitesPage( `/overview/${ urlToSlug( stagingSite.url ) }` );
 					} }
 					disabled={ isButtonDisabled }

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -10,6 +10,7 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { urlToSlug } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { removeNotice, successNotice } from 'calypso/state/notices/actions';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -177,6 +178,10 @@ const StagingToProductionSync = ( {
 } ) => {
 	const [ typedSiteName, setTypedSiteName ] = useState( '' );
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const trackClick = () => {
+		dispatch( recordTracksEvent( 'calypso_hosting_staging_site_push' ) );
+	};
 	const synchronizationOptions: CheckboxOptionItem[] = useMemo(
 		() => [
 			{
@@ -252,6 +257,7 @@ const StagingToProductionSync = ( {
 					disabled={ disabled || isSyncButtonDisabled }
 					isConfirmationDisabled={ typedSiteName !== siteSlug }
 					onConfirm={ onConfirm }
+					onClick={ trackClick }
 					modalTitle={ translate( 'You’re about to update your production site' ) }
 					extraModalContent={
 						<div>
@@ -319,11 +325,17 @@ const ProductionToStagingSync = ( {
 	isSyncButtonDisabled: boolean;
 	onConfirm: () => void;
 } ) => {
+	const dispatch = useDispatch();
+	const trackClick = () => {
+		dispatch( recordTracksEvent( 'calypso_hosting_staging_site_pull' ) );
+	};
+
 	return (
 		<ConfirmationModalContainer>
 			<ConfirmationModal
 				disabled={ disabled || isSyncButtonDisabled }
 				onConfirm={ onConfirm }
+				onClick={ trackClick }
 				modalTitle={ translate( 'You are about to update your staging site' ) }
 				modalMessage={ translate(
 					'Synchronizing your staging site will replace the contents of the staging site with those of your production site.'
@@ -523,6 +535,7 @@ export const SiteSyncCard = ( {
 	}, [] );
 
 	const onPushInternal = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_hosting_staging_site_push_confirm' ) );
 		resetSyncStatus();
 		dispatch( removeNotice( stagingSiteSyncSuccess ) );
 		if ( type === 'production' ) {
@@ -535,6 +548,7 @@ export const SiteSyncCard = ( {
 
 	const syncError = error || checkStatusError;
 	const onPullInternal = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_hosting_staging_site_pull_confirm' ) );
 		resetSyncStatus();
 		dispatch( removeNotice( stagingSiteSyncSuccess ) );
 		if ( type === 'production' ) {

--- a/client/sites/tools/staging-site/components/staging-site-card/confirmation-modal.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/confirmation-modal.tsx
@@ -12,6 +12,7 @@ const ActionButtons = styled.div( {
 type ConfirmationModalButtonProps = {
 	onConfirm?: () => void;
 	onCancel?: () => void;
+	onClick?: () => void;
 	isBusy?: boolean;
 	isPrimary?: boolean;
 	isScary?: boolean;
@@ -32,6 +33,7 @@ type ConfirmationModalButtonProps = {
 export function ConfirmationModal( {
 	onConfirm,
 	onCancel,
+	onClick,
 	disabled = false,
 	isConfirmationDisabled,
 	isBusy = false,
@@ -49,7 +51,10 @@ export function ConfirmationModal( {
 	cancelLabel,
 }: ConfirmationModalButtonProps ) {
 	const [ isOpen, setOpen ] = useState( false );
-	const openModal = () => setOpen( true );
+	const openModal = () => {
+		onClick?.();
+		setOpen( true );
+	};
 	const closeModal = () => setOpen( false );
 
 	return (

--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
+import { zipObject } from 'lodash';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { connect } from 'react-redux';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
@@ -425,8 +426,16 @@ export const StagingSiteCard = ( {
 	} );
 
 	const { pullFromStaging } = usePullFromStagingMutation( siteId, stagingSite?.id, {
-		onSuccess: () => {
-			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_success' ) );
+		onSuccess: ( data, variables ) => {
+			dispatch(
+				recordTracksEvent(
+					'calypso_hosting_configuration_staging_site_pull_success',
+					zipObject(
+						variables ? variables : [],
+						Array( variables ? variables.length : 0 ).fill( true )
+					)
+				)
+			);
 			setSyncError( null );
 		},
 		onError: ( error ) => {

--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -395,6 +395,7 @@ export const StagingSiteCard = ( {
 
 	const initiateDelete = useCallback( () => {
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_REVERTING ) );
+		dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_remove_click' ) );
 		setProgress( 0.1 );
 		deleteStagingSite();
 	}, [ dispatch, siteId, deleteStagingSite ] );

--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -426,13 +426,13 @@ export const StagingSiteCard = ( {
 	} );
 
 	const { pullFromStaging } = usePullFromStagingMutation( siteId, stagingSite?.id, {
-		onSuccess: ( data, variables ) => {
+		onSuccess: ( data, syncOptions ) => {
 			dispatch(
 				recordTracksEvent(
 					'calypso_hosting_configuration_staging_site_pull_success',
 					zipObject(
-						variables ? variables : [],
-						Array( variables ? variables.length : 0 ).fill( true )
+						syncOptions ? syncOptions : [],
+						Array( syncOptions ? syncOptions.length : 0 ).fill( true )
 					)
 				)
 			);

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -22,6 +22,7 @@ import {
 	usePullFromStagingMutation,
 	usePushToStagingMutation,
 } from '../../hooks/use-staging-sync';
+import { CardContentWrapper } from './card-content/card-content-wrapper';
 import { SiteSyncCard } from './card-content/staging-sync-card';
 import { ConfirmationModal } from './confirmation-modal';
 import { LoadingPlaceholder } from './loading-placeholder';

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -142,7 +142,10 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 				<ActionButtons>
 					<Button
 						primary
-						onClick={ () => showSitesPage( `/overview/${ urlToSlug( productionSite.url ) }` ) }
+						onClick={ () => {
+							dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_to_prod' ) );
+							showSitesPage( `/overview/${ urlToSlug( productionSite.url ) }` );
+						} }
 						disabled={ disabled || isSyncInProgress }
 					>
 						<span>{ __( 'Switch to production site' ) }</span>

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -2,6 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
+import { zipObject } from 'lodash';
 import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -15,8 +16,12 @@ import { getSiteUrl } from 'calypso/state/sites/selectors';
 import { getIsSyncingInProgress } from 'calypso/state/sync/selectors/get-is-syncing-in-progress';
 import { IAppState } from 'calypso/state/types';
 import { useProductionSiteDetail, ProductionSite } from '../../hooks/use-production-site-detail';
-import { usePullFromStagingMutation, usePushToStagingMutation } from '../../hooks/use-staging-sync';
-import { CardContentWrapper } from './card-content/card-content-wrapper';
+import {
+	MutationVariables,
+	PushStagingMutationResponse,
+	usePullFromStagingMutation,
+	usePushToStagingMutation,
+} from '../../hooks/use-staging-sync';
 import { SiteSyncCard } from './card-content/staging-sync-card';
 import { ConfirmationModal } from './confirmation-modal';
 import { LoadingPlaceholder } from './loading-placeholder';
@@ -88,8 +93,18 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	} );
 
 	const { pullFromStaging } = usePullFromStagingMutation( productionSite?.id as number, siteId, {
-		onSuccess: () => {
-			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_success' ) );
+		onSuccess: (
+			data: PushStagingMutationResponse,
+			variables: MutationVariables,
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			context: unknown
+		) => {
+			dispatch(
+				recordTracksEvent(
+					'calypso_hosting_configuration_staging_site_pull_success',
+					zipObject( variables ?? [], Array( variables?.length ?? 0 ).fill( true ) )
+				)
+			);
 			setSyncError( null );
 		},
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/client/sites/tools/staging-site/hooks/use-staging-sync.ts
+++ b/client/sites/tools/staging-site/hooks/use-staging-sync.ts
@@ -2,13 +2,13 @@ import { useMutation, UseMutationOptions, useIsMutating } from '@tanstack/react-
 import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
 
-type MutationVariables = string[] | undefined;
+export type MutationVariables = string[] | undefined;
 
-interface PushStagingMutationResponse {
+export interface PushStagingMutationResponse {
 	message: string;
 }
 
-interface PushStagingMutationError {
+export interface PushStagingMutationError {
 	code: string;
 	message: string;
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/9589

## Proposed Changes
Add these new tracks

* `calypso_hosting_staging_site_manage`
* `calypso_hosting_staging_site_push`
* `calypso_hosting_staging_site_push_confirm`
* `calypso_hosting_staging_site_pull`
* `calypso_hosting_staging_site_pull_confirm`
* `calypso_hosting_configuration_staging_site_remove_click`
* `calypso_hosting_configuration_staging_site_to_prod`
* `calypso_sites_environment_switched`

Added missing parameters to `calypso_hosting_configuration_staging_site_pull_success`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/Automattic/dotcom-forge/issues/9529

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `http://calypso.localhost:3000/staging-site/_BLOG_`
* Click all links and buttons found in this issue https://github.com/Automattic/dotcom-forge/issues/9589
* Ensure on Tracks Vigilante that all the tracks are generated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?