### PR TITLE
Odie Client: hide contact button after clicking

### DIFF
--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -6,7 +6,8 @@ import './get-support.scss';
 
 export const GetSupport = () => {
 	const newConversation = useCreateZendeskConversation();
-	const { shouldUseHelpCenterExperience } = useOdieAssistantContext();
+	const { shouldUseHelpCenterExperience, chat } = useOdieAssistantContext();
+
 	const handleOnClick = async ( event: React.MouseEvent< HTMLButtonElement > ) => {
 		event.preventDefault();
 
@@ -18,6 +19,12 @@ export const GetSupport = () => {
 			? __( 'Get instant support', __i18n_text_domain__ )
 			: __( 'Get support', __i18n_text_domain__ );
 	};
+
+	// We don't want the user to see this button if they are already talking to a human.
+	if ( chat.provider !== 'odie' ) {
+		return null;
+	}
+
 	return (
 		<div className="odie__transfer-to-human">
 			<button onClick={ handleOnClick }>{ getButtonText() }</button>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9738

## Proposed Changes

Only show "Get Support" button in chat if the user is talking to Odie.

<img width="300" alt="Screen Shot 2024-11-08 at 10 48 26" src="https://github.com/user-attachments/assets/48218b35-b5e0-4e37-9f69-a0ff59551999">

<img width="300" alt="Screen Shot 2024-11-08 at 10 48 44" src="https://github.com/user-attachments/assets/449bdfaf-ca41-4371-8127-89b6d8da6b01">

## Why are these changes being made?

The button currently is showing perpetually. This allows the user to click it often.

## Testing Instructions

1. Open a new chat with Odie and get transferred to ZD
2. After clicking the button it should go away.
3. Test in both flagged an unflagged versions.