### PR TITLE
Substack importer: update "all set" copy for content

### DIFF
--- a/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Notice } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { verse, page, file } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
@@ -8,71 +9,9 @@ import useUsersQuery from 'calypso/data/users/use-users-query';
 import AuthorMapping from 'calypso/my-sites/importer/author-mapping-item';
 import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
+import SummaryStat from '../summary/SummaryStat';
 
 import './author-mapping-pane.scss';
-
-function getNoticeContent( postsNumber, pagesNumber, attachmentsNumber ) {
-	if ( postsNumber > 0 && pagesNumber > 0 && attachmentsNumber > 0 ) {
-		return (
-			<>
-				All set! We’ve found <strong>{ postsNumber } posts</strong>,{ ' ' }
-				<strong>{ pagesNumber } pages</strong>
-				and <strong>{ attachmentsNumber } media</strong> to import.
-			</>
-		);
-	}
-
-	if ( postsNumber > 0 && pagesNumber > 0 ) {
-		return (
-			<>
-				All set! We’ve found <strong>{ postsNumber } posts</strong> and{ ' ' }
-				<strong>{ pagesNumber } pages</strong> to import.
-			</>
-		);
-	}
-
-	if ( postsNumber > 0 && attachmentsNumber > 0 ) {
-		return (
-			<>
-				All set! We’ve found <strong>{ postsNumber } posts</strong> and{ ' ' }
-				<strong>{ attachmentsNumber } media</strong> to import.
-			</>
-		);
-	}
-
-	if ( pagesNumber > 0 && attachmentsNumber > 0 ) {
-		return (
-			<>
-				All set! We’ve found <strong>{ pagesNumber } pages</strong> and{ ' ' }
-				<strong>{ attachmentsNumber } media</strong> to import.
-			</>
-		);
-	}
-
-	if ( postsNumber > 0 ) {
-		return (
-			<>
-				All set! We’ve found <strong>{ postsNumber } posts</strong> to import.
-			</>
-		);
-	}
-
-	if ( pagesNumber > 0 ) {
-		return (
-			<>
-				All set! We’ve found <strong>{ pagesNumber } pages</strong> to import.
-			</>
-		);
-	}
-
-	if ( attachmentsNumber > 0 ) {
-		return (
-			<>
-				All set! We’ve found <strong>{ attachmentsNumber } media</strong> to import.
-			</>
-		);
-	}
-}
 
 class AuthorMappingPane extends PureComponent {
 	static displayName = 'AuthorMappingPane';
@@ -210,15 +149,39 @@ class AuthorMappingPane extends PureComponent {
 			targetTitle,
 			sourceType
 		);
+		const posts = importerStatus?.customData?.postsNumber || 0;
+		const pages = importerStatus?.customData?.pagesNumber || 0;
+		const attachments = importerStatus?.customData?.attachmentsNumber || 0;
 
 		return (
 			<div className="importer__mapping-pane">
 				<Notice status="success" className="importer__notice" isDismissible={ false }>
-					{ getNoticeContent(
-						importerStatus?.customData?.postsNumber || 0,
-						importerStatus?.customData?.pagesNumber || 0,
-						importerStatus?.customData?.attachmentsNumber || 0
-					) }
+					<p>
+						<strong>{ this.props.translate( 'All set! We’ve found:' ) }</strong>
+					</p>
+					<div className="summary__content-stats">
+						{ posts > 0 && (
+							<SummaryStat
+								count={ posts }
+								label={ this.props.translate( 'Posts' ) }
+								icon={ verse }
+							/>
+						) }
+						{ pages > 0 && (
+							<SummaryStat
+								count={ pages }
+								label={ this.props.translate( 'Pages' ) }
+								icon={ page }
+							/>
+						) }
+						{ attachments > 0 && (
+							<SummaryStat
+								count={ attachments }
+								label={ this.props.translate( 'Media items' ) }
+								icon={ file }
+							/>
+						) }
+					</div>
 				</Notice>
 				<h2>{ this.props.translate( 'Author mapping' ) }</h2>
 				<div className="importer__mapping-description">{ mappingDescription }</div>

--- a/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.jsx
@@ -156,10 +156,8 @@ class AuthorMappingPane extends PureComponent {
 		return (
 			<div className="importer__mapping-pane">
 				<Notice status="success" className="importer__notice" isDismissible={ false }>
-					<p>
-						<strong>{ this.props.translate( 'All set! We’ve found:' ) }</strong>
-					</p>
-					<div className="summary__content-stats">
+					<p>{ this.props.translate( 'All set! We’ve found:' ) }</p>
+					<div className="importer__notice-stats">
 						{ posts > 0 && (
 							<SummaryStat
 								count={ posts }

--- a/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.scss
+++ b/client/my-sites/importer/newsletter/content-upload/author-mapping-pane.scss
@@ -1,5 +1,12 @@
 .importer__notice {
 	margin-bottom: 32px;
+	p:first-of-type {
+		margin-bottom: 10px;
+	}
+}
+
+.importer__notice-stats {
+	max-width: 190px;
 }
 
 .importer__mapping-header {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/96112

## Proposed Changes

* Update "all set" to be such that it's easier to translate. Visual copied from summary page, added in https://github.com/Automattic/wp-calypso/pull/96014 .

Before
<img width="769" alt="Screenshot 2024-11-06 at 18 15 03" src="https://github.com/user-attachments/assets/e1142081-884d-43cd-96fa-59739926cbb2">


After
<img width="797" alt="Screenshot 2024-11-13 at 15 35 07" src="https://github.com/user-attachments/assets/236bf895-2143-4d89-a2ea-088e552bf34e">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
