### PR TITLE
Help Center: Fallback for History without DB integrations

### DIFF
--- a/packages/help-center/src/components/help-center-chat-history.tsx
+++ b/packages/help-center/src/components/help-center-chat-history.tsx
@@ -59,7 +59,7 @@ export const HelpCenterChatHistory = () => {
 					if ( lastMessage ) {
 						return (
 							<HelpCenterSupportChatMessage
-								navigateTo={ `/odie/${ conversation.id }` }
+								navigateTo={ `/odie-fallback/${ conversation.id }` }
 								key={ conversation.id }
 								message={ lastMessage }
 								isUnread={ conversation.participants[ 0 ]?.unreadCount > 0 }

--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -20,10 +20,12 @@ export function HelpCenterChat( {
 	isLoadingEnvironment,
 	isUserEligibleForPaidSupport,
 	searchTerm,
+	isFallback,
 }: {
 	isLoadingEnvironment: boolean;
 	isUserEligibleForPaidSupport: boolean;
 	searchTerm: string;
+	isFallback?: boolean;
 } ): JSX.Element {
 	const navigate = useNavigate();
 	const shouldUseWapuu = useShouldUseWapuu();
@@ -53,6 +55,7 @@ export function HelpCenterChat( {
 			extraContactOptions={
 				<ExtraContactOptions isUserEligible={ isUserEligibleForPaidSupport } />
 			}
+			isFallback={ isFallback }
 		>
 			<div className="help-center__container-chat">
 				<OdieAssistant />

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -130,6 +130,17 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 							/>
 						}
 					/>
+					<Route
+						path="/odie-fallback/:id"
+						element={
+							<HelpCenterChat
+								isLoadingEnvironment={ isLoadingEnvironment }
+								isUserEligibleForPaidSupport={ isUserEligibleForPaidSupport }
+								searchTerm={ searchTerm }
+								isFallback
+							/>
+						}
+					/>
 					<Route path="/chat-history" element={ <HelpCenterChatHistory /> } />
 				</Routes>
 			</Wrapper>

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -131,6 +131,7 @@ type OdieAssistantProviderProps = {
 	selectedSiteId?: number | null;
 	selectedConversationId?: string | null;
 	version?: string | null;
+	isFallback?: boolean;
 	children?: ReactNode;
 } & PropsWithChildren;
 // Create a provider component for the context
@@ -144,6 +145,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 	selectedSiteId,
 	selectedConversationId,
 	version = null,
+	isFallback = false,
 	currentUser,
 	children,
 } ) => {
@@ -185,6 +187,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 		setSupportProvider,
 		isChatLoaded,
 		selectedConversationId,
+		isFallback,
 	} );
 
 	const urlSearchParams = new URLSearchParams( window.location.search );
@@ -253,10 +256,15 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 	);
 
 	useEffect( () => {
+		if ( isFallback && existingChat?.messages?.length > 0 ) {
+			setChat( existingChat );
+			return;
+		}
+
 		if ( existingChat.chat_id ) {
 			setChat( existingChat );
 		}
-	}, [ existingChat, existingChat.chat_id ] );
+	}, [ isFallback, existingChat, existingChat.chat_id ] );
 
 	useOdieBroadcastWithCallbacks( { addMessage, clearChat }, odieClientId );
 

--- a/packages/odie-client/src/context/use-load-previous-chat.ts
+++ b/packages/odie-client/src/context/use-load-previous-chat.ts
@@ -10,12 +10,14 @@ export const useLoadPreviousChat = ( {
 	setSupportProvider,
 	isChatLoaded,
 	selectedConversationId,
+	isFallback,
 }: {
 	botNameSlug: OdieAllowedBots;
 	odieInitialPromptText?: string;
 	setSupportProvider: ( supportProvider: SupportProvider ) => void;
 	isChatLoaded: boolean;
 	selectedConversationId?: string | null;
+	isFallback?: boolean;
 } ) => {
 	const { chat: existingChat } = useOdieChat( 1, 30 );
 
@@ -25,6 +27,31 @@ export const useLoadPreviousChat = ( {
 	} );
 
 	useEffect( () => {
+		if ( isFallback ) {
+			if ( isChatLoaded ) {
+				getZendeskConversation( {
+					chatId: existingChat?.chat_id,
+					conversationId: selectedConversationId,
+					loadOnlyZendesk: true,
+				} )?.then( ( conversation ) => {
+					if ( conversation ) {
+						setSupportProvider( 'zendesk' );
+						setChat( {
+							chat_id: conversation.metadata[ 'odieChatId' ]
+								? Number( conversation.metadata[ 'odieChatId' ] )
+								: null,
+							...existingChat,
+							conversationId: conversation.id,
+							messages: [ ...( conversation.messages as Message[] ) ],
+						} );
+					}
+					return;
+				} );
+			}
+
+			return;
+		}
+
 		if ( existingChat || selectedConversationId ) {
 			const initialMessage = getOdieInitialMessage( botNameSlug, odieInitialPromptText );
 			const messages = [ initialMessage ];

--- a/packages/odie-client/src/data/use-get-zendesk-conversation.ts
+++ b/packages/odie-client/src/data/use-get-zendesk-conversation.ts
@@ -17,11 +17,13 @@ const parseResponse = ( conversation: Conversation ) => {
 export const getZendeskConversation = ( {
 	chatId,
 	conversationId,
+	loadOnlyZendesk = false,
 }: {
 	chatId: number | string | null | undefined;
 	conversationId?: string | null | undefined;
+	loadOnlyZendesk?: boolean;
 } ) => {
-	if ( ! chatId ) {
+	if ( ! chatId && ! loadOnlyZendesk ) {
 		return null;
 	}
 


### PR DESCRIPTION


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

With this PR, only the Zendesk conversation will be showed in the history. Useful until we have the appropriate use of the API for the support interations.
