### PR TITLE
Introduce Horizontal Scrolling in Sites Dashboard

### DIFF
--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -122,15 +122,6 @@
 		}
 	}
 
-	table.dataviews-view-table {
-		table-layout: fixed;
-	}
-
-	table.dataviews-view-table th,
-	table.dataviews-view-table td {
-		white-space: nowrap; /* Optional: ensures text in cells does not wrap */
-	}
-
 	table.dataviews-view-table thead .dataviews-view-table__row th {
 		border-bottom-color: var(--color-border-secondary);
 
@@ -142,42 +133,10 @@
 
 	table.dataviews-view-table .dataviews-view-table__row td {
 		border-bottom-color: var(--color-border-secondary);
-		&:nth-child(2) {
-			white-space: wrap;
-			overflow-wrap: anywhere;
-		}
-	}
-
-	table.dataviews-view-table th:first-child,
-	table.dataviews-view-table td:first-child,
-	table.dataviews-view-table th:last-child,
-	table.dataviews-view-table td:last-child {
-		display: table-cell; /* ensures these cells are always shown */
 	}
 
 	.sites-overview__content {
 		margin-top: 0;
-	}
-
-	@media (max-width: $break-wide) {
-		table.dataviews-view-table th:nth-child(5),
-		table.dataviews-view-table td:nth-child(5) {
-			display: none;
-		}
-	}
-
-	@media (max-width: $break-wide - 100px) {
-		table.dataviews-view-table th:nth-child(4),
-		table.dataviews-view-table td:nth-child(4) {
-			display: none;
-		}
-	}
-
-	@media (max-width: $break-xlarge) {
-		table.dataviews-view-table th:nth-child(3),
-		table.dataviews-view-table td:nth-child(3) {
-			display: none;
-		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9694

## Proposed Changes

This PR introduces Horizontal Scrolling in the Sites Dashboard. 

before

https://github.com/user-attachments/assets/60d64241-2ce0-4d47-991f-69dbff8b618c

after

https://github.com/user-attachments/assets/1e255f92-fb71-480b-9685-383953fcc4a4



### Other Notes
- In the mobile view (<960), only the Site Title and Actions are displayed, as seen [here](https://github.com/Automattic/wp-calypso/blob/e12b9c111e396bdfb4ad81bbfabdfe2e785436e0/client/sites/components/sites-dashboard.tsx#L147-L148). This is the same behavior as the current production. I would consider this a valid customization rather than an "override" since it [utilizes](https://github.com/okmttdhr/gutenberg/blob/4651b8235d5220f02b1133266995f32c34fc9122/packages/dataviews/src/dataviews-layouts/index.ts#L85) Core's props.
- Related PRs
	- https://github.com/Automattic/wp-calypso/pull/90842
	- https://github.com/Automattic/wp-calypso/pull/90787
	- https://github.com/Automattic/wp-calypso/pull/90420/
	- https://github.com/Automattic/wp-calypso/pull/90211/

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To remove unnecessary overrides and align with Core: pbxlJb-6A9-p2#comment-4026, pbxlJb-6DF-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`.
* Try to break the Site Dashboard's DataView with desktop/mobile views and short/long texts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?