### PR TITLE
Remove unnecessary style overrides regarding fly-out panel

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -409,10 +409,6 @@
 				align-items: stretch;
 				overflow: hidden;
 			}
-
-			.components-button:focus:not(:disabled) {
-				box-shadow: 0 0 0 2px var(--color-primary-light);
-			}
 		}
 
 		.a4a-layout__top-wrapper,

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -153,6 +153,11 @@
 			}
 		}
 	}
+
+	// Color overrides for focus states of Action button
+	.components-button:focus:not(:disabled) {
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+	}
 }
 
 // TODO: remove when updating to dataviews@4.3.0.

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -156,7 +156,7 @@
 
 	// Color overrides for focus states of Action button
 	.components-button:focus:not(:disabled) {
-		box-shadow: 0 0 0 2px var(--color-primary-light);
+		--wp-components-color-accent: var(--color-primary-light);
 	}
 }
 

--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -327,15 +327,8 @@
 			margin-right: 12px;
 		}
 
+		// DataView overrides: Selected and hover states on the site list.
 		ul.dataviews-view-list {
-			.components-h-stack {
-				gap: 0;
-			}
-
-			li {
-				cursor: pointer;
-			}
-
 			li.is-selected,
 			li.is-selected:hover {
 				background-color: #ebf2fc;
@@ -560,14 +553,10 @@
 		}
 
 		.dataviews-wrapper {
-			width: 100%;
-
 			.dataviews-view-list {
-				flex: 1;
-				max-height: none;
-
-				// Ideally instead of reusing the site name full field
+				// DataView overrides: Ideally instead of reusing the site name full field
 				// We should be setting a media field and a primary field.
+				// Or update Core to hide them when not specified.
 				.dataviews-view-list__media-wrapper {
 					display: none;
 				}
@@ -614,6 +603,54 @@
 	.wpcom-site .a4a-layout.sites-dashboard .site-preview-pane {
 		.item-preview__header {
 			padding: 0;
+		}
+	}
+}
+
+// DataView overrides:
+// Using the List view for the fly-out panel requires hiding certain elements 
+// to properly fit the site list when the panel is open.
+.main.a4a-layout.sites-dashboard {
+	@media (min-width: $break-large) {
+		ul.dataviews-view-list {
+			// This override could potentially be removed if we’re able to pass the Actions column via data.actions
+			.components-h-stack,
+			.dataviews-view-list__item {
+				width: 100%;
+			}
+		
+			/* This styling is a bit of a hack: To make the site name clickable area larger, will need
+			 * to hide the other fields when in preview mode.
+			 */
+			.dataviews-view-list__field {
+				// Hide the field except first (Site name) and last (actions menu)
+				&:not(:first-child):not(:last-child) {
+					display: none;
+				}
+		
+				// Force the site name to take up the full width
+				&:first-child {
+					flex-grow: 1;
+		
+					.sites-dataviews__site {
+						width: 100%;
+						justify-content: flex-start;
+					}
+				}
+			}
+		
+			.sites-overview__stats-trend,
+			.sites-overview__column-action-button,
+			.sites-overview__row-status,
+			.toggle-activate-monitoring__toggle-button,
+			.sites-dataviews__favorite-btn-wrapper,
+			.sites-overview__boost-score {
+				display: none;
+			}
+		
+			.site-actions__actions-large-screen {
+				display: block;
+			}
 		}
 	}
 }

--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -210,58 +210,6 @@
 				align-items: center;
 				height: 28px;
 			}
-
-			ul.dataviews-view-list {
-				list-style: none;
-				margin: 0;
-				padding: 0;
-				overflow-y: auto;
-				max-height: calc(100vh - 300px); /* 300px is the size of all content above the dataview in list style, which includes our CTA elements, the pagination bottom bar, and an additional 20px margin. */
-
-				.dataviews-view-list__fields {
-					display: flex;
-					justify-content: space-between;
-				}
-
-				.components-h-stack,
-				.dataviews-view-list__item {
-					width: 100%;
-				}
-
-				/* This styling is a bit of a hack: To make the site name clickable area larger, will need
-				 * to hide the other fields when in preview mode.
-				 */
-				.dataviews-view-list__field {
-					// Hide the field except first (Site name) and last (actions menu)
-					&:not(:first-child):not(:last-child) {
-						display: none;
-					}
-
-					// Force the site name to take up the full width
-					&:first-child {
-						flex-grow: 1;
-
-						.sites-dataviews__site {
-							width: 100%;
-							justify-content: flex-start;
-						}
-					}
-				}
-
-				.sites-overview__stats-trend,
-				.sites-overview__column-action-button,
-				.sites-overview__row-status,
-				.toggle-activate-monitoring__toggle-button,
-				.sites-dataviews__favorite-btn-wrapper,
-				.sites-overview__boost-score {
-					display: none;
-				}
-
-				.site-actions__actions-large-screen {
-					display: block;
-				}
-
-			}
 		}
 	}
 
@@ -347,12 +295,6 @@
 
 		.sites-overview__add-new-site {
 			white-space: nowrap;
-		}
-
-		.dataviews-wrapper {
-			.components-button:focus:not(:disabled) {
-				box-shadow: 0 0 0 2px var(--color-primary-light);
-			}
 		}
 
 		.sites-overview {
@@ -952,4 +894,3 @@
 		border-color: var(--color-border-subtle);
 	}
 }
-


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9646

## Proposed Changes

This PR removes unnecessary style overrides related to the fly-out panel in Dotcom's Sites Dashboard, focusing on straightforward eliminations. Many of these styles are now redundant and have been removed.

| production | this PR (no change) |
|--------|--------|
| <img width="1480" alt="Screenshot 2024-11-06 at 16 58 36" src="https://github.com/user-attachments/assets/04641a0b-fa46-4f68-8388-0da413397ee1"> | <img width="1481" alt="Screenshot 2024-11-06 at 16 58 28" src="https://github.com/user-attachments/assets/137535cb-513e-4c7e-aedf-6e40f65480de"> |
| <img width="1484" alt="Screenshot 2024-11-06 at 17 02 49" src="https://github.com/user-attachments/assets/a34be061-2de3-46db-9c69-c3abab1e0d1e"> | <img width="1482" alt="Screenshot 2024-11-06 at 17 02 38" src="https://github.com/user-attachments/assets/a0c26f90-2e20-4abe-8eb0-4ccaeca61db4"> |
| <img width="406" alt="Screenshot 2024-11-06 at 16 56 33" src="https://github.com/user-attachments/assets/f024ba40-d712-438d-b394-2b6872425ee6"> focus style | <img width="406" alt="Screenshot 2024-11-06 at 16 56 33" src="https://github.com/user-attachments/assets/a32a03ec-e590-461d-92bd-67bf6f064b4b"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pbxlJb-6DF-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Compare the Calypso Live with production and observe there are no changes from large to mobile view
* Pick any site on /sites
* Compare the Calypso Live with production and observe there are no changes from large to mobile view

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?