### PR TITLE
Start: Fix "Skip Purchase" Button Styling During Launch

### DIFF
--- a/client/components/domains/domain-skip-suggestion/style.scss
+++ b/client/components/domains/domain-skip-suggestion/style.scss
@@ -5,6 +5,10 @@
 	& .button.domain-suggestion__action.is-borderless {
 		flex: 1 0 auto;
 	}
+
+	.domain-suggestion__action-container {
+		display: flex;
+	}
 }
 
 .domain-skip-suggestion__domain-description {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -363,10 +363,12 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.domain-suggestion {
-		flex-direction: column;
 		box-shadow: none;
-
 		margin: 0;
+
+		&:not(.domain-skip-suggestion) {
+			flex-direction: column;
+		}
 
 		@include break-small {
 			margin: 0 20px;
@@ -544,6 +546,7 @@ body.is-section-signup.is-white-signup {
 				}
 				.domain-suggestion__chevron {
 					fill: $cod-grey;
+					margin-right: 20px;
 					margin-left: 0;
 				}
 			}


### PR DESCRIPTION
Fixes #96080

## Proposed Changes

Ensures the styling looks better for the "Skip Purchase" button when Launching a site.  

## Why are these changes being made?

Bug fix - it seems that the button is just inheriting unintended styles, which makes it look off.

## Testing Instructions

* Select an unlaunched site without a custom domain
* Navigate to Settings > General and Launch your site
* Scroll to the bottom of the domains list
* Confirm that the styling looks okay, including on mobile.

| Before | After |
|--------|--------|
| <img width="1355" alt="Screenshot 2024-11-09 at 14 00 46" src="https://github.com/user-attachments/assets/10793255-6a23-4dd3-b70e-958c6719fe05"> | <img width="1305" alt="Screenshot 2024-11-09 at 14 00 38" src="https://github.com/user-attachments/assets/cde69065-25a1-46ed-b11d-be36f0fde258"> | 

cc @lsl, @renancarvalho, @escapemanuele 
