### PR TITLE
Performance Profiler: use a list of high impact audits

### DIFF
--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -10,7 +10,11 @@ import {
 } from 'calypso/data/site-profiler/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { MetricsInsight } from 'calypso/performance-profiler/components/metrics-insight';
-import { filterRecommendations, metricsNames } from 'calypso/performance-profiler/utils/metrics';
+import {
+	filterRecommendations,
+	metricsNames,
+	highImpactAudits,
+} from 'calypso/performance-profiler/utils/metrics';
 import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
 import { updateQueryParams } from 'calypso/performance-profiler/utils/query-params';
 import './style.scss';
@@ -57,15 +61,11 @@ export const InsightsSection = forwardRef(
 			props;
 		const [ selectedFilter, setSelectedFilter ] = useState( filter ?? 'all' );
 
-		const sumMetricSavings = ( key: string ) =>
-			Object.values( audits[ key ].metricSavings ?? {} ).reduce( ( acc, val ) => acc + val, 0 );
-
-		const sortInsightKeys = ( a: string, b: string ) =>
-			sumMetricSavings( b ) - sumMetricSavings( a );
-
+		const sortHighImpactAudits = ( a: string, b: string ) =>
+			highImpactAudits.indexOf( b ) - highImpactAudits.indexOf( a );
 		const filteredAudits = Object.keys( audits )
 			.filter( ( key ) => filterRecommendations( selectedFilter, audits[ key ] ) )
-			.sort( sortInsightKeys );
+			.sort( sortHighImpactAudits );
 		const onFilter = useCallback(
 			( option: { label: string; value: string } ) => {
 				recordTracksEvent( 'calypso_performance_profiler_recommendations_filter_change', {

--- a/client/performance-profiler/components/metrics-insight/insight-header.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-header.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import Markdown from 'react-markdown';
 import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
+import { highImpactAudits } from 'calypso/performance-profiler/utils/metrics';
 
 interface InsightHeaderProps {
 	data: PerformanceMetricsItemQueryResponse;
@@ -14,13 +15,10 @@ export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
 	const { data, index } = props;
 	const title = data.title ?? '';
 	const value = data.displayValue ?? '';
-	const { type, metricSavings } = data;
+	const { id, type } = data;
 
 	const renderBadge = () => {
-		if (
-			! metricSavings ||
-			! ( metricSavings?.FCP || metricSavings?.LCP || metricSavings?.CLS || metricSavings?.INP )
-		) {
+		if ( ! highImpactAudits.includes( id ) ) {
 			return null;
 		}
 

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -188,3 +188,13 @@ export const filterRecommendations = (
 		selectedFilter === 'all' || audit?.metricSavings?.hasOwnProperty( selectedFilter.toUpperCase() )
 	);
 };
+
+export const highImpactAudits = [
+	'render-blocking-resources',
+	'uses-responsive-images',
+	'uses-optimized-images',
+	'offscreen-images',
+	'server-response-time',
+	'mainthread-work-breakdown',
+	'largest-contentful-paint-element',
+];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9670

## Proposed Changes

This PR removes sorting the audits by the sum of metric savings, that's included in the report. It now uses a hardcoded list of audits that we consider high-impact.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We received feedback on our CfT that the audits with the High Impact badge are not always the highest impact ones.

> The Recommendations listed as High Impact seemed to be not that impactful and the things lower down in the list seem to be the actual main offenders of the bad score

![image](https://github.com/user-attachments/assets/1b90ea44-9769-405b-b15b-7fcabb3b1952)

## Testing Instructions

* Go to `/speed-test` and start a new test, or go to a results page eg.
```
/speed-test-tool?url=https://travelingtango.com/en/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MTA1MDV9.XlZSLGu36jefgLxpUhqhbxA8YpdR5Zpf_NIlFG84BNw&tab=mobile&filter=all
```
* Check that the High impact badge is now assigned to the audits on the [hardcoded list](https://github.com/Automattic/wp-calypso/pull/96073/files#diff-ec73b492c46888d52c8d23baa304792bf0d92d0570887634d3bc0024ebb4f3b6R192-R200)
* Check that the High impact audits are still at the top of the list

| Before | After |
|--------|--------|
| <img width="1070" alt="image" src="https://github.com/user-attachments/assets/344f43e3-c56f-492b-b852-f3122d658fac"> | <img width="1070" alt="image" src="https://github.com/user-attachments/assets/0ff27072-afdc-40a8-b54b-f8a728181ee6"> |
