### PR TITLE
Help Center: Remove disclaimer if not needed

### DIFF
--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -34,6 +34,10 @@ export const MessageContent = ( {
 		shouldUseHelpCenterExperience && isNextMessageFromSameSender && 'next-chat-message-same-sender'
 	);
 
+	const isMessageWithOnlyText =
+		message.context?.flags?.hide_disclaimer_content ||
+		message.context?.question_tags?.inquiry_type === 'user-is-greeting';
+
 	return (
 		<>
 			<div className={ containerClasses } data-is-message="true">
@@ -41,7 +45,13 @@ export const MessageContent = ( {
 					{ messageHeader }
 					{ message.type === 'error' && <ErrorMessage message={ message } /> }
 					{ ( [ 'message', 'image', 'file', 'text' ].includes( message.type ) ||
-						! message.type ) && <UserMessage message={ message } isDisliked={ isDisliked } /> }
+						! message.type ) && (
+						<UserMessage
+							message={ message }
+							isDisliked={ isDisliked }
+							isMessageWithoutEscalationOption={ isMessageWithOnlyText }
+						/>
+					) }
 					{ message.type === 'introduction' && (
 						<div className="odie-introduction-message-content">
 							<div className="odie-chatbox-introduction-message">
@@ -58,7 +68,7 @@ export const MessageContent = ( {
 					) }
 					{ message.type === 'dislike-feedback' && <DislikeFeedbackMessage /> }
 				</div>
-				<Sources message={ message } />
+				{ ! isMessageWithOnlyText && <Sources message={ message } /> }
 			</div>
 			{ shouldUseHelpCenterExperience && displayChatWithSupportLabel && <ChatWithSupportLabel /> }
 		</>


### PR DESCRIPTION


## Proposed Changes

Do not show "Was this helpful" if not needed.
Change as in https://github.com/Automattic/wp-calypso/pull/95771, but it was overwritten by a merge
