### PR TITLE
A4A: Fix Contact Sales & Support submit button

### DIFF
--- a/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
@@ -39,7 +39,9 @@ export default function A4AContactSupportWidget() {
 		translate( '[your message here]' );
 
 	const defaultProduct =
-		window.location.hash === CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT ? getDefaultProduct() : '';
+		window.location.hash === CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT
+			? getDefaultProduct()
+			: undefined;
 
 	return isNewHostingPage &&
 		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/automattic-for-agencies-dev/issues/1452

## Proposed Changes

* Fix the submit button of the Contact Sales & Support form by replacing the value of `defaultProduct` when no product is in the URL from `''` to `undefined`. With this change, the `UserContactSupportModalForm` component can use `a4a` as the default value.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix a bug that leaves the submit button disabled even when every form field is complete.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a Live Branch.
* Visit `/overview#contact-support`.
* Ensure that if you complete every form field without touching the product dropdown, the submit button is enabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
