### PR TITLE
Reader Recent Feed Overhaul: Change to list view and add selection.

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -1,7 +1,7 @@
 import { SubscriptionManager } from '@automattic/data-stores';
 import { WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { DataViews, filterSortAndPaginate, SupportedLayouts, View } from '@wordpress/dataviews';
+import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { translate } from 'i18n-calypso';
 import { useState, useEffect, useCallback, useMemo, useLayoutEffect } from 'react';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
@@ -30,7 +30,7 @@ const Recent = () => {
 	const [ isLoading, setIsLoading ] = useState( false );
 
 	const [ view, setView ] = useState< View >( {
-		type: 'table',
+		type: 'list',
 		search: '',
 		fields: [ 'seen', 'post' ],
 		perPage: 10,
@@ -58,7 +58,7 @@ const Recent = () => {
 				postId: item.postId,
 			} );
 			if ( post ) {
-				acc[ `${ item.feedId }-${ item.postId }` ] = post;
+				acc[ `${ item?.feedId }-${ item?.postId }` ] = post;
 			}
 			return acc;
 		}, {} );
@@ -66,7 +66,7 @@ const Recent = () => {
 
 	const getPostFromItem = useCallback(
 		( item: ReaderPost ) => {
-			const postKey = `${ item.feedId }-${ item.postId }`;
+			const postKey = `${ item?.feedId }-${ item?.postId }`;
 			return posts[ postKey ];
 		},
 		[ posts ]
@@ -110,13 +110,6 @@ const Recent = () => {
 		],
 		[ getPostFromItem, setSelectedItem ]
 	);
-
-	const defaultLayouts = [
-		{
-			label: translate( 'Table' ),
-			icon: 'table-view',
-		},
-	];
 
 	const fetchData = useCallback( () => {
 		dispatch( viewStream( streamKey, window.location.pathname ) as AnyAction );
@@ -212,8 +205,15 @@ const Recent = () => {
 								} )
 							}
 							paginationInfo={ paginationInfo }
-							defaultLayouts={ defaultLayouts as SupportedLayouts }
+							defaultLayouts={ { list: {} } }
 							isLoading={ isLoading }
+							selection={ selectedItem ? [ selectedItem.postId?.toString() ] : [] }
+							onChangeSelection={ ( newSelection: string[] ) => {
+								const selectedPost = data?.items?.find(
+									( item: ReaderPost ) => item.postId?.toString() === newSelection[ 0 ]
+								);
+								setSelectedItem( selectedPost || null );
+							} }
 						/>
 					) }
 				</div>

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -5,7 +5,7 @@ import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { translate } from 'i18n-calypso';
 import { useState, useEffect, useCallback, useMemo, useLayoutEffect } from 'react';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
-import { AnyAction } from 'redux';
+import { UnknownAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import AsyncLoad from 'calypso/components/async-load';
 import EmptyContent from 'calypso/components/empty-content';
@@ -24,7 +24,7 @@ import type { AppState } from 'calypso/types';
 import './style.scss';
 
 const Recent = () => {
-	const dispatch = useDispatch< ThunkDispatch< AppState, void, AnyAction > >();
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
 	const [ selectedItem, setSelectedItem ] = useState< ReaderPost | null >( null );
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
 	const [ isLoading, setIsLoading ] = useState( false );
@@ -78,13 +78,7 @@ const Recent = () => {
 				id: 'seen',
 				label: translate( 'Seen' ),
 				render: ( { item }: { item: ReaderPost } ) => {
-					return (
-						<RecentSeenField
-							item={ item }
-							post={ getPostFromItem( item ) }
-							setSelectedItem={ () => {} }
-						/>
-					);
+					return <RecentSeenField post={ getPostFromItem( item ) } />;
 				},
 				enableHiding: false,
 				enableSorting: false,
@@ -95,30 +89,24 @@ const Recent = () => {
 				getValue: ( { item }: { item: ReaderPost } ) =>
 					`${ getPostFromItem( item )?.title ?? '' } - ${ item?.site_name ?? '' }`,
 				render: ( { item }: { item: ReaderPost } ) => {
-					return (
-						<RecentPostField
-							item={ item }
-							post={ getPostFromItem( item ) }
-							setSelectedItem={ () => {} }
-						/>
-					);
+					return <RecentPostField post={ getPostFromItem( item ) } />;
 				},
 				enableHiding: false,
 				enableSorting: false,
 				enableGlobalSearch: true,
 			},
 		],
-		[ getPostFromItem, setSelectedItem ]
+		[ getPostFromItem ]
 	);
 
 	const fetchData = useCallback( () => {
-		dispatch( viewStream( streamKey, window.location.pathname ) as AnyAction );
+		dispatch( viewStream( streamKey, window.location.pathname ) as UnknownAction );
 		dispatch(
 			requestPaginatedStream( {
 				streamKey,
 				page: view.page,
 				perPage: view.perPage,
-			} ) as AnyAction
+			} ) as UnknownAction
 		);
 	}, [ dispatch, view, streamKey ] );
 

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -82,7 +82,7 @@ const Recent = () => {
 						<RecentSeenField
 							item={ item }
 							post={ getPostFromItem( item ) }
-							setSelectedItem={ setSelectedItem }
+							setSelectedItem={ () => {} }
 						/>
 					);
 				},
@@ -99,7 +99,7 @@ const Recent = () => {
 						<RecentPostField
 							item={ item }
 							post={ getPostFromItem( item ) }
-							setSelectedItem={ setSelectedItem }
+							setSelectedItem={ () => {} }
 						/>
 					);
 				},

--- a/client/reader/recent/recent-post-field.tsx
+++ b/client/reader/recent/recent-post-field.tsx
@@ -1,22 +1,19 @@
-import { Button } from '@wordpress/components';
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
-import type { ReaderPost, PostItem } from './types';
+import type { PostItem } from './types';
 interface RecentPostFieldProps {
-	item: ReaderPost;
 	post: PostItem;
-	setSelectedItem: ( post: ReaderPost | null ) => void;
 }
 
-const RecentPostField: React.FC< RecentPostFieldProps > = ( { item, post, setSelectedItem } ) => {
+const RecentPostField: React.FC< RecentPostFieldProps > = ( { post } ) => {
 	if ( ! post ) {
 		return null;
 	}
 
 	return (
-		<Button className="recent-post-field" onClick={ () => setSelectedItem( item ) }>
+		<div className="recent-post-field">
 			<div className="recent-post-field__title">
 				<div className="recent-post-field__title-text">{ post?.title }</div>
-				<div className="recent-post-field__site-name">{ item.site_name }</div>
+				<div className="recent-post-field__site-name">{ post?.site_name }</div>
 			</div>
 			<div className="recent-post-field__featured-image">
 				<ReaderFeaturedImage
@@ -26,7 +23,7 @@ const RecentPostField: React.FC< RecentPostFieldProps > = ( { item, post, setSel
 					isCompactPost
 				/>
 			</div>
-		</Button>
+		</div>
 	);
 };
 

--- a/client/reader/recent/recent-seen-field.tsx
+++ b/client/reader/recent/recent-seen-field.tsx
@@ -1,18 +1,15 @@
-import { Button } from '@wordpress/components';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
-import type { PostItem, ReaderPost } from './types';
+import type { PostItem } from './types';
 
 interface RecentSeenFieldProps {
-	item: ReaderPost;
 	post: PostItem;
-	setSelectedItem: ( post: ReaderPost | null ) => void;
 }
 
-const RecentSeenField: React.FC< RecentSeenFieldProps > = ( { item, post, setSelectedItem } ) => {
+const RecentSeenField: React.FC< RecentSeenFieldProps > = ( { post } ) => {
 	return (
-		<Button className="recent-seen-field" onClick={ () => setSelectedItem( item ) }>
+		<div className="recent-seen-field">
 			<ReaderAvatar siteIcon={ post?.site_icon?.img || post?.author?.avatar_URL } iconSize={ 24 } />
-		</Button>
+		</div>
 	);
 };
 

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -86,24 +86,27 @@
 
 			.dataviews-view-list__item-wrapper {
 				justify-content: start;
+
+				[role="gridcell"] {
+					width: 100%;
+				}
+			}
+
+			.dataviews-view-list__field-wrapper {
+				width: 100%;
 			}
 
 			.dataviews-view-list__fields {
 				display: flex;
 				align-items: center;
-				justify-content: space-between;
 				gap: $recent-feed-spacing;
 				padding: 0 $recent-feed-spacing;
 			}
 
 			.dataviews-view-list__field:has(.recent-post-field) {
 				overflow: hidden;
+				flex-grow: 1;
 			}
-		}
-
-		button:focus {
-			box-shadow: none;
-			outline: none;
 		}
 
 		.recent-seen-field {
@@ -111,6 +114,10 @@
 
 			img {
 				border-radius: 50%;
+			}
+
+			svg:hover {
+				fill: unset;
 			}
 		}
 
@@ -136,6 +143,7 @@
 
 			&__title-text {
 				font-weight: 700;
+				font-size: rem(13px);
 				@extend %text-shared;
 			}
 

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -56,30 +56,44 @@
 			padding: 0 12px;
 		}
 
-		table {
-			border-collapse: collapse;
-			margin-top: 16px;
+		ul {
+			list-style: none;
+			margin: 16px 0 0;
 		}
 
-		thead {
-			display: none;
-		}
-
-		tr {
+		li {
 			border-top: 1px solid var( --studio-gray-0 );
-		}
 
-		td {
-			vertical-align: middle;
-			padding: 12px;
+			&:hover {
+				cursor: pointer;
+				background-color: #f7faff;
+			}
 
-			&:first-child {
-				padding-right: 0;
+			&.is-selected {
+				background-color: #f7faff;
+				border-top: 1px solid #3858e940;
+			}
+
+			.dataviews-view-list__item-wrapper {
+				justify-content: start;
+			}
+
+			.dataviews-view-list__fields {
+				display: flex;
+				flex-wrap: wrap;
+				align-items: center;
+				justify-content: space-between;
+				gap: 12px;
 			}
 		}
 
+		button:focus {
+			box-shadow: none;
+			outline: none;
+		}
+
 		.recent-seen-field {
-			padding: 0;
+			padding: 12px 0;
 
 			img {
 				border-radius: 50%;
@@ -91,21 +105,22 @@
 			justify-content: space-between;
 			align-items: center;
 			text-align: left;
-			padding: 0;
+			padding: 12px 0;
 			width: 100%;
+			min-height: fit-content;
 
 			%text-shared {
 				white-space: nowrap;
 				text-overflow: ellipsis;
 				overflow: hidden;
-				max-width: 200px;
+				width: 200px;
 
 				@media ( min-width: $break-wide ) {
-					max-width: 125px;
+					width: 125px;
 				}
 
 				@media ( min-width: 1540px ) {
-					max-width: 200px;
+					width: 200px;
 				}
 			}
 

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -1,6 +1,8 @@
 @import '@wordpress/base-styles/breakpoints';
 
 .is-section-reader .recent-feed {
+	$recent-feed-spacing: 12px;
+
 	@media ( min-width: $break-wide ) {
 		display: flex;
 		background: var( --studio-gray-0 );
@@ -34,7 +36,7 @@
 		}
 
 		&-header {
-			padding: 0 12px;
+			padding: 0 $recent-feed-spacing;
 			border-bottom: 1px solid var( --studio-gray-0 );
 			margin-bottom: 16px;
 
@@ -43,17 +45,17 @@
 			}
 
 			@media ( min-width: $break-wide ) {
-				padding: 16px 12px 0;
+				padding: 16px $recent-feed-spacing 0;
 			}
 		}
 
 		.dataviews__view-actions {
 			box-sizing: border-box;
-			padding: 0 12px;
+			padding: 0 $recent-feed-spacing;
 		}
 
 		.dataviews-no-results {
-			padding: 0 12px;
+			padding: 0 $recent-feed-spacing;
 		}
 
 		ul {
@@ -74,16 +76,28 @@
 				border-top: 1px solid #3858e940;
 			}
 
+			// This is necessary because the media field wrapper in DataView is rendered even
+			// if no media is given.
+			// The presence of this element adds a gap on the left side of the element,
+			// throwing off the padding.
+			.dataviews-view-list__media-wrapper {
+				display: none;
+			}
+
 			.dataviews-view-list__item-wrapper {
 				justify-content: start;
 			}
 
 			.dataviews-view-list__fields {
 				display: flex;
-				flex-wrap: wrap;
 				align-items: center;
 				justify-content: space-between;
-				gap: 12px;
+				gap: $recent-feed-spacing;
+				padding: 0 $recent-feed-spacing;
+			}
+
+			.dataviews-view-list__field:has(.recent-post-field) {
+				overflow: hidden;
 			}
 		}
 
@@ -93,7 +107,7 @@
 		}
 
 		.recent-seen-field {
-			padding: 12px 0;
+			padding: $recent-feed-spacing 0;
 
 			img {
 				border-radius: 50%;
@@ -105,23 +119,19 @@
 			justify-content: space-between;
 			align-items: center;
 			text-align: left;
-			padding: 12px 0;
+			padding: $recent-feed-spacing 0;
 			width: 100%;
 			min-height: fit-content;
+			gap: $recent-feed-spacing;
 
 			%text-shared {
 				white-space: nowrap;
 				text-overflow: ellipsis;
 				overflow: hidden;
-				width: 200px;
+			}
 
-				@media ( min-width: $break-wide ) {
-					width: 125px;
-				}
-
-				@media ( min-width: 1540px ) {
-					width: 200px;
-				}
+			&__title {
+				min-width: 0;
 			}
 
 			&__title-text {
@@ -138,6 +148,7 @@
 			&__featured-image {
 				max-width: 38px;
 				align-self: flex-end;
+				flex-shrink: 0;
 			}
 		}
 

--- a/client/reader/recent/types.ts
+++ b/client/reader/recent/types.ts
@@ -13,4 +13,5 @@ export interface PostItem {
 	author: {
 		avatar_URL: string;
 	};
+	site_name: string;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/193
Closes Automattic/loop#220
Closes Automattic/loop#225

## Proposed Changes

* Change to a list view.
* Add selection.
* Fix a console warning about `feedId` being undefined.
* Needs some style tweaks.
* Console warning about nested buttons.

https://github.com/user-attachments/assets/9088e8ff-2e4e-4e74-bf88-58626f604902

## To do

* ~Needs some style tweaks.~
* ~Console warning about nested buttons.~

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2iv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/read?flags=reader/recent-feed-overhaul`
* Interact with middle feed column
* Styles should match [mockup](https://www.figma.com/design/GUCLmXhkvBY3IVFRkrs737/Reader---Recent-Feed-Overhaul)
* No functionality should be broken

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?