### PR TITLE
Domains: Update cart/checkout to show correct data for 100-year domains

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -295,18 +295,24 @@ const ProductTitleAreaForCostOverridesList = styled.div`
 	}
 `;
 
+function getProductAmountDisplay( product: ResponseCartProduct ) {
+	// Always display the price without the introductory offer information
+	// for 100-year domains.
+	let total = product.item_original_subtotal_integer;
+	if ( isHundredYearDomain( product ) ) {
+		total = product.item_subtotal_integer;
+	}
+	return formatCurrency( total, product.currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
+}
+
 function SingleProductAndCostOverridesList( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 	const costOverridesList = filterCostOverridesForLineItem( product, translate );
 	const label = getLabel( product );
-	const actualAmountDisplay = formatCurrency(
-		product.item_original_subtotal_integer,
-		product.currency,
-		{
-			isSmallestUnit: true,
-			stripZeros: true,
-		}
-	);
+	const actualAmountDisplay = getProductAmountDisplay( product );
 	return (
 		<SingleProductAndCostOverridesListWrapper>
 			<ProductTitleAreaForCostOverridesList>

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -1,6 +1,7 @@
 import {
 	isBiennially,
 	isDIFMProduct,
+	isHundredYearDomain,
 	isMonthlyProduct,
 	isTriennially,
 	isYearly,
@@ -92,6 +93,10 @@ function LineItemIntroOfferCostOverrideDetail( {
 
 	if ( ! isOverrideCodeIntroductoryOffer( costOverride.overrideCode ) ) {
 		return false;
+	}
+
+	if ( isHundredYearDomain( product ) ) {
+		return null;
 	}
 
 	// We only want to display this info for introductory offers which have

--- a/packages/calypso-products/src/is-hundred-year-domain.ts
+++ b/packages/calypso-products/src/is-hundred-year-domain.ts
@@ -1,0 +1,9 @@
+import { ResponseCartProduct } from '@automattic/shopping-cart';
+
+// Currently, the only way to define if a 100-year domain product is being handled is
+// by checking the property in the `extra` field on the cart product.
+// Later, if needed, we can add a new product for 100-year domains
+// and replace this function usages with one that checks the product type.
+export const isHundredYearDomain = ( product: ResponseCartProduct ) =>
+	Boolean( product.introductory_offer_terms?.enabled ) &&
+	Boolean( product.extra?.is_hundred_year_domain );

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -80,6 +80,7 @@ export { isGSuiteOrExtraLicenseProductSlug } from './is-gsuite-or-extra-license-
 export { isGSuiteOrGoogleWorkspace } from './is-gsuite-or-google-workspace';
 export { isGSuiteOrGoogleWorkspaceProductSlug } from './is-gsuite-or-google-workspace-product-slug';
 export { isGSuiteProductSlug } from './is-gsuite-product-slug';
+export { isHundredYearDomain } from './is-hundred-year-domain';
 export { isJetpackAISlug } from './is-jetpack-ai-slug';
 export { isJetpackAntiSpam } from './is-jetpack-anti-spam';
 export { isJetpackAntiSpamSlug } from './is-jetpack-anti-spam-slug';

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -618,6 +618,7 @@ export interface ResponseCartProductExtra {
 	domain_registration_agreement_url?: string;
 	legal_agreements?: never[] | DomainLegalAgreements;
 	is_gravatar_domain?: boolean;
+	is_hundred_year_domain?: boolean;
 
 	/**
 	 * Set to 'renewal' if requesting a renewal.

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -17,6 +17,7 @@ import {
 	isDIFMProduct,
 	isTieredVolumeSpaceAddon,
 	isAkismetProduct,
+	isHundredYearDomain,
 } from '@automattic/calypso-products';
 import { Gridicon, Popover } from '@automattic/components';
 import {
@@ -754,6 +755,14 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 	const isDomainRegistration = product.is_domain_registration;
 	const isDomainMapping = productSlug === 'domain_map';
 	const isDomainTransfer = productSlug === 'domain_transfer';
+
+	if ( isHundredYearDomain( product ) ) {
+		let label = <DefaultLineItemSublabel product={ product } />;
+		if ( isDomainRegistration ) {
+			label = <>{ translate( '100-Year Domain Registration' ) }</>;
+		}
+		return label;
+	}
 
 	if ( ( isDomainRegistration || isDomainMapping ) && product.months_per_bill_period === 12 ) {
 		const premiumLabel = product.extra?.premium ? translate( 'Premium' ) : '';

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -1,4 +1,4 @@
-import { isDomainRegistration } from '@automattic/calypso-products';
+import { isDomainRegistration, isHundredYearDomain } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import i18n from 'i18n-calypso';
 import { doesIntroductoryOfferHavePriceIncrease } from './transformations';
@@ -224,6 +224,10 @@ export function getItemIntroductoryOfferDisplay(
 
 	if ( premiumDomainText ) {
 		return { enabled: true, text: premiumDomainText };
+	}
+
+	if ( isHundredYearDomain( product ) ) {
+		return null;
 	}
 
 	const isFreeTrial = product.item_subtotal_integer === 0;


### PR DESCRIPTION
Depends on D165430-code and D164729-code.

## Proposed Changes
Add specific checks for 100-year domain products to the cart to display the correct data. 

## Why are these changes being made?
We're using introductory offers for the 100-year domains. These changes are needed because we don't want to handle the messaging and some UI elements the same way we usually do for introductory offers. It's a very specific, tailored case that needs to be handled differently.

## Testing Instructions
- Go to `/setup/hundred-year-domain`;
- Add a domain of your choice to the cart;
- Ensure you see the checkout page with the correct data - same as in the screenshots below;

## Preview

| Before | After  |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/b83b932c-73a5-4f54-965f-552fbb7d6734) | ![image](https://github.com/user-attachments/assets/6be18ed0-56a6-47f5-bf1d-e4266351c111) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
