### PR TITLE
Checkout: add expiry dates to renewal line items with far future expiry

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -299,31 +299,6 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	 */
 	is_gift_purchase?: boolean;
 
-	/**
-	 * The date when the product's subscription will expire if not renewed. This
-	 * might be its renewal date, but it might not be since we often renew
-	 * products earlier than their expiry date.
-	 *
-	 * This is ISO 8601 formatted (eg: `2004-02-12T15:19:21+00:00`).
-	 *
-	 * Only set if we can easily determine when the product will renew. Does not
-	 * apply to domain transfers or multi-year domains.
-	 */
-	subscription_expiry_date?: string;
-
-	/**
-	 * The date when the product's subscription will expire if not renewed
-	 * after the current cart item is purchased. This might be its renewal
-	 * date, but it might not be since we often renew products earlier than
-	 * their expiry date.
-	 *
-	 * This is ISO 8601 formatted (eg: `2004-02-12T15:19:21+00:00`).
-	 *
-	 * Only set if we can easily determine when the product will renew. Does not
-	 * apply to domain transfers or multi-year domains.
-	 */
-	subscription_post_purchase_expiry_date?: string;
-
 	currency: string;
 	allowed_payment_methods: string[];
 	coupon: string;
@@ -539,6 +514,31 @@ export interface ResponseCartProduct {
 	stored_details_id?: string;
 
 	product_variants: ResponseCartProductVariant[];
+
+	/**
+	 * The date when the product's subscription will expire if not renewed. This
+	 * might be its renewal date, but it might not be since we often renew
+	 * products earlier than their expiry date.
+	 *
+	 * This is ISO 8601 formatted (eg: `2004-02-12T15:19:21+00:00`).
+	 *
+	 * Only set if we can easily determine when the product will renew. Does not
+	 * apply to domain transfers or multi-year domains.
+	 */
+	subscription_expiry_date?: string;
+
+	/**
+	 * The date when the product's subscription will expire if not renewed
+	 * after the current cart item is purchased. This might be its renewal
+	 * date, but it might not be since we often renew products earlier than
+	 * their expiry date.
+	 *
+	 * This is ISO 8601 formatted (eg: `2004-02-12T15:19:21+00:00`).
+	 *
+	 * Only set if we can easily determine when the product will renew. Does not
+	 * apply to domain transfers or multi-year domains.
+	 */
+	subscription_post_purchase_expiry_date?: string;
 }
 
 export interface ResponseCartProductVariant {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -299,6 +299,31 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	 */
 	is_gift_purchase?: boolean;
 
+	/**
+	 * The date when the product's subscription will expire if not renewed. This
+	 * might be its renewal date, but it might not be since we often renew
+	 * products earlier than their expiry date.
+	 *
+	 * This is ISO 8601 formatted (eg: `2004-02-12T15:19:21+00:00`).
+	 *
+	 * Only set if we can easily determine when the product will renew. Does not
+	 * apply to domain transfers or multi-year domains.
+	 */
+	subscription_expiry_date?: string;
+
+	/**
+	 * The date when the product's subscription will expire if not renewed
+	 * after the current cart item is purchased. This might be its renewal
+	 * date, but it might not be since we often renew products earlier than
+	 * their expiry date.
+	 *
+	 * This is ISO 8601 formatted (eg: `2004-02-12T15:19:21+00:00`).
+	 *
+	 * Only set if we can easily determine when the product will renew. Does not
+	 * apply to domain transfers or multi-year domains.
+	 */
+	subscription_post_purchase_expiry_date?: string;
+
 	currency: string;
 	allowed_payment_methods: string[];
 	coupon: string;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -525,7 +525,7 @@ export interface ResponseCartProduct {
 	 * Only set if we can easily determine when the product will renew. Does not
 	 * apply to domain transfers or multi-year domains.
 	 */
-	subscription_expiry_date?: string;
+	subscription_current_expiry_date?: string;
 
 	/**
 	 * The date when the product's subscription will expire if not renewed

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -785,6 +785,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
 				{ translate( '%(price)s per month', { args: { price } } ) }
+				<LineItemExpiryDates product={ product } />
 			</>
 		);
 	}
@@ -794,6 +795,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
 				{ translate( '%(price)s per year', { args: { price } } ) }
+				<LineItemExpiryDates product={ product } />
 			</>
 		);
 	}
@@ -803,6 +805,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
 				{ translate( '%(price)s per two years', { args: { price } } ) }
+				<LineItemExpiryDates product={ product } />
 			</>
 		);
 	}
@@ -812,11 +815,51 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
 				{ translate( '%(price)s per three years', { args: { price } } ) }
+				<LineItemExpiryDates product={ product } />
 			</>
 		);
 	}
 
 	return <DefaultLineItemSublabel product={ product } />;
+}
+
+function LineItemExpiryDates( { product }: { product: ResponseCartProduct } ) {
+	const translate = useTranslate();
+	const expiryDate = product.subscription_expiry_date
+		? formatDate( product.subscription_expiry_date )
+		: undefined;
+	const postRenewExpiry = product.subscription_post_purchase_expiry_date
+		? formatDate( product.subscription_post_purchase_expiry_date )
+		: undefined;
+	return (
+		<>
+			{ expiryDate && (
+				<>
+					<br />
+					{ translate( 'Currently expires on %(expiryDate)s', { args: { expiryDate } } ) }{ ' ' }
+				</>
+			) }
+			{ postRenewExpiry && (
+				<>
+					<br />
+					{ translate( 'After purchase, will expire on %(postRenewExpiry)s', {
+						args: { postRenewExpiry },
+					} ) }
+				</>
+			) }
+		</>
+	);
+}
+
+function formatDate( isoDate: string ): string {
+	// This somewhat mimics `moment.format('ll')` (used here formerly) without
+	// needing the deprecated `moment` package.
+	return new Date( Date.parse( isoDate ) ).toLocaleDateString( 'en-US', {
+		weekday: undefined,
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric',
+	} );
 }
 
 function GetBillingIntervalLabel( { product }: { product: ResponseCartProduct } ) {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -831,21 +831,37 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 	);
 }
 
+function getApproximateDifferenceInMonths( dateFrom: Date, dateTo: Date ): number {
+	return Math.abs(
+		dateTo.getMonth() - dateFrom.getMonth() + 12 * ( dateTo.getFullYear() - dateFrom.getFullYear() )
+	);
+}
+
 function LineItemExpiryDates( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
+
+	// We only currently show the expiry date for renewals when the current
+	// subscription is more than 9 months away from expiration (to help
+	// prevent accidental renewals), although it should be accurate for
+	// other cart items as well.
+	if ( ! product.is_renewal ) {
+		return null;
+	}
+	if ( ! product.subscription_current_expiry_date ) {
+		return null;
+	}
+	const expiryTimestamp = new Date( product.subscription_current_expiry_date );
+	const minNumberOfMonths = 10;
+	if ( getApproximateDifferenceInMonths( expiryTimestamp, new Date() ) < minNumberOfMonths ) {
+		return null;
+	}
+
 	const expiryDate = product.subscription_current_expiry_date
 		? formatDate( product.subscription_current_expiry_date )
 		: undefined;
 	const postRenewExpiry = product.subscription_post_purchase_expiry_date
 		? formatDate( product.subscription_post_purchase_expiry_date )
 		: undefined;
-
-	// We only currently show the expiry date for renewals, although it is
-	// accurate for new products as well.
-	if ( ! product.is_renewal ) {
-		return null;
-	}
-
 	return (
 		<>
 			{ expiryDate && (

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -691,6 +691,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 			return (
 				<>
 					<DefaultLineItemSublabel product={ product } />: { billingInterval }
+					<LineItemExpiryDates product={ product } />
 				</>
 			);
 		}
@@ -700,6 +701,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 			return (
 				<>
 					<DefaultLineItemSublabel product={ product } />: { billingInterval }
+					<LineItemExpiryDates product={ product } />
 				</>
 			);
 		}
@@ -763,6 +765,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 				{ ! product.is_included_for_100yearplan && (
 					<>: { GetBillingIntervalLabel( { product } ) }</>
 				) }
+				<LineItemExpiryDates product={ product } />
 			</>
 		);
 	}
@@ -820,7 +823,12 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		);
 	}
 
-	return <DefaultLineItemSublabel product={ product } />;
+	return (
+		<>
+			<DefaultLineItemSublabel product={ product } />
+			<LineItemExpiryDates product={ product } />
+		</>
+	);
 }
 
 function LineItemExpiryDates( { product }: { product: ResponseCartProduct } ) {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -833,8 +833,8 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 
 function LineItemExpiryDates( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
-	const expiryDate = product.subscription_expiry_date
-		? formatDate( product.subscription_expiry_date )
+	const expiryDate = product.subscription_current_expiry_date
+		? formatDate( product.subscription_current_expiry_date )
 		: undefined;
 	const postRenewExpiry = product.subscription_post_purchase_expiry_date
 		? formatDate( product.subscription_post_purchase_expiry_date )

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -831,6 +831,13 @@ function LineItemExpiryDates( { product }: { product: ResponseCartProduct } ) {
 	const postRenewExpiry = product.subscription_post_purchase_expiry_date
 		? formatDate( product.subscription_post_purchase_expiry_date )
 		: undefined;
+
+	// We only currently show the expiry date for renewals, although it is
+	// accurate for new products as well.
+	if ( ! product.is_renewal ) {
+		return null;
+	}
+
 	return (
 		<>
 			{ expiryDate && (


### PR DESCRIPTION
## Proposed Changes

This PR adds the **current expiry date** and the **next expiry date** (after the purchase is complete) to the checkout line item list for renewals when the renewal is more than 9 months away. 

Before             |  After
:-------------------------:|:-------------------------:
<img width="579" alt="Screenshot 2024-11-05 at 6 17 35 PM" src="https://github.com/user-attachments/assets/26305dc5-ce05-4bb6-b449-0780ec274d55"> | <img width="585" alt="Screenshot 2024-11-05 at 6 01 06 PM" src="https://github.com/user-attachments/assets/7a77338e-aefc-419f-bcdc-e5976dce8f32">
<img width="611" alt="domain-w-dates-before" src="https://github.com/user-attachments/assets/8fd2faab-7995-4538-ab92-127dcf60b7e8"> | <img width="588" alt="domain-w-dates-after" src="https://github.com/user-attachments/assets/a9fc494c-87d6-4905-b893-eba4f6bba3d9">
<img width="578" alt="domain-w-dates-before-2" src="https://github.com/user-attachments/assets/781bc6e9-b5b1-4250-8a67-9a52307423f5"> | <img width="577" alt="domain-w-dates-after-2" src="https://github.com/user-attachments/assets/a43efcd6-fa8c-49e9-b7da-e6422029c2d4">


## Why are these changes being made?

The goal is to prevent users from manually renewing their purchases accidentally by showing them when their product will expire.

Fixes https://github.com/Automattic/wp-calypso/issues/93966
Fixes https://github.com/Automattic/wp-calypso/issues/96534

## Testing Instructions

- Apply D165321-code and point `public-api.wordpress.com` to your sandbox.
- Make sure you have a site that has an existing subscription. 
- Modify the subscription expiry date to be sometime in the next 9 months.
- Add a renewal of the subscription to your shopping cart and visit checkout.
- Verify that you do not see the expiry dates shown (ie: it's the same as production).
- Modify the subscription expiry date to be sometime AFTER the next 9 months.
- Reload checkout and verify that you see the expiry dates in the checkout line item and that they seem accurate.
- Repeat the above with different products, specifically domains, plans, and email; make sure to select different billing intervals for the domain renewals!