### PR TITLE
Jetpack cloud visual improvements for DataViews integration

### DIFF
--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -223,6 +223,10 @@
 // Follow-up issue: https://github.com/Automattic/dotcom-forge/issues/9554
 body.is-section-plugins .plugin-management-wrapper {
     --wp-components-color-accent: var(--color-accent);
+
+	.dataviews-loading {
+		padding: 15px 0 0 0;
+	}
 }
 body.is-section-plugins .plugin-management-wrapper,
 .is-section-jetpack-cloud-plugin-management {

--- a/client/my-sites/plugins/plugins-list/style-compatibilty.scss
+++ b/client/my-sites/plugins/plugins-list/style-compatibilty.scss
@@ -1,3 +1,5 @@
+// ########### This file will be removed after we release the new Bulk Plugins Managament with DataViews ###########
+
 .plugins-list {
 	margin-bottom: 16px;
 }
@@ -55,3 +57,12 @@
 	padding: 0;
 }
 
+.is-section-jetpack-cloud-plugin-management {
+    .layout__content {
+        padding: 79px 32px 32px calc(var(--sidebar-width-max) + 32px);
+    }
+
+	.plugins__top-container-jc {
+        padding-left: 50px;
+    }
+}

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -17,3 +17,36 @@ body.is-section-plugins .plugin-management-wrapper,
         }
     }
 }
+
+.is-section-jetpack-cloud-plugin-management {
+    --wp-admin-theme-color: var(--studio-jetpack-green-50);
+
+    .select-partner-key {
+        padding: 0 40px;
+    }
+
+    .dataviews-wrapper {
+        button {
+            border: none;
+            background-color: transparent;
+    
+            &:hover {
+                background-color: var(--color-background-alt);
+            }
+        }
+
+        thead .dataviews-view-table__row button {
+            &:focus {
+                box-shadow: none;
+            }
+        }
+    }
+
+    .layout__content {
+        padding: 79px 0 32px calc(var(--sidebar-width-max));
+    }
+
+    .plugins__top-container-jc {
+        padding-left: 80px;
+    }
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9681

## Proposed Changes

- Fixed title, edge of the table, search box, filter alignments
- Fixed accent color and hover state colors
- Fixed "Button style" on DataViews filters

<img width="1602" alt="image" src="https://github.com/user-attachments/assets/d5dd13b3-b91b-4f3b-8e51-845f13e191c2">

- Updated DataViews loading spinner padding

| Before | After |
|--------|--------|
| <img width="1258" alt="image" src="https://github.com/user-attachments/assets/96828157-0b0e-4482-af3c-102c9b574670"> | <img width="1276" alt="image" src="https://github.com/user-attachments/assets/b668e514-3d44-45ff-a3f3-e27b9290fd42"> | 



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the Jetpack cloud locally with `yarn start-jetpack-cloud`
* Access the new version and check if everything looks good: http://jetpack.cloud.localhost:3000/plugins/manage?flags=bulk-plugin-management
* Access the old version and ensure it also works fine: http://jetpack.cloud.localhost:3000/plugins/manage

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
