### PR TITLE
Help Center: Disable long message to be sent from users

### DIFF
--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -592,11 +592,14 @@ $custom-border-corner-size: 16px;
 }
 
 .odie-chatbox-invalid__message{
-	width: 100%;
 	color: rgb(140, 35, 44);
-	font-size: 0.75rem;
-	display: flex;
-    justify-content: center;
-    position: absolute;
+    font-size: 0.75rem;
     top: 66%;
+    width: 95%;
+    background: #fff;
+    position: fixed;
+    bottom: 73px;
+    height: 30px;
+    text-align: center;
+	padding-top: 6px;
 }

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -590,3 +590,13 @@ $custom-border-corner-size: 16px;
 .odie-chatbox-thinking-icon {
 	margin-left: 8px;
 }
+
+.odie-chatbox-invalid__message{
+	width: 100%;
+	color: rgb(140, 35, 44);
+	font-size: 0.75rem;
+	display: flex;
+    justify-content: center;
+    position: absolute;
+    top: 66%;
+}

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -14,14 +14,28 @@ import './style.scss';
 
 export const OdieSendMessageButton = ( {
 	containerReference,
+	isMessageSizeValid,
+	onKeyUp,
 }: {
 	containerReference: RefObject< HTMLDivElement >;
+	isMessageSizeValid: boolean;
+	onKeyUp: ( messageSize: boolean ) => void;
 } ) => {
 	const divContainerRef = useRef< HTMLDivElement >( null );
 	const inputRef = useRef< HTMLTextAreaElement >( null );
 	const { trackEvent, chatStatus, shouldUseHelpCenterExperience } = useOdieAssistantContext();
 	const sendMessage = useSendChatMessage();
 	const shouldBeDisabled = chatStatus === 'loading' || chatStatus === 'sending';
+
+	const isMessageExceedingMaxLength = ( messageLength: number ) => {
+		// api validation
+		return messageLength <= 4096;
+	};
+
+	const onKeyUpHandler = useCallback( () => {
+		const messageLength = inputRef.current?.value.trim().length || 0;
+		onKeyUp( isMessageExceedingMaxLength( messageLength ) );
+	}, [ onKeyUp ] );
 
 	const sendMessageHandler = useCallback( async () => {
 		if ( inputRef.current?.value.trim() === '' || shouldBeDisabled ) {
@@ -48,7 +62,7 @@ export const OdieSendMessageButton = ( {
 				error: error?.message,
 			} );
 		}
-	}, [ sendMessage, trackEvent ] );
+	}, [ sendMessage, shouldBeDisabled, trackEvent ] );
 	const classes = clsx(
 		'odie-send-message-inner-button',
 		shouldUseHelpCenterExperience && 'odie-send-message-inner-button__flag'
@@ -68,9 +82,14 @@ export const OdieSendMessageButton = ( {
 						sendMessageHandler={ sendMessageHandler }
 						className="odie-send-message-input"
 						inputRef={ inputRef }
+						keyUpHandler={ onKeyUpHandler }
 					/>
 					{ shouldBeDisabled && <Spinner className="odie-send-message-input-spinner" /> }
-					<button type="submit" className={ classes } disabled={ shouldBeDisabled }>
+					<button
+						type="submit"
+						className={ classes }
+						disabled={ shouldBeDisabled || ! isMessageSizeValid }
+					>
 						{ shouldUseHelpCenterExperience ? (
 							<SendMessageIcon />
 						) : (

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -69,6 +69,11 @@ export const OdieSendMessageButton = ( {
 	);
 	return (
 		<>
+			{ ! isMessageSizeValid && shouldUseHelpCenterExperience && (
+				<div className="odie-chatbox-invalid__message">
+					{ __( 'Message exceeds 4096 characters limit.' ) }
+				</div>
+			) }
 			<JumpToRecent containerReference={ containerReference } />
 			<div className="odie-chat-message-input-container" ref={ divContainerRef }>
 				<form

--- a/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
+++ b/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
@@ -7,9 +7,11 @@ export const ResizableTextarea: React.FC< {
 	className: string;
 	inputRef: React.RefObject< HTMLTextAreaElement >;
 	sendMessageHandler: () => Promise< void >;
-} > = ( { className, sendMessageHandler, inputRef } ) => {
-	const onKeyDown = useCallback(
+	keyUpHandler: () => void;
+} > = ( { className, sendMessageHandler, inputRef, keyUpHandler } ) => {
+	const onKeyUp = useCallback(
 		async ( event: KeyboardEvent< HTMLTextAreaElement > ) => {
+			keyUpHandler();
 			if ( inputRef.current?.value.trim() === '' ) {
 				return;
 			}
@@ -18,7 +20,7 @@ export const ResizableTextarea: React.FC< {
 				await sendMessageHandler();
 			}
 		},
-		[ inputRef, sendMessageHandler ]
+		[ inputRef, keyUpHandler, sendMessageHandler ]
 	);
 
 	useEffect( () => {
@@ -45,7 +47,7 @@ export const ResizableTextarea: React.FC< {
 			ref={ inputRef }
 			rows={ 1 }
 			className={ className }
-			onKeyDown={ onKeyDown }
+			onKeyUp={ onKeyUp }
 			placeholder={ __( 'Type a message…', __i18n_text_domain__ ) }
 			style={ { transition: 'none' } }
 		/>

--- a/packages/odie-client/src/components/send-message-input/style.scss
+++ b/packages/odie-client/src/components/send-message-input/style.scss
@@ -61,7 +61,7 @@ $blueberry-color: #3858e9;
 
 
 	&[disabled] {
-		background-color: var(--color-neutral-20);
+		background-color: var(--color-neutral-20) !important;
 		border-color: var(--color-neutral-5);
 		cursor: default;
 

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -1,4 +1,3 @@
-import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from 'react';
 import { MessagesContainer } from './components/message/messages-container';
 import { OdieSendMessageButton } from './components/send-message-input';
@@ -9,8 +8,7 @@ import useLastMessageVisibility from './useLastMessageVisibility';
 import './style.scss';
 
 export const OdieAssistant: React.FC = () => {
-	const { chat, trackEvent, currentUser, shouldUseHelpCenterExperience } =
-		useOdieAssistantContext();
+	const { chat, trackEvent, currentUser } = useOdieAssistantContext();
 	const containerRef = useRef< HTMLDivElement >( null );
 	const messagesContainerRef = useRef< HTMLDivElement >( null );
 	const [ isMessageSizeValid, setIsMessageSizeValid ] = useState( true );
@@ -31,11 +29,7 @@ export const OdieAssistant: React.FC = () => {
 			<div className="chat-box-message-container" ref={ containerRef } id="odie-messages-container">
 				<MessagesContainer currentUser={ currentUser } ref={ messagesContainerRef } />
 			</div>
-			{ ! isMessageSizeValid && shouldUseHelpCenterExperience && (
-				<div className="odie-chatbox-invalid__message">
-					{ __( 'Message exceeds 4096 characters limit.' ) }
-				</div>
-			) }
+
 			<OdieSendMessageButton
 				containerReference={ messagesContainerRef }
 				isMessageSizeValid={ isMessageSizeValid }

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useRef, useState } from 'react';
 import { MessagesContainer } from './components/message/messages-container';
 import { OdieSendMessageButton } from './components/send-message-input';
 import { useOdieAssistantContext, OdieAssistantProvider } from './context';
@@ -8,9 +9,15 @@ import useLastMessageVisibility from './useLastMessageVisibility';
 import './style.scss';
 
 export const OdieAssistant: React.FC = () => {
-	const { chat, trackEvent, currentUser } = useOdieAssistantContext();
+	const { chat, trackEvent, currentUser, shouldUseHelpCenterExperience } =
+		useOdieAssistantContext();
 	const containerRef = useRef< HTMLDivElement >( null );
 	const messagesContainerRef = useRef< HTMLDivElement >( null );
+	const [ isMessageSizeValid, setIsMessageSizeValid ] = useState( true );
+
+	const onKeyUp = ( isValidMessageSize: boolean ) => {
+		setIsMessageSizeValid( isValidMessageSize );
+	};
 
 	useEffect( () => {
 		trackEvent( 'chatbox_view' );
@@ -24,7 +31,16 @@ export const OdieAssistant: React.FC = () => {
 			<div className="chat-box-message-container" ref={ containerRef } id="odie-messages-container">
 				<MessagesContainer currentUser={ currentUser } ref={ messagesContainerRef } />
 			</div>
-			<OdieSendMessageButton containerReference={ messagesContainerRef } />
+			{ ! isMessageSizeValid && shouldUseHelpCenterExperience && (
+				<div className="odie-chatbox-invalid__message">
+					{ __( 'Message exceeds 4096 characters limit.' ) }
+				</div>
+			) }
+			<OdieSendMessageButton
+				containerReference={ messagesContainerRef }
+				isMessageSizeValid={ isMessageSizeValid }
+				onKeyUp={ onKeyUp }
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95584
Fixes https://github.com/Automattic/wp-calypso/issues/95584

## Proposed Changes

* Prevent long messages (4096 chars) from being sent since the API doesn't accept it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Prevent API errors and display to users that long messages are not allowed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and add flag `?flags=help-center-experience`
* Open a chat and type a really long message
* You should get a message explaining that the message is long
* The send button should get disabled

<img width="433" alt="image" src="https://github.com/user-attachments/assets/c8c632b1-5a9e-405a-b8c9-6b4017339a6f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
