### PR TITLE
Site Profiler CSS improvements

### DIFF
--- a/client/hosting/performance/components/device-tab-control/style.scss
+++ b/client/hosting/performance/components/device-tab-control/style.scss
@@ -33,6 +33,10 @@
 				border-color: var(--studio-gray-20);
 				border-right: unset;
 			}
+
+			&.is-selected + .segmented-control__item .segmented-control__link {
+				border-left-color: var(--studio-gray-20);
+			}
 		}
 	}
 }

--- a/client/performance-profiler/components/charts/history-chart.jsx
+++ b/client/performance-profiler/components/charts/history-chart.jsx
@@ -79,7 +79,7 @@ const drawGrid = ( svg, yScale, width, margin ) => {
 		.attr( 'y1', yScale )
 		.attr( 'y2', yScale )
 		.attr( 'stroke', '#F6F7F7' )
-		.attr( 'stroke-width', 2 );
+		.attr( 'stroke-width', 1 );
 };
 
 // Draw line with gradient

--- a/client/performance-profiler/components/core-web-vitals-accordion/styles.scss
+++ b/client/performance-profiler/components/core-web-vitals-accordion/styles.scss
@@ -1,4 +1,5 @@
 @import "@automattic/components/src/styles/typography";
+@import "@wordpress/base-styles/breakpoints";
 
 $blueberry-color: #3858e9;
 
@@ -59,6 +60,12 @@ $blueberry-color: #3858e9;
 					font-family: $font-sf-pro-display;
 					font-size: 1rem;
 					font-weight: 500;
+
+					.core-web-vitals-accordion__header-text-value {
+						@media (max-width: $break-mobile) {
+							font-size: 1.75rem;
+						}
+					}
 				}
 			}
 
@@ -92,8 +99,6 @@ $blueberry-color: #3858e9;
 			}
 		}
 	}
-
-
 }
 
 .core-web-vitals-accordion__header {
@@ -116,11 +121,9 @@ $blueberry-color: #3858e9;
 }
 
 .core-web-vitals-accordion__header-text-value {
-
 	font-family: $font-sf-pro-display;
 	font-size: $font-size-header-small;
 	margin-top: 6px;
-
 
 	&.good {
 		color: #00ba37;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9293 https://github.com/Automattic/dotcom-forge/issues/9295 https://github.com/Automattic/dotcom-forge/issues/9296

## Proposed Changes

1. Consistent border colors for the device switcher.

| Before | After |
| --- | --- |
| ![Screenshot 2024-11-12 at 2 46 08 PM](https://github.com/user-attachments/assets/5dac9e0e-c7e0-49fe-9d2a-8cf1028bd2c7) | ![Screenshot 2024-11-12 at 2 46 50 PM](https://github.com/user-attachments/assets/12819b67-c0f9-4ecf-a2ca-4d2fc9079fc4) |

2. Update the stroke width of the chart line to be 1px.

| Before | After |
| --- | --- |
| ![Screenshot 2024-11-12 at 2 47 42 PM](https://github.com/user-attachments/assets/cb025762-ed7b-4f3d-8b92-82ff16cc027f) |  ![Screenshot 2024-11-12 at 2 47 34 PM](https://github.com/user-attachments/assets/147df5d8-c438-4c20-9431-24c9afa26405) |

3. Metric value should increase to 28px when select on mobile.

| Before | After |
| --- | --- |
| ![Screenshot 2024-11-12 at 2 47 10 PM](https://github.com/user-attachments/assets/7572c0bd-c665-485d-956a-9da49a02d146) | ![Screenshot 2024-11-12 at 2 47 24 PM](https://github.com/user-attachments/assets/2ba28d19-f26e-4d76-9f76-040cc93b6c98)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall WordPress.com polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites/performance/:domain using an Atomic site.
* Ensure that the UI is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
