### PR TITLE
Optimized how we load plugins and improved load state

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -10,7 +10,7 @@ import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/vie
 import { Icon, upload } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { capitalize, flow, isEmpty } from 'lodash';
+import { filter as lodashFilter, capitalize, flow, isEmpty } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -373,13 +373,11 @@ export class PluginsMain extends Component {
 					header={ this.props.translate( 'Manage Plugins' ) }
 					plugins={ this.getCurrentPlugins() }
 					isPlaceholder={ this.shouldShowPluginListPlaceholders() }
-					isLoading={ this.props.requestingPluginsForSites }
+					isLoading={ this.props.requestingPluginsForSites || this.props.isLoadingSites }
 					isJetpackCloud={ this.props.isJetpackCloud }
 					searchTerm={ this.props.search }
 					filter={ this.props.filter }
 					requestPluginsError={ this.props.requestPluginsError }
-					activePlugins={ this.props.activePlugins }
-					inactivePlugins={ this.props.inactivePlugins }
 					onSearch={ this.props.doSearch }
 				/>
 			);
@@ -426,7 +424,7 @@ export class PluginsMain extends Component {
 				header={ this.props.translate( 'Manage Plugins' ) }
 				plugins={ currentPlugins }
 				isPlaceholder={ this.shouldShowPluginListPlaceholders() }
-				isLoading={ this.props.requestingPluginsForSites }
+				isLoading={ this.props.requestingPluginsForSites || this.props.isLoadingSites }
 				isJetpackCloud={ this.props.isJetpackCloud }
 				searchTerm={ search }
 				filter={ this.props.filter }
@@ -624,17 +622,10 @@ export default flow(
 			const selectedSite = getSelectedSite( state );
 			const selectedSiteId = getSelectedSiteId( state );
 			const siteIds = siteObjectsToSiteIds( sites ) ?? [];
-			const pluginsWithUpdates = getPlugins( state, siteIds, 'updates' );
-			const activePlugins = getPlugins( state, siteIds, 'active' );
-			const inactivePlugins = getPlugins( state, siteIds, 'inactive' );
+			const isLoadingSites = isRequestingSites( state );
 			const allPlugins = getPlugins( state, siteIds, 'all' );
-			const pluginsWithUpdatesAndStatuses = getPluginsWithUpdateStatuses(
-				state,
-				allPlugins,
-				pluginsWithUpdates,
-				inactivePlugins,
-				activePlugins
-			);
+			const pluginsWithUpdates = lodashFilter( allPlugins, 'updates' );
+			const pluginsWithUpdatesAndStatuses = getPluginsWithUpdateStatuses( state, allPlugins );
 
 			const jetpackNonAtomic =
 				isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId );
@@ -654,6 +645,7 @@ export default flow(
 				sites,
 				selectedSite,
 				selectedSiteId,
+				isLoadingSites,
 				selectedSiteSlug: getSelectedSiteSlug( state ),
 				selectedSiteIsJetpack: selectedSite && isJetpackSite( state, selectedSiteId ),
 				siteIds,
@@ -669,8 +661,6 @@ export default flow(
 					: getPlugins( state, siteObjectsToSiteIds( getVisibleSites( sites ) ) ?? [], filter ),
 				pluginsWithUpdates,
 				pluginUpdateCount: pluginsWithUpdates && pluginsWithUpdates.length,
-				activePlugins,
-				inactivePlugins,
 				allPluginsCount: allPlugins && allPlugins.length,
 				requestingPluginsForSites:
 					isRequestingForSites( state, siteIds ) || isRequestingForAllSites( state ),

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -121,8 +121,12 @@ export const getPlugins = createSelector(
 );
 
 export const getPluginsWithUpdateStatuses = createSelector(
-	( state, plugins, withUpdate, inactive, active ) => {
-		return plugins.reduce( ( memo, plugin ) => {
+	( state, allPlugins ) => {
+		const active = filter( allPlugins, _filters.active );
+		const inactive = filter( allPlugins, _filters.inactive );
+		const withUpdate = filter( allPlugins, _filters.updates );
+
+		return allPlugins.reduce( ( memo, plugin ) => {
 			const status = [];
 			plugin.allStatuses = [];
 

--- a/client/state/plugins/installed/test/selectors.js
+++ b/client/state/plugins/installed/test/selectors.js
@@ -449,48 +449,38 @@ describe( 'Installed plugin selectors', () => {
 				{
 					id: 'jetpack/jetpack',
 					slug: 'jetpack/jetpack',
+					sites: {
+						'site.one': {
+							active: true,
+							autoupdate: true,
+							update: true,
+							version: '1.0',
+						},
+					},
 				},
 				{
 					id: 'hello-dolly/hello-dolly',
 					slug: 'hello-dolly/hello-dolly',
+					sites: {
+						'site.one': {
+							active: true,
+						},
+					},
 				},
 				{
 					id: 'vaultpress/vaultpress',
 					slug: 'vaultpress/vaultpress',
-				},
-			];
-
-			const pluginsWithUpdates = [
-				{
-					id: 'jetpack/jetpack',
-					slug: 'jetpack/jetpack',
-				},
-			];
-
-			const activePlugins = [
-				{
-					id: 'jetpack/jetpack',
-					slug: 'jetpack/jetpack',
-				},
-				{
-					id: 'hello-dolly/hello-dolly',
-					slug: 'hello-dolly/hello-dolly',
-				},
-			];
-
-			const inactivePlugins = [
-				{
-					id: 'vaultpress/vaultpress',
-					slug: 'vaultpress/vaultpress',
+					sites: {
+						'site.one': {
+							active: false,
+						},
+					},
 				},
 			];
 
 			const pluginsWithUpdatesAndStatuses = selectors.getPluginsWithUpdateStatuses(
 				state,
-				allPlugins,
-				pluginsWithUpdates,
-				inactivePlugins,
-				activePlugins
+				allPlugins
 			);
 
 			expect( pluginsWithUpdatesAndStatuses ).toEqual(
@@ -498,6 +488,14 @@ describe( 'Installed plugin selectors', () => {
 					{
 						id: 'jetpack/jetpack',
 						slug: 'jetpack/jetpack',
+						sites: {
+							'site.one': {
+								active: true,
+								autoupdate: true,
+								update: true,
+								version: '1.0',
+							},
+						},
 						status: [ PLUGINS_STATUS.UPDATE, PLUGINS_STATUS.ACTIVE ],
 						allStatuses: [
 							{
@@ -517,12 +515,14 @@ describe( 'Installed plugin selectors', () => {
 					{
 						id: 'hello-dolly/hello-dolly',
 						slug: 'hello-dolly/hello-dolly',
+						sites: { 'site.one': { active: true } },
 						status: [ PLUGINS_STATUS.ACTIVE ],
 						allStatuses: [],
 					},
 					{
 						id: 'vaultpress/vaultpress',
 						slug: 'vaultpress/vaultpress',
+						sites: { 'site.one': { active: false } },
 						status: [ PLUGINS_STATUS.INACTIVE ],
 						allStatuses: [],
 					},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9681

## Proposed Changes

* Optimized plugin load by avoiding multiple `getPlugin` calls
* Improved isLoading state to cover when we're loading sites from backend

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Delete Calypso `indexedDB` cache
* Load the /plugins/manage page
* Ensure we get a loading state all the time until the render happens (before we got a temporary "No results" state)

**Before**

https://github.com/user-attachments/assets/a05fd200-570e-4408-9e0e-22deefaa4d00

**After**

https://github.com/user-attachments/assets/4fe658af-d499-4c68-b8ee-adbe3cc22262



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
