### PR TITLE
Jetpack Manage: Only create Setup Intent ID just before using it

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/lib/create-stripe-setup-intent-for-jetpack-manage.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/create-stripe-setup-intent-for-jetpack-manage.ts
@@ -1,0 +1,16 @@
+import { getStripeConfiguration } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/get-stripe-configuration';
+import type { StripeSetupIntentId } from '@automattic/calypso-stripe';
+
+export async function createStripeSetupIntentForJetpackManage(): Promise< StripeSetupIntentId > {
+	const configuration = await getStripeConfiguration( { needs_intent: true } );
+	const intentId: string | undefined =
+		configuration?.setup_intent_id && typeof configuration.setup_intent_id === 'string'
+			? configuration.setup_intent_id
+			: undefined;
+	if ( ! intentId ) {
+		throw new Error(
+			'Error loading new payment method intent. Received invalid data from the server.'
+		);
+	}
+	return intentId;
+}

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
@@ -1,11 +1,5 @@
 import page from '@automattic/calypso-router';
-import {
-	ReloadSetupIntentId,
-	StripeHookProvider,
-	StripeSetupIntentIdProvider,
-	useStripe,
-	useStripeSetupIntentId,
-} from '@automattic/calypso-stripe';
+import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { Button } from '@automattic/components';
 import {
 	CheckoutProvider,
@@ -49,16 +43,12 @@ function onPaymentSelectComplete( {
 	successCallback,
 	translate,
 	showSuccessMessage,
-	reloadSetupIntentId,
 }: {
 	successCallback: () => void;
 	translate: ReturnType< typeof useTranslate >;
 	showSuccessMessage: ( message: string | TranslateResult ) => void;
-	reloadSetupIntentId: ReloadSetupIntentId;
 } ) {
 	showSuccessMessage( translate( 'Your payment method has been added successfully.' ) );
-	// We need to regenerate the setup intent if the form was submitted.
-	reloadSetupIntentId();
 	successCallback();
 }
 
@@ -67,11 +57,6 @@ function PaymentMethodForm() {
 	const reduxDispatch = useDispatch();
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
-	const {
-		reload: reloadSetupIntentId,
-		setupIntentId: stripeSetupIntentId,
-		error: setupIntentError,
-	} = useStripeSetupIntentId();
 	const stripeMethod = useCreateStoredCreditCardMethod( {
 		isStripeLoading,
 		stripeLoadingError,
@@ -156,10 +141,8 @@ function PaymentMethodForm() {
 					{ id: 'payment-method-failure' }
 				)
 			);
-			// We need to regenerate the setup intent if the form was submitted.
-			reloadSetupIntentId();
 		},
-		[ reduxDispatch, translate, reloadSetupIntentId ]
+		[ reduxDispatch, translate ]
 	);
 
 	const showSuccessMessage = useCallback(
@@ -229,12 +212,6 @@ function PaymentMethodForm() {
 		}
 	}, [ stripeLoadingError, reduxDispatch ] );
 
-	useEffect( () => {
-		if ( setupIntentError ) {
-			reduxDispatch( errorNotice( setupIntentError.message ) );
-		}
-	}, [ setupIntentError, reduxDispatch ] );
-
 	const elements = useElements();
 
 	const getPreviousPageLink = () => {
@@ -262,7 +239,6 @@ function PaymentMethodForm() {
 					successCallback,
 					translate,
 					showSuccessMessage,
-					reloadSetupIntentId,
 				} );
 			} }
 			onPaymentError={ handleChangeError }
@@ -276,7 +252,6 @@ function PaymentMethodForm() {
 							translate,
 							stripe,
 							stripeConfiguration,
-							stripeSetupIntentId,
 							cardElement: elements?.getElement( CardElement ) ?? undefined,
 							reduxDispatch,
 						},
@@ -373,11 +348,7 @@ export default function PaymentMethodFormWrapper() {
 
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<StripeSetupIntentIdProvider
-				fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
-			>
-				<PaymentMethodForm />
-			</StripeSetupIntentIdProvider>
+			<PaymentMethodForm />
 		</StripeHookProvider>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions.ts
@@ -3,6 +3,7 @@ import { makeSuccessResponse, makeErrorResponse } from '@automattic/composite-ch
 import { useTranslate } from 'i18n-calypso';
 import { saveCreditCard } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/stored-payment-method-api';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { createStripeSetupIntentForJetpackManage } from '../lib/create-stripe-setup-intent-for-jetpack-manage';
 import type { StripeConfiguration, StripeSetupIntent } from '@automattic/calypso-stripe';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { Stripe, StripeCardElement } from '@stripe/stripe-js';
@@ -13,7 +14,6 @@ interface Props {
 	translate: ReturnType< typeof useTranslate >;
 	stripe: Stripe | null;
 	stripeConfiguration: StripeConfiguration | null;
-	stripeSetupIntentId: string | undefined;
 	cardElement: StripeCardElement | undefined;
 	reduxDispatch: CalypsoDispatch;
 }
@@ -24,7 +24,6 @@ export async function assignNewCardProcessor(
 		translate,
 		stripe,
 		stripeConfiguration,
-		stripeSetupIntentId,
 		cardElement,
 		reduxDispatch,
 	}: Props,
@@ -36,12 +35,14 @@ export async function assignNewCardProcessor(
 		if ( ! isNewCardDataValid( submitData ) ) {
 			throw new Error( 'Credit Card data is missing your full name.' );
 		}
-		if ( ! stripe || ! stripeConfiguration || ! stripeSetupIntentId ) {
+		if ( ! stripe || ! stripeConfiguration ) {
 			throw new Error( 'Cannot assign payment method if Stripe is not loaded' );
 		}
 		if ( ! cardElement ) {
 			throw new Error( 'Cannot assign payment method if there is no card element' );
 		}
+
+		const stripeSetupIntentId = await createStripeSetupIntentForJetpackManage();
 
 		const { name } = submitData;
 


### PR DESCRIPTION
## Proposed Changes

This PR removes the deprecated `StripeSetupIntentIdProvider` and `useStripeSetupIntentId` from Jetpack Manage and instead creates the Stripe Setup Intent on-the-fly when the "add new card" forms are submitted.

Fixes https://github.com/Automattic/payments-shilling/issues/3177 

## Why are these changes being made?

In order to add a new credit card without a (paid) purchase, we must create a Stripe Setup Intent. To do this requires first fetching an intent ID from our endpoint. Because of the implementation details when this was originally implemented, we fetched this ID when the "Add new payment method" form (originally the only place that used a Setup Intent) loaded. This was fine because it was very likely that the user would add a new card on that form. However, now that we accept new credit cards for free purchases in checkout, this means we are creating far more setup intent IDs than we need.

This was completed for wpcom checkout in https://github.com/Automattic/wp-calypso/pull/79881 and A4A in https://github.com/Automattic/wp-calypso/pull/93095, but the Jetpack Manage instance has remained unchanged because this interface was supposedly being removed. Since that has not happened in the months since that discussion (see Slack p1716781951921369/1716579009.648549-slack-C02DQP0FP), I think it's best if we migrate this code anyway.

## Testing Instructions

I have no idea how to test this component, but you can verify that the changes match those in https://github.com/Automattic/wp-calypso/pull/79881 and the TypeScript types are all satisfied. We are re-using the special Jetpack Manage version of `getStripeConfiguration()` that was already used by the code here, so I assume it will continue to work.

I'll include the Jetpack team on the reviews in case they know how to test it properly.