### PR TITLE
Fixed plugin count on the old interface

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -10,7 +10,7 @@ import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/vie
 import { Icon, upload } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { filter as lodashFilter, capitalize, flow, isEmpty } from 'lodash';
+import { filter as capitalize, flow, isEmpty } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -424,7 +424,7 @@ export class PluginsMain extends Component {
 				header={ this.props.translate( 'Manage Plugins' ) }
 				plugins={ currentPlugins }
 				isPlaceholder={ this.shouldShowPluginListPlaceholders() }
-				isLoading={ this.props.requestingPluginsForSites || this.props.isLoadingSites }
+				isLoading={ this.props.requestingPluginsForSites }
 				isJetpackCloud={ this.props.isJetpackCloud }
 				searchTerm={ search }
 				filter={ this.props.filter }
@@ -624,7 +624,6 @@ export default flow(
 			const siteIds = siteObjectsToSiteIds( sites ) ?? [];
 			const isLoadingSites = isRequestingSites( state );
 			const allPlugins = getPlugins( state, siteIds, 'all' );
-			const pluginsWithUpdates = lodashFilter( allPlugins, 'updates' );
 			const pluginsWithUpdatesAndStatuses = getPluginsWithUpdateStatuses( state, allPlugins );
 
 			const jetpackNonAtomic =
@@ -659,8 +658,6 @@ export default flow(
 				currentPluginsOnVisibleSites: newBulkPluginManagement
 					? []
 					: getPlugins( state, siteObjectsToSiteIds( getVisibleSites( sites ) ) ?? [], filter ),
-				pluginsWithUpdates,
-				pluginUpdateCount: pluginsWithUpdates && pluginsWithUpdates.length,
 				allPluginsCount: allPlugins && allPlugins.length,
 				requestingPluginsForSites:
 					isRequestingForSites( state, siteIds ) || isRequestingForAllSites( state ),
@@ -675,6 +672,9 @@ export default flow(
 				breadcrumbs,
 				requestPluginsError: requestPluginsError( state ),
 				newBulkPluginManagement,
+				pluginUpdateCount: newBulkPluginManagement
+					? 0
+					: getPlugins( state, siteIds, 'updates' )?.length,
 			};
 		},
 		{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9681

## Proposed Changes

* Follow-up from a previous update that removed the plugin count

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
