### PR TITLE
Reader: Fix comments anchor links on full page posts

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -294,6 +294,7 @@ export class FullPostView extends Component {
 		this._scrolling = true;
 		scrollToComments( {
 			focusTextArea,
+			container: this.readerMainWrapper.current,
 			onScrollComplete: () => {
 				this._scrolling = false;
 				if ( this.hasCommentAnchor ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/96172

## Proposed Changes

* This PR fixes a regression introduced in https://github.com/Automattic/wp-calypso/pull/96172, where links with a #comments anchor do not properly scroll to the comments section as expected.
* This PR fixes that regression by passing the target container to the recently introduced `scrollToComments` function.


Before | After
--|--
<video src="https://github.com/user-attachments/assets/64fd0ab9-1405-4bae-81a1-475a346dab97" />  |  <video src="https://github.com/user-attachments/assets/97879e98-9cb9-425d-a4a7-42c9f06886e3" />








## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix a regression.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The testing instructions on https://github.com/Automattic/wp-calypso/pull/96172 should still pass.
* Going to a full post page with the #comments anchor should scroll to the comments section. Ex: /read/feeds/53145824/posts/5452342889#comments

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
