### PR TITLE
e2e: Fix block highlight step in i18n__editor spec

### DIFF
--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -348,7 +348,7 @@ describe( 'I18N: Editor', function () {
 						.locator(
 							`:is( ${ block.blockEditorSelector }.is-selected, ${ block.blockEditorSelector }.has-child-selected)`
 						)
-						.click();
+						.click( { position: { x: 0, y: 0 } } );
 
 					// If on block insertion, one of the sub-blocks are selected, click on
 					// the first button in the floating toolbar which selects the overall

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -341,14 +341,6 @@ describe( 'I18N: Editor', function () {
 
 				it( 'Render block title translations', async function () {
 					await editorPage.openSettings();
-					await editorParent.locator( block.blockEditorSelector ).click();
-
-					// Ensure the block is highlighted.
-					await editorParent
-						.locator(
-							`:is( ${ block.blockEditorSelector }.is-selected, ${ block.blockEditorSelector }.has-child-selected)`
-						)
-						.click( { position: { x: 0, y: 0 } } );
 
 					// If on block insertion, one of the sub-blocks are selected, click on
 					// the first button in the floating toolbar which selects the overall


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to N/A

## Proposed Changes

* Remove the extra click action to select the block as the block is already pre-selected after inserting.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* By default, the `Locator.click()` performs click action in the middle of the element, which has resulted in accidentally clicking on a child component that happened to be position in the center of the block that was being selected. The click action, however, appears to be redundant as the block is already pre-selected after inserting.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run I18n Tests in TeamCity for this branch.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
