### PR TITLE
Change Reader Onboarding title links to open feed in modal.

### DIFF
--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -71,6 +71,7 @@ class ConnectedSubscriptionListItem extends Component {
 			onItemClick,
 			isSelected,
 			onFollowToggle,
+			replaceStreamClickWithItemClick,
 		} = this.props;
 
 		return (
@@ -87,6 +88,7 @@ class ConnectedSubscriptionListItem extends Component {
 				followSource={ followSource }
 				railcar={ railcar }
 				disableSuggestedFollows={ disableSuggestedFollows }
+				replaceStreamClickWithItemClick={ replaceStreamClickWithItemClick }
 				onItemClick={ onItemClick }
 				isSelected={ isSelected }
 				onFollowToggle={ onFollowToggle }

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -48,6 +48,7 @@ function ReaderSubscriptionListItem( {
 	onItemClick,
 	isSelected,
 	onFollowToggle,
+	replaceStreamClickWithItemClick,
 } ) {
 	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
@@ -94,12 +95,22 @@ function ReaderSubscriptionListItem( {
 
 	const streamClicked = ( event, streamLink ) => {
 		recordTitleClick();
-		if ( ! isLoggedIn ) {
+
+		// Prevent default if we need to handle the click differently.
+		if ( ! isLoggedIn || ( replaceStreamClickWithItemClick && onItemClick ) ) {
 			event.preventDefault();
+		}
+
+		if ( ! isLoggedIn ) {
 			registerLastActionRequiresLoginProp( {
 				type: 'sidebar-link',
 				redirectTo: streamLink,
 			} );
+			return;
+		}
+
+		if ( replaceStreamClickWithItemClick && onItemClick ) {
+			onItemClick();
 		}
 	};
 

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -293,6 +293,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 										showFollowedOnDate={ false }
 										followSource="reader-onboarding-modal"
 										disableSuggestedFollows
+										replaceStreamClickWithItemClick
 										onItemClick={ () => handleItemClick( site ) }
 										isSelected={ selectedSite?.feed_ID === site.feed_ID }
 										onFollowToggle={ ( following: boolean ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/210

## Proposed Changes

* Add `replaceStreamClickWithItemClick` prop and link to the `itemClick` handler instead of the feed when true. 


https://github.com/user-attachments/assets/0f466b21-50f3-4497-9f4f-4d2601cc0497


https://github.com/user-attachments/assets/461cafc9-fbf4-4899-958a-5a08f0aa75a7



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the Reader Onboarding user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/onboarding on a new account with a verified email.
* Click "Select some of your interests," choose interests, and click Continue.
* Click on both the titles of sites, and on the site cards. The feeds should load in the preview on the right.
* Regression test: Click on the subscription card titles on Discover and Search. The feed links should open.
* Regression test: Go to the logged out view of /read. Click on the subscription card titles. You should see a modal and the link should not open.

Note that on mobile the card will be selected, but no preview is shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
