### PR TITLE
Help Center: add feature flag for testing new experiece

### DIFF
--- a/apps/help-center/config.js
+++ b/apps/help-center/config.js
@@ -11,6 +11,7 @@ window.configData = {
 	zendesk_support_chat_key: isProxied ? ZENDESK_STAGING_SUPPORT_CHAT_KEY : ZENDESK_SUPPORT_CHAT_KEY,
 	features: {
 		'help/gpt-response': true,
+		'help-center-experience': false,
 	},
 	wapuu: false,
 };

--- a/config/development.json
+++ b/config/development.json
@@ -76,6 +76,7 @@
 		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
+		"help-center-experience": false,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
 		"hosting/datacenter-picker": true,

--- a/config/production.json
+++ b/config/production.json
@@ -55,6 +55,7 @@
 		"google-photos-picker": false,
 		"help": true,
 		"help/gpt-response": true,
+		"help-center-experience": false,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -55,6 +55,7 @@
 		"google-photos-picker": false,
 		"help": true,
 		"help/gpt-response": true,
+		"help-center-experience": false,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": true,
 		"importer/site-backups": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -61,6 +61,7 @@
 		"google-photos-picker": false,
 		"help": true,
 		"help/gpt-response": true,
+		"help-center-experience": false,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
 		"hosting-server-settings-enhancements": true,


### PR DESCRIPTION
## Proposed Changes

* Add `help-center-experience` to the config.

## Why are these changes being made?

This _should_ allow us to use the feature flag in `wp-admin`.

## Testing Instructions

Check it out