### PR TITLE
Reader Onboarding: Align byline text left

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -2,7 +2,6 @@
 	color: var(--color-text);
 	margin: 0 12px;
 	flex: 1 1 0;
-	text-align: left;
 }
 
 .reader-subscription-list-item__link,

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -2,6 +2,7 @@
 	color: var(--color-text);
 	margin: 0 12px;
 	flex: 1 1 0;
+	text-align: left;
 }
 
 .reader-subscription-list-item__link,

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -54,7 +54,6 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 		@media ( max-width: $break-medium ) {
 			padding: 0;
 			max-width: 700px;
-			text-align: center;
 		}
 
 		.subscribe-modal__continue-button {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/211

## Proposed Changes

* Remove `text-align: center;` style.

Before | After
---- | ----
<img width="376" alt="Screen Shot 2024-10-31 at 1 16 16 PM" src="https://github.com/user-attachments/assets/5a0120c5-8799-4f50-a4d0-f667ca327b20"> | <img width="376" alt="Screen Shot 2024-10-31 at 1 30 51 PM" src="https://github.com/user-attachments/assets/a8610ba9-8e37-456a-ad39-fa7167a45ee0">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/onboarding on a new account with a verified email.
* Click "Select some of your interests," choose interests, and click Continue.
* Check that the site card bylines are left-aligned.
* Change to a mobile screen size. Check that the bylines are still left-aligned.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
