### PR TITLE
Reader Recent Feed Overhaul: Enable search, disable sorting, add loading.

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -78,7 +78,8 @@ const Recent = () => {
 			{
 				id: 'post',
 				label: translate( 'Post' ),
-				getValue: ( { item }: { item: ReaderPost } ) => getPostFromItem( item )?.title ?? '',
+				getValue: ( { item }: { item: ReaderPost } ) =>
+					`${ getPostFromItem( item )?.title ?? '' } - ${ item?.site_name ?? '' }`,
 				render: ( { item }: { item: ReaderPost } ) => {
 					return (
 						<RecentPostField

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -134,10 +134,10 @@ const Recent = () => {
 		return filterSortAndPaginate( data?.items ?? [], view, fields );
 	}, [ data?.items, view, fields ] );
 
-	// Fetch the data when the component is mounted and when the view changes.
+	// Fetch the data when the component is mounted.
 	useEffect( () => {
 		fetchData();
-	}, [ fetchData, view ] );
+	}, [ fetchData ] );
 
 	// Set the first item as selected if no item is selected and screen is wide.
 	useEffect( () => {

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -24,6 +24,7 @@ const Recent = () => {
 
 	const [ view, setView ] = useState< View >( {
 		type: 'table',
+		search: '',
 		fields: [ 'seen', 'post' ],
 		perPage: 10,
 		page: 1,
@@ -72,10 +73,12 @@ const Recent = () => {
 					);
 				},
 				enableHiding: false,
+				enableSorting: false,
 			},
 			{
 				id: 'post',
 				label: translate( 'Post' ),
+				getValue: ( { item }: { item: ReaderPost } ) => getPostFromItem( item )?.title ?? '',
 				render: ( { item }: { item: ReaderPost } ) => {
 					return (
 						<RecentPostField
@@ -86,6 +89,8 @@ const Recent = () => {
 					);
 				},
 				enableHiding: false,
+				enableSorting: false,
+				enableGlobalSearch: true,
 			},
 		],
 		[ getPostFromItem, setSelectedItem ]
@@ -128,7 +133,7 @@ const Recent = () => {
 		return filterSortAndPaginate( data?.items ?? [], view, fields );
 	}, [ data?.items, view, fields ] );
 
-	// Fetch the data when the component is mounted.
+	// Fetch the data when the component is mounted and when the view changes.
 	useEffect( () => {
 		fetchData();
 	}, [ fetchData, view ] );
@@ -161,10 +166,12 @@ const Recent = () => {
 								layout: view.layout,
 								perPage: newView.perPage,
 								page: newView.page,
+								search: newView.search,
 							} )
 						}
 						paginationInfo={ paginationInfo }
 						defaultLayouts={ defaultLayouts as SupportedLayouts }
+						isLoading={ data?.isRequesting }
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/193

## Proposed Changes

* Enable search for post titles and site titles (for loaded data only).
* Disable sorting.
* Add loading state.

https://github.com/user-attachments/assets/c83fb856-4f95-4066-a444-fa4135501cd1

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2iv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/read?flags=reader/recent-feed-overhaul`
* Check that you see a loading animation while the data is loading.
* Search by keyword for post titles and site titles (for loaded posts).
* Check that there are no sorting options.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?