### PR TITLE
Email Verification: Fix duplicated email confirmed notice

### DIFF
--- a/client/components/email-verification/index.js
+++ b/client/components/email-verification/index.js
@@ -12,6 +12,7 @@ export default function emailVerification( context, next ) {
 	const showNewEmailNotice = '1' === context.query.new_email_result;
 
 	if ( showVerifiedNotice ) {
+		context.page.replace( removeQueryArgs( context.canonicalPath, 'verified' ) );
 		sendVerificationSignal();
 		setTimeout( () => {
 			const message = i18n.translate( 'Email confirmed!' );


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/96051

## Proposed Changes

* Fix duplicated email confirmed notice, removing the `verified` query arg when showing the first notice. A similar approach is used for the `new_email_result` in the same function.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* "Email confirmed" notice appears twice when entering accessing `/sites?verified=1`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local or use a test env
* Go to `/sites?verified=1`
* You should see only one notice

<img width="344" alt="image" src="https://github.com/user-attachments/assets/ba06f2a4-0e69-4aa8-be19-9f9baab29fca">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
