### PR TITLE
A4A: Update a few copies related to Agency Tier and benefits.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { isPathAllowed } from 'calypso/a8c-for-agencies/lib/permission';
+import Badge from 'calypso/components/badge';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -199,6 +200,7 @@ const useMainMenuItems = ( path: string ) => {
 							path: '/',
 							link: A4A_AGENCY_TIER_LINK,
 							title: translate( 'Agency Tier' ),
+							extraContent: <Badge type="info-blue">{ translate( 'beta' ) }</Badge>,
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Agency Tier',
 							},

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
@@ -50,7 +50,7 @@ const getAgencyTierInfo = (
 					{ args: { amount: '$1,200' }, comment: 'Amount of revenue' }
 				),
 				description: translate(
-					'Progress towards the Agency Partner tier and access extra benefits with additional purchases and referrals.'
+					'Progress towards the Agency Partner Tier and access extra benefits with additional purchases and referrals.'
 				),
 				logo: EmergingPartnerLogo,
 				includedTiers: [ 'emerging-partner' ],

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
@@ -13,11 +13,11 @@ const getAgencyTierInfo = (
 	translate: ( key: string, args?: Record< string, unknown > ) => string
 ) => {
 	let tierInfo: AgencyTierInfo = {
-		title: translate( 'Make your {{b}}first purchase{{/b}} to {{b}}activate your account{{/b}}', {
+		title: translate( '{{b}}Activate your account{{/b}} by {{b}}making your first purchase{{/b}}', {
 			components: { b: <b /> },
 		} ),
 		fullTitle: translate(
-			'{{label}}Make your first purchase to{{/label}} {{title}}Activate your Account{{/title}}',
+			'{{title}}Activate your account{{/title}} {{label}}by making your first purchase{{/label}}',
 			{
 				components: {
 					label: <div className="agency-tier-overview__current-agency-tier-label"></div>,
@@ -55,9 +55,9 @@ const getAgencyTierInfo = (
 				logo: EmergingPartnerLogo,
 				includedTiers: [ 'emerging-partner' ],
 				celebrationModal: {
-					title: translate( 'You made your first purchase, your account is now activated!' ),
+					title: translate( 'Woo-hoo! You’ve made your first purchase.' ),
 					description: translate(
-						'Progress towards the Agency Partner tier and access extra benefits with additional purchases and referrals.'
+						'Your account is now activated, and you’re on your way to reaching the next tier of benefits: Agency Partner.'
 					),
 					video:
 						'https://automattic.com/wp-content/uploads/2024/10/emerging_partner_tier_celebration.mp4',
@@ -91,13 +91,12 @@ const getAgencyTierInfo = (
 				logo: AgencyPartnerLogo,
 				includedTiers: [ 'emerging-partner', 'agency-partner' ],
 				celebrationModal: {
-					title: translate( "Congratulations! You've reached the Partner tier!" ),
+					title: translate( 'Congrats! You’ve reached the Agency Partner Tier.' ),
 					description: translate(
 						"You've reached at least $1,200 in influenced revenue and have unlocked these additional benefits:"
 					),
 					benefits: [
-						translate( 'Inclusion in agency directories.' ),
-						translate( 'A free WordPress.com and Pressable site.' ),
+						translate( 'Eligibility for inclusion in our agency directories.' ),
 						translate( 'Early access to new Automattic products and features.' ),
 					],
 					video:
@@ -126,9 +125,9 @@ const getAgencyTierInfo = (
 				logo: ProAgencyPartnerLogo,
 				includedTiers: [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ],
 				celebrationModal: {
-					title: translate( "Congratulations, you've reached the Pro Partner tier!" ),
+					title: translate( "Congratulations, you've reached the Pro Partner Tier!" ),
 					description: translate(
-						"You've influenced at least $5,000 in Automattic revenue and have unlocked these additional benefits:"
+						'You’ve reached top-tier status and unlocked these additional benefits:'
 					),
 					benefits: [
 						translate( 'A dedicated partner manager and priority support access.' ),

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
@@ -55,9 +55,9 @@ const getAgencyTierInfo = (
 				logo: EmergingPartnerLogo,
 				includedTiers: [ 'emerging-partner' ],
 				celebrationModal: {
-					title: translate( 'Woo-hoo! You’ve made your first purchase.' ),
+					title: translate( "Woo-hoo! You've made your first purchase." ),
 					description: translate(
-						'Your account is now activated, and you’re on your way to reaching the next tier of benefits: Agency Partner.'
+						"Your account is now activated, and you're on your way to reaching the next tier of benefits: Agency Partner."
 					),
 					video:
 						'https://automattic.com/wp-content/uploads/2024/10/emerging_partner_tier_celebration.mp4',
@@ -91,7 +91,7 @@ const getAgencyTierInfo = (
 				logo: AgencyPartnerLogo,
 				includedTiers: [ 'emerging-partner', 'agency-partner' ],
 				celebrationModal: {
-					title: translate( 'Congrats! You’ve reached the Agency Partner Tier.' ),
+					title: translate( "Congrats! You've reached the Agency Partner Tier." ),
 					description: translate(
 						"You've reached at least $1,200 in influenced revenue and have unlocked these additional benefits:"
 					),
@@ -127,7 +127,7 @@ const getAgencyTierInfo = (
 				celebrationModal: {
 					title: translate( "Congratulations, you've reached the Pro Partner Tier!" ),
 					description: translate(
-						'You’ve reached top-tier status and unlocked these additional benefits:'
+						"You've reached top-tier status and unlocked these additional benefits:"
 					),
 					benefits: [
 						translate( 'A dedicated partner manager and priority support access.' ),

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-benefits.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-benefits.ts
@@ -55,7 +55,7 @@ const getTierBenefits = ( translate: ( key: string ) => string ): Benefit[] => [
 	{
 		title: translate( 'Networking & Community' ),
 		description: translate(
-			'Access Automattic’s community platforms and network with like-minded agencies.'
+			"Access Automattic's community platforms and network with like-minded agencies."
 		),
 		features: [],
 		isComingSoon: true,
@@ -65,7 +65,7 @@ const getTierBenefits = ( translate: ( key: string ) => string ): Benefit[] => [
 		title: translate( 'Directory Visibility & Badging' ),
 		description: preventWidows(
 			translate(
-				'Eligible for inclusion in Automattic’s agency directories and increased exposure to potential clients.'
+				"Eligible for inclusion in Automattic's agency directories and increased exposure to potential clients."
 			)
 		),
 		features: [],
@@ -111,7 +111,7 @@ const getTierBenefits = ( translate: ( key: string ) => string ): Benefit[] => [
 	{
 		title: translate( 'Automattic Advisory Board' ),
 		description: translate(
-			'Pro partners are eligible to receive an invitation to the Automattic for Agencies advisory board to influence the program and Automattic’s products.'
+			"Pro partners are eligible to receive an invitation to the Automattic for Agencies advisory board to influence the program and Automattic's products."
 		),
 		features: [],
 		isComingSoon: false,

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-benefits.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-benefits.ts
@@ -11,40 +11,42 @@ interface Benefit {
 
 const getTierBenefits = ( translate: ( key: string ) => string ): Benefit[] => [
 	{
-		title: translate( 'Sales Training & Resources' ),
+		title: translate( 'Tools & Platforms' ),
 		description: translate(
-			'Foundational product training, marketing materials, and advanced sales training.'
+			'Intuitive agency dashboard for streamlined client billing, and client and product management.'
 		),
-		features: [
-			translate( 'Pro partners eligible to receive advanced sales training upon request.' ),
-		],
-		isComingSoon: true,
+		features: [],
+		isComingSoon: false,
+		availableTiers: [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ],
+	},
+	{
+		title: translate( 'Earning Opportunities' ),
+		description: translate(
+			'All partners get access to referral and reseller earning opportunities across all of Automattic’s suite of products.'
+		),
+		features: [],
+		isComingSoon: false,
 		availableTiers: [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ],
 	},
 	{
 		title: translate( 'Support' ),
 		description: preventWidows(
-			translate( 'Program support, priority product support*, and dedicated partner managers*.' )
-		),
-		features: [
 			translate(
-				'Pro partners receive access to assigned partner manager & priority support across Automattic products.'
-			),
-		],
-		isComingSoon: true,
+				'All program partners receive unified program and product support. Pro partners receive access to priority support across Automattic products.'
+			)
+		),
+		features: [],
+		isComingSoon: false,
 		availableTiers: [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ],
 	},
 	{
-		title: translate( 'Earning & Growth Opportunities' ),
+		title: translate( 'Training & Resources' ),
 		description: translate(
-			'Reseller and referral earning opportunities, access to leads generated through agency directory listing(s)*, and pre-qualified leads from Automattic sales teams*.'
+			'Foundational product training, education and best practices on growing your agency, marketing materials, and advanced sales training*.'
 		),
 		features: [
 			translate(
-				'Agency Partners eligible to receive leads generated through agency directory listings.'
-			),
-			translate(
-				'Pro Partners eligible to receive pre-qualified leads from Automattic sales teams when opportunities arise as well as leads generated through agency directory listings.'
+				'Pro partners eligible to receive advanced sales training and strategic consulting upon request.'
 			),
 		],
 		isComingSoon: true,
@@ -53,41 +55,67 @@ const getTierBenefits = ( translate: ( key: string ) => string ): Benefit[] => [
 	{
 		title: translate( 'Networking & Community' ),
 		description: translate(
-			'Access to Automattic community platforms and advisory board* for strategic insights.'
+			'Access Automattic’s community platforms and network with like-minded agencies.'
 		),
-		features: [
-			translate( 'Pro partners eligible to receive invitation to join Automattic Advisory Board.' ),
-		],
-		isComingSoon: true,
-		availableTiers: [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ],
-	},
-	{
-		title: translate( 'Tools & Platforms' ),
-		description: translate(
-			'Agency dash for streamlined client billing, program and product management, and free agency site on WordPress.com or Pressable*.'
-		),
-		features: [
-			translate( 'Agency partners receive a free WordPress.com and a Pressable site.' ),
-			translate( 'Pro partners receive a free WordPress.com and a Pressable site.' ),
-		],
-		isComingSoon: true,
-		availableTiers: [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ],
-	},
-	{
-		title: translate( 'Visibility & Marketing' ),
-		description: preventWidows(
-			translate( 'Inclusion in agency directories and co-marketing opportunities*.' )
-		),
-		features: [ translate( 'Pro partners eligible for co-marketing opportunities.' ) ],
-		isComingSoon: true,
-		availableTiers: [ 'agency-partner', 'pro-agency-partner' ],
-	},
-	{
-		title: translate( 'Special Features' ),
-		description: translate( 'Early access to new Automattic Products and features.' ),
 		features: [],
 		isComingSoon: true,
 		availableTiers: [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ],
+	},
+	{
+		title: translate( 'Directory Visibility & Badging' ),
+		description: preventWidows(
+			translate(
+				'Eligible for inclusion in Automattic’s agency directories and increased exposure to potential clients.'
+			)
+		),
+		features: [],
+		isComingSoon: false,
+		availableTiers: [ 'agency-partner', 'pro-agency-partner' ],
+	},
+	{
+		title: translate( 'Early Access' ),
+		description: translate(
+			'Early access to new Automattic products and features (as available), and opportunities to contribute to the product roadmap.'
+		),
+		features: [],
+		isComingSoon: false,
+		availableTiers: [ 'agency-partner', 'pro-agency-partner' ],
+	},
+	{
+		title: translate( 'Co-Marketing' ),
+		description: translate(
+			'Pro Agency Partners are eligible to participate in co-marketing activities with Automattic and our suite of brands, including case studies, co-branded campaigns, and other marketing opportunities as they arise.'
+		),
+		features: [],
+		isComingSoon: false,
+		availableTiers: [ 'pro-agency-partner' ],
+	},
+	{
+		title: translate( 'Pre-Qualified Sales Leads' ),
+		description: translate(
+			'Pro Partners eligible to receive pre-qualified leads from Automattic sales teams when opportunities arise as well as leads generated through agency directory listings.'
+		),
+		features: [],
+		isComingSoon: false,
+		availableTiers: [ 'pro-agency-partner' ],
+	},
+	{
+		title: translate( 'Dedicated Agency Partner Manager' ),
+		description: translate(
+			'Pro partners receive access to an assigned agency partner manager for strategic guidance.'
+		),
+		features: [],
+		isComingSoon: false,
+		availableTiers: [ 'pro-agency-partner' ],
+	},
+	{
+		title: translate( 'Automattic Advisory Board' ),
+		description: translate(
+			'Pro partners are eligible to receive an invitation to the Automattic for Agencies advisory board to influence the program and Automattic’s products.'
+		),
+		features: [],
+		isComingSoon: false,
+		availableTiers: [ 'pro-agency-partner' ],
 	},
 ];
 

--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-benefits.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-tier-benefits.ts
@@ -22,7 +22,7 @@ const getTierBenefits = ( translate: ( key: string ) => string ): Benefit[] => [
 	{
 		title: translate( 'Earning Opportunities' ),
 		description: translate(
-			'All partners get access to referral and reseller earning opportunities across all of Automattic’s suite of products.'
+			"All partners get access to referral and reseller earning opportunities across all of Automattic's suite of products."
 		),
 		features: [],
 		isComingSoon: false,

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -6,7 +6,6 @@ import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
-	LayoutHeaderSubtitle as Subtitle,
 	LayoutHeaderActions as Actions,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
@@ -27,7 +26,7 @@ export default function AgencyTierOverview() {
 
 	const agency = useSelector( getActiveAgency );
 
-	const title = translate( 'Agency Tiers' );
+	const title = translate( 'Agency Tier and benefits' );
 	const benefits = getTierBenefits( translate );
 
 	const currentAgencyTier = agency?.tier?.id;
@@ -47,9 +46,6 @@ export default function AgencyTierOverview() {
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title } </Title>
-					<Subtitle>
-						{ translate( 'Experience the rewards of selling Automattic products and hosting.' ) }
-					</Subtitle>
 					<Actions>
 						<MobileSidebarNavigation />
 						{ showDownloadBadges && <DownloadBadges /> }
@@ -149,7 +145,7 @@ export default function AgencyTierOverview() {
 						{ translate( 'Take a closer look' ) }
 					</div>
 					<div className="agency-tier-overview__bottom-content-heading">
-						{ translate( 'Explore the benefits of using Automattic for Agencies' ) }
+						{ translate( 'Experience the benefits of being an Automattic Agency Partner' ) }
 					</div>
 					<div className="agency-tier-overview__bottom-content-cards">
 						{ benefits.map( ( benefit ) => (

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
@@ -37,7 +37,7 @@ export default function OverviewSidebarAgencyTier() {
 			<Card className="agency-tier__card">
 				<FoldableCard
 					className="foldable-nav"
-					header={ translate( 'Agency Tiers' ) }
+					header={ translate( 'Your progress' ) }
 					expanded
 					compact
 					iconSize={ 18 }
@@ -71,7 +71,7 @@ export default function OverviewSidebarAgencyTier() {
 							}
 						>
 							<Icon icon={ arrowRight } size={ 18 } />
-							{ translate( 'Explore tiers and benefits' ) }
+							{ translate( 'Explore Tiers and benefits' ) }
 						</Button>
 					</div>
 				</FoldableCard>


### PR DESCRIPTION
This PR revises several copies regarding the Agency Tier and its benefits. These are the final copies before the release.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1457

## Proposed Changes
See the following copies that have been updated:

| Description | Before | After |
|--------|--------|--------|
| The Agency Tier card on the overview page has been updated. The title has been changed to **'Your Progress'**, and **'Tier'** in the explore link is now capitalized. | <img width="508" alt="Screenshot 2024-11-12 at 5 33 07 PM" src="https://github.com/user-attachments/assets/0c21b6ca-4db6-4cf5-a1f7-e0d45c1d7618"> | <img width="515" alt="Screenshot 2024-11-12 at 5 32 50 PM" src="https://github.com/user-attachments/assets/98ce2212-061e-4cbc-b3ee-881a4e4143dc"> |
| We have revised the card text for **'No tier'**.  | <img width="505" alt="Screenshot 2024-11-12 at 5 36 51 PM" src="https://github.com/user-attachments/assets/865a5c67-0253-4ed2-8d6d-41191130ee63"> | <img width="500" alt="Screenshot 2024-11-12 at 5 37 01 PM" src="https://github.com/user-attachments/assets/78e3bedd-8fc3-417c-9668-45cc2d6a107a"> |
| We have revised the pop-up message for **'Emerging Partner'**. | <img width="800" alt="Screenshot 2024-11-12 at 5 41 52 PM" src="https://github.com/user-attachments/assets/bd0346c1-a545-4881-8977-6da67a68bd86"> | <img width="804" alt="Screenshot 2024-11-12 at 5 41 30 PM" src="https://github.com/user-attachments/assets/cd9d159c-ab93-40d3-b1f7-0fefafdb97b8"> |
| We have revised the pop-up message for **'Agency Partner'**.  | <img width="803" alt="Screenshot 2024-11-12 at 5 44 33 PM" src="https://github.com/user-attachments/assets/ea47bf7f-1e6e-4a28-b101-184522fcd75c"> | <img width="801" alt="Screenshot 2024-11-12 at 5 44 49 PM" src="https://github.com/user-attachments/assets/92e7d124-02e7-4013-98ed-cad47f1329be"> |
| We have revised the pop-up message for **'Pro Partner'**. | <img width="796" alt="Screenshot 2024-11-12 at 5 47 39 PM" src="https://github.com/user-attachments/assets/bada47a0-8c22-4908-b351-eaa324467e91"> | <img width="799" alt="Screenshot 2024-11-12 at 5 47 47 PM" src="https://github.com/user-attachments/assets/d9c60ba4-9bdc-4311-95e8-f248d84a9be4"> | 
| We have revised the headings on the **Agency Tier and benefits** page. | <img width="719" alt="Screenshot 2024-11-12 at 5 50 58 PM" src="https://github.com/user-attachments/assets/6477d49a-9e5e-4a3a-974a-99c7fa7da5f0"> | <img width="601" alt="Screenshot 2024-11-12 at 5 51 06 PM" src="https://github.com/user-attachments/assets/0e1c0fd3-f291-4f64-81e3-97657442867d"> | 
| We have updated the cards on the **Agency Tier and benefits** page.  | <img width="1049" alt="Screenshot 2024-11-12 at 5 53 03 PM" src="https://github.com/user-attachments/assets/f6313949-94af-4e1b-8de6-d8f445d56448"> | <img width="1018" alt="Screenshot 2024-11-12 at 5 53 35 PM" src="https://github.com/user-attachments/assets/d898ec8f-349d-4526-9e6a-b5d244d97aa7"> | 
| We have revised the card text for **'No tier'** on the **Agency Tier and benefits** page.   | <img width="751" alt="Screenshot 2024-11-12 at 5 55 42 PM" src="https://github.com/user-attachments/assets/064af5a1-108c-4462-bb91-73e8d28a8035"> | <img width="721" alt="Screenshot 2024-11-12 at 5 55 51 PM" src="https://github.com/user-attachments/assets/1d46e8b0-5063-4efa-a855-45bfc4ad691b"> | 
| Add a **'beta'** tag to the Agency Tier sidebar menu item. | <img width="266" alt="Screenshot 2024-11-12 at 6 58 12 PM" src="https://github.com/user-attachments/assets/5d7e03f0-c5cc-4138-8117-68269a23d03f"> | <img width="256" alt="Screenshot 2024-11-12 at 6 58 05 PM" src="https://github.com/user-attachments/assets/88deefda-bea5-42b8-8ccb-483586177ee5"> |


## Why are these changes being made?

* This is part of the Agency Tiering project.

## Testing Instructions

* Refer to the testing items above.
* Use the MC tool to update your agency tier to a different one and test various scenarios.
* Make sure you also reset the `a4a-agency-tier-celebration-modal-dismissed-type` preference to test the pop-up modal again.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
