### PR TITLE
A4a: Remove the product state from the hasCompletedForm condition.

### DIFF
--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -48,8 +48,7 @@ export default function UserContactSupportModalForm( {
 
 	const isPressableSelected = product === 'pressable';
 	const isClient = isClientView();
-	const hasCompletedForm =
-		!! message && !! name && !! email && !! product && ( !! agency || isClient );
+	const hasCompletedForm = !! message && !! name && !! email && ( !! agency || isClient );
 
 	const { isSubmitting, submit, isSubmissionSuccessful } = useSubmitContactSupport();
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR fixes an issue trying to send a contact form when the default `product` is selected.

![image](https://github.com/user-attachments/assets/fe7804fa-ef3f-477d-bd5e-8edaadc77c1e)

If you select another product, and select again the first one `Automattic for Agencies` it works.

This change remove the `product` field check because really it is unnecessary, there is always one selected, so we can remove it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
