### PR TITLE
Domain Search: Fix back button redirect when coming from the mailboxes screen

### DIFF
--- a/client/my-sites/email/email-management/home/email-no-domain.tsx
+++ b/client/my-sites/email/email-management/home/email-no-domain.tsx
@@ -53,6 +53,8 @@ const EmailNoDomain = ( {
 		);
 	};
 
+	const addDomainUrl = `/domains/add/${ selectedSite.slug }?redirect_to=/mailboxes/${ selectedSite.slug }`;
+
 	if ( isFreePlanProduct ) {
 		return (
 			<EmptyContent
@@ -61,7 +63,7 @@ const EmailNoDomain = ( {
 				actionURL={ `/plans/${ selectedSite.slug }` }
 				secondaryAction={ translate( 'Just search for a domain' ) }
 				secondaryActionCallback={ trackEventForDomain }
-				secondaryActionURL={ `/domains/add/${ selectedSite.slug }` }
+				secondaryActionURL={ addDomainUrl }
 				illustration={ Illustration }
 				line={ translate(
 					'Upgrade to a plan now, set up your domain and pick from one of our flexible options to connect your domain with email and start getting emails today.'
@@ -78,7 +80,7 @@ const EmailNoDomain = ( {
 			<EmptyContent
 				action={ translate( 'Add a Domain' ) }
 				actionCallback={ trackEventForDomain }
-				actionURL={ `/domains/add/${ selectedSite.slug }` }
+				actionURL={ addDomainUrl }
 				illustration={ Illustration }
 				line={ translate(
 					'Claim your domain, pick from one of our flexible options to connect your domain with email and start getting emails today.'
@@ -93,7 +95,7 @@ const EmailNoDomain = ( {
 	return (
 		<EmptyContent
 			action={ translate( 'Add a Domain' ) }
-			actionURL={ `/domains/add/${ selectedSite.slug }` }
+			actionURL={ addDomainUrl }
 			actionCallback={ trackEventForDomain }
 			illustration={ Illustration }
 			line={ translate(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #95922

## Proposed Changes

This fixes the domain search back button redirecting to the wrong place when the user is coming from the "My Mailboxes" screen.

![image](https://github.com/user-attachments/assets/b0ab02a5-b72e-4450-922a-af4955b7c035)

![image](https://github.com/user-attachments/assets/eb8b9cf9-a893-4d58-a80b-8de34f1920e6)


## Testing Instructions

* Start at /mailboxes/:domain. (My Mailboxes)
* Click on the "Just search for a domain" or "Add a Domain" button. (text depends on the case)
* Once in the domain search screen, click on the back button.
* Make sure you're redirected back to the "My Mailboxes" screen instead of the domain management page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
