### PR TITLE
Performance Profiler: Consolidate all time metrics to seconds

### DIFF
--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -169,12 +169,8 @@ export const displayValue = ( metric: Metrics, value: number ): string => {
 		return '';
 	}
 
-	if ( [ 'lcp', 'fcp', 'ttfb' ].includes( metric ) ) {
+	if ( [ 'lcp', 'fcp', 'ttfb', 'inp', 'fid', 'tbt' ].includes( metric ) ) {
 		return `${ max2Decimals( value / 1000 ) }s`;
-	}
-
-	if ( [ 'inp', 'fid', 'tbt' ].includes( metric ) ) {
-		return `${ max2Decimals( value ) }ms`;
 	}
 
 	return `${ max2Decimals( value ) }`;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/95891

## Proposed Changes

* Updates the unit of the `inp`, `fid` and `tbt` metrics to seconds to be consistent with the others

||Before | After|
|-------|-------|------|
|    WP      | ![CleanShot 2024-11-07 at 12 16 43@2x](https://github.com/user-attachments/assets/927032d5-472a-422b-a762-bfa3c2fc90b4) | ![CleanShot 2024-11-07 at 12 21 52@2x](https://github.com/user-attachments/assets/ab9d39d8-29d0-4bd4-aeed-6e33669801f0)|
|    A8c      | ![CleanShot 2024-11-07 at 12 16 51@2x](https://github.com/user-attachments/assets/2583eb97-4851-49f9-9e85-4bede0e48e77) | ![CleanShot 2024-11-07 at 12 22 04@2x](https://github.com/user-attachments/assets/617918f3-29c6-421b-9c43-211e8d14b9a3)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It seems more natural to the user to see all metrics displayed in the same unit

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch, and run a test, or navigate to an existing report, e.g. `/speed-test-tool?hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzA3MX0.m3-63iGZmpJOpOfkZ4ww184EoKd8P3UHzTYwv1VLQUo&url=https%3A%2F%2Fwordpress.com%2F&tab=mobile`
* Ensure all the metrics on the top section have the same metrics 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
