### PR TITLE
Reader Recent Feed Overhaul: Fix site icon

### DIFF
--- a/client/reader/recent/recent-seen-field.tsx
+++ b/client/reader/recent/recent-seen-field.tsx
@@ -11,7 +11,7 @@ interface RecentSeenFieldProps {
 const RecentSeenField: React.FC< RecentSeenFieldProps > = ( { item, post, setSelectedItem } ) => {
 	return (
 		<Button className="recent-seen-field" onClick={ () => setSelectedItem( item ) }>
-			<ReaderAvatar siteIcon={ post?.site_icon?.img } iconSize={ 24 } />
+			<ReaderAvatar siteIcon={ post?.site_icon?.img || post?.author?.avatar_URL } iconSize={ 24 } />
 		</Button>
 	);
 };

--- a/client/reader/recent/recent-seen-field.tsx
+++ b/client/reader/recent/recent-seen-field.tsx
@@ -11,12 +11,7 @@ interface RecentSeenFieldProps {
 const RecentSeenField: React.FC< RecentSeenFieldProps > = ( { item, post, setSelectedItem } ) => {
 	return (
 		<Button className="recent-seen-field" onClick={ () => setSelectedItem( item ) }>
-			<ReaderAvatar
-				siteIcon={ post.site_icon }
-				feedIcon={ post.feed_icon }
-				author={ post.author }
-				iconSize={ 24 }
-			/>
+			<ReaderAvatar siteIcon={ post?.site_icon?.img } iconSize={ 24 } />
 		</Button>
 	);
 };

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -40,6 +40,10 @@
 
 		.recent-seen-field {
 			padding: 0;
+
+			img {
+				border-radius: 50%;
+			}
 		}
 
 		.recent-post-field {

--- a/client/reader/recent/types.ts
+++ b/client/reader/recent/types.ts
@@ -9,7 +9,8 @@ export interface ReaderPost {
 export interface PostItem {
 	title: string;
 	featured_image: string;
-	site_icon: string;
-	feed_icon: string;
+	site_icon: {
+		img: string;
+	};
 	author: Author;
 }

--- a/client/reader/recent/types.ts
+++ b/client/reader/recent/types.ts
@@ -1,5 +1,3 @@
-import { Author } from 'calypso/state/comments/actions';
-
 export interface ReaderPost {
 	site_name: string;
 	postId: number;
@@ -12,5 +10,7 @@ export interface PostItem {
 	site_icon: {
 		img: string;
 	};
-	author: Author;
+	author: {
+		avatar_URL: string;
+	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/193

## Proposed Changes

* Fix site icon in the post list.

Before | After
---- | ----
<img width="328" alt="Screen Shot 2024-11-07 at 1 35 01 PM" src="https://github.com/user-attachments/assets/453ea381-b463-48b8-9d71-946fbf5bd34b"> | <img width="356" alt="Screen Shot 2024-11-07 at 1 35 20 PM" src="https://github.com/user-attachments/assets/d751d98a-50a3-40da-9de4-8db10ae7016a">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The icon wasn't loading correctly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/recent-feed-overhaul
* Check that site icons load in the list, for both WordPress.com blogs and external feeds.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
