### PR TITLE
Stats Traffic Page: Alway use period `day` for summarize mode

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -86,8 +86,8 @@ const memoizedQuery = memoizeLast( ( period, endOf ) => ( {
 	date: endOf,
 } ) );
 
-const chartRangeToQuery = memoizeLast( ( period, chartRange ) => ( {
-	period,
+const chartRangeToQuery = memoizeLast( ( chartRange ) => ( {
+	period: 'day',
 	start_date: chartRange.chartStart,
 	date: chartRange.chartEnd,
 	summarize: 1,
@@ -326,7 +326,7 @@ class StatsSite extends Component {
 		}
 
 		const query = isNewDateFilteringEnabled
-			? chartRangeToQuery( period, customChartRange )
+			? chartRangeToQuery( customChartRange )
 			: memoizedQuery( period, endOf.format( 'YYYY-MM-DD' ) );
 
 		// For period option links


### PR DESCRIPTION
Related to p1730815464660819/1730775627.392539-slack-C82FZ5T4G

## Proposed Changes

* Always use `day` as period for summarize mode

## Why are these changes being made?

* Minor fix

## Testing Instructions

* Open Calypso Live `/stats/day/jetpack.com?flags=stats/new-date-filtering`
* Inspect network requests
* Ensure all modules below the chart is querying with period set to `day` regardless of what the chat period is.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?