### PR TITLE
Reader: update post actions positioning

### DIFF
--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -22,8 +22,8 @@ function CommentButton( {
 
 	return (
 		<TagName
-			className="comment-button"
-			title={ translate( 'Comment' ) }
+			className="comment-button tooltip"
+			data-tooltip={ translate( 'Comment' ) }
 			onClick={ onClick }
 			href={ 'a' === TagName ? href : undefined }
 			target={ 'a' === TagName ? target : undefined }

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -20,6 +20,33 @@
 			display: none;
 		}
 	}
+
+	&.tooltip {
+		position: relative;
+		overflow: visible;
+	}
+
+	&.tooltip::after {
+		height: 20px;
+		line-height: 20px;
+		background: var(--color-sidebar-tooltip-background);
+		border-radius: 4px;
+		color: var(--color-sidebar-tooltip-text);
+		content: attr(data-tooltip);
+		display: none;
+		font-size: $font-body-extra-small;
+		padding: 3px 6px;
+		position: absolute;
+		white-space: nowrap;
+		top: -29px;
+		left: 50%;
+		transform: translateX(-50%);
+		z-index: 8;
+	}
+
+	&.tooltip:hover::after {
+		display: block;
+	}
 }
 
 .comment-button__label {

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -64,7 +64,10 @@ const ReaderPostActions = ( {
 						post={ post }
 						onClick={ onCommentClick }
 						tagName="button"
-						icon={ ReaderCommentIcon( { iconSize } ) }
+						icon={ ReaderCommentIcon( {
+							iconSize,
+							viewBox: '0 -1 20 20',
+						} ) }
 						defaultLabel={ translate( 'Comment' ) }
 					/>
 				</li>

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -98,7 +98,7 @@ class ReaderShare extends Component {
 			'reader-share__button': true,
 			'ignore-click': true,
 			'is-active': this.state.showingMenu,
-			tooltip: this.props.isReblogSelection,
+			tooltip: true,
 		} );
 
 		const popoverProps = {
@@ -123,13 +123,17 @@ class ReaderShare extends Component {
 					onMouseEnter={ preloadEditor }
 					onTouchStart={ preloadEditor }
 					ref={ this.shareButton }
-					data-tooltip={ this.props.isReblogSelection && translate( 'Repost with your thoughts' ) }
-					title={ ! this.props.isReblogSelection && translate( 'Share' ) }
+					data-tooltip={
+						this.props.isReblogSelection
+							? translate( 'Repost with your thoughts' )
+							: translate( 'Share' )
+					}
 				>
 					{ ! this.props.isReblogSelection ? (
 						<>
 							{ ReaderShareIcon( {
 								iconSize: this.props.iconSize,
+								viewBox: '0 -2 24 24',
 							} ) }
 							<span className="reader-share__label">{ translate( 'Share' ) }</span>
 						</>
@@ -137,6 +141,7 @@ class ReaderShare extends Component {
 						<>
 							{ ReaderRepostIcon( {
 								iconSize: this.props.iconSize,
+								viewBox: '0 -1 20 20',
 							} ) }
 							<span className="repost__label">{ translate( 'Repost' ) }</span>
 						</>

--- a/client/reader/components/icons/repost.jsx
+++ b/client/reader/components/icons/repost.jsx
@@ -1,10 +1,10 @@
-export default function ReaderRepostIcon( { iconSize } ) {
+export default function ReaderRepostIcon( { iconSize, viewBox = '0 0 20 20' } ) {
 	return (
 		<svg
 			key="repost"
 			width={ iconSize }
 			height={ iconSize }
-			viewBox="0 0 20 20"
+			viewBox={ viewBox }
 			xmlns="http://www.w3.org/2000/svg"
 		>
 			<path

--- a/client/reader/components/icons/share-icon.jsx
+++ b/client/reader/components/icons/share-icon.jsx
@@ -1,8 +1,8 @@
-export default function ReaderShareIcon( { iconSize } ) {
+export default function ReaderShareIcon( { iconSize, viewBox = '0 0 20 20' } ) {
 	return (
 		<svg
 			key="share"
-			viewBox="0 0 24 24"
+			viewBox={ viewBox }
 			width={ iconSize }
 			height={ iconSize }
 			xmlns="http://www.w3.org/2000/svg"

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -420,10 +420,6 @@
 	.like-button__label-status {
 		@include hide-content-accessibly();
 	}
-
-	.reader-share__button {
-		top: 2px;
-	}
 }
 
 .search-stream__results.is-two-columns .search-stream__site-results {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/95887

I noticed on Chrome the post action icons weren't aligned. Also I noticed that the hover over each icon wasn't consistent - it showed a tooltip on repost but icon title on share and comment. 

## Proposed Changes

* Aligns the post action icons
* Adds tooltip to comment icon
* Updates share icon to use tooltip

| **Before** | **After** |
|--------|-------|
| <img width="329" alt="Screenshot 2024-11-01 at 12 47 52" src="https://github.com/user-attachments/assets/f4038552-5d41-4feb-a6dd-6b5e2fe2de2b">  | <img width="336" alt="Screenshot 2024-11-01 at 12 49 12" src="https://github.com/user-attachments/assets/bf1bc831-92da-4a6d-b74f-0acced775223">  |
| <img width="337" alt="Screenshot 2024-11-01 at 12 47 31" src="https://github.com/user-attachments/assets/833fbb86-b48f-4f2a-b7b6-d331fcc9a41a">  | <img width="311" alt="Screenshot 2024-11-01 at 12 49 50" src="https://github.com/user-attachments/assets/101d1f30-87f1-4824-9e91-3644c24098a8"> |
| <img width="347" alt="Screenshot 2024-11-01 at 12 46 57" src="https://github.com/user-attachments/assets/8ec320a0-41dd-4101-9f43-9df11c675a9f">  | <img width="334" alt="Screenshot 2024-11-01 at 12 49 57" src="https://github.com/user-attachments/assets/68c31360-b467-4ccc-b9b0-a056c5637044"> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Better UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso.live `/read/search` and confirm it looks/behaves ok.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
