### PR TITLE
Help Center Chat: Enhance file upload button styles for better accessibility

### DIFF
--- a/packages/help-center/src/components/help-center-chat.scss
+++ b/packages/help-center/src/components/help-center-chat.scss
@@ -28,6 +28,7 @@
 			button {
 				padding: 7px;
 				&:focus {
+					outline: 2px solid #3858e9;
 					outline-offset: 1px;
 				}
 			}

--- a/packages/help-center/src/components/help-center-chat.scss
+++ b/packages/help-center/src/components/help-center-chat.scss
@@ -23,5 +23,14 @@
 			/* stylelint-disable-next-line length-zero-no-unit */
 			margin: 0px 11px 0px 0px;
 		}
+
+		.components-form-file-upload {
+			button {
+				padding: 7px;
+				&:focus {
+					outline-offset: 1px;
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/9725

## Proposed Changes

* Improve chat file upload button focus

<img width="412" alt="CleanShot 2024-11-07 at 11 47 26@2x" src="https://github.com/user-attachments/assets/add2217b-3f07-4652-aa7c-1da1fcca552d">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix focus and improve accessibility

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to `/home?flags=help-center-experience` and open the Help Center.
* Open one of your existing chats and verify the upload icon focus is correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
