### PR TITLE
Enable Bulk Plugin Management: Fix issue where dataview page freezes

### DIFF
--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -40,8 +40,10 @@ export default function PluginsListDataViews( {
 
 	// When search changes, notify the parent component
 	useEffect( () => {
-		onSearch && onSearch( dataViewsState.search || '' );
-	}, [ dataViewsState.search, onSearch ] );
+		if ( dataViewsState.search !== initialSearch ) {
+			onSearch && onSearch( dataViewsState.search || '' );
+		}
+	}, [ dataViewsState.search, onSearch, initialSearch ] );
 
 	const { data, paginationInfo } = useMemo( () => {
 		const result = filterSortAndPaginate( currentPlugins, dataViewsState, fields );

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -24,7 +24,9 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 	const [ previousPath, setPreviousPath ] = useState( path );
 	const isManagedPluginSelected =
 		managePluginsPattern.test( path ) ||
-		( path.startsWith( '/plugins/' ) && managePluginsPattern.test( previousPath ) );
+		( path.startsWith( '/plugins/' ) &&
+			managePluginsPattern.test( previousPath ) &&
+			! path.startsWith( '/plugins/scheduled-updates' ) );
 
 	return (
 		<GlobalSidebar


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes
When navigating from marketplace to `Manage Plugins` the screen freezes and the plugins page is not rendered. 
This PR fixes the issue: The `onSearch` callback was being called multiple times causing re-renders.

* Only calling the `onSearch` callback if the user searches the dataview. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

**Before**

https://github.com/user-attachments/assets/7ee7dd74-3888-4f47-8696-2eeb93799490


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins` click `Marketplace` then `Manage Plugins`
* You should navigate to `Manage Plugins` and see the Dataview.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
