### PR TITLE
ToS: Add 'b' tag to instances of productName

### DIFF
--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -122,14 +122,11 @@ function MessageForTermsOfServiceRecordUnknown( {
 				'After you renew today, your %(productName)s subscription will last until %(endDate)s.'
 			);
 		const renewalTermLengthText = translate(
-			'After you renew today, your {{b}}%(productName)s{{/b}} subscription will last until %(endDate)s.',
+			'After you renew today, your %(productName)s subscription will last until %(endDate)s.',
 			{
 				args: {
 					productName,
 					endDate: subscriptionEndDate,
-				},
-				components: {
-					b: <strong />,
 				},
 			}
 		);
@@ -230,7 +227,7 @@ function MessageForTermsOfServiceRecordUnknown( {
 	}
 
 	return translate(
-		'At the end of the promotional period your {{b}}%(productName)s{{/b}} subscription will renew for %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
+		'At the end of the promotional period your %(productName)s subscription will renew for %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
 		{
 			args: {
 				productName,
@@ -238,7 +235,6 @@ function MessageForTermsOfServiceRecordUnknown( {
 				regularPrice,
 			},
 			components: {
-				b: <strong />,
 				link: <a href={ manageSubscriptionLink } target="_blank" rel="noopener noreferrer" />,
 			},
 		}

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -104,12 +104,15 @@ function MessageForTermsOfServiceRecordUnknown( {
 		);
 
 		const termLengthText = translate(
-			'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s.',
+			'The promotional period for your {{b}}%(productName)s{{/b}} subscription lasts from %(startDate)s to %(endDate)s.',
 			{
 				args: {
 					productName,
 					startDate,
 					endDate: promotionEndDate,
+				},
+				components: {
+					b: <strong />,
 				},
 			}
 		);
@@ -119,11 +122,14 @@ function MessageForTermsOfServiceRecordUnknown( {
 				'After you renew today, your %(productName)s subscription will last until %(endDate)s.'
 			);
 		const renewalTermLengthText = translate(
-			'After you renew today, your %(productName)s subscription will last until %(endDate)s.',
+			'After you renew today, your {{b}}%(productName)s{{/b}} subscription will last until %(endDate)s.',
 			{
 				args: {
 					productName,
 					endDate: subscriptionEndDate,
+				},
+				components: {
+					b: <strong />,
 				},
 			}
 		);
@@ -224,7 +230,7 @@ function MessageForTermsOfServiceRecordUnknown( {
 	}
 
 	return translate(
-		'At the end of the promotional period your %(productName)s subscription will renew for %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
+		'At the end of the promotional period your {{b}}%(productName)s{{/b}} subscription will renew for %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
 		{
 			args: {
 				productName,
@@ -232,6 +238,7 @@ function MessageForTermsOfServiceRecordUnknown( {
 				regularPrice,
 			},
 			components: {
+				b: <strong />,
 				link: <a href={ manageSubscriptionLink } target="_blank" rel="noopener noreferrer" />,
 			},
 		}


### PR DESCRIPTION
As noted in https://github.com/Automattic/wp-calypso/issues/95867#issuecomment-2450194400, this change wraps ~any instances~ just the one instance of `productName` suggested by @sirbrillig with a `<b>` tag to bold the product name in our Terms of Service.

~This PR relies on feedback from our i18n team as we hope to avoid retranslating all of these strings.~ i18n said the strings are close enough that Glotpress will pass this change automatically once String Freeze completes.

**Just waiting on the string translation process to be finished, updated @dlind1 in Slack thread below**

Slack p1730851881703629-slack-i18n

Related to #95867 

## Testing Instructions

- Add different products to your cart and go to Checkout
- Scroll down to the Terms of Service section and check that any instance of a product name is bolded
