### PR TITLE
Checkout: Move contact validity message up a component and show on complete as well

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -24,7 +24,12 @@ import {
 } from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/format-currency';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { styled, joinClasses, getContactDetailsType } from '@automattic/wpcom-checkout';
+import {
+	styled,
+	joinClasses,
+	getContactDetailsType,
+	ContactDetailsType,
+} from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
@@ -143,6 +148,27 @@ const SideBarLoadingCopy = styled.p`
 	padding: 0;
 	animation: ${ pulse } 2s ease-in-out infinite;
 `;
+
+const ContactDetailsFormDescription = styled.p`
+	font-size: 14px;
+	color: ${ ( props ) => props.theme.colors.textColor };
+	margin: 0 0 16px;
+`;
+
+function ConditionalContactDetailsMessage( {
+	contactDetailsType,
+}: {
+	contactDetailsType: ContactDetailsType;
+} ) {
+	const translate = useTranslate();
+	return contactDetailsType === 'domain' ? (
+		<ContactDetailsFormDescription>
+			{ translate(
+				'Registering a domain name requires valid contact information. Privacy Protection is included for all eligible domains to protect your personal information.'
+			) }
+		</ContactDetailsFormDescription>
+	) : null;
+}
 
 function LoadingSidebarContent() {
 	return (
@@ -678,24 +704,30 @@ export default function CheckoutMainContent( {
 								return validationResponse;
 							} }
 							activeStepContent={
-								<WPContactForm
-									countriesList={ countriesList }
-									shouldShowContactDetailsValidationErrors={
-										shouldShowContactDetailsValidationErrors
-									}
-									contactDetailsType={ contactDetailsType }
-									isLoggedOutCart={ isLoggedOutCart }
-									setShouldShowContactDetailsValidationErrors={
-										setShouldShowContactDetailsValidationErrors
-									}
-								/>
+								<>
+									<ConditionalContactDetailsMessage contactDetailsType={ contactDetailsType } />
+									<WPContactForm
+										countriesList={ countriesList }
+										shouldShowContactDetailsValidationErrors={
+											shouldShowContactDetailsValidationErrors
+										}
+										contactDetailsType={ contactDetailsType }
+										isLoggedOutCart={ isLoggedOutCart }
+										setShouldShowContactDetailsValidationErrors={
+											setShouldShowContactDetailsValidationErrors
+										}
+									/>
+								</>
 							}
 							completeStepContent={
-								<WPContactFormSummary
-									areThereDomainProductsInCart={ areThereDomainProductsInCart }
-									isGSuiteInCart={ isGSuiteInCart }
-									isLoggedOutCart={ isLoggedOutCart }
-								/>
+								<>
+									<ConditionalContactDetailsMessage contactDetailsType={ contactDetailsType } />
+									<WPContactFormSummary
+										areThereDomainProductsInCart={ areThereDomainProductsInCart }
+										isGSuiteInCart={ isGSuiteInCart }
+										isLoggedOutCart={ isLoggedOutCart }
+									/>
+								</>
 							}
 							titleContent={ <ContactFormTitle /> }
 							editButtonText={ String( translate( 'Edit' ) ) }

--- a/client/my-sites/checkout/src/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/src/components/contact-details-container.tsx
@@ -84,11 +84,6 @@ export default function ContactDetailsContainer( {
 		case 'domain':
 			return (
 				<Fragment>
-					<ContactDetailsFormDescription>
-						{ translate(
-							'Registering a domain name requires valid contact information. Privacy Protection is included for all eligible domains to protect your personal information.'
-						) }
-					</ContactDetailsFormDescription>
 					<DomainContactDetails
 						domainNames={ domainNames }
 						contactDetails={ contactDetails }


### PR DESCRIPTION
I added the "Contact Validity" warning we present to users, warning that icann requires true and valid contact information to the 'completed' state. Currently, the message (and empty contact form) appear for a moment, then if a user already owns a domain (and so has their contact information saved) it flashes away and the contact preview component displays. This is sub-optimal, both because of the flashing away information and because users have reported issues related to not being adequately warned about the validity requirements.

To reduce duplicate translations and functionality across components, I moved the message up a component level.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95954
https://github.com/Automattic/wp-calypso/issues/95954

## Proposed Changes

* Moves domain contact validity warning up by one component and adds it to the 'Completed' version of the contact verification step, for domains only.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Improve communication with the users
- Response to user feedback, at the request of an HE

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- If user owns 0 domains (and has never filled out an address form)
  - The current functionality doesn't change. The warning and contact form both appear and require the user to complete
- If the user owns 1 or more domains (and has filled out an address form previously)
  - The message appears alongside the contact form, but the contact form is replaced with the Contact Preview component
  - The message is still presented to the user, to remind them to update their contact information appropriately
- If the user is checking out with any product other than a domain
  - This message should not show for any product other than domain

![image](https://github.com/user-attachments/assets/3072f9cb-c883-4cf5-9759-dcb447b32a9d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
