### PR TITLE
Newsletter settings: add floating subscribe button

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/SubscribeFloatingButtonSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeFloatingButtonSetting.tsx
@@ -1,0 +1,63 @@
+import { ExternalLink, ToggleControl } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const SUBSCRIBE_FLOATING_BUTTON_OPTION = 'jetpack_subscribe_floating_button_enabled';
+
+type SubscribeFloatingButtonSettingProps = {
+	value?: boolean;
+	handleToggle: ( field: string ) => ( value: boolean ) => void;
+	disabled?: boolean;
+};
+
+export const SubscribeFloatingButtonSetting = ( {
+	value = false,
+	handleToggle,
+	disabled,
+}: SubscribeFloatingButtonSettingProps ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+
+	// Construct a link to edit the overlay
+	const { data: activeThemeData } = useActiveThemeQuery( siteId, true );
+	const isFSEActive = activeThemeData?.[ 0 ]?.is_block_theme ?? false;
+	const themeSlug = activeThemeData?.[ 0 ]?.stylesheet;
+	const siteEditorUrl = useSelector( ( state: object ) => getSiteEditorUrl( state, siteId ) );
+	const subscribeFloatingButtonEditorUrl = isFSEActive
+		? addQueryArgs( siteEditorUrl, {
+				postType: 'wp_template_part',
+				postId: `${ themeSlug }//jetpack-subscribe-floating-button`,
+				canvas: 'edit',
+		  } )
+		: false;
+
+	const onEditClick = () => {
+		recordTracksEvent( 'calypso_settings_subscribe_floating_button_edit_click' );
+	};
+
+	return (
+		<ToggleControl
+			checked={ !! value }
+			onChange={ handleToggle( SUBSCRIBE_FLOATING_BUTTON_OPTION ) }
+			disabled={ disabled }
+			label={
+				<>
+					{ translate( "Floating subscribe button on site's bottom corner." ) }
+					{ subscribeFloatingButtonEditorUrl && (
+						<>
+							{ ' ' }
+							<ExternalLink href={ subscribeFloatingButtonEditorUrl } onClick={ onEditClick }>
+								{ translate( 'Preview and edit' ) }
+							</ExternalLink>
+						</>
+					) }
+				</>
+			}
+		/>
+	);
+};

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -20,6 +20,7 @@ import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
 import { PaidNewsletterSection } from './PaidNewsletterSection';
 import { ReplyToSetting } from './ReplyToSetting';
 import { SenderNameSetting } from './SenderNameSetting';
+import { SubscribeFloatingButtonSetting } from './SubscribeFloatingButtonSetting';
 import { SubscribeModalOnCommentSetting } from './SubscribeModalOnCommentSetting';
 import { SubscribeModalSetting } from './SubscribeModalSetting';
 import { SubscribeNavigationSetting } from './SubscribeNavigationSetting';
@@ -47,6 +48,7 @@ type Fields = {
 	jetpack_subscriptions_from_name?: string;
 	sm_enabled?: boolean;
 	jetpack_subscribe_overlay_enabled?: boolean;
+	jetpack_subscribe_floating_button_enabled?: boolean;
 	jetpack_subscriptions_subscribe_post_end_enabled?: boolean;
 	jetpack_subscriptions_subscribe_navigation_enabled?: boolean;
 	jetpack_subscriptions_login_navigation_enabled?: boolean;
@@ -72,6 +74,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		jetpack_subscriptions_from_name,
 		sm_enabled,
 		jetpack_subscribe_overlay_enabled,
+		jetpack_subscribe_floating_button_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled,
 		jetpack_subscriptions_subscribe_navigation_enabled,
 		jetpack_subscriptions_login_navigation_enabled,
@@ -92,6 +95,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		jetpack_subscriptions_from_name: jetpack_subscriptions_from_name || '',
 		sm_enabled: !! sm_enabled,
 		jetpack_subscribe_overlay_enabled: !! jetpack_subscribe_overlay_enabled,
+		jetpack_subscribe_floating_button_enabled: !! jetpack_subscribe_floating_button_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled:
 			!! jetpack_subscriptions_subscribe_post_end_enabled,
 		jetpack_subscriptions_subscribe_navigation_enabled:
@@ -136,6 +140,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		subscription_options,
 		sm_enabled,
 		jetpack_subscribe_overlay_enabled,
+		jetpack_subscribe_floating_button_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled,
 		jetpack_subscriptions_subscribe_navigation_enabled,
 		jetpack_subscriptions_login_navigation_enabled,
@@ -208,6 +213,11 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					disabled={ disabled }
 					handleToggle={ handleToggle }
 					value={ jetpack_subscribe_overlay_enabled }
+				/>
+				<SubscribeFloatingButtonSetting
+					disabled={ disabled }
+					handleToggle={ handleToggle }
+					value={ jetpack_subscribe_floating_button_enabled }
 				/>
 				<FormLabel>{ translate( 'Navigation' ) }</FormLabel>
 				<SubscribeNavigationSetting


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Details https://github.com/Automattic/jetpack/issues/39772

Jetpack counterpart: https://github.com/Automattic/jetpack/pull/37722

Requires backend D165358-code

## Proposed Changes

* Adds "floating subscribe button" to Newsletter settings, just like it's in Jetpack settings too.


Setting:

<img width="809" alt="Screenshot 2024-11-04 at 12 38 35" src="https://github.com/user-attachments/assets/b1cc7769-11f9-4b84-a0d1-61bf75ebbf71">


Website:
<img width="954" alt="Screenshot 2024-11-04 at 13 10 57" src="https://github.com/user-attachments/assets/abbbf6f4-0936-4a8f-aa33-1f53dc66fa69">
<img width="958" alt="Screenshot 2024-11-04 at 13 10 54" src="https://github.com/user-attachments/assets/6f4168d0-92fc-4700-98ea-24a034d1ad63">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D165358-code and sandbox a simple site
* Go to Settings -> Newsletter
* Enable floating subscribe button toggle
* Open frontend of the site and see the button in the bottom corner
* Note how logged-out action bar was visible before but gets disabled when floating button is enabled:
    Before
    <img width="238" alt="image" src="https://github.com/user-attachments/assets/3aa2a01a-8e81-41ed-a52b-67ad07e6201b">
   After
   <img width="214" alt="image" src="https://github.com/user-attachments/assets/0fc61023-567d-4b8f-be66-d4288d96a93d">

* Logged-in action bar is still visible:
    <img width="397" alt="Screenshot 2024-11-04 at 13 55 42" src="https://github.com/user-attachments/assets/2ad1d1a1-1a0c-49c2-ae4c-97da6129f837">

* Test that you can edit the template, and changes get applied to the button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
