### PR TITLE
Check for translations before using new copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,3 +1,4 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useMemo, useState } from 'react';
@@ -14,7 +15,6 @@ import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-prov
 import FlowCard from '../components/flow-card';
 import usePendingMigrationStatus from './use-pending-migration-status';
 import type { StepProps } from '../../types';
-
 import './style.scss';
 
 interface Props extends StepProps {
@@ -29,13 +29,21 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 	const importSiteQueryParam = useQuery().get( 'from' ) || '';
 	usePresalesChat( 'wpcom' );
 
+	const hasEnTranslation = useHasEnTranslation();
+
 	const options = useMemo(
 		() => [
 			{
 				label: translate( 'Do it for me' ),
-				description: translate(
+				description: hasEnTranslation(
 					"Share your site with us. We'll review it and handle the migration if possible."
-				),
+				)
+					? translate(
+							"Share your site with us. We'll review it and handle the migration if possible."
+					  )
+					: translate(
+							"Share your site with us, and we'll review it and handle the migration if possible."
+					  ),
 				value: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
 				selected: true,
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

[Related to #](https://github.com/Automattic/wp-calypso/pull/95838/files)

## Proposed Changes

I merged the previous PR but the translations are ready yet. This diff checks for translations before using it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See instructions here https://github.com/Automattic/wp-calypso/pull/95838
* Try in different languages and see that the string is correctly translated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
