### PR TITLE
Converting GitHub Deployments list to DataViews

### DIFF
--- a/client/sites/tools/deployments/deployments/index.tsx
+++ b/client/sites/tools/deployments/deployments/index.tsx
@@ -1,25 +1,48 @@
-import page from '@automattic/calypso-router';
-import { useI18n } from '@wordpress/react-i18n';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { translate } from 'i18n-calypso';
+import { useMemo, useState } from 'react';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { HostingCard } from 'calypso/components/hosting-card';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { GitHubDeploymentSurvey } from '../components/deployments-survey';
 import { GitHubLoadingPlaceholder } from '../components/loading-placeholder';
-import { PageShell } from '../components/page-shell';
 import { GitHubDeploymentCreationForm } from '../deployment-creation/deployment-creation-form';
-import { createDeploymentPage } from '../routes';
-import { ConnectionWizardButton } from './connection-wizard-button';
 import { GitHubDeploymentsList } from './deployments-list';
+import { useActions } from './use-actions';
 import { useCodeDeploymentsQuery } from './use-code-deployments-query';
+import { useFields } from './use-fields';
 
 import './styles.scss';
 
+const defaultLayouts = { table: {} };
+
 export function GitHubDeployments() {
 	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
-	const { __ } = useI18n();
+	const selectedSite = useSelector( getSelectedSite );
 
 	const { data: deployments, isLoading, refetch } = useCodeDeploymentsQuery( siteId );
+	const fields = useFields( selectedSite?.slug );
+	const actions = useActions( selectedSite?.slug );
+
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( () => ( {
+		...initialDataViewsState,
+		perPage: 15,
+		search: '',
+		// fields: [ 'repository', 'sites', 'update' ],
+	} ) );
+
+	const { data, paginationInfo } = useMemo( () => {
+		const result = filterSortAndPaginate( deployments, dataViewsState, fields );
+
+		return {
+			data: result.data,
+			paginationInfo: result.paginationInfo,
+		};
+	}, [ deployments, dataViewsState, fields ] );
+
+	console.log( 'deployments: ', deployments );
 
 	const renderContent = () => {
 		if ( deployments?.length ) {
@@ -45,20 +68,18 @@ export function GitHubDeployments() {
 	};
 
 	return (
-		<PageShell
-			pageTitle={ __( 'Deployments' ) }
-			topRightButton={
-				deployments &&
-				deployments?.length > 0 && (
-					<ConnectionWizardButton
-						onClick={ () => {
-							page( createDeploymentPage( siteSlug! ) );
-						} }
-					/>
-				)
-			}
-		>
-			{ renderContent() }
-		</PageShell>
+		<DataViews
+			data={ data }
+			view={ dataViewsState }
+			onChangeView={ setDataViewsState }
+			fields={ fields }
+			search
+			searchLabel={ translate( 'Search by repository name …' ) }
+			actions={ actions }
+			// isLoading={ isLoading }
+			paginationInfo={ paginationInfo }
+			defaultLayouts={ defaultLayouts }
+			// header={ header }
+		/>
 	);
 }

--- a/client/sites/tools/deployments/deployments/use-actions.tsx
+++ b/client/sites/tools/deployments/deployments/use-actions.tsx
@@ -1,0 +1,65 @@
+import page from '@automattic/calypso-router';
+import { dispatch } from '@wordpress/data';
+import { Icon, link, linkOff } from '@wordpress/icons';
+import { translate } from 'i18n-calypso';
+import { navigate } from 'calypso/lib/navigate';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
+import { Plugin } from 'calypso/state/plugins/installed/types';
+import { CodeDeploymentData } from './use-code-deployments-query';
+
+export function useActions( siteSlug: { siteSlug?: string }, onManualDeployment: () => void ) {
+	const actions = [
+		{
+			id: 'manual-deployment',
+			href: `some-url`,
+			callback: ( plugins: Array< CodeDeploymentData > ) => {
+				plugins.length && navigate( '/plugins/' + plugins[ 0 ].slug );
+
+				dispatch( recordTracksEvent( 'calypso_hosting_github_manual_deployment_run_click' ) );
+				onManualDeployment();
+			},
+			label: translate( 'Trigger manual deployment' ),
+			isExternalLink: true,
+			isEnabled: true,
+		},
+		{
+			id: 'deployment-runs',
+			href: `some-url`,
+			callback: ( plugins: Array< CodeDeploymentData > ) => {
+				dispatch( recordTracksEvent( 'calypso_hosting_github_see_deployment_runs_click' ) );
+				page( viewDeploymentLogs( siteSlug, deployment.id ) );
+			},
+			label: translate( 'See deployment runs' ),
+			isExternalLink: true,
+			isEligible( plugin: Plugin ) {
+				return plugin.status?.includes( PLUGINS_STATUS.INACTIVE ) ?? true;
+			},
+			icon: <Icon icon={ link } />,
+		},
+		{
+			id: 'connection',
+			href: `some-url`,
+			callback: ( plugins: Array< CodeDeploymentData > ) => {},
+			label: translate( 'Configure connection' ),
+			isExternalLink: true,
+			isEligible( plugin: CodeDeploymentData ) {
+				return plugin.status?.includes( PLUGINS_STATUS.ACTIVE ) ?? true;
+			},
+			icon: <Icon icon={ linkOff } />,
+		},
+		{
+			id: 'disconnect',
+			href: `some-url`,
+			callback: ( plugins: Array< CodeDeploymentData > ) => {},
+			label: translate( 'Disconnect repository' ),
+			icon: linkOff,
+			isExternalLink: true,
+			isEligible( plugin: CodeDeploymentData ) {
+				return plugin.status?.includes( PLUGINS_STATUS.AUTOUPDATE_DISABLED ) ?? true;
+			},
+		},
+	];
+
+	return actions;
+}

--- a/client/sites/tools/deployments/deployments/use-fields.tsx
+++ b/client/sites/tools/deployments/deployments/use-fields.tsx
@@ -1,0 +1,123 @@
+import page from '@automattic/calypso-router';
+import { useLocale } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
+import { Operator } from '@wordpress/dataviews';
+import { translate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
+import { manageDeploymentPage, viewDeploymentLogs } from '../routes';
+import { formatDate } from '../utils/dates';
+import { DeploymentCommitDetails } from './deployment-commit-details';
+import { DeploymentDuration } from './deployment-duration';
+import { DeploymentStatus, DeploymentStatusValue } from './deployment-status';
+import { CodeDeploymentData } from './use-code-deployments-query';
+
+export function useFields( siteSlug?: string ) {
+	const locale = useLocale();
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'repository',
+				label: translate( 'Repository' ),
+				getValue: ( { item }: { item: CodeDeploymentData } ) => item.repository_name,
+				enableGlobalSearch: true,
+				render: ( { item }: { item: CodeDeploymentData } ) => {
+					const [ installation, repo ] = item.repository_name.split( '/' );
+
+					return (
+						<>
+							<Button
+								onClick={ () => {
+									page( manageDeploymentPage( siteSlug!, item.id ) );
+								} }
+							>
+								{ repo }
+							</Button>
+							<span>{ installation }</span>
+						</>
+					);
+				},
+				enableSorting: true,
+			},
+			{
+				id: 'last-commit',
+				label: translate( 'Last commit' ),
+				enableHiding: false,
+				render: ( { item }: { item: CodeDeploymentData } ) => {
+					return (
+						item?.current_deployment_run && (
+							<DeploymentCommitDetails run={ item.current_deployment_run } deployment={ item } />
+						)
+					);
+				},
+			},
+			{
+				id: 'status',
+				label: translate( 'Status' ),
+				getValue: ( { item }: { item: CodeDeploymentData } ) => {
+					return item.current_deployment_run?.status;
+				},
+				render: ( { item }: { item: CodeDeploymentData } ) => {
+					return (
+						item?.current_deployment_run && (
+							<DeploymentStatus
+								status={ item.current_deployment_run?.status as DeploymentStatusValue }
+								href={ viewDeploymentLogs( siteSlug!, item.id ) }
+							/>
+						)
+					);
+				},
+				elements: [
+					{
+						value: PLUGINS_STATUS.ACTIVE,
+						label: translate( 'Active' ),
+					},
+					{
+						value: PLUGINS_STATUS.INACTIVE,
+						label: translate( 'Inactive' ),
+					},
+					{
+						value: PLUGINS_STATUS.UPDATE,
+						label: translate( 'Needs update' ),
+					},
+				],
+				filterBy: {
+					operators: [ 'is' as Operator ],
+					isPrimary: true,
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'date',
+				label: translate( 'Date' ),
+				getValue: ( { item }: { item: CodeDeploymentData } ) => {
+					return item?.current_deployment_run?.created_on;
+				},
+				enableHiding: false,
+				render: ( { item }: { item: CodeDeploymentData } ) => {
+					return formatDate( locale, new Date( item?.current_deployment_run?.created_on || 0 ) );
+				},
+			},
+			{
+				id: 'duration',
+				label: translate( 'Duration' ),
+				getValue: ( { item }: { item: CodeDeploymentData } ) => {
+					return item?.current_deployment_run?.created_on;
+				},
+				enableHiding: false,
+				render: ( { item }: { item: CodeDeploymentData } ) => {
+					return (
+						item?.current_deployment_run && (
+							<DeploymentDuration run={ item.current_deployment_run } />
+						)
+					);
+				},
+			},
+		],
+		[ locale, siteSlug ]
+	);
+
+	return fields;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9598

## Proposed Changes

* We're migrating GHD to DataViews:

https://github.com/user-attachments/assets/38808f73-cc0e-4970-b6b2-0bd2c4468718



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
