### PR TITLE
Fix style of launch confirmation modal for A4A dev sites

### DIFF
--- a/client/sites/settings/site/visibility/launch-confirmation-modal.tsx
+++ b/client/sites/settings/site/visibility/launch-confirmation-modal.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
-import { Modal } from '@wordpress/components';
+import { Modal, Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 
 const ActionButtons = styled.div( {
@@ -23,22 +22,19 @@ export function LaunchConfirmationModal( {
 	const modalTitle = translate( "You're about to launch this website" );
 
 	return (
-		<Modal
-			className="site-settings__launch-confirmation-modal"
-			title={ modalTitle }
-			onRequestClose={ closeModal }
-		>
+		<Modal title={ modalTitle } onRequestClose={ closeModal } size="medium">
 			{ message && <p>{ message }</p> }
 			<p>{ translate( 'Ready to launch?' ) }</p>
 			<ActionButtons>
 				<Button
+					variant="secondary"
 					onClick={ () => {
 						closeModal();
 					} }
 				>
 					{ translate( 'Cancel' ) }
 				</Button>
-				<Button primary onClick={ onConfirmation }>
+				<Button variant="primary" onClick={ onConfirmation }>
 					{ translate( 'Launch site' ) }
 				</Button>
 			</ActionButtons>

--- a/client/sites/settings/site/visibility/styles.scss
+++ b/client/sites/settings/site/visibility/styles.scss
@@ -21,6 +21,3 @@
 	white-space: nowrap;
 }
 
-.site-settings__launch-confirmation-modal {
-	max-width: 60%;
-}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9602

## Proposed Changes

* Use Core's Modal: https://wordpress.github.io/gutenberg/?path=/docs/components-modal--docs

| Screen | Before  | After |
| :-------------: | :-------------: | :-------------: |
| Mobile | <img src="https://github.com/user-attachments/assets/4e20fb98-a4b2-490b-837a-74170d6d8ad9">  | <img src="https://github.com/user-attachments/assets/03ffbe13-defd-499b-9647-09a8cb959ee5">|
| Desktop | <img src="https://github.com/user-attachments/assets/5cee23d1-2dba-47fe-b078-940bd4530ac4">  | <img src="https://github.com/user-attachments/assets/4e568343-4a03-4e25-adaf-46ec3f3cd25e">|

Related discussion: p1731332571284379/1730421945.626839-slack-C9EJ7KSGH


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistency in Dotcom UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new development site in A4A
![create a dev site@2x](https://github.com/user-attachments/assets/73acb750-c1ac-4a83-9e10-bef807d8f5e8)
* Go to /settings/general/:site
* Click on Launch Site
![launch site@2x](https://github.com/user-attachments/assets/0234b0f6-c9bb-4abd-a821-750f8a82a624)
* Check the style for the modal on mobile/desktop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?