### PR TITLE
Performance Profiler: Remove Generated with AI badge as it confuses users

### DIFF
--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -1,7 +1,4 @@
 import { SelectDropdown } from '@automattic/components';
-import { useDesktopBreakpoint } from '@automattic/viewport-react';
-import styled from '@emotion/styled';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { ForwardedRef, forwardRef, useCallback, useEffect, useState } from 'react';
 import {
@@ -29,36 +26,9 @@ type InsightsSectionProps = {
 	onRecommendationsFilterChange?: ( filter: string ) => void;
 };
 
-const AIBadge = styled.span`
-	padding: 0 8px;
-	margin-left: 8px;
-	margin-top: 2px;
-	width: fit-content;
-	height: fit-content;
-	border-radius: 4px;
-	float: right;
-	font-size: 12px;
-	line-height: 20px;
-	color: var( --studio-gray-100 );
-	background: linear-gradient(
-			0deg,
-			rgba( 255, 255, 255, 0.95 ) 0%,
-			rgba( 255, 255, 255, 0.95 ) 100%
-		),
-		linear-gradient( 90deg, #4458e4 0%, #069e08 100% );
-
-	&.is-mobile {
-		float: none;
-		display: block;
-		margin-left: 0;
-		margin-top: 8px;
-	}
-`;
-
 export const InsightsSection = forwardRef(
 	( props: InsightsSectionProps, ref: ForwardedRef< HTMLDivElement > ) => {
 		const translate = useTranslate();
-		const isMobile = ! useDesktopBreakpoint();
 		const { audits, fullPageScreenshot, isWpcom, hash, filter, onRecommendationsFilterChange } =
 			props;
 		const [ selectedFilter, setSelectedFilter ] = useState( filter ?? 'all' );
@@ -93,12 +63,7 @@ export const InsightsSection = forwardRef(
 			<div className="performance-profiler-insights-section" ref={ ref }>
 				<div className="header">
 					<div>
-						<h2 className="title">
-							{ translate( 'Personalized Recommendations' ) }
-							<AIBadge className={ clsx( { 'is-mobile': isMobile } ) }>
-								{ translate( 'Generated with AI' ) }
-							</AIBadge>
-						</h2>
+						<h2 className="title">{ translate( 'Personalized Recommendations' ) }</h2>
 						<p className="subtitle">
 							{ getSubtitleText( selectedFilter, filteredAudits.length, translate ) }
 						</p>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9699

## Proposed Changes

* Removes the `Generated with AI` badge on top of Insights section 

|Before | After|
|-------|------|
|  ![CleanShot 2024-11-07 at 16 55 39@2x](https://github.com/user-attachments/assets/0f6b6281-7804-4e9f-821d-839283f93ced)| ![CleanShot 2024-11-07 at 16 56 44@2x](https://github.com/user-attachments/assets/899cd00e-8c1d-4f03-a9e1-bbbcc3646857)|
|![CleanShot 2024-11-07 at 16 58 17@2x](https://github.com/user-attachments/assets/91dfb664-284c-43fb-acc7-75a6ddf57199) | ![CleanShot 2024-11-07 at 16 58 03@2x](https://github.com/user-attachments/assets/68c0f61e-da38-41bd-83c3-bdf12aa39a20)|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It seems to confuse users into thinking that the insights are generated with AI when they come from Lighthouse
* The content generated by AI  is labelled when expanding the insight <img src="https://github.com/user-attachments/assets/f71116f4-1e2c-472b-a7b6-26941817c2e9" width=200 />
* Feedback reported in the linked task https://github.com/Automattic/dotcom-forge/issues/9699 and agreed in the following comment https://github.com/Automattic/dotcom-forge/issues/9699#issuecomment-2462198148

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch, navigate to the tool and run a test, or open this URL `/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6Nzc3Mn0.048zsfIxmJ0M_YpPGRg0QSsTmtMglyBAlPMJhrGB1vg`
* Check the `Generated with AI` badge is not displayed
* Check also in the internal tool by navigating to an atomic site with the flag `performance-profiler/logged-in` active, e.g. `/sites/performance/<your site>?flags=performance-profiler/logged-in`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
