### PR TITLE
Docs: Add subsection for `i18n-calypso` best practices

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -6,6 +6,14 @@ We extract the translatable texts wrapped inside the function and write a POT fi
 
 Translated texts are [split into chunks loaded via JSON asynchronously](translation-chunks.md).
 
+## Best Practices
+
+The recommended way to use [i18n-calypso](../packages/i18n-calypso/README.md) in Calypso is through `useTranslate()` for function components and custom hooks, and `props.translate()` from the `localize()` higher-order component for class components.
+
+Both methods ensure that the component subscribes to i18n events and re-renders when translation data is updated. This is crucial because translation data is loaded asynchronously, and components might render before translations are available. Otherwise, components could initially display English text and fail to update when translations are loaded.
+
+Another key benefit of these methods is that they use the `i18n-calypso` instance [provided by context](https://github.com/Automattic/wp-calypso/blob/634d000d827b78e37e6c46458c928fdcdd917dd6/client/components/calypso-i18n-provider/index.tsx#L33), which may differ from the [default `i18n-calypso` instance in some cases](https://github.com/Automattic/wp-calypso/blob/bbc5cce795bff4f557f736bb79e65d9f72e2df27/client/controller/ssr-setup-locale.js#L15).
+
 ## String Freeze
 
 If you're launching or updating a feature, and want to make sure that all new strings are translated before merging,
@@ -26,8 +34,8 @@ While the following is still supported:
 ```css
 /* LTR-specific code */
 .element {
-  position: absolute;
-  left: 0;
+	position: absolute;
+	left: 0;
 }
 ```
 
@@ -36,8 +44,8 @@ Better:
 ```css
 /* Will render correctly in LTR or RTL */
 .element {
-  position: absolute;
-  inset-inline-start: 0; /* inset-inline-start evaluates to left in LTR and right in RTL */
+	position: absolute;
+	inset-inline-start: 0; /* inset-inline-start evaluates to left in LTR and right in RTL */
 }
 ```
 
@@ -47,10 +55,10 @@ values like `start` and `end`. For example, the following is still supported:
 ```css
 /* LTR-specific code */
 .is-right-align {
-  text-align: right;
+	text-align: right;
 }
 .is-left-align {
-  text-align: left;
+	text-align: left;
 }
 ```
 
@@ -59,10 +67,10 @@ Better:
 ```css
 /* Will render correctly in LTR or RTL */
 .is-right-align {
-  text-align: end; /* end evaluates to right in LTR and left in RTL */
+	text-align: end; /* end evaluates to right in LTR and left in RTL */
 }
 .is-left-align {
-  text-align: start; /* start evaluates to left in LTR and right in RTL */
+	text-align: start; /* start evaluates to left in LTR and right in RTL */
 }
 ```
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to N/A

## Proposed Changes

* Add a subsection for best practices when using `i18n-calypso` in Calypso.
* Auto-formatted CSS snippets.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve docs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review the updated docs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
