### PR TITLE
Purchases and Checkout: Rename createStripeSetupIntent to confirmStripeSetupIntentAndAttachCard for clarity

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-assign-new-card-processor.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-assign-new-card-processor.ts
@@ -1,4 +1,4 @@
-import { createStripeSetupIntent } from '@automattic/calypso-stripe';
+import { confirmStripeSetupIntentAndAttachCard } from '@automattic/calypso-stripe';
 import {
 	makeSuccessResponse,
 	makeErrorResponse,
@@ -52,7 +52,7 @@ export function useAssignNewCardProcessor( {
 
 				const stripeSetupIntentId = await fetchStripeSetupIntentId();
 
-				const tokenResponse = await createStripeSetupIntentAsync(
+				const tokenResponse = await prepareAndConfirmStripeSetupIntent(
 					formFieldValues,
 					stripe,
 					cardElement,
@@ -75,7 +75,7 @@ export function useAssignNewCardProcessor( {
 	);
 }
 
-async function createStripeSetupIntentAsync(
+async function prepareAndConfirmStripeSetupIntent(
 	{
 		name,
 	}: {
@@ -88,7 +88,7 @@ async function createStripeSetupIntentAsync(
 	const paymentDetailsForStripe = {
 		name,
 	};
-	return createStripeSetupIntent(
+	return confirmStripeSetupIntentAndAttachCard(
 		stripe,
 		cardElement,
 		stripeSetupIntentId,

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
@@ -1,4 +1,4 @@
-import { createStripeSetupIntent } from '@automattic/calypso-stripe';
+import { confirmStripeSetupIntentAndAttachCard } from '@automattic/calypso-stripe';
 import { makeSuccessResponse, makeErrorResponse } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { saveCreditCard } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api';
@@ -48,7 +48,7 @@ export async function assignNewCardProcessor(
 		const formFieldValues = {
 			name,
 		};
-		const tokenResponse = await createStripeSetupIntentAsync(
+		const tokenResponse = await prepareAndConfirmStripeSetupIntent(
 			formFieldValues,
 			stripe,
 			cardElement,
@@ -72,7 +72,7 @@ export async function assignNewCardProcessor(
 	}
 }
 
-async function createStripeSetupIntentAsync(
+async function prepareAndConfirmStripeSetupIntent(
 	{
 		name,
 	}: {
@@ -85,7 +85,7 @@ async function createStripeSetupIntentAsync(
 	const paymentDetailsForStripe = {
 		name,
 	};
-	return createStripeSetupIntent(
+	return confirmStripeSetupIntentAndAttachCard(
 		stripe,
 		cardElement,
 		stripeSetupIntentId,

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -1,4 +1,4 @@
-import { createStripeSetupIntent } from '@automattic/calypso-stripe';
+import { confirmStripeSetupIntentAndAttachCard } from '@automattic/calypso-stripe';
 import {
 	makeRedirectResponse,
 	makeSuccessResponse,
@@ -178,7 +178,7 @@ export async function assignNewCardProcessor(
 			postal_code: postalCode ?? '',
 			name: name ?? '',
 		};
-		const tokenResponse = await createStripeSetupIntentAsync(
+		const tokenResponse = await prepareAndConfirmStripeSetupIntent(
 			formFieldValues,
 			stripe,
 			cardNumberElement,
@@ -226,7 +226,7 @@ export async function assignNewCardProcessor(
 	}
 }
 
-async function createStripeSetupIntentAsync(
+async function prepareAndConfirmStripeSetupIntent(
 	{
 		name,
 		country,
@@ -247,7 +247,7 @@ async function createStripeSetupIntentAsync(
 			postal_code,
 		},
 	};
-	return createStripeSetupIntent(
+	return confirmStripeSetupIntentAndAttachCard(
 		stripe,
 		cardNumberElement,
 		setupIntentId,

--- a/packages/calypso-stripe/README.md
+++ b/packages/calypso-stripe/README.md
@@ -32,15 +32,15 @@ A React hook that allows access to Stripe.js. This returns an object with the fo
 
 ## useStripeSetupIntentId
 
-A React hook that allows access to creating a setup intent ID that can be passed to createStripeSetupIntent. This returns an object with the following properties:
+A React hook that allows access to creating a setup intent ID that can be passed to confirmStripeSetupIntentAndAttachCard. This returns an object with the following properties:
 
 - `setupIntentId: string | undefined`. The setup intent ID.
 - `error: undefined | null | Error`. An error, if one exists.
 - `reload: () => void`. A function that can be used to reload the setupIntentId, which should be done if it is used at all (even if it fails).
 
-## createStripeSetupIntent
+## confirmStripeSetupIntentAndAttachCard
 
-A function that can be used to create a Stripe setup intent with a setup intent ID and a Stripe credit card field.
+A function that can be used to confirm a Stripe setup intent with a setup intent ID and a Stripe credit card field. The setup intent itself must have already been created, typically without a payment method attached. This function will create and attach the credit card as a payment method to the setup intent.
 
 ## withStripeProps
 

--- a/packages/calypso-stripe/README.md
+++ b/packages/calypso-stripe/README.md
@@ -13,14 +13,6 @@ You'll need to wrap this context provider around any component that wishes to us
 - `locale?: string` An optional locale string used to localize error messages for the Stripe elements fields.
 - `country?: string` An optional country string used to determine which Stripe account to use. If not provided, the country will be detected based on Geo IP.
 
-## StripeSetupIntentIdProvider
-
-You'll need to wrap this context provider around any component that wishes to use `useStripeSetupIntentId`. It accepts the following props:
-
-- `children: React.ReactNode`
-- `fetchStripeSetupIntentId: GetStripeSetupIntentId` A function to fetch the stripe setup intent from the WP.com HTTP API.
-- `isDisabled?: boolean` An option to disable the fetching of the setup intent if it is not needed.
-
 ## useStripe
 
 A React hook that allows access to Stripe.js. This returns an object with the following properties:
@@ -29,14 +21,6 @@ A React hook that allows access to Stripe.js. This returns an object with the fo
 - `stripeConfiguration: null | StripeConfiguration` The object containing the data returned by the wpcom stripe configuration endpoint. May include a payment intent.
 - `isStripeLoading: boolean` A boolean that is true if stripe is currently being loaded.
 - `stripeLoadingError: undefined | null | Error` An optional object that will be set if there is an error loading stripe.
-
-## useStripeSetupIntentId
-
-A React hook that allows access to creating a setup intent ID that can be passed to confirmStripeSetupIntentAndAttachCard. This returns an object with the following properties:
-
-- `setupIntentId: string | undefined`. The setup intent ID.
-- `error: undefined | null | Error`. An error, if one exists.
-- `reload: () => void`. A function that can be used to reload the setupIntentId, which should be done if it is used at all (even if it fails).
 
 ## confirmStripeSetupIntentAndAttachCard
 

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -223,6 +223,19 @@ export async function createStripeSetupIntent(
 	setupIntentId: StripeSetupIntentId,
 	paymentDetails: PaymentDetails
 ): Promise< StripeSetupIntent > {
+	// eslint-disable-next-line no-console
+	console.warn(
+		'createStripeSetupIntent is poorly named and deprecated. Please switch to confirmStripeSetupIntentAndAttachCard instead.'
+	);
+	return confirmStripeSetupIntentAndAttachCard( stripe, element, setupIntentId, paymentDetails );
+}
+
+export async function confirmStripeSetupIntentAndAttachCard(
+	stripe: Stripe,
+	element: StripeCardNumberElement | StripeCardElement,
+	setupIntentId: StripeSetupIntentId,
+	paymentDetails: PaymentDetails
+): Promise< StripeSetupIntent > {
 	debug( 'creating setup intent...', paymentDetails );
 	let stripeResponse;
 	try {
@@ -565,7 +578,7 @@ export function useStripe(): StripeData {
  *
  * First you must wrap a parent component in `StripeSetupIntentIdProvider`.
  * Then you can call this hook in any sub-component to get access to the setup
- * intent ID which can be passed to `createStripeSetupIntent`.
+ * intent ID which can be passed to `confirmStripeSetupIntentAndAttachCard`.
  */
 export function useStripeSetupIntentId(): StripeSetupIntentIdData {
 	const stripeData = useContext( StripeSetupIntentContext );

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -504,6 +504,10 @@ export function StripeSetupIntentIdProvider( {
 	fetchStripeSetupIntentId: GetStripeSetupIntentId;
 	isDisabled?: boolean;
 } > ) {
+	// eslint-disable-next-line no-console
+	console.warn(
+		'StripeSetupIntentIdProvider creates too many setup intents and is deprecated. Please create the setup intent on the fly when submitting the form. See https://github.com/Automattic/wp-calypso/pull/79881'
+	);
 	const setupIntentData = useFetchSetupIntentId( fetchStripeSetupIntentId, { isDisabled } );
 
 	return (
@@ -581,6 +585,10 @@ export function useStripe(): StripeData {
  * intent ID which can be passed to `confirmStripeSetupIntentAndAttachCard`.
  */
 export function useStripeSetupIntentId(): StripeSetupIntentIdData {
+	// eslint-disable-next-line no-console
+	console.warn(
+		'useStripeSetupIntentId creates too many setup intents and is deprecated. Please create the setup intent on the fly when submitting the form. See https://github.com/Automattic/wp-calypso/pull/79881'
+	);
 	const stripeData = useContext( StripeSetupIntentContext );
 	if ( ! stripeData ) {
 		throw new Error(


### PR DESCRIPTION
## Proposed Changes

This PR renames the `createStripeSetupIntent()` function exported by the `@automattic/calypso-stripe` package to `confirmStripeSetupIntentAndAttachCard()`. The old function remains with a deprecation notice .

## Why are these changes being made?

This function was always poorly named since the Setup Intent must already be created for it to work. In fact, it basically just calls `stripe.confirmCardSetup()` which reads,

> When called, it will confirm the SetupIntent with data you provide and carry out 3DS or other next actions if they are required. ... In addition to confirming the SetupIntent, this method can automatically create and attach a new PaymentMethod for you.

The primary use of the function is to create a payment method from the user's credit card and attach it to the Setup Intent as a payment method before confirming.

## Testing Instructions

As this is a simple rename and the old function remains, no testing should be required. A visual check should be sufficient.

Also, `@automattic/calypso-stripe` is currently [an unpublished package](https://github.com/Automattic/wp-calypso/blob/6e54e321649be0eff4e5b632838c7cf14601ed0d/packages/calypso-stripe/package.json#L48) so this should not create any problems for other apps.