### PR TITLE
Removed override for components-button hover color style

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -6,13 +6,6 @@
 }
 
 /* @wordpress/components Button overrides */
-.components-button {
-	&,
-	&:hover:not(:disabled):not([aria-disabled="true"]) {
-		color: var(--color-neutral-70);
-	}
-}
-
 .components-button.is-primary {
 	background-color: var(--color-accent);
 	border-color: var(--color-accent);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95915

**Issue**:

https://github.com/user-attachments/assets/9b5a4cee-1410-426e-943e-032468ad8b19

**Fix**:

https://github.com/user-attachments/assets/58a79943-9e54-4384-8bed-3f2aec17b37a


## Proposed Changes

* Removed global override for `.components-button:hover` color style

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to avoid custom code and any override on core components.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the action filters of the DataViews don't have the hover effect anymore (as [the core component doesn't](https://wordpress.github.io/gutenberg/?path=/docs/dataviews-dataviews--docs)).
* Ensure we're not adding regressions to the change [that motivated partial change to this code](https://github.com/Automattic/wp-calypso/pull/94786).
* Compare the [/devdocs/wordpress-components-gallery](http://calypso.localhost:3000/devdocs/wordpress-components-gallery) pages from prod and local to ensure [the original code that motivated this override](https://github.com/Automattic/wp-calypso/pull/48683) is not needed anymore.
* Test other usages of `.components-button:hover` inside Calypso to see if it makes sense to complete remove it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
