### PR TITLE
Added update count at the update available column

### DIFF
--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -5,6 +5,7 @@ import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import QueryDotorgPlugins from 'calypso/components/data/query-dotorg-plugins';
 import { DataViews } from 'calypso/components/dataviews';
+import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
 import { Plugin } from 'calypso/state/plugins/installed/types';
 import { useActions } from './use-actions';
 import { useFields } from './use-fields';
@@ -29,7 +30,10 @@ export default function PluginsListDataViews( {
 	bulkActionDialog,
 }: Props ) {
 	const translate = useTranslate();
-	const fields = useFields( bulkActionDialog );
+	const pluginUpdateCount = currentPlugins.filter(
+		( plugin ) => plugin.status?.includes( PLUGINS_STATUS.UPDATE )
+	).length;
+	const fields = useFields( bulkActionDialog, pluginUpdateCount );
 	const actions = useActions( bulkActionDialog );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( () => ( {

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -33,7 +34,7 @@ export default function PluginsListDataViews( {
 	const pluginUpdateCount = currentPlugins.filter(
 		( plugin ) => plugin.status?.includes( PLUGINS_STATUS.UPDATE )
 	).length;
-	const fields = useFields( bulkActionDialog, pluginUpdateCount );
+	const fields = useFields( bulkActionDialog );
 	const actions = useActions( bulkActionDialog );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( () => ( {
@@ -43,12 +44,56 @@ export default function PluginsListDataViews( {
 		fields: [ 'plugins', 'sites', 'update' ],
 	} ) );
 
+	const [ isFilteringUpdates, setIsFilteringUpdates ] = useState( false );
+
+	const header = (
+		<>
+			<Button
+				isPressed={ isFilteringUpdates }
+				onClick={ () => {
+					if ( isFilteringUpdates ) {
+						setDataViewsState( {
+							...dataViewsState,
+							filters: [],
+						} );
+					} else {
+						setDataViewsState( {
+							...dataViewsState,
+							filters: [
+								{
+									field: 'status',
+									operator: 'isAny',
+									value: [ PLUGINS_STATUS.UPDATE ],
+								},
+							],
+						} );
+					}
+					setIsFilteringUpdates( ! isFilteringUpdates );
+				} }
+			>
+				{ translate( 'Pending update (%s)', { args: [ pluginUpdateCount ] } ) }
+			</Button>
+		</>
+	);
+
 	// When search changes, notify the parent component
 	useEffect( () => {
 		if ( dataViewsState.search !== initialSearch ) {
 			onSearch && onSearch( dataViewsState.search || '' );
 		}
 	}, [ dataViewsState.search, onSearch, initialSearch ] );
+
+	useEffect( () => {
+		if (
+			dataViewsState.filters?.length === 1 &&
+			dataViewsState.filters[ 0 ].field === 'status' &&
+			dataViewsState.filters[ 0 ].value.includes( PLUGINS_STATUS.UPDATE )
+		) {
+			setIsFilteringUpdates( true );
+		} else {
+			setIsFilteringUpdates( false );
+		}
+	}, [ dataViewsState.filters ] );
 
 	const { data, paginationInfo } = useMemo( () => {
 		const result = filterSortAndPaginate( currentPlugins, dataViewsState, fields );
@@ -73,6 +118,7 @@ export default function PluginsListDataViews( {
 				isLoading={ isLoading }
 				paginationInfo={ paginationInfo }
 				defaultLayouts={ defaultLayouts }
+				header={ header }
 			/>
 		</>
 	);

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -9,7 +9,8 @@ import { PluginActions } from '../hooks/types';
 import PluginActionStatus from '../plugin-management-v2/plugin-action-status';
 
 export function useFields(
-	bulkActionDialog: ( action: string, plugins: Array< Plugin > ) => void
+	bulkActionDialog: ( action: string, plugins: Array< Plugin > ) => void,
+	pluginUpdateCount: number
 ) {
 	const fields = useMemo(
 		() => [
@@ -83,7 +84,12 @@ export function useFields(
 			},
 			{
 				id: 'update',
-				label: translate( 'Update available' ),
+				label:
+					pluginUpdateCount > 0
+						? translate( 'Update available (%(count)s)', {
+								args: { count: pluginUpdateCount },
+						  } )
+						: translate( 'Update available' ),
 				getValue: ( { item }: { item: Plugin } ) => {
 					// Used exclusively for sorting
 					return item.status?.includes( PLUGINS_STATUS.UPDATE ) ? 'a' : 'b';
@@ -109,7 +115,7 @@ export function useFields(
 				},
 			},
 		],
-		[ bulkActionDialog ]
+		[ bulkActionDialog, pluginUpdateCount ]
 	);
 
 	return fields;

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -9,8 +9,7 @@ import { PluginActions } from '../hooks/types';
 import PluginActionStatus from '../plugin-management-v2/plugin-action-status';
 
 export function useFields(
-	bulkActionDialog: ( action: string, plugins: Array< Plugin > ) => void,
-	pluginUpdateCount: number
+	bulkActionDialog: ( action: string, plugins: Array< Plugin > ) => void
 ) {
 	const fields = useMemo(
 		() => [
@@ -84,12 +83,7 @@ export function useFields(
 			},
 			{
 				id: 'update',
-				label:
-					pluginUpdateCount > 0
-						? translate( 'Update available (%(count)s)', {
-								args: { count: pluginUpdateCount },
-						  } )
-						: translate( 'Update available' ),
+				label: translate( 'Update available' ),
 				getValue: ( { item }: { item: Plugin } ) => {
 					// Used exclusively for sorting
 					return item.status?.includes( PLUGINS_STATUS.UPDATE ) ? 'a' : 'b';
@@ -115,7 +109,7 @@ export function useFields(
 				},
 			},
 		],
-		[ bulkActionDialog, pluginUpdateCount ]
+		[ bulkActionDialog ]
 	);
 
 	return fields;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9729
pet6gk-1CP-p2.

## Proposed Changes

* We're adding a way for users to quickly see which plugins are available for update:

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/21791a55-595f-4e0d-8053-5523ee6cf4f8">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure you can easily use the filter feature and it works fine with other filters of the page
* Ignore the hover effect of the button, we'll fix that in another iteration

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?