### PR TITLE
Help Center: prevent new conversation initiation if already started and disable button accordingly

### DIFF
--- a/packages/odie-client/src/components/message/direct-escalation-link.tsx
+++ b/packages/odie-client/src/components/message/direct-escalation-link.tsx
@@ -3,8 +3,10 @@ import { __ } from '@wordpress/i18n';
 import { useNavigate } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
 import { useCreateZendeskConversation } from '../../query/use-create-zendesk-conversation';
+import { getHelpCenterZendeskConversationStarted } from '../../utils/storage-utils';
 
 export const DirectEscalationLink = ( { messageId }: { messageId: number | undefined } ) => {
+	const conversationStarted = Boolean( getHelpCenterZendeskConversationStarted() );
 	const newConversation = useCreateZendeskConversation();
 	const { shouldUseHelpCenterExperience, trackEvent, isUserEligibleForPaidSupport } =
 		useOdieAssistantContext();
@@ -17,6 +19,9 @@ export const DirectEscalationLink = ( { messageId }: { messageId: number | undef
 
 		if ( isUserEligibleForPaidSupport ) {
 			if ( shouldUseHelpCenterExperience ) {
+				if ( conversationStarted ) {
+					return;
+				}
 				newConversation();
 			} else {
 				navigate( '/contact-options' );
@@ -24,12 +29,20 @@ export const DirectEscalationLink = ( { messageId }: { messageId: number | undef
 		} else {
 			navigate( '/contact-form?mode=FORUM' );
 		}
-	}, [ navigate, isUserEligibleForPaidSupport, trackEvent, messageId ] );
+	}, [
+		trackEvent,
+		messageId,
+		isUserEligibleForPaidSupport,
+		shouldUseHelpCenterExperience,
+		conversationStarted,
+		newConversation,
+		navigate,
+	] );
 
 	return (
 		<div className="disclaimer">
 			{ __( 'Feeling stuck?', __i18n_text_domain__ ) }{ ' ' }
-			<button onClick={ handleClick } className="odie-button-link">
+			<button onClick={ handleClick } className="odie-button-link" disabled={ conversationStarted }>
 				{ isUserEligibleForPaidSupport
 					? __( 'Contact our support team.', __i18n_text_domain__ )
 					: __( 'Ask in our forums.', __i18n_text_domain__ ) }

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -113,9 +113,13 @@ $blueberry-color: #3858e9;
 	font-size: inherit;
 }
 
-.odie-button-link:hover {
+.odie-button-link:hover, .odie-button-link:disabled {
 	text-decoration: none;
 	color: var(--color-link-dark);
+}
+
+.odie-button-link:disabled {
+	cursor: not-allowed;
 }
 
 .odie-sources-foldable-card {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/9678

## Proposed Changes

* Disable the contact support chat link if users have already started a chat (human).
![CleanShot 2024-11-05 at 10 08 46@2x](https://github.com/user-attachments/assets/9a779953-ebcd-4dec-868d-56dffcd8ae88)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Prevent a loop of starting a new conversation from the same link

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use link live.
* Navigate to `/home?helps=help-center-experience`, open the Help Center, and start a new chat.
* Send a random message, wait for the AI response, then click the `Contact our support team` link.
* Verify you can't click the link again after the support chat is initiated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
