### PR TITLE
Reader: add recent stream

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -29,7 +29,7 @@ const Recent = () => {
 
 	const { data, post } = useSelector(
 		( state: AppState ) => ( {
-			data: state.reader?.streams?.following,
+			data: state.reader?.streams?.recent,
 			post: selectedItem
 				? getPostByKey( state, {
 						feedId: +selectedItem.feedId,
@@ -59,9 +59,9 @@ const Recent = () => {
 	];
 
 	const fetchData = useCallback( () => {
-		dispatch( viewStream( 'following', window.location.pathname ) as AnyAction );
+		dispatch( viewStream( 'recent', window.location.pathname ) as AnyAction );
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		dispatch( ( requestPage as any )( { streamKey: 'following' } ) );
+		dispatch( ( requestPage as any )( { streamKey: 'recent' } ) );
 	}, [ dispatch ] );
 
 	// Fetch the data when the component is mounted.

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -14,7 +14,7 @@ import './style.scss';
 interface ReaderPost {
 	site_name: string;
 	postId: number;
-	feedId: number;
+	blogId: number;
 }
 
 const Recent = () => {
@@ -32,8 +32,8 @@ const Recent = () => {
 			data: state.reader?.streams?.recent,
 			post: selectedItem
 				? getPostByKey( state, {
-						feedId: +selectedItem.feedId,
 						postId: +selectedItem.postId,
+						blogId: +selectedItem.blogId,
 				  } )
 				: null,
 		} ),
@@ -74,7 +74,7 @@ const Recent = () => {
 		if ( data?.items?.length > 0 && ! selectedItem ) {
 			setSelectedItem( data.items[ 0 ] );
 		}
-	}, [ data?.items, selectedItem ] );
+	}, [ data?.items?.length, selectedItem ] );
 
 	return (
 		<div className="recent-feed">
@@ -91,8 +91,8 @@ const Recent = () => {
 						setView( { type: newView.type, fields: newView.fields ?? [] } )
 					}
 					paginationInfo={ {
-						totalItems: 0,
-						totalPages: 0,
+						totalItems: 100,
+						totalPages: 10,
 					} }
 					defaultLayouts={ defaultLayouts as SupportedLayouts }
 				/>

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -74,7 +74,7 @@ const Recent = () => {
 		if ( data?.items?.length > 0 && ! selectedItem ) {
 			setSelectedItem( data.items[ 0 ] );
 		}
-	}, [ data?.items?.length, selectedItem ] );
+	}, [ data?.items, selectedItem ] );
 
 	return (
 		<div className="recent-feed">
@@ -91,8 +91,8 @@ const Recent = () => {
 						setView( { type: newView.type, fields: newView.fields ?? [] } )
 					}
 					paginationInfo={ {
-						totalItems: 100,
-						totalPages: 10,
+						totalItems: 0,
+						totalPages: 0,
 					} }
 					defaultLayouts={ defaultLayouts as SupportedLayouts }
 				/>

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -191,6 +191,11 @@ const streamApis = {
 		path: () => '/read/following',
 		dateProperty: 'date',
 	},
+	recent: {
+		path: () => '/read/streams/following',
+		dateProperty: 'date',
+		apiNamespace: 'wpcom/v2',
+	},
 	search: {
 		path: () => '/read/search',
 		dateProperty: 'date',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/192

## Proposed Changes

* Adds Recent stream that is hooked up to `/read/stream/following` API endpoint added with D165377-code

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the Recent feed overhaul project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D165377-code on sandbox
* Ensure public-api.wordpress.com is sandboxed
* Go to calypso.live `/read?flags=reader/recent-feed-overhaul` and confirm dataview loads with data

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?