### PR TITLE
Help Center: Add spinner while loading chat conversation

### DIFF
--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -1,6 +1,6 @@
 import { getShortDateString } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ThumbsDown } from '../../assets/thumbs-down';
 import { useOdieAssistantContext } from '../../context';
 import { useAutoScroll, useZendeskMessageListener } from '../../hooks';
@@ -39,10 +39,13 @@ interface ChatMessagesProps {
 
 export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	const { chat, shouldUseHelpCenterExperience, botNameSlug } = useOdieAssistantContext();
-
+	const [ chatMessagesLoaded, setChatLoaded ] = useState( false );
 	const messagesContainerRef = useRef< HTMLDivElement >( null );
 	useZendeskMessageListener();
 	useAutoScroll( messagesContainerRef );
+	useEffect( () => {
+		chat.conversationId !== null && setChatLoaded( true );
+	}, [ chat ] );
 
 	// Used to apply the correct styling on messages
 	const isNextMessageFromSameSender = ( currentMessage: string, nextMessage: string ) => {
@@ -53,26 +56,30 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		<>
 			<div className="chatbox-messages" ref={ messagesContainerRef }>
 				{ shouldUseHelpCenterExperience && <ChatDate chat={ chat } /> }
-				<ChatMessage
-					message={ getOdieInitialMessage( botNameSlug, shouldUseHelpCenterExperience ) }
-					key={ 0 }
-					currentUser={ currentUser }
-					isNextMessageFromSameSender={ false }
-					displayChatWithSupportLabel={ false }
-				/>
-				{ chat.conversationId === null && <LoadingChatSpinner /> }
-				{ chat.messages.map( ( message, index ) => (
-					<ChatMessage
-						message={ message }
-						key={ index }
-						currentUser={ currentUser }
-						isNextMessageFromSameSender={ isNextMessageFromSameSender(
-							message.role,
-							chat.messages[ index + 1 ]?.role
-						) }
-						displayChatWithSupportLabel={ message.context?.flags?.show_contact_support_msg }
-					/>
-				) ) }
+				{ chatMessagesLoaded === false && <LoadingChatSpinner /> }
+				{ chatMessagesLoaded && (
+					<>
+						<ChatMessage
+							message={ getOdieInitialMessage( botNameSlug, shouldUseHelpCenterExperience ) }
+							key={ 0 }
+							currentUser={ currentUser }
+							isNextMessageFromSameSender={ false }
+							displayChatWithSupportLabel={ false }
+						/>
+						{ chat.messages.map( ( message, index ) => (
+							<ChatMessage
+								message={ message }
+								key={ index }
+								currentUser={ currentUser }
+								isNextMessageFromSameSender={ isNextMessageFromSameSender(
+									message.role,
+									chat.messages[ index + 1 ]?.role
+								) }
+								displayChatWithSupportLabel={ message.context?.flags?.show_contact_support_msg }
+							/>
+						) ) }
+					</>
+				) }
 				<JumpToRecent containerReference={ messagesContainerRef } />
 				{ chat.status === 'dislike' && shouldUseHelpCenterExperience && <DislikeThumb /> }
 				{ [ 'sending', 'dislike', 'transfer' ].includes( chat.status ) && (

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -56,8 +56,9 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		<>
 			<div className="chatbox-messages" ref={ messagesContainerRef }>
 				{ shouldUseHelpCenterExperience && <ChatDate chat={ chat } /> }
-				{ chatMessagesLoaded === false && <LoadingChatSpinner /> }
-				{ chatMessagesLoaded && (
+				{ shouldUseHelpCenterExperience && chatMessagesLoaded === false && <LoadingChatSpinner /> }
+				{ ( ! shouldUseHelpCenterExperience ||
+					( shouldUseHelpCenterExperience && chatMessagesLoaded ) ) && (
 					<>
 						<ChatMessage
 							message={ getOdieInitialMessage( botNameSlug, shouldUseHelpCenterExperience ) }
@@ -78,15 +79,15 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 								displayChatWithSupportLabel={ message.context?.flags?.show_contact_support_msg }
 							/>
 						) ) }
+						<JumpToRecent containerReference={ messagesContainerRef } />
+						{ chat.status === 'dislike' && shouldUseHelpCenterExperience && <DislikeThumb /> }
+						{ [ 'sending', 'dislike', 'transfer' ].includes( chat.status ) && (
+							<div className="odie-chatbox__action-message">
+								{ chat.status === 'sending' && <ThinkingPlaceholder /> }
+								{ chat.status === 'dislike' && <DislikeFeedbackMessage /> }
+							</div>
+						) }
 					</>
-				) }
-				<JumpToRecent containerReference={ messagesContainerRef } />
-				{ chat.status === 'dislike' && shouldUseHelpCenterExperience && <DislikeThumb /> }
-				{ [ 'sending', 'dislike', 'transfer' ].includes( chat.status ) && (
-					<div className="odie-chatbox__action-message">
-						{ chat.status === 'sending' && <ThinkingPlaceholder /> }
-						{ chat.status === 'dislike' && <DislikeFeedbackMessage /> }
-					</div>
 				) }
 			</div>
 		</>

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -44,8 +44,11 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	useZendeskMessageListener();
 	useAutoScroll( messagesContainerRef );
 	useEffect( () => {
-		chat.conversationId !== null && setChatLoaded( true );
+		chat?.status === 'loaded' && setChatLoaded( true );
 	}, [ chat ] );
+
+	const shouldLoadChat: boolean =
+		! shouldUseHelpCenterExperience || ( shouldUseHelpCenterExperience && chatMessagesLoaded );
 
 	// Used to apply the correct styling on messages
 	const isNextMessageFromSameSender = ( currentMessage: string, nextMessage: string ) => {
@@ -56,9 +59,9 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		<>
 			<div className="chatbox-messages" ref={ messagesContainerRef }>
 				{ shouldUseHelpCenterExperience && <ChatDate chat={ chat } /> }
-				{ shouldUseHelpCenterExperience && chatMessagesLoaded === false && <LoadingChatSpinner /> }
-				{ ( ! shouldUseHelpCenterExperience ||
-					( shouldUseHelpCenterExperience && chatMessagesLoaded ) ) && (
+				{ ! shouldLoadChat ? (
+					<LoadingChatSpinner />
+				) : (
 					<>
 						<ChatMessage
 							message={ getOdieInitialMessage( botNameSlug, shouldUseHelpCenterExperience ) }

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -1,4 +1,5 @@
 import { getShortDateString } from '@automattic/i18n-utils';
+import { Spinner } from '@wordpress/components';
 import { useRef } from 'react';
 import { ThumbsDown } from '../../assets/thumbs-down';
 import { useOdieAssistantContext } from '../../context';
@@ -14,6 +15,13 @@ const DislikeThumb = () => {
 	return (
 		<div className="chatbox-message__dislike-thumb">
 			<ThumbsDown />
+		</div>
+	);
+};
+const LoadingChatSpinner = () => {
+	return (
+		<div className="chatbox-loading-chat__spinner">
+			<Spinner />
 		</div>
 	);
 };
@@ -52,6 +60,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 					isNextMessageFromSameSender={ false }
 					displayChatWithSupportLabel={ false }
 				/>
+				{ chat.conversationId === null && <LoadingChatSpinner /> }
 				{ chat.messages.map( ( message, index ) => (
 					<ChatMessage
 						message={ message }

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -267,13 +267,6 @@ $blueberry-color: #3858e9;
 	margin-bottom: 72px;
 }
 
-.chatbox-loading-chat__spinner {
-	display: flex;
-	width: 100%;
-	justify-content: center;
-	padding: 16px 0;
-}
-
 .odie-sources {
 	display: flex;
 	align-items: center;
@@ -587,17 +580,6 @@ $custom-border-corner-size: 16px;
 	&.next-chat-message-same-sender {
 		padding-bottom: 8px;
 	}
-}
-
-
-.odie-chat__date {
-	display: flex;
-    flex-direction: row;
-    justify-content: center;
-    width: 100%;
-    padding-bottom: 16px;
-    color: var(--studio-gray-50);
-    font-size: 0.75rem;
 }
 
 .odie-chatbox-thinking-icon {

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -269,7 +269,7 @@ $blueberry-color: #3858e9;
 
 .chatbox-loading-chat__spinner {
 	display: flex;
-	width: 10	0%;
+	width: 100%;
 	justify-content: center;
 	padding: 16px 0;
 }

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -267,6 +267,13 @@ $blueberry-color: #3858e9;
 	margin-bottom: 72px;
 }
 
+.chatbox-loading-chat__spinner {
+	display: flex;
+	width: 10	0%;
+	justify-content: center;
+	padding: 16px 0;
+}
+
 .odie-sources {
 	display: flex;
 	align-items: center;

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -50,6 +50,23 @@
 			margin-bottom: 64px;
 		}
 	}
+	
+	.chatbox-loading-chat__spinner {
+		display: flex;
+		width: 100%;
+		justify-content: center;
+		padding: 16px 0;
+	}
+
+	.odie-chat__date {
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
+		width: 100%;
+		padding-bottom: 16px;
+		color: var(--studio-gray-50);
+		font-size: 0.75rem;
+	}
 }
 
 .odie-chatbox-message-dislike-feedback {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9739
Fixes https://github.com/Automattic/dotcom-forge/issues/9739

## Proposed Changes

* While loading the chat conversation, show a loading spinner.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and add the flag `?flags=help-center-experience`
* Navigate to the history chat messages
* Click in any chat, while loading the messages, you should see the spinner.

<img width="417" alt="image" src="https://github.com/user-attachments/assets/db82b9ac-da59-4328-9d4b-e7d0b8d89c09">
 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
