### PR TITLE
Photos Picker: Google Photos: Hide filtering if feature flag is ON

### DIFF
--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { includes } from 'lodash';
 import PropTypes from 'prop-types';
@@ -95,6 +96,11 @@ export class MediaLibraryFilterBar extends Component {
 		return enabledFilters && ( ! filter.length || ! includes( enabledFilters, filter ) );
 	}
 
+	shouldSkipFilters() {
+		const { source } = this.props;
+		return config.isEnabled( 'google-photos-picker' ) && source === 'google_photos';
+	}
+
 	changeFilter = ( filter ) => () => {
 		this.props.onFilterChange( filter );
 	};
@@ -112,6 +118,10 @@ export class MediaLibraryFilterBar extends Component {
 	}
 
 	renderTabItems() {
+		if ( this.shouldSkipFilters() ) {
+			return null;
+		}
+
 		let tabs = this.getFiltersForSource( this.props.source );
 
 		if ( ! this.props.post ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9664

## Proposed Changes

* Hide filtering for the google photos if the `google-photos-picker` feature flag is ON

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Google Photos Picker API doesn't support filtering

## Testing Instructions

* Go to `/media/{SITE_SLUG}?flags=google-photos-picker`
* Select "Google Photos" source
* Check the bar next to the source dropdown; it should be empty (check screenshots below)

**Before:**
<img width="1457" alt="Screenshot 2024-11-03 at 00 25 25" src="https://github.com/user-attachments/assets/7a0265aa-d0b2-4b8f-8a48-7cd662186364">
**After:**
<img width="1457" alt="Screenshot 2024-11-03 at 00 25 00" src="https://github.com/user-attachments/assets/017cc6ec-4c45-4dff-8930-9635428d9ee6">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
