### PR TITLE
Help Center: second attempt feature flag

### DIFF
--- a/apps/help-center/config.js
+++ b/apps/help-center/config.js
@@ -5,13 +5,15 @@ import {
 } from '@automattic/zendesk-client/src/constants';
 
 const isProxied = typeof helpCenterData !== 'undefined' && helpCenterData?.isProxied;
+const flags = new URLSearchParams( window.location.search ).get( 'flags' );
+const isHelpCenterExperienceEnabled = flags?.includes( 'help-center-experience' ) ?? false;
 
 window.configData = {
 	env_id: isProxied ? 'staging' : 'production',
 	zendesk_support_chat_key: isProxied ? ZENDESK_STAGING_SUPPORT_CHAT_KEY : ZENDESK_SUPPORT_CHAT_KEY,
 	features: {
 		'help/gpt-response': true,
-		'help-center-experience': false,
+		'help-center-experience': isHelpCenterExperienceEnabled,
 	},
 	wapuu: false,
 };


### PR DESCRIPTION
## Proposed Changes

Dynamically set the feature in config based on the query params.

## Why are these changes being made?

First attempt didn't work. This is a more dynamic option than my first attempt.

## Testing Instructions

You should be able to use `?flags=help-center-experience` to see the new changes. You can also check `window.configData` to make sure that it is set properly.
