### PR TITLE
A4A > Migrations: Implement Commission's list view

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
@@ -1,0 +1,56 @@
+import { BadgeType } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
+import FormattedDate from 'calypso/components/formatted-date';
+
+const DETAILS_DATE_FORMAT_SHORT = 'DD MMM YYYY';
+
+export const SiteColumn = ( { site }: { site: string } ) => {
+	return site;
+};
+
+export const MigratedOnColumn = ( { migratedOn }: { migratedOn: string } ) => {
+	return <FormattedDate date={ migratedOn } format={ DETAILS_DATE_FORMAT_SHORT } />;
+};
+
+export const ReviewStatusColumn = ( {
+	reviewStatus,
+}: {
+	reviewStatus: 'confirmed' | 'pending' | 'rejected';
+} ) => {
+	const translate = useTranslate();
+
+	const getStatusProps = () => {
+		switch ( reviewStatus ) {
+			case 'confirmed':
+				return {
+					statusText: translate( 'Confirmed' ),
+					statusType: 'success',
+				};
+			case 'pending':
+				return {
+					statusText: translate( 'Pending' ),
+					statusType: 'warning',
+				};
+			case 'rejected':
+				return {
+					statusText: translate( 'Rejected' ),
+					statusType: 'error',
+				};
+		}
+	};
+
+	const statusProps = getStatusProps();
+
+	if ( ! statusProps ) {
+		return null;
+	}
+	return (
+		<StatusBadge
+			statusProps={ {
+				children: statusProps.statusText,
+				type: statusProps.statusType as BadgeType,
+			} }
+		/>
+	);
+};

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -1,0 +1,75 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, ReactNode, useState } from 'react';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { MigratedOnColumn, ReviewStatusColumn, SiteColumn } from './commission-columns';
+import type { MigrationCommissionItem } from '../types';
+import type { Field } from '@wordpress/dataviews';
+
+export default function MigrationsCommissionsList( {
+	items,
+}: {
+	items: MigrationCommissionItem[];
+} ) {
+	const translate = useTranslate();
+
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
+		...initialDataViewsState,
+	} );
+
+	const pagination = {
+		totalItems: items.length,
+		totalPages: 1,
+	};
+
+	const fields: Field< any >[] = useMemo(
+		() => [
+			{
+				id: 'site',
+				label: translate( 'Site' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item } ): ReactNode => <SiteColumn site={ item.siteUrl } />,
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'migratedOn',
+				label: translate( 'Migrated on' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item } ): ReactNode => <MigratedOnColumn migratedOn={ item.migratedOn } />,
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'reviewStatus',
+				label: translate( 'Review status' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item } ): ReactNode => (
+					<ReviewStatusColumn reviewStatus={ item.reviewStatus } />
+				),
+				enableHiding: false,
+				enableSorting: false,
+			},
+		],
+		[ translate ]
+	);
+
+	return (
+		<div className="redesigned-a8c-table full-width">
+			<ItemsDataViews
+				data={ {
+					items,
+					getItemId: ( item ) => `${ item.id }`,
+					pagination,
+					enableSearch: false,
+					fields,
+					actions: [],
+					setDataViewsState,
+					dataViewsState,
+					defaultLayouts: { table: {} },
+				} }
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/migrations/consolidated-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/consolidated-commissions/index.tsx
@@ -32,8 +32,9 @@ export default function MigrationsConsolidatedCommissions( {
 			<Card compact>
 				<div className="consolidated-commissions__value"> ${ migrationCommissions }</div>
 				<div className="consolidated-commissions__label">
-					{ translate( 'Migration commissions expected in %(currentQuarter)s', {
-						args: { currentQuarter: `Q${ currentQuarter }` },
+					{ translate( 'Migration commissions expected in Q%(currentQuarter)s', {
+						args: { currentQuarter },
+						comment: 'Quarterly commission value, where Q is the short form of "Quarter"',
 					} ) }
 				</div>
 			</Card>

--- a/client/a8c-for-agencies/sections/migrations/consolidated-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/consolidated-commissions/index.tsx
@@ -1,34 +1,44 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import type { MigrationCommissionItem } from '../types';
 
 import './style.scss';
 
-const getCurrentQuarter = () => {
-	const currentMonth = new Date().getMonth();
-	const quarter = Math.ceil( ( currentMonth + 1 ) / 3 );
-	return `Q${ quarter }`;
+const getQuarter = ( date = new Date() ) => {
+	const currentMonth = date.getMonth();
+	return Math.ceil( ( currentMonth + 1 ) / 3 );
 };
 
-export default function MigrationsConsolidatedCommissions() {
+export default function MigrationsConsolidatedCommissions( {
+	items,
+}: {
+	items: MigrationCommissionItem[];
+} ) {
 	const translate = useTranslate();
 
-	const data = {
-		migrationCommissions: 300,
-		sitesPendingReview: 2,
-	}; // FIXME: Replace with real data
+	const migrationCommissions =
+		items.filter(
+			( item ) =>
+				// Consider only confirmed migrations for the current quarter
+				item.reviewStatus === 'confirmed' && getQuarter( item.migratedOn ) === getQuarter()
+		).length * 100; // FIXME: Consider the maximum commission value
+
+	const sitesPendingReview = items.filter( ( item ) => item.reviewStatus === 'pending' ).length;
+
+	const currentQuarter = getQuarter();
 
 	return (
 		<div className="consolidated-commissions">
 			<Card compact>
-				<div className="consolidated-commissions__value"> ${ data.migrationCommissions }</div>
+				<div className="consolidated-commissions__value"> ${ migrationCommissions }</div>
 				<div className="consolidated-commissions__label">
 					{ translate( 'Migration commissions expected in %(currentQuarter)s', {
-						args: { currentQuarter: getCurrentQuarter() },
+						args: { currentQuarter: `Q${ currentQuarter }` },
 					} ) }
 				</div>
 			</Card>
 			<Card compact>
-				<div className="consolidated-commissions__value">{ data.sitesPendingReview }</div>
+				<div className="consolidated-commissions__value">{ sitesPendingReview }</div>
 				<div className="consolidated-commissions__label">
 					{ translate( 'Sites pending review' ) }
 				</div>

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-migration-commissions.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-migration-commissions.ts
@@ -1,0 +1,76 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type { MigrationCommissionItem } from '../types';
+
+export const getMigrationCommissionsQueryKey = ( agencyId?: number ) => {
+	return [ 'a4a-migration-commissions', agencyId ];
+};
+
+// FIXME: Replace 'any' with the correct type once the API is implemented
+const getMigrationCommissions = ( commissions: any ): MigrationCommissionItem[] => {
+	return commissions.map( ( commission: any ) => {
+		return {
+			id: commission.blog_id,
+			siteUrl: commission.site_url,
+			migratedOn: new Date( commission.migrated_on ),
+			reviewStatus: commission.review_status,
+		};
+	} );
+};
+
+export default function useFetchMigrationCommissions() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const isAPIEnabled = false; // Remove this line once the API is implemented
+
+	const data = useQuery( {
+		// Since, we will be removing the hardcoded data, we need not pass the isAPIEnabled as a dependency
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
+		queryKey: getMigrationCommissionsQueryKey( agencyId ),
+		queryFn: () =>
+			isAPIEnabled
+				? wpcom.req.get( {
+						apiNamespace: 'wpcom/v2',
+						path: `/agency/${ agencyId }/migrations/commissions`, // FIXME: Replace with the correct API path
+				  } )
+				: [
+						{
+							blog_id: 1,
+							site_url: 'site1.com',
+							migrated_on: '2024-10-14 13:14:22',
+							review_status: 'confirmed',
+						},
+						{
+							blog_id: 2,
+							site_url: 'site4.com',
+							migrated_on: '2024-06-14 13:14:22',
+							review_status: 'confirmed',
+						},
+						{
+							blog_id: 3,
+							site_url: 'site2.com',
+							migrated_on: '2024-06-14 13:14:22',
+							review_status: 'pending',
+						},
+						{
+							blog_id: 4,
+							site_url: 'site2.com',
+							migrated_on: '2024-06-14 13:14:22',
+							review_status: 'pending',
+						},
+						{
+							blog_id: 5,
+							site_url: 'site5.com',
+							migrated_on: '2024-06-14 13:14:22',
+							review_status: 'rejected',
+						},
+				  ], // Remove this line once the API is implemented
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+		select: getMigrationCommissions,
+	} );
+
+	return data;
+}

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -13,7 +13,9 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import { A4A_MIGRATIONS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import MigrationsCommissionsList from '../../commissions-list';
 import MigrationsConsolidatedCommissions from '../../consolidated-commissions';
+import useFetchMigrationCommissions from '../../hooks/use-fetch-migration-commissions';
 import MigrationsCommissionsEmptyState from './empty-state';
 
 import './style.scss';
@@ -29,7 +31,15 @@ export default function MigrationsCommissions() {
 		// TODO: Implement the tagging functionality
 	}, [ dispatch ] );
 
-	const showEmptyState = false;
+	const { data: migrationCommissions, isFetching: isFetchingCommissions } =
+		useFetchMigrationCommissions();
+
+	if ( isFetchingCommissions ) {
+		// TODO: Add a loading state
+		return null;
+	}
+
+	const showEmptyState = ! migrationCommissions?.length;
 
 	return (
 		<Layout
@@ -67,7 +77,8 @@ export default function MigrationsCommissions() {
 					<MigrationsCommissionsEmptyState />
 				) : (
 					<div className="migrations-commissions__content">
-						<MigrationsConsolidatedCommissions />
+						<MigrationsConsolidatedCommissions items={ migrationCommissions } />
+						<MigrationsCommissionsList items={ migrationCommissions } />
 					</div>
 				) }
 			</LayoutBody>

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/style.scss
@@ -22,12 +22,11 @@
 	}
 
 	.migrations-commissions__content {
-		padding: 16px;
+		.consolidated-commissions {
+			padding: 16px;
 
-		@include break-large {
-			padding: 16px 64px 48px;
-
-			.consolidated-commissions {
+			@include break-large {
+				padding: 16px 64px 48px;
 				flex-direction: row;
 			}
 		}

--- a/client/a8c-for-agencies/sections/migrations/types.ts
+++ b/client/a8c-for-agencies/sections/migrations/types.ts
@@ -1,0 +1,10 @@
+export interface MigrationCommissionItem {
+	id: number;
+	siteUrl: string;
+	migratedOn: Date;
+	reviewStatus: 'confirmed' | 'pending' | 'rejected';
+}
+
+export interface MigrationCommissionAPIResponse {
+	// TODO: Define the API response shape
+}


### PR DESCRIPTION

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1445

## Proposed Changes

This PR implements the Commission's list view for Migrations using dummy data. Please note the API endpoint will be integrated into this in a separate PR.

## Why are these changes being made?

* To show the Commission's list view on the Migrations page. 

## Testing Instructions

* Open the A4A live link >  Go to Migrations: Commissions and verify that the below screen is displayed
* Also, verify that the consolidated data on the top is correct based on the dummy API response.  

<img width="1728" alt="Screenshot 2024-11-11 at 7 31 09 PM" src="https://github.com/user-attachments/assets/d7f5814c-babd-4bec-bc3a-e5dc9e00bfd2">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
