### PR TITLE
Help Center: Show history for open even if not resolved chats

### DIFF
--- a/packages/help-center/src/components/help-center-chat-history.tsx
+++ b/packages/help-center/src/components/help-center-chat-history.tsx
@@ -92,10 +92,8 @@ export const HelpCenterChatHistory = () => {
 		if (
 			isChatLoaded &&
 			getConversations &&
-			supportInteractionsResolved &&
-			supportInteractionsOpen &&
-			supportInteractionsResolved?.length > 0 &&
-			supportInteractionsOpen?.length > 0
+			( ( supportInteractionsResolved && supportInteractionsResolved?.length > 0 ) ||
+				( supportInteractionsOpen && supportInteractionsOpen?.length > 0 ) )
 		) {
 			const conversations = getConversations();
 			const supportInteractions = [

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -244,7 +244,17 @@ const HelpCenterFooterButton = ( {
 
 export const HelpCenterContactButton: FC = () => {
 	const { __ } = useI18n();
-	const { data: supportInteractions } = useGetSupportInteractions( 'zendesk', 100, 'resolved' );
+	const { data: supportInteractionsResolved } = useGetSupportInteractions(
+		'zendesk',
+		100,
+		'resolved'
+	);
+	const { data: supportInteractionsOpen } = useGetSupportInteractions( 'zendesk', 10, 'open' );
+
+	const supportInteractions = [
+		...( supportInteractionsResolved || [] ),
+		...( supportInteractionsOpen || [] ),
+	];
 
 	return config.isEnabled( 'help-center-experience' ) &&
 		supportInteractions &&

--- a/packages/help-center/src/components/help-center-recent-conversations.tsx
+++ b/packages/help-center/src/components/help-center-recent-conversations.tsx
@@ -44,8 +44,8 @@ const HelpCenterRecentConversations: React.FC = () => {
 		if (
 			isChatLoaded &&
 			getConversations &&
-			supportInteractionsResolved &&
-			supportInteractionsOpen
+			( ( supportInteractionsResolved && supportInteractionsResolved?.length > 0 ) ||
+				( supportInteractionsOpen && supportInteractionsOpen?.length > 0 ) )
 		) {
 			const allConversations = getConversations();
 			const supportInteractions = [


### PR DESCRIPTION

## Proposed Changes

There was a bug that was not showing support interactions in history or recent if there were only open ones.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new user
* Open a chat
* It should be in state open
* It should show in recent conversation

