### PR TITLE
Odie: add support interactions API

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -36,6 +36,13 @@ export function* setHasSeenWhatsNewModal( value: boolean ) {
 	return receiveHasSeenWhatsNewModal( response.has_seen_whats_new_modal );
 }
 
+export function setCurrentSupportInteraction( supportInteraction: any ) {
+	return {
+		type: 'HELP_CENTER_SET_CURRENT_SUPPORT_INTERACTION',
+		supportInteraction,
+	} as const;
+}
+
 export const setNavigateToRoute = ( route?: string ) =>
 	( {
 		type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
@@ -163,5 +170,6 @@ export type HelpCenterAction =
 			| typeof setNavigateToRoute
 			| typeof setOdieInitialPromptText
 			| typeof setOdieBotNameSlug
+			| typeof setCurrentSupportInteraction
 	  >
 	| GeneratorReturnType< typeof setShowHelpCenter | typeof setHasSeenWhatsNewModal >;

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -4,6 +4,7 @@ import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
 import { wpcomRequest } from '../wpcom-request-controls';
 import type { APIFetchOptions } from './types';
+import type { SupportInteraction } from '@automattic/odie-client/src/types/';
 
 export const receiveHasSeenWhatsNewModal = ( value: boolean | undefined ) =>
 	( {
@@ -36,7 +37,7 @@ export function* setHasSeenWhatsNewModal( value: boolean ) {
 	return receiveHasSeenWhatsNewModal( response.has_seen_whats_new_modal );
 }
 
-export function setCurrentSupportInteraction( supportInteraction: any ) {
+export function setCurrentSupportInteraction( supportInteraction: SupportInteraction ) {
 	return {
 		type: 'HELP_CENTER_SET_CURRENT_SUPPORT_INTERACTION',
 		supportInteraction,

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@wordpress/data';
 import { SiteDetails } from '../site';
 import type { HelpCenterAction } from './actions';
+import type { SupportInteraction } from '@automattic/odie-client/src/types/';
 import type { Reducer } from 'redux';
 
 const showHelpCenter: Reducer< boolean | undefined, HelpCenterAction > = ( state, action ) => {
@@ -41,7 +42,10 @@ const hasSeenWhatsNewModal: Reducer< boolean | undefined, HelpCenterAction > = (
 	return state;
 };
 
-const currentSupportInteraction: Reducer< any, HelpCenterAction > = ( state, action ) => {
+const currentSupportInteraction: Reducer< SupportInteraction | undefined, HelpCenterAction > = (
+	state,
+	action
+) => {
 	if ( action.type === 'HELP_CENTER_SET_CURRENT_SUPPORT_INTERACTION' ) {
 		return action.supportInteraction;
 	}

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -41,6 +41,13 @@ const hasSeenWhatsNewModal: Reducer< boolean | undefined, HelpCenterAction > = (
 	return state;
 };
 
+const currentSupportInteraction: Reducer< any, HelpCenterAction > = ( state, action ) => {
+	if ( action.type === 'HELP_CENTER_SET_CURRENT_SUPPORT_INTERACTION' ) {
+		return action.supportInteraction;
+	}
+	return state;
+};
+
 const isMinimized: Reducer< boolean, HelpCenterAction > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'HELP_CENTER_SET_MINIMIZED':
@@ -130,6 +137,7 @@ const odieBotNameSlug: Reducer< string | undefined, HelpCenterAction > = ( state
 };
 
 const reducer = combineReducers( {
+	currentSupportInteraction,
 	showHelpCenter,
 	showMessagingLauncher,
 	showMessagingWidget,

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -14,3 +14,4 @@ export const getHasSeenWhatsNewModal = ( state: State ) => state.hasSeenWhatsNew
 export const getNavigateToRoute = ( state: State ) => state.navigateToRoute;
 export const getOdieInitialPromptText = ( state: State ) => state.odieInitialPromptText;
 export const getOdieBotNameSlug = ( state: State ) => state.odieBotNameSlug;
+export const getCurrentSupportInteraction = ( state: State ) => state.currentSupportInteraction;

--- a/packages/help-center/src/components/utils.tsx
+++ b/packages/help-center/src/components/utils.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { ZendeskConversation } from '@automattic/odie-client';
 import type { ContactOption } from '../types';
+import type { ZendeskConversation } from '@automattic/odie-client';
 
 export const generateContactOnClickEvent = (
 	contactOption: ContactOption,

--- a/packages/odie-client/src/data/handle-support-interactions-fetch.ts
+++ b/packages/odie-client/src/data/handle-support-interactions-fetch.ts
@@ -3,9 +3,9 @@ import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import type { SupportInteractionEvent } from '../types/';
 
 export const handleSupportInteractionsFetch = async (
-	method: 'GET' | 'POST',
+	method: 'GET' | 'POST' | 'PUT',
 	path?: string,
-	data?: SupportInteractionEvent
+	data?: SupportInteractionEvent | { status: string }
 ) => {
 	return canAccessWpcomApis()
 		? await wpcomRequest( {

--- a/packages/odie-client/src/data/handle-support-interactions-fetch.ts
+++ b/packages/odie-client/src/data/handle-support-interactions-fetch.ts
@@ -4,7 +4,7 @@ import type { SupportInteractionEvent } from '../types/';
 
 export const handleSupportInteractionsFetch = async (
 	method: 'GET' | 'POST' | 'PUT',
-	path?: string,
+	path: string | null,
 	data?: SupportInteractionEvent | { status: string }
 ) => {
 	return canAccessWpcomApis()

--- a/packages/odie-client/src/data/handle-support-interactions-fetch.ts
+++ b/packages/odie-client/src/data/handle-support-interactions-fetch.ts
@@ -3,7 +3,7 @@ import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import type { SupportInteractionEvent } from '../types/';
 
 export const handleSupportInteractionsFetch = async (
-	method: string,
+	method: 'GET' | 'POST',
 	path?: string,
 	data?: SupportInteractionEvent
 ) => {

--- a/packages/odie-client/src/data/handle-support-interactions-fetch.ts
+++ b/packages/odie-client/src/data/handle-support-interactions-fetch.ts
@@ -1,0 +1,22 @@
+import apiFetch from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import type { SupportInteractionEvent } from '../types/';
+
+export const handleSupportInteractionsFetch = async (
+	method: string,
+	path?: string,
+	data?: SupportInteractionEvent
+) => {
+	return canAccessWpcomApis()
+		? await wpcomRequest( {
+				method,
+				path: `/support-interactions${ path ?? '' }`,
+				apiNamespace: 'wpcom/v2',
+				body: data,
+		  } )
+		: await apiFetch( {
+				method,
+				path: `/help-center/support-interactions${ path ?? '' }`,
+				data,
+		  } );
+};

--- a/packages/odie-client/src/data/use-create-support-interaction.ts
+++ b/packages/odie-client/src/data/use-create-support-interaction.ts
@@ -1,0 +1,47 @@
+import { useMutation } from '@tanstack/react-query';
+import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
+import { useGetSupportInteractions } from './use-get-support-interactions';
+import type { SupportInteractionEvent, SupportInteraction } from '../types/';
+
+/**
+ * Create a new support interaction event.
+ * If the event already exists, return the current event.
+ * If there is already an interaction, add the event to the interaction.
+ * @param eventData - The event data.
+ * @param currentEventId optional - The current event ID.
+ * @returns The mutation function.
+ */
+export const useCreateSupportInteraction = (
+	eventData: SupportInteractionEvent,
+	currentEventId?: number
+) => {
+	// Get the current interaction if it exists
+	const { data: currentInteraction } = useGetSupportInteractions(
+		currentEventId,
+		!! currentEventId
+	);
+
+	// Check if the new event already exists
+	const { data: currentEvent } = useGetSupportInteractions( eventData.event_external_id );
+
+	const supportInteractionUuid = ( currentInteraction as SupportInteraction )?.uuid ?? null;
+	const path = supportInteractionUuid ? `/${ supportInteractionUuid }/events` : '';
+
+	const createEvent = useMutation( {
+		mutationKey: [
+			'support-interaction',
+			'new-event',
+			eventData.event_external_id,
+			supportInteractionUuid,
+		],
+		mutationFn: () => {
+			return handleSupportInteractionsFetch( 'POST', path, eventData );
+		},
+	} );
+
+	if ( currentEvent ) {
+		return async () => currentEvent;
+	}
+
+	return createEvent.mutateAsync;
+};

--- a/packages/odie-client/src/data/use-create-support-interaction.ts
+++ b/packages/odie-client/src/data/use-create-support-interaction.ts
@@ -1,47 +1,46 @@
 import { useMutation } from '@tanstack/react-query';
 import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
-import { useGetSupportInteractions } from './use-get-support-interactions';
-import type { SupportInteractionEvent, SupportInteraction } from '../types/';
+import type { SupportInteractionEvent } from '../types/';
 
 /**
- * Create a new support interaction event.
- * If the event already exists, return the current event.
- * If there is already an interaction, add the event to the interaction.
- * @param eventData - The event data.
- * @param currentEventId optional - The current event ID.
- * @returns The mutation function.
+ * Manage support interaction events.
  */
-export const useCreateSupportInteraction = (
-	eventData: SupportInteractionEvent,
-	currentEventId?: number
-) => {
-	// Get the current interaction if it exists
-	const { data: currentInteraction } = useGetSupportInteractions(
-		currentEventId,
-		!! currentEventId
-	);
+export const useManageSupportInteraction = () => {
+	/**
+	 * Start a new support interaction.
+	 */
+	const startNewInteraction = useMutation( {
+		mutationKey: [ 'support-interaction', 'new-conversation' ],
+		mutationFn: ( eventData: SupportInteractionEvent ) =>
+			handleSupportInteractionsFetch( 'POST', '', eventData ),
+	} ).mutateAsync;
 
-	// Check if the new event already exists
-	const { data: currentEvent } = useGetSupportInteractions( eventData.event_external_id );
+	/**
+	 * Add an event to a support interaction.
+	 */
+	const addEventToInteraction = useMutation( {
+		mutationKey: [ 'support-interaction', 'add-event' ],
+		mutationFn: ( {
+			interactionId,
+			eventData,
+		}: {
+			interactionId: string;
+			eventData: SupportInteractionEvent;
+		} ) => handleSupportInteractionsFetch( 'POST', `/${ interactionId }/events`, eventData ),
+	} ).mutateAsync;
 
-	const supportInteractionUuid = ( currentInteraction as SupportInteraction )?.uuid ?? null;
-	const path = supportInteractionUuid ? `/${ supportInteractionUuid }/events` : '';
+	/**
+	 * Resolve a support interaction.
+	 */
+	const resolveInteraction = useMutation( {
+		mutationKey: [ 'support-interaction', 'resolve' ],
+		mutationFn: ( interactionId: string ) =>
+			handleSupportInteractionsFetch( 'PUT', `/${ interactionId }/status`, { status: 'resolved' } ),
+	} ).mutateAsync;
 
-	const createEvent = useMutation( {
-		mutationKey: [
-			'support-interaction',
-			'new-event',
-			eventData.event_external_id,
-			supportInteractionUuid,
-		],
-		mutationFn: () => {
-			return handleSupportInteractionsFetch( 'POST', path, eventData );
-		},
-	} );
-
-	if ( currentEvent ) {
-		return async () => currentEvent;
-	}
-
-	return createEvent.mutateAsync;
+	return {
+		startNewInteraction,
+		addEventToInteraction,
+		resolveInteraction,
+	};
 };

--- a/packages/odie-client/src/data/use-get-support-interaction-by-id.ts
+++ b/packages/odie-client/src/data/use-get-support-interaction-by-id.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
+
+/**
+ * Get the support interaction.
+ * @param interactionId - The uuid of the Support Interaction.
+ * @returns The support interaction.
+ */
+export const useGetSupportInteractionById = ( interactionId: number | null ) => {
+	return useQuery( {
+		queryKey: [ 'support-interactions', 'get-interaction-by-id', interactionId ],
+		queryFn: () => handleSupportInteractionsFetch( 'GET', `/${ interactionId }` ),
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
+		enabled: !! interactionId,
+	} );
+};

--- a/packages/odie-client/src/data/use-get-support-interactions.ts
+++ b/packages/odie-client/src/data/use-get-support-interactions.ts
@@ -1,16 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
-import type { SupportInteraction } from '../types/';
+import type { SupportInteraction, SupportProvider } from '../types/';
 
 /**
  * Get the support interaction.
  * @returns Support interactions.
  */
 export const useGetSupportInteractions = (
+	provider: SupportProvider | null = null,
 	per_page = 10,
-	page = 1,
 	status = 'open',
-	provider = null
+	page = 1
 ) => {
 	const path = `?per_page=${ per_page }&page=${ page }&status=${ status }`;
 
@@ -23,7 +23,7 @@ export const useGetSupportInteractions = (
 			}
 
 			return data.filter( ( interaction ) =>
-				interaction.events.some( ( event ) => event.event_source === provider )
+				interaction.events.some( ( event ) => event.source === provider )
 			);
 		},
 		refetchOnWindowFocus: false,

--- a/packages/odie-client/src/data/use-get-support-interactions.ts
+++ b/packages/odie-client/src/data/use-get-support-interactions.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
+import type { SupportInteraction, SupportInteractionEvent } from '../types/';
+
+/**
+ * Get the support interaction.
+ * If no id is provided, return all support interactions.
+ * @param id optional - An ID of an EVENT such as Odie ID or Zendesk ID.
+ * @returns The support interaction.
+ */
+export const useGetSupportInteractions = ( id?: number, enabled = true ) => {
+	return useQuery( {
+		queryKey: [ 'support-interactions', 'get-conversation', id ?? '' ],
+		queryFn: () => handleSupportInteractionsFetch( 'GET' ) as Promise< SupportInteraction[] >,
+		select: ( data: SupportInteraction[] ) => {
+			if ( ! id ) {
+				return data;
+			}
+
+			const supportInteraction = data.find( ( interaction: SupportInteraction ) => {
+				return interaction.events.some(
+					( event: SupportInteractionEvent ) => event.event_external_id === id
+				);
+			} );
+
+			return supportInteraction;
+		},
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
+		enabled,
+	} );
+};

--- a/packages/odie-client/src/data/use-get-support-interactions.ts
+++ b/packages/odie-client/src/data/use-get-support-interactions.ts
@@ -1,32 +1,33 @@
 import { useQuery } from '@tanstack/react-query';
 import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
-import type { SupportInteraction, SupportInteractionEvent } from '../types/';
+import type { SupportInteraction } from '../types/';
 
 /**
  * Get the support interaction.
- * If no id is provided, return all support interactions.
- * @param id optional - An ID of an EVENT such as Odie ID or Zendesk ID.
- * @returns The support interaction.
+ * @returns Support interactions.
  */
-export const useGetSupportInteractions = ( id?: number, enabled = true ) => {
+export const useGetSupportInteractions = (
+	per_page = 10,
+	page = 1,
+	status = 'open',
+	provider = null
+) => {
+	const path = `?per_page=${ per_page }&page=${ page }&status=${ status }`;
+
 	return useQuery( {
-		queryKey: [ 'support-interactions', 'get-conversation', id ?? '' ],
-		queryFn: () => handleSupportInteractionsFetch( 'GET' ) as Promise< SupportInteraction[] >,
+		queryKey: [ 'support-interactions', 'get-interactions', path ],
+		queryFn: () => handleSupportInteractionsFetch( 'GET', path ) as Promise< SupportInteraction[] >,
 		select: ( data: SupportInteraction[] ) => {
-			if ( ! id ) {
+			if ( ! provider ) {
 				return data;
 			}
 
-			const supportInteraction = data.find( ( interaction: SupportInteraction ) => {
-				return interaction.events.some(
-					( event: SupportInteractionEvent ) => event.event_external_id === id
-				);
-			} );
-
-			return supportInteraction;
+			return data.filter( ( interaction ) =>
+				interaction.events.some( ( event ) => event.event_source === provider )
+			);
 		},
 		refetchOnWindowFocus: false,
 		refetchOnReconnect: false,
-		enabled,
+		refetchIntervalInBackground: false,
 	} );
 };

--- a/packages/odie-client/src/data/use-get-support-interactions.ts
+++ b/packages/odie-client/src/data/use-get-support-interactions.ts
@@ -3,7 +3,7 @@ import { handleSupportInteractionsFetch } from './handle-support-interactions-fe
 import type { SupportInteraction, SupportProvider } from '../types/';
 
 /**
- * Get the support interaction.
+ * Get the support interactions.
  * @returns Support interactions.
  */
 export const useGetSupportInteractions = (

--- a/packages/odie-client/src/data/use-manage-support-interaction.ts
+++ b/packages/odie-client/src/data/use-manage-support-interaction.ts
@@ -34,7 +34,7 @@ export const useManageSupportInteraction = () => {
 	 */
 	const resolveInteraction = useMutation( {
 		mutationKey: [ 'support-interaction', 'resolve' ],
-		mutationFn: ( interactionId: string ) =>
+		mutationFn: ( { interactionId }: { interactionId: string } ) =>
 			handleSupportInteractionsFetch( 'PUT', `/${ interactionId }/status`, { status: 'resolved' } ),
 	} ).mutateAsync;
 

--- a/packages/odie-client/src/data/use-manage-support-interaction.ts
+++ b/packages/odie-client/src/data/use-manage-support-interaction.ts
@@ -12,7 +12,7 @@ export const useManageSupportInteraction = () => {
 	const startNewInteraction = useMutation( {
 		mutationKey: [ 'support-interaction', 'new-conversation' ],
 		mutationFn: ( eventData: SupportInteractionEvent ) =>
-			handleSupportInteractionsFetch( 'POST', '', eventData ),
+			handleSupportInteractionsFetch( 'POST', null, eventData ),
 	} ).mutateAsync;
 
 	/**

--- a/packages/odie-client/src/types/index.ts
+++ b/packages/odie-client/src/types/index.ts
@@ -165,6 +165,11 @@ export type ZendeskConversation = {
 	type: 'sdkGroup' | string;
 	participants: ConversationParticipant[];
 	messages: ZendeskMessage[];
+	metadata: Metadata;
+};
+
+export type Metadata = {
+	odieChatId: number;
 };
 
 export type SupportInteractionUser = {

--- a/packages/odie-client/src/types/index.ts
+++ b/packages/odie-client/src/types/index.ts
@@ -170,6 +170,7 @@ export type ZendeskConversation = {
 
 export type Metadata = {
 	odieChatId: number;
+	createdAt: string;
 };
 
 export type SupportInteractionUser = {

--- a/packages/odie-client/src/types/index.ts
+++ b/packages/odie-client/src/types/index.ts
@@ -120,7 +120,8 @@ export const odieAllowedBots = [ 'wpcom-support-chat', 'wpcom-plan-support' ] as
 
 export type OdieAllowedBots = ( typeof odieAllowedBots )[ number ];
 
-export type SupportProvider = 'zendesk' | 'odie';
+export type SupportProvider = 'zendesk' | 'odie' | 'zendesk-staging';
+
 interface ConversationParticipant {
 	id: string;
 	userId: string;
@@ -166,4 +167,26 @@ export type ZendeskConversation = {
 	participants: ConversationParticipant[];
 	metadata: Metadata;
 	messages: ZendeskMessage[];
+};
+
+export type SupportInteractionUser = {
+	user_id: string;
+	provider: 'wpcom';
+	is_owner: boolean;
+};
+
+export type SupportInteractionEvent = {
+	event_external_id: number;
+	event_source: SupportProvider;
+	metadata?: object;
+	event_order?: number;
+};
+
+export type SupportInteraction = {
+	uuid: string;
+	status: 'open' | 'closed';
+	start_date: string;
+	last_updated: string;
+	users: SupportInteractionUser[];
+	events: SupportInteractionEvent[];
 };

--- a/packages/odie-client/src/types/index.ts
+++ b/packages/odie-client/src/types/index.ts
@@ -133,7 +133,6 @@ export type ZendeskMessage = {
 	avatarUrl: string;
 	displayName: string;
 	id: string;
-	metadata: Metadata;
 	received: number;
 	role: string;
 	source: {
@@ -165,7 +164,6 @@ export type ZendeskConversation = {
 	iconUrl: string;
 	type: 'sdkGroup' | string;
 	participants: ConversationParticipant[];
-	metadata: Metadata;
 	messages: ZendeskMessage[];
 };
 
@@ -177,7 +175,7 @@ export type SupportInteractionUser = {
 
 export type SupportInteractionEvent = {
 	event_external_id: number;
-	event_source: SupportProvider;
+	source: SupportProvider;
 	metadata?: object;
 	event_order?: number;
 };


### PR DESCRIPTION
## Proposed Changes

* Add 2 new hooks to create and get support interactions

## Why are these changes being made?

We are going to use the Support Interactions API to keep track of odie and zendesk IDs. In order to do this we needed wrappers to get and post data. This uses one hook to get interactions and another to post.

If you pass no ID to the GET hook it will return ALL interactions.

If you only pass the required EVENT data to the POST it will create a new interaction other wise it will grab the interaction based on the ID you supply and append the event there.

In both hooks we use the event ID's, not the interaction ID's. This is because the interaction ID is more obscure and adds another ID to keep track of.

## Testing Instructions

Read the code and critique. This only adds hooks, it does not use them anywhere.