### PR TITLE
Reader Recent Feed Overhaul: Fix feed icon on `recent` full post layout

### DIFF
--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -33,10 +33,10 @@ const ReaderFullPostHeader = ( { post, authorProfile, layout } ) => {
 	}
 
 	// Rather than pass in additional props for the `recent` layout, we extract the props we need from authorProfile.
-	const { props: { author, siteIcon, feedIcon, siteName, followCount } = {} } = authorProfile || {};
+	const { props: { siteName, followCount } = {} } = authorProfile || {};
 
 	const isDefaultLayout = layout === 'default';
-	const iconSrc = author?.avatar_URL || siteIcon || feedIcon;
+	const iconSrc = post?.site_icon?.img || post?.author?.avatar_URL;
 
 	/* eslint-disable react/jsx-no-target-blank */
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/96152

## Proposed Changes

* This PR pulls the site icon like https://github.com/Automattic/wp-calypso/pull/96152 and fixes some missing feed icons.

Before | After
--|--
<img width="1723" alt="Screenshot 2024-11-07 at 4 02 27 PM" src="https://github.com/user-attachments/assets/ee1d27fc-00b4-4e11-b24f-067c94656f85"> | <img width="1724" alt="Screenshot 2024-11-07 at 4 02 00 PM" src="https://github.com/user-attachments/assets/e66e9fc2-5391-4f77-bbfa-4103af17e838">

  
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix missing icon and match the middle column.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/recent-feed-overhaul
* Check that site icons load in the full post view and match the icon in the middle column.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
