### PR TITLE
Delete boilerplate "About" page if launching Big Sky

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -27,6 +27,22 @@ const LaunchBigSky: Step = function () {
 	const hasStaticHomepage = site?.options?.show_on_front === 'page' && site?.options?.page_on_front;
 	const assemblerThemeActive = site?.options?.theme_slug === 'pub/assembler';
 
+	const deletePage = async ( siteId: string, pageId: number ): Promise< boolean > => {
+		try {
+			await wpcomRequest( {
+				path: '/sites/' + siteId + '/pages/' + pageId,
+				method: 'DELETE',
+				apiNamespace: 'wp/v2',
+			} );
+			return true;
+		} catch ( error ) {
+			// fail silently here, just log an error and return false, Big Sky will still launch
+			// eslint-disable-next-line no-console
+			console.error( `Failed to delete page ${ pageId } for site ${ siteId }:`, error );
+			return false;
+		}
+	};
+
 	useEffect( () => {
 		if ( ! isLoading && ! isEligible ) {
 			window.location.assign( '/start' );
@@ -61,6 +77,9 @@ const LaunchBigSky: Step = function () {
 				} )
 			);
 		}
+
+		// Delete the existing boilerplate about page, always has a page ID of 1
+		pendingActions.push( deletePage( selectedSiteId, 1 ) );
 
 		try {
 			const results = await Promise.all( pendingActions );


### PR DESCRIPTION
## Proposed Changes

* Trashes the default `About` page that gets created during the initial WPCOM install

## Why are these changes being made?

* Big Sky doesn't expose this default page or populate it with content. If the user wishes to create an About page, they can ask Big Sky to do it for them.

## Testing Instructions

1. Go to http://calypso.localhost:3000/setup/site-setup/design-choices?siteSlug=YOUR_SITE_URL_WITH_SUPPORTED_PLAN
2. Click on Try Big Sky
3. After Big Sky launches, go to http://calypso.localhost:3000/pages/trashed/YOUR_SITE_URL_WITH_SUPPORTED_PLAN and verify the `About` page is trashed.
4. Try navigating back to http://calypso.localhost:3000/setup/site-setup/design-choices?siteSlug=YOUR_SITE_URL_WITH_SUPPORTED_PLAN
5. If clicking Big Sky again, the delete page request should fail silently -- a console error gets logged but Big Sky still launches

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
