### PR TITLE
Expand site_name acceptable types to include boolean accounting for purged sites

### DIFF
--- a/client/state/connected-applications/schema.js
+++ b/client/state/connected-applications/schema.js
@@ -31,7 +31,7 @@ export default {
 						properties: {
 							site_ID: { type: 'string' },
 							site_URL: { type: 'string' },
-							site_name: { type: 'string' },
+							site_name: { type: [ 'string', 'boolean' ] },
 						},
 						required: [ 'site_ID', 'site_URL', 'site_name' ],
 						additionalProperties: false,

--- a/client/state/data-layer/wpcom/me/connected-applications/schema.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/schema.js
@@ -34,7 +34,7 @@ export default {
 								properties: {
 									site_ID: { type: 'string' },
 									site_URL: { type: 'string' },
-									site_name: { type: 'string' },
+									site_name: { type: [ 'string', 'boolean' ] },
 								},
 								required: [ 'site_ID', 'site_URL', 'site_name' ],
 								additionalProperties: false,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9690

## Proposed Changes

Includes boolean's as a valid property values for site_name on the connected accounts schema.

I couldn't find this value being used anywhere so rather than falling back to an empty string on the backend I decided the better fix was just to allow the false value on the front end..

## Testing

- http://calypso.localhost:3000/me/security
- http://calypso.localhost:3000/me/security/connected-applications

Both pages should render application connections when viewed from user 223970963 or any user with a purged site that had ios app connections.

Before

![Screenshot 2024-11-06 at 16-27-45 Security — WordPress com](https://github.com/user-attachments/assets/78033385-5d19-481b-9a53-59be682f3d9b)

After

![Screenshot 2024-11-06 at 16-28-50 Security — WordPress com](https://github.com/user-attachments/assets/fa4d6bc0-f704-4921-a106-2f9d50a021a7)
