### PR TITLE
Plans: ship the simplified grid to all users

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-simplified-features-grid-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-simplified-features-grid-experiment.ts
@@ -1,11 +1,8 @@
-import config from '@automattic/calypso-config';
 import {
 	setSimplifiedFeaturesGridExperimentVariant as setExperimentVariant,
-	SIMPLIFIED_FEATURES_GRID_EXPERIMENT_ID as EXPERIMENT_ID,
 	SimplifiedFeaturesGridExperimentVariant as ExperimentVariant,
 } from '@automattic/calypso-products';
 import { useEffect, useState } from 'react';
-import { useExperiment } from 'calypso/lib/explat';
 
 interface Params {
 	flowName?: string | null;
@@ -13,6 +10,10 @@ interface Params {
 	isInSignup: boolean;
 }
 
+/**
+ * This function has been modified to always 'simplified' if isTargetedView is true.
+ * It will be removed in #95977.
+ */
 function useSimplifiedFeaturesGridExperiment( { flowName, isInSignup, intent }: Params ): {
 	isLoading: boolean;
 	isTargetedView: boolean;
@@ -22,24 +23,20 @@ function useSimplifiedFeaturesGridExperiment( { flowName, isInSignup, intent }: 
 	const isTargetedSignupFlow = isInSignup && flowName === 'onboarding';
 	const isTargetedAdminIntent = ! isInSignup && intent === 'plans-default-wpcom';
 	const isTargetedView = isTargetedSignupFlow || isTargetedAdminIntent;
-	const [ isLoading, assignment ] = useExperiment( EXPERIMENT_ID, { isEligible: isTargetedView } );
 	const [ variantOverride, setVariantOverride ] = useState< ExperimentVariant | null >( null );
 
-	let variant = ( assignment?.variationName ?? 'control' ) as ExperimentVariant;
+	let variant: ExperimentVariant = 'control';
 
-	if ( isTargetedView && config.isEnabled( 'simplified-features-grid-a' ) ) {
-		variant = 'fix_inaccuracies';
-	} else if ( isTargetedView && config.isEnabled( 'simplified-features-grid-b' ) ) {
+	if ( isTargetedView ) {
 		variant = 'simplified';
 	}
-
 	if ( variantOverride ) {
 		variant = variantOverride;
 	}
 
-	useEffect( () => setExperimentVariant( variant ), [ isLoading, variant ] );
+	useEffect( () => setExperimentVariant( variant ), [ variant ] );
 
-	return { isLoading, isTargetedView, variant, setVariantOverride };
+	return { isLoading: false, isTargetedView, variant, setVariantOverride };
 }
 
 export default useSimplifiedFeaturesGridExperiment;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3535

## Proposed Changes

* This change ships the "simplified" variant of the experiment added in Automattic/wp-calypso#94044.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/martech/issues/3535

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` and `/plans/<site slug>` and confirm that the simplified plans grid is shown.
* Go to `/setup/newsletter/plans` and `/setup/design-first/plans?siteId=<site id>` and confirm that the plans grid does not differ from production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
