### PR TITLE
Stats: Allow aggregate data for Stats Tabs

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -21,6 +22,8 @@ import ChartHeader from './chart-header';
 import { buildChartData, getQueryDate } from './utility';
 
 import './style.scss';
+
+const isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' );
 
 const ChartTabShape = PropTypes.shape( {
 	attr: PropTypes.string,
@@ -129,6 +132,7 @@ class StatModuleChartTabs extends Component {
 					selectedTab={ this.props.chartTab }
 					activeIndex={ this.props.queryDate }
 					activeKey="period"
+					aggregate={ isNewDateFilteringEnabled }
 				/>
 			</div>
 		);

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -17,15 +17,37 @@ class StatsTabs extends Component {
 		switchTab: PropTypes.func,
 		tabs: PropTypes.array,
 		borderless: PropTypes.bool,
+		aggregate: PropTypes.bool,
 	};
 
 	render() {
-		const { children, data, activeIndex, activeKey, tabs, switchTab, selectedTab, borderless } =
-			this.props;
+		const {
+			children,
+			data,
+			activeIndex,
+			activeKey,
+			tabs,
+			switchTab,
+			selectedTab,
+			borderless,
+			aggregate,
+		} = this.props;
+
 		let statsTabs;
 
 		if ( data && ! children ) {
-			const activeData = find( data, { [ activeKey ]: activeIndex } );
+			let activeData = {};
+			if ( ! aggregate ) {
+				activeData = find( data, { [ activeKey ]: activeIndex } );
+			} else {
+				// TODO: not major but we might want to cache the data.
+				data.map( ( day ) =>
+					tabs.map( ( tab ) => {
+						activeData[ tab.attr ] = ( activeData?.[ tab.attr ] ?? 0 ) + ( day[ tab.attr ] ?? 0 );
+					} )
+				);
+			}
+
 			statsTabs = tabs.map( ( tab ) => {
 				const hasData =
 					activeData && activeData[ tab.attr ] >= 0 && activeData[ tab.attr ] !== null;


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/226

## Proposed Changes

* Support sum up for the Stats tabs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to support showing the whole range rather than a single one

## Testing Instructions

* Open Calypso Live `/stats/day/jetpack.com?flags=stats%2Fnew-date-filtering`
* Choose Last 30 Days
* Ensure the tabs are showing all the views/vistors/like/comments for the whole date range
* Choose Last 7 Days
* Ensure the tabs are showing all the views/vistors/like/comments for the whole date range

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
