### PR TITLE
Stats: Fix module setting popup width

### DIFF
--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -218,7 +218,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 .tooltip.popover {
 	// @TODO: Refactor styling into the Popover component for more extensive usage. E.g., tooltip and popover in StatsNavigation.
 	&.highlight-card-tooltip,
-	&.highlight-card-popover{ // overload tooltip's styles
+	&.highlight-card-popover { // overload tooltip's styles
 		.popover__inner {
 			padding: 16px 24px;
 			box-sizing: border-box;

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -218,7 +218,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 .tooltip.popover {
 	// @TODO: Refactor styling into the Popover component for more extensive usage. E.g., tooltip and popover in StatsNavigation.
 	&.highlight-card-tooltip,
-	&.highlight-card-popover { // overload tooltip's styles
+	&.highlight-card-popover{ // overload tooltip's styles
 		.popover__inner {
 			padding: 16px 24px;
 			box-sizing: border-box;
@@ -235,6 +235,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		z-index: z-index("root", ".tooltip.popover.page-modules-settings-popover");
 		.popover__inner {
 			padding: 14px 16px;
+			width: 244px;
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Fix module settings popup width

## Why are these changes being made?

* Styling fix

## Testing Instructions

* Open Calypso Live Branch
* Ensure the width is wider

| Before | After |
|--------|------|
| <img width="248" alt="image" src="https://github.com/user-attachments/assets/6ab3b1fb-8107-43b6-9909-9419ddfb9aa1"> | <img width="352" alt="image" src="https://github.com/user-attachments/assets/4c294f6a-5856-46d4-bc87-857a15a52962"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
