### PR TITLE
Post Purchase: Fix the dashboard heading cache after the user cancels a migration

### DIFF
--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -32,7 +32,9 @@ import {
 	SitesDashboardQueryParams,
 	handleQueryParamChange,
 } from 'calypso/sites-dashboard/components/sites-content-controls';
+import { useSelector } from 'calypso/state';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { useInitializeDataViewsPage } from '../hooks/use-initialize-dataviews-page';
 import { useShowSiteCreationNotice } from '../hooks/use-show-site-creation-notice';
 import { useShowSiteTransferredNotice } from '../hooks/use-show-site-transferred-notice';
@@ -49,7 +51,6 @@ import SitesDashboardBannersManager from './sites-dashboard-banners-manager';
 import SitesDashboardHeader from './sites-dashboard-header';
 import DotcomSitesDataViews, { useSiteStatusGroups } from './sites-dataviews';
 import { getSitesPagination } from './sites-dataviews/utils';
-import type { SiteDetails } from '@automattic/data-stores';
 import type { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 
 // todo: we are using A4A styles until we extract them as common styles in the ItemsDashboard component
@@ -62,7 +63,6 @@ import './guided-tours.scss';
 
 interface SitesDashboardProps {
 	queryParams: SitesDashboardQueryParams;
-	selectedSite?: SiteDetails | null;
 	initialSiteFeature?: string;
 	selectedSiteFeaturePreview?: React.ReactNode;
 	sectionName?: string;
@@ -90,7 +90,6 @@ const SitesDashboard = ( {
 		status,
 		siteType = DEFAULT_SITE_TYPE,
 	},
-	selectedSite,
 	initialSiteFeature = DOTCOM_OVERVIEW,
 	selectedSiteFeaturePreview = undefined,
 }: SitesDashboardProps ) => {
@@ -98,6 +97,8 @@ const SitesDashboard = ( {
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
+	const selectedSite = useSelector( getSelectedSite );
+
 	const sitesFilterCallback = ( site: SiteExcerptData ) => {
 		const { options } = site || {};
 

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -130,11 +130,8 @@ export function sitesDashboard( context: Context, next: () => void ) {
 
 export function siteDashboard( feature: string ) {
 	return ( context: Context, next: () => void ) => {
-		const state = context.store.getState();
-
 		context.primary = (
 			<SitesDashboard
-				selectedSite={ getSelectedSite( state ) }
 				initialSiteFeature={ feature }
 				selectedSiteFeaturePreview={ context.primary }
 				queryParams={ getQueryParams( context ) }


### PR DESCRIPTION

https://github.com/user-attachments/assets/31a3d0c7-392d-4db7-a8c9-b96d7c9071f2

Related to #96230

## Proposed Changes
Make the [/sites-dashboard.tsx](https://github.com/Automattic/wp-calypso/compare/fix/header-update-when-load-site?expand=1#diff-666054b1e2a6f78aeb37afc6a89df6cd13092428043dfb620572824d2c6d15c3) component to listen to changes on the site data, incoming from the store. 

## Why are these changes being made?
* Before this PR, we get the site data from the store and outside the react rendering flow. 
It was preventing the header from reacting to site data changes.  We need reactivity when the user cancels a migration, which requires reloading the site data. This PR makes the component listen to changes on the site objective. 

## Testing Instructions
* Go to any migration flow (e.g./setup/migration)
* Enable the feature flag `sessionStorage.setItem('flags', 'automated-migration/pending-status')` and reload the page
* Follow all migration steps until you see the credential or setup instructions steps.
* Close the tab
* Go to `/sites` 
* Select the create site, which now should have the `migration pending` label
* Click on the `Cancel Migration` CTA


## Tech Notes
We are reloading the site [here](https://github.com/Automattic/wp-calypso/blob/5802642a899e82b9b52a404c58e2728feb4eae79/client/hosting/overview/components/migration-overview/components/migration-pending/index.tsx#L49-L50)

<!-- Uploading d.pr/v/lFzgv4 to GitHub… -->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?