### PR TITLE
Remove styles for non-existent DOM

### DIFF
--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -124,15 +124,6 @@
 			min-width: 40px;
 		}
 
-		.sites-overview__stats-trend,
-		.sites-overview__column-action-button,
-		.sites-overview__row-status,
-		.toggle-activate-monitoring__toggle-button,
-		.sites-dataviews__favorite-btn-wrapper,
-		.sites-overview__boost-score {
-			display: none;
-		}
-
 		.item-preview__content {
 			padding: 10px 10px 88px; /* 88px matches the padding from PR #39201. */
 
@@ -218,18 +209,6 @@
 		font-weight: 500;
 		line-height: 14px;
 		color: var(--color-accent-80);
-	}
-
-	tr.dataviews-view-table__row th[data-field-id="favorite"] {
-		vertical-align: top;
-	}
-
-	tr.dataviews-view-table__row {
-		&:hover {
-			.site-set-favorite__favorite-icon {
-				visibility: visible;
-			}
-		}
 	}
 
 	.sites-overview__content-wrapper {
@@ -824,26 +803,6 @@
 
 	.margin-top-16 {
 		margin-top: 16px;
-	}
-
-	.sites-dataviews__favorite-btn-wrapper {
-		display: flex;
-		align-items: center;
-
-		.site-set-favorite__favorite-icon {
-			visibility: hidden;
-			color: var(--color-primary);
-		}
-
-		button.site-set-favorite__favorite-icon {
-			position: unset;
-		}
-
-		&:hover {
-			.site-set-favorite__favorite-icon {
-				visibility: visible;
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Remove styles for non-existent DOM in Dotcom's Sites Dashboard (they were for A4A). 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pbxlJb-6DF-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Observe nothing breaks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?