### PR TITLE
Untangling: redirect to /hosting-features if Advanced Tools is not supported

### DIFF
--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { siteLaunchStatusGroupValues } from '@automattic/sites';
 import { Global, css } from '@emotion/react';
 import { removeQueryArgs } from '@wordpress/url';
@@ -148,5 +149,17 @@ export function maybeRemoveCheckoutSuccessNotice( context: PageJSContext, next: 
 		// so hide the checkout success notice if it's there.
 		context.store.dispatch( removeNotice( 'checkout-thank-you-success' ) );
 	}
+	next();
+}
+
+export function redirectToHostingFeaturesIfNotAtomic( context: PageJSContext, next: () => void ) {
+	const state = context.store.getState();
+	const site = getSelectedSite( state );
+	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
+
+	if ( ! isAtomicSite || site.plan?.expired ) {
+		return page.redirect( `/hosting-features/${ site?.slug }` );
+	}
+
 	next();
 }

--- a/client/sites/tools/index.tsx
+++ b/client/sites/tools/index.tsx
@@ -9,7 +9,7 @@ import {
 	TOOLS_SFTP_SSH,
 	TOOLS_DATABASE,
 } from 'calypso/sites/components/site-preview-pane/constants';
-import { siteDashboard } from 'calypso/sites/controller';
+import { redirectToHostingFeaturesIfNotAtomic, siteDashboard } from 'calypso/sites/controller';
 import { stagingSite, deployments, monitoring, logs, sftpSsh, database } from './controller';
 
 export default function () {
@@ -17,6 +17,7 @@ export default function () {
 	page(
 		'/sites/tools/staging-site/:site',
 		siteSelection,
+		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		stagingSite,
 		siteDashboard( TOOLS_STAGING_SITE ),
@@ -28,6 +29,7 @@ export default function () {
 	page(
 		'/sites/tools/deployments/:site',
 		siteSelection,
+		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		deployments,
 		siteDashboard( TOOLS_DEPLOYMENTS ),
@@ -39,6 +41,7 @@ export default function () {
 	page(
 		'/sites/tools/monitoring/:site',
 		siteSelection,
+		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		monitoring,
 		siteDashboard( TOOLS_MONITORING ),
@@ -50,6 +53,7 @@ export default function () {
 	page(
 		'/sites/tools/logs/:site',
 		siteSelection,
+		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		logs,
 		siteDashboard( TOOLS_LOGS ),
@@ -61,6 +65,7 @@ export default function () {
 	page(
 		'/sites/tools/sftp-ssh/:site',
 		siteSelection,
+		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		sftpSsh,
 		siteDashboard( TOOLS_SFTP_SSH ),
@@ -72,6 +77,7 @@ export default function () {
 	page(
 		'/sites/tools/database/:site',
 		siteSelection,
+		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		database,
 		siteDashboard( TOOLS_DATABASE ),


### PR DESCRIPTION
## Proposed Changes

This PR redirects us to /hosting-features if a Simple site goes to Advanced Tools tab.

## Testing Instructions

1. Go to /sites, click an Atomic site.
   - Verify you can see and click Advanced Tools tab.
1. Click Advanced Tools tab and click any subtab.
1. Now click any simple site in the site list sidebar.
   - Verify you are redirected to `/hosting-features` for that site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
