### PR TITLE
Update /hosting-config layout

### DIFF
--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -162,7 +162,7 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting = false } ) => {
 			>
 				<HostingCardDescription>
 					{ translate(
-						'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}.',
+						'Set the admin interface style for all users. {{supportLink}}Learn more{{/supportLink}}',
 						{
 							components: {
 								supportLink: (

--- a/client/sites/settings/caches/form.tsx
+++ b/client/sites/settings/caches/form.tsx
@@ -118,7 +118,7 @@ export default function CacheForm( {
 	const edgeCacheToggleDescription = isEdgeCacheEligible
 		? translate( 'Enable global edge caching for faster content delivery.' )
 		: translate(
-				'Global edge cache can only be enabled for public sites. {{a}}Review privacy settings.{{/a}}',
+				'Global edge cache can only be enabled for public sites. {{a}}Review privacy settings{{/a}}',
 				{
 					components: {
 						a: config.isEnabled( 'untangling/hosting-menu' ) ? (

--- a/client/sites/settings/caches/form.tsx
+++ b/client/sites/settings/caches/form.tsx
@@ -141,7 +141,7 @@ export default function CacheForm( {
 		>
 			<div className="cache-card__all-cache-block">
 				<DescriptionComponent>
-					{ translate( 'Manage your site’s server-side caching. {{a}}Learn more{{/a}}.', {
+					{ translate( 'Manage your site’s server-side caching. {{a}}Learn more{{/a}}', {
 						components: {
 							a: <InlineSupportLink supportContext="hosting-clear-cache" showIcon={ false } />,
 						},
@@ -258,7 +258,7 @@ export default function CacheForm( {
 					</div>
 					<SubdescriptionComponent>
 						{ translate(
-							'Data is cached using Memcached to reduce database lookups. {{a}}Learn more{{/a}}.',
+							'Data is cached using Memcached to reduce database lookups. {{a}}Learn more{{/a}}',
 							{
 								comment: 'Explanation for how object cache works',
 								components: {
@@ -303,7 +303,7 @@ export default function CacheForm( {
 							<JetpackLogo size={ 16 } />
 							<SubdescriptionComponent>
 								{ translate(
-									'Jetpack indexes the content of your site with Elasticsearch. {{a}}Learn more{{/a}}.',
+									'Jetpack indexes the content of your site with Elasticsearch. {{a}}Learn more{{/a}}',
 									{
 										comment:
 											'Refers to how Jetpack Search uses Elasticsearch to index posts and pages on some WordPress.com sites',

--- a/client/sites/settings/web-server/web-server-form.tsx
+++ b/client/sites/settings/web-server/web-server-form.tsx
@@ -431,8 +431,8 @@ export default function WebServerSettingsForm( {
 				) }
 			</DescriptionComponent>
 			{ ! isLoading && getWpVersionContent() }
-			{ ! isLoading && getGeoAffinityContent() }
 			{ ! isLoading && getPhpVersionContent() }
+			{ ! isLoading && getGeoAffinityContent() }
 			{ ! isLoading && getStaticFile404Content() }
 			{ isLoading && getPlaceholderContent() }
 		</ContainerComponent>

--- a/client/sites/tools/sftp-ssh/sftp-form.tsx
+++ b/client/sites/tools/sftp-ssh/sftp-form.tsx
@@ -247,7 +247,7 @@ export const SftpForm = ( {
 					checked={ isSshAccessEnabled }
 					onChange={ handleToggleSshAccess }
 					label={ translate(
-						'Enable SSH access for this site. {{supportLink}}Learn more{{/supportLink}}.',
+						'Enable SSH access for this site. {{supportLink}}Learn more{{/supportLink}}',
 						{
 							components: {
 								supportLink: (


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/9531

## Proposed Changes

1. Reorder web server settings

Moved PHP version under WordPress version

(Staging site)

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/user-attachments/assets/571f528b-c7b7-4334-b63c-fff119a22ef0">  | <img src="https://github.com/user-attachments/assets/556eec63-bad1-43d5-b130-45908d381016">|

2. Consistent treatment for links at the end of a sentence
Remove `.` after `Learn more`

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/user-attachments/assets/37b1273b-526e-4399-ae7f-01303cd69ffe">  | <img src="https://github.com/user-attachments/assets/e73a8d23-cfc3-4e54-b44a-bf1db4b809be">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve consistency

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/hosting-config/:site`, note that you may see different navigation tabs on wpcalypso and dev environment, you can turn it off by adding `?flags=-untangling/hosting-menu`, this is part of pbxlJb-6ye-p2
* Check if those changes are there
* Note that not every site has the same options available (e.g. WordPress version), so remember to check between staging and atomic sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?