### PR TITLE
Update copy on Delete account screen

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -202,7 +202,7 @@ class AccountSettingsClose extends Component {
 								</p>
 								<p className="account-close__body-copy">
 									{ translate(
-										'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Polldaddy.com, IntenseDebate.com, and Gravatar.com. Once your WordPress.com account is deleted, these services will also be deleted and you will lose access to any orders or support history you may have.'
+										'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Crowdsignal.com, IntenseDebate.com, and Gravatar.com. Once your WordPress.com account is deleted, these services will also be deleted and you will lose access to any orders or support history you may have.'
 									) }
 								</p>
 								<p className="account-close__body-copy">

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
-import i18n, { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -81,7 +81,7 @@ class AccountSettingsClose extends Component {
 				<NavigationHeader navigationItems={ [] } title={ translate( 'Account Settings' ) } />
 
 				<HeaderCake onClick={ this.goBack }>
-					<h1>{ translate( 'Close account' ) }</h1>
+					<h1>{ translate( 'Delete account' ) }</h1>
 				</HeaderCake>
 				<ActionPanel>
 					<ActionPanelBody>
@@ -175,11 +175,9 @@ class AccountSettingsClose extends Component {
 						{ ( isLoading || isDeletePossible ) && (
 							<Fragment>
 								<p className="account-close__body-copy">
-									{ this.props.sitesToBeDeleted.length > 0
-										? translate(
-												'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
-										  )
-										: translate( 'Account closure cannot be undone.' ) }
+									{ translate(
+										'Deleting your account will also delete all your sites and their content.'
+									) }
 								</p>
 								{ purchasedPremiumThemes && purchasedPremiumThemes.length > 0 && (
 									<Fragment>
@@ -204,39 +202,20 @@ class AccountSettingsClose extends Component {
 								</p>
 								<p className="account-close__body-copy">
 									{ translate(
-										'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Crowdsignal.com, IntenseDebate.com and Gravatar.com. Once your WordPress.com account is closed, these services will also be closed and you will lose access to any orders or support history you may have.'
+										'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Polldaddy.com, IntenseDebate.com, and Gravatar.com. Once your WordPress.com account is deleted, these services will also be deleted and you will lose access to any orders or support history you may have.'
 									) }
 								</p>
 								<p className="account-close__body-copy">
-									{ getLocaleSlug().startsWith( 'en' ) ||
-									i18n.hasTranslation(
-										'If you have any questions at all about what happens when you close an account, ' +
+									{ translate(
+										'If you have any questions at all about what happens when you delete an account, ' +
 											'please {{a}}contact someone from our support team{{/a}} first. ' +
-											"They'll explain the ramifications and help you explore alternatives. "
-									)
-										? translate(
-												'If you have any questions at all about what happens when you close an account, ' +
-													'please {{a}}contact someone from our support team{{/a}} first. ' +
-													"They'll explain the ramifications and help you explore alternatives. ",
-												{
-													components: {
-														a: <ActionPanelLink href="/help/contact" />,
-													},
-												}
-										  )
-										: translate(
-												'If you have any questions at all about what happens when you close an account, ' +
-													'please {{a}}chat with someone from our support team{{/a}} first. ' +
-													"They'll explain the ramifications and help you explore alternatives. ",
-												{
-													components: {
-														a: <ActionPanelLink href="/help/contact" />,
-													},
-												}
-										  ) }
-								</p>
-								<p className="account-close__body-copy">
-									{ translate( 'When you\'re ready to proceed, use the "Close account" button.' ) }
+											"They'll explain the ramifications and help you explore alternatives. ",
+										{
+											components: {
+												a: <ActionPanelLink href="/help/contact" />,
+											},
+										}
+									) }
 								</p>
 							</Fragment>
 						) }
@@ -245,7 +224,7 @@ class AccountSettingsClose extends Component {
 						{ ( isLoading || isDeletePossible ) && (
 							<Button scary onClick={ this.handleDeleteClick } data-testid="close-account-button">
 								<Gridicon icon="trash" />
-								{ translate( 'Close account', { context: 'button label' } ) }
+								{ translate( 'Delete account', { context: 'button label' } ) }
 							</Button>
 						) }
 						{ hasAtomicSites && ! hasCancelablePurchases && (


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9499

> [!WARNING]  
> Merge after translations are done.

## Proposed Changes

* Update copy for close account -> delete account
* All mentions of close will be delete, deleted for alignment

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improvements on copy alignment

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me/account/close on an account with purchases and one that doesn't
* Check if all mentions of "close account" has been "delete account"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
