### PR TITLE
Jetpack Cloud: allow redirect on "Start for free" button from My Jetpack

### DIFF
--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/test/use-jetpack-free-button-props.js
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/test/use-jetpack-free-button-props.js
@@ -52,6 +52,19 @@ describe( 'useJetpackFreeButtonProps', () => {
 		expect( result.current.href ).toEqual( `/pricing/jetpack-free/welcome` );
 	} );
 
+	it( 'should link back to redirect_to, for Jetpack Cloud while unlinked and coming from My Jetpack', () => {
+		isJetpackCloud.mockReturnValue( true );
+		const { result } = renderHook( () =>
+			useJetpackFreeButtonProps( undefined, {
+				unlinked: '1',
+				source: 'my-jetpack',
+				redirect_to: adminUrl,
+			} )
+		);
+
+		expect( result.current.href ).toEqual( adminUrl );
+	} );
+
 	it( 'should link to the Jetpack section in the site admin, when site in state', () => {
 		getSelectedSite.mockReturnValue( {
 			options: { admin_url: adminUrl },

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -51,6 +51,13 @@ const buildHref = (
 	const isSiteinContext = siteId || site;
 
 	if ( isJetpackCloud() && ! isSiteinContext ) {
+		const { source, unlinked, redirect_to: redirectTo } = urlQueryArgs;
+
+		// Redirect users coming from My Jetpack while unlinked
+		if ( unlinked === '1' && source === 'my-jetpack' && redirectTo ) {
+			return redirectTo;
+		}
+
 		return '/pricing/jetpack-free/welcome';
 	}
 	return wpAdminUrl || jetpackAdminUrlFromQuery || JPC_PATH_BASE;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/39902

## Proposed Changes

* Update the useJetpackFreeButtonProps hook to allow redirects when the user comes from My Jetpack. This will help prevent sending users to the "Welcome" page for Jetpack Free if they already have a site-connection.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The idea is to support the changes on https://github.com/Automattic/jetpack/pull/39902, where users would be redirected to the pricing page after a site connection.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Unit tests apply. Alternatively:
* Open the Calypso Green (Jetpack Cloud) live link
* Visit `/pricing?unlinked=1&source=my-jetpack&redirect_to=https%3A%2F%2Fwordpress.com`
* Scroll down and hover the "Start for free" button
* Confirm that the `href` matches the `redirect_to` URL

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
