### PR TITLE
Stats: Change width of most cards to 50% for easier layout

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -351,11 +351,11 @@ class StatsSite extends Component {
 			'stats__flexible-grid-container'
 		);
 
-		const halfWidthModuleClasses = [
+		const halfWidthModuleClasses = clsx(
 			'stats__flexible-grid-item--half',
 			'stats__flexible-grid-item--full--large',
-			'stats__flexible-grid-item--full--medium',
-		];
+			'stats__flexible-grid-item--full--medium'
+		);
 
 		return (
 			<div className="stats">

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -67,7 +67,6 @@ import PromoCards from './promo-cards';
 import StatsCardUpdateJetpackVersion from './stats-card-upsell/stats-card-update-jetpack-version';
 import ChartTabs from './stats-chart-tabs';
 import DatePicker from './stats-date-picker';
-import StatsModule from './stats-module';
 import StatsNotices from './stats-notices';
 import PageViewTracker from './stats-page-view-tracker';
 import StatsPeriodHeader from './stats-period-header';
@@ -250,7 +249,6 @@ class StatsSite extends Component {
 			shouldForceDefaultDateRange,
 			supportUserFeedback,
 		} = this.props;
-		const isNewStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
 		const isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' );
 		let defaultPeriod = PAST_SEVEN_DAYS;
 
@@ -352,6 +350,12 @@ class StatsSite extends Component {
 			'stats__module--unified',
 			'stats__flexible-grid-container'
 		);
+
+		const halfWidthModuleClasses = [
+			'stats__flexible-grid-item--half',
+			'stats__flexible-grid-item--full--large',
+			'stats__flexible-grid-item--full--medium',
+		];
 
 		return (
 			<div className="stats">
@@ -482,62 +486,20 @@ class StatsSite extends Component {
 					{ ! isOdysseyStats && <MiniCarousel slug={ slug } isSitePrivate={ isSitePrivate } /> }
 
 					<div className={ moduleListClasses }>
-						{ ! isNewStateEnabled && (
-							<StatsModule
-								path="posts"
-								moduleStrings={ moduleStrings.posts }
-								period={ this.props.period }
-								query={ query }
-								statType="statsTopPosts"
-								showSummaryLink
-								className={ clsx(
-									'stats__flexible-grid-item--60',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
-							/>
-						) }
-						{ isNewStateEnabled && (
-							<StatsModuleTopPosts
-								moduleStrings={ moduleStrings.posts }
-								period={ this.props.period }
-								query={ query }
-								summaryUrl={ this.getStatHref( this.props.period, 'posts', slug ) }
-								className={ clsx(
-									'stats__flexible-grid-item--60',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
-							/>
-						) }
-						{ ! isNewStateEnabled && (
-							<StatsModule
-								path="referrers"
-								moduleStrings={ moduleStrings.referrers }
-								period={ this.props.period }
-								query={ query }
-								statType="statsReferrers"
-								showSummaryLink
-								className={ clsx(
-									'stats__flexible-grid-item--40--once-space',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
-							/>
-						) }
-						{ isNewStateEnabled && (
-							<StatsModuleReferrers
-								moduleStrings={ moduleStrings.referrers }
-								period={ this.props.period }
-								query={ query }
-								summaryUrl={ this.getStatHref( this.props.period, 'referrers', slug ) }
-								className={ clsx(
-									'stats__flexible-grid-item--40--once-space',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
-							/>
-						) }
+						<StatsModuleTopPosts
+							moduleStrings={ moduleStrings.posts }
+							period={ this.props.period }
+							query={ query }
+							summaryUrl={ this.getStatHref( this.props.period, 'posts', slug ) }
+							className={ halfWidthModuleClasses }
+						/>
+						<StatsModuleReferrers
+							moduleStrings={ moduleStrings.referrers }
+							period={ this.props.period }
+							query={ query }
+							summaryUrl={ this.getStatHref( this.props.period, 'referrers', slug ) }
+							className={ halfWidthModuleClasses }
+						/>
 
 						<StatsModuleCountries
 							moduleStrings={ moduleStrings.countries }
@@ -555,22 +517,14 @@ class StatsSite extends Component {
 								query={ query }
 								summaryUrl={ this.getStatHref( this.props.period, 'utm', slug ) }
 								summary={ false }
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
+								className={ halfWidthModuleClasses }
 							/>
 						) }
 
 						{ supportsUTMStats && isOldJetpack && (
 							<StatsModuleUTMOverlay
 								siteId={ siteId }
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
+								className={ halfWidthModuleClasses }
 								overlay={
 									<StatsCardUpdateJetpackVersion
 										className="stats-module__upsell stats-module__upgrade"
@@ -581,65 +535,21 @@ class StatsSite extends Component {
 							/>
 						) }
 
-						{ /* If UTM card or update card is not visible, shift "Clicks" and reduct to 1/2 for easier stacking */ }
-						{ isNewStateEnabled && (
-							<StatsModuleClicks
-								moduleStrings={ moduleStrings.clicks }
-								period={ this.props.period }
-								query={ query }
-								summaryUrl={ this.getStatHref( this.props.period, 'clicks', slug ) }
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
-							/>
-						) }
+						<StatsModuleClicks
+							moduleStrings={ moduleStrings.clicks }
+							period={ this.props.period }
+							query={ query }
+							summaryUrl={ this.getStatHref( this.props.period, 'clicks', slug ) }
+							className={ halfWidthModuleClasses }
+						/>
 
-						{ ! isNewStateEnabled && (
-							<StatsModule
-								path="clicks"
-								moduleStrings={ moduleStrings.clicks }
-								period={ this.props.period }
-								query={ query }
-								statType="statsClicks"
-								showSummaryLink
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
-							/>
-						) }
-						{ /* Either stacks with Clicks or with Emails depending on UTM */ }
-						{ ! this.isModuleHidden( 'authors' ) && ! isNewStateEnabled && (
-							<StatsModule
-								path="authors"
-								moduleStrings={ moduleStrings.authors }
-								period={ this.props.period }
-								query={ query }
-								statType="statsTopAuthors"
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
-								showSummaryLink
-							/>
-						) }
-
-						{ /* Either stacks with Clicks or with Emails depending on UTM */ }
-						{ ! this.isModuleHidden( 'authors' ) && isNewStateEnabled && (
+						{ ! this.isModuleHidden( 'authors' ) && (
 							<StatsModuleAuthors
 								moduleStrings={ moduleStrings.authors }
 								period={ this.props.period }
 								query={ query }
 								summaryUrl={ this.getStatHref( this.props.period, 'authors', slug ) }
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
+								className={ halfWidthModuleClasses }
 							/>
 						) }
 
@@ -650,127 +560,53 @@ class StatsSite extends Component {
 								moduleStrings={ moduleStrings.emails }
 								query={ query }
 								summaryUrl={ this.getStatHref( this.props.period, 'emails', slug ) }
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
+								className={ halfWidthModuleClasses }
 							/>
 						) }
 
-						{ isNewStateEnabled && (
-							<StatsModuleSearch
-								moduleStrings={ moduleStrings.search }
-								period={ this.props.period }
-								query={ query }
-								summaryUrl={ this.getStatHref( this.props.period, 'searchterms', slug ) }
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
-							/>
-						) }
-						{ ! isNewStateEnabled && (
-							<StatsModule
-								path="searchterms"
-								moduleStrings={ moduleStrings.search }
-								period={ this.props.period }
-								query={ query }
-								statType="statsSearchTerms"
-								showSummaryLink
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
-							/>
-						) }
+						<StatsModuleSearch
+							moduleStrings={ moduleStrings.search }
+							period={ this.props.period }
+							query={ query }
+							summaryUrl={ this.getStatHref( this.props.period, 'searchterms', slug ) }
+							className={ halfWidthModuleClasses }
+						/>
 
-						{ isNewStateEnabled && ! this.isModuleHidden( 'videos' ) && (
+						{ ! this.isModuleHidden( 'videos' ) && (
 							<StatsModuleVideos
 								moduleStrings={ moduleStrings.videoplays }
 								period={ this.props.period }
 								query={ query }
 								summaryUrl={ this.getStatHref( this.props.period, 'videoplays', slug ) }
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
-							/>
-						) }
-
-						{ ! isNewStateEnabled && ! this.isModuleHidden( 'videos' ) && (
-							<StatsModule
-								path="videoplays"
-								moduleStrings={ moduleStrings.videoplays }
-								period={ this.props.period }
-								query={ query }
-								statType="statsVideoPlays"
-								showSummaryLink
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large',
-									'stats__flexible-grid-item--full--medium'
-								) }
+								className={ halfWidthModuleClasses }
 							/>
 						) }
 
 						{
 							// File downloads are not yet supported in Jetpack environment
-							isNewStateEnabled && ! isJetpack && (
+							! isJetpack && (
 								<StatsModuleDownloads
 									moduleStrings={ moduleStrings.filedownloads }
 									period={ this.props.period }
 									query={ query }
 									summaryUrl={ this.getStatHref( this.props.period, 'filedownloads', slug ) }
-									className={ clsx(
-										'stats__flexible-grid-item--half',
-										'stats__flexible-grid-item--full--large',
-										'stats__flexible-grid-item--full--medium'
-									) }
+									className={ halfWidthModuleClasses }
 								/>
 							)
 						}
-						{
-							// File downloads are not yet supported in Jetpack environment
-							// TODO: Confirm the above statement.
-							! isNewStateEnabled && ! isJetpack && (
-								<StatsModule
-									path="filedownloads"
-									metricLabel={ translate( 'Downloads' ) }
-									moduleStrings={ moduleStrings.filedownloads }
-									period={ this.props.period }
-									query={ query }
-									statType="statsFileDownloads"
-									showSummaryLink
-									useShortLabel
-									className={ clsx(
-										'stats__flexible-grid-item--half',
-										'stats__flexible-grid-item--full--large',
-										'stats__flexible-grid-item--full--medium'
-									) }
-								/>
-							)
-						}
+
 						{ supportsDevicesStats && ! isOldJetpack && (
 							<StatsModuleDevices
 								siteId={ siteId }
 								period={ this.props.period }
 								query={ query }
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large'
-								) }
+								className={ halfWidthModuleClasses }
 							/>
 						) }
+
 						{ ! supportsDevicesStats && isOldJetpack && (
 							<StatsModuleUpgradeDevicesOverlay
-								className={ clsx(
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large'
-								) }
+								className={ halfWidthModuleClasses }
 								siteId={ siteId }
 								overlay={
 									<StatsCardUpdateJetpackVersion

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -560,7 +560,7 @@ class StatsSite extends Component {
 								summaryUrl={ this.getStatHref( this.props.period, 'utm', slug ) }
 								summary={ false }
 								className={ clsx(
-									'stats__flexible-grid-item--60',
+									'stats__flexible-grid-item--half',
 									'stats__flexible-grid-item--full--large',
 									'stats__flexible-grid-item--full--medium'
 								) }
@@ -571,7 +571,7 @@ class StatsSite extends Component {
 							<StatsModuleUTMOverlay
 								siteId={ siteId }
 								className={ clsx(
-									'stats__flexible-grid-item--60',
+									'stats__flexible-grid-item--half',
 									'stats__flexible-grid-item--full--large',
 									'stats__flexible-grid-item--full--medium'
 								) }
@@ -593,15 +593,8 @@ class StatsSite extends Component {
 								query={ query }
 								summaryUrl={ this.getStatHref( this.props.period, 'clicks', slug ) }
 								className={ clsx(
-									{
-										'stats__flexible-grid-item--40--once-space': supportsUTMStats,
-										'stats__flexible-grid-item--full--large': supportsUTMStats,
-										'stats__flexible-grid-item--full--medium': supportsUTMStats,
-									},
-									{
-										'stats__flexible-grid-item--half': ! supportsUTMStats,
-										'stats__flexible-grid-item--full--large': ! supportsUTMStats,
-									},
+									'stats__flexible-grid-item--half',
+									'stats__flexible-grid-item--full--large',
 									'stats__flexible-grid-item--full--medium'
 								) }
 							/>
@@ -616,15 +609,8 @@ class StatsSite extends Component {
 								statType="statsClicks"
 								showSummaryLink
 								className={ clsx(
-									{
-										'stats__flexible-grid-item--40--once-space': supportsUTMStats,
-										'stats__flexible-grid-item--full--large': supportsUTMStats,
-										'stats__flexible-grid-item--full--medium': supportsUTMStats,
-									},
-									{
-										'stats__flexible-grid-item--half': ! supportsUTMStats,
-										'stats__flexible-grid-item--full--large': ! supportsUTMStats,
-									},
+									'stats__flexible-grid-item--half',
+									'stats__flexible-grid-item--full--large',
 									'stats__flexible-grid-item--full--medium'
 								) }
 							/>
@@ -638,11 +624,9 @@ class StatsSite extends Component {
 								query={ query }
 								statType="statsTopAuthors"
 								className={ clsx(
-									{
-										'stats__author-views': ! supportsUTMStats,
-									},
 									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large'
+									'stats__flexible-grid-item--full--large',
+									'stats__flexible-grid-item--full--medium'
 								) }
 								showSummaryLink
 							/>
@@ -656,11 +640,9 @@ class StatsSite extends Component {
 								query={ query }
 								summaryUrl={ this.getStatHref( this.props.period, 'authors', slug ) }
 								className={ clsx(
-									{
-										'stats__author-views': ! supportsUTMStats,
-									},
 									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large'
+									'stats__flexible-grid-item--full--large',
+									'stats__flexible-grid-item--full--medium'
 								) }
 							/>
 						) }
@@ -673,16 +655,7 @@ class StatsSite extends Component {
 								query={ query }
 								summaryUrl={ this.getStatHref( this.props.period, 'emails', slug ) }
 								className={ clsx(
-									{
-										// half if odd number of modules after countries - UTM + Clicks + Authors or Clicks
-										'stats__flexible-grid-item--half':
-											( supportsUTMStats && ! this.isModuleHidden( 'authors' ) ) ||
-											( ! supportsUTMStats && this.isModuleHidden( 'authors' ) ),
-										// full if even number of modules after countries - UTM + Clicks or Authors + Clicks
-										'stats__flexible-grid-item--full':
-											( supportsUTMStats && this.isModuleHidden( 'authors' ) ) ||
-											( ! supportsUTMStats && ! this.isModuleHidden( 'authors' ) ),
-									},
+									'stats__flexible-grid-item--half',
 									'stats__flexible-grid-item--full--large',
 									'stats__flexible-grid-item--full--medium'
 								) }
@@ -696,21 +669,8 @@ class StatsSite extends Component {
 								query={ query }
 								summaryUrl={ this.getStatHref( this.props.period, 'searchterms', slug ) }
 								className={ clsx(
-									{
-										// Show "Search terms" as 1/3 when it's not Jetpack ("Downloads" visible) + "Videos" is visible
-										'stats__flexible-grid-item--one-third--two-spaces':
-											! isJetpack && ! this.isModuleHidden( 'videos' ),
-									},
-									{
-										'stats__flexible-grid-item--full--large':
-											isJetpack && this.isModuleHidden( 'videos' ),
-									},
-									{
-										// 1/2 for all other cases to stack with Devices or empty space
-										'stats__flexible-grid-item--half': this.isModuleHidden( 'videos' ),
-										// Avoid 1/3 on smaller screen if Videos is visible
-										'stats__flexible-grid-item--full--large': ! this.isModuleHidden( 'videos' ),
-									},
+									'stats__flexible-grid-item--half',
+									'stats__flexible-grid-item--full--large',
 									'stats__flexible-grid-item--full--medium'
 								) }
 							/>
@@ -724,21 +684,8 @@ class StatsSite extends Component {
 								statType="statsSearchTerms"
 								showSummaryLink
 								className={ clsx(
-									{
-										// Show "Search terms" as 1/3 when it's not Jetpack ("Downloads" visible) + "Videos" is visible
-										'stats__flexible-grid-item--one-third--two-spaces':
-											! isJetpack && ! this.isModuleHidden( 'videos' ),
-									},
-									{
-										'stats__flexible-grid-item--full--large':
-											isJetpack && this.isModuleHidden( 'videos' ),
-									},
-									{
-										// 1/2 for all other cases to stack with Devices or empty space
-										'stats__flexible-grid-item--half': this.isModuleHidden( 'videos' ),
-										// Avoid 1/3 on smaller screen if Videos is visible
-										'stats__flexible-grid-item--full--large': ! this.isModuleHidden( 'videos' ),
-									},
+									'stats__flexible-grid-item--half',
+									'stats__flexible-grid-item--full--large',
 									'stats__flexible-grid-item--full--medium'
 								) }
 							/>
@@ -751,10 +698,7 @@ class StatsSite extends Component {
 								query={ query }
 								summaryUrl={ this.getStatHref( this.props.period, 'videoplays', slug ) }
 								className={ clsx(
-									{
-										'stats__flexible-grid-item--one-third--two-spaces': ! isJetpack, // 1/3 when Downloads is supported, 1/2 for Jetpack
-										'stats__flexible-grid-item--half': isJetpack,
-									},
+									'stats__flexible-grid-item--half',
 									'stats__flexible-grid-item--full--large',
 									'stats__flexible-grid-item--full--medium'
 								) }
@@ -770,10 +714,7 @@ class StatsSite extends Component {
 								statType="statsVideoPlays"
 								showSummaryLink
 								className={ clsx(
-									{
-										'stats__flexible-grid-item--one-third--two-spaces': ! isJetpack, // 1/3 when Downloads is supported, 1/2 for Jetpack
-										'stats__flexible-grid-item--half': isJetpack,
-									},
+									'stats__flexible-grid-item--half',
 									'stats__flexible-grid-item--full--large',
 									'stats__flexible-grid-item--full--medium'
 								) }
@@ -789,17 +730,8 @@ class StatsSite extends Component {
 									query={ query }
 									summaryUrl={ this.getStatHref( this.props.period, 'filedownloads', slug ) }
 									className={ clsx(
-										{
-											'stats__flexible-grid-item--half': this.isModuleHidden( 'videos' ),
-										},
-										{
-											'stats__flexible-grid-item--one-third--two-spaces':
-												! this.isModuleHidden( 'videos' ),
-										},
-										{
-											// Avoid 1/3 on smaller screen if Videos is visible
-											'stats__flexible-grid-item--full--large': ! this.isModuleHidden( 'videos' ),
-										},
+										'stats__flexible-grid-item--half',
+										'stats__flexible-grid-item--full--large',
 										'stats__flexible-grid-item--full--medium'
 									) }
 								/>
@@ -819,18 +751,9 @@ class StatsSite extends Component {
 									showSummaryLink
 									useShortLabel
 									className={ clsx(
-										{
-											'stats__flexible-grid-item--half': this.isModuleHidden( 'videos' ),
-										},
-										{
-											'stats__flexible-grid-item--one-third--two-spaces':
-												! this.isModuleHidden( 'videos' ),
-										},
-
-										{
-											// Avoid 1/3 on smaller screen if Videos is visible
-											'stats__flexible-grid-item--full--large': ! this.isModuleHidden( 'videos' ),
-										},
+										'stats__flexible-grid-item--half',
+										// Avoid 1/3 on smaller screen if Videos is visible
+										'stats__flexible-grid-item--full--large',
 										'stats__flexible-grid-item--full--medium'
 									) }
 								/>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -350,11 +350,7 @@ class StatsSite extends Component {
 			'stats__module-list',
 			'stats__module-list--traffic',
 			'stats__module--unified',
-			'stats__flexible-grid-container',
-			{
-				'stats__module-list--traffic-no-authors': this.isModuleHidden( 'authors' ),
-				'stats__module-list--traffic-no-videos': this.isModuleHidden( 'videos' ),
-			}
+			'stats__flexible-grid-container'
 		);
 
 		return (
@@ -752,7 +748,6 @@ class StatsSite extends Component {
 									useShortLabel
 									className={ clsx(
 										'stats__flexible-grid-item--half',
-										// Avoid 1/3 on smaller screen if Videos is visible
 										'stats__flexible-grid-item--full--large',
 										'stats__flexible-grid-item--full--medium'
 									) }


### PR DESCRIPTION
Related to #

## Proposed Changes

* Change widths for all modules to half for bigger screens except for the countries module
* Remove feature flag `stats/empty-module-traffic` for the Traffic page, which is in the way of the change

## Why are these changes being made?

* Simplify layout for more flexible module show/hide combinations

## Testing Instructions

* Open Calypso Live `/stats/day/jetpack.com`
* Ensure All modules are set to half width for wider screens except for the countries module
* Change the width of view port
* Ensure it still looks okay
* Add feature flag `flags=stats/new-date-filtering`
* Ensure it looks okay without the Email stats module

<img width="334" alt="image" src="https://github.com/user-attachments/assets/d6505740-05bd-43fa-ac6b-a8fe37285a4e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
