### PR TITLE
Server Settings: remove Elasticsearch note in Performance Optimization card

### DIFF
--- a/client/sites/settings/caching/form.scss
+++ b/client/sites/settings/caching/form.scss
@@ -32,17 +32,6 @@
 
 .cache-card__hr,
 .cache-card__global-edge-cache-block,
-.cache-card__global-object-cache-block,
-.cache-card__jetpack-block {
+.cache-card__global-object-cache-block {
 	margin-top: 24px;
-}
-
-.cache-card__jetpack-description {
-	align-items: center;
-	display: flex;
-	gap: 10px;
-
-	p {
-		margin: 0;
-	}
 }

--- a/client/sites/settings/caching/form.tsx
+++ b/client/sites/settings/caching/form.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { Button, JetpackLogo } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { ToggleControl, Tooltip } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useState } from 'react';
@@ -291,36 +291,6 @@ export default function CacheForm( {
 						</div>
 					</Tooltip>
 				</div>
-			) }
-
-			{ config.isEnabled( 'hosting-server-settings-enhancements' ) && (
-				<>
-					<div className="cache-card__hr" />
-
-					<div className="cache-card__jetpack-block">
-						<div className="cache-card__subtitle">{ translate( 'Elasticsearch' ) }</div>
-						<div className="cache-card__jetpack-description">
-							<JetpackLogo size={ 16 } />
-							<SubdescriptionComponent>
-								{ translate(
-									'Jetpack indexes the content of your site with Elasticsearch. {{a}}Learn more{{/a}}',
-									{
-										comment:
-											'Refers to how Jetpack Search uses Elasticsearch to index posts and pages on some WordPress.com sites',
-										components: {
-											a: (
-												<InlineSupportLink
-													supportContext="hosting-elasticsearch"
-													showIcon={ false }
-												/>
-											),
-										},
-									}
-								) }
-							</SubdescriptionComponent>
-						</div>
-					</div>
-				</>
 			) }
 		</ContainerComponent>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pfsHM7-1qC-p2#comment-1840

## Proposed Changes

This PR removes the mention of how Jetpack indexes site content using Elasticsearch in Server Settings.

|Before|After|
|-|-|
|<img width="654" alt="image" src="https://github.com/user-attachments/assets/817b783f-a4a8-497c-82ee-5e95ea7c222b">|<img width="655" alt="image" src="https://github.com/user-attachments/assets/d21c8415-07b0-492c-8bbf-c47894965136"><br><br><br>|

## Why are these changes being made?

See: pfsHM7-1qC-p2#comment-1840

## Testing Instructions

1. Go to `/sites?flags=-untangling/hosting-menu`
2. Click an Atomic site
3. Go to Server Settings tab
4. Verify you don't see the Elasticsearch section as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?