### PR TITLE
wpcom-block-editor: Support getting the canvas mode from the query string after GB 19.6

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -6,13 +6,13 @@ import {
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState, useMemo } from 'react';
 import wpcom from 'calypso/lib/wp';
+import useLocation from '../../../hooks/use-location';
 import {
 	currentlyPreviewingTheme,
 	PERSONAL_THEME,
 	PREMIUM_THEME,
 	WOOCOMMERCE_THEME,
 } from '../utils';
-import useLocation from './use-location';
 import type { Theme } from 'calypso/types';
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-sidebar-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-sidebar-notice.tsx
@@ -1,13 +1,10 @@
 import { Notice } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { render } from '@wordpress/element';
 import { useEffect, useRef, FC, ComponentProps } from 'react';
-import { getUnlock } from '../utils';
+import useCanvasMode from '../../../hooks/use-canvas-mode';
 
 const SAVE_HUB_SELECTOR = '.edit-site-save-hub';
 const SIDEBAR_NOTICE_SELECTOR = 'wpcom-live-preview-sidebar-notice';
-
-const unlock = getUnlock();
 
 const SidebarNotice: FC< {
 	noticeProps: ComponentProps< typeof Notice >;
@@ -27,11 +24,7 @@ export const useSidebarNotice = ( {
 	shouldShowNotice?: boolean;
 } ) => {
 	const isRendered = useRef( false );
-	const canvasMode = useSelect(
-		( select ) =>
-			unlock && select( 'core/edit-site' ) && unlock( select( 'core/edit-site' ) ).getCanvasMode(),
-		[]
-	);
+	const canvasMode = useCanvasMode();
 
 	useEffect( () => {
 		if ( ! shouldShowNotice ) {

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
@@ -1,13 +1,13 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { FC, useEffect } from 'react';
+import { getUnlock } from '../../utils';
 import { NOTICE_ID } from './constants';
 import { useCanPreviewButNeedUpgrade } from './hooks/use-can-preview-but-need-upgrade';
 import { useHideTemplatePartHint } from './hooks/use-hide-template-part-hint';
 import { usePreviewingTheme } from './hooks/use-previewing-theme';
 import { LivePreviewUpgradeButton } from './upgrade-button';
 import { LivePreviewUpgradeNotice } from './upgrade-notice';
-import { getUnlock } from './utils';
 
 const unlock = getUnlock();
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-button.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-button.tsx
@@ -1,26 +1,19 @@
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { FC, useEffect } from 'react';
+import useCanvasMode from '../../hooks/use-canvas-mode';
 import tracksRecordEvent from '../tracking/track-record-event';
 import { usePreviewingTheme } from './hooks/use-previewing-theme';
-import { getUnlock } from './utils';
 
 import './upgrade-button.scss';
 
 const SAVE_HUB_SAVE_BUTTON_SELECTOR = '.edit-site-save-hub__button';
 const HEADER_SAVE_BUTTON_SELECTOR = '.edit-site-save-button__button';
 
-const unlock = getUnlock();
-
 export const LivePreviewUpgradeButton: FC< {
 	previewingTheme: ReturnType< typeof usePreviewingTheme >;
 	upgradePlan: () => void;
 } > = ( { previewingTheme, upgradePlan } ) => {
-	const canvasMode = useSelect(
-		( select ) =>
-			unlock && select( 'core/edit-site' ) && unlock( select( 'core/edit-site' ) ).getCanvasMode(),
-		[]
-	);
+	const canvasMode = useCanvasMode();
 
 	/**
 	 * This overrides the `SaveButton` behavior by adding a listener and changing the copy.

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
@@ -1,32 +1,8 @@
-import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { getQueryArg } from '@wordpress/url';
 
 export const WOOCOMMERCE_THEME = 'woocommerce';
 export const PREMIUM_THEME = 'premium';
 export const PERSONAL_THEME = 'personal';
-
-/**
- * Get unlock API from Gutenberg.
- * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
- */
-export const getUnlock = () => {
-	/**
-	 * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
-	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	let unlock: ( object: any ) => any | undefined;
-	try {
-		unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-			'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-			'@wordpress/edit-site'
-		).unlock;
-		return unlock;
-	} catch ( error ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Error: Unable to get the unlock api. Reason: %s', error );
-		return undefined;
-	}
-};
 
 /**
  * Return true if the user is currently previewing a theme.

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/site-editor-load.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/site-editor-load.tsx
@@ -1,34 +1,11 @@
-import { select, useSelect } from '@wordpress/data';
+import { select } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
-import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { useEffect } from 'react';
+import useCanvasMode from '../../hooks/use-canvas-mode';
 import tracksRecordEvent from './track-record-event';
 
-/**
- * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
- * FIXME: The new version allow it by default, but we might need to ensure that all the site has the new version.
- * @see https://github.com/Automattic/wp-calypso/pull/79663
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let unlock: ( object: any ) => any | undefined;
-try {
-	unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-		'@wordpress/edit-site'
-	).unlock;
-} catch ( error ) {
-	// eslint-disable-next-line no-console
-	console.error( 'Error: Unable to get the unlock api. Reason: %s', error );
-}
-
 const SiteEditorLoad = () => {
-	const canvasMode = useSelect(
-		( _select ) =>
-			unlock &&
-			_select( 'core/edit-site' ) &&
-			unlock( _select( 'core/edit-site' ) ).getCanvasMode(),
-		[]
-	);
+	const canvasMode = useCanvasMode();
 
 	useEffect( () => {
 		// Don't send the event in the Post Editor context.

--- a/apps/wpcom-block-editor/src/wpcom/hooks/use-canvas-mode.ts
+++ b/apps/wpcom-block-editor/src/wpcom/hooks/use-canvas-mode.ts
@@ -1,0 +1,27 @@
+import { useSelect } from '@wordpress/data';
+import { getUnlock } from '../utils';
+import useLocation from './use-location';
+
+const unlock = getUnlock();
+
+const useCanvasMode = () => {
+	const location = useLocation();
+
+	return useSelect(
+		( select ) => {
+			const getCanvasMode = ( unlock &&
+				select( 'core/edit-site' ) &&
+				unlock( select( 'core/edit-site' ) ).getCanvasMode ) as ( () => string ) | undefined;
+
+			// The selector is deprecated after GB 19.6. See https://github.com/WordPress/gutenberg/pull/66213.
+			if ( getCanvasMode ) {
+				return getCanvasMode();
+			}
+
+			return new URLSearchParams( location?.search ).get( 'canvas' ) || 'view';
+		},
+		[ location?.search ]
+	);
+};
+
+export default useCanvasMode;

--- a/apps/wpcom-block-editor/src/wpcom/hooks/use-canvas-mode.ts
+++ b/apps/wpcom-block-editor/src/wpcom/hooks/use-canvas-mode.ts
@@ -1,21 +1,14 @@
 import { useSelect } from '@wordpress/data';
-import { getUnlock } from '../utils';
 import useLocation from './use-location';
-
-const unlock = getUnlock();
 
 const useCanvasMode = () => {
 	const location = useLocation();
 
 	return useSelect(
 		( select ) => {
-			const getCanvasMode = ( unlock &&
-				select( 'core/edit-site' ) &&
-				unlock( select( 'core/edit-site' ) ).getCanvasMode ) as ( () => string ) | undefined;
-
-			// The selector is deprecated after GB 19.6. See https://github.com/WordPress/gutenberg/pull/66213.
-			if ( getCanvasMode ) {
-				return getCanvasMode();
+			// The canvas mode is limited to the site editor.
+			if ( ! select( 'core/edit-site' ) ) {
+				return null;
 			}
 
 			return new URLSearchParams( location?.search ).get( 'canvas' ) || 'view';

--- a/apps/wpcom-block-editor/src/wpcom/hooks/use-location.ts
+++ b/apps/wpcom-block-editor/src/wpcom/hooks/use-location.ts
@@ -5,7 +5,7 @@ const unlock = getUnlock();
 
 const routerPrivateApis = router?.privateApis;
 
-let useLocation = () => null;
+let useLocation: () => Location | null = () => null;
 
 // The routerPrivateApis may be unavailable.
 if ( unlock && routerPrivateApis && unlock( routerPrivateApis ) ) {

--- a/apps/wpcom-block-editor/src/wpcom/utils.ts
+++ b/apps/wpcom-block-editor/src/wpcom/utils.ts
@@ -1,0 +1,24 @@
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+/**
+ * Get unlock API from Gutenberg.
+ * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
+ */
+export const getUnlock = () => {
+	/**
+	 * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let unlock: ( object: any ) => any | undefined;
+	try {
+		unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+			'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+			'@wordpress/edit-site'
+		).unlock;
+		return unlock;
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Error: Unable to get the unlock api. Reason: %s', error );
+		return undefined;
+	}
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95960

## Proposed Changes

* Support getting the canvas mode from the query string because the `getCanvasMode` selector is removed after GB 19.6

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `getCanvasMode` selector is removed after GB 19.6 and causes the error.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `widgets.wp.com`
* Apply changes to your site by either one of below
  * Run `yarn dev --sync`
  * Run `install-plugin.sh wpcom-block-editor fix/wpcom-block-editor-canvas-mode` on your sandbox
* Go to Theme Showcase on your free site
* Pick any paid block theme
* Preview the theme in the editor
* Make sure to disable the cache of `https://widgets.wp.com/wpcom-block-editor/wpcom.editor.min.js`
* Make sure you can see the upgrade notice of the live preview on both view and edit mode

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
