### PR TITLE
Site Address Changer: Fix Bleeding Dialog Styles

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -553,10 +553,10 @@ export class SiteAddressChanger extends Component {
 		return (
 			<Dialog
 				buttons={ this.getStepButtons() }
-				className="site-address-changer"
 				isVisible={ isDialogVisible }
 				onClose={ onClose }
 				leaveTimeout={ 0 }
+				showCloseIcon
 			>
 				{ 0 === this.state.step && this.renderNewAddressForm() }
 				{ 1 === this.state.step && this.renderConfirmationForm() }

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -1,21 +1,6 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/colors.native";
 
-.dialog__content.site-address-changer {
-	padding: 48px 48px 0;
-	max-width: 800px;
-
-}
-
-.dialog__action-buttons {
-	border: 0;
-	padding: 35px 48px 48px;
-
-	&::before {
-		display: none;
-	}
-}
-
 .site-address-changer__dialog {
 	text-align: left;
 

--- a/client/sites/tools/database/restore-db-password.js
+++ b/client/sites/tools/database/restore-db-password.js
@@ -36,19 +36,19 @@ const RestorePasswordDialog = ( {
 
 	const buttons = [
 		{
+			action: 'cancel',
+			label: translate( 'Cancel' ),
+			onClick: onCancel,
+		},
+		{
 			action: 'restore',
 			label: translate( 'Restore' ),
 			onClick: () => setShouldRestore( true ),
 			isPrimary: true,
 		},
-		{
-			action: 'cancel',
-			label: translate( 'Cancel' ),
-			onClick: onCancel,
-		},
 	];
 	return (
-		<Dialog isVisible={ isVisible } buttons={ buttons } onClose={ onCancel }>
+		<Dialog isVisible={ isVisible } buttons={ buttons } onClose={ onCancel } showCloseIcon>
 			<h1>{ translate( 'Restore database password' ) }</h1>
 			<p>
 				{ translate( 'Are you sure you want to restore the default password of your database?' ) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/95889

## Proposed Changes
See #95971 - changes just brought in from over there. The styles are seeping to the Password Reset Dialog for the PHPMyAdmin card, when it should look like this:

<img width="623" alt="Screenshot 2024-11-02 at 11 14 34" src="https://github.com/user-attachments/assets/68762781-77fa-49f2-be44-4f4e5b0dccb4">

The Site Address Changer dialog should be unaffected, with the exception of the close icon now being shown:

<img width="774" alt="Screenshot 2024-11-05 at 16 58 25" src="https://github.com/user-attachments/assets/64b72b0b-ed82-4884-a409-c86de512846b">

cc @wongasy 