### PR TITLE
Reader Onboarding: Update subscribe modal mobile view

### DIFF
--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -280,7 +280,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 				<div className="subscribe-modal__content">
 					<div className="subscribe-modal__site-list-column">
 						<h2 className="subscribe-modal__title">{ __( "Discover sites that you'll love" ) }</h2>
-						<p>
+						<p className="subscribe-modal__description">
 							{ __(
 								'Preview sites by clicking below, then subscribe to any site that inspires you.'
 							) }

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -51,6 +51,11 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 			max-width: 450px;
 		}
 
+		@media ( max-width: $break-medium ) {
+			padding: 0;
+			max-width: 700px;
+		}
+
 		.subscribe-modal__continue-button {
 			width: 100%;
 			justify-content: center;

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -51,11 +51,6 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 			max-width: 450px;
 		}
 
-		@media ( max-width: $break-medium ) {
-			padding: 0;
-			max-width: 700px;
-		}
-
 		.subscribe-modal__continue-button {
 			width: 100%;
 			justify-content: center;
@@ -66,17 +61,25 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 			text-wrap: balance;
 		}
 
+		.subscribe-modal__description {
+			@media ( max-width: 1199px ) {
+				display: none;
+			}
+		}
+
 		.reader-subscription-list-item {
 			padding: 12px;
 			border: 1px solid var( --color-neutral-5 );
 			border-radius: 6px; /* stylelint-disable-line scales/radii */
-			cursor: pointer;
 			margin-bottom: 12px;
 
-			&.is-selected {
-				background-color: #e6f3fa;
-				border: 1px solid #0087be;
-				border-radius: 6px; /* stylelint-disable-line scales/radii */
+			@media ( min-width: 1200px ) {
+				cursor: pointer;
+				&.is-selected {
+					background-color: #e6f3fa;
+					border: 1px solid #0087be;
+					border-radius: 6px; /* stylelint-disable-line scales/radii */
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1730151360177069/1730147718.316839-slack-C03NLNTPZ2T

## Proposed Changes

* On mobile and screen widths < 1200px, the preview pane is not available. So, this PR removes the copy that references the preview pane and removes the "selectability/highlighting" of blogs.

Before | After
--|--
<img width="388" alt="Screenshot 2024-10-31 at 1 34 49 PM" src="https://github.com/user-attachments/assets/692fcd4b-c146-4799-b1ad-4b64bf0987ad">  | <img width="389" alt="Screenshot 2024-10-31 at 1 37 49 PM" src="https://github.com/user-attachments/assets/a752c3f7-9ff0-49f1-8dae-e5ccfc8cfbf3">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve mobile experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /read?flags=reader/onboarding with a new user with a verified email.
* View the "subscribe" modal with various widths and on mobile and consider the user experience. Does this PR improve it?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?