### PR TITLE
Reader: Strip HTML from site description

### DIFF
--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -1,7 +1,7 @@
 import { getUrlParts } from '@automattic/calypso-url';
 import { translate } from 'i18n-calypso';
 import { trim } from 'lodash';
-import { decodeEntities } from 'calypso/lib/formatting';
+import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
 import { isSiteDescriptionBlocked } from 'calypso/reader/lib/site-description-blocklist';
 
@@ -92,7 +92,7 @@ export const getSiteDescription = ( { site, feed } ) => {
 	if ( isSiteDescriptionBlocked( description ) ) {
 		return null;
 	}
-	return description;
+	return description ? stripHTML( description ) : description;
 };
 
 export const getSiteAuthorName = ( site ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/212

## Proposed Changes

* This PR strips HTML from the site description before it is displayed.

Before | After
--|--
<img width="1531" alt="Screenshot 2024-11-04 at 11 13 13 AM" src="https://github.com/user-attachments/assets/e41d2ae9-41e0-4955-a7fb-40d65a832cb5">  | <img width="1528" alt="Screenshot 2024-11-04 at 11 13 33 AM" src="https://github.com/user-attachments/assets/8075206f-b5e6-4360-8d77-94db8eed639b">

Before | After
--|--
<img width="1531" alt="Screenshot 2024-11-04 at 11 14 19 AM" src="https://github.com/user-attachments/assets/afe7d193-578b-4347-b7a7-3c2623652239"> | <img width="1531" alt="Screenshot 2024-11-04 at 11 13 57 AM" src="https://github.com/user-attachments/assets/a6b4c567-7734-4672-86a1-391d00bf9a92">





## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read/feeds/160693774 on a production and then on Calypso Live. View that this PR removes the HTML link.
* Go to /read/search?q=wordpress+santa on a production and then on Calypso Live. View that this PR removes the HTML link on "WordPress Santa Clarita Valley" under Sites.
* Go to /discover and look for "WordPress Santa Clarita Valley" under "Popular sites"; you will see that the HTML link has been removed.
* Look at other sites in /discover and /read/search to check for regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
