### PR TITLE
Help Center: Add long message validation error

### DIFF
--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -590,3 +590,16 @@ $custom-border-corner-size: 16px;
 .odie-chatbox-thinking-icon {
 	margin-left: 8px;
 }
+
+.odie-chatbox-invalid__message{
+	color: rgb(140, 35, 44);
+    font-size: 0.75rem;
+    top: 66%;
+    width: 95%;
+    background: #fff;
+    position: fixed;
+    bottom: 73px;
+    height: 30px;
+    text-align: center;
+	padding-top: 6px;
+}

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -38,11 +38,11 @@ export const OdieSendMessageButton = ( {
 	const sendMessageHandler = useCallback( async () => {
 		const message = inputRef.current?.value.trim();
 		const messageLength = message?.length || 0;
-		const isMessageValidLength = isMessageExceedingMaxLength( messageLength );
+		const isMessageLengthValid = isMessageExceedingMaxLength( messageLength );
 
-		setIsMessageSizeValid( isMessageValidLength );
+		setIsMessageSizeValid( isMessageLengthValid );
 
-		if ( message === '' || shouldBeDisabled || ! isMessageValidLength ) {
+		if ( message === '' || shouldBeDisabled || ! isMessageLengthValid ) {
 			return;
 		}
 		const messageString = inputRef.current?.value;

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -24,11 +24,6 @@ export const OdieSendMessageButton = ( {
 	const shouldBeDisabled = chatStatus === 'loading' || chatStatus === 'sending';
 	const [ isMessageSizeValid, setIsMessageSizeValid ] = useState( true );
 
-	const isMessageExceedingMaxLength = ( messageLength: number ) => {
-		// zendesk api validation
-		return messageLength <= 4096;
-	};
-
 	const onKeyUp = useCallback( () => {
 		// Only triggered when the message is empty
 		// used to remove validation message.
@@ -38,11 +33,15 @@ export const OdieSendMessageButton = ( {
 	const sendMessageHandler = useCallback( async () => {
 		const message = inputRef.current?.value.trim();
 		const messageLength = message?.length || 0;
-		const isMessageLengthValid = isMessageExceedingMaxLength( messageLength );
+		const isMessageLengthValid = messageLength <= 4096; // zendesk api validation
 
 		setIsMessageSizeValid( isMessageLengthValid );
 
-		if ( message === '' || shouldBeDisabled || ! isMessageLengthValid ) {
+		if (
+			message === '' ||
+			shouldBeDisabled ||
+			( shouldUseHelpCenterExperience && ! isMessageLengthValid )
+		) {
 			return;
 		}
 		const messageString = inputRef.current?.value;

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@wordpress/components';
-import { useCallback, useRef, RefObject } from '@wordpress/element';
+import { useCallback, useRef, RefObject, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import ArrowUp from '../../assets/arrow-up.svg';
@@ -22,9 +22,27 @@ export const OdieSendMessageButton = ( {
 	const { trackEvent, chatStatus, shouldUseHelpCenterExperience } = useOdieAssistantContext();
 	const sendMessage = useSendChatMessage();
 	const shouldBeDisabled = chatStatus === 'loading' || chatStatus === 'sending';
+	const [ isMessageSizeValid, setIsMessageSizeValid ] = useState( true );
+
+	const isMessageExceedingMaxLength = ( messageLength: number ) => {
+		// zendesk api validation
+		return messageLength <= 4096;
+	};
+
+	const onKeyUp = useCallback( () => {
+		// Only triggered when the message is empty
+		// used to remove validation message.
+		setIsMessageSizeValid( true );
+	}, [] );
 
 	const sendMessageHandler = useCallback( async () => {
-		if ( inputRef.current?.value.trim() === '' || shouldBeDisabled ) {
+		const message = inputRef.current?.value.trim();
+		const messageLength = message?.length || 0;
+		const isMessageValidLength = isMessageExceedingMaxLength( messageLength );
+
+		setIsMessageSizeValid( isMessageValidLength );
+
+		if ( message === '' || shouldBeDisabled || ! isMessageValidLength ) {
 			return;
 		}
 		const messageString = inputRef.current?.value;
@@ -48,13 +66,18 @@ export const OdieSendMessageButton = ( {
 				error: error?.message,
 			} );
 		}
-	}, [ sendMessage, trackEvent ] );
+	}, [ sendMessage, shouldBeDisabled, trackEvent ] );
 	const classes = clsx(
 		'odie-send-message-inner-button',
 		shouldUseHelpCenterExperience && 'odie-send-message-inner-button__flag'
 	);
 	return (
 		<>
+			{ ! isMessageSizeValid && shouldUseHelpCenterExperience && (
+				<div className="odie-chatbox-invalid__message">
+					{ __( 'Message exceeds 4096 characters limit.' ) }
+				</div>
+			) }
 			<JumpToRecent containerReference={ containerReference } />
 			<div className="odie-chat-message-input-container" ref={ divContainerRef }>
 				<form
@@ -68,6 +91,7 @@ export const OdieSendMessageButton = ( {
 						sendMessageHandler={ sendMessageHandler }
 						className="odie-send-message-input"
 						inputRef={ inputRef }
+						keyUpHandle={ onKeyUp }
 					/>
 					{ shouldBeDisabled && <Spinner className="odie-send-message-input-spinner" /> }
 					<button type="submit" className={ classes } disabled={ shouldBeDisabled }>

--- a/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
+++ b/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
@@ -6,11 +6,14 @@ import React, { KeyboardEvent } from 'react';
 export const ResizableTextarea: React.FC< {
 	className: string;
 	inputRef: React.RefObject< HTMLTextAreaElement >;
+	keyUpHandle: () => void;
 	sendMessageHandler: () => Promise< void >;
-} > = ( { className, sendMessageHandler, inputRef } ) => {
-	const onKeyDown = useCallback(
+} > = ( { className, sendMessageHandler, inputRef, keyUpHandle } ) => {
+	const onKeyUp = useCallback(
 		async ( event: KeyboardEvent< HTMLTextAreaElement > ) => {
 			if ( inputRef.current?.value.trim() === '' ) {
+				// call the handler to remove the validation message if visible.
+				keyUpHandle();
 				return;
 			}
 			if ( event.key === 'Enter' && ! event.shiftKey ) {
@@ -18,7 +21,7 @@ export const ResizableTextarea: React.FC< {
 				await sendMessageHandler();
 			}
 		},
-		[ inputRef, sendMessageHandler ]
+		[ inputRef, sendMessageHandler, keyUpHandle ]
 	);
 
 	useEffect( () => {
@@ -45,7 +48,7 @@ export const ResizableTextarea: React.FC< {
 			ref={ inputRef }
 			rows={ 1 }
 			className={ className }
-			onKeyDown={ onKeyDown }
+			onKeyUp={ onKeyUp }
 			placeholder={ __( 'Type a message…', __i18n_text_domain__ ) }
 			style={ { transition: 'none' } }
 		/>

--- a/packages/odie-client/src/components/send-message-input/style.scss
+++ b/packages/odie-client/src/components/send-message-input/style.scss
@@ -61,7 +61,7 @@ $blueberry-color: #3858e9;
 
 
 	&[disabled] {
-		background-color: var(--color-neutral-20) !important;;
+		background-color: var(--color-neutral-20);
 		border-color: var(--color-neutral-5);
 		cursor: default;
 

--- a/packages/odie-client/src/components/send-message-input/style.scss
+++ b/packages/odie-client/src/components/send-message-input/style.scss
@@ -61,7 +61,7 @@ $blueberry-color: #3858e9;
 
 
 	&[disabled] {
-		background-color: var(--color-neutral-20);
+		background-color: var(--color-neutral-20) !important;;
 		border-color: var(--color-neutral-5);
 		cursor: default;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95584
Fixes https://github.com/Automattic/wp-calypso/issues/95584

## Proposed Changes

* Prevent long messages (4096 chars) from being sent since the API doesn't accept it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Prevent API errors and display to users that long messages are not allowed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and add flag `?flags=help-center-experience`
* Open a chat and type a really long message
* You should get a message explaining that the message is long

<img width="433" alt="image" src="https://github.com/user-attachments/assets/c8c632b1-5a9e-405a-b8c9-6b4017339a6f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
