### PR TITLE
Updated auto-update copy

### DIFF
--- a/client/my-sites/plugins/plugins-list/use-actions.tsx
+++ b/client/my-sites/plugins/plugins-list/use-actions.tsx
@@ -49,7 +49,7 @@ export function useActions(
 			callback: ( plugins: Array< Plugin > ) => {
 				bulkActionDialog( PluginActions.ENABLE_AUTOUPDATES, plugins );
 			},
-			label: translate( 'Enable Autoupdate' ),
+			label: translate( 'Enable auto-updates' ),
 			isExternalLink: true,
 			isEnabled: true,
 			supportsBulk: true,
@@ -60,7 +60,7 @@ export function useActions(
 			callback: ( plugins: Array< Plugin > ) => {
 				bulkActionDialog( PluginActions.DISABLE_AUTOUPDATES, plugins );
 			},
-			label: translate( 'Disable Autoupdate' ),
+			label: translate( 'Disable auto-updates' ),
 			isExternalLink: true,
 			isEnabled: true,
 			supportsBulk: true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9681

## Proposed Changes

* Updated the copy to follow core style

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Open /plugins/manage and ensure the copy for "Auto updates" follows core style:

<img width="1242" alt="image" src="https://github.com/user-attachments/assets/97830cbf-2a38-44b9-af19-7c1a12c9856f">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
