### PR TITLE
Global Styles on Personal: Update upsells and modals

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -1,4 +1,5 @@
-import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { isEnabled } from '@automattic/calypso-config';
+import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Button, Gridicon, Dialog, ScreenReaderText, PlanPrice } from '@automattic/components';
 import { Plans } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
@@ -32,19 +33,23 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	numOfSelectedGlobalStyles = 1,
 }: PremiumGlobalStylesUpgradeModalProps ) {
 	const translate = useTranslate();
-	const premiumPlanProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
+	// @TODO Cleanup once the test phase is over.
+	const upgradeToPlan = isEnabled( 'global-styles/on-personal-plan' )
+		? PLAN_PERSONAL
+		: PLAN_PREMIUM;
+	const premiumPlanProduct = useSelector( ( state ) => getProductBySlug( state, upgradeToPlan ) );
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
 	const isPremiumPlanProductLoaded = !! premiumPlanProduct;
 	const pricingMeta = Plans.usePricingMetaForGridPlans( {
 		coupon: undefined,
-		planSlugs: [ PLAN_PREMIUM ],
+		planSlugs: [ upgradeToPlan ],
 		siteId: selectedSiteId,
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
 	} );
 
-	const pricing = pricingMeta?.[ PLAN_PREMIUM ];
+	const pricing = pricingMeta?.[ upgradeToPlan ];
 	const isPricingLoaded =
 		pricing?.currencyCode && pricing?.originalPrice.monthly && pricing?.originalPrice.full;
 

--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -1,4 +1,5 @@
-import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { isEnabled } from '@automattic/calypso-config';
+import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
@@ -11,9 +12,15 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const plans = Plans.usePlans( { coupon: undefined } );
-	const planTitle = plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '';
 
-	const features = [
+	// @TODO Cleanup once the test phase is over.
+	const upgradeToPlan = isEnabled( 'global-styles/on-personal-plan' )
+		? PLAN_PERSONAL
+		: PLAN_PREMIUM;
+
+	const planTitle = plans?.data?.[ upgradeToPlan ]?.productNameShort ?? '';
+
+	const premiumFeatures = [
 		<strong>{ translate( 'Free domain for one year' ) }</strong>,
 		<strong>{ translate( 'Premium themes' ) }</strong>,
 		translate( 'Style customization' ),
@@ -24,12 +31,19 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 		translate( 'Earn with WordAds' ),
 	];
 
+	const personalFeatures = [
+		<strong>{ translate( 'Free domain for one year' ) }</strong>,
+		<strong>{ translate( 'Dozens of premium themes' ) }</strong>,
+		translate( 'Style customization' ),
+		translate( 'Ad-free experience' ),
+	];
+
 	return {
 		planTitle,
 		featuresTitle: translate( 'Included with your %(planTitle)s plan', {
 			args: { planTitle },
 		} ),
-		features: features,
+		features: isEnabled( 'global-styles/on-personal-plan' ) ? personalFeatures : premiumFeatures,
 		description: translate(
 			'You’ve selected a premium style that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',
 			'You’ve selected premium styles that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
@@ -1,4 +1,5 @@
-import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
+import { isEnabled } from '@automattic/calypso-config';
+import { PLAN_PREMIUM, getPlan, PLAN_PERSONAL } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
@@ -9,7 +10,10 @@ import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 export default function ThemeTierStyleVariationBadge() {
 	const translate = useTranslate();
 
-	const premiumPlan = getPlan( PLAN_PREMIUM );
+	// @TODO Cleanup once the test phase is over.
+	const upgradeToPlan = isEnabled( 'global-styles/on-personal-plan' )
+		? getPlan( PLAN_PERSONAL )
+		: getPlan( PLAN_PREMIUM );
 
 	const tooltipContent = (
 		<>
@@ -17,12 +21,12 @@ export default function ThemeTierStyleVariationBadge() {
 			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header" />
 			<div data-testid="upsell-message">
 				{ createInterpolateElement(
-					// Translators: %(premiumPlanName)s is the name of the premium plan that includes this theme. Examples: "Explorer" or "Premium".
+					// Translators: %(upgradePlanName)s is the name of the premium plan that includes this theme. Examples: "Explorer" or "Premium".
 					translate(
-						'Unlock this style, and tons of other features, by upgrading to a <Link>%(premiumPlanName)s plan</Link>.',
-						{ args: { premiumPlanName: premiumPlan?.getTitle() } }
+						'Unlock this style, and tons of other features, by upgrading to a <Link>%(upgradePlanName)s plan</Link>.',
+						{ args: { upgradePlanName: upgradeToPlan?.getTitle() } }
 					),
-					{ Link: <ThemeTierBadgeCheckoutLink plan={ premiumPlan?.getPathSlug() } /> }
+					{ Link: <ThemeTierBadgeCheckoutLink plan={ upgradeToPlan?.getPathSlug() } /> }
 				) }
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
@@ -571,13 +572,16 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				} )
 			);
 
+			// @TODO Cleanup once the test phase is over.
+			const upgradeToPlan = isEnabled( 'global-styles/on-personal-plan' ) ? 'personal' : 'premium';
+
 			goToCheckout( {
 				flowName: flow,
 				stepName,
 				siteSlug: siteSlug || urlToSlug( site?.URL || '' ) || '',
 				// When the user is done with checkout, send them back to the current url
 				destination: window.location.href.replace( window.location.origin, '' ),
-				plan: 'premium',
+				plan: upgradeToPlan,
 			} );
 
 			setShowPremiumGlobalStylesModal( false );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
@@ -1,4 +1,9 @@
-import { FEATURE_STYLE_CUSTOMIZATION, isFreePlanProduct } from '@automattic/calypso-products';
+import { isEnabled } from '@automattic/calypso-config';
+import {
+	FEATURE_STYLE_CUSTOMIZATION,
+	isFreePlanProduct,
+	PLAN_PERSONAL,
+} from '@automattic/calypso-products';
 import { updateLaunchpadSettings } from '@automattic/data-stores/src/queries/use-launchpad';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Task } from '@automattic/launchpad';
@@ -49,6 +54,11 @@ export const getPlanSelectedTask: TaskAction = ( task, flow, context ): Task => 
 	const { siteSlug, displayGlobalStylesWarning, globalStylesMinimumPlan, hasSkippedCheckout } =
 		context;
 
+	// @TODO Cleanup once the test phase is over.
+	const upgradeToPlan = isEnabled( 'global-styles/on-personal-plan' )
+		? PLAN_PERSONAL
+		: globalStylesMinimumPlan;
+
 	const shouldDisplayWarning = displayGlobalStylesWarning;
 
 	return {
@@ -62,7 +72,7 @@ export const getPlanSelectedTask: TaskAction = ( task, flow, context ): Task => 
 		},
 		calypso_path: addQueryArgs( `/plans/${ siteSlug }`, {
 			...( shouldDisplayWarning && {
-				plan: globalStylesMinimumPlan,
+				plan: upgradeToPlan,
 				feature: FEATURE_STYLE_CUSTOMIZATION,
 			} ),
 		} ),

--- a/client/my-sites/site-settings/site-setting-privacy/notice.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/notice.tsx
@@ -1,5 +1,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { FEATURE_STYLE_CUSTOMIZATION, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
+import { isEnabled } from '@automattic/calypso-config';
+import {
+	FEATURE_STYLE_CUSTOMIZATION,
+	PLAN_PREMIUM,
+	getPlan,
+	PLAN_PERSONAL,
+} from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -11,7 +17,11 @@ interface SiteSettingPrivacyNoticeProps {
 
 const SiteSettingPrivacyNotice = ( { selectedSite, siteSlug }: SiteSettingPrivacyNoticeProps ) => {
 	const translate = useTranslate();
-	const upgradeUrl = `/plans/${ siteSlug }?plan=${ PLAN_PREMIUM }&feature=${ FEATURE_STYLE_CUSTOMIZATION }`;
+	// @TODO Cleanup once the test phase is over.
+	const upgradeToPlan = isEnabled( 'global-styles/on-personal-plan' )
+		? PLAN_PERSONAL
+		: PLAN_PREMIUM;
+	const upgradeUrl = `/plans/${ siteSlug }?plan=${ upgradeToPlan }&feature=${ FEATURE_STYLE_CUSTOMIZATION }`;
 
 	return (
 		<>
@@ -23,7 +33,7 @@ const SiteSettingPrivacyNotice = ( { selectedSite, siteSlug }: SiteSettingPrivac
 							'Your site contains premium styles that will only be visible once you upgrade to a %(planName)s plan.',
 							{
 								args: {
-									planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
+									planName: getPlan( upgradeToPlan )?.getTitle() ?? '',
 								},
 							}
 						) }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1,5 +1,5 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_UPLOAD_THEMES,
 	PLAN_BUSINESS,
@@ -1277,7 +1277,9 @@ class ThemeSheet extends Component {
 		params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
 
 		this.setState( { showUnlockStyleUpgradeModal: false } );
-		page( `/checkout/${ this.props.siteSlug || '' }/premium?${ params.toString() }` );
+		const upgradeToPlan = isEnabled( 'global-styles/on-personal-plan' ) ? 'personal' : 'premium';
+
+		page( `/checkout/${ this.props.siteSlug || '' }/${ upgradeToPlan }?${ params.toString() }` );
 	};
 
 	onPremiumGlobalStylesUpgradeModalTryStyle = () => {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	WPCOM_FEATURES_INSTALL_PLUGINS,
 	PLAN_PERSONAL,
@@ -99,10 +100,15 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 				options?.styleVariationSlug &&
 				! isDefaultGlobalStylesVariationSlug( options.styleVariationSlug );
 
-			const minimumPlan =
-				tierMinimumUpsellPlan === PLAN_PERSONAL && isLockedStyleVariation
-					? PLAN_PREMIUM
-					: tierMinimumUpsellPlan;
+			// @TODO Cleanup once the test phase is over.
+			let minimumPlan;
+			if ( isEnabled( 'global-styles/on-personal-plan' ) ) {
+				minimumPlan = tierMinimumUpsellPlan;
+			} else if ( tierMinimumUpsellPlan === PLAN_PERSONAL && isLockedStyleVariation ) {
+				minimumPlan = PLAN_PREMIUM;
+			} else {
+				minimumPlan = tierMinimumUpsellPlan;
+			}
 
 			const planPathSlug = getPlanPathSlugForThemes( state, siteId, minimumPlan );
 

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -1,4 +1,5 @@
-import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
+import { isEnabled } from '@automattic/calypso-config';
+import { PLAN_PREMIUM, getPlan, PLAN_PERSONAL } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useState } from '@wordpress/element';
@@ -105,9 +106,12 @@ const GlobalStylesVariations = ( {
 }: GlobalStylesVariationsProps ) => {
 	const hasEnTranslation = useHasEnTranslation();
 	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
+	const upgradeToPlan = isEnabled( 'global-styles/on-personal-plan' )
+		? PLAN_PERSONAL
+		: PLAN_PREMIUM;
 	const premiumStylesDescription = translate(
 		'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
-		{ args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
+		{ args: { planName: getPlan( upgradeToPlan )?.getTitle() ?? '' } }
 	);
 
 	const baseGlobalStyles = useMemo(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/9520

## Proposed Changes

* Updated launchpad upsell to reference the Personal plan when the feature is active.
* Updated Privacy Settings upsell to reference the Personal plan when the feature is active.
* Updated Global Styles try before you buy modal to reference the Personal plan and its features when the feature flag is active.
* Updated Theme Badges to show the required plan as Personal when the feature flag is active.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to change the Global Styles feature from being gated to the Premium plan to being behind the Personal plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link.
* Enable the feature flag with `?flags=global-styles/on-personal-plan`
* Create a site using the free plan.
* Go through all the Calypso screens/pages where a modal or upsell is shown.
* All the messages and modal should reference the Personal plan, and its features (when applicable), and should proceed to checking out the Personal plan when clicking on the Update CTA.
* Disable the flag and make sure all the texts reference the Premium plan and its features, and that there are no regressions.

Having the correct plan is out of scope, we're just checking the messaging. In order to see the correct plan we need to have the BE feature flag code merged, this does not impact the changes made in this PR.

The site editor and non-Calypso screens, modals, and notices are out of scope.

![Screenshot 2024-11-05 at 12 25 14](https://github.com/user-attachments/assets/c46e9c5b-7871-4957-9fb0-9df3769ee883)
![Screenshot 2024-11-05 at 12 53 18](https://github.com/user-attachments/assets/6d554b07-4629-464d-984e-6fad78735c86)
![Screenshot 2024-11-05 at 12 55 43](https://github.com/user-attachments/assets/7ab75afd-88b6-47d6-b8b2-44178e19281a)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
