### PR TITLE
Domains: Fix the spacing on Domains page to match with Sites page

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -118,9 +118,31 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			}
 
 			.domains-table {
-				margin-top: 35px;
+				margin-top: 40px;
 				.domains-table-toolbar {
-					margin-inline: 16px;
+					margin-inline: 48px;
+
+					.domains-table-bulk-actions-toolbar {
+						align-items: flex-start;
+
+						.button {
+							padding: 4px 12px 4px 8px;
+
+							&:disabled img {
+								opacity: 0.5;
+							}
+						}
+
+						.select-dropdown {
+							border-radius: 2px;
+
+							.select-dropdown__header {
+								border-radius: 2px;
+								height: 32px;
+								padding: 0 8px;
+							}
+						}
+					}
 				}
 				table {
 					overflow-y: auto;
@@ -128,23 +150,37 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					margin-bottom: 0;
 					padding-inline: 0;
 					margin-inline-start: 0;
+					margin-top: 0;
 
-					grid-template-columns: 50px 1fr minmax( auto, 1fr ) auto auto auto;
+					grid-template-columns: 75px 1fr minmax( auto, 1fr ) auto auto auto auto;
 
 					th:last-child,
 					td:last-child {
-						padding: 0 16px 0 0;
+						padding-right: 16px;
 					}
 
 					th:first-child,
 					td:first-child {
-						padding: 0 0 0 24px;
+						padding-left: 56px;
 					}
 
 					thead.domains-table-header {
 						position: sticky;
 						top: 0;
 						z-index: 2;
+					}
+
+					th {
+						padding-top: 22px;
+						padding-bottom: 14px;
+
+						.list__header-column {
+							color: #1e1e1e;
+
+							&:hover {
+								color: var( --color-accent );
+							}
+						}
 					}
 				}
 			}
@@ -213,19 +249,19 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			@media only screen and ( min-width: 960px ) {
 				.domains-table {
 					.domains-table-toolbar {
-						margin-inline: 26px;
+						margin-inline: 48px;
 					}
 					table {
 						grid-template-columns: 75px 2fr 1fr 1fr 1fr auto auto auto auto;
 
 						th:last-child,
 						td:last-child {
-							padding: 0 26px 0 0;
+							padding-right: 56px;
 						}
 
 						th:first-child,
 						td:first-child {
-							padding: 0 0 0 34px;
+							padding-left: 56px;
 						}
 					}
 				}
@@ -243,21 +279,22 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				}
 				.domains-table {
 					table {
-						grid-template-columns: 50px 1fr minmax( auto, 1fr ) auto auto auto;
+						grid-template-columns: 75px 1fr minmax( auto, 1fr ) auto auto auto auto;
 
 						th:last-child,
 						td:last-child {
-							padding: 0 16px 0 0;
+							padding-right: 16px;
 						}
 
 						th:first-child,
 						td:first-child {
-							padding: 0 0 0 24px;
+							padding: 0 0 0 40px;
+							padding-left: 40px;
 						}
 					}
 				}
 				.domains-table-toolbar {
-					margin-inline: 0 !important;
+					margin-inline: 32px !important;
 				}
 			}
 
@@ -280,19 +317,19 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			@media only screen and ( min-width: 601px ) and ( max-width: 781px ) {
 				.domains-table {
 					.domains-table-toolbar {
-						margin-inline: 16px;
+						margin-inline: 48px;
 					}
 					table {
-						grid-template-columns: 50px 1fr minmax( auto, 1fr ) auto auto auto;
+						grid-template-columns: 75px 1fr minmax( auto, 1fr ) auto auto auto auto;
 
 						th:last-child,
 						td:last-child {
-							padding: 0 16px 0 0;
+							padding-right: 16px;
 						}
 
 						th:first-child,
 						td:first-child {
-							padding: 0 0 0 24px;
+							padding-left: 56px;
 						}
 					}
 				}

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -294,7 +294,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					}
 				}
 				.domains-table-toolbar {
-					margin-inline: 32px !important;
+					margin-inline: 32px;
 				}
 			}
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -234,6 +234,10 @@
 			margin-inline: 0;
 
 			@include break-mobile {
+				margin-inline: 32px;
+			}
+
+			@include break-small {
 				margin-inline: 48px;
 			}
 		}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -170,6 +170,49 @@
 	}
 	.domains-table-filter {
 		align-items: flex-start;
+
+		.domains-table-search {
+			.components-input-control__container {
+				background-color: var(--wp-components-color-background, #fff);
+				border-radius: 2px;
+
+				.components-input-control__suffix {
+					> div {
+						padding-right: 4px;
+					}
+
+					svg {
+						fill: var( --studio-gray-80 );
+					}
+				}
+			}
+
+			.components-input-base {
+				height: 32px;
+				max-width: 186px;
+			}
+
+			.components-input-control__input {
+				font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				height: 32px;
+				padding-left: 8px;
+				padding-right: 8px;
+			}
+
+			.components-input-control__backdrop {
+				box-shadow: none;
+			}
+
+			@media only screen and ( max-width: 600px ) {
+				.components-input-base {
+					max-width: 217px;
+				}
+
+				.components-input-control__input {
+					font-size: 1rem;
+				}
+			}
+		}
 	}
 	.domains-table {
 		max-width: 1400px;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -146,16 +146,18 @@
 	overflow: auto;
 	.main {
 		.navigation-header {
-			@include break-huge {
-				padding-inline: 64px;
+			padding-inline: 0;
+
+			.navigation-header__main {
+				padding-inline: 48px;
 			}
-			@include break-xhuge {
+
+			@include break-huge {
 				max-width: 100%;
 
 				.navigation-header__main {
 					max-width: 1400px;
 					margin: 0 auto;
-					padding-inline: 64px;
 				}
 			}
 		}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -149,7 +149,11 @@
 			padding-inline: 0;
 
 			.navigation-header__main {
-				padding-inline: 48px;
+				padding-inline: 16px;
+
+				@include break-mobile {
+					padding-inline: 48px;
+				}
 			}
 
 			@include break-huge {
@@ -158,6 +162,7 @@
 				.navigation-header__main {
 					max-width: 1400px;
 					margin: 0 auto;
+					padding-inline: 48px;
 				}
 			}
 		}
@@ -223,8 +228,12 @@
 			margin-left: auto;
 			margin-right: auto;
 		}
+
+
 		.domains-table-toolbar {
-			@include break-huge {
+			margin-inline: 0;
+
+			@include break-mobile {
 				margin-inline: 48px;
 			}
 		}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -170,14 +170,17 @@
 		align-items: flex-start;
 	}
 	.domains-table {
+		max-width: 1400px;
+		margin-left: auto;
+		margin-right: auto;
+
 		@include break-xhuge {
-			max-width: 1400px;
 			margin-left: auto;
 			margin-right: auto;
 		}
 		.domains-table-toolbar {
 			@include break-huge {
-				margin-inline: 64px;
+				margin-inline: 48px;
 			}
 		}
 

--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -70,6 +70,7 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 	return (
 		<div className="domains-table-filter">
 			<SearchControl
+				className="domains-table-search"
 				onChange={ onSearch }
 				value={ filter.query }
 				placeholder={ __( 'Search by domain…' ) }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/95945

## Proposed Changes

* Fix the spacing on the Domains page to make it consistent with the Sites page.
* Fix spacing for table elements
* Fix toolbar spacing, search component layout, and bulk actions layout
* Fix action column breaking on smaller screens

**Sites Page**
<img width="1439" alt="Screenshot 2024-11-05 at 15 08 53" src="https://github.com/user-attachments/assets/409e6fd3-e3bc-4ed6-929a-e6afe18cc770">

**Domains Page**
<img width="1431" alt="Screenshot 2024-11-05 at 15 09 04" src="https://github.com/user-attachments/assets/ce12cc5e-011c-4c5e-93e5-b4fe98dc52c0">

**Search (Hover)**
<img width="300" alt="Screenshot 2024-11-05 at 15 08 36" src="https://github.com/user-attachments/assets/6ae54f75-f3d0-4b0c-af88-2eb7cbb2b084">

**Bulk Actions**
<img width="300" alt="Screenshot 2024-11-05 at 15 08 19" src="https://github.com/user-attachments/assets/a103492b-424c-495b-a8f5-66b202abcf33">

## Why are these changes being made?

* To ensure consistent spacing between the Domains and Sites pages, making switching between them feel more natural.

## Testing Instructions

* Apply this PR to your local (or use a test env)
* Go to `domains/manage`
* Using the sidebar, switch to the Sites page
* You should see the navbar, search component, and table in the same positions
* Go back to the Domains page, and test with smaller screen sizes
* They should work consistently, matching the Sites spacing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
