### PR TITLE
Help Center: Integrate config for conditional navigation to Odie experience

### DIFF
--- a/packages/help-center/src/components/help-center-contact-support-option.tsx
+++ b/packages/help-center/src/components/help-center-contact-support-option.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { FormInputValidation } from '@automattic/components';
 import { HelpCenterSelect, HelpCenterSite } from '@automattic/data-stores';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
@@ -11,6 +12,7 @@ import { hasTranslation } from '@wordpress/i18n';
 import { Icon, comment } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import useChatStatus from '../hooks/use-chat-status';
 import { HELP_CENTER_STORE } from '../stores';
 import ThirdPartyCookiesNotice from './help-center-third-party-cookies-notice';
@@ -49,6 +51,8 @@ const HelpCenterContactSupportOption = ( {
 			?.event_external_id ?? null;
 
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
+	const shouldUseHelpCenterExperience = config.isEnabled( 'help-center-experience' );
+	const navigate = useNavigate();
 
 	const { isOpeningZendeskWidget, openZendeskWidget } = useOpenZendeskMessaging(
 		sectionName,

--- a/packages/help-center/src/components/help-center-contact-support-option.tsx
+++ b/packages/help-center/src/components/help-center-contact-support-option.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
 import { FormInputValidation } from '@automattic/components';
 import { HelpCenterSelect, HelpCenterSite } from '@automattic/data-stores';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
@@ -12,7 +11,6 @@ import { hasTranslation } from '@wordpress/i18n';
 import { Icon, comment } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import useChatStatus from '../hooks/use-chat-status';
 import { HELP_CENTER_STORE } from '../stores';
 import ThirdPartyCookiesNotice from './help-center-third-party-cookies-notice';
@@ -51,8 +49,6 @@ const HelpCenterContactSupportOption = ( {
 			?.event_external_id ?? null;
 
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
-	const shouldUseHelpCenterExperience = config.isEnabled( 'help-center-experience' );
-	const navigate = useNavigate();
 
 	const { isOpeningZendeskWidget, openZendeskWidget } = useOpenZendeskMessaging(
 		sectionName,

--- a/packages/help-center/src/components/help-center-feedback-form.tsx
+++ b/packages/help-center/src/components/help-center-feedback-form.tsx
@@ -2,14 +2,11 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { getPlan } from '@automattic/calypso-products';
 import { HelpCenterSite } from '@automattic/data-stores';
-import CustomALink from '@automattic/odie-client/src/components/message/custom-a-link';
 import { GetSupport } from '@automattic/odie-client/src/components/message/get-support';
-import { uriTransformer } from '@automattic/odie-client/src/components/message/uri-transformer';
 import { useManageSupportInteraction } from '@automattic/odie-client/src/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
-import Markdown from 'react-markdown';
 import { useNavigate } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
@@ -128,17 +125,12 @@ const HelpCenterFeedbackForm = ( {
 				( shouldUseHelpCenterExperience ? (
 					<>
 						<div className="odie-chatbox-dislike-feedback-message">
-							<Markdown
-								urlTransform={ uriTransformer }
-								components={ {
-									a: CustomALink,
-								} }
-							>
+							<p>
 								{ __(
 									'Would you like to contact our support team? Select an option below:',
 									__i18n_text_domain__
 								) }
-							</Markdown>
+							</p>
 						</div>
 						<GetSupport onClickAdditionalEvent={ handleContactSupportClick } />
 					</>

--- a/packages/help-center/src/components/help-center-feedback-form.tsx
+++ b/packages/help-center/src/components/help-center-feedback-form.tsx
@@ -5,16 +5,21 @@ import { HelpCenterSite } from '@automattic/data-stores';
 import CustomALink from '@automattic/odie-client/src/components/message/custom-a-link';
 import { GetSupport } from '@automattic/odie-client/src/components/message/get-support';
 import { uriTransformer } from '@automattic/odie-client/src/components/message/uri-transformer';
+import { useManageSupportInteraction } from '@automattic/odie-client/src/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import Markdown from 'react-markdown';
 import { useNavigate } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
+import { useResetSupportInteraction } from '../hooks/use-reset-support-interaction';
 import { ThumbsDownIcon, ThumbsUpIcon } from '../icons/thumbs';
 import HelpCenterContactSupportOption from './help-center-contact-support-option';
-import './help-center-feedback-form.scss';
 import { generateContactOnClickEvent } from './utils';
+
+import './help-center-feedback-form.scss';
+
 interface HelpCenterFeedbackFormProps {
 	postId: number;
 	blogId?: number | null;
@@ -37,6 +42,8 @@ const HelpCenterFeedbackForm = ( {
 	const productSlug = ( site as HelpCenterSite )?.plan?.product_slug;
 	const plan = getPlan( productSlug );
 	const productId = plan?.getProductId();
+	const resetSupportInteraction = useResetSupportInteraction();
+	const { startNewInteraction } = useManageSupportInteraction();
 
 	const handleFeedbackClick = ( value: number ) => {
 		setStartedFeedback( true );
@@ -101,8 +108,13 @@ const HelpCenterFeedbackForm = ( {
 		);
 	};
 
-	const handleContactSupportClick = () => {
+	const handleContactSupportClick = async () => {
 		generateContactOnClickEvent( 'chat', 'calypso_helpcenter_feedback_contact_support' );
+		await resetSupportInteraction();
+		startNewInteraction( {
+			event_source: 'help-center',
+			event_external_id: uuidv4(),
+		} );
 		navigate( '/odie' );
 	};
 

--- a/packages/help-center/src/components/help-center-feedback-form.tsx
+++ b/packages/help-center/src/components/help-center-feedback-form.tsx
@@ -2,13 +2,19 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { getPlan } from '@automattic/calypso-products';
 import { HelpCenterSite } from '@automattic/data-stores';
+import CustomALink from '@automattic/odie-client/src/components/message/custom-a-link';
+import { GetSupport } from '@automattic/odie-client/src/components/message/get-support';
+import { uriTransformer } from '@automattic/odie-client/src/components/message/uri-transformer';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
+import Markdown from 'react-markdown';
+import { useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { ThumbsDownIcon, ThumbsUpIcon } from '../icons/thumbs';
 import HelpCenterContactSupportOption from './help-center-contact-support-option';
 import './help-center-feedback-form.scss';
+import { generateContactOnClickEvent } from './utils';
 interface HelpCenterFeedbackFormProps {
 	postId: number;
 	blogId?: number | null;
@@ -27,6 +33,7 @@ const HelpCenterFeedbackForm = ( {
 
 	const { sectionName, site } = useHelpCenterContext();
 	const shouldUseHelpCenterExperience = config.isEnabled( 'help-center-experience' );
+	const navigate = useNavigate();
 	const productSlug = ( site as HelpCenterSite )?.plan?.product_slug;
 	const plan = getPlan( productSlug );
 	const productId = plan?.getProductId();
@@ -94,20 +101,45 @@ const HelpCenterFeedbackForm = ( {
 		);
 	};
 
+	const handleContactSupportClick = () => {
+		generateContactOnClickEvent( 'chat', 'calypso_helpcenter_feedback_contact_support' );
+		navigate( '/odie' );
+	};
+
 	return (
 		<div className="help-center-feedback__form">
 			{ startedFeedback === null && <FeedbackButtons /> }
 			{ startedFeedback !== null && answerValue === 1 && <FeedbackTextArea /> }
-			{ startedFeedback !== null && answerValue === 2 && site && (
-				<HelpCenterContactSupportOption
-					sectionName={ sectionName }
-					productId={ productId }
-					site={ site }
-					triggerSource="article-feedback-form"
-					articleUrl={ articleUrl }
-					trackEventName="calypso_helpcenter_feedback_contact_support"
-				/>
-			) }
+			{ startedFeedback !== null &&
+				answerValue === 2 &&
+				site &&
+				( shouldUseHelpCenterExperience ? (
+					<>
+						<div className="odie-chatbox-dislike-feedback-message">
+							<Markdown
+								urlTransform={ uriTransformer }
+								components={ {
+									a: CustomALink,
+								} }
+							>
+								{ __(
+									'Would you like to contact our support team? Select an option below:',
+									__i18n_text_domain__
+								) }
+							</Markdown>
+						</div>
+						<GetSupport onClickAdditionalEvent={ handleContactSupportClick } />
+					</>
+				) : (
+					<HelpCenterContactSupportOption
+						sectionName={ sectionName }
+						productId={ productId }
+						site={ site }
+						triggerSource="article-feedback-form"
+						articleUrl={ articleUrl }
+						trackEventName="calypso_helpcenter_feedback_contact_support"
+					/>
+				) ) }
 		</div>
 	);
 };

--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -1,7 +1,9 @@
-.help-center__container-chat .chatbox-messages .odie__transfer-to-human {
+
+
+.help-center__container-chat .chatbox-messages .odie__transfer-to-human,
+.help-center-article-content .help-center-feedback__form .odie__transfer-to-human {
 	display: flex;
 	width: 100%;
-	margin-left: 11%;
 	padding-bottom: 16px;
 
 	button {
@@ -26,4 +28,8 @@
 			outline: none;
 		}
 	}
+}
+
+.help-center__container-chat .chatbox-messages .odie__transfer-to-human {
+	margin-left: 11%;
 }

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -4,12 +4,18 @@ import { useCreateZendeskConversation } from '../../hooks';
 
 import './get-support.scss';
 
-export const GetSupport = () => {
+export const GetSupport = ( {
+	onClickAdditionalEvent,
+}: {
+	onClickAdditionalEvent?: () => void;
+} ) => {
 	const newConversation = useCreateZendeskConversation();
 	const { shouldUseHelpCenterExperience, chat } = useOdieAssistantContext();
 
 	const handleOnClick = async ( event: React.MouseEvent< HTMLButtonElement > ) => {
 		event.preventDefault();
+
+		onClickAdditionalEvent?.();
 
 		await newConversation();
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/9540

## Proposed Changes

* Update article feedback button (thumbs-down) and start a new chat.

<img width="397" alt="CleanShot 2024-11-07 at 12 31 32@2x" src="https://github.com/user-attachments/assets/9de1968b-7ac3-4c3e-a1bd-23a1c7c1e4c4">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout or use live link
* Navigate to `/home?flags=help-center-experience` and open the Help Center.
* Click on a random article, scroll down, and click the thumbs-down icon.
* Verify the `Get support` button appears and starts a new HE chat.
* Compare against production with the flag disabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
