### PR TITLE
Media: Update video/audio uploads upsell nudge

### DIFF
--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -75,7 +75,7 @@ class MediaLibraryHeader extends Component {
 					site={ site }
 					filter={ filter }
 					onAddMedia={ onAddMedia }
-					className="media-library__upload-button button is-compact"
+					className="media-library__upload-button button is-compact is-primary"
 				>
 					<Gridicon icon="add-image" />
 					<span className="media-library__upload-button-label">

--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -83,10 +83,7 @@ class MediaLibraryListNoContent extends Component {
 		if ( userCan( 'upload_files', this.props.site ) && ! this.props.source ) {
 			line = this.props.translate( 'Would you like to upload something?' );
 			action = (
-				<UploadButton
-					className="media-library__no-content-upload-button is-primary"
-					site={ this.props.site }
-				>
+				<UploadButton className="media-library__no-content-upload-button" site={ this.props.site }>
 					{ this.props.translate( 'Upload media' ) }
 				</UploadButton>
 			);

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -1,4 +1,10 @@
-import { PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
+import {
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	getPlan,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
@@ -56,9 +62,9 @@ class MediaLibraryListPlanPromo extends Component {
 			case 'videos':
 				return preventWidows(
 					this.props.canUpgrade
-						? this.props.translate( 'To upload video files to your site, upgrade your plan.', {
-								textOnly: true,
-								context: 'Media upgrade promo',
+						? /* translators: %(planName)s is the short-hand version of the Premium plan name */
+						  this.props.translate( 'Upgrade to the %(planName)s plan to enable VideoPress', {
+								args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
 						  } )
 						: this.props.translate( 'Uploading video requires a paid plan.' ) +
 								' ' +
@@ -69,9 +75,9 @@ class MediaLibraryListPlanPromo extends Component {
 			case 'audio':
 				return preventWidows(
 					this.props.canUpgrade
-						? this.props.translate( 'To upload audio files to your site, upgrade your plan.', {
-								textOnly: true,
-								context: 'Media upgrade promo',
+						? /* translators: %(planName)s is the short-hand version of the Personal plan name */
+						  this.props.translate( 'Upgrade to the %(planName)s plan to enable audio uploads', {
+								args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
 						  } )
 						: this.props.translate( 'Uploading audio requires a paid plan.' ) +
 								' ' +

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -3,72 +3,57 @@ import {
 	WPCOM_FEATURES_UPLOAD_VIDEO_FILES,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
-	getPlan,
 } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
+import { Button } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import ListPlanPromo from './list-plan-promo';
 
-function getTitle( filter, translate ) {
-	if ( filter === 'audio' ) {
-		/* translators: %(planName)s is the short-hand version of the Personal plan name */
-		return translate( 'Upgrade to the %(planName)s Plan to Enable Audio Uploads', {
-			args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+export const MediaLibraryUpgradeNudge = ( { translate, filter = 'video', site } ) => {
+	const commonEventProps = {
+		cta_name: 'calypso_media_uploads_upgrade_nudge',
+		cta_feature:
+			'audio' === filter ? WPCOM_FEATURES_UPLOAD_AUDIO_FILES : WPCOM_FEATURES_UPLOAD_VIDEO_FILES,
+		cta_size: 'regular',
+	};
+
+	const handleClick = () => {
+		const planSlug = 'audio' === filter ? PLAN_PERSONAL : PLAN_PREMIUM;
+		const checkoutUrl = addQueryArgs( `/checkout/${ site.slug }/${ planSlug }`, {
+			redirect_to: `/media/${ filter }/${ site.slug }`,
 		} );
-	}
-	/* translators: %(planName)s is the short-hand version of the Premium plan name */
-	return translate( 'Upgrade to the %(planName)s Plan to Enable VideoPress', {
-		args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
-	} );
-}
 
-function getSubtitle( filter, translate ) {
-	if ( filter === 'audio' ) {
-		return translate(
-			/* translators: %(planName)s is the short-hand version of the Personal plan name */
-			"By upgrading to the %(planName)s plan, you'll enable audio upload support on your site.",
-			{
-				args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
-			}
-		);
+		recordTracksEvent( 'calypso_upgrade_nudge_cta_click', commonEventProps );
+		page.redirect( checkoutUrl );
+	};
+
+	if ( ! site ) {
+		return null;
 	}
-	/* translators: %(planName)s is the short-hand version of the Premium plan name */
-	return translate(
-		"By upgrading to the %(planName)s plan, you'll enable VideoPress support on your site.",
-		{
-			args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
-		}
+
+	return (
+		<div className="media-library__videopress-nudge-container">
+			<ListPlanPromo site={ site } filter={ filter }>
+				<Button variant="primary" onClick={ handleClick }>
+					{ translate( 'Upgrade now' ) }
+				</Button>
+				<TrackComponentView
+					eventName="calypso_upgrade_nudge_impression"
+					eventProperties={ commonEventProps }
+				/>
+			</ListPlanPromo>
+		</div>
 	);
-}
-
-export const MediaLibraryUpgradeNudge = ( { translate, filter, site } ) => (
-	<div className="media-library__videopress-nudge-container">
-		<ListPlanPromo site={ site } filter={ filter }>
-			<UpsellNudge
-				className="media-library__videopress-nudge-regular"
-				title={ getTitle( filter, translate ) }
-				description={ getSubtitle( filter, translate ) }
-				feature={
-					'audio' === filter ? WPCOM_FEATURES_UPLOAD_AUDIO_FILES : WPCOM_FEATURES_UPLOAD_VIDEO_FILES
-				}
-				event="calypso_media_uploads_upgrade_nudge"
-				tracksImpressionName="calypso_upgrade_nudge_impression"
-				tracksClickName="calypso_upgrade_nudge_cta_click"
-				showIcon
-			/>
-		</ListPlanPromo>
-	</div>
-);
+};
 
 MediaLibraryUpgradeNudge.propTypes = {
 	site: PropTypes.object,
 	translate: PropTypes.func,
 	filter: PropTypes.string,
-};
-
-MediaLibraryUpgradeNudge.defaultProps = {
-	filter: 'video',
 };
 
 export default localize( MediaLibraryUpgradeNudge );

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -23,9 +23,7 @@ export const MediaLibraryUpgradeNudge = ( { translate, filter = 'video', site } 
 
 	const handleClick = () => {
 		const planSlug = 'audio' === filter ? PLAN_PERSONAL : PLAN_PREMIUM;
-		const checkoutUrl = addQueryArgs( `/checkout/${ site.slug }/${ planSlug }`, {
-			redirect_to: `/media/${ filter }/${ site.slug }`,
-		} );
+		const checkoutUrl = addQueryArgs( `/checkout/${ site.slug }/${ planSlug }` );
 
 		recordTracksEvent( 'calypso_upgrade_nudge_cta_click', commonEventProps );
 		page.redirect( checkoutUrl );

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -271,6 +271,10 @@
 	right: 0;
 	left: 0;
 	margin: 0;
+
+	.empty-content {
+		padding: 20px 0;
+	}
 }
 
 .editor-media-modal .media-library__videopress-nudge-container {
@@ -282,12 +286,4 @@
 		margin-right: 20px;
 		margin-left: 20px;
 	}
-}
-
-.empty-content .media-library__videopress-nudge-regular.card.upsell-nudge {
-	margin-left: auto;
-	margin-right: auto;
-	text-align: left;
-	width: 70%;
-	text-decoration: none;
 }

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -74,9 +74,7 @@ class MediaLibraryUploadButton extends Component {
 	};
 
 	render() {
-		const classes = clsx( 'media-library__upload-button', 'button', this.props.className, {
-			'is-primary': this.props.sectionName === 'media',
-		} );
+		const classes = clsx( 'media-library__upload-button', 'button', this.props.className );
 
 		return (
 			<form ref={ this.formRef } className={ classes }>


### PR DESCRIPTION
## Proposed Changes

This PR updates the video/audio uploads upsell nudge in the following ways:

1. The upsell UI uses a button instead of a banner.
2. The upsell description displays the plan needed for the upload.
3. The CTA action takes users to the checkout page instead of the plans page.
4. Upon checkout completion, the user is redirected to the media page instead the thank you page.

Before

https://github.com/user-attachments/assets/8c2dcf2a-dfd1-4e74-8fb4-261746b90e6e

After

https://github.com/user-attachments/assets/f6b777ba-9f5c-4236-acf9-1af47ee02c0d


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WordPress.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /media/:domain
* Ensure that the user experience is updated as described above and working as intended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
