### PR TITLE
Help Center: Add HelpCenterFooterButton component and refactor contact button logic

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -5,7 +5,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { getPlan } from '@automattic/calypso-products';
 import { Spinner, GMClosureNotice } from '@automattic/components';
-import { HelpCenterSite } from '@automattic/data-stores';
+import { HelpCenterSelect, HelpCenterSite } from '@automattic/data-stores';
 import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
 import { useLoadZendeskMessaging } from '@automattic/zendesk-client';
 import { useEffect, useMemo } from '@wordpress/element';
@@ -13,7 +13,7 @@ import { hasTranslation, sprintf } from '@wordpress/i18n';
 import { comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { FC } from 'react';
+import { FC, ReactNode, useState } from 'react';
 import { Link } from 'react-router-dom';
 /**
  * Internal Dependencies
@@ -22,6 +22,7 @@ import { EMAIL_SUPPORT_LOCALES } from '../constants';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useChatStatus, useShouldRenderEmailOption, useStillNeedHelpURL } from '../hooks';
 import { Mail } from '../icons';
+import { HELP_CENTER_STORE } from '../stores';
 import HelpCenterContactSupportOption from './help-center-contact-support-option';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';
 import { generateContactOnClickEvent } from './utils';
@@ -41,6 +42,61 @@ type HelpCenterContactPageProps = {
 	onClick?: () => void;
 	trackEventName?: string;
 	isUserEligible?: boolean;
+};
+
+const HelpCenterFooterButton = ( {
+	children,
+	buttonTextEventProp,
+	redirectTo,
+}: {
+	children: ReactNode;
+	buttonTextEventProp: string;
+	redirectTo: string;
+} ) => {
+	const { url, isLoading } = useStillNeedHelpURL();
+	const helpCenterContext = useHelpCenterContext();
+	const sectionName = helpCenterContext.sectionName;
+	const redirectToWpcom = url === 'https://wordpress.com/help/contact';
+	const setChatId = useSetOdieStorage( 'chat_id' );
+
+	const handleContactButtonClicked = ( {
+		buttonTextEventProp,
+	}: {
+		buttonTextEventProp: string;
+	} ) => {
+		recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
+			force_site_id: true,
+			location: 'help-center',
+			section: sectionName,
+			button_type: buttonTextEventProp,
+		} );
+
+		if ( buttonTextEventProp === 'New conversation' ) {
+			setChatId( null );
+		}
+	};
+
+	const redirectionURL = () => {
+		if ( buttonTextEventProp === 'Still need help?' ) {
+			if ( isLoading ) {
+				return '';
+			}
+			return redirectToWpcom ? { pathname: url } : url;
+		}
+		return redirectTo;
+	};
+
+	return (
+		<Link
+			to={ redirectionURL() }
+			target={ redirectToWpcom ? '_blank' : '_self' }
+			onClick={ () => handleContactButtonClicked( { buttonTextEventProp: buttonTextEventProp } ) }
+			className="button help-center-contact-page__button"
+		>
+			<Icon icon={ comment } />
+			{ children }
+		</Link>
+	);
 };
 
 export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
@@ -180,34 +236,32 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 
 export const HelpCenterContactButton: FC = () => {
 	const { __ } = useI18n();
-	const { url, isLoading } = useStillNeedHelpURL();
-	const helpCenterContext = useHelpCenterContext();
-	const sectionName = helpCenterContext.sectionName;
-	const redirectToWpcom = url === 'https://wordpress.com/help/contact';
+	const { getConversations } = useSmooch();
+	const [ conversations, setConversations ] = useState< ZendeskConversation[] >( [] );
+	const { isChatLoaded } = useSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		return { isChatLoaded: store.getIsChatLoaded() };
+	}, [] );
 
-	const trackContactButtonClicked = () => {
-		recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
-			force_site_id: true,
-			location: 'help-center',
-			section: sectionName,
-		} );
-	};
+	useEffect( () => {
+		if ( isChatLoaded && getConversations ) {
+			const conversations = getConversations() as ZendeskConversation[];
+			setConversations( conversations );
+		}
+	}, [ isChatLoaded, getConversations ] );
 
-	let to = redirectToWpcom ? { pathname: url } : url;
-
-	if ( isLoading ) {
-		to = '';
-	}
-
-	return (
-		<Link
-			to={ to }
-			target={ redirectToWpcom ? '_blank' : '_self' }
-			onClick={ trackContactButtonClicked }
-			className="button help-center-contact-page__button"
-		>
-			<Icon icon={ comment } />
+	return conversations.length ? (
+		<>
+			<HelpCenterFooterButton buttonTextEventProp="New conversation" redirectTo="/odie">
+				<span>{ __( 'New conversation', __i18n_text_domain__ ) }</span>
+			</HelpCenterFooterButton>
+			<HelpCenterFooterButton buttonTextEventProp="History" redirectTo="/chat-history">
+				<span>{ __( 'History', __i18n_text_domain__ ) }</span>
+			</HelpCenterFooterButton>
+		</>
+	) : (
+		<HelpCenterFooterButton buttonTextEventProp="Still need help?" redirectTo="/odie">
 			<span>{ __( 'Still need help?', __i18n_text_domain__ ) }</span>
-		</Link>
+		</HelpCenterFooterButton>
 	);
 };

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -10,10 +10,10 @@ import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-uti
 import { useLoadZendeskMessaging } from '@automattic/zendesk-client';
 import { useEffect, useMemo } from '@wordpress/element';
 import { hasTranslation, sprintf } from '@wordpress/i18n';
-import { comment, Icon } from '@wordpress/icons';
+import { comment, Icon, backup } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { FC, ReactNode, useState } from 'react';
+import { FC, ReactElement, ReactNode, useState } from 'react';
 import { Link } from 'react-router-dom';
 /**
  * Internal Dependencies
@@ -48,10 +48,12 @@ const HelpCenterFooterButton = ( {
 	children,
 	buttonTextEventProp,
 	redirectTo,
+	icon,
 }: {
 	children: ReactNode;
 	buttonTextEventProp: string;
 	redirectTo: string;
+	icon: ReactElement;
 } ) => {
 	const { url, isLoading } = useStillNeedHelpURL();
 	const helpCenterContext = useHelpCenterContext();
@@ -93,7 +95,7 @@ const HelpCenterFooterButton = ( {
 			onClick={ () => handleContactButtonClicked( { buttonTextEventProp: buttonTextEventProp } ) }
 			className="button help-center-contact-page__button"
 		>
-			<Icon icon={ comment } />
+			<Icon icon={ icon } />
 			{ children }
 		</Link>
 	);
@@ -252,15 +254,27 @@ export const HelpCenterContactButton: FC = () => {
 
 	return conversations.length ? (
 		<>
-			<HelpCenterFooterButton buttonTextEventProp="New conversation" redirectTo="/odie">
+			<HelpCenterFooterButton
+				icon={ comment }
+				buttonTextEventProp="New conversation"
+				redirectTo="/odie"
+			>
 				<span>{ __( 'New conversation', __i18n_text_domain__ ) }</span>
 			</HelpCenterFooterButton>
-			<HelpCenterFooterButton buttonTextEventProp="History" redirectTo="/chat-history">
+			<HelpCenterFooterButton
+				icon={ backup }
+				buttonTextEventProp="History"
+				redirectTo="/chat-history"
+			>
 				<span>{ __( 'History', __i18n_text_domain__ ) }</span>
 			</HelpCenterFooterButton>
 		</>
 	) : (
-		<HelpCenterFooterButton buttonTextEventProp="Still need help?" redirectTo="/odie">
+		<HelpCenterFooterButton
+			icon={ comment }
+			buttonTextEventProp="Still need help?"
+			redirectTo="/odie"
+		>
 			<span>{ __( 'Still need help?', __i18n_text_domain__ ) }</span>
 		</HelpCenterFooterButton>
 	);

--- a/packages/help-center/src/components/help-center-footer.scss
+++ b/packages/help-center/src/components/help-center-footer.scss
@@ -17,6 +17,7 @@
 		justify-content: center;
 		margin-bottom: 0;
 		line-height: 2.15;
+		gap: 10px;
 
 		&:hover {
 			border-color: var(--color-neutral-20);
@@ -31,12 +32,16 @@
 		}
 
 		svg {
-			margin-right: 10px;
+			// margin-right: 10px;
 			vertical-align: middle;
+			fill: #8C8F94;
 		}
 
 		span {
 			color: var(--studio-gray-100);
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/9641

## Proposed Changes

TODO: I need to fix the new chat logic. The chat is cleared, but the messages are not removed until you navigate back and forth.

* Add `New conversation` and `History` contact buttons
`New conversation` - starts a new chat
`History` - redirects user to chat history page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allows users to start a new chat or view their chat history.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Navigate to `/home?flags=help-center-experience`
* Open the Help Center, verify the two new buttons appear, test their functionality and styling.
