### PR TITLE
Help Center: Fix avatar size

### DIFF
--- a/packages/odie-client/src/assets/wapuu-avatar.tsx
+++ b/packages/odie-client/src/assets/wapuu-avatar.tsx
@@ -1,12 +1,5 @@
-export const WapuuAvatar = ( { className }: { className: string } ) => (
-	<svg
-		className={ className }
-		width="38"
-		height="38"
-		viewBox="0 0 38 38"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-	>
+export const WapuuAvatar = () => (
+	<svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<circle cx="19" cy="19" r="19" fill="#FFD200" />
 		<g clipPath="url(#clip0_286_11962)">
 			<circle cx="30.0846" cy="15.8333" r="1.58333" fill="black" />

--- a/packages/odie-client/src/components/message/dislike-feedback-message.tsx
+++ b/packages/odie-client/src/components/message/dislike-feedback-message.tsx
@@ -14,7 +14,7 @@ export const DislikeFeedbackMessage = () => {
 		return (
 			<>
 				<div className="message-header bot">
-					<WapuuAvatar className="odie-chatbox-message-avatar" />
+					<WapuuAvatar />
 					<strong className="message-header-name"></strong>
 				</div>
 				<div className="odie-chatbox-dislike-feedback-message">

--- a/packages/odie-client/src/components/message/index.tsx
+++ b/packages/odie-client/src/components/message/index.tsx
@@ -48,7 +48,7 @@ const MessageAvatarHeader = ( {
 	if ( shouldUseHelpCenterExperience ) {
 		return message.role === 'bot' ? (
 			<>
-				<WapuuAvatar className={ wapuuAvatarClasses } />
+				<WapuuAvatar />
 				<strong className="message-header-name"></strong>
 
 				{ ! shouldUseHelpCenterExperience && (

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -181,13 +181,6 @@ $blueberry-color: #3858e9;
 	}
 }
 
-.odie-chatbox-message-avatar {
-	width: 32px;
-	height: 32px;
-	justify-content: center;
-	align-items: center;
-}
-
 .message-header {
 	display: flex;
 	align-items: end;

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -199,6 +199,10 @@ $blueberry-color: #3858e9;
 	.bot {
 		justify-content: space-between;
 	}
+	svg {
+		width: 38px;
+		height: 38px;
+	}
 }
 
 .message-header-name {

--- a/packages/odie-client/src/components/message/thinking-placeholder.tsx
+++ b/packages/odie-client/src/components/message/thinking-placeholder.tsx
@@ -11,7 +11,7 @@ export const ThinkingPlaceholder = () => {
 		<div className="message-header bot">
 			{ shouldUseHelpCenterExperience ? (
 				<>
-					<WapuuAvatar className="odie-chatbox-message-avatar" />
+					<WapuuAvatar />
 					<img
 						src={ WapuuThinkingNew }
 						alt={ __( 'Loading state, awaiting response from AI', __i18n_text_domain__ ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9639
Fixes https://github.com/Automattic/dotcom-forge/issues/9639

## Proposed Changes

* Fix Wapuu avatar image size, it should be 38px as in Figma CMvR9P4FontAbv2b0TNMzj-fi-321_53097

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Align with the designs CMvR9P4FontAbv2b0TNMzj-fi-321_53097


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a new chat using live link
* Check if Wapuu avatar size is W: 38px and H:38px

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?