### PR TITLE
Refactor: Move global staticFilters constant to class method

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -152,32 +152,26 @@ class ThemeShowcase extends Component {
 
 	isThemeDiscoveryEnabled = () => config.isEnabled( 'themes/discovery' );
 
-	translatedStaticFilters() {
+	getStaticFilters() {
 		const { translate } = this.props;
 		return {
 			MYTHEMES: {
 				key: STATIC_FILTERS.MYTHEMES,
-				get text() {
-					return translate( 'My Themes' );
-				},
+				text: translate( 'My Themes' ),
 			},
 			RECOMMENDED: {
 				key: STATIC_FILTERS.RECOMMENDED,
-				get text() {
-					return translate( 'Recommended' );
-				},
+				text: translate( 'Recommended' ),
 			},
 			ALL: {
 				key: STATIC_FILTERS.ALL,
-				get text() {
-					return translate( 'All' );
-				},
+				text: translate( 'All' ),
 			},
 		};
 	}
 
 	getDefaultStaticFilter = () =>
-		Object.values( this.translatedStaticFilters() ).find(
+		Object.values( this.getStaticFilters() ).find(
 			( staticFilter ) => staticFilter.key === DEFAULT_STATIC_FILTER
 		);
 
@@ -192,7 +186,7 @@ class ThemeShowcase extends Component {
 
 	getTabFilters = () => {
 		const { translate } = this.props;
-		const staticFilters = this.translatedStaticFilters();
+		const staticFilters = this.getStaticFilters();
 		if ( this.props.siteId && ! this.props.areSiteFeaturesLoaded ) {
 			return null;
 		}
@@ -243,7 +237,7 @@ class ThemeShowcase extends Component {
 	getSelectedTabFilter = () => {
 		const filter = this.props.filter ?? '';
 		const filterArray = filter.split( '+' );
-		const staticFilters = this.translatedStaticFilters();
+		const staticFilters = this.getStaticFilters();
 		const matches = Object.values( this.subjectTermTable ).filter( ( value ) =>
 			filterArray.includes( value )
 		);
@@ -291,7 +285,7 @@ class ThemeShowcase extends Component {
 	doSearch = ( searchBoxContent ) => {
 		const filterRegex = /([\w-]*):([\w-]*)/g;
 		const { filterToTermTable, subjectStringFilter, isSearchV2 } = this.props;
-		const staticFilters = this.translatedStaticFilters();
+		const staticFilters = this.getStaticFilters();
 
 		const filters =
 			`${ searchBoxContent } ${ isSearchV2 ? subjectStringFilter : '' }`.match( filterRegex ) || [];
@@ -345,7 +339,7 @@ class ThemeShowcase extends Component {
 		const category = tier !== 'all' && ! this.props.category ? '' : this.props.category;
 		const showCollection =
 			this.isThemeDiscoveryEnabled() && ! this.props.filterString && ! category && tier !== 'all';
-		const staticFilters = this.translatedStaticFilters();
+		const staticFilters = this.getStaticFilters();
 
 		const url = this.constructUrl( {
 			tier,
@@ -366,7 +360,7 @@ class ThemeShowcase extends Component {
 		recordTracksEvent( 'calypso_themeshowcase_filter_category_click', { category: tabFilter.key } );
 		trackClick( 'section nav filter', tabFilter );
 
-		const staticFilters = this.translatedStaticFilters();
+		const staticFilters = this.getStaticFilters();
 		const { filter = '', filterToTermTable } = this.props;
 		const subjectFilters = Object.values( this.subjectTermTable );
 		const filterWithoutSubjects = filter
@@ -569,7 +563,7 @@ class ThemeShowcase extends Component {
 
 	renderThemes = ( themeProps ) => {
 		const tabKey = this.getSelectedTabFilter().key;
-		const staticFilters = this.translatedStaticFilters();
+		const staticFilters = this.getStaticFilters();
 
 		switch ( tabKey ) {
 			case staticFilters.MYTHEMES?.key:
@@ -644,7 +638,7 @@ class ThemeShowcase extends Component {
 		} = this.props;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
-		const staticFilters = this.translatedStaticFilters();
+		const staticFilters = this.getStaticFilters();
 
 		const themeProps = {
 			forceWpOrgSearch: true,

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -5,7 +5,7 @@ import page from '@automattic/calypso-router';
 import { SelectDropdown } from '@automattic/components';
 import { isAssemblerSupported } from '@automattic/design-picker';
 import clsx from 'clsx';
-import { localize, translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -71,31 +71,6 @@ const optionShape = PropTypes.shape( {
 	getUrl: PropTypes.func,
 	action: PropTypes.func,
 } );
-
-const staticFilters = {
-	MYTHEMES: {
-		key: STATIC_FILTERS.MYTHEMES,
-		get text() {
-			return translate( 'My Themes' );
-		},
-	},
-	RECOMMENDED: {
-		key: STATIC_FILTERS.RECOMMENDED,
-		get text() {
-			return translate( 'Recommended' );
-		},
-	},
-	ALL: {
-		key: STATIC_FILTERS.ALL,
-		get text() {
-			return translate( 'All' );
-		},
-	},
-};
-
-const defaultStaticFilter = Object.values( staticFilters ).find(
-	( staticFilter ) => staticFilter.key === DEFAULT_STATIC_FILTER
-);
 
 class ThemeShowcase extends Component {
 	state = {
@@ -177,7 +152,34 @@ class ThemeShowcase extends Component {
 
 	isThemeDiscoveryEnabled = () => config.isEnabled( 'themes/discovery' );
 
-	getDefaultStaticFilter = () => defaultStaticFilter;
+	translatedStaticFilters() {
+		const { translate } = this.props;
+		return {
+			MYTHEMES: {
+				key: STATIC_FILTERS.MYTHEMES,
+				get text() {
+					return translate( 'My Themes' );
+				},
+			},
+			RECOMMENDED: {
+				key: STATIC_FILTERS.RECOMMENDED,
+				get text() {
+					return translate( 'Recommended' );
+				},
+			},
+			ALL: {
+				key: STATIC_FILTERS.ALL,
+				get text() {
+					return translate( 'All' );
+				},
+			},
+		};
+	}
+
+	getDefaultStaticFilter = () =>
+		Object.values( this.translatedStaticFilters() ).find(
+			( staticFilter ) => staticFilter.key === DEFAULT_STATIC_FILTER
+		);
 
 	isStaticFilter = ( tabFilter ) => isStaticFilter( tabFilter.key );
 
@@ -189,6 +191,8 @@ class ThemeShowcase extends Component {
 	};
 
 	getTabFilters = () => {
+		const { translate } = this.props;
+		const staticFilters = this.translatedStaticFilters();
 		if ( this.props.siteId && ! this.props.areSiteFeaturesLoaded ) {
 			return null;
 		}
@@ -214,7 +218,7 @@ class ThemeShowcase extends Component {
 	};
 
 	getTiers = () => {
-		const { themeTiers } = this.props;
+		const { themeTiers, translate } = this.props;
 
 		const tiers = Object.keys( themeTiers ).reduce( ( availableTiers, tier ) => {
 			if ( ! THEME_TIERS[ tier ]?.isFilterable ) {
@@ -239,6 +243,7 @@ class ThemeShowcase extends Component {
 	getSelectedTabFilter = () => {
 		const filter = this.props.filter ?? '';
 		const filterArray = filter.split( '+' );
+		const staticFilters = this.translatedStaticFilters();
 		const matches = Object.values( this.subjectTermTable ).filter( ( value ) =>
 			filterArray.includes( value )
 		);
@@ -286,6 +291,7 @@ class ThemeShowcase extends Component {
 	doSearch = ( searchBoxContent ) => {
 		const filterRegex = /([\w-]*):([\w-]*)/g;
 		const { filterToTermTable, subjectStringFilter, isSearchV2 } = this.props;
+		const staticFilters = this.translatedStaticFilters();
 
 		const filters =
 			`${ searchBoxContent } ${ isSearchV2 ? subjectStringFilter : '' }`.match( filterRegex ) || [];
@@ -339,6 +345,7 @@ class ThemeShowcase extends Component {
 		const category = tier !== 'all' && ! this.props.category ? '' : this.props.category;
 		const showCollection =
 			this.isThemeDiscoveryEnabled() && ! this.props.filterString && ! category && tier !== 'all';
+		const staticFilters = this.translatedStaticFilters();
 
 		const url = this.constructUrl( {
 			tier,
@@ -359,6 +366,7 @@ class ThemeShowcase extends Component {
 		recordTracksEvent( 'calypso_themeshowcase_filter_category_click', { category: tabFilter.key } );
 		trackClick( 'section nav filter', tabFilter );
 
+		const staticFilters = this.translatedStaticFilters();
 		const { filter = '', filterToTermTable } = this.props;
 		const subjectFilters = Object.values( this.subjectTermTable );
 		const filterWithoutSubjects = filter
@@ -561,6 +569,7 @@ class ThemeShowcase extends Component {
 
 	renderThemes = ( themeProps ) => {
 		const tabKey = this.getSelectedTabFilter().key;
+		const staticFilters = this.translatedStaticFilters();
 
 		switch ( tabKey ) {
 			case staticFilters.MYTHEMES?.key:
@@ -631,9 +640,11 @@ class ThemeShowcase extends Component {
 			isSiteWooExpress,
 			isCollectionView,
 			lastNonEditorRoute,
+			translate,
 		} = this.props;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
+		const staticFilters = this.translatedStaticFilters();
 
 		const themeProps = {
 			forceWpOrgSearch: true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to https://github.com/Automattic/wp-calypso/pull/95995#pullrequestreview-2412589439

## Proposed Changes

- Refactor `staticFilters` from a globally scoped constant to a method `getStaticFilters` within the ThemeShowcase component.
- Use the `props.translate()` function provided by the `localize()` HOC to ensure translation accuracy based on the specific i18n context.
- Ensure filter text dynamically updates in response to translation context changes, aligning with user session translation data.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These changes address feedback from a [previous code review](https://github.com/Automattic/wp-calypso/pull/95995#pullrequestreview-2412589439), which highlighted the limitations of using static `translate()` calls. By moving the filter's definition inside the `ThemeShowcase` component, we leverage the props.translate() method, reflecting the localized translation instance tied to the user's session, which may differ from the global one. This ensures filters display accurately across different translation contexts, particularly in environments like `/<locale>/themes` where previously, static translations appeared in English due to data discrepancies between global and session-specific translation instances.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Switch the user locale to Mag-16 locale, e.g. Spanish

- Visit `/home` for a website

- Hover over `Appearance` and wait for the Popup menu to appear with the `Themes` option
![image](https://github.com/user-attachments/assets/c7428900-86a0-497a-8fb5-6ce1b3aad36f)

- Click the `Themes` (Temas in Spanish) and observe that `My Themes` filter menu remains translated.
![image](https://github.com/user-attachments/assets/472e4480-3a82-48cc-addd-3cbac60edeb8)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
