### PR TITLE
Reader Recent Feed Overhaul: Use DataViews pagination

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
-import { DataViews, SupportedLayouts, View } from '@wordpress/dataviews';
+import { DataViews, filterSortAndPaginate, SupportedLayouts, View } from '@wordpress/dataviews';
 import { translate } from 'i18n-calypso';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
@@ -22,7 +22,7 @@ const Recent = () => {
 
 	const [ selectedItem, setSelectedItem ] = useState< ReaderPost | null >( null );
 
-	const [ view, setView ] = useState( {
+	const [ view, setView ] = useState< View >( {
 		type: 'list',
 		fields: [ 'post' ],
 	} );
@@ -40,16 +40,19 @@ const Recent = () => {
 		shallowEqual
 	);
 
-	const fields = [
-		{
-			id: 'post',
-			label: translate( 'Blog' ),
-			render: ( { item }: { item: ReaderPost } ) => {
-				return <Button onClick={ () => setSelectedItem( item ) }>{ item.site_name }</Button>;
+	const fields = useMemo(
+		() => [
+			{
+				id: 'post',
+				label: translate( 'Post' ),
+				render: ( { item }: { item: ReaderPost } ) => {
+					return <Button onClick={ () => setSelectedItem( item ) }>{ item.site_name }</Button>;
+				},
+				enableHiding: false,
 			},
-			enableHiding: false,
-		},
-	];
+		],
+		[]
+	);
 
 	const defaultLayouts = [
 		{
@@ -63,6 +66,10 @@ const Recent = () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		dispatch( ( requestPage as any )( { streamKey: 'following' } ) );
 	}, [ dispatch ] );
+
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data?.items ?? [], view, fields );
+	}, [ data, view, fields ] );
 
 	// Fetch the data when the component is mounted.
 	useEffect( () => {
@@ -86,14 +93,11 @@ const Recent = () => {
 					}
 					view={ view as View }
 					fields={ fields }
-					data={ data?.items ?? [] }
+					data={ shownData }
 					onChangeView={ ( newView: View ) =>
 						setView( { type: newView.type, fields: newView.fields ?? [] } )
 					}
-					paginationInfo={ {
-						totalItems: 0,
-						totalPages: 0,
-					} }
+					paginationInfo={ paginationInfo }
 					defaultLayouts={ defaultLayouts as SupportedLayouts }
 				/>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes [Recent Feed Overhaul - Pagination](https://github.com/Automattic/loop/issues/215)

## Proposed Changes (WIP)

* Use DataViews pagination. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2iv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?