### PR TITLE
Purchases: Fix Crash within RemoveDomainDialog

### DIFF
--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -14,6 +14,7 @@ import wpcom from 'calypso/lib/wp';
 import { domainManagementEdit, domainManagementTransferOut } from 'calypso/my-sites/domains/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 class RemoveDomainDialog extends Component {
 	static propTypes = {
@@ -31,8 +32,7 @@ class RemoveDomainDialog extends Component {
 	};
 
 	renderDomainDeletionWarning( productName ) {
-		const { currentRoute, isGravatarDomain, purchase, translate } = this.props;
-		const domain = purchase?.domain;
+		const { translate, slug, currentRoute, isGravatarDomain } = this.props;
 
 		return (
 			<Fragment>
@@ -55,11 +55,9 @@ class RemoveDomainDialog extends Component {
 							args: { domain: productName },
 							components: {
 								strong: <strong />,
-								moveAnchor: (
-									<a href={ domainManagementEdit( domain, productName, currentRoute ) } />
-								),
+								moveAnchor: <a href={ domainManagementEdit( slug, productName, currentRoute ) } />,
 								transferAnchor: (
-									<a href={ domainManagementTransferOut( domain, productName, currentRoute ) } />
+									<a href={ domainManagementTransferOut( slug, productName, currentRoute ) } />
 								),
 							},
 						}
@@ -248,6 +246,10 @@ class RemoveDomainDialog extends Component {
 			},
 		];
 
+		if ( ! purchase ) {
+			return;
+		}
+
 		if ( chatButton ) {
 			buttons.unshift( chatButton );
 		}
@@ -276,5 +278,6 @@ export default connect( ( state, ownProps ) => {
 		isGravatarDomain: selectedDomain?.isGravatarDomain,
 		hasTitanWithUs: hasTitanMailWithUs( selectedDomain ),
 		currentRoute: getCurrentRoute( state ),
+		slug: getSiteSlug( state, ownProps.purchase.siteId ),
 	};
 } )( localize( RemoveDomainDialog ) );

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -14,7 +14,6 @@ import wpcom from 'calypso/lib/wp';
 import { domainManagementEdit, domainManagementTransferOut } from 'calypso/my-sites/domains/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 class RemoveDomainDialog extends Component {
 	static propTypes = {
@@ -32,16 +31,14 @@ class RemoveDomainDialog extends Component {
 	};
 
 	renderDomainDeletionWarning( productName ) {
-		const { translate, slug, currentRoute, isGravatarDomain } = this.props;
+		const { currentRoute, isGravatarDomain, purchase, slug, translate } = this.props;
+		const domain = purchase.domain;
 
 		return (
 			<Fragment>
 				<p>
 					{ translate(
-						'Deleting a domain will make all services connected to it unreachable, including your email and website. It will also make the domain available for someone else to register.',
-						{
-							args: { domain: productName },
-						}
+						'Deleting a domain will make all services connected to it unreachable, including your email and website. It will also make the domain available for someone else to register.'
 					) }
 				</p>
 				{ isGravatarDomain && (
@@ -58,9 +55,11 @@ class RemoveDomainDialog extends Component {
 							args: { domain: productName },
 							components: {
 								strong: <strong />,
-								moveAnchor: <a href={ domainManagementEdit( slug, productName, currentRoute ) } />,
+								moveAnchor: (
+									<a href={ domainManagementEdit( domain, productName, currentRoute ) } />
+								),
 								transferAnchor: (
-									<a href={ domainManagementTransferOut( slug, productName, currentRoute ) } />
+									<a href={ domainManagementTransferOut( domain, productName, currentRoute ) } />
 								),
 							},
 						}
@@ -277,6 +276,5 @@ export default connect( ( state, ownProps ) => {
 		isGravatarDomain: selectedDomain?.isGravatarDomain,
 		hasTitanWithUs: hasTitanMailWithUs( selectedDomain ),
 		currentRoute: getCurrentRoute( state ),
-		slug: getSelectedSiteSlug( state ),
 	};
 } )( localize( RemoveDomainDialog ) );

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -32,7 +32,7 @@ class RemoveDomainDialog extends Component {
 
 	renderDomainDeletionWarning( productName ) {
 		const { currentRoute, isGravatarDomain, purchase, translate } = this.props;
-		const domain = purchase.domain;
+		const domain = purchase?.domain;
 
 		return (
 			<Fragment>

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -31,7 +31,7 @@ class RemoveDomainDialog extends Component {
 	};
 
 	renderDomainDeletionWarning( productName ) {
-		const { currentRoute, isGravatarDomain, purchase, slug, translate } = this.props;
+		const { currentRoute, isGravatarDomain, purchase, translate } = this.props;
 		const domain = purchase.domain;
 
 		return (

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/index.jsx
@@ -35,7 +35,7 @@ class Transfer extends Component {
 		const topLevelOfTld = getTopLevelOfTld( this.props.selectedDomainName );
 		const { locked, transferProhibited } = this.props.wapiDomainInfo.data;
 		const { currentUserCanManage, isPendingIcannVerification, transferAwayEligibleAt } =
-			getSelectedDomain( this.props );
+			getSelectedDomain( this.props ) ?? {};
 		let section = null;
 
 		if ( ! currentUserCanManage ) {


### PR DESCRIPTION
## Proposed Changes

The links in the `RemoveDomainDialog` currently cause a fatal crash. The reason for this is because they're using the selected site slug, but as far as I can tell, this component is only used in the Me > Purchases screen. As such, we can't rely on there being the correct site slug - instead, we should use the site slug for the purchase itself.

## Why are these changes being made?

Bug fix - currently causes a crash when the link is clicked. 

<img width="1606" alt="Screenshot 2024-11-09 at 11 22 35" src="https://github.com/user-attachments/assets/7243eb12-fcf5-4266-9f8a-d19eea9bcbfd">

## Testing Instructions

* Register a domain that is close to expiring (I'm not sure if there's any way to mock this) 
* Go to Me > Purchases and select the domain
* Select "Remove Domain" 

<img width="1057" alt="Screenshot 2024-11-09 at 11 44 50" src="https://github.com/user-attachments/assets/0be08379-4401-4cc2-8abb-66915fa4a39d">

* Confirm that the links now work.

<img width="1299" alt="Screenshot 2024-11-09 at 11 46 19" src="https://github.com/user-attachments/assets/cd00564f-17c3-44dc-a1ab-2abfd5c17b0f">

(By the way, I think this dialog could do with some love - especially a max width to make it more readable - but I thought it made sense to address this first as a crash is quite bad)