### PR TITLE
A4A: Update Migrations page's Pressable CTA messaging.

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/migrations-overview-v2/sections/migrations-hosting-options/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview-v2/sections/migrations-hosting-options/index.tsx
@@ -83,6 +83,12 @@ export default function MigrationsHostingOptions() {
 		);
 	}, [ dispatch ] );
 
+	const onClickPressableDemoLink = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_migrations_hosting_options_pressable_demo_link_click' )
+		);
+	}, [ dispatch ] );
+
 	return (
 		<PageSection
 			heading={ translate( 'Unsure which host suits your needs?' ) }
@@ -115,9 +121,21 @@ export default function MigrationsHostingOptions() {
 
 				<HostingOptionCard
 					banner={ PressableBanner }
-					title={ translate( 'Schedule a demo' ) }
+					title={ translate( 'Managing over 50 sites? Schedule a demo' ) }
 					description={ translate(
-						'Our friendly experts are happy to give you a personalized one-on-one tour of our platform to discuss your needs and everything Pressable has to offer.'
+						'Schedule a personalized demo to explore Pressable’s advanced features for high-performing agencies! If you’re managing fewer sites, we invite you to watch our {{a}}pre-recorded demo{{/a}} and contact our Automattic for Agencies support with any additional questions.',
+						{
+							components: {
+								a: (
+									<a
+										href="https://href.li/?https://www.youtube.com/watch?v=GMNQYrp7tkQ"
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={ onClickPressableDemoLink }
+									/>
+								),
+							},
+						}
 					) }
 					buttons={ [
 						<Button


### PR DESCRIPTION
This PR updates the Pressable CTA messaging on the Migrations page to clarify that the customized demo is intended for agencies managing over 50 sites.

| Before | After |
|--------|--------|
| <img width="752" alt="Screenshot 2024-11-06 at 8 24 06 PM" src="https://github.com/user-attachments/assets/23f9fcb4-c540-4d32-9424-c3b0bfa8217a"> | <img width="750" alt="Screenshot 2024-11-06 at 8 23 41 PM" src="https://github.com/user-attachments/assets/5f2df816-9d30-4f53-bd1c-ff8ff159afb3"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1430

## Proposed Changes

* Update the messaging on the Pressable CTA button with a pre-recorded demo link.

## Why are these changes being made?

* To prevent agencies with fewer sites from requesting a demo, we need to make sure we are clear with our messaging.

## Testing Instructions

* Use the A4A live link and go to the `/migrations` page.
* Confirm that you see the new Pressable CTA messaging with working links.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
