### PR TITLE
Performance Profiler: fix mobile header

### DIFF
--- a/client/performance-profiler/components/header/style.scss
+++ b/client/performance-profiler/components/header/style.scss
@@ -117,6 +117,10 @@
 			justify-content: space-between;
 		}
 
+		.section-nav-tabs {
+			width: auto;
+		}
+
 		.section-nav-tabs__list {
 			// Add padding to display the rounded border and remove the same distance to keep it aligned vertically
 			padding-left: 6px;

--- a/client/performance-profiler/components/header/style.scss
+++ b/client/performance-profiler/components/header/style.scss
@@ -117,10 +117,6 @@
 			justify-content: space-between;
 		}
 
-		.section-nav-tabs {
-			width: auto;
-		}
-
 		.section-nav-tabs__list {
 			// Add padding to display the rounded border and remove the same distance to keep it aligned vertically
 			padding-left: 6px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related thread: p1731067531566569-slack-C02JPCHEKDY

## Proposed Changes

* Update the styles to show the header tabs below mobile breakpoint

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The header tabs were updated to be shown instead of a drop-down earlier in https://github.com/Automattic/wp-calypso/pull/94121. However, the tabs were still hidden below a page width of 480px (mobile breakpoint).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/speed-test` and start a new test, or go to a results page eg. 
```
/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MTA3NjV9.og62XXGaCfWagcL2EsvhoJbuIeR9GfCcqYhWd6kVMOg&tab=mobile
```
* Resize the window and test mobile sizes on the browser
* The tabs should not disappear or turn into a dropdown

| Before | After |
|--------|--------|
| ![CleanShot 2024-11-08 at 12 35 07@2x](https://github.com/user-attachments/assets/d20bdab4-94af-45a5-9073-b4da19bb7e8b) | ![CleanShot 2024-11-08 at 12 34 45@2x](https://github.com/user-attachments/assets/81b9164e-0c1a-493f-bc10-2d333ad20a69) | 