### PR TITLE
Help Center: Load attachments from zendesk

### DIFF
--- a/packages/odie-client/src/components/message/custom-a-link.tsx
+++ b/packages/odie-client/src/components/message/custom-a-link.tsx
@@ -13,10 +13,12 @@ const CustomALink = ( {
 	href,
 	children,
 	inline = true,
+	target = '_self',
 }: {
 	href?: string;
 	children?: React.ReactNode;
 	inline?: boolean;
+	target?: string;
 } ) => {
 	const { trackEvent } = useOdieAssistantContext();
 	const [ transformedHref, setTransformedHref ] = useState( '' );
@@ -41,7 +43,7 @@ const CustomALink = ( {
 			<a
 				className="odie-sources-link"
 				href={ transformedHref }
-				target="_self"
+				target={ target }
 				rel="noopener noreferrer"
 				onClick={ () => {
 					trackEvent( 'chat_message_action_click', {

--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -40,9 +40,8 @@ export const MessageContent = ( {
 				<div className={ messageClasses }>
 					{ messageHeader }
 					{ message.type === 'error' && <ErrorMessage message={ message } /> }
-					{ ( [ 'message', 'image', 'file' ].includes( message.type ) || ! message.type ) && (
-						<UserMessage message={ message } isDisliked={ isDisliked } />
-					) }
+					{ ( [ 'message', 'image', 'file', 'text' ].includes( message.type ) ||
+						! message.type ) && <UserMessage message={ message } isDisliked={ isDisliked } /> }
 					{ message.type === 'introduction' && (
 						<div className="odie-introduction-message-content">
 							<div className="odie-chatbox-introduction-message">

--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -40,7 +40,7 @@ export const MessageContent = ( {
 				<div className={ messageClasses }>
 					{ messageHeader }
 					{ message.type === 'error' && <ErrorMessage message={ message } /> }
-					{ ( message.type === 'message' || ! message.type ) && (
+					{ ( [ 'message', 'image', 'file' ].includes( message.type ) || ! message.type ) && (
 						<UserMessage message={ message } isDisliked={ isDisliked } />
 					) }
 					{ message.type === 'introduction' && (

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -98,7 +98,9 @@ export const UserMessage = ( {
 				<Markdown
 					urlTransform={ uriTransformer }
 					components={ {
-						a: CustomALink,
+						a: ( props: React.ComponentProps< 'a' > ) => (
+							<CustomALink { ...props } target="_blank" />
+						),
 					} }
 				>
 					{ isRequestingHumanSupport ? displayMessage : message.content }

--- a/packages/odie-client/src/data/use-get-zendesk-conversation.ts
+++ b/packages/odie-client/src/data/use-get-zendesk-conversation.ts
@@ -1,8 +1,9 @@
 import Smooch from 'smooch';
 import { zendeskMessageConverter } from '../utils';
+import type { ZendeskMessage } from '../types/';
 
 const parseResponse = ( conversation: Conversation ) => {
-	const messages = conversation?.messages.map( ( message ) => {
+	const messages = conversation?.messages.map( ( message: ZendeskMessage ) => {
 		return zendeskMessageConverter( message );
 	} );
 

--- a/packages/odie-client/src/data/use-get-zendesk-conversation.ts
+++ b/packages/odie-client/src/data/use-get-zendesk-conversation.ts
@@ -1,9 +1,8 @@
 import Smooch from 'smooch';
 import { zendeskMessageConverter } from '../utils';
-import type { ZendeskMessage, Conversation } from '../types/';
 
 const parseResponse = ( conversation: Conversation ) => {
-	const messages = conversation?.messages.map( ( message: ZendeskMessage ) => {
+	const messages = conversation?.messages.map( ( message ) => {
 		return zendeskMessageConverter( message );
 	} );
 

--- a/packages/odie-client/src/data/use-get-zendesk-conversation.ts
+++ b/packages/odie-client/src/data/use-get-zendesk-conversation.ts
@@ -1,12 +1,10 @@
 import Smooch from 'smooch';
+import { zendeskMessageConverter } from '../utils';
+import type { ZendeskMessage, Conversation } from '../types';
 
 const parseResponse = ( conversation: Conversation ) => {
-	const messages = conversation?.messages.map( ( message ) => {
-		return {
-			content: message.text,
-			role: message.role,
-			type: message.type === 'text' ? 'message' : message.type,
-		};
+	const messages = conversation?.messages.map( ( message: ZendeskMessage ) => {
+		return zendeskMessageConverter( message );
 	} );
 
 	return { ...conversation, messages };

--- a/packages/odie-client/src/data/use-get-zendesk-conversation.ts
+++ b/packages/odie-client/src/data/use-get-zendesk-conversation.ts
@@ -1,6 +1,6 @@
 import Smooch from 'smooch';
 import { zendeskMessageConverter } from '../utils';
-import type { ZendeskMessage, Conversation } from '../types';
+import type { ZendeskMessage, Conversation } from '../types/';
 
 const parseResponse = ( conversation: Conversation ) => {
 	const messages = conversation?.messages.map( ( message: ZendeskMessage ) => {

--- a/packages/odie-client/src/types/index.ts
+++ b/packages/odie-client/src/types/index.ts
@@ -146,6 +146,7 @@ export type ZendeskMessage = {
 	type: ZendeskContentType;
 	text: string;
 	mediaUrl?: string;
+	altText?: string;
 };
 
 export type ZendeskContentType =

--- a/packages/odie-client/src/types/index.ts
+++ b/packages/odie-client/src/types/index.ts
@@ -133,7 +133,7 @@ interface ConversationParticipant {
 }
 
 export type ZendeskMessage = {
-	avatarUrl: string;
+	avatarUrl?: string;
 	displayName: string;
 	id: string;
 	received: number;

--- a/packages/odie-client/src/types/index.ts
+++ b/packages/odie-client/src/types/index.ts
@@ -84,6 +84,8 @@ export type MessageType =
 	| 'placeholder'
 	| 'dislike-feedback'
 	| 'help-link'
+	| 'file'
+	| 'image'
 	| 'introduction';
 
 export type Message = {
@@ -143,6 +145,7 @@ export type ZendeskMessage = {
 	};
 	type: ZendeskContentType;
 	text: string;
+	mediaUrl?: string;
 };
 
 export type ZendeskContentType =

--- a/packages/odie-client/src/utils/zendesk-message-converter.ts
+++ b/packages/odie-client/src/utils/zendesk-message-converter.ts
@@ -5,11 +5,14 @@ function prepareMarkdownImage( imgUrl: string ): string {
 }
 
 function convertUrlsToMarkdown( text: string ): string {
-	const urlRegex = /\b((https?:\/\/)?(www\.)?[\w-]+\.[\w.-]+\b)/g;
+	const urlRegex =
+		/\b(?:https?:\/\/)?(?:www\.)?[a-z0-9-]+(?:\.[a-z0-9-]+)+(?:\/[^\s<>[\](){}'"]*)?/gi;
 
 	return text.replace( urlRegex, ( url ) => {
-		const fullUrl = url.startsWith( 'http' ) ? url : `https://${ url }`;
-		return `[${ url }](${ fullUrl })`;
+		// Clean up any trailing punctuation
+		const cleanUrl = url.replace( /[.,!?]+$/, '' );
+		const fullUrl = cleanUrl.startsWith( 'http' ) ? cleanUrl : `https://${ cleanUrl }`;
+		return `[${ cleanUrl }](${ fullUrl })`;
 	} );
 }
 

--- a/packages/odie-client/src/utils/zendesk-message-converter.ts
+++ b/packages/odie-client/src/utils/zendesk-message-converter.ts
@@ -1,35 +1,56 @@
 import { __ } from '@wordpress/i18n';
 import { Message, MessageRole, MessageType, ZendeskMessage } from '../types/';
 
+// Format markdown to support images attachments
 function prepareMarkdownImage( imgUrl: string ): string {
 	return `![Image](${ imgUrl })`;
 }
 
+// Format markdown to support links inside text
 function convertUrlsToMarkdown( text: string ): string {
-	const urlRegex =
-		/\b(?:https?:\/\/)?(?:www\.)?[a-z0-9-]+(?:\.[a-z0-9-]+)+(?:\/[^\s<>[\](){}'"]*)?/gi;
+	const urlRegex = /\b((https?:\/\/)?(www\.)?[\w-]+\.[\w.-]+\b)/g;
 
 	return text.replace( urlRegex, ( url ) => {
-		// Clean up any trailing punctuation
-		const cleanUrl = url.replace( /[.,!?]+$/, '' );
-		const fullUrl = cleanUrl.startsWith( 'http' ) ? cleanUrl : `https://${ cleanUrl }`;
-		return `[${ cleanUrl }](${ fullUrl })`;
+		const fullUrl = url.startsWith( 'http' ) ? url : `https://${ url }`;
+		return `[${ url }](${ fullUrl })`;
 	} );
 }
 
-export const zendeskMessageConverter: ( message: ZendeskMessage ) => Message = ( message ) => {
-	let messageContent = '';
-	if ( message.type === 'image' && message.mediaUrl ) {
-		messageContent = prepareMarkdownImage( message.mediaUrl );
-	} else if ( message.type === 'text' ) {
-		messageContent = convertUrlsToMarkdown( message.text );
-	} else if ( message.type === 'file' && message.mediaUrl ) {
-		// We don't support it yet return generic message.
-		messageContent = __( 'Message content not supported' );
-	}
+// Format markdown to support file attachments, returns a link to download the file.
+function createDownloadableMarkdownLink( url: string, AttachmentTitle: string ): string {
+	const fileName = url.split( '/' ).pop()?.split( '?' )[ 0 ];
+	return `[${ AttachmentTitle } ${ fileName }](${ url })`;
+}
 
+function getContentMessage( message: ZendeskMessage ): string {
+	let messageContent = '';
+	switch ( message.type ) {
+		case 'image':
+			if ( message.mediaUrl ) {
+				messageContent = prepareMarkdownImage( message.mediaUrl );
+			}
+			break;
+		case 'text':
+			messageContent = convertUrlsToMarkdown( message.text );
+			break;
+		case 'file':
+			if ( message.mediaUrl ) {
+				messageContent = createDownloadableMarkdownLink(
+					message.mediaUrl,
+					message.altText || __( 'Attachment' )
+				);
+			}
+			break;
+		default:
+			// We don't support it yet return generic message.
+			messageContent = __( 'Message content not supported' );
+	}
+	return messageContent;
+}
+
+export const zendeskMessageConverter: ( message: ZendeskMessage ) => Message = ( message ) => {
 	return {
-		content: messageContent,
+		content: getContentMessage( message ),
 		role: ( [ 'user', 'business' ].includes( message.role )
 			? message.role
 			: 'user' ) as MessageRole,

--- a/packages/odie-client/src/utils/zendesk-message-converter.ts
+++ b/packages/odie-client/src/utils/zendesk-message-converter.ts
@@ -1,8 +1,17 @@
 import { Message, MessageRole, ZendeskMessage } from '../types/';
 
+const prepareMarkdownImage = ( imgUrl: string ) => {
+	return `![Image](${ imgUrl })`;
+};
+
 export const zendeskMessageConverter: ( message: ZendeskMessage ) => Message = ( message ) => {
+	const messageContent =
+		message.type === 'image' && message.mediaUrl
+			? prepareMarkdownImage( message.mediaUrl )
+			: message.text;
+
 	return {
-		content: message.text as string,
+		content: messageContent,
 		role: ( [ 'user', 'business' ].includes( message.role )
 			? message.role
 			: 'user' ) as MessageRole,

--- a/packages/odie-client/src/utils/zendesk-message-converter.ts
+++ b/packages/odie-client/src/utils/zendesk-message-converter.ts
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import { Message, MessageRole, MessageType, ZendeskMessage } from '../types/';
 
 function prepareMarkdownImage( imgUrl: string ): string {
@@ -14,10 +15,15 @@ function convertUrlsToMarkdown( text: string ): string {
 }
 
 export const zendeskMessageConverter: ( message: ZendeskMessage ) => Message = ( message ) => {
-	const messageContent =
-		message.type === 'image' && message.mediaUrl
-			? prepareMarkdownImage( message.mediaUrl )
-			: convertUrlsToMarkdown( message.text );
+	let messageContent = '';
+	if ( message.type === 'image' && message.mediaUrl ) {
+		messageContent = prepareMarkdownImage( message.mediaUrl );
+	} else if ( message.type === 'text' ) {
+		messageContent = convertUrlsToMarkdown( message.text );
+	} else if ( message.type === 'file' && message.mediaUrl ) {
+		// We don't support it yet return generic message.
+		messageContent = __( 'Message content not supported' );
+	}
 
 	return {
 		content: messageContent,

--- a/packages/odie-client/src/utils/zendesk-message-converter.ts
+++ b/packages/odie-client/src/utils/zendesk-message-converter.ts
@@ -1,20 +1,29 @@
-import { Message, MessageRole, ZendeskMessage } from '../types/';
+import { Message, MessageRole, MessageType, ZendeskMessage } from '../types/';
 
-const prepareMarkdownImage = ( imgUrl: string ) => {
+function prepareMarkdownImage( imgUrl: string ): string {
 	return `![Image](${ imgUrl })`;
-};
+}
+
+function convertUrlsToMarkdown( text: string ): string {
+	const urlRegex = /\b((https?:\/\/)?(www\.)?[\w-]+\.[\w.-]+\b)/g;
+
+	return text.replace( urlRegex, ( url ) => {
+		const fullUrl = url.startsWith( 'http' ) ? url : `https://${ url }`;
+		return `[${ url }](${ fullUrl })`;
+	} );
+}
 
 export const zendeskMessageConverter: ( message: ZendeskMessage ) => Message = ( message ) => {
 	const messageContent =
 		message.type === 'image' && message.mediaUrl
 			? prepareMarkdownImage( message.mediaUrl )
-			: message.text;
+			: convertUrlsToMarkdown( message.text );
 
 	return {
 		content: messageContent,
 		role: ( [ 'user', 'business' ].includes( message.role )
 			? message.role
 			: 'user' ) as MessageRole,
-		type: 'message',
+		type: message.type as MessageType,
 	};
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9644


## Proposed Changes

* Make help center chat capable to load images and links from a message sent from someone using Zendesk
* This is a first step to allow users to send attachment files to Zendesk.

<img width="413" alt="image" src="https://github.com/user-attachments/assets/787dcce5-b5e2-4433-a844-2bdb339e2c9d">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve chat experience and features

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and add the flag `?flags=help-center-experience`
* Start a new chat and ask `odie` to talk to a human
* Open Zendesk and reply yourself.
* From ZENDESK send attachments like images or texts with link
* It should load properly on HelpCenter

The other way around will be implemented in a followup PR

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
