### PR TITLE
Move skip purchase button to middle, remove chevron

### DIFF
--- a/client/components/domains/domain-skip-suggestion/index.jsx
+++ b/client/components/domains/domain-skip-suggestion/index.jsx
@@ -20,7 +20,7 @@ class DomainSkipSuggestion extends Component {
 				extraClasses="is-visible domain-skip-suggestion"
 				hidePrice
 				onButtonClick={ this.props.onButtonClick }
-				showChevron
+				showChevron={ false }
 				// tracksButtonClickSource={ this.props.tracksButtonClickSource }
 			>
 				<div className="domain-skip-suggestion__domain-description">

--- a/client/components/domains/domain-skip-suggestion/style.scss
+++ b/client/components/domains/domain-skip-suggestion/style.scss
@@ -1,6 +1,7 @@
 .domain-skip-suggestion {
 	display: flex;
 	align-items: center;
+	justify-content: center;
 
 	& .button.domain-suggestion__action.is-borderless {
 		flex: 1 0 auto;
@@ -9,6 +10,14 @@
 	.domain-suggestion__action-container {
 		display: flex;
 	}
+
+	.domain-suggestion__content {
+		width: auto;
+	}
+}
+
+.domain-skip-suggestion::after {
+	display: none;
 }
 
 .domain-skip-suggestion__domain-description {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -363,12 +363,9 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.domain-suggestion {
+		flex-direction: column;
 		box-shadow: none;
 		margin: 0;
-
-		&:not(.domain-skip-suggestion) {
-			flex-direction: column;
-		}
 
 		@include break-small {
 			margin: 0 20px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96222

## Proposed Changes

* As per the suggestion made here https://github.com/Automattic/wp-calypso/issues/96222, we're moving the skip purchase button to the middle and removing the chevorn icon

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because the whole area is no longer clickable.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a site without a custom domain and don't launch it
- Go to wordpress.com/sites
- Select the unlaunched site without a custom domain
- Navigate to [...]Settings > General and Launch your site
- Scroll to the bottom of the domains list
- Confirm that "Skip Purchase" button looks good and it's in the middle and the chevron icon of the right is not there anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
