### PR TITLE
Small UX fixes on UTM modal

### DIFF
--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -158,8 +158,10 @@ const UtmBuilder: React.FC = () => {
 		  }`;
 
 	const handleCopy = () => {
-		navigator.clipboard.writeText( utmString );
-		triggerConfirmation();
+		if ( url ) {
+			navigator.clipboard.writeText( utmString );
+			triggerConfirmation();
+		}
 	};
 
 	return (
@@ -194,7 +196,12 @@ const UtmBuilder: React.FC = () => {
 				<div className="stats-utm-builder__url">{ utmString }</div>
 			</div>
 			<div className="stats-utm-builder__copy-area">
-				<StatsButton className="stats-utm-builder__copy-button" primary onClick={ handleCopy }>
+				<StatsButton
+					className="stats-utm-builder__copy-button"
+					primary
+					onClick={ handleCopy }
+					disabled={ ! url }
+				>
 					{ translate( 'Copy to clipboard' ) }
 				</StatsButton>
 				<CopyConfirmation show={ showConfirmation } fadeOut={ fadeOut } />

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -1,4 +1,6 @@
 import { FormLabel } from '@automattic/components';
+import { Icon, check } from '@wordpress/icons';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useRef, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -23,6 +25,56 @@ type UtmKeyType = ( typeof utmKeys )[ number ];
 
 type inputValuesType = Record< UtmKeyType, string >;
 type formLabelsType = Record< UtmKeyType, { label: string; placeholder: string } >;
+
+const useConfirmationMessage = ( visibleDuration = 2000, fadeOutDuration = 500 ) => {
+	const [ showConfirmation, setShowConfirmation ] = useState( false );
+	const [ fadeOut, setFadeOut ] = useState( false );
+	const timeoutRef = useRef< NodeJS.Timeout | null >( null );
+
+	useEffect( () => {
+		return () => {
+			if ( timeoutRef.current ) {
+				clearTimeout( timeoutRef.current );
+			}
+		};
+	}, [] );
+
+	const triggerConfirmation = () => {
+		if ( timeoutRef.current ) {
+			clearTimeout( timeoutRef.current );
+		}
+
+		setFadeOut( false );
+		setShowConfirmation( true );
+
+		timeoutRef.current = setTimeout( () => {
+			setFadeOut( true );
+
+			timeoutRef.current = setTimeout( () => {
+				setShowConfirmation( false );
+			}, fadeOutDuration );
+		}, visibleDuration );
+	};
+
+	return { showConfirmation, fadeOut, triggerConfirmation };
+};
+
+const CopyConfirmation = ( { show, fadeOut }: { show: boolean; fadeOut: boolean } ) => {
+	const translate = useTranslate();
+
+	return (
+		show && (
+			<div
+				className={ clsx( 'stats-utm-builder__copy-confirmation', {
+					'fade-out': fadeOut,
+				} ) }
+			>
+				<Icon size={ 24 } icon={ check } />
+				{ translate( 'Copied' ) }
+			</div>
+		)
+	);
+};
 
 const InputField: React.FC< InputFieldProps > = ( {
 	id,
@@ -59,6 +111,7 @@ const UtmBuilder: React.FC = () => {
 	} );
 	// Focus the initial input field when rendered.
 	const initialInputReference = useRef< HTMLInputElement >( null );
+	const { showConfirmation, fadeOut, triggerConfirmation } = useConfirmationMessage();
 
 	useEffect( () => {
 		initialInputReference.current!.focus();
@@ -104,6 +157,11 @@ const UtmBuilder: React.FC = () => {
 				campaignString ? `${ url.includes( '?' ) ? '&' : '?' }${ campaignString }` : ''
 		  }`;
 
+	const handleCopy = () => {
+		navigator.clipboard.writeText( utmString );
+		triggerConfirmation();
+	};
+
 	return (
 		<>
 			<form onSubmit={ handleSubmit }>
@@ -135,15 +193,12 @@ const UtmBuilder: React.FC = () => {
 				<div className="stats-utm-builder__label">{ translate( 'Your URL to share' ) }</div>
 				<div className="stats-utm-builder__url">{ utmString }</div>
 			</div>
-			<StatsButton
-				className="stats-utm-builder__copy-button"
-				primary
-				onClick={ () => {
-					navigator.clipboard.writeText( utmString );
-				} }
-			>
-				{ translate( 'Copy to clipboard' ) }
-			</StatsButton>
+			<div className="stats-utm-builder__copy-area">
+				<StatsButton className="stats-utm-builder__copy-button" primary onClick={ handleCopy }>
+					{ translate( 'Copy to clipboard' ) }
+				</StatsButton>
+				<CopyConfirmation show={ showConfirmation } fadeOut={ fadeOut } />
+			</div>
 		</>
 	);
 };

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -107,7 +107,7 @@ const UtmBuilder: React.FC = () => {
 	return (
 		<>
 			<form onSubmit={ handleSubmit }>
-				<FormFieldset>
+				<FormFieldset className="stats-utm-builder__form-fieldset">
 					<InputField
 						id="url"
 						name="url"
@@ -136,6 +136,7 @@ const UtmBuilder: React.FC = () => {
 				<div className="stats-utm-builder__url">{ utmString }</div>
 			</div>
 			<StatsButton
+				className="stats-utm-builder__copy-button"
 				primary
 				onClick={ () => {
 					navigator.clipboard.writeText( utmString );

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -53,8 +53,28 @@ $modal-content-padding: 32px;
 	margin-bottom: 0;
 }
 
+.stats-utm-builder__copy-area {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
 .stats-utm-builder__copy-button {
 	align-self: baseline;
+}
+
+.stats-utm-builder__copy-confirmation {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	color: $studio-jetpack-green-50;
+	fill: $studio-jetpack-green-50;
+	opacity: 1;
+	transition: opacity 0.5s ease;
+
+	&.fade-out {
+		opacity: 0;
+	}
 }
 
 .stats-utm-builder__url {

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -39,6 +39,9 @@ $modal-content-padding: 32px;
 	flex: 1 0 55%;
 	padding: 0 32px 0 0;
 	width: 500px;
+	display: flex;
+	flex-direction: column;
+	gap: $stats-utm-builder-vertical-spacing;
 
 	@media (max-width: $break-small) {
 		padding: 0;
@@ -46,8 +49,15 @@ $modal-content-padding: 32px;
 	}
 }
 
+.stats-utm-builder__form-fieldset {
+	margin-bottom: 0;
+}
+
+.stats-utm-builder__copy-button {
+	align-self: baseline;
+}
+
 .stats-utm-builder__url {
-	margin: 8px 0;
 	background-color: $studio-gray-0;
 	border: 1px solid var(--color-neutral-10);
 	padding: 6px;
@@ -87,18 +97,18 @@ $modal-content-padding: 32px;
 	}
 }
 
-.stats-utm-builder__description {
-	padding: 0 0 $stats-utm-builder-vertical-spacing 0;
-}
-
 .stats-utm-builder__form-field {
-	margin-bottom: 12px;
 	max-width: 700px;
+
+	& + .stats-utm-builder__form-field {
+		margin-top: 12px;
+	}
 }
 
 .stats-utm-builder__label {
 	font-family: $font-sf-pro-text;
 	font-weight: 600;
+	margin-bottom: 5px;
 }
 
 .stats-utm-builder__help-section-parameter {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #https://github.com/Automattic/red-team/issues/204

## Proposed Changes

* Makes the vertical spacing consistent
* Adds a confirmation message on copy
* Disables the copy button when there is no URL to copy

![Screenshot from 2024-11-11 14-16-04](https://github.com/user-attachments/assets/13f6e582-2956-4a4c-bdcc-877b9840319c)
![Screenshot from 2024-11-11 14-16-15](https://github.com/user-attachments/assets/153e9074-6a5b-4d7f-99fe-6f07a8a80ff3)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* UX improvements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Stats admin page
* Click on the UTM button to open the UTM URL builder modal
* Check that the copy button has the same vertical spacing as the other modal sections
* Check that the button is disabled when there is no URL
* Fill some URL and click on the copy button
* Check that there is a confirmation message that fades away

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
