### PR TITLE
A4A > Migrations: Update Payment Settings page

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-migrations-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-migrations-menu-items.tsx
@@ -1,4 +1,4 @@
-import { category, cog, help } from '@wordpress/icons';
+import { category, cog, currencyDollar } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
@@ -36,7 +36,7 @@ const useMigrationsMenuItems = ( path: string ) => {
 			),
 			createItem(
 				{
-					icon: help,
+					icon: currencyDollar,
 					path: A4A_MIGRATIONS_LINK,
 					link: A4A_MIGRATIONS_COMMISSIONS_LINK,
 					title: translate( 'Commissions' ),

--- a/client/a8c-for-agencies/sections/migrations/controller.tsx
+++ b/client/a8c-for-agencies/sections/migrations/controller.tsx
@@ -45,7 +45,7 @@ export const migrationsPaymentSettingsContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Migrations > Payment Settings" path={ context.path } />
-			<ReferralsBankDetails isAutomatedReferral />
+			<ReferralsBankDetails isAutomatedReferral isMigrations />
 		</>
 	);
 	context.secondary = <MigrationsSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/migrations/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/index.tsx
@@ -11,14 +11,6 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import * as controller from './controller';
 
 export default function () {
-	page(
-		A4A_MIGRATIONS_LINK,
-		requireAccessContext,
-		controller.migrationsContext,
-		makeLayout,
-		clientRender
-	);
-
 	if ( isEnabled( 'a4a-tracking-site-migrations' ) ) {
 		page(
 			A4A_MIGRATIONS_OVERVIEW_LINK,
@@ -42,5 +34,13 @@ export default function () {
 			clientRender
 		);
 		page( A4A_MIGRATIONS_LINK, () => page.redirect( A4A_MIGRATIONS_OVERVIEW_LINK ) );
+	} else {
+		page(
+			A4A_MIGRATIONS_LINK,
+			requireAccessContext,
+			controller.migrationsContext,
+			makeLayout,
+			clientRender
+		);
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -10,7 +10,10 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { A4A_REFERRALS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_REFERRALS_LINK,
+	A4A_MIGRATIONS_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useGetTipaltiIFrameURL from '../../hooks/use-get-tipalti-iframe-url';
@@ -21,8 +24,10 @@ import './style.scss';
 
 export default function ReferralsBankDetails( {
 	isAutomatedReferral = false,
+	isMigrations = false,
 }: {
 	isAutomatedReferral?: boolean;
+	isMigrations?: boolean;
 } ) {
 	const translate = useTranslate();
 	const isDesktop = useDesktopBreakpoint();
@@ -33,9 +38,13 @@ export default function ReferralsBankDetails( {
 		? translate( 'Your referrals and commissions: Set up secure payments' )
 		: translate( 'Payment Settings' );
 
-	const title = isAutomatedReferral
+	let title = isAutomatedReferral
 		? automatedReferralTitle
 		: translate( 'Referrals: Add bank details' );
+
+	if ( isMigrations ) {
+		title = translate( 'Migrations: Payment Settings' );
+	}
 
 	const { data, isFetching } = useGetTipaltiIFrameURL();
 	const { data: tipaltiData } = useGetTipaltiPayee();
@@ -58,6 +67,18 @@ export default function ReferralsBankDetails( {
 		};
 	}, [] );
 
+	let mainPageBreadCrumb = {
+		label:
+			isAutomatedReferral && isDesktop
+				? translate( 'Your referrals and commissions' )
+				: translate( 'Referrals' ),
+		href: A4A_REFERRALS_LINK,
+	};
+
+	if ( isMigrations ) {
+		mainPageBreadCrumb = { label: translate( 'Migrations' ), href: A4A_MIGRATIONS_LINK };
+	}
+
 	return (
 		<Layout
 			className={ clsx( 'bank-details__layout', {
@@ -71,13 +92,7 @@ export default function ReferralsBankDetails( {
 				<LayoutHeader>
 					<Breadcrumb
 						items={ [
-							{
-								label:
-									isAutomatedReferral && isDesktop
-										? translate( 'Your referrals and commissions' )
-										: translate( 'Referrals' ),
-								href: A4A_REFERRALS_LINK,
-							},
+							mainPageBreadCrumb,
 							{
 								label: isAutomatedReferral
 									? translate( 'Set up secure payments' )


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1446

## Proposed Changes

This PR updates the payment settings page for the Migrations context.


## Why are these changes being made?

* To match the payment settings page to the Migrations context.

## Testing Instructions

* Open the A4A live link
* Append the URL with ?flags=-a4a-tracking-site-migrations 
* Go to Referrals > Payment Settings > Verify that the page title & breadcrumbs (with the link) aren't changed.
* Go to Migrations > Verify that you have not been redirected to migrations/overview.
* Remove the feature flag > Refresh the page
* Go to Migrations > Verify the sidebar menu icon for Commissions is updated

<img width="272" alt="Screenshot 2024-11-12 at 4 21 09 PM" src="https://github.com/user-attachments/assets/6a196441-d0dc-4499-bfa3-113662cf539a">


* Go to Migrations > Payment Settings and verify the page title & breadcrumbs (with the link ) are updated as per the Migrations context. 

<img width="1728" alt="Screenshot 2024-11-12 at 4 20 59 PM" src="https://github.com/user-attachments/assets/82eeded4-1cc3-4348-b74b-0dd39575a08f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
