### PR TITLE
Reader Onboarding: Move continue button to modal header

### DIFF
--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -265,6 +265,9 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 			<Button onClick={ handleClose } variant="link">
 				{ __( 'Cancel' ) }
 			</Button>
+			<Button onClick={ handleContinue } variant="primary">
+				{ __( 'Continue' ) }
+			</Button>
 		</>
 	);
 
@@ -322,12 +325,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 								{ __( 'Load more recommendations' ) }
 							</Button>
 						) }
-						<Button
-							className="subscribe-modal__continue-button is-primary"
-							onClick={ handleContinue }
-						>
-							{ __( 'Continue' ) }
-						</Button>
 					</div>
 					<div className="subscribe-modal__preview-column">
 						<div className="subscribe-modal__preview-placeholder">

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -56,12 +56,6 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 			max-width: 700px;
 		}
 
-		.subscribe-modal__continue-button {
-			width: 100%;
-			justify-content: center;
-			margin-top: 36px;
-		}
-
 		p {
 			text-wrap: balance;
 		}
@@ -136,5 +130,17 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 		height: 100%;
 		overflow-y: auto;
 		padding-top: 40px;
+	}
+
+	.components-modal__header {
+		.components-button {
+			&.is-link {
+				margin-right: auto;
+			}
+
+			&.is-primary {
+				margin-left: 16px;
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/214

## Proposed Changes

* This PR moves the "Continue" button in the `SubscribeModal` from the bottom of the recommendations list to the upper right of the modal header.

Before | After
--|--
<img width="1608" alt="Screenshot 2024-10-31 at 3 15 11 PM" src="https://github.com/user-attachments/assets/9fa7a052-d1dd-41ca-adf7-e2749982fb06">  | <img width="1609" alt="Screenshot 2024-10-31 at 3 14 49 PM" src="https://github.com/user-attachments/assets/f46cc564-1522-4d6a-af39-fdbe3fa3bcfd">




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX and usability.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /read?flags=reader/onboarding
* Go to the "Discover" modal and see that the "Continue" button has moved to the top right, just like in the tag selection modal.
* Make sure the "Continue" button still works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
