### PR TITLE
Global Styles on Personal: Added FEATURE_STYLE_CUSTOMIZATION to Personal Plan

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -845,14 +845,19 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_FAST_SUPPORT_FROM_EXPERTS,
 		FEATURE_ALL_FREE_FEATURES,
 	],
-	getSignupCompareAvailableFeatures: () => [
-		FEATURE_CUSTOM_DOMAIN,
-		FEATURE_HOSTING,
-		FEATURE_NO_ADS,
-		FEATURE_COLLECT_PAYMENTS_V2,
-		FEATURE_FAST_SUPPORT_FROM_EXPERTS,
-		isEnabled( 'global-styles/on-personal-plan' ) ? FEATURE_STYLE_CUSTOMIZATION : null,
-	],
+	getSignupCompareAvailableFeatures: () => {
+		const baseFeatures = [
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_HOSTING,
+			FEATURE_NO_ADS,
+			FEATURE_COLLECT_PAYMENTS_V2,
+			FEATURE_FAST_SUPPORT_FROM_EXPERTS,
+		];
+
+		return isEnabled( 'global-styles/on-personal-plan' )
+			? [ ...baseFeatures, FEATURE_STYLE_CUSTOMIZATION ]
+			: baseFeatures;
+	},
 	get2023PricingGridSignupWpcomFeatures: () => {
 		if ( isAssignedToSimplifiedFeaturesGridExperimentVariant( 'fix_inaccuracies' ) ) {
 			return [
@@ -892,13 +897,17 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		return [];
 	},
 	get2023PlanComparisonFeatureOverride: () => {
-		return [
+		const baseFeatures = [
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_AD_FREE_EXPERIENCE,
 			FEATURE_FAST_DNS,
 			FEATURE_PAYMENT_TRANSACTION_FEES_8,
 			FEATURE_PREMIUM_THEMES,
 		];
+
+		return isEnabled( 'global-styles/on-personal-plan' )
+			? [ ...baseFeatures, FEATURE_STYLE_CUSTOMIZATION ]
+			: baseFeatures;
 	},
 	getStorageFeature: () => FEATURE_6GB_STORAGE,
 	getPlanComparisonFeatureLabels: () => ( {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -817,17 +817,24 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_JETPACK_ESSENTIAL,
 			FEATURE_FAST_SUPPORT_FROM_EXPERTS,
 			FEATURE_FREE_THEMES,
+			isEnabled( 'global-styles/on-personal-plan' ) ? FEATURE_STYLE_CUSTOMIZATION : null,
 			FEATURE_6GB_STORAGE,
 			FEATURE_NO_ADS,
 			FEATURE_MEMBERSHIPS,
 			FEATURE_PREMIUM_CONTENT_BLOCK,
 			FEATURE_PAYMENT_TRANSACTION_FEES_8,
 		] ),
-	getSignupFeatures: () => [
-		FEATURE_FREE_DOMAIN,
-		FEATURE_FAST_SUPPORT_FROM_EXPERTS,
-		FEATURE_FREE_THEMES,
-	],
+	getSignupFeatures: () => {
+		const baseFeatures = [
+			FEATURE_FREE_DOMAIN,
+			FEATURE_FAST_SUPPORT_FROM_EXPERTS,
+			FEATURE_FREE_THEMES,
+		];
+
+		return isEnabled( 'global-styles/on-personal-plan' )
+			? [ ...baseFeatures, FEATURE_STYLE_CUSTOMIZATION ]
+			: baseFeatures;
+	},
 	getBlogSignupFeatures: () => [
 		FEATURE_FREE_DOMAIN,
 		FEATURE_FAST_SUPPORT_FROM_EXPERTS,
@@ -844,6 +851,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_NO_ADS,
 		FEATURE_COLLECT_PAYMENTS_V2,
 		FEATURE_FAST_SUPPORT_FROM_EXPERTS,
+		isEnabled( 'global-styles/on-personal-plan' ) ? FEATURE_STYLE_CUSTOMIZATION : null,
 	],
 	get2023PricingGridSignupWpcomFeatures: () => {
 		if ( isAssignedToSimplifiedFeaturesGridExperimentVariant( 'fix_inaccuracies' ) ) {
@@ -855,13 +863,17 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 				FEATURE_PAYMENT_TRANSACTION_FEES_8,
 			];
 		} else if ( isAssignedToSimplifiedFeaturesGridExperimentVariant( 'simplified' ) ) {
-			return [
+			const baseFeatures = [
 				FEATURE_UNLIMITED_ENTITIES,
 				FEATURE_CUSTOM_DOMAIN,
 				FEATURE_AD_FREE_EXPERIENCE,
 				WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
 				FEATURE_FAST_SUPPORT_FROM_EXPERTS,
 			];
+
+			return isEnabled( 'global-styles/on-personal-plan' )
+				? [ ...baseFeatures, FEATURE_STYLE_CUSTOMIZATION ]
+				: baseFeatures;
 		}
 
 		return [


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/9521

## Proposed Changes

* Conditionally added the Global Styles feature to the different Calypso Plan Grids.
* When upgrading, the plan list shows the Global Styles feature. The comparison grid also shows it.
* When creating a new site, the feature is also displayed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the Calypso live link
* Go to `/start/plans`, make sure you have the `global-styles/on-personal-plan` feature enabled through ?flags={feature}
* The plans grid should show the Global Styles feature on the Personal plan and comparison tables.
* Go to `/plans/{site}?plan=personal-bundle&feature=style-customization`
* The plans grid should show the Global Styles feature on the Personal plan and comparison tables.
* The Global Styles feature should be highlighted.
* Bonus: check other Calypso screens I might have missed.

https://github.com/user-attachments/assets/f923fab9-1259-4672-98b2-7197222ada8b

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
