### PR TITLE
Reader Recent Feed Overhaul: Handle navigation and improve site selection UX

### DIFF
--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import React, { useState } from 'react';
@@ -49,6 +50,7 @@ const ReaderSidebarRecent = ( {
 	const selectedSiteId = useSelector< AppState, number >(
 		( state ) => state.readerUi.sidebar.selectedRecentSite
 	);
+	const dispatch = useDispatch();
 
 	const sitesToShow = showAllSites ? sites : sites.slice( 0, SITE_DISPLAY_CUTOFF );
 	const totalUnseenCount = sites.reduce( ( total, site ) => total + site.unseen_count, 0 );
@@ -57,9 +59,11 @@ const ReaderSidebarRecent = ( {
 		setShowAllSites( ! showAllSites );
 	};
 
-	const dispatch = useDispatch();
 	const selectSite = ( feedId: number | null ) => {
 		dispatch( selectSidebarRecentSite( { feedId } ) );
+		if ( ! RECENT_PATH_REGEX.test( path ) ) {
+			page( '/read' );
+		}
 	};
 
 	return (

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -47,13 +47,24 @@ const ReaderSidebarRecent = ( {
 }: Props ): React.JSX.Element => {
 	const [ showAllSites, setShowAllSites ] = useState( false );
 	const sites = useSelector< AppState, Site[] >( getReaderFollowedSites );
-	const selectedSiteId = useSelector< AppState, number >(
+	const selectedSiteFeedId = useSelector< AppState, number >(
 		( state ) => state.readerUi.sidebar.selectedRecentSite
 	);
 	const dispatch = useDispatch();
 
-	const sitesToShow = showAllSites ? sites : sites.slice( 0, SITE_DISPLAY_CUTOFF );
+	let sitesToShow = showAllSites ? sites : sites.slice( 0, SITE_DISPLAY_CUTOFF );
 	const totalUnseenCount = sites.reduce( ( total, site ) => total + site.unseen_count, 0 );
+
+	const selectedSite = sites.find( ( site ) => site.feed_ID === selectedSiteFeedId );
+	if ( selectedSite && ! sitesToShow.includes( selectedSite ) ) {
+		sitesToShow = [ ...sitesToShow, selectedSite ];
+	}
+
+	const shouldShowViewMoreButton =
+		sites.length > SITE_DISPLAY_CUTOFF &&
+		( showAllSites ||
+			sitesToShow.length < sites.length ||
+			sitesToShow[ sitesToShow.length - 1 ].feed_ID !== selectedSiteFeedId );
 
 	const toggleShowAllSites = () => {
 		setShowAllSites( ! showAllSites );
@@ -86,7 +97,7 @@ const ReaderSidebarRecent = ( {
 					className={ clsx(
 						'reader-sidebar-recent__item reader-sidebar-recent__item--without-icon',
 						{
-							'reader-sidebar-recent__item--selected': selectedSiteId === null,
+							'reader-sidebar-recent__item--selected': selectedSiteFeedId === null,
 						}
 					) }
 					onClick={ () => selectSite( null ) }
@@ -99,7 +110,7 @@ const ReaderSidebarRecent = ( {
 				<li key={ site.ID }>
 					<button
 						className={ clsx( 'reader-sidebar-recent__item', {
-							'reader-sidebar-recent__item--selected': site.feed_ID === selectedSiteId,
+							'reader-sidebar-recent__item--selected': site.feed_ID === selectedSiteFeedId,
 						} ) }
 						onClick={ () => selectSite( site.feed_ID ) }
 					>
@@ -111,7 +122,7 @@ const ReaderSidebarRecent = ( {
 					</button>
 				</li>
 			) ) }
-			{ sites.length > SITE_DISPLAY_CUTOFF && (
+			{ shouldShowViewMoreButton && (
 				<li>
 					<button
 						className="reader-sidebar-recent__item reader-sidebar-recent__item--without-icon reader-sidebar-recent__view-more"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/loop#190

## Proposed Changes

* Clicking on a site will navigate to /read if the user is at a different path
* Always show the selected site even if it's "beyond" the cutoff point and the section is collapsed

https://github.com/user-attachments/assets/54c2a1cb-280b-4c7d-bb5d-8b8105fe04a3


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2iv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/read?flags=reader/recent-feed-overhaul`
* Navigate to another section of the site
* Click on a site in the Recent sidebar section
* You should navigate to `/read` (note: the feed filtering is not implemented yet)
* If you are on `/read` and click a site, you should not navigate, i.e. your browser history should not have multiple `/read` entries.

* If you have less than 8 subscribed sites, no view more link should render
* If you have more than 8, it should render
* If you select a site beyond the cutoff point and select "view less" the selected site should become the last visible site
* If you select a site before the cutoff point, the selected site should disappear and the view more link should render

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
