### PR TITLE
e2e: Disable flaky Twitter embed test

### DIFF
--- a/test/e2e/specs/blocks/blocks__core-jetpack-extended.ts
+++ b/test/e2e/specs/blocks/blocks__core-jetpack-extended.ts
@@ -3,7 +3,11 @@
  * @group jetpack-wpcom-integration
  */
 
-import { InstagramBlockFlow, TwitterBlockFlow, BlockFlow } from '@automattic/calypso-e2e';
+import {
+	InstagramBlockFlow,
+	// TwitterBlockFlow,
+	BlockFlow,
+} from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
@@ -11,10 +15,12 @@ const blockFlows: BlockFlow[] = [
 		embedUrl: 'https://www.instagram.com/p/BlDOZMil933/',
 		expectedPostText: 'woocommerce',
 	} ),
-	new TwitterBlockFlow( {
-		embedUrl: 'https://twitter.com/automattic/status/1360312228415700993',
-		expectedTweetText: '@automattic',
-	} ),
+	// Skip Twitter embed test for now, upstream API is being too flaky.
+	// p1730760290984869-slack-C07RS1SCKBK
+	//new TwitterBlockFlow( {
+	//	embedUrl: 'https://twitter.com/automattic/status/1360312228415700993',
+	//	expectedTweetText: '@automattic',
+	//} ),
 ];
 
 createBlockTests( 'Blocks: Jetpack Extended Core Blocks', blockFlows );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Disable Twitter embed test.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This has been increasingly flaky, Twitter's oembed API has been returning 404s for this tweet that definitely exists.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
