### PR TITLE
Summary: Show clearer number of users imported/failed after import

### DIFF
--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -58,8 +58,6 @@
 			fill: var(--studio-gray-50);
 		}
 	}
-	*/
-
 	dl.summary__content-stats {
 		max-width: 200px;
 		display: flex;
@@ -68,16 +66,30 @@
 		dt {
 			font-weight: 400;
 			margin: 0;
+			width: 80%;
+
+			&.summary__content-indent {
+				font-weight: 400;
+				padding-left: 24px;
+			}
 		}
 
 		dd {
 			font-weight: 600;
 			margin: 0 0 0 auto;
+			width: 20%;
+			text-align: right;
 		}
+	}
+	*/
 
-		.summary__content-indent {
-			margin-left: 30px;
-		}
+	table.summary__content-stats {
+		max-width: 200px;
+	}
+
+	.summary__content-stats-label {
+		min-width: 180px;
+		padding-right: 10px;
 	}
 
 	.stripe-logo {

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -55,7 +55,6 @@ $newsletter_importer_line-height: 20px;
 		max-width: 250px;
 		font-size: $newsletter_importer_font-size;
 		line-height: $newsletter_importer_line-height;
-		margin-bottom: 20px;
 	}
 
 	.summary__content-row {

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -58,6 +58,18 @@
 		}
 	}
 
+	.summary__content-stats {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+	
+	.summary__content-stat-item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
 	.summary__content-indent {
 		margin-top: -20;
 		margin-left: 20px;

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -40,10 +40,11 @@
 		box-shadow: none;
 	}
 
-	/*
 	.summary__content {
 		clear: both;
 		margin-bottom: 12px;
+	}
+	/*
 
 		p {
 			position: relative;
@@ -58,33 +59,26 @@
 			fill: var(--studio-gray-50);
 		}
 	}
-	dl.summary__content-stats {
-		max-width: 200px;
-		display: flex;
-		flex-wrap: wrap;
-
-		dt {
-			font-weight: 400;
-			margin: 0;
-			width: 80%;
-
-			&.summary__content-indent {
-				font-weight: 400;
-				padding-left: 24px;
-			}
-		}
-
-		dd {
-			font-weight: 600;
-			margin: 0 0 0 auto;
-			width: 20%;
-			text-align: right;
-		}
-	}
 	*/
 
 	table.summary__content-stats {
 		max-width: 200px;
+		margin-bottom: 0;
+		td {
+			vertical-align: middle;
+			font-size: $font-body;
+		}
+		svg {
+			margin-top: 3px;
+			margin-right: 5px;
+		}
+	}
+
+	.summary__content-indent {
+		color: var( --studio-gray-50 );
+		svg {
+			fill: var( --studio-gray-50 );
+		}
 	}
 
 	.summary__content-stats-label {

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -1,5 +1,8 @@
 @import "@wordpress/base-styles/mixins";
 
+$newsletter_importer_font-size: rem(14px);
+$newsletter_importer_line-height: 20px;
+
 .newsletter-importer {
 	margin: 24px auto 0;
 	max-width: 720px;
@@ -18,8 +21,8 @@
 		}
 
 		p {
-			font-size: rem(14px);
-			line-height: 20px;
+			font-size: $newsletter_importer_font-size;
+			line-height: $newsletter_importer_line-height;
 			color: var(--studio-gray-50);
 		}
 
@@ -44,46 +47,50 @@
 		clear: both;
 		margin-bottom: 12px;
 	}
-	/*
 
-		p {
-			position: relative;
-			overflow: hidden;
-			margin-bottom: 0;
-		}
+	/**
+	 * Summary table of numbers of posts/pages/subscribers imported
+	 */
+	.summary__content-stats {
+		max-width: 250px;
+		font-size: $newsletter_importer_font-size;
+		line-height: $newsletter_importer_line-height;
+		margin-bottom: 20px;
+	}
 
-		svg {
-			float: left;
-			margin-right: 6px;
-			margin-top: -1px;
-			fill: var(--studio-gray-50);
+	.summary__content-row {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: nowrap;
+		gap: 8px;
+		margin-bottom: 4px;
+		color: var( --studio-gray-70 );
+		> * {
+			align-content: center;
 		}
 	}
-	*/
 
-	table.summary__content-stats {
-		max-width: 200px;
-		margin-bottom: 0;
-		td {
-			vertical-align: middle;
-			font-size: $font-body;
-		}
-		svg {
-			margin-top: 3px;
-			margin-right: 5px;
-		}
+	.summary__content-stats-icon {
+		flex-shrink: 0;
+	}
+
+	.summary__content-stats-count {
+		font-weight: 600;
+		margin-left: auto;
+		text-align: left;
+		min-width: 60px;
+		flex-shrink: 0;
 	}
 
 	.summary__content-indent {
+		margin-left: 28px;
 		color: var( --studio-gray-50 );
 		svg {
 			fill: var( --studio-gray-50 );
 		}
-	}
-
-	.summary__content-stats-label {
-		min-width: 180px;
-		padding-right: 10px;
+		.summary__content-stats-count {
+			font-weight: 400;
+		}
 	}
 
 	.stripe-logo {

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -40,6 +40,7 @@
 		box-shadow: none;
 	}
 
+	/*
 	.summary__content {
 		clear: both;
 		margin-bottom: 12px;
@@ -57,22 +58,26 @@
 			fill: var(--studio-gray-50);
 		}
 	}
+	*/
 
-	.summary__content-stats {
+	dl.summary__content-stats {
+		max-width: 200px;
 		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
-	
-	.summary__content-stat-item {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-	}
+		flex-wrap: wrap;
 
-	.summary__content-indent {
-		margin-top: -20;
-		margin-left: 20px;
+		dt {
+			font-weight: 400;
+			margin: 0;
+		}
+
+		dd {
+			font-weight: 600;
+			margin: 0 0 0 auto;
+		}
+
+		.summary__content-indent {
+			margin-left: 30px;
+		}
 	}
 
 	.stripe-logo {

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -1,6 +1,7 @@
 import { Card, ConfettiAnimation } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { ProgressBar, ExternalLink, Notice } from '@wordpress/components';
+import { useReducedMotion } from '@wordpress/compose';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -57,7 +58,7 @@ export default function Summary( {
 }: SummaryProps ) {
 	const { __ } = useI18n();
 	const { resetPaidNewsletter } = useResetMutation();
-	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+	const prefersReducedMotion = useReducedMotion();
 
 	const onButtonClick = () => resetPaidNewsletter( selectedSite.ID, engine, 'content' );
 	const paidSubscribersCount = parseInt(

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -30,8 +30,8 @@ interface SummaryProps {
 }
 
 function getSummaryDescription(
-	contentStepContent: ContentStepContent,
-	subscribersStepContent: SubscribersStepContent
+	contentStepContent: ContentStepContent | undefined,
+	subscribersStepContent: SubscribersStepContent | undefined
 ) {
 	if ( contentStepContent && subscribersStepContent ) {
 		return __( 'We’re importing your content and subscribers' );

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -1,12 +1,16 @@
 import { Card, ConfettiAnimation } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
-import { ExternalLink, Notice } from '@wordpress/components';
+import { ProgressBar, ExternalLink, Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import pauseSubstackBillingImg from 'calypso/assets/images/importer/pause-substack-billing.png';
-import { Steps, StepStatus } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import {
+	Steps,
+	SubscribersStepContent,
+	ContentStepContent,
+} from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import { useResetMutation } from 'calypso/data/paid-newsletter/use-reset-mutation';
 import ImporterActionButton from '../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../importer-action-buttons/container';
@@ -15,18 +19,6 @@ import SubscribersSummary from './summary/subscribers';
 import { EngineTypes } from './types';
 import { getImporterStatus, normalizeFromSite } from './utils';
 
-function getStepTitle( importerStatus: StepStatus ) {
-	if ( importerStatus === 'done' ) {
-		return __( 'Success!' ) + ' 🎉';
-	}
-
-	if ( importerStatus === 'importing' ) {
-		return __( 'Almost there…' );
-	}
-
-	return __( 'Summary' );
-}
-
 interface SummaryProps {
 	selectedSite: SiteDetails;
 	steps: Steps;
@@ -34,6 +26,25 @@ interface SummaryProps {
 	fromSite: string;
 	showConfetti: boolean;
 	shouldShownConfetti: Dispatch< SetStateAction< boolean > >;
+}
+
+function getSummaryDescription(
+	contentStepContent: ContentStepContent,
+	subscribersStepContent: SubscribersStepContent
+) {
+	if ( contentStepContent && subscribersStepContent ) {
+		return __( 'We’re importing your content and subscribers' );
+	}
+
+	if ( contentStepContent ) {
+		return __( 'We’re importing your content' );
+	}
+
+	if ( subscribersStepContent ) {
+		return __( 'We’re importing your subscribers' );
+	}
+
+	return null;
 }
 
 export default function Summary( {
@@ -60,69 +71,100 @@ export default function Summary( {
 		}
 	}, [ showConfetti, shouldShownConfetti ] );
 
+	// Combined status of subscriber & content importer
 	const importerStatus = getImporterStatus( steps.content.status, steps.subscribers.status );
 
 	return (
 		<Card>
-			{ showConfetti && <ConfettiAnimation trigger={ ! prefersReducedMotion } /> }
-			<h2>{ getStepTitle( importerStatus ) }</h2>
+			{ importerStatus === 'done' ? (
+				<>
+					{ showConfetti && <ConfettiAnimation trigger={ ! prefersReducedMotion } /> }
+					<h2>{ __( 'Success!' ) } 🎉</h2>
 
-			{ steps.content.content && (
-				<ContentSummary stepContent={ steps.content.content } status={ steps.content.status } />
-			) }
+					<p>
+						{ sprintf(
+							// translators: %s the site name
+							__( 'Here’s a summary of the imported data to %s' ),
+							selectedSite.name
+						) }
+					</p>
 
-			{ steps.subscribers.content && (
-				<SubscribersSummary
-					stepContent={ steps.subscribers.content }
-					status={ steps.subscribers.status }
-				/>
-			) }
-
-			{ showPauseSubstackBillingWarning && (
-				<Notice status="warning" className="importer__notice" isDismissible={ false }>
-					<h2>{ __( 'Action required' ) }</h2>
-					{ createInterpolateElement(
-						__(
-							'To prevent any charges from Substack, go to your <substackPaymentsSettingsLink>Substack Payments Settings</substackPaymentsSettingsLink>, select "Pause billing" and click "<strong>Pause indefinitely</strong>".'
-						),
-						{
-							strong: <strong />,
-							substackPaymentsSettingsLink: (
-								// @ts-expect-error Used in createInterpolateElement doesn't need children.
-								<ExternalLink
-									href={ `https://${ normalizeFromSite(
-										fromSite
-									) }/publish/settings?search=Pause%20subscription` }
-								/>
-							),
-						}
+					{ steps.content.content && (
+						<ContentSummary stepContent={ steps.content.content } status={ steps.content.status } />
 					) }
-					<img
-						src={ pauseSubstackBillingImg }
-						alt={ __( 'Pause Substack billing' ) }
-						className="pause-billing"
-					/>
-				</Notice>
-			) }
 
-			<ImporterActionButtonContainer noSpacing>
-				<ImporterActionButton
-					href={ '/settings/newsletter/' + selectedSite.slug }
-					onClick={ onButtonClick }
-					primary
-				>
-					{ __( 'Customize your newsletter' ) }
-				</ImporterActionButton>
-				<ImporterActionButton href={ '/posts/' + selectedSite.slug } onClick={ onButtonClick }>
-					{ __( 'View content' ) }
-				</ImporterActionButton>
-				<ImporterActionButton
-					href={ '/subscribers/' + selectedSite.slug }
-					onClick={ onButtonClick }
-				>
-					{ __( 'Check subscribers' ) }
-				</ImporterActionButton>
-			</ImporterActionButtonContainer>
+					{ steps.subscribers.content && (
+						<SubscribersSummary
+							stepContent={ steps.subscribers.content }
+							status={ steps.subscribers.status }
+						/>
+					) }
+					{ showPauseSubstackBillingWarning && (
+						<Notice status="warning" className="importer__notice" isDismissible={ false }>
+							<h2>{ __( 'Action required' ) }</h2>
+							{ createInterpolateElement(
+								__(
+									'To prevent any charges from Substack, go to your <substackPaymentsSettingsLink>Substack Payments Settings</substackPaymentsSettingsLink>, select "Pause billing" and click "<strong>Pause indefinitely</strong>".'
+								),
+								{
+									strong: <strong />,
+									substackPaymentsSettingsLink: (
+										// @ts-expect-error Used in createInterpolateElement doesn't need children.
+										<ExternalLink
+											href={ `https://${ normalizeFromSite(
+												fromSite
+											) }/publish/settings?search=Pause%20subscription` }
+										/>
+									),
+								}
+							) }
+							<img
+								src={ pauseSubstackBillingImg }
+								alt={ __( 'Pause Substack billing' ) }
+								className="pause-billing"
+							/>
+						</Notice>
+					) }
+					<ImporterActionButtonContainer noSpacing>
+						<ImporterActionButton
+							href={ '/settings/newsletter/' + selectedSite.slug }
+							onClick={ onButtonClick }
+							primary
+						>
+							{ __( 'Customize your newsletter' ) }
+						</ImporterActionButton>
+						<ImporterActionButton href={ '/posts/' + selectedSite.slug } onClick={ onButtonClick }>
+							{ __( 'View content' ) }
+						</ImporterActionButton>
+						<ImporterActionButton
+							href={ '/subscribers/' + selectedSite.slug }
+							onClick={ onButtonClick }
+						>
+							{ __( 'Check subscribers' ) }
+						</ImporterActionButton>
+					</ImporterActionButtonContainer>
+				</>
+			) : (
+				<>
+					<h2>{ __( 'Almost there…' ) }</h2>
+					<div className="summary__content">
+						<p>
+							<strong>
+								{ getSummaryDescription( steps.content.content, steps.subscribers.content ) }
+							</strong>
+							<br />
+						</p>
+					</div>
+					<p>
+						{ __(
+							"This may take a few minutes. Feel free to leave this window – we'll let you know when it's done."
+						) }
+					</p>
+					<p>
+						<ProgressBar className="is-larger-progress-bar" />
+					</p>
+				</>
+			) }
 		</Card>
 	);
 }

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -85,21 +85,24 @@ export default function Summary( {
 					<p>
 						{ sprintf(
 							// translators: %s the site name
-							__( 'Here’s a summary of the imported data to %s' ),
+							__( 'Here’s a summary of the imported data to %s:' ),
 							selectedSite.name
 						) }
 					</p>
-
-					{ steps.content.content && (
-						<ContentSummary stepContent={ steps.content.content } status={ steps.content.status } />
-					) }
-
-					{ steps.subscribers.content && (
-						<SubscribersSummary
-							stepContent={ steps.subscribers.content }
-							status={ steps.subscribers.status }
-						/>
-					) }
+					<div className="summary__content">
+						{ steps.content.content && (
+							<ContentSummary
+								stepContent={ steps.content.content }
+								status={ steps.content.status }
+							/>
+						) }
+						{ steps.subscribers.content && (
+							<SubscribersSummary
+								stepContent={ steps.subscribers.content }
+								status={ steps.subscribers.status }
+							/>
+						) }
+					</div>
 					{ showPauseSubstackBillingWarning && (
 						<Notice status="warning" className="importer__notice" isDismissible={ false }>
 							<h2>{ __( 'Action required' ) }</h2>
@@ -126,6 +129,8 @@ export default function Summary( {
 							/>
 						</Notice>
 					) }
+					<hr />
+					<p>{ __( 'What would you like to do next?' ) }</p>
 					<ImporterActionButtonContainer noSpacing>
 						<ImporterActionButton
 							href={ '/settings/newsletter/' + selectedSite.slug }

--- a/client/my-sites/importer/newsletter/summary/SummaryStat.tsx
+++ b/client/my-sites/importer/newsletter/summary/SummaryStat.tsx
@@ -1,0 +1,22 @@
+import { Icon } from '@wordpress/icons';
+import { clsx } from 'clsx';
+
+interface SummaryStatProps {
+	count?: number;
+	icon?: JSX.Element | null;
+	label: JSX.Element | string;
+}
+
+export default function SummaryStat( { count, icon, label }: SummaryStatProps ) {
+	return (
+		<div
+			className={ clsx( 'summary__content-row', {
+				'summary__content-indent': ! icon,
+			} ) }
+		>
+			{ icon && <Icon icon={ icon } size={ 20 } className="summary__content-stats-icon" /> }
+			<div className="summary__content-stats-label">{ label }</div>
+			{ count !== undefined && <div className="summary__content-stats-count">{ count }</div> }
+		</div>
+	);
+}

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -1,31 +1,7 @@
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { Icon, verse, page, file } from '@wordpress/icons';
+import { Icon, verse, page, post, file } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { ContentStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
-
-function getSummaryCopy( postsNumber: number, pagesNumber: number, attachmentsNumber: number ) {
-	return (
-		<div className="summary__content-stats">
-			{ postsNumber > 0 && (
-				<div className="summary__content-stat-item">
-					<Icon icon={ verse } /> <span>{ __( 'Posts' ) }</span> <strong>{ postsNumber }</strong>
-				</div>
-			) }
-			{ pagesNumber > 0 && (
-				<div className="summary__content-stat-item">
-					<Icon icon={ page } /> <span>{ __( 'Pages' ) }</span> <strong>{ pagesNumber }</strong>
-				</div>
-			) }
-			{ attachmentsNumber > 0 && (
-				<div className="summary__content-stat-item">
-					<Icon icon={ file } /> <span>{ __( 'Media' ) }</span>{ ' ' }
-					<strong>{ attachmentsNumber }</strong>
-				</div>
-			) }
-		</div>
-	);
-}
 
 interface ContentSummaryProps {
 	stepContent: ContentStepContent;
@@ -48,36 +24,41 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 		);
 	}
 
-	if ( status === 'importing' || status === 'processing' ) {
-		return (
-			<div className="summary__content">
-				<p>
-					<Icon icon={ post } /> <strong>{ __( "We're importing your content." ) }</strong>
-					<br />
-					{ __(
-						"This may take a few minutes. Feel free to leave this window — we'll let you know when it's done."
-					) }
-				</p>
-			</div>
-		);
-	}
-
 	if ( status === 'done' ) {
 		const progress = stepContent.progress;
+		const posts = progress.post.completed;
+		const pages = progress.page.completed;
+		const attachments = progress.attachment.completed;
 
 		return (
-			<div className="summary__content">
-				<p>{ __( "Here's a summary of the imported data:" ) }</p>
-				<p>
-					{ getSummaryCopy(
-						progress.post.completed,
-						progress.page.completed,
-						progress.attachment.completed
-					) }
-				</p>
-			</div>
+			<dl className="summary__content-stats">
+				{ posts > 0 && (
+					<>
+						<dt>
+							<Icon icon={ verse } /> { __( 'Posts' ) }
+						</dt>
+						<dd>{ posts }</dd>
+					</>
+				) }
+				{ pages > 0 && (
+					<>
+						<dt>
+							<Icon icon={ page } /> { __( 'Pages' ) }
+						</dt>
+						<dd>{ pages }</dd>
+					</>
+				) }
+				{ attachments > 0 && (
+					<>
+						<dt>
+							<Icon icon={ file } /> { __( 'Media items' ) }
+						</dt>
+						<dd>{ attachments }</dd>
+					</>
+				) }
+			</dl>
 		);
 	}
 
-	return;
+	return null;
 }

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -7,7 +7,6 @@ import SummaryStat from './SummaryStat';
 interface ContentSummaryProps {
 	stepContent: ContentStepContent;
 	status: string;
-	siteName: string;
 }
 
 export default function ContentSummary( { status, stepContent }: ContentSummaryProps ) {

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -1,7 +1,8 @@
 import { createInterpolateElement } from '@wordpress/element';
-import { Icon, verse, page, post, file } from '@wordpress/icons';
+import { verse, page, post, file } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { ContentStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import SummaryStat from './SummaryStat';
 
 interface ContentSummaryProps {
 	stepContent: ContentStepContent;
@@ -14,10 +15,15 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 	if ( status === 'skipped' ) {
 		return (
 			<p>
-				<Icon icon={ post } />
-				{ createInterpolateElement( __( 'You <strong>skipped</strong> content importing.' ), {
-					strong: <strong />,
-				} ) }
+				<SummaryStat
+					icon={ post }
+					label={ createInterpolateElement(
+						__( 'You <strong>skipped</strong> content importing.' ),
+						{
+							strong: <strong />,
+						}
+					) }
+				/>
 			</p>
 		);
 	}
@@ -29,41 +35,13 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 		const attachments = progress.attachment.completed;
 
 		return (
-			<table className="summary__content-stats">
-				{ posts > 0 && (
-					<tr>
-						<td>
-							<Icon icon={ verse } />
-						</td>
-						<td className="summary__content-stats-label">{ __( 'Posts' ) }</td>
-						<td>
-							<strong>{ posts }</strong>
-						</td>
-					</tr>
-				) }
-				{ pages > 0 && (
-					<tr>
-						<td>
-							<Icon icon={ page } />
-						</td>
-						<td className="summary__content-stats-label">{ __( 'Pages' ) }</td>
-						<td>
-							<strong>{ pages }</strong>
-						</td>
-					</tr>
-				) }
+			<div className="summary__content-stats">
+				{ posts > 0 && <SummaryStat count={ posts } icon={ verse } label={ __( 'Posts' ) } /> }
+				{ pages > 0 && <SummaryStat count={ pages } icon={ page } label={ __( 'Pages' ) } /> }
 				{ attachments > 0 && (
-					<tr>
-						<td>
-							<Icon icon={ file } />
-						</td>
-						<td className="summary__content-stats-label">{ __( 'Media items' ) }</td>
-						<td>
-							<strong>{ attachments }</strong>
-						</td>
-					</tr>
+					<SummaryStat count={ attachments } icon={ file } label={ __( 'Media items' ) } />
 				) }
-			</table>
+			</div>
 		);
 	}
 

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -31,32 +31,35 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 		const attachments = progress.attachment.completed;
 
 		return (
-			<dl className="summary__content-stats">
+			<table className="summary__content-stats">
 				{ posts > 0 && (
-					<>
-						<dt>
-							<Icon icon={ verse } /> { __( 'Posts' ) }
-						</dt>
-						<dd>{ posts }</dd>
-					</>
+					<tr>
+						<td>
+							<Icon icon={ verse } />
+						</td>
+						<td className="summary__content-stats-label">{ __( 'Posts' ) }</td>
+						<td>{ posts }</td>
+					</tr>
 				) }
 				{ pages > 0 && (
-					<>
-						<dt>
-							<Icon icon={ page } /> { __( 'Pages' ) }
-						</dt>
-						<dd>{ pages }</dd>
-					</>
+					<tr>
+						<td>
+							<Icon icon={ page } />
+						</td>
+						<td className="summary__content-stats-label">{ __( 'Pages' ) }</td>
+						<td>{ pages }</td>
+					</tr>
 				) }
 				{ attachments > 0 && (
-					<>
-						<dt>
-							<Icon icon={ file } /> { __( 'Media items' ) }
-						</dt>
-						<dd>{ attachments }</dd>
-					</>
+					<tr>
+						<td>
+							<Icon icon={ file } />
+						</td>
+						<td className="summary__content-stats-label">{ __( 'Media items' ) }</td>
+						<td>{ attachments }</td>
+					</tr>
 				) }
-			</dl>
+			</table>
 		);
 	}
 

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -1,74 +1,36 @@
 import { createInterpolateElement } from '@wordpress/element';
-import { Icon, post } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { Icon, verse, page, file } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { ContentStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
 function getSummaryCopy( postsNumber: number, pagesNumber: number, attachmentsNumber: number ) {
-	if ( postsNumber > 0 && pagesNumber > 0 && attachmentsNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } posts</strong>, <strong>{ pagesNumber } pages</strong>{ ' ' }
-				and
-				<strong>{ attachmentsNumber } media</strong>.
-			</>
-		);
-	}
-
-	if ( postsNumber > 0 && pagesNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } posts</strong> and{ ' ' }
-				<strong>{ pagesNumber } pages</strong>.
-			</>
-		);
-	}
-
-	if ( postsNumber > 0 && attachmentsNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } posts</strong> and{ ' ' }
-				<strong>{ attachmentsNumber } media</strong>.
-			</>
-		);
-	}
-
-	if ( pagesNumber > 0 && attachmentsNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber }</strong> pages and{ ' ' }
-				<strong>{ attachmentsNumber } media</strong>.
-			</>
-		);
-	}
-
-	if ( postsNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } posts</strong>.
-			</>
-		);
-	}
-
-	if ( pagesNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } pages</strong>.
-			</>
-		);
-	}
-
-	if ( attachmentsNumber > 0 ) {
-		return (
-			<>
-				We imported <strong>{ postsNumber } media</strong>.
-			</>
-		);
-	}
+	return (
+		<div className="summary__content-stats">
+			{ postsNumber > 0 && (
+				<div className="summary__content-stat-item">
+					<Icon icon={ verse } /> <span>{ __( 'Posts' ) }</span> <strong>{ postsNumber }</strong>
+				</div>
+			) }
+			{ pagesNumber > 0 && (
+				<div className="summary__content-stat-item">
+					<Icon icon={ page } /> <span>{ __( 'Pages' ) }</span> <strong>{ pagesNumber }</strong>
+				</div>
+			) }
+			{ attachmentsNumber > 0 && (
+				<div className="summary__content-stat-item">
+					<Icon icon={ file } /> <span>{ __( 'Media' ) }</span>{ ' ' }
+					<strong>{ attachmentsNumber }</strong>
+				</div>
+			) }
+		</div>
+	);
 }
 
 interface ContentSummaryProps {
 	stepContent: ContentStepContent;
 	status: string;
+	siteName: string;
 }
 
 export default function ContentSummary( { status, stepContent }: ContentSummaryProps ) {
@@ -105,8 +67,8 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 
 		return (
 			<div className="summary__content">
+				<p>{ __( "Here's a summary of the imported data:" ) }</p>
 				<p>
-					<Icon icon={ post } />
 					{ getSummaryCopy(
 						progress.post.completed,
 						progress.page.completed,

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -13,14 +13,12 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 	const { __ } = useI18n();
 	if ( status === 'skipped' ) {
 		return (
-			<div className="summary__content">
-				<p>
-					<Icon icon={ post } />
-					{ createInterpolateElement( __( 'You <strong>skipped</strong> content importing.' ), {
-						strong: <strong />,
-					} ) }
-				</p>
-			</div>
+			<p>
+				<Icon icon={ post } />
+				{ createInterpolateElement( __( 'You <strong>skipped</strong> content importing.' ), {
+					strong: <strong />,
+				} ) }
+			</p>
 		);
 	}
 
@@ -38,7 +36,9 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 							<Icon icon={ verse } />
 						</td>
 						<td className="summary__content-stats-label">{ __( 'Posts' ) }</td>
-						<td>{ posts }</td>
+						<td>
+							<strong>{ posts }</strong>
+						</td>
 					</tr>
 				) }
 				{ pages > 0 && (
@@ -47,7 +47,9 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 							<Icon icon={ page } />
 						</td>
 						<td className="summary__content-stats-label">{ __( 'Pages' ) }</td>
-						<td>{ pages }</td>
+						<td>
+							<strong>{ pages }</strong>
+						</td>
 					</tr>
 				) }
 				{ attachments > 0 && (
@@ -56,7 +58,9 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 							<Icon icon={ file } />
 						</td>
 						<td className="summary__content-stats-label">{ __( 'Media items' ) }</td>
-						<td>{ attachments }</td>
+						<td>
+							<strong>{ attachments }</strong>
+						</td>
 					</tr>
 				) }
 			</table>

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,5 +1,5 @@
 import { ProgressBar } from '@wordpress/components';
-import { Icon, people, atSymbol, payment, info, warning } from '@wordpress/icons';
+import { Icon, people, atSymbol, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
@@ -45,59 +45,53 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 	if ( status === 'done' ) {
 		const subscribedCount = parseInt( stepContent.meta?.email_count || '0' );
 		const addedFree = parseInt( stepContent.meta?.subscribed_count || '0' );
-		const existingFree = parseInt( stepContent.meta?.already_subscribed_count || '0' );
-		const failedFree = parseInt( stepContent.meta?.failed_subscribed_count || '0' );
-
 		const addedPaid = parseInt( stepContent.meta?.paid_subscribed_count || '0' );
-		const existingPaid = parseInt( stepContent.meta?.paid_already_subscribed_count || '0' );
-		const failedPaid = parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' );
+		const existingTotal =
+			parseInt( stepContent.meta?.already_subscribed_count || '0' ) +
+			parseInt( stepContent.meta?.paid_already_subscribed_count || '0' );
+		const failedTotal =
+			parseInt( stepContent.meta?.failed_subscribed_count || '0' ) +
+			parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' );
 
 		return (
-			<>
-				<div className="summary__content">
-					<p>
-						<Icon icon={ atSymbol } /> We imported { subscribedCount } subscribers, where:
-					</p>
-				</div>
-				<div className="summary__content summary__content-indent">
-					{ !! addedFree && (
-						<p>
-							<Icon icon={ people } />
-							<strong>{ addedFree }</strong> free subscribers.
-						</p>
-					) }
-					{ !! addedPaid && (
-						<p>
-							<Icon icon={ payment } />
-							<strong>{ addedPaid }</strong> paid subscribers added.
-						</p>
-					) }
-					{ !! existingFree && (
-						<p>
-							<Icon icon={ info } />
-							<strong>{ existingFree }</strong> existing subscribers.
-						</p>
-					) }
-					{ !! existingPaid && (
-						<p>
-							<Icon icon={ info } />
-							<strong>{ existingPaid }</strong> existing paid subscribers.
-						</p>
-					) }
-					{ !! failedFree && (
-						<p>
-							<Icon icon={ warning } />
-							<strong>{ failedFree }</strong> error in the email format.
-						</p>
-					) }
-					{ !! failedPaid && (
-						<p>
-							<Icon icon={ warning } />
-							<strong>{ failedPaid }</strong> error in the email format.
-						</p>
-					) }
-				</div>
-			</>
+			<div className="summary__content-stats">
+				{ subscribedCount > 0 && (
+					<div className="summary__content-stat-item">
+						<Icon icon={ people } />
+						<span>{ __( 'Total Subscribers' ) }</span>
+						<strong>{ subscribedCount }</strong>
+					</div>
+				) }
+
+				{ addedFree > 0 && (
+					<div className="summary__content-stat-item summary__content-stat-item-indent">
+						<span>{ __( 'Free subscribers' ) }</span>
+						<strong>{ addedFree }</strong>
+					</div>
+				) }
+
+				{ addedPaid > 0 && (
+					<div className="summary__content-stat-item summary__content-stat-item-indent">
+						<span>{ __( 'Paid subscribers' ) }</span>
+						<strong>{ addedPaid }</strong>
+					</div>
+				) }
+
+				{ existingTotal > 0 && (
+					<div className="summary__content-stat-item summary__content-stat-item-indent">
+						<span>{ __( 'Skipped (Duplicate)' ) }</span>
+						<strong>{ existingTotal }</strong>
+					</div>
+				) }
+
+				{ failedTotal > 0 && (
+					<div className="summary__content-stat-item summary__content-stat-item-indent">
+						<span>{ __( 'Not imported' ) }</span>
+						<Icon icon={ info } className="info-icon" />
+						<strong>{ failedTotal }</strong>
+					</div>
+				) }
+			</div>
 		);
 	}
 }

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,4 +1,5 @@
-import { ProgressBar } from '@wordpress/components';
+import { Tooltip } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { Icon, people, atSymbol, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
@@ -14,31 +15,12 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 		return (
 			<div className="summary__content">
 				<p>
-					<Icon icon={ atSymbol } /> You <strong>skipped</strong> subscriber importing.
+					<Icon icon={ atSymbol } />
+					{ createInterpolateElement( __( 'You <strong>skipped</strong> subscriber importing.' ), {
+						strong: <strong />,
+					} ) }
 				</p>
 			</div>
-		);
-	}
-
-	if ( status === 'importing' ) {
-		return (
-			<>
-				<div className="summary__content">
-					<p>
-						<Icon icon={ atSymbol } />{ ' ' }
-						<strong>{ __( "We're importing your subscribers." ) }</strong>
-						<br />
-					</p>
-				</div>
-				<p>
-					{ __(
-						"This may take a few minutes. Feel free to leave this window – we'll let you know when it's done."
-					) }
-				</p>
-				<p>
-					<ProgressBar className="is-larger-progress-bar" />
-				</p>
-			</>
 		);
 	}
 
@@ -54,44 +36,53 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 			parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' );
 
 		return (
-			<div className="summary__content-stats">
+			<dl className="summary__content-stats">
 				{ subscribedCount > 0 && (
-					<div className="summary__content-stat-item">
-						<Icon icon={ people } />
-						<span>{ __( 'Total Subscribers' ) }</span>
-						<strong>{ subscribedCount }</strong>
-					</div>
+					<>
+						<dt>
+							<Icon icon={ people } /> { __( 'Total Subscribers' ) }
+						</dt>
+						<dd>{ subscribedCount }</dd>
+					</>
 				) }
-
 				{ addedFree > 0 && (
-					<div className="summary__content-stat-item summary__content-stat-item-indent">
-						<span>{ __( 'Free subscribers' ) }</span>
-						<strong>{ addedFree }</strong>
-					</div>
+					<>
+						<dt className="summary__content-indent">{ __( 'Free subscribers' ) }</dt>
+						<dd>{ addedFree }</dd>
+					</>
 				) }
-
+				{ addedFree > 0 && (
+					<>
+						<dt className="summary__content-indent">{ __( 'Free subscribers' ) }</dt>
+						<dd>{ addedFree }</dd>
+					</>
+				) }
 				{ addedPaid > 0 && (
-					<div className="summary__content-stat-item summary__content-stat-item-indent">
-						<span>{ __( 'Paid subscribers' ) }</span>
-						<strong>{ addedPaid }</strong>
-					</div>
+					<>
+						<dt className="summary__content-indent">{ __( 'Paid subscribers' ) }</dt>
+						<dd>{ addedPaid }</dd>
+					</>
 				) }
-
 				{ existingTotal > 0 && (
-					<div className="summary__content-stat-item summary__content-stat-item-indent">
-						<span>{ __( 'Skipped (Duplicate)' ) }</span>
-						<strong>{ existingTotal }</strong>
-					</div>
+					<>
+						<dt className="summary__content-indent">{ __( 'Skipped (duplicate)' ) }</dt>
+						<dd>{ existingTotal }</dd>
+					</>
 				) }
-
 				{ failedTotal > 0 && (
-					<div className="summary__content-stat-item summary__content-stat-item-indent">
-						<span>{ __( 'Not imported' ) }</span>
-						<Icon icon={ info } className="info-icon" />
-						<strong>{ failedTotal }</strong>
-					</div>
+					<>
+						<dt className="summary__content-indent">
+							{ __( 'Not imported' ) }
+							<Tooltip>
+								<Icon icon={ info } size={ 16 } />
+							</Tooltip>
+						</dt>
+						<dd>{ failedTotal }</dd>
+					</>
 				) }
-			</div>
+			</dl>
 		);
 	}
+
+	return null;
 }

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,6 +1,6 @@
 import { Tooltip } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { Icon, people, atSymbol, info } from '@wordpress/icons';
+import { Icon, people, help } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 
@@ -13,14 +13,12 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 	const { __ } = useI18n();
 	if ( status === 'skipped' ) {
 		return (
-			<div className="summary__content">
-				<p>
-					<Icon icon={ atSymbol } />
-					{ createInterpolateElement( __( 'You <strong>skipped</strong> subscriber importing.' ), {
-						strong: <strong />,
-					} ) }
-				</p>
-			</div>
+			<p>
+				<Icon icon={ people } />
+				{ createInterpolateElement( __( 'You <strong>skipped</strong> subscriber importing.' ), {
+					strong: <strong />,
+				} ) }
+			</p>
 		);
 	}
 
@@ -43,37 +41,39 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 							<Icon icon={ people } />
 						</td>
 						<td className="summary__content-stats-label">{ __( 'Total Subscribers' ) }</td>
-						<td>{ subscribedCount }</td>
+						<td>
+							<strong>{ subscribedCount }</strong>
+						</td>
 					</tr>
 				) }
 				{ addedFree > 0 && (
-					<tr>
+					<tr className="summary__content-indent">
 						<td></td>
 						<td className="summary__content-stats-label">{ __( 'Free subscribers' ) }</td>
 						<td>{ addedFree }</td>
 					</tr>
 				) }
 				{ addedPaid > 0 && (
-					<tr>
+					<tr className="summary__content-indent">
 						<td></td>
 						<td className="summary__content-stats-label">{ __( 'Paid subscribers' ) }</td>
 						<td>{ addedPaid }</td>
 					</tr>
 				) }
 				{ existingTotal > 0 && (
-					<tr>
+					<tr className="summary__content-indent">
 						<td></td>
 						<td className="summary__content-stats-label">{ __( 'Skipped (duplicate)' ) }</td>
 						<td>{ existingTotal }</td>
 					</tr>
 				) }
 				{ failedTotal > 0 && (
-					<tr>
+					<tr className="summary__content-indent">
 						<td></td>
 						<td className="summary__content-stats-label">
 							{ __( 'Not imported' ) }
 							<Tooltip>
-								<Icon icon={ info } size={ 16 } />
+								<Icon icon={ help } size={ 16 } />
 							</Tooltip>
 						</td>
 						<td>{ failedTotal }</td>

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -51,12 +51,6 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 						<dd>{ addedFree }</dd>
 					</>
 				) }
-				{ addedFree > 0 && (
-					<>
-						<dt className="summary__content-indent">{ __( 'Free subscribers' ) }</dt>
-						<dd>{ addedFree }</dd>
-					</>
-				) }
 				{ addedPaid > 0 && (
 					<>
 						<dt className="summary__content-indent">{ __( 'Paid subscribers' ) }</dt>

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -36,45 +36,50 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 			parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' );
 
 		return (
-			<dl className="summary__content-stats">
+			<table className="summary__content-stats">
 				{ subscribedCount > 0 && (
-					<>
-						<dt>
-							<Icon icon={ people } /> { __( 'Total Subscribers' ) }
-						</dt>
-						<dd>{ subscribedCount }</dd>
-					</>
+					<tr>
+						<td>
+							<Icon icon={ people } />
+						</td>
+						<td className="summary__content-stats-label">{ __( 'Total Subscribers' ) }</td>
+						<td>{ subscribedCount }</td>
+					</tr>
 				) }
 				{ addedFree > 0 && (
-					<>
-						<dt className="summary__content-indent">{ __( 'Free subscribers' ) }</dt>
-						<dd>{ addedFree }</dd>
-					</>
+					<tr>
+						<td></td>
+						<td className="summary__content-stats-label">{ __( 'Free subscribers' ) }</td>
+						<td>{ addedFree }</td>
+					</tr>
 				) }
 				{ addedPaid > 0 && (
-					<>
-						<dt className="summary__content-indent">{ __( 'Paid subscribers' ) }</dt>
-						<dd>{ addedPaid }</dd>
-					</>
+					<tr>
+						<td></td>
+						<td className="summary__content-stats-label">{ __( 'Paid subscribers' ) }</td>
+						<td>{ addedPaid }</td>
+					</tr>
 				) }
 				{ existingTotal > 0 && (
-					<>
-						<dt className="summary__content-indent">{ __( 'Skipped (duplicate)' ) }</dt>
-						<dd>{ existingTotal }</dd>
-					</>
+					<tr>
+						<td></td>
+						<td className="summary__content-stats-label">{ __( 'Skipped (duplicate)' ) }</td>
+						<td>{ existingTotal }</td>
+					</tr>
 				) }
 				{ failedTotal > 0 && (
-					<>
-						<dt className="summary__content-indent">
+					<tr>
+						<td></td>
+						<td className="summary__content-stats-label">
 							{ __( 'Not imported' ) }
 							<Tooltip>
 								<Icon icon={ info } size={ 16 } />
 							</Tooltip>
-						</dt>
-						<dd>{ failedTotal }</dd>
-					</>
+						</td>
+						<td>{ failedTotal }</td>
+					</tr>
 				) }
-			</dl>
+			</table>
 		);
 	}
 

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,8 +1,8 @@
-import { Tooltip } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { Icon, people, help } from '@wordpress/icons';
+import { people } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import SummaryStat from './SummaryStat';
 
 interface SubscriberSummaryProps {
 	stepContent: SubscribersStepContent;
@@ -14,10 +14,15 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 	if ( status === 'skipped' ) {
 		return (
 			<p>
-				<Icon icon={ people } />
-				{ createInterpolateElement( __( 'You <strong>skipped</strong> subscriber importing.' ), {
-					strong: <strong />,
-				} ) }
+				<SummaryStat
+					icon={ people }
+					label={ createInterpolateElement(
+						__( 'You <strong>skipped</strong> subscriber importing.' ),
+						{
+							strong: <strong />,
+						}
+					) }
+				/>
 			</p>
 		);
 	}
@@ -34,52 +39,21 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 			parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' );
 
 		return (
-			<table className="summary__content-stats">
+			<div className="summary__content-stats">
 				{ subscribedCount > 0 && (
-					<tr>
-						<td>
-							<Icon icon={ people } />
-						</td>
-						<td className="summary__content-stats-label">{ __( 'Total Subscribers' ) }</td>
-						<td>
-							<strong>{ subscribedCount }</strong>
-						</td>
-					</tr>
+					<SummaryStat
+						count={ subscribedCount }
+						icon={ people }
+						label={ __( 'Total Subscribers' ) }
+					/>
 				) }
-				{ addedFree > 0 && (
-					<tr className="summary__content-indent">
-						<td></td>
-						<td className="summary__content-stats-label">{ __( 'Free subscribers' ) }</td>
-						<td>{ addedFree }</td>
-					</tr>
-				) }
-				{ addedPaid > 0 && (
-					<tr className="summary__content-indent">
-						<td></td>
-						<td className="summary__content-stats-label">{ __( 'Paid subscribers' ) }</td>
-						<td>{ addedPaid }</td>
-					</tr>
-				) }
+				{ addedFree > 0 && <SummaryStat count={ addedFree } label={ __( 'Free Subscribers' ) } /> }
+				{ addedPaid > 0 && <SummaryStat count={ addedPaid } label={ __( 'Paid Subscribers' ) } /> }
 				{ existingTotal > 0 && (
-					<tr className="summary__content-indent">
-						<td></td>
-						<td className="summary__content-stats-label">{ __( 'Skipped (duplicate)' ) }</td>
-						<td>{ existingTotal }</td>
-					</tr>
+					<SummaryStat count={ existingTotal } label={ __( 'Skipped (duplicate)' ) } />
 				) }
-				{ failedTotal > 0 && (
-					<tr className="summary__content-indent">
-						<td></td>
-						<td className="summary__content-stats-label">
-							{ __( 'Not imported' ) }
-							<Tooltip>
-								<Icon icon={ help } size={ 16 } />
-							</Tooltip>
-						</td>
-						<td>{ failedTotal }</td>
-					</tr>
-				) }
-			</table>
+				{ failedTotal > 0 && <SummaryStat count={ failedTotal } label={ __( 'Not imported' ) } /> }
+			</div>
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/jetpack-roadmap/issues/1898

## Proposed Changes

* Simplifies summary screen copy for clarity and simplified translations, and improves code structure
<img width="905" alt="Screenshot 2024-11-06 at 11 18 40" src="https://github.com/user-attachments/assets/25e53aef-ba7c-4b79-b0a3-96566aacc60d">

<img width="786" alt="Screenshot 2024-11-06 at 14 53 36" src="https://github.com/user-attachments/assets/a165c3a6-f3d4-4269-ae0b-c55c62fb24b9">
<img width="804" alt="Screenshot 2024-11-06 at 14 59 56" src="https://github.com/user-attachments/assets/73049535-56cc-4992-8837-3ff71689f98d">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Import and try skipping content and subscribers separately, and one run where you don't skip either one.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
