### PR TITLE
Revert "`Theme`: Use intersection observer to render a placeholder when not visible"

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -11,7 +11,6 @@ import { isEmpty, isEqual } from 'lodash';
 import photon from 'photon';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
-import { InView } from 'react-intersection-observer';
 import { connect } from 'react-redux';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { decodeEntities } from 'calypso/lib/formatting';
@@ -24,9 +23,6 @@ import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
 import ThemeMoreButton from './more-button';
 
 import './style.scss';
-
-const THEME_CARD_HEIGHT = 420;
-const VIEWPORT_HEIGHT = `${ 3 * THEME_CARD_HEIGHT }px`;
 
 const noop = () => {};
 
@@ -351,37 +347,27 @@ export class Theme extends Component {
 		}
 
 		return (
-			<InView triggerOnce rootMargin={ VIEWPORT_HEIGHT }>
-				{ ( { inView, ref } ) => (
-					<div ref={ ref }>
-						{ inView ? (
-							<ThemeCard
-								ref={ this.props.bookmarkRef }
-								name={ name }
-								description={ themeDescription }
-								image={ this.renderScreenshot() }
-								imageClickUrl={ this.props.screenshotClickUrl }
-								imageActionLabel={ this.props.actionLabel }
-								banner={ this.renderUpdateAlert() }
-								badge={ this.renderBadge() }
-								styleVariations={ style_variations }
-								selectedStyleVariation={ selectedStyleVariation }
-								optionsMenu={ this.renderMoreButton() }
-								isActive={ this.props.active }
-								isLoading={ this.props.loading }
-								isSoftLaunched={ this.props.softLaunched }
-								isShowDescriptionOnImageHover={ ! isCustomGeneratedTheme }
-								onClick={ this.setBookmark }
-								onImageClick={ this.onScreenshotClick }
-								onStyleVariationClick={ this.onStyleVariationClick }
-								onStyleVariationMoreClick={ this.onStyleVariationClick }
-							/>
-						) : (
-							this.renderPlaceholder()
-						) }
-					</div>
-				) }
-			</InView>
+			<ThemeCard
+				ref={ this.props.bookmarkRef }
+				name={ name }
+				description={ themeDescription }
+				image={ this.renderScreenshot() }
+				imageClickUrl={ this.props.screenshotClickUrl }
+				imageActionLabel={ this.props.actionLabel }
+				banner={ this.renderUpdateAlert() }
+				badge={ this.renderBadge() }
+				styleVariations={ style_variations }
+				selectedStyleVariation={ selectedStyleVariation }
+				optionsMenu={ this.renderMoreButton() }
+				isActive={ this.props.active }
+				isLoading={ this.props.loading }
+				isSoftLaunched={ this.props.softLaunched }
+				isShowDescriptionOnImageHover={ ! isCustomGeneratedTheme }
+				onClick={ this.setBookmark }
+				onImageClick={ this.onScreenshotClick }
+				onStyleVariationClick={ this.onStyleVariationClick }
+				onStyleVariationMoreClick={ this.onStyleVariationClick }
+			/>
 		);
 	}
 }

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -1,45 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Theme rendering should match snapshot 1`] = `
-<div>
+<div
+  class="card theme-card theme-card--is-actionable is-clickable"
+  data-e2e-theme="twenty-seventeen"
+>
   <div
-    class="card theme-card theme-card--is-actionable is-clickable"
-    data-e2e-theme="twenty-seventeen"
+    class="theme-card__content"
   >
     <div
-      class="theme-card__content"
+      class="theme-card__image-container"
     >
-      <div
-        class="theme-card__image-container"
+      <a
+        aria-label="Twenty Seventeen"
+        class="theme-card__image"
+        href="#"
       >
-        <a
-          aria-label="Twenty Seventeen"
-          class="theme-card__image"
-          href="#"
-        >
-          <img
-            alt=""
-            class="theme__img"
-            src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
-            srcset="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
-          />
-        </a>
-      </div>
-      <div
-        class="theme-card__info"
-      >
-        <h2
-          class="theme-card__info-title"
-        >
-          <span>
-            Twenty Seventeen
-          </span>
-        </h2>
-        <components--theme-tier-badge
-          islockedstylevariation="false"
-          themeid="twentyseventeen"
+        <img
+          alt=""
+          class="theme__img"
+          src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
+          srcset="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
         />
-      </div>
+      </a>
+    </div>
+    <div
+      class="theme-card__info"
+    >
+      <h2
+        class="theme-card__info-title"
+      >
+        <span>
+          Twenty Seventeen
+        </span>
+      </h2>
+      <components--theme-tier-badge
+        islockedstylevariation="false"
+        themeid="twentyseventeen"
+      />
     </div>
   </div>
 </div>

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -2,9 +2,8 @@
  * @jest-environment jsdom
  */
 import { parse } from 'url';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
 import { Theme } from '../';
 
 jest.mock( 'calypso/components/popover-menu', () => 'components--popover--menu' );
@@ -25,31 +24,20 @@ describe( 'Theme', () => {
 	};
 
 	describe( 'rendering', () => {
-		test( 'should render an element with a className of "theme"', async () => {
+		test( 'should render an element with a className of "theme"', () => {
 			const { container } = render( <Theme { ...props } /> );
-
-			mockAllIsIntersecting( true );
-
-			await waitFor( () => {
-				expect( container.firstChild.firstChild ).toHaveClass( 'theme-card--is-actionable' );
-			} );
+			expect( container.firstChild ).toHaveClass( 'theme-card--is-actionable' );
 			expect( container.getElementsByTagName( 'h2' )[ 0 ] ).toHaveTextContent( 'Twenty Seventeen' );
 		} );
 
 		test( 'should render a screenshot', () => {
 			render( <Theme { ...props } /> );
-
-			mockAllIsIntersecting( true );
-
 			const img = screen.getByRole( 'presentation' );
 			expect( img ).toHaveAttribute( 'src', expect.stringContaining( '/screenshot.png' ) );
 		} );
 
 		test( 'should include photon parameters', () => {
 			render( <Theme { ...props } /> );
-
-			mockAllIsIntersecting( true );
-
 			const img = screen.getByRole( 'presentation' );
 			const { query } = parse( img.getAttribute( 'src' ), true );
 
@@ -62,8 +50,6 @@ describe( 'Theme', () => {
 			const onScreenshotClick = jest.fn();
 			render( <Theme { ...props } onScreenshotClick={ onScreenshotClick } index={ 1 } /> );
 
-			mockAllIsIntersecting( true );
-
 			const img = screen.getByRole( 'presentation' );
 			await userEvent.click( img );
 			expect( onScreenshotClick ).toHaveBeenCalledTimes( 1 );
@@ -73,16 +59,11 @@ describe( 'Theme', () => {
 		test( 'should not show a price when there is none', () => {
 			const { container } = render( <Theme { ...props } /> );
 
-			mockAllIsIntersecting( true );
-
 			expect( container.getElementsByClassName( 'price' ) ).toHaveLength( 0 );
 		} );
 
 		test( 'should match snapshot', () => {
 			const { container } = render( <Theme { ...props } /> );
-
-			mockAllIsIntersecting( true );
-
 			expect( container.firstChild ).toMatchSnapshot();
 		} );
 	} );
@@ -91,8 +72,6 @@ describe( 'Theme', () => {
 		test( 'should render an element with an is-placeholder class', () => {
 			const theme = { id: 'placeholder-1', name: 'Loading' };
 			const { container } = render( <Theme { ...props } theme={ theme } isPlaceholder /> );
-
-			mockAllIsIntersecting( true );
 
 			expect( container.firstChild ).toHaveClass( 'is-placeholder' );
 		} );
@@ -108,32 +87,7 @@ describe( 'Theme', () => {
 				},
 			};
 			const { container } = render( <Theme { ...updateThemeProps } /> );
-
-			mockAllIsIntersecting( true );
-
 			expect( container.getElementsByClassName( 'theme__update-alert' ).length ).toBe( 1 );
-		} );
-	} );
-
-	describe( 'In view', () => {
-		it( 'should render a placeholder when the component is not visible', () => {
-			const { container } = render( <Theme { ...props } /> );
-
-			mockAllIsIntersecting( false );
-
-			expect( container.firstChild.firstChild ).toHaveClass( 'is-placeholder' );
-		} );
-
-		it( 'should render the component when it is visible', () => {
-			render( <Theme { ...props } /> );
-
-			mockAllIsIntersecting( false );
-
-			expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
-
-			mockAllIsIntersecting( true );
-
-			expect( screen.getByRole( 'presentation' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -3,7 +3,6 @@
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
-import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
 import { setStore } from 'calypso/state/redux-store';
@@ -117,8 +116,6 @@ describe( 'logged-out', () => {
 		);
 		render( <TestComponent store={ store } /> );
 
-		mockAllIsIntersecting( true );
-
 		await waitFor( () => {
 			expect( screen.getByText( 'No themes match your search' ) ).toBeInTheDocument();
 		} );
@@ -136,8 +133,6 @@ describe( 'logged-out', () => {
 			)
 		);
 		render( <TestComponent store={ store } /> );
-
-		mockAllIsIntersecting( true );
 
 		await waitFor( () => {
 			themes.forEach( ( theme ) => {
@@ -158,8 +153,6 @@ describe( 'logged-out', () => {
 			error: 'Error',
 		} );
 		render( <TestComponent store={ store } /> );
-
-		mockAllIsIntersecting( true );
 
 		await waitFor( () => {
 			expect( screen.queryByText( 'No themes match your search' ) ).toBeInTheDocument();

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -12,7 +12,6 @@ const selectors = {
 	// Transitions
 	spinner: '.themes__content > .spinner',
 	placeholder: '.themes-list .is-placeholder',
-	actionableTheme: '.theme-card--is-actionable',
 
 	// Search
 	showAllThemesButton: 'text=Show all themes',
@@ -43,7 +42,7 @@ export class ThemesPage {
 	private async pageSettled(): Promise< void > {
 		await Promise.all( [
 			this.page.waitForSelector( selectors.spinner, { state: 'hidden' } ),
-			this.page.locator( selectors.actionableTheme ).first().waitFor(),
+			this.page.waitForSelector( selectors.placeholder, { state: 'hidden' } ),
 		] );
 	}
 
@@ -59,10 +58,7 @@ export class ThemesPage {
 		const searchInput = await this.page.waitForSelector( selectors.searchInput );
 		await searchInput.fill( keyword );
 		await Promise.all( [ this.page.waitForNavigation(), searchInput.press( 'Enter' ) ] );
-		// wait for the loadin placeholders to appear after search is triggered
-		await this.page.waitForSelector( selectors.placeholder, { state: 'attached' } );
-		// wait for an actionable theme to appear, meaning the search results are shown
-		await this.page.locator( selectors.actionableTheme ).first().waitFor();
+		await this.page.waitForSelector( selectors.placeholder, { state: 'detached' } );
 	}
 
 	/**


### PR DESCRIPTION
Reverts Automattic/wp-calypso#95881 because it was breaking an E2E test: `Selects a Premium theme` on the `Lifecyle: Premium theme signup, onboard, launch and cancel subscription` suite