### PR TITLE
Performance improvements for Bulk Plugin Management

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -67,12 +67,11 @@ export class PluginsMain extends Component {
 		super( props );
 		this.state = {
 			isMobile: isWithinBreakpoint( '<960px' ),
-			limitPluginsToDisplayGlobalUpdate: 100,
 		};
 	}
 
 	componentWillMount() {
-		if ( ! config.isEnabled( 'bulk-plugin-management' ) ) {
+		if ( ! this.props.newBulkPluginManagement ) {
 			import( './style-compatibilty.scss' );
 		}
 	}
@@ -90,7 +89,7 @@ export class PluginsMain extends Component {
 
 		currentPlugins.map( ( plugin ) => {
 			const pluginData = this.props.wporgPlugins?.[ plugin.slug ];
-			if ( ! pluginData && ! config.isEnabled( 'bulk-plugin-management' ) ) {
+			if ( ! pluginData && ! this.props.newBulkPluginManagement ) {
 				this.props.wporgFetchPluginData( plugin.slug );
 			}
 		} );
@@ -165,7 +164,7 @@ export class PluginsMain extends Component {
 	}
 
 	getCurrentPlugins() {
-		if ( config.isEnabled( 'bulk-plugin-management' ) ) {
+		if ( this.props.newBulkPluginManagement ) {
 			return this.addWporgDataToPlugins( this.props.currentPlugins );
 		}
 
@@ -368,7 +367,7 @@ export class PluginsMain extends Component {
 	}
 
 	renderPluginsContent() {
-		if ( config.isEnabled( 'bulk-plugin-management' ) ) {
+		if ( this.props.newBulkPluginManagement ) {
 			return (
 				<PluginsList
 					header={ this.props.translate( 'Manage Plugins' ) }
@@ -487,7 +486,7 @@ export class PluginsMain extends Component {
 		let selectedTextContent = null;
 		const { title, count } = this.getSelectedText();
 
-		if ( ! config.isEnabled( 'bulk-plugin-management' ) ) {
+		if ( ! this.props.newBulkPluginManagement ) {
 			navItems = this.getFilters().map( ( filterItem ) => {
 				if ( 'updates' === filterItem.id && ! this.getUpdatesTabVisibility() ) {
 					return null;
@@ -551,10 +550,9 @@ export class PluginsMain extends Component {
 								<>
 									{ this.renderAddPluginButton() }
 									{ this.renderUploadPluginButton() }
-									{ currentPlugins &&
-										currentPlugins.length < this.state.limitPluginsToDisplayGlobalUpdate && (
-											<UpdatePlugins isWpCom plugins={ currentPlugins } />
-										) }
+									{ ! this.props.newBulkPluginManagement && (
+										<UpdatePlugins isWpCom plugins={ currentPlugins } />
+									) }
 								</>
 							) }
 						</NavigationHeader>
@@ -649,6 +647,7 @@ export default flow(
 				jetpackNonAtomic;
 
 			const breadcrumbs = getBreadcrumbs( state );
+			const newBulkPluginManagement = config.isEnabled( 'bulk-plugin-management' );
 
 			return {
 				hasJetpackSites: hasJetpackSites( state ),
@@ -662,10 +661,10 @@ export default flow(
 					selectedSite && canJetpackSiteUpdateFiles( state, selectedSiteId ),
 				wporgPlugins: getAllWporgPlugins( state ),
 				isRequestingSites: isRequestingSites( state ),
-				currentPlugins: config.isEnabled( 'bulk-plugin-management' )
+				currentPlugins: newBulkPluginManagement
 					? pluginsWithUpdatesAndStatuses
 					: getPlugins( state, siteIds, filter ),
-				currentPluginsOnVisibleSites: config.isEnabled( 'bulk-plugin-management' )
+				currentPluginsOnVisibleSites: newBulkPluginManagement
 					? []
 					: getPlugins( state, siteObjectsToSiteIds( getVisibleSites( sites ) ) ?? [], filter ),
 				pluginsWithUpdates,
@@ -685,6 +684,7 @@ export default flow(
 				isJetpackCloud,
 				breadcrumbs,
 				requestPluginsError: requestPluginsError( state ),
+				newBulkPluginManagement,
 			};
 		},
 		{

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -67,6 +67,7 @@ export class PluginsMain extends Component {
 		super( props );
 		this.state = {
 			isMobile: isWithinBreakpoint( '<960px' ),
+			limitPluginsToDisplayGlobalUpdate: 100,
 		};
 	}
 
@@ -550,7 +551,10 @@ export class PluginsMain extends Component {
 								<>
 									{ this.renderAddPluginButton() }
 									{ this.renderUploadPluginButton() }
-									<UpdatePlugins isWpCom plugins={ currentPlugins } />
+									{ currentPlugins &&
+										currentPlugins.length < this.state.limitPluginsToDisplayGlobalUpdate && (
+											<UpdatePlugins isWpCom plugins={ currentPlugins } />
+										) }
 								</>
 							) }
 						</NavigationHeader>

--- a/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
+import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import ButtonGroup from 'calypso/components/button-group';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -39,7 +40,10 @@ export default function UpdatePlugins( { plugins, isWpCom }: Props ): ReactEleme
 		)
 	);
 
-	const allSites = useSelector( getSites );
+	// We don't want null or undefined "sites"
+	const allSites = useSelector( ( state ) =>
+		getSites( state ).filter( ( s ): s is SiteDetails => Boolean( s ) )
+	);
 
 	const pluginsOnSites = useSelector( ( state ) => getPluginsOnSites( state, plugins ) );
 	const selectedSite = useSelector( getSelectedSite );

--- a/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
-import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import ButtonGroup from 'calypso/components/button-group';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -40,10 +39,7 @@ export default function UpdatePlugins( { plugins, isWpCom }: Props ): ReactEleme
 		)
 	);
 
-	// We don't want null or undefined "sites"
-	const allSites = useSelector( ( state ) =>
-		getSites( state ).filter( ( s ): s is SiteDetails => Boolean( s ) )
-	);
+	const allSites = useSelector( getSites );
 
 	const pluginsOnSites = useSelector( ( state ) => getPluginsOnSites( state, plugins ) );
 	const selectedSite = useSelector( getSelectedSite );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -72,7 +72,7 @@ export class PluginsList extends Component {
 	};
 
 	componentWillMount() {
-		if ( config.isEnabled( 'bulk-plugin-management' ) ) {
+		if ( this.props.newBulkPluginManagement ) {
 			import( './style.scss' );
 		} else {
 			import( './style-compatibilty.scss' );
@@ -176,7 +176,7 @@ export class PluginsList extends Component {
 	recordEvent( eventAction, includeSelectedPlugins ) {
 		eventAction += this.props.selectedSite ? '' : ' on Multisite';
 		if ( includeSelectedPlugins ) {
-			const pluginSlugs = config.isEnabled( 'bulk-plugin-management' )
+			const pluginSlugs = this.props.newBulkPluginManagement
 				? this.state.selectedPlugins.map( ( plugin ) => plugin.slug )
 				: this.getSelected().map( ( plugin ) => plugin.slug );
 
@@ -206,7 +206,7 @@ export class PluginsList extends Component {
 	}
 
 	doActionOverSelected( actionName, action, selectedPlugins ) {
-		if ( ! selectedPlugins && ! config.isEnabled( 'bulk-plugin-management' ) ) {
+		if ( ! selectedPlugins && ! this.props.newBulkPluginManagement ) {
 			selectedPlugins = this.props.plugins.filter( this.isSelected );
 		}
 
@@ -216,7 +216,7 @@ export class PluginsList extends Component {
 		this.removePluginStatuses();
 
 		const pluginAndSiteObjects = (
-			config.isEnabled( 'bulk-plugin-management' ) ? this.state.selectedPlugins : selectedPlugins
+			this.props.newBulkPluginManagement ? this.state.selectedPlugins : selectedPlugins
 		)
 			.filter( ( plugin ) => ! isDeactivatingOrRemovingAndJetpackSelected( plugin ) ) // ignore sites that are deactivating, activating or removing jetpack
 			.map( ( p ) => {
@@ -248,7 +248,7 @@ export class PluginsList extends Component {
 	}
 
 	bulkActionDialog = ( actionName, selectedPlugins ) => {
-		if ( config.isEnabled( 'bulk-plugin-management' ) ) {
+		if ( this.props.newBulkPluginManagement ) {
 			this.setState( {
 				selectedPlugins,
 			} );
@@ -256,7 +256,7 @@ export class PluginsList extends Component {
 
 		const { plugins, allSites, showPluginActionDialog } = this.props;
 
-		if ( ! config.isEnabled( 'bulk-plugin-management' ) ) {
+		if ( ! this.props.newBulkPluginManagement ) {
 			selectedPlugins = selectedPlugins ? [ selectedPlugins ] : plugins.filter( this.isSelected );
 		}
 
@@ -432,7 +432,7 @@ export class PluginsList extends Component {
 	}
 
 	render() {
-		if ( config.isEnabled( 'bulk-plugin-management' ) ) {
+		if ( this.props.newBulkPluginManagement ) {
 			return (
 				<div className="plugins-list">
 					<PluginsListDataViews
@@ -533,10 +533,15 @@ export class PluginsList extends Component {
 export default connect(
 	( state, { plugins } ) => {
 		const selectedSite = getSelectedSite( state );
+		const newBulkPluginManagement = config.isEnabled( 'bulk-plugin-management' );
+
 		return {
 			allSites: getSites( state ),
-			pluginsOnSites: getPluginsOnSites( state, plugins ),
+			// This is critical and destroys the performance of the page
+			// TODO: Remove when launched
+			pluginsOnSites: newBulkPluginManagement ? [] : getPluginsOnSites( state, plugins ),
 			selectedSite,
+			newBulkPluginManagement,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			hasManagePlugins: siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS ),
 			inProgressStatuses: getPluginStatusesByType( state, 'inProgress' ),

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -1,13 +1,14 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isMagnificentLocale } from '@automattic/i18n-utils';
+import { createSelector } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
-export function siteObjectsToSiteIds( sites ) {
-	return sites?.map( ( site ) => site.ID ) ?? [];
-}
+export const siteObjectsToSiteIds = createSelector(
+	( sites ) => sites?.map( ( site ) => site.ID ) ?? []
+);
 
 export function getVisibleSites( sites ) {
 	return sites?.filter( ( site ) => site.visible );

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -163,13 +163,13 @@ export function getPluginsWithUpdates( state, siteIds ) {
 	} ) );
 }
 
-export function getPluginsOnSites( state, plugins ) {
+export const getPluginsOnSites = createSelector( ( state, plugins ) => {
 	return Object.values( plugins ).reduce( ( acc, plugin ) => {
 		const siteIds = Object.keys( plugin.sites );
 		acc[ plugin.slug ] = getPluginOnSites( state, siteIds, plugin.slug );
 		return acc;
 	}, {} );
-}
+} );
 
 export function getPluginOnSites( state, siteIds, pluginSlug ) {
 	return getPlugins( state, siteIds ).find( ( plugin ) => isEqualSlugOrId( pluginSlug, plugin ) );

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -163,6 +163,10 @@ export function getPluginsWithUpdates( state, siteIds ) {
 	} ) );
 }
 
+export const getPluginOnSites = createSelector( ( state, siteIds, pluginSlug ) =>
+	getPlugins( state, siteIds ).find( ( plugin ) => isEqualSlugOrId( pluginSlug, plugin ) )
+);
+
 export const getPluginsOnSites = createSelector( ( state, plugins ) => {
 	return Object.values( plugins ).reduce( ( acc, plugin ) => {
 		const siteIds = Object.keys( plugin.sites );
@@ -170,10 +174,6 @@ export const getPluginsOnSites = createSelector( ( state, plugins ) => {
 		return acc;
 	}, {} );
 } );
-
-export function getPluginOnSites( state, siteIds, pluginSlug ) {
-	return getPlugins( state, siteIds ).find( ( plugin ) => isEqualSlugOrId( pluginSlug, plugin ) );
-}
 
 export function getPluginOnSite( state, siteId, pluginSlug ) {
 	const pluginList = getPlugins( state, [ siteId ] );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9362
pet6gk-1CP-p2.

## Proposed Changes

- Showing Global plugins updates only when having less than 100 plugins
- Using pluginsOnSites only for the old version of the feature
- Improved selector cache

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access a user with more than 500 sites and ensure [the new interface](https://wpcalypso.wordpress.com/plugins/manage) works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?