### PR TITLE
Reader: Fix author profile for feeds on full post view

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -43,17 +43,17 @@ class AuthorCompactProfile extends Component {
 			post,
 		} = this.props;
 
-		if ( ! author ) {
+		if ( ! author && ! siteName ) {
 			return <AuthorCompactProfilePlaceholder />;
 		}
 
-		const hasAuthorName = author.hasOwnProperty( 'name' );
+		const hasAuthorName = author?.hasOwnProperty( 'name' );
 		const hasMatchingAuthorAndSiteNames =
 			hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, author.name );
 		const classes = clsx( {
 			'author-compact-profile': true,
 			'has-author-link': ! hasMatchingAuthorAndSiteNames,
-			'has-author-icon': siteIcon || feedIcon || author.has_avatar,
+			'has-author-icon': siteIcon || feedIcon || author?.has_avatar,
 		} );
 		const streamUrl = getStreamUrl( feedId, siteId );
 
@@ -63,7 +63,7 @@ class AuthorCompactProfile extends Component {
 		return (
 			<div className={ classes }>
 				<a href={ streamUrl } className="author-compact-profile__avatar-link">
-					<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author } />
+					<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author || {} } />
 				</a>
 				<div className="author-compact-profile__names">
 					{ hasAuthorName && ! hasMatchingAuthorAndSiteNames && (

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -528,7 +528,7 @@ export class FullPostView extends Component {
 						{ isDefaultLayout && (
 							<div className="reader-full-post__sidebar">
 								{ isLoading && <AuthorCompactProfile author={ null } /> }
-								{ ! isLoading && post.author && (
+								{ ! isLoading && (
 									<AuthorCompactProfile
 										author={ post.author }
 										siteIcon={ get( site, 'icon.img' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* This PR updates the `AuthorCompactProfile` to work when the `author` prop is missing. Essentially, it will now render as much as it can without the `author` prop.

Note that the feed icon still defaults to the globe icon. This can be improved, but the fix appears non-trivial, so I'm saving it for a future PR.

Before | After
--|--
<img width="1054" alt="Screenshot 2024-11-07 at 3 16 36 PM" src="https://github.com/user-attachments/assets/3f5b52a7-d638-4e24-b00e-937b7b2bdb05">  | <img width="1058" alt="Screenshot 2024-11-07 at 3 16 43 PM" src="https://github.com/user-attachments/assets/92e742b8-f7a6-46ed-b6ca-96295ae95102">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improving the Reader experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live and go to /read/feeds/66240748/posts/5446187041 and view the author/site profile section in different browser widths.
* Go to a wpcom site like /read/feeds/37010753/posts/5446764158 and view the author/site profile section in different browser widths.
* Try some other sites and posts to check for regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
