### PR TITLE
Login: Remove padding right for password error message

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -292,15 +292,22 @@ $breakpoint-mobile: 782px; //Mobile size.
 	}
 }
 
-.login__form-password.is-hidden {
-	// hide the password field in a way that still makes it "visible" for password managers.
-	// 1Password doesn't fill the field if it has display:none or visibility:hidden.
-	position: fixed;
-	bottom: 0;
-	height: 0;
-	width: 0;
-	overflow: hidden;
-	opacity: 0;
+.login__form-password {
+
+	&.is-hidden {
+		// hide the password field in a way that still makes it "visible" for password managers.
+		// 1Password doesn't fill the field if it has display:none or visibility:hidden.
+		position: fixed;
+		bottom: 0;
+		height: 0;
+		width: 0;
+		overflow: hidden;
+		opacity: 0;
+	}
+
+	.form-input-validation {
+		padding-right: 0;
+	}
 }
 
 .login__jetpack-logo {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/96281

## Proposed Changes

* Remove padding-right for password error message

After changes:

<img width="387" alt="CleanShot 2024-11-12 at 10 25 38@2x" src="https://github.com/user-attachments/assets/ff7b7b9d-164e-4656-842e-9bd9be5e687b">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Add more space for message

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Log out of WordPress or use new incognito window.
* Navigate to `/log-in`, and enter a valid email and an invalid password.
* Verify the password validation message does not have any right padding.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
