### PR TITLE
Business tools redesign: Update card styling

### DIFF
--- a/client/sites/marketing/tools/feature.tsx
+++ b/client/sites/marketing/tools/feature.tsx
@@ -22,13 +22,20 @@ const MarketingToolsFeature: FunctionComponent< Props > = ( {
 	return (
 		<Card className="tools__feature-list-item">
 			<div className="tools__feature-list-item-body">
-				{ imagePath && (
-					<img alt={ imageAlt } className="tools__feature-list-item-body-image" src={ imagePath } />
-				) }
+				<div className="tools__feature-list-item-header">
+					{ imagePath && (
+						<img
+							alt={ imageAlt }
+							className="tools__feature-list-item-body-image"
+							src={ imagePath }
+							height={ 32 }
+							width={ 32 }
+						/>
+					) }
+					<CardHeading>{ title }</CardHeading>
+				</div>
 
 				<div className="tools__feature-list-item-body-text">
-					<CardHeading>{ title }</CardHeading>
-
 					<p>{ description }</p>
 
 					{ disclaimer && <p className="tools__feature-list-item-disclaimer">{ disclaimer }</p> }

--- a/client/sites/marketing/tools/index.tsx
+++ b/client/sites/marketing/tools/index.tsx
@@ -1,9 +1,10 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { Button } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
-import { Fragment, FunctionComponent } from 'react';
+import { Fragment, FunctionComponent, ReactNode } from 'react';
 import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
 import rocket from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 import earnIllustration from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
@@ -19,6 +20,20 @@ import MarketingToolsFeature from './feature';
 import MarketingToolsHeader from './header';
 
 import './style.scss';
+
+const FeaturedButton: FunctionComponent< {
+	children: ReactNode;
+	onClick: () => void;
+	href?: string;
+	target?: string;
+} > = ( { children, onClick, href, target } ) => {
+	return (
+		<Button onClick={ onClick } href={ href } target={ target } variant="link">
+			{ children }
+			<Gridicon style={ { marginLeft: '8px' } } icon="chevron-right" size={ 12 } />
+		</Button>
+	);
+};
 
 export const MarketingTools: FunctionComponent = () => {
 	const translate = useTranslate();
@@ -77,13 +92,13 @@ export const MarketingTools: FunctionComponent = () => {
 					) }
 					imagePath={ wordPressLogo }
 				>
-					<Button
+					<FeaturedButton
 						onClick={ handleBuiltByWpClick }
 						href={ localizeUrl( 'https://wordpress.com/website-design-service/?ref=tools-banner' ) }
 						target="_blank"
 					>
 						{ translate( 'Get started' ) }
-					</Button>
+					</FeaturedButton>
 				</MarketingToolsFeature>
 
 				<MarketingToolsFeature
@@ -94,7 +109,9 @@ export const MarketingTools: FunctionComponent = () => {
 					imagePath={ earnIllustration }
 					imageAlt={ translate( 'A stack of coins' ) }
 				>
-					<Button onClick={ handleEarnClick }>{ translate( 'Start earning' ) }</Button>
+					<FeaturedButton onClick={ handleEarnClick }>
+						{ translate( 'Start earning' ) }
+					</FeaturedButton>
 				</MarketingToolsFeature>
 
 				<MarketingToolsFeature
@@ -105,13 +122,13 @@ export const MarketingTools: FunctionComponent = () => {
 					imagePath={ fiverrLogo }
 					imageAlt={ translate( 'Fiverr logo' ) }
 				>
-					<Button
+					<FeaturedButton
 						onClick={ handleCreateALogoClick }
 						href="https://wp.me/logo-maker/?utm_campaign=marketing_tab"
 						target="_blank"
 					>
 						{ translate( 'Make your brand' ) }
-					</Button>
+					</FeaturedButton>
 				</MarketingToolsFeature>
 
 				<MarketingToolsFeature
@@ -122,13 +139,13 @@ export const MarketingTools: FunctionComponent = () => {
 					imagePath={ fiverrLogo }
 					imageAlt={ translate( 'Fiverr logo' ) }
 				>
-					<Button
+					<FeaturedButton
 						onClick={ handleHireAnSEOExpertClick }
 						href="https://wp.me/hire-seo-expert/?utm_source=marketing_tab"
 						target="_blank"
 					>
 						{ translate( 'Talk to an SEO expert today' ) }
-					</Button>
+					</FeaturedButton>
 				</MarketingToolsFeature>
 
 				<MarketingToolsFeature
@@ -139,7 +156,9 @@ export const MarketingTools: FunctionComponent = () => {
 					imagePath="/calypso/images/marketing/social-media-logos.svg"
 					imageAlt={ translate( 'Logos for Facebook, Twitter, LinkedIn, and Tumblr' ) }
 				>
-					<Button onClick={ handleStartSharingClick }>{ translate( 'Start sharing' ) }</Button>
+					<FeaturedButton onClick={ handleStartSharingClick }>
+						{ translate( 'Start sharing' ) }
+					</FeaturedButton>
 				</MarketingToolsFeature>
 
 				{ isEnglish && (
@@ -151,13 +170,13 @@ export const MarketingTools: FunctionComponent = () => {
 						imagePath={ rocket }
 						imageAlt={ translate( 'A rocketship' ) }
 					>
-						<Button
+						<FeaturedButton
 							onClick={ handleSEOCourseClick }
 							href="https://wordpress.com/learn/courses/intro-to-seo/"
 							target="_blank"
 						>
 							{ translate( 'Register now' ) }
-						</Button>
+						</FeaturedButton>
 					</MarketingToolsFeature>
 				) }
 			</div>

--- a/client/sites/marketing/tools/style.scss
+++ b/client/sites/marketing/tools/style.scss
@@ -75,8 +75,14 @@
 .tools__header-image-wrapper {
 	@include wide-screen {
 		display: flex;
+<<<<<<< HEAD
 		margin-right: -20px; // This is to compensate the gap in .tools__header-body 
 		margin-left: auto;
+||||||| parent of 4209204614 (Update styles for better responsiveness in both screens)
+		margin-left: auto;
+=======
+		margin-right: -20px; // This is to compensate the gap in .tools__header-body 
+>>>>>>> 4209204614 (Update styles for better responsiveness in both screens)
 	}
 
 	.tools__header-image {

--- a/client/sites/marketing/tools/style.scss
+++ b/client/sites/marketing/tools/style.scss
@@ -167,9 +167,8 @@
 
 .tools__feature-list-item-body-image {
 	margin-right: 1rem;
-	max-width: 75px;
-	max-height: 75px;
-	width: 16%;
+	max-width: 32px;
+	max-height: 32px;
 
 	@include wide-screen {
 		display: flex;

--- a/client/sites/marketing/tools/style.scss
+++ b/client/sites/marketing/tools/style.scss
@@ -116,15 +116,6 @@
 	width: calc(100% - 1rem);
 	border-radius: 4px;
 
-	// Reduce top margin of GMB logo
-	&:nth-child(3) .tools__feature-list-item-body-image {
-		margin-top: 18px;
-	}
-
-	// Reduce top margin of Upwork logo
-	&:nth-child(5) .tools__feature-list-item-body-image {
-		margin-top: 20px;
-	}
 
 	@include wide-screen {
 		width: calc(33.33% - 1rem);
@@ -153,6 +144,7 @@
 
 .tools__feature-list-item-header {
 	display: flex;
+	align-items: center;
 	margin-bottom: 16px;
 	> h1 {
 		font-size: $font-body;
@@ -171,7 +163,7 @@
 }
 
 .tools__feature-list-item-body-image {
-	margin: 10px 20px 0 0;
+	margin-right: 1rem;
 	max-width: 75px;
 	max-height: 75px;
 	width: 16%;

--- a/client/sites/marketing/tools/style.scss
+++ b/client/sites/marketing/tools/style.scss
@@ -115,7 +115,7 @@
 	margin: 0.5rem;
 	width: calc(100% - 1rem);
 	border-radius: 4px;
-
+	padding: 30px;
 
 	@include wide-screen {
 		width: calc(33.33% - 1rem);

--- a/client/sites/marketing/tools/style.scss
+++ b/client/sites/marketing/tools/style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/typography/styles/variables";
+
 @mixin wide-screen() {
 	// nav unification (Tools/Hosting -> Marketing)
 	.sharing & {
@@ -55,7 +57,7 @@
 	margin-top: 32px;
 
 	@include breakpoint-deprecated( "<1040px" ) {
-	margin-bottom: 16px;
+	margin-bottom: 1rem;
 	}
 
 	.components-button {
@@ -96,18 +98,23 @@
 
 .tools__feature-list {
 	position: relative;
-	left: calc(-0.5em);
+	left: calc(-0.5rem);
 	display: flex;
 	flex-wrap: wrap;
 	// margins of the items will "hang off the side" invisibly
-	width: calc(100% + 1em);
+	width: calc(100% + 1rem);
+
+	a.components-button.is-link {
+		text-decoration: none;
+	}
 }
 
 .tools__feature-list-item {
 	display: flex;
 	flex-direction: column;
-	margin: 0.5em;
-	width: calc(100% - 1em);
+	margin: 0.5rem;
+	width: calc(100% - 1rem);
+	border-radius: 4px;
 
 	// Reduce top margin of GMB logo
 	&:nth-child(3) .tools__feature-list-item-body-image {
@@ -120,9 +127,16 @@
 	}
 
 	@include wide-screen {
-		width: calc(50% - 1em);
+		width: calc(33.33% - 1rem);
 	}
 }
+
+.panel-with-sidebar  {
+	.tools__feature-list-item {
+		width: calc(50% - 1rem);
+	}
+}
+
 
 .tools__feature-list-item-disclaimer {
 	color: var(--color-text-subtle);
@@ -132,7 +146,18 @@
 .tools__feature-list-item-body {
 	align-items: flex-start;
 	display: flex; // grow this, leave buttons on the bottom of the card
+	flex-direction: column;
 	flex: 1 0 auto;
+	margin-bottom: 1rem;
+}
+
+.tools__feature-list-item-header {
+	display: flex;
+	margin-bottom: 16px;
+	> h1 {
+		font-size: $font-body;
+		font-weight: 500;
+	}
 }
 
 .tools__feature-list-item-body-text {
@@ -142,10 +167,6 @@
 		color: var(--color-text-subtle);
 		font-size: $font-body-small;
 		margin-bottom: 0;
-	}
-
-	@include wide-screen {
-		width: 75%;
 	}
 }
 
@@ -168,13 +189,9 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	margin-top: 1em;
 
-	.button {
-		margin: 0;
-		margin-left: calc(15% + 20px);
-		text-align: center;
-		width: auto;
+	.components-button.is-link{
+		text-decoration: none;
 	}
 
 	.purchase-detail__info {

--- a/client/sites/marketing/tools/style.scss
+++ b/client/sites/marketing/tools/style.scss
@@ -77,14 +77,8 @@
 .tools__header-image-wrapper {
 	@include wide-screen {
 		display: flex;
-<<<<<<< HEAD
 		margin-right: -20px; // This is to compensate the gap in .tools__header-body 
 		margin-left: auto;
-||||||| parent of 4209204614 (Update styles for better responsiveness in both screens)
-		margin-left: auto;
-=======
-		margin-right: -20px; // This is to compensate the gap in .tools__header-body 
->>>>>>> 4209204614 (Update styles for better responsiveness in both screens)
 	}
 
 	.tools__header-image {
@@ -103,10 +97,6 @@
 	flex-wrap: wrap;
 	// margins of the items will "hang off the side" invisibly
 	width: calc(100% + 1rem);
-
-	a.components-button.is-link {
-		text-decoration: none;
-	}
 }
 
 .tools__feature-list-item {
@@ -152,6 +142,7 @@
 	> h1 {
 		font-size: $font-body;
 		font-weight: 500;
+		margin: 0;
 	}
 }
 
@@ -186,6 +177,7 @@
 
 	.components-button.is-link{
 		text-decoration: none;
+		font-weight: 500;
 	}
 
 	.purchase-detail__info {

--- a/client/sites/marketing/tools/style.scss
+++ b/client/sites/marketing/tools/style.scss
@@ -124,7 +124,10 @@
 
 .panel-with-sidebar  {
 	.tools__feature-list-item {
-		width: calc(50% - 1rem);
+		@include breakpoint-deprecated( ">1400px" ) {
+			width: calc(50% - 1rem);
+		}
+
 	}
 }
 

--- a/client/sites/marketing/tools/style.scss
+++ b/client/sites/marketing/tools/style.scss
@@ -78,7 +78,6 @@
 	@include wide-screen {
 		display: flex;
 		margin-right: -20px; // This is to compensate the gap in .tools__header-body 
-		margin-left: auto;
 	}
 
 	.tools__header-image {

--- a/client/sites/marketing/tools/style.scss
+++ b/client/sites/marketing/tools/style.scss
@@ -76,6 +76,7 @@
 	@include wide-screen {
 		display: flex;
 		margin-right: -20px; // This is to compensate the gap in .tools__header-body 
+		margin-left: auto;
 	}
 
 	.tools__header-image {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9656

## Proposed Changes

* Update the style of the Cards in Business Tools pages `/marketing/tools/:siteId` and `/sites/marketing/tools/:siteId` to match the new designs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the Business Services offered as described in the parent task https://github.com/Automattic/dotcom-forge/issues/9340

|Before | After|
|-------|------|
| ![CleanShot 2024-11-11 at 13 51 15@2x](https://github.com/user-attachments/assets/585248e1-cfe4-41df-abb8-bc447f15a884) |  ![CleanShot 2024-11-11 at 13 50 07@2x](https://github.com/user-attachments/assets/3ac6c547-393e-41c2-9492-1c121037c03b)|
| ![CleanShot 2024-11-11 at 13 50 54@2x](https://github.com/user-attachments/assets/d1ac1873-f6b6-42b2-b7c1-a44686187dc5)| ![CleanShot 2024-11-11 at 13 50 20@2x](https://github.com/user-attachments/assets/6df5273e-2530-4d08-86c3-a28eeaa1a535)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch and navigate to the Business Tools pages in both, the site view and the multi-sites view:
  * `/marketing/tools/:siteId`
  * `/sites/marketing/tools/:siteId` 
* Make sure the style of the cards matches the designs pIiTEGIxHIzKfHv1KHOUM5-fi-3130_24771 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?