### PR TITLE
Jetpack connect-after-checkout: bypass license activation page & redirect directly.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-pending-async-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-pending-async-activation.tsx
@@ -1,0 +1,261 @@
+import page from '@automattic/calypso-router';
+import { useTranslate } from 'i18n-calypso';
+import { FC, useState, useCallback, useEffect, useMemo } from 'react';
+import QueryProducts from 'calypso/components/data/query-products-list';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { addQueryArgs } from 'calypso/lib/url';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { requestUpdateJetpackCheckoutSupportTicket } from 'calypso/state/jetpack-checkout/actions';
+import { getProductName, getProductsList } from 'calypso/state/products-list/selectors';
+import getJetpackCheckoutSupportTicketDestinationSiteId from 'calypso/state/selectors/get-jetpack-checkout-support-ticket-destination-site-id';
+import getJetpackCheckoutSupportTicketIncompatibleProductIds from 'calypso/state/selectors/get-jetpack-checkout-support-ticket-incompatible-products';
+import getSupportTicketRequestStatus from 'calypso/state/selectors/get-jetpack-checkout-support-ticket-status';
+import getJetpackSites from 'calypso/state/selectors/get-jetpack-sites';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { filterAllowedRedirect } from '../src/lib/pending-page';
+import useGetJetpackActivationConfirmationInfo from './use-get-jetpack-activation-confirmation-info';
+
+import './pending/style.scss';
+
+interface Props {
+	productSlug: string | 'no_product';
+	receiptId?: number;
+	source?: string;
+	jetpackTemporarySiteId?: number;
+	fromSiteSlug: string;
+	redirectTo?: string;
+}
+
+type Product = {
+	product_id: number;
+	product_name: string;
+	product_slug: string;
+};
+
+type JetpackSite = {
+	ID: number;
+	URL: string;
+	is_wpcom_atomic: boolean;
+	products: Product[];
+	plan: Product;
+	slug: string;
+};
+
+interface ProductsList {
+	[ P: string ]: Product;
+}
+
+const LicensingPendingAsyncActivation: FC< Props > = ( {
+	productSlug,
+	receiptId = 0,
+	source = 'connect-after-checkout',
+	jetpackTemporarySiteId = 0,
+	fromSiteSlug,
+	redirectTo,
+} ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const hasProductInfo = productSlug !== 'no_product';
+
+	const productName = useSelector( ( state ) =>
+		hasProductInfo ? getProductName( state, productSlug ) : null
+	);
+	const productsList: ProductsList = useSelector( getProductsList );
+	const jetpackSites = useSelector( getJetpackSites ) as JetpackSite[];
+
+	const supportTicketRequestStatus = useSelector( ( state ) =>
+		getSupportTicketRequestStatus( state, receiptId )
+	);
+
+	const destinationSiteId = useSelector( ( state ) =>
+		getJetpackCheckoutSupportTicketDestinationSiteId( state, jetpackTemporarySiteId )
+	);
+	const incompatibleProductIds = useSelector( ( state ) =>
+		getJetpackCheckoutSupportTicketIncompatibleProductIds( state, jetpackTemporarySiteId )
+	);
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, destinationSiteId ) );
+	const productConfirmationInfo = useGetJetpackActivationConfirmationInfo(
+		destinationSiteId,
+		productSlug
+	);
+
+	const [ selectedSite, setSelectedSite ] = useState( '' );
+	const [ error, setError ] = useState< boolean >( false );
+
+	const initialSelectedSite = useMemo( () => {
+		if ( ! fromSiteSlug ) {
+			return '';
+		}
+		const validSiteThatMatchesFromSiteSlugProp = ( site: JetpackSite ) =>
+			site.is_wpcom_atomic === false && site.slug === fromSiteSlug;
+
+		return jetpackSites.find( validSiteThatMatchesFromSiteSlugProp )?.URL || '';
+	}, [ jetpackSites, fromSiteSlug ] );
+
+	useEffect( () => {
+		setSelectedSite( initialSelectedSite );
+	}, [ initialSelectedSite ] );
+
+	const licenseActivationPageUrl = useMemo( () => {
+		return addQueryArgs(
+			{
+				receiptId,
+				source: 'connect-after-checkout',
+				jetpackTemporarySiteId,
+				fromSiteSlug,
+				redirect_to: redirectTo,
+			},
+			`/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }`
+		);
+	}, [ receiptId, jetpackTemporarySiteId, fromSiteSlug, redirectTo, productSlug ] );
+
+	const handleAutoActivate = useCallback(
+		( siteUrl: string ) => {
+			// Update the support ticket with the submitted site URL(selectedSite) and attempt to activate
+			// the license (transfer the temporary-site subscription to the user's selectedSite).
+			dispatch(
+				requestUpdateJetpackCheckoutSupportTicket(
+					siteUrl,
+					receiptId,
+					source,
+					jetpackTemporarySiteId
+				)
+			);
+		},
+		[ dispatch, jetpackTemporarySiteId, receiptId, source ]
+	);
+
+	// Prevent auto-activation if it will fail at the initial attempt.
+	const [ attemptAutoActivate, setAttemptAutoActivate ] = useState( true );
+	useEffect( () => {
+		if ( attemptAutoActivate && fromSiteSlug && initialSelectedSite.includes( fromSiteSlug ) ) {
+			setAttemptAutoActivate( false );
+			handleAutoActivate( initialSelectedSite );
+		}
+	}, [ attemptAutoActivate, fromSiteSlug, handleAutoActivate, initialSelectedSite ] );
+
+	useEffect( () => {
+		if (
+			error ||
+			supportTicketRequestStatus === undefined ||
+			supportTicketRequestStatus === 'pending' ||
+			( supportTicketRequestStatus === 'success' && destinationSiteId === undefined )
+		) {
+			return;
+		}
+		if (
+			supportTicketRequestStatus === 'failed' ||
+			( supportTicketRequestStatus === 'success' && incompatibleProductIds.length ) ||
+			( supportTicketRequestStatus === 'success' && destinationSiteId === 0 )
+		) {
+			// If there is some sort of error, we redirect to the user license activation page where we can display an error.
+			dispatch(
+				recordTracksEvent( 'calypso_siteless_checkout_auto-activate-license', {
+					product_slug: productSlug,
+					site_url: initialSelectedSite,
+					receipt_id: receiptId,
+					status: 'failed',
+				} )
+			);
+			setError( true );
+			page( licenseActivationPageUrl );
+			return;
+		}
+
+		// The license activation (subscription transfer) was successful!
+		// ( supportTicketRequestStatus === 'success' && destinationSiteId == truthy )
+		// If `redirectTo` exists, redirect to it, otherwise redirect to fallback url.
+		const finalRedirect = filterAllowedRedirect(
+			redirectTo ?? '',
+			siteSlug ?? '',
+			productConfirmationInfo.buttonUrl
+		);
+		dispatch(
+			recordTracksEvent( 'calypso_siteless_checkout_auto-activate-license', {
+				product_slug: productSlug,
+				site_url: initialSelectedSite,
+				receipt_id: receiptId,
+				status: 'success',
+				redirect_to: finalRedirect,
+			} )
+		);
+
+		performRedirect( finalRedirect );
+		return;
+	}, [
+		destinationSiteId,
+		error,
+		incompatibleProductIds,
+		licenseActivationPageUrl,
+		productName,
+		productsList,
+		productSlug,
+		redirectTo,
+		selectedSite,
+		supportTicketRequestStatus,
+		translate,
+		siteSlug,
+		productConfirmationInfo.buttonUrl,
+		dispatch,
+		initialSelectedSite,
+		receiptId,
+	] );
+
+	return (
+		<Main className="checkout-thank-you__pending">
+			{ hasProductInfo && <QueryProducts type="jetpack" /> }
+			<PageViewTracker
+				options={ { useJetpackGoogleAnalytics: true } }
+				path="/checkout/jetpack/thank-you/licensing-pending-async-activation/:product"
+				properties={ { product_slug: productSlug } }
+				title="Checkout > Jetpack Thank You Licensing Pending Async Activation"
+			/>
+			<PendingContent productName={ productName } siteUrl={ initialSelectedSite } />
+		</Main>
+	);
+};
+
+export default LicensingPendingAsyncActivation;
+
+function PendingContent( {
+	productName,
+	siteUrl,
+}: {
+	productName: string | null;
+	siteUrl: string;
+} ) {
+	const translate = useTranslate();
+	const headingText = translate( 'Auto-activating your product license key.' );
+	const productLabel = translate( 'Product' );
+	const siteLabel = translate( 'Site' );
+
+	return (
+		<div className="pending-content__wrapper">
+			<div className="pending-content__title">{ headingText }</div>
+			<LoadingEllipsis />
+			<br />
+			<div className="pending-content__info-text-container">
+				{ productName && (
+					<div className="pending-content__info-text">
+						{ productLabel }: <span>{ productName }</span>
+					</div>
+				) }
+				<div className="pending-content__info-text">
+					{ siteLabel }: <span>{ siteUrl }</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function performRedirect( url: string ): void {
+	if ( url.startsWith( '/' ) ) {
+		page( url );
+		return;
+	}
+	window.location.href = url;
+}

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -283,10 +283,14 @@ const LicensingActivationThankYou: FC< Props > = ( {
 			{ hasProductInfo && <QueryProducts type="jetpack" /> }
 			<LicensingActivation
 				title={
-					<>
-						{ translate( 'Thank you for your purchase!' ) }{ ' ' }
-						{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
-					</>
+					source === 'connect-after-checkout' ? (
+						<>{ translate( 'Activate your product:' ) }</>
+					) : (
+						<>
+							{ translate( 'Thank you for your purchase!' ) }{ ' ' }
+							{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
+						</>
+					)
 				}
 				footerImage={ footerCardImg }
 				showProgressIndicator

--- a/client/my-sites/checkout/checkout-thank-you/pending/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/pending/style.scss
@@ -13,3 +13,22 @@
 	vertical-align: middle;
 	margin: 0;
 }
+
+.pending-content__info-text-container {
+	display: inline-block;
+    font-size: 1rem;
+    text-align: left;
+    border: 1px solid var( --studio-gray-5 );
+    padding: 1rem;
+	@extend .wp-brand-font;
+    border-radius: 4px;
+    background-color: var( --studio-gray-0 );
+
+	.pending-content__info-text {
+		> span {
+			font-family: var( --p2-font-inter );
+			font-size: var( --p2-font-size-form-xxs );
+			color: var( --studio-gray-60 );
+		}
+	}
+}

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -8,6 +8,7 @@ import { CALYPSO_PLANS_PAGE } from 'calypso/jetpack-connect/constants';
 import { MARKETING_COUPONS_KEY } from 'calypso/lib/analytics/utils';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { addQueryArgs } from 'calypso/lib/url';
+import LicensingPendingAsyncActivation from 'calypso/my-sites/checkout/checkout-thank-you/licensing-pending-async-activation';
 import LicensingThankYouAutoActivation from 'calypso/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation';
 import LicensingThankYouAutoActivationCompleted from 'calypso/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed';
 import LicensingThankYouManualActivationInstructions from 'calypso/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions';
@@ -444,6 +445,33 @@ export function redirectToSupportSession( context ) {
 		page.redirect( `/checkout/offer-support-session/${ receiptId }/${ site }` );
 	}
 	page.redirect( `/checkout/offer-support-session/${ site }` );
+}
+
+export function licensingPendingAsyncActivation( context, next ) {
+	const { product: productSlug } = context.params;
+	const { receiptId, source, siteId, fromSiteSlug, redirect_to } = context.query;
+
+	if ( ! fromSiteSlug ) {
+		page.redirect(
+			addQueryArgs(
+				{ receiptId },
+				`/checkout/jetpack/thank-you/licensing-manual-activate/${ productSlug }`
+			)
+		);
+	} else {
+		context.primary = (
+			<LicensingPendingAsyncActivation
+				productSlug={ productSlug }
+				receiptId={ receiptId }
+				source={ source }
+				jetpackTemporarySiteId={ siteId }
+				fromSiteSlug={ fromSiteSlug }
+				redirectTo={ redirect_to }
+			/>
+		);
+	}
+
+	next();
 }
 
 export function licensingThankYouManualActivationInstructions( context, next ) {

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -157,7 +157,7 @@ export default function getThankYouPageUrl( {
 	// (i.e. on WordPress.com), the same site as the cart's site, a Jetpack cloud URL,
 	// or a Jetpack or WP.com site's block editor (in wp-admin). This is required for Jetpack's
 	// (and WP.com's) paid blocks Upgrade Nudge.
-	if ( redirectTo ) {
+	if ( redirectTo && ! connectAfterCheckout ) {
 		const { protocol, hostname, port, pathname, searchParams } = getUrlParts( redirectTo );
 
 		if ( resemblesUrl( redirectTo ) && isRedirectSameSite( redirectTo, siteSlug ) ) {
@@ -264,7 +264,7 @@ export default function getThankYouPageUrl( {
 					productSlug,
 					redirect_to: redirectTo,
 				},
-				`${ calypsoHost }/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }`
+				`${ calypsoHost }/checkout/jetpack/thank-you/licensing-pending-async-activation/${ productSlug }`
 			);
 
 			const remoteSiteConnectUrl = addQueryArgs(

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1778,7 +1778,7 @@ describe( 'getThankYouPageUrl', () => {
 				receiptId: 'invalid receipt ID' as any,
 			} );
 
-			const redirectAfterAuth = `https://wordpress.com/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }?fromSiteSlug=${ fromSiteSlug }&productSlug=${ productSlug }`;
+			const redirectAfterAuth = `https://wordpress.com/checkout/jetpack/thank-you/licensing-pending-async-activation/${ productSlug }?fromSiteSlug=${ fromSiteSlug }&productSlug=${ productSlug }`;
 
 			expect( url ).toBe(
 				addQueryArgs(
@@ -1818,7 +1818,7 @@ describe( 'getThankYouPageUrl', () => {
 				redirectTo: 'https://foo.bar/some-path?with-args=yes',
 			} );
 
-			const redirectAfterAuth = `https://wordpress.com/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }?fromSiteSlug=${ fromSiteSlug }&productSlug=${ productSlug }&redirect_to=https%3A%2F%2Ffoo.bar%2Fsome-path%3Fwith-args%3Dyes`;
+			const redirectAfterAuth = `https://wordpress.com/checkout/jetpack/thank-you/licensing-pending-async-activation/${ productSlug }?fromSiteSlug=${ fromSiteSlug }&productSlug=${ productSlug }&redirect_to=https%3A%2F%2Ffoo.bar%2Fsome-path%3Fwith-args%3Dyes`;
 
 			expect( url ).toBe(
 				addQueryArgs(

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -16,6 +16,7 @@ import {
 	checkoutJetpackSiteless,
 	checkoutMarketplaceSiteless,
 	checkoutThankYou,
+	licensingPendingAsyncActivation,
 	licensingThankYouManualActivationInstructions,
 	licensingThankYouManualActivationLicenseKey,
 	licensingThankYouAutoActivation,
@@ -42,6 +43,14 @@ export default function () {
 		setLocaleMiddleware(),
 		noSite,
 		checkoutJetpackSiteless,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/jetpack/thank-you/licensing-pending-async-activation/:product',
+		noSite,
+		licensingPendingAsyncActivation,
 		makeLayout,
 		clientRender
 	);


### PR DESCRIPTION
This PR updates the connect-after-checkout flow so that after user account authorization, the license activation step occurs automatically while displaying a full-screen loading state (instead of the license auto-activation page) and then redirects directly to the product's defined final location.
If, however, there is some error during the license activation step, the license auto-activation page will display and also display the error.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/jetpack-marketing/issues/1013

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is an attempt to simplify and optimize the 'connect-after-checkout' flow, providing a better user experience, and therefore a smoother plan purchase experience.
* The user should be able to purchase a product, and ideally not have to concern themselves with connecting Jetpack and activating their product license key. They should be able to make the purchase and then redirect right back to their wp-admin dashboard, while the connection and license activation steps can happen automatically in the background.

### Implementation notes:

- In this flow, when the license auto-activation step fails with error, I think the errors displayed could use improvement, along with possible next steps to resolve the error. The error improvements mentioned here are not included in this PR and will possibly look to address them in a follow-up PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test license auto-activation without error:

- Checkout this PR branch and `yarn start`. (ensure you are logged-in)
- With a new Jurassic Ninja site, go to My Jetpack and establish a "site-only" connection by clicking "Activate Jetpack with one click" button in the top banner.
- Once site-connected (not user-connected) click the VaultPress Backup product card, then select to purchase Jetpack Security.
- Once on the wordpress.com checkout page, in the url, replace `https://wordpress.com` with `http://calypso.localhost:3000` and reload the page.
- Go ahead and complete the purchase (using A11N credits is fine).
- After purchase completed, Jetpack should auto-connect to your site. You should see the Authorization form (See screenshot ⤵️). Click "Approve".
![Screen Shot on 2024-11-05 at 11-09-38](https://github.com/user-attachments/assets/999dcb1c-da61-416a-bffb-fccf84bdab5f)
- After connection, Jetpack should attempt to auto-activate your product license key. You should see a full-screen loading state page. It will say, "Auto-activating your product license key" with a 3-dots loading animation/image. You should also see the product that is being activated, and on which site it is being activated. (See screenshot ⤵️)
![Screen Shot 2024-11-05 at 11 01 31](https://github.com/user-attachments/assets/c12d8ae7-86d1-42a9-93cb-1eced36523a9)
- If the license auto-activation is successful, you should be automatically redirected back to wp-admin My Jetpack page (the final redirect defined for the Jetpack Security product).
- On the My Jetpack page, bottom of the page in the Your Plan section and the Connection section, verify that Jetpack Security is attached to your site and that Jetpack is fully connected (site and user connected).

Test license auto-activation with error:

- On the My Jetpack page, disconnect your site:
    - Down in the Connection section, click "Manage", then click "Disconnect".
- Next, establish a "site-only" connection by clicking "Connect your site" in the top banner of the My Jetpack page.
- Once site-connected (not user-connected) click the VaultPress Backup product card, then select to purchase Jetpack VaultPress Backup.
- Once on the wordpress.com checkout page, in the url, replace `https://wordpress.com` with `http://calypso.localhost:3000` and reload the page.
- Go ahead and complete the purchase (using A11N credits is fine).
- After purchase completed, Jetpack should auto-connect to your site. You should see the Authorization form (See screenshot ⤵️). Click "Approve".
![Screen Shot 2024-11-05 at 11 40 42](https://github.com/user-attachments/assets/34372bad-941d-46e1-beed-cf17a3f44c22)
- After connection, Jetpack should attempt to auto-activate your product license key. You should see a full-screen loading state page. It will say, "Auto-activating your product license key" with a 3-dots loading animation/image. You should also see the product that is being activated, and on which site it is being activated. (See screenshot ⤵️)
![Screen Capture on 2024-11-05 at 11-44-49](https://github.com/user-attachments/assets/7890296e-dd2d-4c93-a621-e37cc9d6de7d)
- Since your site already has Jetpack Security and VaultPress backup is already included in the plan, VaultPress Backup is therefore not a compatible product, so the license auto-activation process will produce an error and fail.
- In this case, verify you are instead redirected to the checkout thank-you license auto-activation page.
- Verify the heading reads, "Activate your product:", instead of "Thank you for your purchase! 🎉"
- Verify the license activation error is displayed to the user (See screenshot:)
![Screen Shot 2024-11-05 at 11 36 34](https://github.com/user-attachments/assets/a663f152-078a-447a-95b2-6651962aee27)
- Verify that at this step the user can either select another connected site from the dropdown list, or they can choose, "I don't see my site. Let me configure it manually."

Run Unit tests:

Command: `yarn test-client client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
