### PR TITLE
Center migration overview and hosting features component

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-content/style.scss
@@ -7,7 +7,7 @@
 	overflow-x: hidden;
 	display: flex;
 
-	&:has( .migration-overview ) {
+	&:has( .migration-overview, .hosting-features ) {
 		justify-content: center;
 	}
 }

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-content/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-content/style.scss
@@ -6,4 +6,8 @@
 	overflow-y: auto;
 	overflow-x: hidden;
 	display: flex;
+
+	&:has( .migration-overview ) {
+		justify-content: center;
+	}
 }

--- a/client/hosting/overview/components/migration-overview/index.tsx
+++ b/client/hosting/overview/components/migration-overview/index.tsx
@@ -10,17 +10,17 @@ const MigrationOverview = ( { site }: { site: SiteDetails } ) => {
 	const migrationStatus = getMigrationStatus( site );
 	const isPending = 'pending' === migrationStatus;
 
+	let component;
+
 	if ( isPending ) {
-		return <MigrationPending site={ site } />;
+		component = <MigrationPending site={ site } />;
+	} else if ( migrationType === 'difm' ) {
+		component = <MigrationStartedDIFM site={ site } />;
+	} else if ( migrationType === 'diy' ) {
+		component = <MigrationStartedDIY site={ site } />;
 	}
 
-	if ( migrationType === 'difm' ) {
-		return <MigrationStartedDIFM site={ site } />;
-	}
-
-	if ( migrationType === 'diy' ) {
-		return <MigrationStartedDIY site={ site } />;
-	}
+	return <div className="migration-overview">{ component }</div>;
 };
 
 export default MigrationOverview;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

Horizontally center migration and hosting features overview components on `/sites`. This two screens doesn't look good when left aligned.

**Before**
<img width="2488" alt="image" src="https://github.com/user-attachments/assets/381fec57-0b37-4b9c-8ae2-505c4537734e">

**After**
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/e91231d2-2c39-43f2-bae4-e6b48c8b645b">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The migration overview and the hosting features components rendered in /sites where not centered on big screens. This kind of card layout looks weird if left aligned.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the change or navigate to the Calypso Live link below
* Go to `/sites` 
* Select a site that's on a free plan
* Verify the hosting features component looks centered on big screens
* For the migration overview follow instructions in [this PR](https://github.com/Automattic/wp-calypso/pull/95963) since the feature is not live yet

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
