### PR TITLE
Fix some theme filters appearing untranslated

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -75,15 +75,21 @@ const optionShape = PropTypes.shape( {
 const staticFilters = {
 	MYTHEMES: {
 		key: STATIC_FILTERS.MYTHEMES,
-		text: translate( 'My Themes' ),
+		get text() {
+			return translate( 'My Themes' );
+		},
 	},
 	RECOMMENDED: {
 		key: STATIC_FILTERS.RECOMMENDED,
-		text: translate( 'Recommended' ),
+		get text() {
+			return translate( 'Recommended' );
+		},
 	},
 	ALL: {
 		key: STATIC_FILTERS.ALL,
-		text: translate( 'All' ),
+		get text() {
+			return translate( 'All' );
+		},
 	},
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#879

## Proposed Changes

- Refactored the `staticFilters` object to use getter functions for the text properties.
- The getter functions call the translate() method, ensuring that translation strings are freshly retrieved each time the property is accessed.

## Why are these changes being made?

These changes address a bug where translations in the theme showcase filter under `Appearance` -> `Themes` (pop-up menu) were inconsistently appearing. The text properties were previously static, causing English text to appear once, and then translated once refreshed. By converting these properties to getters that dynamically call the `translate()` function, we ensure that translations are accurately displayed each time the filters are accessed. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Switch the user locale to Mag-16 locale, e.g. Spanish
2. Visit `/home` for a website
3. Hover over `Appearance` and wait for the Popup menu to appear with the `Themes` option
![image](https://github.com/user-attachments/assets/1557c2ba-03c9-49e7-85b5-e6b50d523f67)

4. Click the `Themes` (Temas in Spanish) and observe that `My Themes` filter menu is translated. 
![Theme menu](https://github.com/user-attachments/assets/aec1a410-4048-4361-927d-4f699ac31383)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
