### PR TITLE
Tracks: Add Remote Data Blocks in the list of allowed sources

### DIFF
--- a/packages/calypso-analytics/CHANGELOG.md
+++ b/packages/calypso-analytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.3
 
-- Add "Remote Data Blocks" in the list of allowed sources..
+- Add "Remote Data Blocks" in the list of allowed sources.
 
 ## 1.1.2
 

--- a/packages/calypso-analytics/CHANGELOG.md
+++ b/packages/calypso-analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+- Add "Remote Data Blocks" in the list of allowed sources..
+
 ## 1.1.2
 
 - Add additional 8 US states to the list of CCPA regions (DE, IN, IA, MT, NJ, OR, TN, TX).

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-analytics",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "Automattic Analytics.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -21,6 +21,7 @@ declare const window: undefined | ( Window & { BUILD_TIMESTAMP?: number } );
  * See internal Nosara repo?
  */
 const TRACKS_SPECIAL_PROPS_NAMES = [ 'geo', 'message', 'request', 'geocity', 'ip' ];
+const EVENT_SOURCES = [ 'calypso', 'jetpack', 'remotedatablocks', 'wpcom_dsp_widget' ];
 const EVENT_NAME_EXCEPTIONS = [
 	'a8c_cookie_banner_ok',
 	'a8c_cookie_banner_view',
@@ -212,13 +213,7 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 	}
 
 	if ( process.env.NODE_ENV !== 'production' && typeof console !== 'undefined' ) {
-		if (
-			! /^calypso(?:_[a-z0-9]+){2,}$/.test( eventName ) &&
-			! /^jetpack(?:_[a-z0-9]+){2,}$/.test( eventName ) &&
-			! /^remotedatablocks(?:_[a-z0-9]+){2,}$/.test( eventName ) &&
-			! /^wpcom_dsp_widget(?:_[a-z0-9]+){2,}$/.test( eventName ) &&
-			! EVENT_NAME_EXCEPTIONS.includes( eventName )
-		) {
+		if ( ! isValidEventName( eventName ) && ! EVENT_NAME_EXCEPTIONS.includes( eventName ) ) {
 			// eslint-disable-next-line no-console
 			console.error(
 				'Tracks: Event `%s` will be ignored because it does not match with the naming convention and is ' +
@@ -261,14 +256,8 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 
 	debug( 'Record event "%s" called with props %o', eventName, eventProperties );
 
-	if (
-		! eventName.startsWith( 'calypso_' ) &&
-		! eventName.startsWith( 'jetpack_' ) &&
-		! eventName.startsWith( 'remotedatablocks_' ) &&
-		! eventName.startsWith( 'wpcom_dsp_widget_' ) &&
-		! EVENT_NAME_EXCEPTIONS.includes( eventName )
-	) {
-		debug( '- Event name must be prefixed by source or added to `EVENT_NAME_EXCEPTIONS`' );
+	if ( ! isValidEventSource( eventName ) && ! EVENT_NAME_EXCEPTIONS.includes( eventName ) ) {
+		debug( '- Event name must be prefixed by a known source or added to `EVENT_NAME_EXCEPTIONS`' );
 		return;
 	}
 
@@ -287,6 +276,24 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 
 	pushEventToTracksQueue( [ 'recordEvent', eventName, eventProperties ] );
 	analyticsEvents.emit( 'record-event', eventName, eventProperties );
+}
+
+/**
+ * Checks if the event name follows the Tracks naming convention.
+ */
+function isValidEventName( eventName: string ): boolean {
+	return EVENT_SOURCES.some( ( eventSource: string ): boolean =>
+		new RegExp( `^${ eventSource }(?:_[a-z0-9]+){2,}$` ).test( eventName )
+	);
+}
+
+/**
+ * Checks if the event name has a valid source prefix.
+ */
+function isValidEventSource( eventName: string ): boolean {
+	return EVENT_SOURCES.some( ( eventSource: string ): boolean =>
+		eventName.startsWith( `${ eventSource }_` )
+	);
 }
 
 export function recordTracksPageView( urlPath: string, params: any ) {

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -268,9 +268,7 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 		! eventName.startsWith( 'wpcom_dsp_widget_' ) &&
 		! EVENT_NAME_EXCEPTIONS.includes( eventName )
 	) {
-		debug(
-			'- Event name must be prefixed by source or added to `EVENT_NAME_EXCEPTIONS`'
-		);
+		debug( '- Event name must be prefixed by source or added to `EVENT_NAME_EXCEPTIONS`' );
 		return;
 	}
 

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -215,13 +215,13 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 		if (
 			! /^calypso(?:_[a-z0-9]+){2,}$/.test( eventName ) &&
 			! /^jetpack(?:_[a-z0-9]+){2,}$/.test( eventName ) &&
+			! /^remotedatablocks(?:_[a-z0-9]+){2,}$/.test( eventName ) &&
 			! /^wpcom_dsp_widget(?:_[a-z0-9]+){2,}$/.test( eventName ) &&
 			! EVENT_NAME_EXCEPTIONS.includes( eventName )
 		) {
 			// eslint-disable-next-line no-console
 			console.error(
-				'Tracks: Event `%s` will be ignored because it does not match ' +
-					'/^calypso(?:_[a-z0-9]+){2,}$/ nor /^jetpack(?:_[a-z0-9]+){2,}$/ and is ' +
+				'Tracks: Event `%s` will be ignored because it does not match with the naming convention and is ' +
 					'not a listed exception. Please use a compliant event name.',
 				eventName
 			);
@@ -264,11 +264,12 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 	if (
 		! eventName.startsWith( 'calypso_' ) &&
 		! eventName.startsWith( 'jetpack_' ) &&
+		! eventName.startsWith( 'remotedatablocks_' ) &&
 		! eventName.startsWith( 'wpcom_dsp_widget_' ) &&
 		! EVENT_NAME_EXCEPTIONS.includes( eventName )
 	) {
 		debug(
-			'- Event name must be prefixed by "calypso_", "jetpack_", or added to `EVENT_NAME_EXCEPTIONS`'
+			'- Event name must be prefixed by source or added to `EVENT_NAME_EXCEPTIONS`'
 		);
 		return;
 	}

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -21,7 +21,7 @@ declare const window: undefined | ( Window & { BUILD_TIMESTAMP?: number } );
  * See internal Nosara repo?
  */
 const TRACKS_SPECIAL_PROPS_NAMES = [ 'geo', 'message', 'request', 'geocity', 'ip' ];
-const EVENT_SOURCES = [ 'calypso', 'jetpack', 'remotedatablocks', 'wpcom_dsp_widget' ];
+const ALLOWED_EVENT_SOURCES = [ 'calypso', 'jetpack', 'remotedatablocks', 'wpcom_dsp_widget' ];
 const EVENT_NAME_EXCEPTIONS = [
 	'a8c_cookie_banner_ok',
 	'a8c_cookie_banner_view',
@@ -282,7 +282,7 @@ export function recordTracksEvent( eventName: string, eventProperties?: any ) {
  * Checks if the event name follows the Tracks naming convention.
  */
 function isValidEventName( eventName: string ): boolean {
-	return EVENT_SOURCES.some( ( eventSource: string ): boolean =>
+	return ALLOWED_EVENT_SOURCES.some( ( eventSource: string ): boolean =>
 		new RegExp( `^${ eventSource }(?:_[a-z0-9]+){2,}$` ).test( eventName )
 	);
 }
@@ -291,7 +291,7 @@ function isValidEventName( eventName: string ): boolean {
  * Checks if the event name has a valid source prefix.
  */
 function isValidEventSource( eventName: string ): boolean {
-	return EVENT_SOURCES.some( ( eventSource: string ): boolean =>
+	return ALLOWED_EVENT_SOURCES.some( ( eventSource: string ): boolean =>
 		eventName.startsWith( `${ eventSource }_` )
 	);
 }


### PR DESCRIPTION
## Proposed Changes

Update `@automattic/calypso-analytics` package to add "Remote Data Blocks" in the list of allowed sources.

## Why are these changes being made?

- We are planning to use `@automattic/calypso-analytics` in the "Remote Data Blocks" plugin and, as a result, need to allow it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Link `@automattic/calypso-analytics` package.
* Follow instructions of [this Remote Data Blocks PR](https://github.com/Automattic/remote-data-blocks/pull/185) and verify that events are getting tracked without any error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
