### PR TITLE
Posts/Pages: Provide Notice About Automatic 30-Day Bin Deletion  

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -24,6 +24,7 @@ import {
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
 import { getSite, getSiteFrontPage, getSiteFrontPageType } from 'calypso/state/sites/selectors';
+import PostItemTrashAutoDeleteWarning from '../post-type-list/post-item-trash-warning';
 import BlogPostsPage from './blog-posts-page';
 import { sortPagesHierarchically } from './helpers';
 import Page from './page';
@@ -368,6 +369,7 @@ class Pages extends Component {
 
 		return (
 			<div id="pages" className="pages__page-list">
+				<PostItemTrashAutoDeleteWarning postType="page" />
 				{ this.renderBlogPostsPage() }
 				{ this.renderVirtualHomePage() }
 				{ site && this.renderSectionHeader() }

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -24,6 +24,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PostTypeListEmptyContent from './empty-content';
 import PostTypeListMaxPagesNotice from './max-pages-notice';
 import PostItem from './post-item';
+import PostItemTrashAutoDeleteWarning from './post-item-trash-warning';
+
 import './style.scss';
 
 /**
@@ -249,6 +251,7 @@ class PostTypeList extends Component {
 
 		return (
 			<div className={ classes }>
+				<PostItemTrashAutoDeleteWarning postType="post" />
 				{ this.renderSectionHeader() }
 				{ query &&
 					range( 1, maxRequestedPage + 1 ).map( ( page ) => (

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -24,7 +24,6 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PostTypeListEmptyContent from './empty-content';
 import PostTypeListMaxPagesNotice from './max-pages-notice';
 import PostItem from './post-item';
-
 import './style.scss';
 
 /**

--- a/client/my-sites/post-type-list/post-item-trash-warning/index.jsx
+++ b/client/my-sites/post-type-list/post-item-trash-warning/index.jsx
@@ -1,0 +1,39 @@
+import { CompactCard } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getPostTypeLabel } from 'calypso/state/post-types/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getPostTypeTrashUrl from 'calypso/state/selectors/get-post-type-trash-url';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+const PostItemTrashAutoDeleteWarning = ( { postType } ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const currentRoute = useSelector( getCurrentRoute );
+	const postTrashRoute = useSelector( ( state ) => getPostTypeTrashUrl( state, postType ) );
+	const postTypeLabel = useSelector( ( state ) =>
+		getPostTypeLabel( state, siteId, postType, 'name' )
+	);
+
+	if ( currentRoute !== postTrashRoute ) {
+		return;
+	}
+
+	return (
+		<CompactCard className="post-item-trash-warning">
+			<span>
+				{ translate( '%(postType)s in the Trash are automatically deleted after 30 days.', {
+					args: {
+						postType: postTypeLabel,
+					},
+					comment:
+						'"Trash" should have the same translation as the Navigation menu tab (eg. "Bin" in British English)',
+				} ) }
+			</span>
+		</CompactCard>
+	);
+};
+
+export default PostItemTrashAutoDeleteWarning;

--- a/client/my-sites/post-type-list/post-item-trash-warning/style.scss
+++ b/client/my-sites/post-type-list/post-item-trash-warning/style.scss
@@ -1,0 +1,7 @@
+.post-item-trash-warning.card {
+	background: var(--color-link-0);
+	box-shadow: none;
+	font-size: $font-body-small;
+	margin-bottom: 20px;
+	text-align: center;
+}


### PR DESCRIPTION
Fixes #95629

## Proposed Changes

* Provides some notice that Posts and Pages in the Bin are automatically deleted after 30 days. 

## Why are these changes being made?

See original issue - some users aren't clear that this is the case and even use the Bin for archiving, and Calypso doesn't inform them about the automatic deletion anywhere. This seems like a quick win to address.

## Testing Instructions

1. Go to My Sites > Posts
2. Navigate to the Trash tab
3. Confirm this appears
4. Go to My Sites > Pages and do the same; confirm it's there too
5. Confirm that it doesn't appear for any other tabs

<img width="1086" alt="Screenshot 2024-11-07 at 15 44 37" src="https://github.com/user-attachments/assets/0324a703-3639-4e88-b8d9-684d05b847ce">

cc @lucasmendes-design, @taipeicoder, @fushar 