### PR TITLE
Untangling: refactor feature gating so that sidebar and content use same logic

### DIFF
--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -6,6 +6,7 @@ import React, { useMemo, useEffect } from 'react';
 import ItemPreviewPane from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import HostingFeaturesIcon from 'calypso/hosting/hosting-features/components/hosting-features-icon';
 import { useStagingSite } from 'calypso/hosting/staging-site/hooks/use-staging-site';
+import { isAtomicFeatureSupported } from 'calypso/sites/utils';
 import { getMigrationStatus } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
@@ -125,7 +126,7 @@ const DotcomPreviewPane = ( {
 			},
 			{
 				label: __( 'Advanced Tools' ),
-				enabled: isActiveAtomicSite && config.isEnabled( 'untangling/hosting-menu' ),
+				enabled: isAtomicFeatureSupported( site ) && config.isEnabled( 'untangling/hosting-menu' ),
 				featureIds: [
 					TOOLS_STAGING_SITE,
 					TOOLS_DEPLOYMENTS,

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -8,6 +8,7 @@ import { removeNotice } from 'calypso/state/notices/actions';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import SitesDashboard from './components/sites-dashboard';
+import { isAtomicFeatureSupported } from './utils';
 import type { Context, Context as PageJSContext } from '@automattic/calypso-router';
 
 const getStatusFilterValue = ( status?: string ) => {
@@ -155,9 +156,8 @@ export function maybeRemoveCheckoutSuccessNotice( context: PageJSContext, next: 
 export function redirectToHostingFeaturesIfNotAtomic( context: PageJSContext, next: () => void ) {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
-	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
 
-	if ( ! isAtomicSite || site.plan?.expired ) {
+	if ( ! isAtomicFeatureSupported( site ) ) {
 		return page.redirect( `/hosting-features/${ site?.slug }` );
 	}
 

--- a/client/sites/settings/administration/hooks/use-is-administration-setting-supported.tsx
+++ b/client/sites/settings/administration/hooks/use-is-administration-setting-supported.tsx
@@ -1,0 +1,6 @@
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
+import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
+
+export default function useIsAdministrationSettingSupported() {
+	return ! useSelectedSiteSelector( isSiteWpcomStaging );
+}

--- a/client/sites/settings/administration/index.tsx
+++ b/client/sites/settings/administration/index.tsx
@@ -1,15 +1,30 @@
 import { useTranslate } from 'i18n-calypso';
 import NavigationHeader from 'calypso/components/navigation-header';
+import Notice from 'calypso/components/notice';
 import SiteTools from 'calypso/my-sites/site-settings/site-tools';
 import { SOURCE_SETTINGS_ADMINISTRATION } from 'calypso/my-sites/site-settings/site-tools/utils';
+import useIsAdministrationSettingSupported from './hooks/use-is-administration-setting-supported';
 
 export default function AdministrationSettings() {
 	const translate = useTranslate();
+	const isSupported = useIsAdministrationSettingSupported();
+
+	const renderNotSupportedNotice = () => {
+		return (
+			<Notice showDismiss={ false } status="is-warning">
+				{ translate( 'This setting is not supported for staging sites.' ) }
+			</Notice>
+		);
+	};
+
+	const renderSetting = () => {
+		return <SiteTools source={ SOURCE_SETTINGS_ADMINISTRATION } />;
+	};
 
 	return (
 		<div className="administration-settings">
 			<NavigationHeader title={ translate( 'Administration' ) } />
-			<SiteTools source={ SOURCE_SETTINGS_ADMINISTRATION } />
+			{ isSupported ? renderSetting() : renderNotSupportedNotice() }
 		</div>
 	);
 }

--- a/client/sites/settings/agency/hooks/use-is-agency-setting-supported.tsx
+++ b/client/sites/settings/agency/hooks/use-is-agency-setting-supported.tsx
@@ -1,0 +1,12 @@
+import useFetchAgencyFromBlog from 'calypso/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+export default function useIsAgencySettingSupported() {
+	const site = useSelector( getSelectedSite );
+	const { data: agencySite } = useFetchAgencyFromBlog( site?.ID ?? 0, { enabled: !! site?.ID } );
+
+	const isAtomicSite = site?.is_wpcom_atomic;
+
+	return !! agencySite && isAtomicSite;
+}

--- a/client/sites/settings/agency/index.tsx
+++ b/client/sites/settings/agency/index.tsx
@@ -1,10 +1,11 @@
-import { __ } from '@wordpress/i18n';
-import useFetchAgencyFromBlog from 'calypso/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog';
+import { useTranslate } from 'i18n-calypso';
 import NavigationHeader from 'calypso/components/navigation-header';
+import Notice from 'calypso/components/notice';
 import { A4AFullyManagedSiteSetting } from 'calypso/my-sites/site-settings/a4a-fully-managed-site-setting';
 import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import useIsAgencySettingSupported from './hooks/use-is-agency-setting-supported';
 
 interface Fields {
 	is_fully_managed_agency_site: boolean;
@@ -27,18 +28,22 @@ const AgencySettings = ( {
 	isSavingSettings,
 }: AgencySettingsProps ) => {
 	const site = useSelector( getSelectedSite );
-	const { data: agencySite } = useFetchAgencyFromBlog( site?.ID ?? 0, { enabled: !! site?.ID } );
+	const translate = useTranslate();
+	const isSupported = useIsAgencySettingSupported();
 
-	const isAtomicSite = site?.is_wpcom_atomic;
+	const renderNotSupportedNotice = () => {
+		return (
+			<Notice showDismiss={ false } status="is-warning">
+				{ translate( 'This setting is not supported for non-agency sites.' ) }
+			</Notice>
+		);
+	};
 
-	const shouldShowToggle = agencySite && isAtomicSite;
-
-	return (
-		<div className="agency-settings">
-			<NavigationHeader title={ __( 'Agency' ) } />
-			{ shouldShowToggle && site && (
+	const renderSetting = () => {
+		return (
+			site && (
 				<A4AFullyManagedSiteSetting
-					title={ __( 'Client Access' ) }
+					title={ translate( 'Client Access' ) }
 					site={ site }
 					isFullyManagedAgencySite={ fields.is_fully_managed_agency_site }
 					onChange={ handleToggle( 'is_fully_managed_agency_site' ) }
@@ -46,12 +51,14 @@ const AgencySettings = ( {
 					onSaveSetting={ handleSubmitForm }
 					disabled={ isRequestingSettings || isSavingSettings }
 				/>
-			) }
-			{ ! shouldShowToggle && (
-				<div>
-					<p>{ __( 'Agency settings are not available for this site.' ) }</p>
-				</div>
-			) }
+			)
+		);
+	};
+
+	return (
+		<div className="agency-settings">
+			<NavigationHeader title={ translate( 'Agency' ) } />
+			{ isSupported ? renderSetting() : renderNotSupportedNotice() }
 		</div>
 	);
 };

--- a/client/sites/utils.ts
+++ b/client/sites/utils.ts
@@ -1,0 +1,8 @@
+import { SiteExcerptData } from '@automattic/sites';
+
+export function isAtomicFeatureSupported( site?: SiteExcerptData | null ) {
+	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
+	const isPlanExpired = site?.plan?.expired;
+
+	return isAtomicSite && ! isPlanExpired;
+}


### PR DESCRIPTION
## Proposed Changes

This is a refactor PR. This PR extract the feature gating logic so that the sidebar and actual component share the same logic of whether or not to show the feature.

This also "reverts" some decision made in

- https://github.com/Automattic/wp-calypso/pull/95937

as I work on improving the Agency setting. Specifically, this is because the logic to decide whether the Agency subtab is available or not, needs to call a hook, which cannot be done in controller/router level.

So, in this PR:

- Extract the feature gating logic to `isAgencySettingSupported()` and `useIsAdministrationSettingSupported()`.
- The component itself (such as `<AgencySettings/>`, `<AdministrationSettings/>`) needs to gate the feature using the shared functions.
- The sidebar also calls the functions.
- With this, we can show the heading when a showing a non-supported feature.

I realize that it's useful for individual components to decide what to do if that subtab is not supported. For example, we might [want to show upsell](https://github.com/Automattic/dotcom-forge/issues/9623#issuecomment-2451369705).

Sorry for back-and-forth discussion!

## Why are these changes being made?

Refactor a logic.

## Testing Instructions

1. Go to `/sites/administration/:siteSlug` of a staging site, verify you see:
    <img width="661" alt="image" src="https://github.com/user-attachments/assets/3418bf4f-9d34-4332-ba7d-71a85636fa26">
1. Go to `/sites/agency/:siteSlug` of a non-agency site, verify you see:
    <img width="663" alt="image" src="https://github.com/user-attachments/assets/e494f904-52b3-4ef0-8fc3-58e8c02ccaf8">
1. Go to `/sites/tools/staging-site/:siteSlug` of a Simple site, verify you are redirected to Hosting Features.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
