### PR TITLE
Reader Recent Feed Overhaul: Populate posts in middle column

### DIFF
--- a/client/blocks/reader-avatar/index.tsx
+++ b/client/blocks/reader-avatar/index.tsx
@@ -25,7 +25,6 @@ type ReaderAvatarProps = {
 	preferBlavatar?: boolean;
 	showPlaceholder?: boolean;
 	isCompact?: boolean;
-	isRecentFeed?: boolean;
 	onClick?: () => void;
 	iconSize?: number | null;
 };
@@ -36,7 +35,6 @@ const ReaderAvatar = ( {
 	feedIcon,
 	siteUrl,
 	isCompact = false,
-	isRecentFeed = false,
 	preferGravatar = false,
 	preferBlavatar = false,
 	showPlaceholder = false,
@@ -91,9 +89,6 @@ const ReaderAvatar = ( {
 	if ( isCompact ) {
 		siteIconSize = 40;
 		gravatarSize = hasBothIcons ? 32 : 40;
-	} else if ( isRecentFeed ) {
-		siteIconSize = 24;
-		gravatarSize = 24;
 	} else {
 		siteIconSize = 96;
 		gravatarSize = hasBothIcons ? 32 : 96;

--- a/client/blocks/reader-avatar/index.tsx
+++ b/client/blocks/reader-avatar/index.tsx
@@ -25,6 +25,7 @@ type ReaderAvatarProps = {
 	preferBlavatar?: boolean;
 	showPlaceholder?: boolean;
 	isCompact?: boolean;
+	isRecentFeed?: boolean;
 	onClick?: () => void;
 	iconSize?: number | null;
 };
@@ -35,6 +36,7 @@ const ReaderAvatar = ( {
 	feedIcon,
 	siteUrl,
 	isCompact = false,
+	isRecentFeed = false,
 	preferGravatar = false,
 	preferBlavatar = false,
 	showPlaceholder = false,
@@ -89,6 +91,9 @@ const ReaderAvatar = ( {
 	if ( isCompact ) {
 		siteIconSize = 40;
 		gravatarSize = hasBothIcons ? 32 : 40;
+	} else if ( isRecentFeed ) {
+		siteIconSize = 24;
+		gravatarSize = 24;
 	} else {
 		siteIconSize = 96;
 		gravatarSize = hasBothIcons ? 32 : 96;

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -9,39 +9,75 @@ import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPage } from 'calypso/state/reader/streams/actions';
 import { viewStream } from 'calypso/state/reader-ui/actions';
 import RecentPostField from './recent-post-field';
-import type { ReaderPost } from './types';
+import RecentSeenField from './recent-seen-field';
+import type { PostItem, ReaderPost } from './types';
 import type { AppState } from 'calypso/types';
 import './style.scss';
 
 const Recent = () => {
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, AnyAction > >();
-
 	const [ selectedItem, setSelectedItem ] = useState< ReaderPost | null >( null );
 
 	const [ view, setView ] = useState( {
-		type: 'list',
-		fields: [ 'post' ],
+		type: 'table',
+		fields: [ 'recent_post', 'seen', 'post' ],
+		layout: {
+			combinedFields: [
+				{
+					id: 'recent_post',
+					children: [ 'seen', 'post' ],
+					direction: 'horizontal',
+				},
+			],
+		},
 	} );
 
-	const { data, post } = useSelector(
-		( state: AppState ) => ( {
-			data: state.reader?.streams?.recent,
-			post: selectedItem
-				? getPostByKey( state, {
-						postId: +selectedItem.postId,
-						blogId: +selectedItem.blogId,
-				  } )
-				: null,
-		} ),
-		shallowEqual
-	);
+	const { data, posts } = useSelector( ( state: AppState ) => {
+		const streamData = state.reader?.streams?.following;
+		const postsMap: Record< string, PostItem > = {};
+
+		// Create a map of posts for all items
+		streamData?.items?.forEach( ( item: ReaderPost ) => {
+			const post = getPostByKey( state, {
+				feedId: +item.feedId,
+				postId: +item.postId,
+			} );
+			if ( post ) {
+				postsMap[ `${ item.feedId }-${ item.postId }` ] = post;
+			}
+		} );
+
+		return {
+			data: streamData,
+			posts: postsMap,
+		};
+	}, shallowEqual );
+
+	const getPostFromItem = ( item: ReaderPost ) => {
+		const postKey = `${ item.feedId }-${ item.postId }`;
+		return posts[ postKey ];
+	};
 
 	const fields = [
 		{
-			id: 'post',
-			label: translate( 'Blog' ),
+			id: 'seen',
+			label: translate( 'Seen' ),
 			render: ( { item }: { item: ReaderPost } ) => {
-				return <RecentPostField item={ item } setSelectedItem={ setSelectedItem } />;
+				return <RecentSeenField post={ getPostFromItem( item ) } />;
+			},
+			enableHiding: false,
+		},
+		{
+			id: 'post',
+			label: translate( 'Post' ),
+			render: ( { item }: { item: ReaderPost } ) => {
+				return (
+					<RecentPostField
+						item={ item }
+						post={ getPostFromItem( item ) }
+						setSelectedItem={ setSelectedItem }
+					/>
+				);
 			},
 			enableHiding: false,
 		},
@@ -49,8 +85,8 @@ const Recent = () => {
 
 	const defaultLayouts = [
 		{
-			label: translate( 'List' ),
-			icon: 'list-view',
+			label: translate( 'Table' ),
+			icon: 'table-view',
 		},
 	];
 
@@ -84,7 +120,7 @@ const Recent = () => {
 					fields={ fields }
 					data={ data?.items ?? [] }
 					onChangeView={ ( newView: View ) =>
-						setView( { type: newView.type, fields: newView.fields ?? [] } )
+						setView( { type: newView.type, fields: newView.fields ?? [], layout: view.layout } )
 					}
 					paginationInfo={ {
 						totalItems: 0,
@@ -94,9 +130,9 @@ const Recent = () => {
 				/>
 			</div>
 			<div className="recent-feed__post-column">
-				{ selectedItem && post && (
+				{ selectedItem && getPostFromItem( selectedItem ) && (
 					<FullPostView
-						post={ post }
+						post={ getPostFromItem( selectedItem ) }
 						referralStream={ window.location.pathname }
 						notificationsOpen
 					/>

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -1,6 +1,6 @@
-import { DataViews, SupportedLayouts, View } from '@wordpress/dataviews';
+import { DataViews, filterSortAndPaginate, SupportedLayouts, View } from '@wordpress/dataviews';
 import { translate } from 'i18n-calypso';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
@@ -18,7 +18,7 @@ const Recent = () => {
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, AnyAction > >();
 	const [ selectedItem, setSelectedItem ] = useState< ReaderPost | null >( null );
 
-	const [ view, setView ] = useState( {
+	const [ view, setView ] = useState< View >( {
 		type: 'table',
 		fields: [ 'recent_post', 'seen', 'post' ],
 		layout: {
@@ -53,35 +53,41 @@ const Recent = () => {
 		};
 	}, shallowEqual );
 
-	const getPostFromItem = ( item: ReaderPost ) => {
-		const postKey = `${ item.blogId }-${ item.postId }`;
-		return posts[ postKey ];
-	};
+	const getPostFromItem = useCallback(
+		( item: ReaderPost ) => {
+			const postKey = `${ item.blogId }-${ item.postId }`;
+			return posts[ postKey ];
+		},
+		[ posts ]
+	);
 
-	const fields = [
-		{
-			id: 'seen',
-			label: translate( 'Seen' ),
-			render: ( { item }: { item: ReaderPost } ) => {
-				return <RecentSeenField post={ getPostFromItem( item ) } />;
+	const fields = useMemo(
+		() => [
+			{
+				id: 'seen',
+				label: translate( 'Seen' ),
+				render: ( { item }: { item: ReaderPost } ) => {
+					return <RecentSeenField post={ getPostFromItem( item ) } />;
+				},
+				enableHiding: false,
 			},
-			enableHiding: false,
-		},
-		{
-			id: 'post',
-			label: translate( 'Post' ),
-			render: ( { item }: { item: ReaderPost } ) => {
-				return (
-					<RecentPostField
-						item={ item }
-						post={ getPostFromItem( item ) }
-						setSelectedItem={ setSelectedItem }
-					/>
-				);
+			{
+				id: 'post',
+				label: translate( 'Post' ),
+				render: ( { item }: { item: ReaderPost } ) => {
+					return (
+						<RecentPostField
+							item={ item }
+							post={ getPostFromItem( item ) }
+							setSelectedItem={ setSelectedItem }
+						/>
+					);
+				},
+				enableHiding: false,
 			},
-			enableHiding: false,
-		},
-	];
+		],
+		[ getPostFromItem ]
+	);
 
 	const defaultLayouts = [
 		{
@@ -95,6 +101,10 @@ const Recent = () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		dispatch( ( requestPage as any )( { streamKey: 'recent' } ) );
 	}, [ dispatch ] );
+
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data?.items ?? [], view, fields );
+	}, [ data, view, fields ] );
 
 	// Fetch the data when the component is mounted.
 	useEffect( () => {
@@ -118,14 +128,11 @@ const Recent = () => {
 					}
 					view={ view as View }
 					fields={ fields }
-					data={ data?.items ?? [] }
+					data={ shownData }
 					onChangeView={ ( newView: View ) =>
 						setView( { type: newView.type, fields: newView.fields ?? [], layout: view.layout } )
 					}
-					paginationInfo={ {
-						totalItems: 0,
-						totalPages: 0,
-					} }
+					paginationInfo={ paginationInfo }
 					defaultLayouts={ defaultLayouts as SupportedLayouts }
 				/>
 			</div>

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -5,6 +5,7 @@ import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { FullPostView } from 'calypso/blocks/reader-full-post';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPage } from 'calypso/state/reader/streams/actions';
 import { viewStream } from 'calypso/state/reader-ui/actions';
@@ -20,16 +21,7 @@ const Recent = () => {
 
 	const [ view, setView ] = useState< View >( {
 		type: 'table',
-		fields: [ 'recent_post', 'seen', 'post' ],
-		layout: {
-			combinedFields: [
-				{
-					id: 'recent_post',
-					children: [ 'seen', 'post' ],
-					direction: 'horizontal',
-				},
-			],
-		},
+		fields: [ 'seen', 'post' ],
 	} );
 
 	const { data, posts } = useSelector( ( state: AppState ) => {
@@ -67,7 +59,13 @@ const Recent = () => {
 				id: 'seen',
 				label: translate( 'Seen' ),
 				render: ( { item }: { item: ReaderPost } ) => {
-					return <RecentSeenField post={ getPostFromItem( item ) } />;
+					return (
+						<RecentSeenField
+							item={ item }
+							post={ getPostFromItem( item ) }
+							setSelectedItem={ setSelectedItem }
+						/>
+					);
 				},
 				enableHiding: false,
 			},
@@ -121,20 +119,24 @@ const Recent = () => {
 	return (
 		<div className="recent-feed">
 			<div className="recent-feed__list-column">
-				<h1>{ translate( 'All Recent' ) }</h1>
-				<DataViews
-					getItemId={ ( item: ReaderPost, index = 0 ) =>
-						item.postId?.toString() ?? `item-${ index }`
-					}
-					view={ view as View }
-					fields={ fields }
-					data={ shownData }
-					onChangeView={ ( newView: View ) =>
-						setView( { type: newView.type, fields: newView.fields ?? [], layout: view.layout } )
-					}
-					paginationInfo={ paginationInfo }
-					defaultLayouts={ defaultLayouts as SupportedLayouts }
-				/>
+				<div className="recent-feed__list-column-header">
+					<FormattedHeader align="left" headerText={ translate( 'All Recent' ) } />
+				</div>
+				<div className="recent-feed__list-column-content">
+					<DataViews
+						getItemId={ ( item: ReaderPost, index = 0 ) =>
+							item.postId?.toString() ?? `item-${ index }`
+						}
+						view={ view as View }
+						fields={ fields }
+						data={ shownData }
+						onChangeView={ ( newView: View ) =>
+							setView( { type: newView.type, fields: newView.fields ?? [], layout: view.layout } )
+						}
+						paginationInfo={ paginationInfo }
+						defaultLayouts={ defaultLayouts as SupportedLayouts }
+					/>
+				</div>
 			</div>
 			<div className="recent-feed__post-column">
 				{ selectedItem && getPostFromItem( selectedItem ) && (

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -33,17 +33,17 @@ const Recent = () => {
 	} );
 
 	const { data, posts } = useSelector( ( state: AppState ) => {
-		const streamData = state.reader?.streams?.following;
+		const streamData = state.reader?.streams?.recent;
 		const postsMap: Record< string, PostItem > = {};
 
 		// Create a map of posts for all items
 		streamData?.items?.forEach( ( item: ReaderPost ) => {
 			const post = getPostByKey( state, {
-				feedId: +item.feedId,
+				feedId: +item.blogId,
 				postId: +item.postId,
 			} );
 			if ( post ) {
-				postsMap[ `${ item.feedId }-${ item.postId }` ] = post;
+				postsMap[ `${ item.blogId }-${ item.postId }` ] = post;
 			}
 		} );
 
@@ -54,7 +54,7 @@ const Recent = () => {
 	}, shallowEqual );
 
 	const getPostFromItem = ( item: ReaderPost ) => {
-		const postKey = `${ item.feedId }-${ item.postId }`;
+		const postKey = `${ item.blogId }-${ item.postId }`;
 		return posts[ postKey ];
 	};
 

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@wordpress/components';
 import { DataViews, SupportedLayouts, View } from '@wordpress/dataviews';
 import { translate } from 'i18n-calypso';
 import { useState, useEffect, useCallback } from 'react';
@@ -9,14 +8,10 @@ import { FullPostView } from 'calypso/blocks/reader-full-post';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPage } from 'calypso/state/reader/streams/actions';
 import { viewStream } from 'calypso/state/reader-ui/actions';
+import RecentPostField from './recent-post-field';
+import type { ReaderPost } from './types';
 import type { AppState } from 'calypso/types';
 import './style.scss';
-
-interface ReaderPost {
-	site_name: string;
-	postId: number;
-	blogId: number;
-}
 
 const Recent = () => {
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, AnyAction > >();
@@ -46,7 +41,7 @@ const Recent = () => {
 			id: 'post',
 			label: translate( 'Blog' ),
 			render: ( { item }: { item: ReaderPost } ) => {
-				return <Button onClick={ () => setSelectedItem( item ) }>{ item.site_name }</Button>;
+				return <RecentPostField item={ item } setSelectedItem={ setSelectedItem } />;
 			},
 			enableHiding: false,
 		},

--- a/client/reader/recent/recent-post-field.tsx
+++ b/client/reader/recent/recent-post-field.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@wordpress/components';
+import { useSelector } from 'react-redux';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
+import { AppState } from 'calypso/types';
+import type { ReaderPost } from './types';
+
+interface RecentPostFieldProps {
+	item: ReaderPost;
+	setSelectedItem: ( post: ReaderPost | null ) => void;
+}
+
+const RecentPostField: React.FC< RecentPostFieldProps > = ( { item, setSelectedItem } ) => {
+	const post = useSelector( ( state: AppState ) =>
+		getPostByKey( state, {
+			feedId: +item.feedId,
+			postId: +item.postId,
+		} )
+	);
+
+	return (
+		<Button onClick={ () => setSelectedItem( item ) }>
+			{ post?.title }
+			{ item.site_name }
+		</Button>
+	);
+};
+
+export default RecentPostField;

--- a/client/reader/recent/recent-post-field.tsx
+++ b/client/reader/recent/recent-post-field.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@wordpress/components';
 import { useSelector } from 'react-redux';
+import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { AppState } from 'calypso/types';
 import type { ReaderPost } from './types';
-
 interface RecentPostFieldProps {
 	item: ReaderPost;
 	setSelectedItem: ( post: ReaderPost | null ) => void;
@@ -18,9 +18,19 @@ const RecentPostField: React.FC< RecentPostFieldProps > = ( { item, setSelectedI
 	);
 
 	return (
-		<Button onClick={ () => setSelectedItem( item ) }>
-			{ post?.title }
-			{ item.site_name }
+		<Button className="recent-post-field" onClick={ () => setSelectedItem( item ) }>
+			<div className="recent-post-field__title">
+				<div className="recent-post-field__title-text">{ post?.title }</div>
+				<div className="recent-post-field__site-name">{ item.site_name }</div>
+			</div>
+			<div className="recent-post-field__featured-image">
+				<ReaderFeaturedImage
+					imageUrl={ post?.featured_image }
+					imageWidth={ 38 }
+					imageHeight={ 38 }
+					isCompactPost
+				/>
+			</div>
 		</Button>
 	);
 };

--- a/client/reader/recent/recent-post-field.tsx
+++ b/client/reader/recent/recent-post-field.tsx
@@ -1,21 +1,16 @@
 import { Button } from '@wordpress/components';
-import { useSelector } from 'react-redux';
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
-import { getPostByKey } from 'calypso/state/reader/posts/selectors';
-import { AppState } from 'calypso/types';
-import type { ReaderPost } from './types';
+import type { ReaderPost, PostItem } from './types';
 interface RecentPostFieldProps {
 	item: ReaderPost;
+	post: PostItem;
 	setSelectedItem: ( post: ReaderPost | null ) => void;
 }
 
-const RecentPostField: React.FC< RecentPostFieldProps > = ( { item, setSelectedItem } ) => {
-	const post = useSelector( ( state: AppState ) =>
-		getPostByKey( state, {
-			feedId: +item.feedId,
-			postId: +item.postId,
-		} )
-	);
+const RecentPostField: React.FC< RecentPostFieldProps > = ( { item, post, setSelectedItem } ) => {
+	if ( ! post ) {
+		return null;
+	}
 
 	return (
 		<Button className="recent-post-field" onClick={ () => setSelectedItem( item ) }>

--- a/client/reader/recent/recent-seen-field.tsx
+++ b/client/reader/recent/recent-seen-field.tsx
@@ -15,7 +15,7 @@ const RecentSeenField: React.FC< RecentSeenFieldProps > = ( { item, post, setSel
 				siteIcon={ post.site_icon }
 				feedIcon={ post.feed_icon }
 				author={ post.author }
-				isRecentFeed
+				iconSize={ 24 }
 			/>
 		</Button>
 	);

--- a/client/reader/recent/recent-seen-field.tsx
+++ b/client/reader/recent/recent-seen-field.tsx
@@ -1,18 +1,23 @@
+import { Button } from '@wordpress/components';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
-import type { PostItem } from './types';
+import type { PostItem, ReaderPost } from './types';
 
 interface RecentSeenFieldProps {
+	item: ReaderPost;
 	post: PostItem;
+	setSelectedItem: ( post: ReaderPost | null ) => void;
 }
 
-const RecentSeenField: React.FC< RecentSeenFieldProps > = ( { post } ) => {
+const RecentSeenField: React.FC< RecentSeenFieldProps > = ( { item, post, setSelectedItem } ) => {
 	return (
-		<ReaderAvatar
-			siteIcon={ post.site_icon }
-			feedIcon={ post.feed_icon }
-			author={ post.author }
-			isCompact
-		/>
+		<Button className="recent-seen-field" onClick={ () => setSelectedItem( item ) }>
+			<ReaderAvatar
+				siteIcon={ post.site_icon }
+				feedIcon={ post.feed_icon }
+				author={ post.author }
+				isRecentFeed
+			/>
+		</Button>
 	);
 };
 

--- a/client/reader/recent/recent-seen-field.tsx
+++ b/client/reader/recent/recent-seen-field.tsx
@@ -1,0 +1,19 @@
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
+import type { PostItem } from './types';
+
+interface RecentSeenFieldProps {
+	post: PostItem;
+}
+
+const RecentSeenField: React.FC< RecentSeenFieldProps > = ( { post } ) => {
+	return (
+		<ReaderAvatar
+			siteIcon={ post.site_icon }
+			feedIcon={ post.feed_icon }
+			author={ post.author }
+			isCompact
+		/>
+	);
+};
+
+export default RecentSeenField;

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -3,6 +3,16 @@
 
 	&__list-column {
 		flex: 1;
+
+		.recent-post-field {
+			display: flex;
+			align-items: center;
+			text-align: left;
+
+			&__title-text {
+				font-weight: 700;
+			}
+		}
 	}
 
 	&__post-column {

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -13,6 +13,7 @@
 
 		.dataviews__view-actions {
 			padding: 0 12px;
+			max-width: 300px;
 		}
 
 		table {

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -64,7 +64,7 @@
 
 			&__site-name {
 				font-weight: 400;
-				font-size: 0.6875rem; /* stylelint-disable-line scales/font-sizes */
+				font-size: rem( 11px );
 			}
 
 			&__featured-image {

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -3,6 +3,7 @@
 
 	&__list-column {
 		flex: 1;
+		max-width: 320px;
 
 		&-header {
 			padding: 16px 12px 0;
@@ -42,9 +43,19 @@
 
 		.recent-post-field {
 			display: flex;
+			justify-content: space-between;
 			align-items: center;
 			text-align: left;
 			padding: 0;
+			width: 100%;
+
+			&__title-text,
+			&__site-name {
+				white-space: nowrap;
+				text-overflow: ellipsis;
+				overflow: hidden;
+				max-width: 200px;
+			}
 
 			&__title-text {
 				font-weight: 700;
@@ -53,6 +64,11 @@
 			&__site-name {
 				font-weight: 400;
 				font-size: 0.6875rem; /* stylelint-disable-line scales/font-sizes */
+			}
+
+			&__featured-image {
+				max-width: 38px;
+				align-self: flex-end;
 			}
 		}
 	}

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -4,13 +4,55 @@
 	&__list-column {
 		flex: 1;
 
+		&-header {
+			padding: 16px 12px 0;
+			border-bottom: 1px solid var( --studio-gray-0 );
+			margin-bottom: 16px;
+		}
+
+		.dataviews__view-actions {
+			padding: 0 12px;
+		}
+
+		table {
+			border-collapse: collapse;
+			margin-top: 16px;
+		}
+
+		thead {
+			display: none;
+		}
+
+		tr {
+			border-top: 1px solid var( --studio-gray-0 );
+		}
+
+		td {
+			vertical-align: middle;
+			padding: 12px;
+
+			&:first-child {
+				padding-right: 0;
+			}
+		}
+
+		.recent-seen-field {
+			padding: 0;
+		}
+
 		.recent-post-field {
 			display: flex;
 			align-items: center;
 			text-align: left;
+			padding: 0;
 
 			&__title-text {
 				font-weight: 700;
+			}
+
+			&__site-name {
+				font-weight: 400;
+				font-size: 0.6875rem; /* stylelint-disable-line scales/font-sizes */
 			}
 		}
 	}

--- a/client/reader/recent/types.ts
+++ b/client/reader/recent/types.ts
@@ -1,0 +1,5 @@
+export interface ReaderPost {
+	site_name: string;
+	postId: number;
+	feedId: number;
+}

--- a/client/reader/recent/types.ts
+++ b/client/reader/recent/types.ts
@@ -1,5 +1,15 @@
+import { Author } from 'calypso/state/comments/actions';
+
 export interface ReaderPost {
 	site_name: string;
 	postId: number;
 	feedId: number;
+}
+
+export interface PostItem {
+	title: string;
+	featured_image: string;
+	site_icon: string;
+	feed_icon: string;
+	author: Author;
 }

--- a/client/reader/recent/types.ts
+++ b/client/reader/recent/types.ts
@@ -3,7 +3,7 @@ import { Author } from 'calypso/state/comments/actions';
 export interface ReaderPost {
 	site_name: string;
 	postId: number;
-	feedId: number;
+	blogId: number;
 }
 
 export interface PostItem {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/193

## Proposed Changes

* Create a posts map and use it to populate post data in both the table and the full post view.
* Add components for two fields.
* Replace empty `DataViews` props with `filterSortAndPaginate`.
* Add styling.

<img width="1609" alt="Screen Shot 2024-11-05 at 4 23 51 PM" src="https://github.com/user-attachments/assets/7ceaecef-081b-4ca4-906c-a6b0fe678803">

## Follow ups needed (no gos for this PR)

- [ ] Mobile and breakpoints
- [ ] Pagination https://github.com/Automattic/loop/issues/215
- [ ] Search and sorting
- [ ] Unread / unseen indicators (related to https://github.com/Automattic/loop/issues/216)
- [ ] Between column styling
- [ ] Selection highlight (see https://github.com/Automattic/wp-calypso/pull/96071#issuecomment-2460062610)
- [ ] Check keyboard navigation
- [ ] No results view
- [ ] Filtering based on nav selection (`readerUi.sidebar` and feed:feedId `streamKey`)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2iv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/read?flags=reader/recent-feed-overhaul`
* Check that the expected data is populated (site icon or placeholder, post name, site name, featured image).
* Check that you can click an item to open the full post.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?