### PR TITLE
Payment Management and Checkout: Use dedicated endpoint to create Setup Intent

### DIFF
--- a/client/my-sites/checkout/src/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/src/lib/multi-partner-card-processor.ts
@@ -308,7 +308,6 @@ export default async function multiPartnerCardProcessor(
 				stripeConfiguration: dataForProcessor.stripeConfiguration,
 				cardNumberElement: submitData.cardNumberElement,
 				reduxDispatch: dataForProcessor.reduxDispatch,
-				isCheckout: true,
 				eventSource: '/checkout',
 			},
 			submitDataWithContactInfo


### PR DESCRIPTION
## Proposed Changes

In this PR we change the `assignNewCardProcessor()` payment processor function used by checkout, the "add payment method" form, and the "change payment method" form to use the new `/me/stripe-payment-intent` endpoint to create their Payment Intent.

> [!IMPORTANT]
> This also provides the country code when creating the Setup Intent. Previously, since no country code was being provided, the geolocated country code was being used to determine which Stripe account to use for creating the Setup Intent. Now the Setup Intent will be created based on the country entered for the credit card's tax location. I'm not sure if this will have any major effect but it seems like the right thing to do and it was probably an oversight that it wasn't added sooner.

> [!NOTE]
> There are two other places in calypso that create a Stripe Setup Intent: the A4A page and the Jetpack Manage page. Those places use [different](https://github.com/Automattic/wp-calypso/blob/0db53b61c6d1629abf80f739d847275f73c48c2e/client/a8c-for-agencies/sections/purchases/payment-methods/lib/get-stripe-configuration.ts#L7-L13) [endpoints](https://github.com/Automattic/wp-calypso/blob/0db53b61c6d1629abf80f739d847275f73c48c2e/client/jetpack-cloud/sections/partner-portal/payment-methods/get-stripe-configuration.ts#L7-L13) to create Setup Intents which this PR does not alter as it will require an additional endpoint be added for Jetpack sites.

## Why are these changes being made?

Creating a Stripe Setup Intent when adding a new saved card was originally added as an optional feature of the Stripe configuration endpoint. This was done because it saved time when implementing the "Add card" form in calypso's Payment Method Management pages; the form always required the Stripe configuration, and it also always required creating a Setup Intent to add a new card. The feature was optional because other uses of the Stripe configuration, like checkout, did not need a Setup Intent.

However, more recently we started needing Setup Intents in checkout in order to add a new credit card to a free trial purchase so it can be charged when the free period ends. When implementing this, it became clear that creating a Setup Intent for every page load was creating far too many unused Intents; there wasn't even a guarantee that the user would choose to use the Intent if they completed checkout, say, without attaching a credit card. To that end, we refactored how Setup Intents are created in calypso; they are now created on the fly when they are needed, just before they are confirmed (see https://github.com/Automattic/wp-calypso/pull/79881).

Even though this refactor helps considerably, there's confusion about when and where the Setup Intent is created since it uses the `/me/stripe-configuration` endpoint with a special `needs_intent` parameter.

D165521-code makes a dedicated endpoint to create a Setup Intent to alleviate that confusion. (This may also help as we do more work to create Setup Intents for E-Mandates). In addition, the new endpoint uses the POST verb instead of the GET verb to make it more clear that this action is not trivial.

## Testing Instructions

- Apply D165521-code to your sandbox and point `public-api.wordpress.com` to it.
- Visit `/me/purchases/add-payment-method` and add a new credit card.
- Verify that the card is added successfully.