### PR TITLE
Help Center: History and New Conversation in footer

### DIFF
--- a/packages/help-center/src/components/help-center-chat-history.tsx
+++ b/packages/help-center/src/components/help-center-chat-history.tsx
@@ -68,7 +68,12 @@ export const HelpCenterChatHistory = () => {
 	const [ conversations, setConversations ] = useState< ZendeskConversation[] >( [] );
 	const [ selectedTab, setSelectedTab ] = useState( TAB_STATES.recent );
 	const { getConversations } = useSmooch();
-	const { data: supportInteractions } = useGetSupportInteractions( 'zendesk', 100, 'resolved' );
+	const { data: supportInteractionsResolved } = useGetSupportInteractions(
+		'zendesk',
+		100,
+		'resolved'
+	);
+	const { data: supportInteractionsOpen } = useGetSupportInteractions( 'zendesk', 10, 'open' );
 
 	const { isChatLoaded, unreadCount } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
@@ -87,10 +92,16 @@ export const HelpCenterChatHistory = () => {
 		if (
 			isChatLoaded &&
 			getConversations &&
-			supportInteractions &&
-			supportInteractions?.length > 0
+			supportInteractionsResolved &&
+			supportInteractionsOpen &&
+			supportInteractionsResolved?.length > 0 &&
+			supportInteractionsOpen?.length > 0
 		) {
 			const conversations = getConversations();
+			const supportInteractions = [
+				...( supportInteractionsResolved || [] ),
+				...( supportInteractionsOpen || [] ),
+			];
 
 			const filteredConversations = getConversationsFromSupportInteractions(
 				conversations,
@@ -98,7 +109,13 @@ export const HelpCenterChatHistory = () => {
 			);
 			setConversations( filteredConversations );
 		}
-	}, [ supportInteractions, isChatLoaded, getConversations, setUnreadCount ] );
+	}, [
+		supportInteractionsResolved,
+		supportInteractionsOpen,
+		isChatLoaded,
+		getConversations,
+		setUnreadCount,
+	] );
 
 	const EmptyArchivedConversations = () => {
 		return (

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -7,7 +7,6 @@ import { getPlan } from '@automattic/calypso-products';
 import { Spinner, GMClosureNotice } from '@automattic/components';
 import { HelpCenterSite } from '@automattic/data-stores';
 import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
-import { useOdieAssistantContext } from '@automattic/odie-client';
 import { useGetSupportInteractions } from '@automattic/odie-client/src/data';
 import { useLoadZendeskMessaging } from '@automattic/zendesk-client';
 import { useEffect, useMemo } from '@wordpress/element';
@@ -23,6 +22,7 @@ import { Link } from 'react-router-dom';
 import { EMAIL_SUPPORT_LOCALES } from '../constants';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useChatStatus, useShouldRenderEmailOption, useStillNeedHelpURL } from '../hooks';
+import { useResetSupportInteraction } from '../hooks/use-reset-support-interaction';
 import { Mail } from '../icons';
 import HelpCenterContactSupportOption from './help-center-contact-support-option';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';
@@ -242,7 +242,7 @@ const HelpCenterFooterButton = ( {
 export const HelpCenterContactButton: FC = () => {
 	const { __ } = useI18n();
 	const { data: supportInteractions } = useGetSupportInteractions( 'zendesk', 100, 'resolved' );
-	const { clearChat } = useOdieAssistantContext();
+	const resetSupportInteraction = useResetSupportInteraction();
 
 	return supportInteractions && supportInteractions?.length > 0 ? (
 		<>
@@ -251,7 +251,7 @@ export const HelpCenterContactButton: FC = () => {
 				buttonTextEventProp="New conversation"
 				redirectTo="/odie"
 				onClick={ () => {
-					clearChat();
+					resetSupportInteraction();
 				} }
 			>
 				{ __( 'New conversation', __i18n_text_domain__ ) }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -7,13 +7,15 @@ import { getPlan } from '@automattic/calypso-products';
 import { Spinner, GMClosureNotice } from '@automattic/components';
 import { HelpCenterSite } from '@automattic/data-stores';
 import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
+import { useOdieAssistantContext } from '@automattic/odie-client';
+import { useGetSupportInteractions } from '@automattic/odie-client/src/data';
 import { useLoadZendeskMessaging } from '@automattic/zendesk-client';
 import { useEffect, useMemo } from '@wordpress/element';
 import { hasTranslation, sprintf } from '@wordpress/i18n';
-import { comment, Icon } from '@wordpress/icons';
+import { backup, comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { FC } from 'react';
+import { FC, ReactNode, ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 /**
  * Internal Dependencies
@@ -178,36 +180,97 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	);
 };
 
-export const HelpCenterContactButton: FC = () => {
-	const { __ } = useI18n();
+const HelpCenterFooterButton = ( {
+	children,
+	buttonTextEventProp,
+	redirectTo,
+	icon,
+	onClick,
+}: {
+	children: ReactNode;
+	buttonTextEventProp: string;
+	redirectTo: string;
+	icon: ReactElement;
+	onClick?: () => void;
+} ) => {
 	const { url, isLoading } = useStillNeedHelpURL();
 	const helpCenterContext = useHelpCenterContext();
 	const sectionName = helpCenterContext.sectionName;
 	const redirectToWpcom = url === 'https://wordpress.com/help/contact';
 
-	const trackContactButtonClicked = () => {
+	const handleContactButtonClicked = ( {
+		buttonTextEventProp,
+	}: {
+		buttonTextEventProp: string;
+	} ) => {
 		recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
 			force_site_id: true,
 			location: 'help-center',
 			section: sectionName,
+			button_type: buttonTextEventProp,
 		} );
 	};
 
-	let to = redirectToWpcom ? { pathname: url } : url;
+	const redirectionURL = () => {
+		if ( buttonTextEventProp === 'Still need help?' ) {
+			if ( isLoading ) {
+				return '';
+			}
+			return redirectToWpcom ? { pathname: url } : url;
+		}
+		return redirectTo;
+	};
 
-	if ( isLoading ) {
-		to = '';
-	}
+	const handleClick = () => {
+		handleContactButtonClicked( { buttonTextEventProp: buttonTextEventProp } );
+		onClick?.();
+	};
 
 	return (
 		<Link
-			to={ to }
+			to={ redirectionURL() }
 			target={ redirectToWpcom ? '_blank' : '_self' }
-			onClick={ trackContactButtonClicked }
+			onClick={ handleClick }
 			className="button help-center-contact-page__button"
 		>
-			<Icon icon={ comment } />
-			<span>{ __( 'Still need help?', __i18n_text_domain__ ) }</span>
+			<Icon icon={ icon } />
+			{ children }
 		</Link>
+	);
+};
+
+export const HelpCenterContactButton: FC = () => {
+	const { __ } = useI18n();
+	const { data: supportInteractions } = useGetSupportInteractions( 'zendesk', 100, 'resolved' );
+	const { clearChat } = useOdieAssistantContext();
+
+	return supportInteractions && supportInteractions?.length > 0 ? (
+		<>
+			<HelpCenterFooterButton
+				icon={ comment }
+				buttonTextEventProp="New conversation"
+				redirectTo="/odie"
+				onClick={ () => {
+					clearChat();
+				} }
+			>
+				{ __( 'New conversation', __i18n_text_domain__ ) }
+			</HelpCenterFooterButton>
+			<HelpCenterFooterButton
+				icon={ backup }
+				buttonTextEventProp="History"
+				redirectTo="/chat-history"
+			>
+				{ __( 'History', __i18n_text_domain__ ) }
+			</HelpCenterFooterButton>
+		</>
+	) : (
+		<HelpCenterFooterButton
+			icon={ comment }
+			buttonTextEventProp="Still need help?"
+			redirectTo="/odie"
+		>
+			<span>{ __( 'Still need help?', __i18n_text_domain__ ) }</span>
+		</HelpCenterFooterButton>
 	);
 };

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -3,6 +3,7 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { getPlan } from '@automattic/calypso-products';
 import { Spinner, GMClosureNotice } from '@automattic/components';
 import { HelpCenterSite } from '@automattic/data-stores';
@@ -245,7 +246,9 @@ export const HelpCenterContactButton: FC = () => {
 	const { __ } = useI18n();
 	const { data: supportInteractions } = useGetSupportInteractions( 'zendesk', 100, 'resolved' );
 
-	return supportInteractions && supportInteractions?.length > 0 ? (
+	return config.isEnabled( 'help-center-experience' ) &&
+		supportInteractions &&
+		supportInteractions?.length > 0 ? (
 		<>
 			<HelpCenterFooterButton
 				icon={ comment }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -23,8 +23,6 @@ import { Link, useNavigate } from 'react-router-dom';
 import { EMAIL_SUPPORT_LOCALES } from '../constants';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useChatStatus, useShouldRenderEmailOption, useStillNeedHelpURL } from '../hooks';
-import { useResetSupportInteraction } from '../hooks/use-reset-support-interaction';
-import { useStartSupportInteraction } from '../hooks/use-start-support-interaction';
 import { Mail } from '../icons';
 import HelpCenterContactSupportOption from './help-center-contact-support-option';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -198,8 +198,6 @@ const HelpCenterFooterButton = ( {
 	const sectionName = helpCenterContext.sectionName;
 	const redirectToWpcom = url === 'https://wordpress.com/help/contact';
 	const navigate = useNavigate();
-	const resetSupportInteraction = useResetSupportInteraction();
-	const startSupportInteraction = useStartSupportInteraction();
 	const [ isCreatingChat, setIsCreatingChat ] = useState( false );
 	const handleContactButtonClicked = ( {
 		buttonTextEventProp,
@@ -228,11 +226,6 @@ const HelpCenterFooterButton = ( {
 		setIsCreatingChat( true );
 		handleContactButtonClicked( { buttonTextEventProp: buttonTextEventProp } );
 
-		if ( redirectTo === '/odie' ) {
-			await resetSupportInteraction();
-			await startSupportInteraction();
-		}
-
 		setIsCreatingChat( false );
 		const url = redirectionURL();
 		navigate( url );
@@ -258,10 +251,10 @@ export const HelpCenterContactButton: FC = () => {
 		<>
 			<HelpCenterFooterButton
 				icon={ comment }
-				buttonTextEventProp="New conversation"
+				buttonTextEventProp="Still need help?"
 				redirectTo="/odie"
 			>
-				{ __( 'New conversation', __i18n_text_domain__ ) }
+				<span>{ __( 'Still need help?', __i18n_text_domain__ ) }</span>
 			</HelpCenterFooterButton>
 			<HelpCenterFooterButton
 				icon={ backup }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -7,7 +7,10 @@ import { getPlan } from '@automattic/calypso-products';
 import { Spinner, GMClosureNotice } from '@automattic/components';
 import { HelpCenterSite } from '@automattic/data-stores';
 import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
-import { useGetSupportInteractions } from '@automattic/odie-client/src/data';
+import {
+	useGetSupportInteractions,
+	useManageSupportInteraction,
+} from '@automattic/odie-client/src/data';
 import { useLoadZendeskMessaging } from '@automattic/zendesk-client';
 import { useEffect, useMemo } from '@wordpress/element';
 import { hasTranslation, sprintf } from '@wordpress/i18n';
@@ -16,6 +19,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { FC, ReactNode, ReactElement } from 'react';
 import { Link } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
 /**
  * Internal Dependencies
  */
@@ -243,6 +247,7 @@ export const HelpCenterContactButton: FC = () => {
 	const { __ } = useI18n();
 	const { data: supportInteractions } = useGetSupportInteractions( 'zendesk', 100, 'resolved' );
 	const resetSupportInteraction = useResetSupportInteraction();
+	const { startNewInteraction } = useManageSupportInteraction();
 
 	return supportInteractions && supportInteractions?.length > 0 ? (
 		<>
@@ -250,8 +255,12 @@ export const HelpCenterContactButton: FC = () => {
 				icon={ comment }
 				buttonTextEventProp="New conversation"
 				redirectTo="/odie"
-				onClick={ () => {
-					resetSupportInteraction();
+				onClick={ async () => {
+					await resetSupportInteraction();
+					await startNewInteraction( {
+						event_source: 'help-center',
+						event_external_id: uuidv4(),
+					} );
 				} }
 			>
 				{ __( 'New conversation', __i18n_text_domain__ ) }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -7,19 +7,16 @@ import { getPlan } from '@automattic/calypso-products';
 import { Spinner, GMClosureNotice } from '@automattic/components';
 import { HelpCenterSite } from '@automattic/data-stores';
 import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
-import {
-	useGetSupportInteractions,
-	useManageSupportInteraction,
-} from '@automattic/odie-client/src/data';
+import { useGetSupportInteractions } from '@automattic/odie-client/src/data';
 import { useLoadZendeskMessaging } from '@automattic/zendesk-client';
+import { Button } from '@wordpress/components';
 import { useEffect, useMemo } from '@wordpress/element';
 import { hasTranslation, sprintf } from '@wordpress/i18n';
 import { backup, comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { FC, ReactNode, ReactElement } from 'react';
-import { Link } from 'react-router-dom';
-import { v4 as uuidv4 } from 'uuid';
+import { Link, useNavigate } from 'react-router-dom';
 /**
  * Internal Dependencies
  */
@@ -27,6 +24,7 @@ import { EMAIL_SUPPORT_LOCALES } from '../constants';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useChatStatus, useShouldRenderEmailOption, useStillNeedHelpURL } from '../hooks';
 import { useResetSupportInteraction } from '../hooks/use-reset-support-interaction';
+import { useStartSupportInteraction } from '../hooks/use-start-support-interaction';
 import { Mail } from '../icons';
 import HelpCenterContactSupportOption from './help-center-contact-support-option';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';
@@ -189,18 +187,19 @@ const HelpCenterFooterButton = ( {
 	buttonTextEventProp,
 	redirectTo,
 	icon,
-	onClick,
 }: {
 	children: ReactNode;
 	buttonTextEventProp: string;
 	redirectTo: string;
 	icon: ReactElement;
-	onClick?: () => void;
 } ) => {
 	const { url, isLoading } = useStillNeedHelpURL();
 	const helpCenterContext = useHelpCenterContext();
 	const sectionName = helpCenterContext.sectionName;
 	const redirectToWpcom = url === 'https://wordpress.com/help/contact';
+	const navigate = useNavigate();
+	const resetSupportInteraction = useResetSupportInteraction();
+	const startSupportInteraction = useStartSupportInteraction();
 
 	const handleContactButtonClicked = ( {
 		buttonTextEventProp,
@@ -225,29 +224,34 @@ const HelpCenterFooterButton = ( {
 		return redirectTo;
 	};
 
-	const handleClick = () => {
+	const handleClick = async ( e ) => {
+		e.preventDefault();
 		handleContactButtonClicked( { buttonTextEventProp: buttonTextEventProp } );
-		onClick?.();
+
+		if ( redirectTo === '/odie' ) {
+			await resetSupportInteraction();
+			await startSupportInteraction();
+		}
+
+		const url = redirectionURL();
+		if ( redirectToWpcom ) {
+			// window.open( url, '_blank' );
+		} else {
+			navigate( url );
+		}
 	};
 
 	return (
-		<Link
-			to={ redirectionURL() }
-			target={ redirectToWpcom ? '_blank' : '_self' }
-			onClick={ handleClick }
-			className="button help-center-contact-page__button"
-		>
+		<Button onClick={ handleClick } className="button help-center-contact-page__button">
 			<Icon icon={ icon } />
 			{ children }
-		</Link>
+		</Button>
 	);
 };
 
 export const HelpCenterContactButton: FC = () => {
 	const { __ } = useI18n();
 	const { data: supportInteractions } = useGetSupportInteractions( 'zendesk', 100, 'resolved' );
-	const resetSupportInteraction = useResetSupportInteraction();
-	const { startNewInteraction } = useManageSupportInteraction();
 
 	return supportInteractions && supportInteractions?.length > 0 ? (
 		<>
@@ -255,13 +259,6 @@ export const HelpCenterContactButton: FC = () => {
 				icon={ comment }
 				buttonTextEventProp="New conversation"
 				redirectTo="/odie"
-				onClick={ async () => {
-					await resetSupportInteraction();
-					await startNewInteraction( {
-						event_source: 'help-center',
-						event_external_id: uuidv4(),
-					} );
-				} }
 			>
 				{ __( 'New conversation', __i18n_text_domain__ ) }
 			</HelpCenterFooterButton>

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -10,7 +10,7 @@ import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-uti
 import { useGetSupportInteractions } from '@automattic/odie-client/src/data';
 import { useLoadZendeskMessaging } from '@automattic/zendesk-client';
 import { Button } from '@wordpress/components';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { hasTranslation, sprintf } from '@wordpress/i18n';
 import { backup, comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -200,7 +200,7 @@ const HelpCenterFooterButton = ( {
 	const navigate = useNavigate();
 	const resetSupportInteraction = useResetSupportInteraction();
 	const startSupportInteraction = useStartSupportInteraction();
-
+	const [ isCreatingChat, setIsCreatingChat ] = useState( false );
 	const handleContactButtonClicked = ( {
 		buttonTextEventProp,
 	}: {
@@ -224,8 +224,8 @@ const HelpCenterFooterButton = ( {
 		return redirectTo;
 	};
 
-	const handleClick = async ( e ) => {
-		e.preventDefault();
+	const handleClick = async () => {
+		setIsCreatingChat( true );
 		handleContactButtonClicked( { buttonTextEventProp: buttonTextEventProp } );
 
 		if ( redirectTo === '/odie' ) {
@@ -233,16 +233,17 @@ const HelpCenterFooterButton = ( {
 			await startSupportInteraction();
 		}
 
+		setIsCreatingChat( false );
 		const url = redirectionURL();
-		if ( redirectToWpcom ) {
-			// window.open( url, '_blank' );
-		} else {
-			navigate( url );
-		}
+		navigate( url );
 	};
 
 	return (
-		<Button onClick={ handleClick } className="button help-center-contact-page__button">
+		<Button
+			onClick={ handleClick }
+			disabled={ isCreatingChat }
+			className="button help-center-contact-page__button"
+		>
 			<Icon icon={ icon } />
 			{ children }
 		</Button>

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -6,18 +6,10 @@ import { useManageSupportInteraction } from '@automattic/odie-client/src/data';
 import { CardHeader, Button, Flex } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useMemo, useCallback } from '@wordpress/element';
-import {
-	backup,
-	closeSmall,
-	chevronUp,
-	lineSolid,
-	commentContent,
-	page,
-	Icon,
-} from '@wordpress/icons';
+import { closeSmall, chevronUp, lineSolid, commentContent, page, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { Route, Routes, useLocation, useSearchParams, useNavigate } from 'react-router-dom';
+import { Route, Routes, useLocation, useSearchParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { usePostByUrl } from '../hooks';
@@ -104,26 +96,22 @@ const ChatEllipsisMenu = () => {
 
 const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
 	const { __ } = useI18n();
-	const navigate = useNavigate();
 	const { pathname, key } = useLocation();
 
 	const shouldUseHelpCenterExperience = config.isEnabled( 'help-center-experience' );
 	const shouldDisplayClearChatButton =
 		shouldUseHelpCenterExperience && pathname.startsWith( '/odie' );
-	const shouldDisplayChatHistoryButton =
-		shouldUseHelpCenterExperience && pathname !== '/chat-history' && pathname !== '/odie';
-
 	const isHelpCenterHome = key === 'default';
 
 	const headerText = useMemo( () => {
 		if ( pathname.startsWith( '/odie' ) ) {
-			return config.isEnabled( 'help-center-experience' )
+			return shouldUseHelpCenterExperience
 				? __( 'Support Assistant', __i18n_text_domain__ )
 				: __( 'Wapuu', __i18n_text_domain__ );
 		}
 		switch ( pathname ) {
 			case '/contact-form':
-				return config.isEnabled( 'help-center-experience' )
+				return shouldUseHelpCenterExperience
 					? __( 'Support Assistant', __i18n_text_domain__ )
 					: __( 'Wapuu', __i18n_text_domain__ );
 			case '/chat-history':
@@ -140,16 +128,6 @@ const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
 				{ headerText }
 			</span>
 			{ shouldDisplayClearChatButton && <ChatEllipsisMenu /> }
-			{ shouldDisplayChatHistoryButton && (
-				<Button
-					className="help-center-header__chat-history"
-					label={ __( 'Chat history', __i18n_text_domain__ ) }
-					icon={ backup }
-					tooltipPosition="top left"
-					onClick={ () => navigate( '/chat-history' ) }
-					onTouchStart={ () => navigate( '/chat-history' ) }
-				/>
-			) }
 			<Button
 				className="help-center-header__minimize"
 				label={ __( 'Minimize Help Center', __i18n_text_domain__ ) }

--- a/packages/help-center/src/components/help-center-recent-conversations.tsx
+++ b/packages/help-center/src/components/help-center-recent-conversations.tsx
@@ -27,7 +27,12 @@ const HelpCenterRecentConversations: React.FC = () => {
 	const [ conversations, setConversations ] = useState< ZendeskConversation[] >( [] );
 	const [ unreadConversationsCount, setUnreadConversationsCount ] = useState( 0 );
 	const [ unreadMessagesCount, setUnreadMessagesCount ] = useState( 0 );
-	const { data: supportInteractions } = useGetSupportInteractions( 'zendesk', 100, 'resolved' );
+	const { data: supportInteractionsResolved } = useGetSupportInteractions(
+		'zendesk',
+		100,
+		'resolved'
+	);
+	const { data: supportInteractionsOpen } = useGetSupportInteractions( 'zendesk', 100, 'open' );
 	const { isChatLoaded } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return { isChatLoaded: store.getIsChatLoaded() };
@@ -36,8 +41,17 @@ const HelpCenterRecentConversations: React.FC = () => {
 	const { setUnreadCount } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	useEffect( () => {
-		if ( isChatLoaded && getConversations && supportInteractions ) {
+		if (
+			isChatLoaded &&
+			getConversations &&
+			supportInteractionsResolved &&
+			supportInteractionsOpen
+		) {
 			const allConversations = getConversations();
+			const supportInteractions = [
+				...( supportInteractionsResolved || [] ),
+				...( supportInteractionsOpen || [] ),
+			];
 			const conversations = getConversationsFromSupportInteractions(
 				allConversations,
 				supportInteractions
@@ -48,7 +62,13 @@ const HelpCenterRecentConversations: React.FC = () => {
 			setConversations( conversations );
 			setUnreadCount( unreadConversations );
 		}
-	}, [ isChatLoaded, getConversations, setUnreadCount, supportInteractions ] );
+	}, [
+		isChatLoaded,
+		getConversations,
+		setUnreadCount,
+		supportInteractionsResolved,
+		supportInteractionsOpen,
+	] );
 
 	if ( ! conversations.length ) {
 		return null;

--- a/packages/help-center/src/hooks/use-start-support-interaction.ts
+++ b/packages/help-center/src/hooks/use-start-support-interaction.ts
@@ -1,0 +1,24 @@
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { useManageSupportInteraction } from '@automattic/odie-client/src/data';
+import { useQueryClient } from '@tanstack/react-query';
+import { useDispatch } from '@wordpress/data';
+import { v4 as uuidv4 } from 'uuid';
+
+export const useStartSupportInteraction = () => {
+	const { setCurrentSupportInteraction } = useDispatch( HELP_CENTER_STORE );
+	const { startNewInteraction } = useManageSupportInteraction();
+	const queryClient = useQueryClient();
+
+	const startInteraction = async () => {
+		const interaction = await startNewInteraction( {
+			event_source: 'help-center',
+			event_external_id: uuidv4(),
+		} );
+		await queryClient.invalidateQueries( {
+			queryKey: [ 'support-interactions', 'get-interactions', 'help-center' ],
+		} );
+		setCurrentSupportInteraction( interaction );
+	};
+
+	return startInteraction;
+};

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -130,6 +130,7 @@ $blueberry-color: #3858e9;
 
 .odie-chatbox-message p:last-of-type {
 	margin-bottom: 0;
+	padding-bottom: 0;
 }
 
 .odie-chatbox-message.odie-chatbox-message-user > :last-child {

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -113,7 +113,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 		trackEvent( 'chat_cleared', {} );
 		setMainChatState( emptyChat );
 		resetSupportInteraction();
-	}, [ trackEvent, resetSupportInteraction ] );
+	}, [ trackEvent, resetSupportInteraction, setMainChatState ] );
 
 	const [ waitAnswerToFirstMessageFromHumanSupport, setWaitAnswerToFirstMessageFromHumanSupport ] =
 		useState( getHelpCenterZendeskConversationStarted() !== null );

--- a/packages/odie-client/src/data/use-get-support-interactions.ts
+++ b/packages/odie-client/src/data/use-get-support-interactions.ts
@@ -16,7 +16,7 @@ export const useGetSupportInteractions = (
 
 	return useQuery( {
 		// eslint-disable-next-line
-		queryKey: [ 'support-interactions', 'get-interactions', provider ],
+		queryKey: [ 'support-interactions', 'get-interactions', provider, status ],
 		queryFn: async () => {
 			const response = await handleSupportInteractionsFetch( 'GET', path );
 

--- a/test/e2e/specs/help-center/help-center__calypso.ts
+++ b/test/e2e/specs/help-center/help-center__calypso.ts
@@ -132,7 +132,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )( 'Help Center in Calyp
 	 */
 	describe( 'Support Flow', () => {
 		it( 'start support flow', async () => {
-			const stillNeedHelpButton = helpCenterLocator.getByRole( 'link', {
+			const stillNeedHelpButton = helpCenterLocator.getByRole( 'button', {
 				name: 'Still need help?',
 			} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9641

## Proposed Changes

Add New conversation and History contact buttons
New conversation - starts a new chat
History - redirects user to chat history page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Allows users to start a new chat or view their chat history.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Navigate to /home?flags=help-center-experience
* Open the Help Center, verify the two new buttons appear, test their functionality and styling.

