### PR TITLE
Bulk Plugin Management: Disable auto updating plugins when page loads

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -608,15 +608,6 @@ export function fetchSitePlugins( siteId ) {
 		const receivePluginsDispatchSuccess = ( data ) => {
 			dispatch( receiveSitePlugins( siteId, data.plugins ) );
 			dispatch( { ...defaultAction, type: PLUGINS_REQUEST_SUCCESS } );
-
-			data.plugins.map( ( plugin ) => {
-				if (
-					pluginHasTruthySiteProp( 'update', plugin, siteId ) &&
-					pluginHasTruthySiteProp( 'autoupdate', plugin, siteId )
-				) {
-					updatePlugin( siteId, plugin )( dispatch );
-				}
-			} );
 		};
 
 		const receivePluginsDispatchFail = ( error ) => {
@@ -643,20 +634,6 @@ export function fetchAllPlugins() {
 			dispatch( { type: PLUGINS_ALL_REQUEST_SUCCESS } );
 
 			dispatch( receiveAllSitesPlugins( sites ) );
-
-			Object.entries( sites ).forEach( ( [ siteId, plugins ] ) => {
-				// Cast the enumerable string-keyed property to a number.
-				siteId = Number( siteId );
-
-				plugins.forEach( ( plugin ) => {
-					if (
-						pluginHasTruthySiteProp( 'update', plugin, siteId ) &&
-						pluginHasTruthySiteProp( 'autoupdate', plugin, siteId )
-					) {
-						updatePlugin( siteId, plugin )( dispatch );
-					}
-				} );
-			} );
 		};
 
 		const receivePluginsDispatchFail = ( error ) => {

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -128,16 +128,6 @@ describe( 'actions', () => {
 					},
 				} );
 			} );
-
-			test( 'should dispatch plugin update request if any site plugins need updating', async () => {
-				await fetchAllPlugins()( spy, getState );
-				expect( spy ).toHaveBeenCalledWith( {
-					type: PLUGIN_UPDATE_REQUEST,
-					action: UPDATE_PLUGIN,
-					siteId: 2916284,
-					pluginId: 'jetpack/jetpack',
-				} );
-			} );
 		} );
 
 		describe( 'failure', () => {
@@ -225,16 +215,6 @@ describe( 'actions', () => {
 				error: expect.objectContaining( {
 					message: 'This endpoint is only available for Jetpack powered Sites',
 				} ),
-			} );
-		} );
-
-		test( 'should dispatch plugin update request if any site plugins need updating', async () => {
-			await fetchSitePlugins( 2916284 )( spy, getState );
-			expect( spy ).toHaveBeenCalledWith( {
-				type: PLUGIN_UPDATE_REQUEST,
-				action: UPDATE_PLUGIN,
-				siteId: 2916284,
-				pluginId: 'jetpack/jetpack',
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9706

## Proposed Changes
Currently when the list of plugins are fetched those that have `autoupdate` enabled immediately execute the update on page loads, we want to disable this behaviour.
 
* Disable auto update when page loads

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve performance and product quality

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure some of your plugins have autoupdate enabled
* Go to `/plugins/manage`
* Verify auto update is not executed by checking no update api calls were made
* 
![image](https://github.com/user-attachments/assets/b9327285-f693-467a-9b72-4f83cb535c0b)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
