### PR TITLE
Drop sticky headers from site dashboard

### DIFF
--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -49,12 +49,6 @@
 	@media (min-width: $break-large) {
 		background: inherit;
 
-		.dataviews-view-table thead {
-			position: sticky;
-			top: 0;
-			z-index: 2;
-		}
-
 		&.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-title {
 			font-size: 1.25rem;
 			font-weight: 500;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9692

## Proposed Changes

* Remove the sticky header css for dataviews on dotcom sites dashboard
* The css now falls back to the [gb version](https://github.com/okmttdhr/gutenberg/blob/4651b8235d5220f02b1133266995f32c34fc9122/packages/dataviews/src/dataviews-layouts/table/style.scss#L105-L107)

## Testing Instructions

* /sites
* There should be no change to functionality, ensure there are enough sites to make the window scrollable

Before

![Screenshot_2024-11-12_11-42-05](https://github.com/user-attachments/assets/6efcbad4-479f-4314-8135-88d0dd31604d)


After

![Screenshot_2024-11-12_11-41-02](https://github.com/user-attachments/assets/0131f7d1-0afa-4fef-afee-5434ea41b7a2)

