### PR TITLE
Reader: update ellipsis menu order

### DIFF
--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -307,18 +307,6 @@ class ReaderPostEllipsisMenu extends Component {
 					/>
 				) }
 
-				{ this.props.showFollow && (
-					<ReaderFollowButton
-						tagName={ PopoverMenuItem }
-						siteUrl={ post.feed_URL || post.site_URL }
-						followSource={ followSource }
-						iconSize={ 20 }
-						followLabel={ translate( 'Subscribe' ) }
-						followingLabel={ translate( 'Unsubscribe' ) }
-						onFollowToggle={ this.openSuggestedFollowsModal }
-					/>
-				) }
-
 				{ isEligibleForUnseen( { isWPForTeamsItem, currentRoute, hasOrganization } ) &&
 					canBeMarkedAsSeen( { post, posts } ) &&
 					post.is_seen && (
@@ -350,6 +338,18 @@ class ReaderPostEllipsisMenu extends Component {
 					<PopoverMenuItem onClick={ this.editPost } icon="pencil">
 						{ translate( 'Edit post' ) }
 					</PopoverMenuItem>
+				) }
+
+				{ this.props.showFollow && (
+					<ReaderFollowButton
+						tagName={ PopoverMenuItem }
+						siteUrl={ post.feed_URL || post.site_URL }
+						followSource={ followSource }
+						iconSize={ 20 }
+						followLabel={ translate( 'Subscribe' ) }
+						followingLabel={ translate( 'Unsubscribe' ) }
+						onFollowToggle={ this.openSuggestedFollowsModal }
+					/>
 				) }
 
 				{ isTeamMember && site && <hr className="popover__menu-separator" /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Updates the order of actions in the post ellipsis menu

## Proposed Changes

* Move `Subscribe/Unsubscribe` to the bottom of the menu order

| **Before** | **After** |
|--------|-------|
| <img width="260" alt="Screenshot 2024-11-01 at 15 23 52" src="https://github.com/user-attachments/assets/d01b377a-8a5d-47e0-b056-a9dfde7287d1"> | <img width="240" alt="Screenshot 2024-11-01 at 15 24 13" src="https://github.com/user-attachments/assets/b9fdeb2e-612f-4913-9119-761182e149b3"> |
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Better UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso live streams and click on post ellipsis menu and confirm it looks ok

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
