### PR TITLE
Remove personal plan from big sky eligibility

### DIFF
--- a/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { isBusinessPlan, isPremiumPlan, isPersonalPlan } from '@automattic/calypso-products';
+import { isBusinessPlan, isPremiumPlan } from '@automattic/calypso-products';
 import { useSelect } from '@wordpress/data';
 import userAgent from 'calypso/lib/user-agent';
 import { useIsSiteOwner } from '../hooks/use-is-site-owner';
@@ -21,10 +21,7 @@ export function useIsBigSkyEligible() {
 	);
 
 	const hasValidGoal = goals.every( ( value ) => validGoals.includes( value ) );
-	const isEligiblePlan =
-		isPersonalPlan( product_slug ) ||
-		isPremiumPlan( product_slug ) ||
-		isBusinessPlan( product_slug );
+	const isEligiblePlan = isPremiumPlan( product_slug ) || isBusinessPlan( product_slug );
 
 	const eligibilityResult =
 		( featureFlagEnabled && isOwner && isEligiblePlan && hasValidGoal && onSupportedDevice ) ||


### PR DESCRIPTION
## Proposed Changes

* Removes personal plans from Big Sky eligibility

## Why are these changes being made?

* Using Big Sky for personal plans requires an update to global styles, which is taking longer than expected. We're going to proceed with the launch without this.

## Testing Instructions

1. Create a site on a personal plan if you don't have one already.
2. Navigate to http://calypso.localhost:3000/setup/site-setup/goals?siteSlug=PERSONAL_PLAN_SITE_URL
3. Select Other or Promote as the goal
4. Verify you don't see the design options step at all (which has the Big Sky option)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
