### PR TITLE
Help Center: fix aggressive styles

### DIFF
--- a/apps/help-center/postcss.config.js
+++ b/apps/help-center/postcss.config.js
@@ -13,6 +13,11 @@ module.exports = {
 					return selector === '.card' ? prefixedSelector : selector;
 				}
 
+				// The search component has very generic class that causes many bugs.
+				if ( path.includes( 'count/style.scss' ) ) {
+					return selector === '.count' ? prefixedSelector : selector;
+				}
+
 				return selector;
 			},
 		} ),

--- a/apps/help-center/postcss.config.js
+++ b/apps/help-center/postcss.config.js
@@ -8,12 +8,12 @@ module.exports = {
 					return selector === '.search' ? prefixedSelector : selector;
 				}
 
-				// The search component has very generic class that causes many bugs.
+				// The card component has very generic class that causes many bugs.
 				if ( path.includes( 'card/style.scss' ) ) {
 					return selector === '.card' ? prefixedSelector : selector;
 				}
 
-				// The search component has very generic class that causes many bugs.
+				// The count component has very generic class that causes many bugs.
 				if ( path.includes( 'count/style.scss' ) ) {
 					return selector === '.count' ? prefixedSelector : selector;
 				}


### PR DESCRIPTION
## Proposed Changes

Add postcss prefix for generic stylesheet.

## Why are these changes being made?

We seem to enjoy creating components in Calypso with incredibly generic classnames. This causes a lot of issues when using Calypso components in other packages. Until we sort out the shadow DOM for Help Center this is the best way to mitigate the bleeding.

## Testing Instructions

1. Run `yarn dev --sync` from `apps/help-center`
2. Sandbox your test site and widgets.wp.com
3. Go to `/wp-admin/edit.php` and make sure there are no circles around the counts for drafts and posts.
