### PR TITLE
Add missing server settings tracking events

### DIFF
--- a/client/hosting/server-settings/components/restore-plan-software-card/index.js
+++ b/client/hosting/server-settings/components/restore-plan-software-card/index.js
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
 import { stripHTML } from 'calypso/lib/formatting/strip-html';
 import wpcom from 'calypso/lib/wp';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -13,6 +14,7 @@ export default function RestorePlanSoftwareCard() {
 	const siteId = useSelector( getSelectedSiteId );
 
 	function requestRestore() {
+		dispatch( recordTracksEvent( 'calypso_hosting_restore_plugins_and_themes' ) );
 		wpcom.req
 			.post( {
 				path: `/sites/${ siteId }/hosting/restore-plan-software`,

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -152,6 +152,48 @@ const SiteAdminInterface = ( { siteId, isHosting = false } ) => {
 		);
 	};
 
+	if ( isHosting ) {
+		return (
+			<HostingCard
+				className="admin-interface-style-card"
+				headingId="admin-interface-style"
+				title={ translate( 'Admin interface style' ) }
+			>
+				<HostingCardDescription>
+					{ translate(
+						'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}',
+						{
+							components: {
+								supportLink: (
+									<InlineSupportLink supportContext="admin-interface-style" showIcon={ false } />
+								),
+							},
+						}
+					) }
+				</HostingCardDescription>
+				<p className="form-setting-explanation">
+					{ translate( 'This setting has now moved to {{a}}Settings → General{{/a}}.', {
+						components: {
+							a: (
+								<a
+									href={
+										adminInterface === 'wp-admin'
+											? `${ siteAdminUrl }options-general.php`
+											: `/settings/general/${ siteSlug }#admin-interface-style`
+									}
+									onClick={ () =>
+										dispatch( recordTracksEvent( 'calypso_site_settings_admin_interface_style' ) )
+									}
+									rel="noreferrer"
+								/>
+							),
+						},
+					} ) }
+				</p>
+			</HostingCard>
+		);
+	}
+
 	return (
 		<>
 			<SettingsSectionHeader

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -152,48 +152,6 @@ const SiteAdminInterface = ( { siteId, isHosting = false } ) => {
 		);
 	};
 
-	if ( isHosting ) {
-		return (
-			<HostingCard
-				className="admin-interface-style-card"
-				headingId="admin-interface-style"
-				title={ translate( 'Admin interface style' ) }
-			>
-				<HostingCardDescription>
-					{ translate(
-						'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}',
-						{
-							components: {
-								supportLink: (
-									<InlineSupportLink supportContext="admin-interface-style" showIcon={ false } />
-								),
-							},
-						}
-					) }
-				</HostingCardDescription>
-				<p className="form-setting-explanation">
-					{ translate( 'This setting has now moved to {{a}}Settings → General{{/a}}.', {
-						components: {
-							a: (
-								<a
-									href={
-										adminInterface === 'wp-admin'
-											? `${ siteAdminUrl }options-general.php`
-											: `/settings/general/${ siteSlug }#admin-interface-style`
-									}
-									onClick={ () =>
-										dispatch( recordTracksEvent( 'calypso_site_settings_admin_interface_style' ) )
-									}
-									rel="noreferrer"
-								/>
-							),
-						},
-					} ) }
-				</p>
-			</HostingCard>
-		);
-	}
-
 	return (
 		<>
 			<SettingsSectionHeader

--- a/client/sites/settings/database/form.tsx
+++ b/client/sites/settings/database/form.tsx
@@ -69,6 +69,7 @@ export default function PhpMyAdminForm( { disabled }: PhpMyAdminFormProps ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const [ isRestorePasswordDialogVisible, setIsRestorePasswordDialogVisible ] = useState( false );
 	const { openPhpMyAdmin, loading } = useOpenPhpMyAdmin();
+	const dispatch = useDispatch();
 
 	let isUntangled = useRemoveDuplicateViewsExperimentEnabled();
 	isUntangled = isUntangled && config.isEnabled( 'untangling/settings-i2' );
@@ -110,7 +111,12 @@ export default function PhpMyAdminForm( { disabled }: PhpMyAdminFormProps ) {
 								<Button
 									compact
 									borderless
-									onClick={ () => setIsRestorePasswordDialogVisible( true ) }
+									onClick={ () => {
+										dispatch(
+											recordTracksEvent( 'calypso_hosting_configuration_reset_db_password' )
+										);
+										setIsRestorePasswordDialogVisible( true );
+									} }
 								/>
 							),
 						},

--- a/client/sites/settings/sftp-ssh/sftp-form.tsx
+++ b/client/sites/settings/sftp-ssh/sftp-form.tsx
@@ -285,7 +285,13 @@ export const SftpForm = ( { disabled }: SftpFormProps ) => {
 		<div className="sftp-card__wrapper">
 			{ displayQuestionsAndButton && (
 				<div className="sftp-card__questions-container">
-					<PanelBody title={ translate( 'What is SFTP?' ) } initialOpen={ false }>
+					<PanelBody
+						title={ translate( 'What is SFTP?' ) }
+						initialOpen={ false }
+						onToggle={ () =>
+							dispatch( recordTracksEvent( 'calypso_hosting_configuration_toggle_sftp_card' ) )
+						}
+					>
 						{ translate(
 							'SFTP stands for Secure File Transfer Protocol (or SSH File Transfer Protocol). It’s a secure way for you to access your website files on your local computer via a client program such as {{a}}Filezilla{{/a}}. ' +
 								'For more information see {{supportLink}}SFTP on WordPress.com{{/supportLink}}.',
@@ -300,7 +306,13 @@ export const SftpForm = ( { disabled }: SftpFormProps ) => {
 						) }
 					</PanelBody>
 					{ showSshPanel && (
-						<PanelBody title={ translate( 'What is SSH?' ) } initialOpen={ false }>
+						<PanelBody
+							title={ translate( 'What is SSH?' ) }
+							initialOpen={ false }
+							onToggle={ () =>
+								dispatch( recordTracksEvent( 'calypso_hosting_configuration_toggle_ssh_card' ) )
+							}
+						>
 							{ translate(
 								'SSH stands for Secure Shell. It’s a way to perform advanced operations on your site using the command line. ' +
 									'For more information see {{supportLink}}Connect to SSH on WordPress.com{{/supportLink}}.',


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/9590

## Proposed Changes

Add these new tracks
* `calypso_hosting_configuration_reset_db_password`
* `calypso_hosting_restore_plugins_and_themes`
* `calypso_hosting_configuration_toggle_sftp_card`
* `calypso_hosting_configuration_toggle_ssh_card`
* ~~`calypso_site_settings_admin_interface_style`~~

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/Automattic/dotcom-forge/issues/9529

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `http://calypso.localhost:3000/hosting-config/_BLOG_`
* Click all the links and buttons found in this issue https://github.com/Automattic/dotcom-forge/issues/9590
* Ensure on Tracks Vigilante that all the tracks are generated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?