### PR TITLE
Reader Recent Overhaul: Add styling for sidebar section

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -199,6 +199,7 @@ export class ReaderSidebar extends Component {
 						<ReaderSidebarRecent
 							onClick={ this.props.toggleFollowingVisibility }
 							isOpen={ this.props.isFollowingOpen }
+							path={ path }
 						/>
 					</li>
 				) : (

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -195,13 +195,12 @@ export class ReaderSidebar extends Component {
 				<SidebarSeparator />
 
 				{ isEnabled( 'reader/recent-feed-overhaul' ) ? (
-					<ReaderSidebarRecent
-						onClick={ this.props.toggleFollowingVisibility }
-						isOpen={ this.props.isFollowingOpen }
-						className={ ReaderSidebarHelper.itemLinkClass( '/read', path, {
-							'sidebar-streams__following': true,
-						} ) }
-					/>
+					<li className="sidebar-streams__following">
+						<ReaderSidebarRecent
+							onClick={ this.props.toggleFollowingVisibility }
+							isOpen={ this.props.isFollowingOpen }
+						/>
+					</li>
 				) : (
 					<SidebarItem
 						className={ ReaderSidebarHelper.itemLinkClass( '/read', path, {

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -7,6 +7,8 @@ import ReaderFollowingIcon from 'calypso/reader/components/icons/following-icon'
 import getReaderFollowedSites from 'calypso/state/reader/follows/selectors/get-reader-followed-sites';
 import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions';
 
+import './style.scss';
+
 // TODO: Find the right home for this, or the existing definition
 type Site = {
 	ID: number;
@@ -59,42 +61,48 @@ const ReaderSidebarRecent = ( {
 	};
 
 	return (
-		<li>
-			<ExpandableSidebarMenu
-				expanded={ isOpen }
-				title={ translate( 'Recent' ) }
-				onClick={ onClick }
-				customIcon={ <ReaderFollowingIcon /> }
-				disableFlyout
-				className={ className }
-				count={ undefined }
-				icon={ null }
-				materialIcon={ null }
-				materialIconStyle={ null }
-			>
-				<li>
-					<button onClick={ () => selectSite( null ) }>
-						{ translate( 'All' ) }{ ' ' }
-						{ totalUnseenCount > 0 && <Count count={ totalUnseenCount } compact /> }
+		<ExpandableSidebarMenu
+			expanded={ isOpen }
+			title={ translate( 'Recent' ) }
+			onClick={ onClick }
+			customIcon={ <ReaderFollowingIcon /> }
+			disableFlyout
+			className={ `reader-sidebar-recent ${ className }` }
+			count={ undefined }
+			icon={ null }
+			materialIcon={ null }
+			materialIconStyle={ null }
+		>
+			<li>
+				<button
+					className="reader-sidebar-recent__item sidebar__menu-link"
+					onClick={ () => selectSite( null ) }
+				>
+					{ translate( 'All' ) }{ ' ' }
+					{ totalUnseenCount > 0 && <Count count={ totalUnseenCount } compact /> }
+				</button>
+			</li>
+			{ sitesToShow.map( ( site ) => (
+				<li key={ site.ID }>
+					<button
+						className="reader-sidebar-recent__item sidebar__menu-link"
+						onClick={ () => selectSite( site.feed_ID ) }
+					>
+						{ site.name } { site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
 					</button>
 				</li>
-				{ sitesToShow.map( ( site ) => (
-					<li key={ site.ID }>
-						<button onClick={ () => selectSite( site.feed_ID ) }>
-							{ site.name }{ ' ' }
-							{ site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
-						</button>
-					</li>
-				) ) }
-				{ sites.length > SITE_DISPLAY_CUTOFF && (
-					<li>
-						<button onClick={ toggleShowAllSites }>
-							{ showAllSites ? translate( 'View Less' ) : translate( 'View More' ) }
-						</button>
-					</li>
-				) }
-			</ExpandableSidebarMenu>
-		</li>
+			) ) }
+			{ sites.length > SITE_DISPLAY_CUTOFF && (
+				<li>
+					<button
+						className="reader-sidebar-recent__item reader-sidebar-recent__view-more sidebar__menu-link "
+						onClick={ toggleShowAllSites }
+					>
+						{ showAllSites ? translate( 'View Less' ) : translate( 'View More' ) }
+					</button>
+				</li>
+			) }
+		</ExpandableSidebarMenu>
 	);
 };
 

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -9,7 +9,7 @@ import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions
 
 import './style.scss';
 
-// TODO: Find the right home for this, or the existing definition
+// holdercp TODO: Find the right home for this, or the existing definition
 type Site = {
 	ID: number;
 	URL: string;

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -7,6 +7,7 @@ import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import ReaderFollowingIcon from 'calypso/reader/components/icons/following-icon';
 import getReaderFollowedSites from 'calypso/state/reader/follows/selectors/get-reader-followed-sites';
 import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions';
+import { AppState } from 'calypso/types';
 
 import './style.scss';
 
@@ -47,7 +48,10 @@ const ReaderSidebarRecent = ( {
 	className,
 }: Props ): React.JSX.Element => {
 	const [ showAllSites, setShowAllSites ] = useState( false );
-	const sites = useSelector< Site, Site[] >( getReaderFollowedSites );
+	const sites = useSelector< AppState, Site[] >( getReaderFollowedSites );
+	const selectedSiteId = useSelector< AppState, number >(
+		( state ) => state.readerUi.sidebar.selectedRecentSite
+	);
 
 	const sitesToShow = showAllSites ? sites : sites.slice( 0, SITE_DISPLAY_CUTOFF );
 	const totalUnseenCount = sites.reduce( ( total, site ) => total + site.unseen_count, 0 );
@@ -76,7 +80,9 @@ const ReaderSidebarRecent = ( {
 		>
 			<li>
 				<button
-					className="reader-sidebar-recent__item sidebar__menu-link"
+					className={ clsx( 'reader-sidebar-recent__item sidebar__menu-link', {
+						'reader-sidebar-recent__item--selected': selectedSiteId === null,
+					} ) }
 					onClick={ () => selectSite( null ) }
 				>
 					{ translate( 'All' ) }{ ' ' }
@@ -86,7 +92,9 @@ const ReaderSidebarRecent = ( {
 			{ sitesToShow.map( ( site ) => (
 				<li key={ site.ID }>
 					<button
-						className="reader-sidebar-recent__item sidebar__menu-link"
+						className={ clsx( 'reader-sidebar-recent__item sidebar__menu-link', {
+							'reader-sidebar-recent__item--selected': site.feed_ID === selectedSiteId,
+						} ) }
 						onClick={ () => selectSite( site.feed_ID ) }
 					>
 						{ site.name } { site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -35,16 +35,19 @@ type Site = {
 type Props = {
 	isOpen: boolean;
 	onClick: () => void;
+	path: string;
 	className: string;
 	translate: ( key: string ) => string;
 };
 
 const SITE_DISPLAY_CUTOFF = 8;
+const RECENT_PATH_REGEX = /^\/read\/?(?:\?|$)/;
 
 const ReaderSidebarRecent = ( {
 	translate,
 	isOpen,
 	onClick,
+	path,
 	className,
 }: Props ): React.JSX.Element => {
 	const [ showAllSites, setShowAllSites ] = useState( false );
@@ -70,9 +73,11 @@ const ReaderSidebarRecent = ( {
 			expanded={ isOpen }
 			title={ translate( 'Recent' ) }
 			onClick={ onClick }
-			customIcon={ <ReaderFollowingIcon /> }
+			customIcon={ <ReaderFollowingIcon viewBox="-3 0 24 24" /> }
 			disableFlyout
-			className={ clsx( 'reader-sidebar-recent', className ) }
+			className={ clsx( 'reader-sidebar-recent', className, {
+				'sidebar__menu--selected': ! isOpen && RECENT_PATH_REGEX.test( path ),
+			} ) }
 			count={ undefined }
 			icon={ null }
 			materialIcon={ null }

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -4,6 +4,7 @@ import { localize } from 'i18n-calypso';
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
+import Favicon from 'calypso/reader/components/favicon';
 import ReaderFollowingIcon from 'calypso/reader/components/icons/following-icon';
 import getReaderFollowedSites from 'calypso/state/reader/follows/selectors/get-reader-followed-sites';
 import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions';
@@ -90,8 +91,8 @@ const ReaderSidebarRecent = ( {
 					} ) }
 					onClick={ () => selectSite( null ) }
 				>
-					{ translate( 'All' ) }{ ' ' }
-					{ totalUnseenCount > 0 && <Count count={ totalUnseenCount } compact /> }
+					<span className="sidebar__menu-item-sitename">{ translate( 'All' ) }</span>{ ' ' }
+					<Count count={ totalUnseenCount } compact />
 				</button>
 			</li>
 			{ sitesToShow.map( ( site ) => (
@@ -102,7 +103,9 @@ const ReaderSidebarRecent = ( {
 						} ) }
 						onClick={ () => selectSite( site.feed_ID ) }
 					>
-						{ site.name } { site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
+						<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 18 } />
+						<span className="sidebar__menu-item-sitename">{ site.name }</span>{ ' ' }
+						<Count count={ site.unseen_count } compact />
 					</button>
 				</li>
 			) ) }

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -1,4 +1,3 @@
-import { Count } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import React, { useState } from 'react';
@@ -86,33 +85,38 @@ const ReaderSidebarRecent = ( {
 		>
 			<li>
 				<button
-					className={ clsx( 'reader-sidebar-recent__item sidebar__menu-link', {
-						'reader-sidebar-recent__item--selected': selectedSiteId === null,
-					} ) }
+					className={ clsx(
+						'reader-sidebar-recent__item reader-sidebar-recent__item--without-icon',
+						{
+							'reader-sidebar-recent__item--selected': selectedSiteId === null,
+						}
+					) }
 					onClick={ () => selectSite( null ) }
 				>
-					<span className="sidebar__menu-item-sitename">{ translate( 'All' ) }</span>{ ' ' }
-					<Count count={ totalUnseenCount } compact />
+					<span className="reader-sidebar-recent__site-name">{ translate( 'All' ) }</span>{ ' ' }
+					<span className="reader-sidebar-recent__site-count">{ totalUnseenCount }</span>
 				</button>
 			</li>
 			{ sitesToShow.map( ( site ) => (
 				<li key={ site.ID }>
 					<button
-						className={ clsx( 'reader-sidebar-recent__item sidebar__menu-link', {
+						className={ clsx( 'reader-sidebar-recent__item', {
 							'reader-sidebar-recent__item--selected': site.feed_ID === selectedSiteId,
 						} ) }
 						onClick={ () => selectSite( site.feed_ID ) }
 					>
-						<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 18 } />
-						<span className="sidebar__menu-item-sitename">{ site.name }</span>{ ' ' }
-						<Count count={ site.unseen_count } compact />
+						<Favicon site={ site } className="reader-sidebar-recent__site-icon" size={ 16 } />
+						<span title={ site.name } className="reader-sidebar-recent__site-name">
+							{ site.name }
+						</span>
+						<span className="reader-sidebar-recent__site-count">{ site.unseen_count }</span>
 					</button>
 				</li>
 			) ) }
 			{ sites.length > SITE_DISPLAY_CUTOFF && (
 				<li>
 					<button
-						className="reader-sidebar-recent__item reader-sidebar-recent__view-more sidebar__menu-link "
+						className="reader-sidebar-recent__item reader-sidebar-recent__item--without-icon reader-sidebar-recent__view-more"
 						onClick={ toggleShowAllSites }
 					>
 						{ showAllSites ? translate( 'View Less' ) : translate( 'View More' ) }

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -1,4 +1,5 @@
 import { Count } from '@automattic/components';
+import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -67,7 +68,7 @@ const ReaderSidebarRecent = ( {
 			onClick={ onClick }
 			customIcon={ <ReaderFollowingIcon /> }
 			disableFlyout
-			className={ `reader-sidebar-recent ${ className }` }
+			className={ clsx( 'reader-sidebar-recent', className ) }
 			count={ undefined }
 			icon={ null }
 			materialIcon={ null }

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -11,19 +11,13 @@ import { AppState } from 'calypso/types';
 
 import './style.scss';
 
-// holdercp TODO: Find the right home for this, or the existing definition
+// Not complete, just useful fields for now
 type Site = {
 	ID: number;
 	URL: string;
 	feed_URL: string;
 	feed_ID: number;
-	date_subscribed: number;
 	last_updated: number;
-	delivery_methods: {
-		notification: {
-			send_posts: boolean;
-		};
-	};
 	is_owner: boolean;
 	organization_id: number;
 	name: string;

--- a/client/reader/sidebar/reader-sidebar-recent/style.scss
+++ b/client/reader/sidebar/reader-sidebar-recent/style.scss
@@ -2,6 +2,11 @@
 	&__item {
 		width: 100%;
 		cursor: pointer;
+
+		&--selected {
+			color: var( --color-sidebar-menu-selected-text ) !important;
+			background-color: var( --color-sidebar-menu-selected-background ) !important;
+		}
 	}
 
 	&__view-more {

--- a/client/reader/sidebar/reader-sidebar-recent/style.scss
+++ b/client/reader/sidebar/reader-sidebar-recent/style.scss
@@ -12,4 +12,8 @@
 	&__view-more {
 		color: var( --color-link ) !important;
 	}
+
+	&.sidebar__menu--selected:not( :hover ) path {
+		fill: var( --color-sidebar-gridicon-selected-fill ) !important;
+	}
 }

--- a/client/reader/sidebar/reader-sidebar-recent/style.scss
+++ b/client/reader/sidebar/reader-sidebar-recent/style.scss
@@ -1,16 +1,61 @@
 .reader-sidebar-recent {
+	$recent-font-size: 13px;
+	$recent-line-height: 1.5;
+	$recent-item-padding-x: 18px;
+	$recent-item-padding-y: 6px;
+	$recent-site-icon-size: 16px;
+	$recent-item-gap: 8px;
+
 	&__item {
 		width: 100%;
 		cursor: pointer;
+		text-align: left;
+		display: grid;
+		grid-template-columns: $recent-site-icon-size 1fr auto;
+		gap: $recent-item-gap;
+		align-items: center;
+		padding: $recent-item-padding-y $recent-item-padding-x;
+		font-size: $recent-font-size;
+		line-height: $recent-line-height;
+
+		&:hover {
+			background-color: var( --color-sidebar-menu-hover-background );
+		}
 
 		&--selected {
-			color: var( --color-sidebar-menu-selected-text ) !important;
-			background-color: var( --color-sidebar-menu-selected-background ) !important;
+			font-weight: 700;
+		}
+
+		&--without-icon {
+			padding-left: $recent-item-padding-x + $recent-site-icon-size + $recent-item-gap; // 15px + 16px + 8px;
+			grid-template-columns: 1fr auto;
+		}
+	}
+
+	&__site {
+		&-name {
+			overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+		}
+
+		&-icon {
+			border-radius: 50%;
+			width: $recent-site-icon-size;
+			height: $recent-site-icon-size;
+		}
+
+		&-count {
+			font-size: $recent-font-size;
+			font-weight: 400;
+			margin-right: 6px; // To get alignment with menu chevron icon; bleh
 		}
 	}
 
 	&__view-more {
-		color: var( --color-link ) !important;
+		color: var( --color-link );
+		text-decoration: underline;
+		padding-bottom: $recent-item-padding-y * 2;
 	}
 
 	&.sidebar__menu--selected:not( :hover ) path {

--- a/client/reader/sidebar/reader-sidebar-recent/style.scss
+++ b/client/reader/sidebar/reader-sidebar-recent/style.scss
@@ -1,0 +1,10 @@
+.reader-sidebar-recent {
+	&__item {
+		width: 100%;
+		cursor: pointer;
+	}
+
+	&__view-more {
+		color: var( --color-link ) !important;
+	}
+}

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -203,7 +203,7 @@ body.is-section-reader {
 		margin-right: 8px;
 	}
 
-	/* holdercp TODO: Is this needed with the overhaul */
+	/* @holdercp TODO: This can be removed once calypso/reader/stream/reader-list-followed-sites is removed */
 	.sidebar-streams__following-load-more {
 		color: var(--color-link);
 		cursor: pointer;

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -203,7 +203,7 @@ body.is-section-reader {
 		margin-right: 8px;
 	}
 
-	/* TODO: Is this needed with the overhaul */
+	/* holdercp TODO: Is this needed with the overhaul */
 	.sidebar-streams__following-load-more {
 		color: var(--color-link);
 		cursor: pointer;

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -203,6 +203,7 @@ body.is-section-reader {
 		margin-right: 8px;
 	}
 
+	/* TODO: Is this needed with the overhaul */
 	.sidebar-streams__following-load-more {
 		color: var(--color-link);
 		cursor: pointer;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -742,6 +742,7 @@
 			line-height: 20px;
 		}
 	}
+	/* @holdercp TODO: This can be removed once calypso/reader/stream/reader-list-followed-sites is removed */
 	.sidebar-streams__following-load-more {
 		color: var(--color-neutral-100);
 		font-size: $font-body-small;

--- a/client/state/reader-ui/sidebar/actions.js
+++ b/client/state/reader-ui/sidebar/actions.js
@@ -52,9 +52,8 @@ export function toggleReaderSidebarFollowing() {
  * @param {number|null} params.feedId - The ID of the feed to select.
  * @returns The action object to dispatch.
  */
-
 export function selectSidebarRecentSite( { feedId } ) {
-	// holdercp TODO: Determine if tracking is needed here
+	// @holdercp TODO: Determine if tracking is needed here
 	return {
 		type: READER_SIDEBAR_SELECT_RECENT_SITE,
 		feedId,

--- a/client/state/reader-ui/sidebar/actions.js
+++ b/client/state/reader-ui/sidebar/actions.js
@@ -54,7 +54,7 @@ export function toggleReaderSidebarFollowing() {
  */
 
 export function selectSidebarRecentSite( { feedId } ) {
-	// TODO: Determine if tracking is needed here
+	// holdercp TODO: Determine if tracking is needed here
 	return {
 		type: READER_SIDEBAR_SELECT_RECENT_SITE,
 		feedId,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/loop#190

## Proposed Changes

* Adds styling to match the comps
* Took some liberties with some spacing and alignment to provide the same look but with more consistent values.
* Created new styles scoped to this component rather than trying to override existing styles since this might be the direction we take with other sections of Reader.

<img width="1639" alt="image" src="https://github.com/user-attachments/assets/ae865ebd-98e6-434d-aa5c-ea7fefedd7d4">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2iv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/read?flags="reader/recent-feed-overhaul"
* Interact with the section and see how styles look and feel
* **Note:** Navigation is not implemented yet. This PR to get things looking the way we want them.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
