### PR TITLE
My home: reverse the order of buttons on domains card

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -56,7 +56,7 @@ body .customer-home__layout .domain-upsell__card {
 		padding: 24px 0 0;
 		gap: 16px;
 		@media (min-width: ($break-large + 1)) {
-			flex-direction: row-reverse;
+			flex-direction: row;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9761

## Proposed Changes

This PR switches the order of buttons on the domains card on My Home so that `Get this domain` button comes first:

<img width="674" alt="Screenshot 2024-11-11 at 9 25 43 PM" src="https://github.com/user-attachments/assets/e2b709a2-3e5a-442e-9f04-8513819cd410">

**Before**

<img width="593" alt="Screenshot 2024-11-11 at 9 25 52 PM" src="https://github.com/user-attachments/assets/2905c61e-bc38-4aeb-b209-937757dbff7c">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*Create a site with Business plan but do not purchase a domain
* Navigate to Calypso Live link below
* Navigate to `home/{yourBusinessSite}`
* Scroll down to the card that says "That perfect domain is waiting"
* Observe that `Get this domain` action button comes first and is followed by `Search for this domain`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
