### PR TITLE
A4A > Signup: Signup form accessibility improvements

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -388,7 +388,6 @@ export default function AgencyDetailsForm( {
 							/>
 						</FormFieldset>
 						<FormFieldset>
-							<FormLabel>{ translate( 'Country' ) }</FormLabel>
 							{ showCountryFields && (
 								<SearchableDropdown
 									value={ countryValue }
@@ -398,6 +397,7 @@ export default function AgencyDetailsForm( {
 									} }
 									options={ countryOptions }
 									disabled={ isLoading }
+									label={ translate( 'Country' ) }
 								/>
 							) }
 
@@ -413,13 +413,13 @@ export default function AgencyDetailsForm( {
 						</FormFieldset>
 						{ showCountryFields && stateOptions && (
 							<FormFieldset>
-								<FormLabel>{ translate( 'State' ) }</FormLabel>
 								<SearchableDropdown
 									value={ addressState }
 									onChange={ ( value ) => setAddressState( value ?? '' ) }
 									options={ stateOptions }
 									disabled={ isLoading }
 									allowReset={ false }
+									label={ translate( 'State' ) }
 								/>
 							</FormFieldset>
 						) }
@@ -494,9 +494,7 @@ export default function AgencyDetailsForm( {
 
 						{ noCountryList && <QuerySmsCountries /> }
 						<FormFieldset>
-							<FormLabel optional htmlFor="postalCode">
-								{ translate( 'Phone number' ) }
-							</FormLabel>
+							<FormLabel optional>{ translate( 'Phone number' ) }</FormLabel>
 							<FormPhoneInput
 								countrySelectProps={ {
 									'data-testid': 'a4a-signup-country-code-select',

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
@@ -76,4 +76,11 @@
 			display: none;
 		}
 	}
+
+	.components-base-control__label {
+		font-size: 0.875rem;
+		font-weight: 600;
+		margin-bottom: 5px;
+		text-transform: none;
+	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1424 

## Proposed Changes

This PR:

- updates how label for Country & State fields is used
- removes `htmlFor` from the Phone number field, which was set for the Postal Code.

## Why are these changes being made?

* To improve the accessibility and add E2E tests using user-facing attributes

## Testing Instructions

* Switch to this branch locally
* Go to /signup > Verify the country and state label matches with other fields. Click both the labels and verify that the respective input fields get highlighted. 

<img width="636" alt="Screenshot 2024-11-05 at 3 24 22 PM" src="https://github.com/user-attachments/assets/cf2d2c06-1f09-4178-93aa-1edefced4cfa">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
