### PR TITLE
Passwordless Core Profiler - Update doc link to https://woocommerce.com/document/connect-your-stor…

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -645,7 +645,13 @@ class Login extends Component {
 								components: {
 									signupLink,
 									br: <br />,
-									doc: <a href="https://woocommerce.com/documentation/woocommerce/" />,
+									doc: (
+										<a
+											href="https://woocommerce.com/document/connect-your-store-to-a-wordpress-com-account/"
+											target="_blank"
+											rel="noreferrer"
+										/>
+									),
 								},
 								args: { pluginName },
 							}

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -167,7 +167,13 @@ export class AuthFormHeader extends Component {
 
 		if ( isWooPasswordlessJPC ) {
 			const pluginName = getPluginTitle( this.props.authQuery?.plugin_name, translate );
-			const reviewDocLink = <a href="https://woocommerce.com/documentation/woocommerce/" />;
+			const reviewDocLink = (
+				<a
+					href="https://woocommerce.com/document/connect-your-store-to-a-wordpress-com-account/"
+					target="_blank"
+					rel="noreferrer"
+				/>
+			);
 			const translateParams = {
 				components: {
 					br: <br />,


### PR DESCRIPTION
Slack thread: p1731343983173119-slack-C01SFMVEYAK

This PR updates "Review our documentation" link to https://woocommerce.com/document/connect-your-store-to-a-wordpress-com-account/. The link should be published soon.

## Proposed Changes

* Updated link

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch and run `yarn start`
2. Once the site is ready, open this [link](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=236381464&redirect_uri=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D32ab4c9508%26redirect%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A2ca8ea2582da1c066074563a12cc8b22&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=13.7&secret=QFoaAXaOIPZTr9p6Z5Hqf6RWkCboPylJ&blogname=Noisily+Fortunate+Toucan&site_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&home_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&site_icon&site_lang=en_US&site_created=2024-08-26+19%3A40%3A51&allow_site_connection=1&calypso_env=production&source&_as=search-term&_ak=jetpack&from=woocommerce-core-profiler&installed_ext_success=1&_ui=254662545&_ut=wpcom%3Auser_id&purchase_nonce=lbtPaOlO&_wp_nonce=69744335dc&redirect_after_auth=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja)
3. Click on `Review our documentation` link and confirm it opens a new window to https://woocommerce.com/document/connect-your-store-to-a-wordpress-com-account/ (it's okay the page shows 404 not found. We'll publish the page soon)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?