### PR TITLE
Domains: Prevent email from being purchased for Gravatar domains

### DIFF
--- a/client/lib/emails/email-provider-constants.js
+++ b/client/lib/emails/email-provider-constants.js
@@ -11,3 +11,4 @@ export const EMAIL_WARNING_SLUG_UNVERIFIED_FORWARDS = 'unverified_forwards';
 export const EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION =
 	'other-user-owns-subscription';
 export const EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL = 'other-user-owns-email';
+export const EMAIL_WARNING_CODE_GRAVATAR_DOMAIN = 'domain-gravatar-domain';

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -10,6 +10,7 @@ import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
 import { getCurrentUserCannotAddEmailReason, getSelectedDomain } from 'calypso/lib/domains';
+import { EMAIL_WARNING_CODE_GRAVATAR_DOMAIN } from 'calypso/lib/emails/email-provider-constants';
 import EmailForwardingAddNewCompactList from 'calypso/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
@@ -52,7 +53,7 @@ const EmailForwardsAdd = ( { selectedDomainName, source }: EmailForwardsAddProps
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
 	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( selectedDomain );
-	const isGravatarDomain = cannotAddEmailWarningReason?.code === 'domain-gravatar-domain';
+	const isGravatarDomain = cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN;
 
 	const goToEmail = useCallback( (): void => {
 		if ( ! selectedSite ) {

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -7,7 +7,9 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
+import { getCurrentUserCannotAddEmailReason, getSelectedDomain } from 'calypso/lib/domains';
 import EmailForwardingAddNewCompactList from 'calypso/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
@@ -17,6 +19,7 @@ import {
 import { useSelector } from 'calypso/state';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import {
+	getDomainsBySiteId,
 	hasLoadedSiteDomains,
 	isRequestingSiteDomains,
 } from 'calypso/state/sites/domains/selectors';
@@ -46,6 +49,11 @@ const EmailForwardsAdd = ( { selectedDomainName, source }: EmailForwardsAddProps
 
 	const translate = useTranslate();
 
+	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
+	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
+	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( selectedDomain );
+	const isGravatarDomain = cannotAddEmailWarningReason?.code === 'domain-gravatar-domain';
+
 	const goToEmail = useCallback( (): void => {
 		if ( ! selectedSite ) {
 			return;
@@ -67,6 +75,30 @@ const EmailForwardsAdd = ( { selectedDomainName, source }: EmailForwardsAddProps
 		page( getEmailManagementPath( selectedSite.slug, selectedDomainName, currentRoute ) );
 	}, [ currentRoute, selectedDomainName, selectedSite ] );
 
+	const content = isGravatarDomain ? (
+		<Notice showDismiss={ false } className="email-forwards-add__notice">
+			{ translate( 'This is a Gravatar domain and cannot have email services purchased for it.' ) }
+		</Notice>
+	) : (
+		<Card>
+			{ areDomainsLoading && (
+				<div className="email-forwards-add__placeholder">
+					<p />
+					<p />
+					<Button disabled />
+				</div>
+			) }
+
+			{ ! areDomainsLoading && (
+				<EmailForwardingAddNewCompactList
+					onAddedEmailForwards={ onAddedEmailForwards }
+					onBeforeAddEmailForwards={ noop }
+					selectedDomainName={ selectedDomainName }
+				/>
+			) }
+		</Card>
+	);
+
 	return (
 		<div className="email-forwards-add">
 			<QueryProductsList />
@@ -84,23 +116,7 @@ const EmailForwardsAdd = ( { selectedDomainName, source }: EmailForwardsAddProps
 
 				<SectionHeader label={ translate( 'Add New Email Forwards' ) } />
 
-				<Card>
-					{ areDomainsLoading && (
-						<div className="email-forwards-add__placeholder">
-							<p />
-							<p />
-							<Button disabled />
-						</div>
-					) }
-
-					{ ! areDomainsLoading && (
-						<EmailForwardingAddNewCompactList
-							onAddedEmailForwards={ onAddedEmailForwards }
-							onBeforeAddEmailForwards={ noop }
-							selectedDomainName={ selectedDomainName }
-						/>
-					) }
-				</Card>
+				{ content }
 			</Main>
 		</div>
 	);

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -77,7 +77,9 @@ const EmailForwardsAdd = ( { selectedDomainName, source }: EmailForwardsAddProps
 
 	const content = isGravatarDomain ? (
 		<Notice showDismiss={ false } className="email-forwards-add__notice">
-			{ translate( 'This is a Gravatar domain and cannot have email services purchased for it.' ) }
+			{ translate(
+				'This domain is associated with a Gravatar profile and cannot be used for email services at this time.'
+			) }
 		</Notice>
 	) : (
 		<Card>

--- a/client/my-sites/email/email-forwards-add/style.scss
+++ b/client/my-sites/email/email-forwards-add/style.scss
@@ -30,3 +30,7 @@
 		margin-top: 3em;
 	}
 }
+
+.email-forwards-add__notice {
+	margin-top: 24px;
+}

--- a/client/my-sites/email/email-management/home/email-plan-warning-notice.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-warning-notice.tsx
@@ -5,6 +5,7 @@ import {
 } from 'calypso/lib/domains';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import {
+	EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
 	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
 	EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
 } from 'calypso/lib/emails/email-provider-constants';
@@ -20,15 +21,25 @@ type EmailPlanWarningNoticeProps = {
 export const EmailPlanWarningNotice = ( props: EmailPlanWarningNoticeProps ) => {
 	const { domain, selectedSite } = props;
 
+	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( domain );
+	const cannotAddEmailWarningMessage = cannotAddEmailWarningReason?.message ?? '';
+	const cannotAddEmailWarningCode = cannotAddEmailWarningReason?.code ?? null;
+
+	if ( cannotAddEmailWarningCode === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN ) {
+		return (
+			<div className="email-plan-warning-notice__warning">
+				<div className="email-plan-warning-notice__message">
+					<span>{ cannotAddEmailWarningMessage }</span>
+				</div>
+			</div>
+		);
+	}
+
 	// If email and domain are owned by different users, none of the users will be able to make a purchase and the only way to resolve this
 	// is to reach out to support. Therefore, we should surface a different message to address this scenario.
 	if ( ! isDomainAndEmailSubscriptionsOwnedByDifferentUsers( domain ) ) {
 		return <EmailDifferentDomainOwnerMessage />;
 	}
-
-	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( domain );
-	const cannotAddEmailWarningMessage = cannotAddEmailWarningReason?.message ?? '';
-	const cannotAddEmailWarningCode = cannotAddEmailWarningReason?.code ?? null;
 
 	switch ( cannotAddEmailWarningCode ) {
 		case EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL:

--- a/client/my-sites/email/email-management/home/utils.ts
+++ b/client/my-sites/email/email-management/home/utils.ts
@@ -138,7 +138,7 @@ export function resolveEmailPlanStatus(
 		statusClass: 'warning',
 		icon: 'info',
 		text: translate( 'Gravatar domain', {
-			comment: 'Current user is not allowed to manage email subscription',
+			comment: 'Current user is not allowed to purchase new email subscriptions',
 		} ),
 	};
 

--- a/client/my-sites/email/email-management/home/utils.ts
+++ b/client/my-sites/email/email-management/home/utils.ts
@@ -1,6 +1,6 @@
 import { translate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { canCurrentUserAddEmail } from 'calypso/lib/domains';
+import { canCurrentUserAddEmail, getCurrentUserCannotAddEmailReason } from 'calypso/lib/domains';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import {
@@ -8,6 +8,7 @@ import {
 	hasUnusedMailboxWarning,
 	hasUnverifiedEmailForward,
 } from 'calypso/lib/emails';
+import { EMAIL_WARNING_CODE_GRAVATAR_DOMAIN } from 'calypso/lib/emails/email-provider-constants';
 import {
 	getGSuiteMailboxCount,
 	getGSuiteSubscriptionId,
@@ -132,6 +133,23 @@ export function resolveEmailPlanStatus(
 			comment: 'Current user is not allowed to manage email subscription',
 		} ),
 	};
+
+	const gravatarDomainStatus = {
+		statusClass: 'warning',
+		icon: 'info',
+		text: translate( 'Gravatar domain', {
+			comment: 'Current user is not allowed to manage email subscription',
+		} ),
+	};
+
+	// Some Gravatar domains already had email purchased for them before we disabled it.
+	// These domains have a specific warning message.
+	if (
+		! canCurrentUserAddEmail( domain ) &&
+		getCurrentUserCannotAddEmailReason( domain )?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN
+	) {
+		return gravatarDomainStatus;
+	}
 
 	if ( hasGSuiteWithUs( domain ) ) {
 		if ( ! canCurrentUserAddEmail( domain ) ) {

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -309,7 +309,7 @@ const EmailProvidersStackedComparison = ( {
 				{ isGravatarDomain && (
 					<Notice showDismiss={ false } className="email-providers-stacked-comparison__notice">
 						{ translate(
-							'This is a Gravatar domain and cannot have email services purchased for it.'
+							'This domain is associated with a Gravatar profile and cannot be used for email services at this time.'
 						) }
 					</Notice>
 				) }

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -13,8 +13,13 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { getSelectedDomain, canCurrentUserAddEmail } from 'calypso/lib/domains';
+import {
+	getSelectedDomain,
+	canCurrentUserAddEmail,
+	getCurrentUserCannotAddEmailReason,
+} from 'calypso/lib/domains';
 import {
 	hasEmailForwards,
 	getDomainsWithEmailForwards,
@@ -92,7 +97,9 @@ const EmailProvidersStackedComparison = ( {
 	);
 
 	const currentUserCanAddEmail = canCurrentUserAddEmail( domain );
-	const showNonOwnerMessage = ! currentUserCanAddEmail && ! isDomainInCart;
+	const showNonOwnerMessage = ! currentUserCanAddEmail && ! isDomainInCart && false;
+	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( domain );
+	const isGravatarDomain = cannotAddEmailWarningReason?.code === 'domain-gravatar-domain';
 
 	const isGSuiteSupported =
 		domain && canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
@@ -292,12 +299,19 @@ const EmailProvidersStackedComparison = ( {
 			{ ! isDomainInCart && domain && <EmailExistingPaidServiceNotice domain={ domain } /> }
 
 			<>
-				{ showNonOwnerMessage && (
+				{ showNonOwnerMessage && ! isGravatarDomain && (
 					<EmailNonDomainOwnerMessage
 						domain={ domain }
 						selectedSite={ selectedSite }
 						source="email-comparison"
 					/>
+				) }
+				{ isGravatarDomain && (
+					<Notice showDismiss={ false } className="email-providers-stacked-comparison__notice">
+						{ translate(
+							'This is a Gravatar domain and cannot have email services purchased for it.'
+						) }
+					</Notice>
 				) }
 				{ shouldPromoteGoogleWorkspace ? [ ...emailProviderCards ].reverse() : emailProviderCards }
 			</>

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -97,7 +97,7 @@ const EmailProvidersStackedComparison = ( {
 	);
 
 	const currentUserCanAddEmail = canCurrentUserAddEmail( domain );
-	const showNonOwnerMessage = ! currentUserCanAddEmail && ! isDomainInCart && false;
+	const showNonOwnerMessage = ! currentUserCanAddEmail && ! isDomainInCart;
 	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( domain );
 	const isGravatarDomain = cannotAddEmailWarningReason?.code === 'domain-gravatar-domain';
 

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -24,6 +24,7 @@ import {
 	hasEmailForwards,
 	getDomainsWithEmailForwards,
 } from 'calypso/lib/domains/email-forwarding';
+import { EMAIL_WARNING_CODE_GRAVATAR_DOMAIN } from 'calypso/lib/emails/email-provider-constants';
 import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
@@ -99,7 +100,7 @@ const EmailProvidersStackedComparison = ( {
 	const currentUserCanAddEmail = canCurrentUserAddEmail( domain );
 	const showNonOwnerMessage = ! currentUserCanAddEmail && ! isDomainInCart;
 	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( domain );
-	const isGravatarDomain = cannotAddEmailWarningReason?.code === 'domain-gravatar-domain';
+	const isGravatarDomain = cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN;
 
 	const isGSuiteSupported =
 		domain && canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );

--- a/client/my-sites/email/email-providers-comparison/stacked/style.scss
+++ b/client/my-sites/email/email-providers-comparison/stacked/style.scss
@@ -51,3 +51,7 @@
 		margin: 10px auto;
 	}
 }
+
+.email-providers-stacked-comparison__notice {
+	margin-top: 24px;
+}


### PR DESCRIPTION
## Proposed Changes

This PR:
- Adds a notice to the email service selection page explaining that Gravatar domains cannot have email purchased for them
- Adds a notice to the email forwarding add page with the same explanation

Some Gravatar domains already had email purchased for them. In those cases, users will still be able to manage their email subscription (renew, cancel) but won't be able to buy new mailboxes.

Depends on D165417-code.

This is part of the Custom Domains on Gravatar i2 project (pcYYhz-2oZ-p2).

### Screenshots

- Email services (Google Workspace and Titan)

| Without this PR (shows incorrect notice info) | With PR |
| --- | --- |
| <img width="1090" alt="Screenshot 2024-11-05 at 15 25 14" src="https://github.com/user-attachments/assets/1a68e2ee-c6fb-4000-98d4-dd878d5da64c"> | <img width="1071" alt="Screenshot 2024-11-13 at 16 18 53" src="https://github.com/user-attachments/assets/5d992bc7-4a52-4541-a767-c1892dbc9ae1"> |

- Email management page for domains that already had email purchased for them

| Without this PR and diff | With PR and diff |
| --- | --- |
| ![Markup on 2024-11-13 at 16:27:02](https://github.com/user-attachments/assets/88b4b097-7853-486a-9b37-265744f5cf13) | ![Markup on 2024-11-13 at 16:25:47](https://github.com/user-attachments/assets/6f0131ac-063f-4624-9fdc-29b8487c8bbc) |

- Email forwarding

| Without the PR | With PR |
| --- | --- |
| <img width="1074" alt="Screenshot 2024-11-05 at 17 59 55" src="https://github.com/user-attachments/assets/116884c6-1d8a-4581-a30b-c7fa4df5d036"> | <img width="1080" alt="Screenshot 2024-11-13 at 16 20 02" src="https://github.com/user-attachments/assets/c6bf6bf6-dcde-441a-9d0e-536507477057"> |

## Why are these changes being made?

We don't want Gravatar domains to have any email services attached to them for now.

## Testing Instructions

If D165417-code wasn't merged yet, apply it to your sandbox.

- Build this branch locally or open the live Calypso link
- Go to the domain management page of a Gravatar domain
- Ensure there are no options to attach email to it
- In the left menu, select "My Mailboxes"
- Ensure the notice is shown and you can't purchase any of the email services
- Go to the email forwarding page and ensure you can't purchase that either

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?