### PR TITLE
Add volume in the hundred-year-domain flow

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1054,7 +1054,7 @@ class RegisterDomainStep extends Component {
 		// Skip availability check for the 100-year domain flow if the domain is not com/net/org
 		if (
 			isHundredYearDomainFlow( this.props.flowName ) &&
-			! [ 'com', 'net', 'org' ].includes( getTld( domain ) )
+			! [ 'com', 'net', 'org', 'blog' ].includes( getTld( domain ) )
 		) {
 			this.showSuggestionErrorMessage( domain, 'hundred_year_domain_tld_restriction', {} );
 			return;

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -58,6 +58,7 @@ const HundredYearDomainFlow: Flow = {
 				productSlug: productSlug as string,
 				domain: domainName as string,
 				extra: { is_hundred_year_domain: true },
+				volume: 100,
 			} );
 
 			switch ( _currentStep ) {

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -317,10 +317,12 @@ export function domainRegistration( properties: {
 	domain: string;
 	source?: string;
 	extra?: RequestCartProductExtra;
+	volume?: number;
 } ): MinimalRequestCartProduct & { is_domain_registration: boolean } {
 	return {
 		...domainItem( properties.productSlug, properties.domain, properties.source ),
 		is_domain_registration: true,
+		...( properties.volume ? { volume: properties.volume } : {} ),
 		...( properties.extra ? { extra: properties.extra } : {} ),
 	};
 }

--- a/client/my-sites/checkout/src/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/src/hooks/product-variants.tsx
@@ -14,6 +14,7 @@ import {
 	TERM_OCTENNIALLY,
 	TERM_NOVENNIALLY,
 	TERM_DECENNIALLY,
+	TERM_CENTENNIALLY,
 } from '@automattic/calypso-products';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
@@ -144,6 +145,9 @@ function sortVariant( a: ResponseCartProductVariant, b: ResponseCartProductVaria
 
 function getTermText( term: string, translate: ReturnType< typeof useTranslate > ): string {
 	switch ( term ) {
+		case TERM_CENTENNIALLY:
+			return String( translate( 'Hundred years' ) );
+
 		case TERM_DECENNIALLY:
 			return String( translate( 'Ten years' ) );
 


### PR DESCRIPTION
So we decided to make the 100 year domain registration work with volume. That way we can enable 100 year domain registrations in the special flow but also eventually we can enable that variation in regular flows too.


## Proposed Changes

* Add `volume` property to the domain cart item and set it to 100 in the `hundred-year-domain` flow
* Add .blog in the list of supported TLDs in the `hundred-year-domain` flow

## Why are these changes being made?

* In order to support 100 year domain registrations in the `hundred-year-domain` flow

## Testing Instructions

* Test with the instructions in D165427-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?