### PR TITLE
Login: Forgot your password style fix

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -726,7 +726,7 @@ export class LoginForm extends Component {
 		}
 
 		return this.props.translate(
-			'It seems you entered an incorrect password. Want to get a {{magicLoginLink}}login link{{/magicLoginLink}} via email?',
+			'{{errorWrapper}}It seems you entered an incorrect password. Want to get a {{magicLoginLink}}login link{{/magicLoginLink}} via email?{{/errorWrapper}}',
 			{
 				components: {
 					magicLoginLink: (
@@ -735,6 +735,7 @@ export class LoginForm extends Component {
 							onClick={ () => this.handleMagicLoginClick( 'login-form' ) }
 						/>
 					),
+					errorWrapper: <p className="login-form__validation-error-wrapper"></p>,
 				},
 			}
 		);

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -42,6 +42,9 @@ form {
 				justify-content: center;
 				padding: 0 16px;
 			}
+			.login-form__validation-error-wrapper {
+				margin-bottom: 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96283
Fixes https://github.com/Automattic/wp-calypso/issues/96283

## Proposed Changes

* Wraps the message error in a `<p>` which semantically makes more sense, and remove margin bottom to fit better the spacing. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes word breaking issues in different languages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link or pull this branch
* Navigate to `/log-in` type your email and a wrong password.
* The message should appear, make sure the text is not breaking in the middle of the words
* Check in different languages by adding the language in the URL, Example: `/pt-br?pt-br` or `/it?it`

Should look like
<img width="398" alt="image" src="https://github.com/user-attachments/assets/f1e46c2b-468c-4e9f-a614-c2f604c94830">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
