### PR TITLE
[WIP] Checkout Summary:  Number of days shown in refund policies

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -372,8 +372,10 @@ export function CheckoutSummaryRefundWindows( {
 		const refundWindow = refundWindows[ 0 ];
 		const planBundleRefundPolicy = refundPolicies.find(
 			( refundPolicy ) =>
+				refundPolicy === RefundPolicy.PlanTriennialBundle ||
 				refundPolicy === RefundPolicy.PlanBiennialBundle ||
-				refundPolicy === RefundPolicy.PlanYearlyBundle
+				refundPolicy === RefundPolicy.PlanYearlyBundle ||
+				refundPolicy === RefundPolicy.PlanMonthlyBundle
 		);
 		const planProduct = cart.products.find( isPlan );
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -330,6 +330,13 @@ export function CheckoutSummaryRefundWindows( {
 	const refundPolicies = getRefundPolicies( cart );
 	const refundWindows = getRefundWindows( refundPolicies );
 
+	// Filter out carts with only a Domain Transfer, as the refund period doesn't start until the transfer completes
+	if ( refundPolicies.includes( RefundPolicy.DomainNameTransfer ) ) {
+		if ( refundWindows.length === 1 ) {
+			return null;
+		}
+	}
+
 	if ( ! refundWindows.length || refundPolicies.includes( RefundPolicy.NonRefundable ) ) {
 		return null;
 	}
@@ -405,7 +412,8 @@ export function CheckoutSummaryRefundWindows( {
 			}
 		);
 	} else {
-		const shortestRefundWindow = Math.min( ...refundWindows );
+		// Return the shortest refund window but skip any refund windows which are equal to 0
+		const shortestRefundWindow = Math.min( ...refundWindows.filter( ( value ) => value > 0 ) );
 
 		text = translate(
 			'%(days)d-day full money back guarantee',

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -363,7 +363,8 @@ export function CheckoutSummaryRefundWindows( {
 			refundPolicy === RefundPolicy.DomainNameRenewal ||
 			refundPolicy === RefundPolicy.PlanMonthlyRenewal ||
 			refundPolicy === RefundPolicy.PlanYearlyRenewal ||
-			refundPolicy === RefundPolicy.PlanBiennialRenewal
+			refundPolicy === RefundPolicy.PlanBiennialRenewal ||
+			refundPolicy === RefundPolicy.PlanTriennialRenewal
 	);
 
 	let text: TranslateResult;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/payments-shilling/issues/2874

## Proposed Changes

* This PR addresses inconsistencies in how refund periods are shown in the Checkout Summary



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There is no consistent behavior in which refund policy strings are displayed. Sometimes, they are using the product name, sometimes they are not.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
