### PR TITLE
Fix button roll over

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/migration-instructions/style.scss
@@ -28,7 +28,7 @@
 		background-color: var(--studio-wordpress-blue-50);
 		border-color: var(--studio-wordpress-blue-50);
 
-		&:hover {
+		&:hover:not([disabled]) {
 			background-color: var(--studio-wordpress-blue-60);
 			border-color: var(--studio-wordpress-blue-60);
 		}


### PR DESCRIPTION
## Proposed Changes

This PR fixes a roll over issue on the migration instructions screens. The current button rollover shows the old WordPress blue instead of our new one:

<img width="610" alt="image" src="https://github.com/user-attachments/assets/0ec9ee2b-aaa1-498b-b36b-646360b74ed4">

Here's what the new hover should look like:
<img width="757" alt="image" src="https://github.com/user-attachments/assets/db012b52-5ab8-4546-ac59-f6a459b2eeb4">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make your way to a DIY migration where you're presented with the migration instructions and hover over the primary buttons.