### PR TITLE
Help Center: Fix avatar image on chat history

### DIFF
--- a/packages/help-center/src/components/help-center-recent-conversations.tsx
+++ b/packages/help-center/src/components/help-center-recent-conversations.tsx
@@ -78,7 +78,6 @@ const HelpCenterRecentConversations: React.FC = () => {
 				<HelpCenterSupportChatMessage
 					key={ lastConversation.id }
 					badgeCount={ unreadConversationsCount - 1 }
-					avatarSize={ 38 }
 					message={ chatMessage }
 					isUnread={ unreadMessagesCount > 0 }
 					navigateTo="/chat-history"

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -30,7 +30,7 @@ import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useAdminResults } from '../hooks/use-admin-results';
 import { useContextBasedSearchMapping } from '../hooks/use-context-based-search-mapping';
 import { useHelpSearchQuery } from '../hooks/use-help-search-query';
-import HelpCenterRecentConversation from './help-center-recent-conversations';
+import HelpCenterRecentConversations from './help-center-recent-conversations';
 import PlaceholderLines from './placeholder-lines';
 import type { SearchResult } from '../types';
 
@@ -358,7 +358,7 @@ function HelpSearchResults( {
 				</p>
 			) : null }
 
-			{ shouldDisplayRecentConversations && <HelpCenterRecentConversation /> }
+			{ shouldDisplayRecentConversations && <HelpCenterRecentConversations /> }
 			{ sections }
 		</div>
 	);

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -45,7 +45,7 @@ export const HelpCenterSupportChatMessage = ( {
 		return (
 			<Gravatar
 				user={ currentUser }
-				size={ 32 }
+				size={ 38 }
 				alt={ __( 'User profile display picture', __i18n_text_domain__ ) }
 			/>
 		);

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { getRelativeTimeString, useLocale } from '@automattic/i18n-utils';
+import { HumanAvatar } from '@automattic/odie-client/src/assets';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
@@ -20,7 +21,6 @@ const trackContactButtonClicked = ( sectionName: string ) => {
 export const HelpCenterSupportChatMessage = ( {
 	message,
 	badgeCount = 0,
-	avatarSize = 32,
 	isUnread = false,
 	navigateTo = '',
 }: {
@@ -33,7 +33,7 @@ export const HelpCenterSupportChatMessage = ( {
 	const { __ } = useI18n();
 	const locale = useLocale();
 
-	const { displayName, received, text, avatarUrl } = message;
+	const { displayName, received, text } = message;
 	const helpCenterContext = useHelpCenterContext();
 	const sectionName = helpCenterContext.sectionName;
 
@@ -50,12 +50,7 @@ export const HelpCenterSupportChatMessage = ( {
 					'has-badge': badgeCount > 0,
 				} ) }
 			>
-				<img
-					src={ avatarUrl }
-					alt={ __( 'User Avatar' ) }
-					height={ avatarSize }
-					width={ avatarSize }
-				/>
+				<HumanAvatar title={ __( 'User Avatar', __i18n_text_domain__ ) } />
 
 				{ badgeCount > 0 && (
 					<div className="help-center-support-chat__conversation-badge">+{ badgeCount }</div>

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -1,12 +1,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Gravatar } from '@automattic/components';
 import { getRelativeTimeString, useLocale } from '@automattic/i18n-utils';
+import { type ZendeskMessage } from '@automattic/odie-client';
 import { HumanAvatar } from '@automattic/odie-client/src/assets';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { Link } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
-import type { ZendeskMessage } from '@automattic/odie-client';
 
 import './help-center-support-chat-message.scss';
 
@@ -32,10 +33,23 @@ export const HelpCenterSupportChatMessage = ( {
 } ) => {
 	const { __ } = useI18n();
 	const locale = useLocale();
-
+	const { currentUser } = useHelpCenterContext();
 	const { displayName, received, text } = message;
 	const helpCenterContext = useHelpCenterContext();
 	const sectionName = helpCenterContext.sectionName;
+
+	const renderAvatar = () => {
+		if ( message.role === 'business' ) {
+			return <HumanAvatar title={ __( 'User Avatar', __i18n_text_domain__ ) } />;
+		}
+		return (
+			<Gravatar
+				user={ currentUser }
+				size={ 32 }
+				alt={ __( 'User profile display picture', __i18n_text_domain__ ) }
+			/>
+		);
+	};
 
 	return (
 		<Link
@@ -50,7 +64,7 @@ export const HelpCenterSupportChatMessage = ( {
 					'has-badge': badgeCount > 0,
 				} ) }
 			>
-				<HumanAvatar title={ __( 'User Avatar', __i18n_text_domain__ ) } />
+				{ renderAvatar() }
 
 				{ badgeCount > 0 && (
 					<div className="help-center-support-chat__conversation-badge">+{ badgeCount }</div>

--- a/packages/odie-client/src/assets/human-avatar.tsx
+++ b/packages/odie-client/src/assets/human-avatar.tsx
@@ -1,4 +1,4 @@
-export const HumanAvatar = () => (
+export const HumanAvatar = ( { title }: { title: string } ) => (
 	<svg
 		width="38"
 		height="38"
@@ -7,6 +7,7 @@ export const HumanAvatar = () => (
 		xmlns="http://www.w3.org/2000/svg"
 		xmlnsXlink="http://www.w3.org/1999/xlink"
 	>
+		<title id="svgTitle">{ title }</title>
 		<g clipPath="url(#clip0_351_8437)">
 			<rect width="38" height="38" rx="8" fill="url(#pattern0_351_8437)" />
 		</g>

--- a/packages/odie-client/src/components/message/index.tsx
+++ b/packages/odie-client/src/components/message/index.tsx
@@ -65,7 +65,11 @@ const MessageAvatarHeader = ( {
 				) }
 			</>
 		) : (
-			<>{ message.role === 'business' && <HumanAvatar /> }</>
+			<>
+				{ message.role === 'business' && (
+					<HumanAvatar title={ __( 'User Avatar', __i18n_text_domain__ ) } />
+				) }
+			</>
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9636
Fixes https://github.com/Automattic/dotcom-forge/issues/9636

## Proposed Changes

* Use the correct Avatar on chat history

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Match the designs CMvR9P4FontAbv2b0TNMzj-fi-282_53284

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link with the flag `?flags=help-center-experience`
* Open the Help Center and check if the chat history avatar is matching the designs CMvR9P4FontAbv2b0TNMzj-fi-282_53284

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?