### PR TITLE
Help Center: Disable submit if input is empty

### DIFF
--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -17,8 +17,9 @@ export const OdieSendMessageButton = () => {
 	const inputRef = useRef< HTMLTextAreaElement >( null );
 	const { trackEvent, chat, shouldUseHelpCenterExperience } = useOdieAssistantContext();
 	const sendMessage = useSendChatMessage();
-	const shouldBeDisabled = chat.status === 'loading' || chat.status === 'sending';
+	const isChatBusy = chat.status === 'loading' || chat.status === 'sending';
 	const [ isMessageSizeValid, setIsMessageSizeValid ] = useState( true );
+	const [ submitDisabled, setSubmitDisabled ] = useState( true );
 
 	const onKeyUp = useCallback( () => {
 		// Only triggered when the message is empty
@@ -35,7 +36,7 @@ export const OdieSendMessageButton = () => {
 
 		if (
 			message === '' ||
-			shouldBeDisabled ||
+			isChatBusy ||
 			( shouldUseHelpCenterExperience && ! isMessageLengthValid )
 		) {
 			return;
@@ -61,7 +62,7 @@ export const OdieSendMessageButton = () => {
 				error: error?.message,
 			} );
 		}
-	}, [ sendMessage, shouldBeDisabled, shouldUseHelpCenterExperience, trackEvent ] );
+	}, [ sendMessage, isChatBusy, shouldUseHelpCenterExperience, trackEvent ] );
 
 	const classes = clsx(
 		'odie-send-message-inner-button',
@@ -86,11 +87,12 @@ export const OdieSendMessageButton = () => {
 						sendMessageHandler={ sendMessageHandler }
 						className="odie-send-message-input"
 						inputRef={ inputRef }
+						setSubmitDisabled={ setSubmitDisabled }
 						keyUpHandle={ onKeyUp }
 					/>
-					{ shouldBeDisabled && <Spinner className="odie-send-message-input-spinner" /> }
+					{ isChatBusy && <Spinner className="odie-send-message-input-spinner" /> }
 					{ shouldUseHelpCenterExperience && <AttachmentButton /> }
-					<button type="submit" className={ classes } disabled={ shouldBeDisabled }>
+					<button type="submit" className={ classes } disabled={ submitDisabled }>
 						{ shouldUseHelpCenterExperience ? (
 							<SendMessageIcon />
 						) : (

--- a/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
+++ b/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
@@ -8,20 +8,25 @@ export const ResizableTextarea: React.FC< {
 	inputRef: React.RefObject< HTMLTextAreaElement >;
 	keyUpHandle: () => void;
 	sendMessageHandler: () => Promise< void >;
-} > = ( { className, sendMessageHandler, inputRef, keyUpHandle } ) => {
+	setSubmitDisabled: ( shouldBeDisabled: boolean ) => void;
+} > = ( { className, sendMessageHandler, inputRef, keyUpHandle, setSubmitDisabled } ) => {
 	const onKeyUp = useCallback(
 		async ( event: KeyboardEvent< HTMLTextAreaElement > ) => {
 			if ( inputRef.current?.value.trim() === '' ) {
 				// call the handler to remove the validation message if visible.
 				keyUpHandle();
+				setSubmitDisabled( true );
 				return;
 			}
+
+			setSubmitDisabled( false );
+
 			if ( event.key === 'Enter' && ! event.shiftKey ) {
 				event.preventDefault();
 				await sendMessageHandler();
 			}
 		},
-		[ inputRef, sendMessageHandler, keyUpHandle ]
+		[ inputRef, sendMessageHandler, keyUpHandle, setSubmitDisabled ]
 	);
 
 	useEffect( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9768

## Proposed Changes

Disable the submit button if the input is empty

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Enable the help-center-experience flag (query param: flags=help-center-experience).
* Open the Help Center and click the "Still need help?" button.
