### PR TITLE
Photos Picker: Don't provide filter params to the fetch media items request when the picker is turned ON

### DIFF
--- a/client/components/data/media-list-data/index.jsx
+++ b/client/components/data/media-list-data/index.jsx
@@ -62,10 +62,10 @@ export class MediaListData extends Component {
 			if ( props.source === 'google_photos' ) {
 				if ( props.googlePhotosPickerSession ) {
 					query.session_id = props.googlePhotosPickerSession.id;
+				} else {
+					// Add any query params specific to Google Photos
+					return utils.getGoogleQuery( query, props );
 				}
-
-				// Add any query params specific to Google Photos
-				return utils.getGoogleQuery( query, props );
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/96009

## Proposed Changes

* Disable setting filter query param since it's not supported by the google-photos-picker API

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Google Photos Picker API doesn't support selection filtering

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/posts/{SITE_SLUG}?flags=google-photos-picker`
* Edit any post/page
* Insert `/image` block and click `Select image`
* Choose `Media Library` option
* Change the source to be `Google Photos`
* Open picker and make a selection
* Check if the list of selected media files is loaded (before this change, it was an infinitive load experience)

<img width="832" alt="Screenshot 2024-11-04 at 15 42 55" src="https://github.com/user-attachments/assets/5f9126bd-9b9e-4fd6-8fa4-663e044d38d3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
