### PR TITLE
Importer: use "import" term for CTA rather than "Start import"

### DIFF
--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -48,7 +48,7 @@ class AuthorMappingPane extends PureComponent {
 				'There is one author on your %(sourceType)s site. ' +
 					"Because you're the only author on {{b}}%(destinationSiteTitle)s{{/b}}, " +
 					'all imported content will be assigned to you. ' +
-					'Click Start import to proceed.',
+					'Click {{em}}Import{{/em}} to proceed.',
 				{
 					args: {
 						sourceType: sourceType,
@@ -56,6 +56,7 @@ class AuthorMappingPane extends PureComponent {
 					},
 					components: {
 						b: <strong />,
+						em: <em />,
 					},
 				}
 			);
@@ -64,7 +65,7 @@ class AuthorMappingPane extends PureComponent {
 				'There are multiple authors on your %(sourceType)s site. ' +
 					"Because you're the only author on {{b}}%(destinationSiteTitle)s{{/b}}, " +
 					'all imported content will be assigned to you. ' +
-					'Click {{em}}Start import{{/em}} to proceed.',
+					'Click {{em}}Import{{/em}} to proceed.',
 				{
 					args: {
 						sourceType: sourceType,
@@ -80,7 +81,7 @@ class AuthorMappingPane extends PureComponent {
 			return this.props.translate(
 				'There are multiple authors on your site. ' +
 					'Please reassign the authors of the imported items to an existing ' +
-					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click {{em}}Start import{{/em}}.',
+					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click {{em}}Import{{/em}}.',
 				{
 					args: {
 						sourceType: 'WordPress',
@@ -96,7 +97,7 @@ class AuthorMappingPane extends PureComponent {
 			return this.props.translate(
 				'There are multiple authors on your %(sourceType)s site. ' +
 					'Please reassign the authors of the imported items to an existing ' +
-					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click {{em}}Start import{{/em}}.',
+					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click {{em}}Import{{/em}}.',
 				{
 					args: {
 						sourceType: 'WordPress',
@@ -158,7 +159,7 @@ class AuthorMappingPane extends PureComponent {
 				} ) }
 				<ImporterActionButtonContainer>
 					<ImporterActionButton primary disabled={ ! canStartImport } onClick={ onStartImport }>
-						{ this.props.translate( 'Start import' ) }
+						{ this.props.translate( 'Import' ) }
 					</ImporterActionButton>
 					<ImporterCloseButton importerStatus={ importerStatus } site={ site } isEnabled />
 				</ImporterActionButtonContainer>

--- a/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
@@ -121,7 +121,7 @@ class AuthorMappingPane extends PureComponent {
 				'There is one author on your %(sourceType)s site. ' +
 					"Because you're the only author on {{b}}%(destinationSiteTitle)s{{/b}}, " +
 					'all imported content will be assigned to you. ' +
-					'Click Start import to proceed.',
+					'Click {{em}}Import{{/em}} to proceed.',
 				{
 					args: {
 						sourceType: sourceType,
@@ -129,6 +129,7 @@ class AuthorMappingPane extends PureComponent {
 					},
 					components: {
 						b: <strong />,
+						em: <em />,
 					},
 				}
 			);
@@ -137,7 +138,7 @@ class AuthorMappingPane extends PureComponent {
 				'There are multiple authors on your %(sourceType)s site. ' +
 					"Because you're the only author on {{b}}%(destinationSiteTitle)s{{/b}}, " +
 					'all imported content will be assigned to you. ' +
-					'Click {{em}}Start import{{/em}} to proceed.',
+					'Click {{em}}Import{{/em}} to proceed.',
 				{
 					args: {
 						sourceType: sourceType,
@@ -153,7 +154,7 @@ class AuthorMappingPane extends PureComponent {
 			return this.props.translate(
 				'There are multiple authors on your site. ' +
 					'Please reassign the authors of the imported items to an existing ' +
-					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click {{em}}Start import{{/em}}.',
+					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click {{em}}Import{{/em}}.',
 				{
 					args: {
 						sourceType: 'WordPress',
@@ -169,7 +170,7 @@ class AuthorMappingPane extends PureComponent {
 			return this.props.translate(
 				'There are multiple authors on your %(sourceType)s site. ' +
 					'Please reassign the authors of the imported items to an existing ' +
-					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click {{em}}Start import{{/em}}.',
+					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click {{em}}Import{{/em}}.',
 				{
 					args: {
 						sourceType: 'WordPress',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Consolidate "Start import" CTAs to "Import" as per design
* Add one missing `<em>` when there's just one author to map

<img width="936" alt="Screenshot 2024-11-06 at 17 55 24" src="https://github.com/user-attachments/assets/0c299f6a-1c4e-45aa-b2e4-9b2f4d4b9cff">
<img width="784" alt="Screenshot 2024-11-06 at 17 56 10" src="https://github.com/user-attachments/assets/e7f932be-6703-4f6d-b2ea-1ab41a81459c">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
