### PR TITLE
Limit parallel DotOrg API requests

### DIFF
--- a/client/components/data/query-dotorg-plugins/README.md
+++ b/client/components/data/query-dotorg-plugins/README.md
@@ -1,0 +1,35 @@
+# Query Dotorg Plugins
+
+`<QueryDotorgPlugins />` is a React component used in managing network requests for Dotorg plugins for a given plugin list.
+
+## Usage
+
+Render the component, passing a list of `pluginSlugList[]`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import QueryDotorgPlugins from 'calypso/components/data/query-dotorg-plugins';
+
+export default function AmazingPluginsList( { plugins } ) {
+	const pluginSlugList = [
+		'plugin-1',
+		'plugin-2',
+	];
+
+	return (
+		<div>
+			<QueryDotorgPlugins pluginSlugList />
+		</div>
+	);
+}
+```
+
+## Props
+
+### `pluginSlugList`
+
+<table>
+	<tr><th>Type</th><td>Array</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The Dotorg plugin slug list that should be requested.

--- a/client/components/data/query-dotorg-plugins/index.jsx
+++ b/client/components/data/query-dotorg-plugins/index.jsx
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useInterval } from 'calypso/lib/interval';
+import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
+import { getAllPlugins } from 'calypso/state/plugins/wporg/selectors';
+
+const PLUGIN_RETRIEVE_INTERVAL = 200;
+
+function QueryDotorgPlugins( { pluginSlugList } ) {
+	const dispatch = useDispatch();
+	const queueRef = useRef( [] );
+
+	const dotorgPlugins = useSelector( ( state ) => getAllPlugins( state ) );
+
+	useEffect( () => {
+		pluginSlugList.forEach( ( pluginSlug ) => {
+			if ( ! queueRef.current.includes( pluginSlug ) && ! dotorgPlugins[ pluginSlug ] ) {
+				queueRef.current.push( pluginSlug );
+			}
+		} );
+	}, [ pluginSlugList, dotorgPlugins ] );
+
+	useInterval( () => {
+		if ( pluginSlugList.length ) {
+			const pluginSlug = queueRef.current.shift();
+
+			if ( pluginSlug ) {
+				dispatch( wporgFetchPluginData( pluginSlug ) );
+			}
+		}
+	}, PLUGIN_RETRIEVE_INTERVAL );
+
+	return null;
+}
+
+QueryDotorgPlugins.propTypes = {
+	pluginSlugList: PropTypes.array.isRequired,
+};
+
+export default QueryDotorgPlugins;

--- a/client/components/data/query-dotorg-plugins/index.jsx
+++ b/client/components/data/query-dotorg-plugins/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import PropTypes from 'prop-types';
 import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -14,7 +13,6 @@ function QueryDotorgPlugins( { pluginSlugList } ) {
 	const queueRef = useRef( [] );
 
 	const dotorgPlugins = useSelector( ( state ) => getAllPlugins( state ) );
-	const isBulkManagementEnabled = config.isEnabled( 'bulk-plugin-management' );
 
 	useEffect( () => {
 		pluginSlugList.forEach( ( pluginSlug ) => {
@@ -25,7 +23,7 @@ function QueryDotorgPlugins( { pluginSlugList } ) {
 	}, [ pluginSlugList, dotorgPlugins ] );
 
 	useInterval( async () => {
-		if ( isBulkManagementEnabled && pluginSlugList.length ) {
+		if ( pluginSlugList.length ) {
 			const batch = queueRef.current.splice( 0, BATCH_PLUGIN_RETRIEVE_COUNT );
 
 			await Promise.all(

--- a/client/components/data/query-dotorg-plugins/index.jsx
+++ b/client/components/data/query-dotorg-plugins/index.jsx
@@ -14,6 +14,7 @@ function QueryDotorgPlugins( { pluginSlugList } ) {
 	const queueRef = useRef( [] );
 
 	const dotorgPlugins = useSelector( ( state ) => getAllPlugins( state ) );
+	const isBulkManagementEnabled = config.isEnabled( 'bulk-plugin-management' );
 
 	useEffect( () => {
 		pluginSlugList.forEach( ( pluginSlug ) => {
@@ -24,7 +25,7 @@ function QueryDotorgPlugins( { pluginSlugList } ) {
 	}, [ pluginSlugList, dotorgPlugins ] );
 
 	useInterval( async () => {
-		if ( pluginSlugList.length && config.isEnabled( 'bulk-plugin-management' ) ) {
+		if ( isBulkManagementEnabled && pluginSlugList.length ) {
 			const batch = queueRef.current.splice( 0, BATCH_PLUGIN_RETRIEVE_COUNT );
 
 			await Promise.all(

--- a/client/components/data/query-dotorg-plugins/index.jsx
+++ b/client/components/data/query-dotorg-plugins/index.jsx
@@ -6,7 +6,7 @@ import { useInterval } from 'calypso/lib/interval';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getAllPlugins } from 'calypso/state/plugins/wporg/selectors';
 
-const PLUGIN_RETRIEVE_INTERVAL = 200;
+const PLUGIN_RETRIEVE_INTERVAL = 500;
 const BATCH_PLUGIN_RETRIEVE_COUNT = 5;
 
 function QueryDotorgPlugins( { pluginSlugList } ) {

--- a/client/components/data/query-dotorg-plugins/index.jsx
+++ b/client/components/data/query-dotorg-plugins/index.jsx
@@ -7,6 +7,7 @@ import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/w
 import { getAllPlugins } from 'calypso/state/plugins/wporg/selectors';
 
 const PLUGIN_RETRIEVE_INTERVAL = 200;
+const BATCH_PLUGIN_RETRIEVE_COUNT = 5;
 
 function QueryDotorgPlugins( { pluginSlugList } ) {
 	const dispatch = useDispatch();
@@ -22,13 +23,13 @@ function QueryDotorgPlugins( { pluginSlugList } ) {
 		} );
 	}, [ pluginSlugList, dotorgPlugins ] );
 
-	useInterval( () => {
-		if ( pluginSlugList.length ) {
-			const pluginSlug = queueRef.current.shift();
+	useInterval( async () => {
+		if ( pluginSlugList.length && config.isEnabled( 'bulk-plugin-management' ) ) {
+			const batch = queueRef.current.splice( 0, BATCH_PLUGIN_RETRIEVE_COUNT );
 
-			if ( pluginSlug && config.isEnabled( 'bulk-plugin-management' ) ) {
-				dispatch( wporgFetchPluginData( pluginSlug ) );
-			}
+			await Promise.all(
+				batch.map( ( pluginSlug ) => dispatch( wporgFetchPluginData( pluginSlug ) ) )
+			);
 		}
 	}, PLUGIN_RETRIEVE_INTERVAL );
 

--- a/client/components/data/query-dotorg-plugins/index.jsx
+++ b/client/components/data/query-dotorg-plugins/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import PropTypes from 'prop-types';
 import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -25,7 +26,7 @@ function QueryDotorgPlugins( { pluginSlugList } ) {
 		if ( pluginSlugList.length ) {
 			const pluginSlug = queueRef.current.shift();
 
-			if ( pluginSlug ) {
+			if ( pluginSlug && config.isEnabled( 'bulk-plugin-management' ) ) {
 				dispatch( wporgFetchPluginData( pluginSlug ) );
 			}
 		}

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -37,6 +37,7 @@ import {
 	requestPluginsError,
 	getPluginsWithUpdateStatuses,
 } from 'calypso/state/plugins/installed/selectors';
+import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getAllPlugins as getAllWporgPlugins } from 'calypso/state/plugins/wporg/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
@@ -77,6 +78,7 @@ export class PluginsMain extends Component {
 
 	componentDidUpdate( prevProps ) {
 		const {
+			currentPlugins,
 			hasJetpackSites: hasJpSites,
 			selectedSiteIsJetpack,
 			selectedSiteSlug,
@@ -84,6 +86,13 @@ export class PluginsMain extends Component {
 			hasManagePlugins,
 			search,
 		} = this.props;
+
+		currentPlugins.map( ( plugin ) => {
+			const pluginData = this.props.wporgPlugins?.[ plugin.slug ];
+			if ( ! pluginData && ! config.isEnabled( 'bulk-plugin-management' ) ) {
+				this.props.wporgFetchPluginData( plugin.slug );
+			}
+		} );
 
 		if (
 			( prevProps.isRequestingSites && ! this.props.isRequestingSites ) ||
@@ -675,6 +684,7 @@ export default flow(
 			};
 		},
 		{
+			wporgFetchPluginData,
 			recordTracksEvent,
 			recordGoogleEvent,
 			appendBreadcrumb,

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -37,7 +37,6 @@ import {
 	requestPluginsError,
 	getPluginsWithUpdateStatuses,
 } from 'calypso/state/plugins/installed/selectors';
-import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getAllPlugins as getAllWporgPlugins } from 'calypso/state/plugins/wporg/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
@@ -78,7 +77,6 @@ export class PluginsMain extends Component {
 
 	componentDidUpdate( prevProps ) {
 		const {
-			currentPlugins,
 			hasJetpackSites: hasJpSites,
 			selectedSiteIsJetpack,
 			selectedSiteSlug,
@@ -86,13 +84,6 @@ export class PluginsMain extends Component {
 			hasManagePlugins,
 			search,
 		} = this.props;
-
-		currentPlugins.map( ( plugin ) => {
-			const pluginData = this.props.wporgPlugins?.[ plugin.slug ];
-			if ( ! pluginData ) {
-				this.props.wporgFetchPluginData( plugin.slug );
-			}
-		} );
 
 		if (
 			( prevProps.isRequestingSites && ! this.props.isRequestingSites ) ||
@@ -684,7 +675,6 @@ export default flow(
 			};
 		},
 		{
-			wporgFetchPluginData,
 			recordTracksEvent,
 			recordGoogleEvent,
 			appendBreadcrumb,

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useMemo, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import QueryDotorgPlugins from 'calypso/components/data/query-dotorg-plugins';
 import { DataViews } from 'calypso/components/dataviews';
 import { Plugin } from 'calypso/state/plugins/installed/types';
 import { useActions } from './use-actions';
@@ -53,17 +54,20 @@ export default function PluginsListDataViews( {
 	}, [ currentPlugins, dataViewsState, fields ] );
 
 	return (
-		<DataViews
-			data={ data }
-			view={ dataViewsState }
-			onChangeView={ setDataViewsState }
-			fields={ fields }
-			search
-			searchLabel={ translate( 'Search for plugins' ) }
-			actions={ actions }
-			isLoading={ isLoading }
-			paginationInfo={ paginationInfo }
-			defaultLayouts={ defaultLayouts }
-		/>
+		<>
+			<QueryDotorgPlugins pluginSlugList={ data.map( ( plugin ) => plugin.slug ) } />
+			<DataViews
+				data={ data }
+				view={ dataViewsState }
+				onChangeView={ setDataViewsState }
+				fields={ fields }
+				search
+				searchLabel={ translate( 'Search for plugins' ) }
+				actions={ actions }
+				isLoading={ isLoading }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ defaultLayouts }
+			/>
+		</>
 	);
 }

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -90,7 +90,7 @@ export function useFields(
 				},
 				enableHiding: false,
 				render: ( { item }: { item: Plugin } ) => {
-					if ( item.status?.includes( PLUGINS_STATUS.UPDATE ) ) {
+					if ( item.status?.includes( PLUGINS_STATUS.UPDATE ) && item?.update?.new_version ) {
 						return (
 							<Button
 								variant="secondary"
@@ -98,7 +98,9 @@ export function useFields(
 							>
 								{ translate( 'Update to version %(version)s', {
 									args: {
-										version: item?.update?.new_version.split( '-' ).slice( 0, 2 ).join( '-' ) || '',
+										version: item?.update?.new_version
+											? item.update.new_version.split( '-' ).slice( 0, 2 ).join( '-' )
+											: '',
 									},
 								} ) }
 							</Button>

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -18,6 +18,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import {
 	getNextPluginsListPage,
+	getPlugin,
 	isFetching,
 	isFetchingPluginsList,
 } from 'calypso/state/plugins/wporg/selectors';
@@ -28,6 +29,10 @@ const PLUGINS_LIST_DEFAULT_SIZE = 24;
 
 export function fetchPluginData( pluginSlug, locale = '' ) {
 	return async ( dispatch, getState ) => {
+		if ( getPlugin( getState(), pluginSlug ) ) {
+			return;
+		}
+
 		if ( isFetching( getState(), pluginSlug ) ) {
 			return;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9363
Project related: pet6gk-1CP-p2.

## Proposed Changes

* We're limiting one request to each 200ms; in other words, we get five plugin details/s, and the page renders at a maximum of 15 plugins, so it takes 3 seconds to get them all.
* Fixed an issue with Update button label

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open [the plugins manage screen](https://wordpress.com/plugins/manage) and make sure we don't see parallel Dotorg requests anymore.

| Before | After |
|--------|--------|
|<img width="1535" alt="image" src="https://github.com/user-attachments/assets/1bfd316a-20d6-4067-982e-937085caae8c"> | <img width="1515" alt="image" src="https://github.com/user-attachments/assets/3fe5cdc0-3ee2-4337-9671-9a9b3b8c0284">| 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?