### PR TITLE
Big Sky eligibility: Show on desktop/tablet, support personal plan

### DIFF
--- a/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
-import { isBusinessPlan, isPremiumPlan } from '@automattic/calypso-products';
-import { useBreakpoint } from '@automattic/viewport-react';
+import { isBusinessPlan, isPremiumPlan, isPersonalPlan } from '@automattic/calypso-products';
 import { useSelect } from '@wordpress/data';
+import userAgent from 'calypso/lib/user-agent';
 import { useIsSiteOwner } from '../hooks/use-is-site-owner';
 import { ONBOARD_STORE } from '../stores';
 import { useSite } from './use-site';
@@ -14,17 +14,21 @@ export function useIsBigSkyEligible() {
 	const { isOwner } = useIsSiteOwner();
 	const site = useSite();
 	const product_slug = site?.plan?.product_slug || '';
-	const isNarrowView = useBreakpoint( '<800px' );
+	const onSupportedDevice = userAgent.isTablet || userAgent.isDesktop;
 	const goals = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
 		[ site ]
 	);
 
 	const hasValidGoal = goals.every( ( value ) => validGoals.includes( value ) );
-	const isEligiblePlan = isPremiumPlan( product_slug ) || isBusinessPlan( product_slug );
+	const isEligiblePlan =
+		isPersonalPlan( product_slug ) ||
+		isPremiumPlan( product_slug ) ||
+		isBusinessPlan( product_slug );
 
 	const eligibilityResult =
-		( featureFlagEnabled && isOwner && isEligiblePlan && hasValidGoal && ! isNarrowView ) || false;
+		( featureFlagEnabled && isOwner && isEligiblePlan && hasValidGoal && onSupportedDevice ) ||
+		false;
 
 	return { isLoading: false, isEligible: eligibilityResult };
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

- Removes the device width check
- Add supported device types: `isTablet` and `isDesktop`
- Add Personal plan

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The UX can now handle narrow viewports, but the mobile keyboard still gets in the way. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
(Tip: You can use the "calypso live" link instead of localhost)
1. Go to: http://calypso.localhost:3000/setup/site-setup/design-choices?siteSlug=YOUR_SITE_URL_WITH_SUPPORTED_PLAN
2. You should see the big sky card
3. Open the dev console, select the devices view
4. Select a tablet (like ipad pro). Refresh. The card should show
5. Select an unsupported device, like iPhone. Refresh. The card should not be there

<img width="924" alt="image" src="https://github.com/user-attachments/assets/f52292de-c6f9-4dfe-93dd-16344abded5c">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
