### PR TITLE
A4A > Sites: Fix the site overview flyout panel URL reset

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -155,50 +155,53 @@ export default function SitesDashboard() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ data, isError, isLoading, initialSelectedSiteUrl, setDataViewsState ] );
 
+	const setUpdatedUrl = useCallback(
+		( selectedSite?: Site ) => {
+			const updatedUrl = updateSitesDashboardUrl( {
+				category,
+				setCategory,
+				showOnlyFavorites,
+				showOnlyDevelopmentSites,
+				filters: dataViewsState.filters ?? [],
+				selectedSite,
+				selectedSiteFeature: selectedSiteFeature,
+				search: dataViewsState.search ?? '',
+				currentPage: dataViewsState.page ?? 1,
+				sort: dataViewsState.sort,
+			} );
+			if ( page.current !== updatedUrl && updatedUrl !== undefined ) {
+				page.show( updatedUrl );
+			}
+		},
+		[
+			category,
+			dataViewsState.filters,
+			dataViewsState.page,
+			dataViewsState.search,
+			dataViewsState.sort,
+			selectedSiteFeature,
+			setCategory,
+			showOnlyDevelopmentSites,
+			showOnlyFavorites,
+		]
+	);
+
 	useEffect( () => {
 		// If there isn't a selected site and we are showing only the preview pane we should wait for the selected site to load from the endpoint
 		if ( ! dataViewsState.selectedItem ) {
 			return;
 		}
-
-		if ( dataViewsState.selectedItem ) {
-			dispatch( setSelectedSiteId( dataViewsState.selectedItem.blog_id ) );
-		}
-
-		const updatedUrl = updateSitesDashboardUrl( {
-			category: category,
-			setCategory: setCategory,
-			filters: dataViewsState.filters ?? [],
-			selectedSite: dataViewsState.selectedItem,
-			selectedSiteFeature: selectedSiteFeature,
-			search: dataViewsState.search ?? '',
-			currentPage: dataViewsState.page ?? 1,
-			sort: dataViewsState.sort,
-			showOnlyFavorites,
-			showOnlyDevelopmentSites,
-		} );
-		if ( page.current !== updatedUrl && updatedUrl !== undefined ) {
-			page.show( updatedUrl );
-		}
-	}, [
-		dataViewsState.selectedItem,
-		selectedSiteFeature,
-		category,
-		setCategory,
-		dispatch,
-		dataViewsState.filters,
-		dataViewsState.search,
-		dataViewsState.page,
-		showOnlyFavorites,
-		showOnlyDevelopmentSites,
-		dataViewsState.sort,
-	] );
+		dispatch( setSelectedSiteId( dataViewsState.selectedItem.blog_id ) );
+		setUpdatedUrl( dataViewsState.selectedItem );
+	}, [ dataViewsState.selectedItem, dispatch, setUpdatedUrl ] );
 
 	const closeSitePreviewPane = useCallback( () => {
 		if ( dataViewsState.selectedItem ) {
-			setDataViewsState( { ...dataViewsState, type: DATAVIEWS_TABLE, selectedItem: undefined } );
+			const selectedItem = undefined;
+			setDataViewsState( { ...dataViewsState, type: DATAVIEWS_TABLE, selectedItem } );
+			setUpdatedUrl( selectedItem );
 		}
-	}, [ dataViewsState, setDataViewsState ] );
+	}, [ dataViewsState, setDataViewsState, setUpdatedUrl ] );
 
 	useEffect( () => {
 		if ( jetpackSiteDisconnected ) {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1242

## Proposed Changes

This PR fixes the issue with the site overview flyout panel not resetting the URL

## Why are these changes being made?

* To fix the URL not getting reset after the flyout panel for the site details is closed.

## Testing Instructions

1) Open the A4A live link > Go to Sites 
2) Click on any site to open the site details flyout panel > Close the flyout panel
3) Verify that the URL is now set to /sites ( site slug removed)
4) Go to other sub-menu items like Needs attention, Favorite, etc.> Repeat step 2 > Verify you are redirected to the respective sub-menu. 


https://github.com/user-attachments/assets/722bf5a5-a7ae-46be-8ae8-a1b5b40334dc



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
