### PR TITLE
Recent Feed Overhaul - Use the FullPostView component

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -37,14 +37,9 @@ const Recent = () => {
 						postId: +selectedItem.postId,
 				  } )
 				: null,
-			state,
 		} ),
 		shallowEqual
 	);
-
-	const handleClose = () => {
-		setSelectedItem( null );
-	};
 
 	const fields = [
 		{
@@ -107,7 +102,6 @@ const Recent = () => {
 				{ selectedItem && post && (
 					<FullPostView
 						post={ post }
-						onClose={ handleClose }
 						referralStream={ window.location.pathname }
 						notificationsOpen
 					/>

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
+import { FullPostView } from 'calypso/blocks/reader-full-post';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPage } from 'calypso/state/reader/streams/actions';
 import { viewStream } from 'calypso/state/reader-ui/actions';
@@ -36,9 +37,14 @@ const Recent = () => {
 						postId: +selectedItem.postId,
 				  } )
 				: null,
+			state,
 		} ),
 		shallowEqual
 	);
+
+	const handleClose = () => {
+		setSelectedItem( null );
+	};
 
 	const fields = [
 		{
@@ -97,7 +103,16 @@ const Recent = () => {
 					defaultLayouts={ defaultLayouts as SupportedLayouts }
 				/>
 			</div>
-			<div className="recent-feed__post-column">{ selectedItem && post && post.title }</div>
+			<div className="recent-feed__post-column">
+				{ selectedItem && post && (
+					<FullPostView
+						post={ post }
+						onClose={ handleClose }
+						referralStream={ window.location.pathname }
+						notificationsOpen
+					/>
+				) }
+			</div>
 		</div>
 	);
 };

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -1,5 +1,5 @@
 .is-section-reader .recent-feed {
-    display: flex;
+	display: flex;
 
 	&__list-column {
 		flex: 1;
@@ -7,5 +7,10 @@
 
 	&__post-column {
 		flex: 3;
+
+		.reader-full-post__sidebar,
+		.back-button {
+			display: none;
+		}
 	}
 }

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -9,6 +9,7 @@
 		flex: 3;
 
 		.reader-full-post__sidebar,
+		.reader-full-post__author-block,
 		.back-button {
 			display: none;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/194

## Proposed Changes

* In this PR, I propose we reuse the `FullPostView` component for the Recent Feed Overhaul.
* This PR uses the fewest customization to create a working full post view. We'll follow up on this PR to make the view closer to the comps in https://github.com/Automattic/loop/issues/194, probably by implementing new props and/or CSS. Some noteably missing things in this PR include the site icon, the subscriber count, and the author's name.

Before | After
--|--
<img width="1443" alt="Screenshot 2024-11-04 at 5 24 55 PM" src="https://github.com/user-attachments/assets/7f20b7ae-ea6b-415f-bbd1-288f80eda99b">  |  <img width="1444" alt="Screenshot 2024-11-04 at 5 24 41 PM" src="https://github.com/user-attachments/assets/61b4e32a-ca85-49cc-8d2a-18192d0e233a">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Move the Recent Feed Overhaul project forward.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/recent-feed-overhaul in Calypso Live
* View the full post
* Any objections to reusing the `FullPostView` component here?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
