### PR TITLE
Help Center: Add temp flag for showing simplified chat history

### DIFF
--- a/packages/help-center/src/components/help-center-chat-history.tsx
+++ b/packages/help-center/src/components/help-center-chat-history.tsx
@@ -17,6 +17,10 @@ import type { ZendeskConversation } from '@automattic/odie-client';
 
 import './help-center-chat-history.scss';
 
+// temporarily we want to show a simplified version of the chat history
+// this bool controls it.
+const simplifiedHistoryChat = true;
+
 const Conversations = ( { conversations }: { conversations: ZendeskConversation[] } ) => {
 	const { __ } = useI18n();
 	if ( ! conversations || ! conversations.length ) {
@@ -78,7 +82,7 @@ export const HelpCenterChatHistory = () => {
 			const { unreadConversations } = calculateUnread( conversations );
 			setUnreadCount( unreadConversations );
 		}
-	}, [ getConversations, isChatLoaded ] );
+	}, [ getConversations, isChatLoaded, setUnreadCount ] );
 
 	const EmptyArchivedConversations = () => {
 		return (
@@ -103,6 +107,11 @@ export const HelpCenterChatHistory = () => {
 			</Card>
 		);
 	};
+
+	// Temporarily simplified version
+	if ( simplifiedHistoryChat ) {
+		return <Conversations conversations={ recentConversations } />;
+	}
 
 	return (
 		<div className="help-center-chat-history">

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -13,10 +13,6 @@
 		height: $head-foot-height;
 		padding: 16px;
 
-		&.chat-history {
-			border-bottom: none;
-		}
-
 		&.has-unread {
 			background: #3858E9;
 			color: var(--studio-white);

--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -1,7 +1,4 @@
 .help-center-support-chat__conversation-container {
-	&:first-child {
-		border-top: 1px solid #C3C4C7;
-	}
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;

--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -1,4 +1,7 @@
 .help-center-support-chat__conversation-container {
+	&:first-child {
+		border-top: 1px solid #C3C4C7;
+	}
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -107,5 +110,12 @@
 		align-items: center;
 		fill: #787C82;
 	}
+}
+.help-center-chat-history__no-results {
+	display: flex;
+    flex-direction: row;
+    justify-content: center;
+    border-top: solid 1px #C3C4C7;
+    padding-top: 20px;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9727
Fixes https://github.com/Automattic/dotcom-forge/issues/9727

## Proposed Changes

* Temporarily render a simplified version of chat history by adding a simple boolean flag.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are figuring out the best way of showing old chats to users. This PR keeps the component working as before with archived lists, it just disabled it by adding a flag. Will make easier to enable it back later.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link, add the flag `?flags=help-center-experience`
* Make sure you have chats
* Check the history, should look like this, without any tabs
<img width="414" alt="image" src="https://github.com/user-attachments/assets/f400d875-d98a-4a9c-b757-9654ffb9da9b">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
