### PR TITLE
Help Center: fix wp-admin overrides

### DIFF
--- a/packages/help-center/src/components/help-center-footer.scss
+++ b/packages/help-center/src/components/help-center-footer.scss
@@ -10,6 +10,7 @@
 	.button.help-center-contact-page__button {
 		background-color: transparent;
 		border: 1px solid var(--studio-gray-10);
+		color: var(--studio-gray-100);
 		padding: 5px;
 		width: 100%;
 		display: flex;
@@ -19,6 +20,7 @@
 		line-height: 2.15;
 
 		&:hover {
+			color: var(--studio-gray-100);
 			border-color: var(--color-neutral-20);
 			box-shadow: none;
 			outline: none;
@@ -33,6 +35,7 @@
 		svg {
 			margin-right: 10px;
 			vertical-align: middle;
+			fill: var(--studio-gray-100);
 		}
 
 		span {

--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -10,6 +10,7 @@
 	align-items: center;
 	border-bottom: 1px solid;
 	border-color: rgba(0, 0, 0, 0.1);
+	text-decoration: none;
 
 	&:hover {
 		border-bottom: 1px solid;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
| Before  | After |
| ------------- | ------------- |
|  <img width="967" alt="Screenshot 2024-11-11 at 13 29 30" src="https://github.com/user-attachments/assets/5e882b1d-2a9a-49ce-be85-661753806b2d"> | <img width="968" alt="Screenshot 2024-11-11 at 13 27 49" src="https://github.com/user-attachments/assets/c1402974-e3bf-4426-80f2-edf2bb79d614">  |

- The card text for support cards is underlined for wp-admin
- The footer buttons and their icons have wrong colors for wp-admin 

Related to #
https://github.com/Automattic/dotcom-forge/issues/9754

## Proposed Changes

* Fix relevant styles

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync this branch
* Visit https://sandboxedsite.com/wp-admin/edit.php?flags=help-center-experience
* Test the relevant changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
