### PR TITLE
Components: add FlowQuestion component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Add FlowQuestion component
+
 ## 2.1.1
 
 - Fix import path in post-stats-card/index.tsx and fix can't resolve "assets" error #90267.

--- a/packages/components/src/flow-question/index.tsx
+++ b/packages/components/src/flow-question/index.tsx
@@ -1,0 +1,66 @@
+import { Flex, FlexBlock, FlexItem, Card, CardBody, Icon } from '@wordpress/components';
+import { chevronRight } from '@wordpress/icons';
+import clsx from 'clsx';
+import Badge from '../badge';
+import type { BadgeType } from '../badge';
+import './style.scss';
+
+interface FlowQuestionProps {
+	icon?: JSX.Element;
+	onClick: () => void;
+	text: string;
+	title: string;
+	disabled?: boolean;
+	badge?: {
+		type: BadgeType;
+		text: string;
+	};
+	className?: string;
+}
+
+const bemElement = ( customClassName?: string ) => ( element: string ) =>
+	customClassName ? `${ customClassName }__${ element }` : undefined;
+
+const FlowQuestion = ( {
+	icon,
+	onClick,
+	text,
+	title,
+	disabled = false,
+	badge,
+	className,
+}: FlowQuestionProps ) => {
+	const bem = bemElement( className );
+
+	return (
+		<Card
+			className={ clsx( 'flow-question', className ) }
+			as="button"
+			size="small"
+			onClick={ onClick }
+			disabled={ disabled }
+		>
+			<CardBody>
+				<Flex>
+					{ icon && (
+						<FlexItem className={ clsx( 'flow-question__icon', bem( 'icon' ) ) }>
+							<Icon icon={ icon } size={ 24 } />
+						</FlexItem>
+					) }
+					<FlexBlock>
+						<h3 className={ clsx( 'flow-question__heading', bem( 'heading' ) ) }>
+							{ title }
+							{ badge && <Badge type={ badge.type }>{ badge.text }</Badge> }
+						</h3>
+						<p className={ clsx( 'flow-question__description', bem( 'description' ) ) }>{ text }</p>
+					</FlexBlock>
+					<FlexItem>
+						<Icon icon={ chevronRight } size={ 24 } />
+					</FlexItem>
+				</Flex>
+			</CardBody>
+		</Card>
+	);
+};
+
+export default FlowQuestion;

--- a/packages/components/src/flow-question/style.scss
+++ b/packages/components/src/flow-question/style.scss
@@ -1,0 +1,45 @@
+@import "@automattic/typography/styles/variables";
+
+button.flow-question {
+	margin: 0;
+	border-radius: 4px;
+	cursor: pointer;
+	text-align: left;
+
+	.components-card__body {
+		padding: 22px 22px 24px;
+	}
+
+	&:hover,
+	&:focus {
+		box-shadow: 0 0 0 1px var(--studio-blue-50);
+
+		svg path {
+			fill: var(--studio-blue-50);
+		}
+
+		.flow-question__description,
+		.flow-question__heading {
+			color: var(--studio-blue-50);
+		}
+	}
+
+	.flow-question__icon {
+		align-self: flex-start;
+		padding: 2px 1px 0 0;
+	}
+
+	.flow-question__heading {
+		font-weight: 500;
+		font-size: $font-body-large;
+		display: flex;
+		align-items: center;
+		gap: 0.5em;
+	}
+
+	.flow-question__description {
+		color: var(--studio-gray-60);
+		padding-right: 10px;
+		margin: 0;
+	}
+}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -70,6 +70,7 @@ export { default as PlanPrice } from './plan-price';
 export { default as ExternalLink } from './external-link';
 export { default as ExternalLinkWithTracking } from './external-link/with-tracking';
 export * from './theme-type-badge';
+export { default as FlowQuestion } from './flow-question';
 
 // Types
 export type { RenderThumbFunction } from './pricing-slider/types';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

In https://github.com/Automattic/wp-calypso/pull/96143 I started moving around "flow question" component from onboarding into Calypso subscriber management screen.

The component is going to be used in "add subscribers" modal:

<img width="582" alt="Screenshot 2024-11-11 at 15 53 39" src="https://github.com/user-attachments/assets/776e323c-40f5-416e-add1-30af35655d44">

Next up I'd use the component in onboarding (replace existing [FlowCard component](https://github.com/Automattic/wp-calypso/tree/e7fda8936bd66e535f64bee07596bfd8c64a4042/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card) used [mostly in migration flows](https://github.com/search?q=repo%3AAutomattic%2Fwp-calypso%20FlowCard&type=code)) and in subscription management.

There could be better alternative name than "FlowQuestion"

There's something wrong with Badge sub-component, but I think it's styles leaking from surrounding code into the component. Should be good to fix in another PR.

## Proposed Changes

* Add "FlowQuestion" component.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just code review at this point.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
