### PR TITLE
A4A > Referrals: Enable Enterprise hosting for refer mode

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/index.tsx
@@ -18,13 +18,19 @@ import HostingTestimonialsSection from '../../../common/hosting-testimonials-sec
 
 import './style.scss';
 
-export default function EnterpriseAgencyHosting() {
+export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode: boolean } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const onRequestDemoClick = () => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_hosting_enterprise_request_demo_click' )
+		);
+	};
+
+	const onReferClientClick = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_marketplace_hosting_enterprise_refer_client_click' )
 		);
 	};
 
@@ -35,6 +41,24 @@ export default function EnterpriseAgencyHosting() {
 					<div className="enterprise-agency-hosting__details-heading">
 						{ translate( 'Enterprise CMS' ) }
 					</div>
+					{ isReferMode && (
+						<div className="enterprise-agency-hosting__details-subheading">
+							{ translate(
+								'Earn a one-time 5% commission on client referrals to WordPress VIP. {{a}}Full Terms ↗{{/a}}',
+								{
+									components: {
+										a: (
+											<a
+												href="https://automattic.com/for-agencies/program-incentives"
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						</div>
+					) }
 					<SimpleList
 						items={ [
 							translate( 'Unmatched flexibility to build a customized web experience' ),
@@ -46,11 +70,12 @@ export default function EnterpriseAgencyHosting() {
 					/>
 					<Button
 						href="https://wpvip.com/partner-application/?utm_source=partner&utm_medium=referral&utm_campaign=a4a"
-						onClick={ onRequestDemoClick }
+						onClick={ isReferMode ? onReferClientClick : onRequestDemoClick }
 						target="_blank"
 						variant="primary"
 					>
-						{ translate( 'Request a Demo' ) } <Icon icon={ external } size={ 16 } />
+						{ isReferMode ? translate( 'Refer client' ) : translate( 'Request a Demo' ) }
+						<Icon icon={ external } size={ 16 } />
 					</Button>
 				</div>
 				<div className="enterprise-agency-hosting__details">

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/style.scss
@@ -29,6 +29,7 @@
 
 		&:nth-child(2) {
 			background-color: #f5f2f1;
+			justify-content: start;
 		}
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/style.scss
@@ -36,6 +36,10 @@
 		@include a4a-font-heading-xl;
 	}
 
+	.enterprise-agency-hosting__details-subheading {
+		padding-block-end: 24px;
+	}
+
 	.enterprise-agency-hosting__logos {
 		padding-block: 24px;
 		display: grid;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
@@ -2,12 +2,9 @@ import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useCallback, useContext, useEffect } from 'react';
+import { useMemo, useCallback, useContext } from 'react';
 import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer-v2';
-import {
-	A4A_MARKETPLACE_HOSTING_LINK,
-	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { A4A_MARKETPLACE_HOSTING_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
 import VIPLogo from 'calypso/assets/images/a8c-for-agencies/vip-full-logo.svg';
 import WPCOMLogo from 'calypso/assets/images/a8c-for-agencies/wpcom-logo.svg';
@@ -31,6 +28,10 @@ type Props = {
 const HostingContent = ( { section, onAddToCart }: Props ) => {
 	const translate = useTranslate();
 
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+
+	const isReferMode = marketplaceType === 'referral';
+
 	let content;
 	let logo;
 	let title;
@@ -49,7 +50,7 @@ const HostingContent = ( { section, onAddToCart }: Props ) => {
 		);
 	}
 	if ( section === 'vip' ) {
-		content = <EnterpriseAgencyHosting />;
+		content = <EnterpriseAgencyHosting isReferMode={ isReferMode } />;
 		logo = <img src={ VIPLogo } alt="VIP" />;
 		title = translate(
 			'Deliver unmatched performance with the highest security standards on our enterprise content platform.'
@@ -72,10 +73,6 @@ export default function HostingV2( { onAddToCart, section }: Props ) {
 
 	const isLargeScreen = useBreakpoint( '>1280px' );
 
-	const { marketplaceType } = useContext( MarketplaceTypeContext );
-
-	const isReferMode = marketplaceType === 'referral';
-
 	const handleTabClick = useCallback(
 		( tab: string ) => {
 			page.show( `${ A4A_MARKETPLACE_HOSTING_LINK }/${ tab }` );
@@ -83,13 +80,6 @@ export default function HostingV2( { onAddToCart, section }: Props ) {
 		},
 		[ dispatch ]
 	);
-
-	useEffect( () => {
-		// Redirect since the VIP section is not available in refer mode
-		if ( isReferMode && section === 'vip' ) {
-			page.show( A4A_MARKETPLACE_HOSTING_WPCOM_LINK );
-		}
-	}, [ isReferMode, section ] );
 
 	const featureTabs = useMemo(
 		() => [
@@ -113,22 +103,18 @@ export default function HostingV2( { onAddToCart, section }: Props ) {
 					handleTabClick( 'pressable' );
 				},
 			},
-			...( isReferMode
-				? []
-				: [
-						{
-							key: 'vip',
-							label: translate( 'Enterprise' ),
-							subtitle: isLargeScreen && translate( 'WordPress for enterprise-level demands' ),
-							visible: true,
-							selected: section === 'vip',
-							onClick: () => {
-								handleTabClick( 'vip' );
-							},
-						},
-				  ] ),
+			{
+				key: 'vip',
+				label: translate( 'Enterprise' ),
+				subtitle: isLargeScreen && translate( 'WordPress for enterprise-level demands' ),
+				visible: true,
+				selected: section === 'vip',
+				onClick: () => {
+					handleTabClick( 'vip' );
+				},
+			},
 		],
-		[ handleTabClick, isLargeScreen, isReferMode, section, translate ]
+		[ handleTabClick, isLargeScreen, section, translate ]
 	);
 
 	const navItems = featureTabs.map( ( featureTab ) => {


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1415

## Proposed Changes

This PR 
- Enables Enterprise hosting for refer mode
- Adds a subheading for Enterprise hosting when the refer mode is enabled 
- Changes the CTA text for Enterprise hosting when the refer mode is enabled 

## Why are these changes being made?

* To allow agencies to refer the Enterprise hosting.

## Testing Instructions

* Open the A4A live link
* Go to Marketplace > Toggle `Refer products` on > Verify you can see the `Enterprise` tab, and it looks as shown below. Click the `Refer client` button and verify you are redirected to https://wpvip.com/partner-application/?utm_source=partner&utm_medium=referral&utm_campaign=a4a

<img width="1704" alt="Screenshot 2024-11-04 at 6 29 43 PM" src="https://github.com/user-attachments/assets/2a210f53-cf84-4671-8168-2be2354964f7">

When the refer mode is off

<img width="1704" alt="Screenshot 2024-11-04 at 6 29 27 PM" src="https://github.com/user-attachments/assets/9fb549d3-8235-4cd2-9992-9ac85783db71">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
