### PR TITLE
Ensure site prop is not null

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -601,6 +601,10 @@ export class SiteSettingsFormGeneral extends Component {
 		} );
 		const isDevelopmentSite = Boolean( site?.is_a4a_dev_site );
 
+		if ( ! site ) {
+			return null;
+		}
+
 		return (
 			<div className={ clsx( classes ) }>
 				{ site && <QuerySiteSettings siteId={ site.ID } /> }

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -377,7 +377,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 
 			return (
 				<div>
-					<QuerySiteSettings siteId={ this.props.siteId } />
+					{ this.props.siteId && <QuerySiteSettings siteId={ this.props.siteId } /> }
 					{ this.props.siteIsJetpack && <QueryJetpackSettings siteId={ this.props.siteId } /> }
 					<SettingsForm { ...this.props } { ...utils } />
 				</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/95973

## Proposed Changes

Ensures site / siteId is not null before trying to render the settings form. This was occurring during navigation between `/settings/general` and `/sites`. See issue for repro video.

## Testing

- Navigate to Settings > General
- Click the "W" logo to navigate to /sites
- The /sites dashboard should load first time
- There should be no console errors (other than the unrelated warning about "Invalid prop `callToAction`".)