### PR TITLE
Fix /plugins/manage pagination filter issue

### DIFF
--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -48,31 +48,35 @@ export default function PluginsListDataViews( {
 
 	const header = (
 		<>
-			<Button
-				isPressed={ isFilteringUpdates }
-				onClick={ () => {
-					if ( isFilteringUpdates ) {
-						setDataViewsState( {
-							...dataViewsState,
-							filters: [],
-						} );
-					} else {
-						setDataViewsState( {
-							...dataViewsState,
-							filters: [
-								{
-									field: 'status',
-									operator: 'isAny',
-									value: [ PLUGINS_STATUS.UPDATE ],
-								},
-							],
-						} );
-					}
-					setIsFilteringUpdates( ! isFilteringUpdates );
-				} }
-			>
-				{ translate( 'Pending update (%s)', { args: [ pluginUpdateCount ] } ) }
-			</Button>
+			{ pluginUpdateCount > 0 && (
+				<Button
+					isPressed={ isFilteringUpdates }
+					onClick={ () => {
+						if ( isFilteringUpdates ) {
+							setDataViewsState( {
+								...dataViewsState,
+								filters: [],
+								page: 1,
+							} );
+						} else {
+							setDataViewsState( {
+								...dataViewsState,
+								filters: [
+									{
+										field: 'status',
+										operator: 'isAny',
+										value: [ PLUGINS_STATUS.UPDATE ],
+									},
+								],
+								page: 1,
+							} );
+						}
+						setIsFilteringUpdates( ! isFilteringUpdates );
+					} }
+				>
+					{ translate( 'Pending update (%s)', { args: [ pluginUpdateCount ] } ) }
+				</Button>
+			) }
 		</>
 	);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9749

## Proposed Changes

* Setting pagination to page 1 when filtering for "Pending updates"
* Only showing the filter when having one or more plugins with updates


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
