### PR TITLE
Reader Onboarding: Do not reset selected site on load more click

### DIFF
--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -198,10 +198,10 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 
 	// Select the first site by default when recommendations are loaded.
 	useEffect( () => {
-		if ( displayedRecommendations.length > 0 ) {
+		if ( displayedRecommendations.length > 0 && ! selectedSite ) {
 			setSelectedSite( displayedRecommendations[ 0 ] );
 		}
-	}, [ displayedRecommendations ] );
+	}, [ displayedRecommendations, selectedSite ] );
 
 	const handleItemClick = useCallback( ( site: CardData ) => {
 		setSelectedSite( site );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Do not reset the selected site when the "Load more recommendations" button is clicked.


Before | After
--|--
<video src="https://github.com/user-attachments/assets/2e7c95f4-e779-4b49-9e6f-83f8b552f59c" /> | <video src="https://github.com/user-attachments/assets/6b9f3dae-771f-449c-b717-b2d2a91ea306" />







## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /read?flags=reader/onboarding on a new user with a verified email
* Open up the Discover site modal, select a site to preview, then click "Load more recommendations."
* Your selected site should not change when you click "Load more recommendations."
* Click the "Cancel" button
* Go back to the Interests modal and select some new tags and click "Continue"
* The 1st site in the Discover modal should be selected by default.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
