### PR TITLE
Post-purchase: Reload the site list after cancel a migration

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { SITE_EXCERPT_REQUEST_FIELDS, SITE_EXCERPT_REQUEST_OPTIONS } from '@automattic/sites';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import { getJetpackSiteCollisions, getUnmappedUrl } from 'calypso/lib/site/utils';
 import { urlToSlug, withoutHttp } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
@@ -27,6 +28,15 @@ const fetchSites = (
 		options: additional_options.concat( SITE_EXCERPT_REQUEST_OPTIONS ).join( ',' ),
 		filters: siteFilter.length > 0 ? siteFilter.join( ',' ) : undefined,
 	} );
+};
+
+export const useSiteExcerptsQueryInvalidator = () => {
+	const queryClient = useQueryClient();
+	const invalidate = useCallback(
+		() => queryClient.invalidateQueries( { queryKey: [ USE_SITE_EXCERPTS_QUERY_KEY ] } ),
+		[ queryClient ]
+	);
+	return invalidate;
 };
 
 export const useSiteExcerptsQuery = (

--- a/client/hosting/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/hosting/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -4,6 +4,7 @@ import { translate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
 import { HostingHeroButton } from 'calypso/components/hosting-hero';
 import { useMigrationCancellation } from 'calypso/data/site-migration/landing/use-migration-cancellation';
+import { useSiteExcerptsQueryInvalidator } from 'calypso/data/sites/use-site-excerpts-query';
 import { addQueryArgs } from 'calypso/lib/url';
 import { getMigrationType } from 'calypso/sites-dashboard/utils';
 import { useDispatch } from 'calypso/state';
@@ -44,10 +45,13 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 		isPending: isCancelling,
 	} = useMigrationCancellation( site.ID );
 	const dispatch = useDispatch();
+	const invalidateSiteExcerptsQuery = useSiteExcerptsQueryInvalidator();
 
 	const reloadSite = useCallback( () => {
 		dispatch( requestSite( site.ID ) );
-	}, [ dispatch, site.ID ] );
+		// invalidate the site excerpts query to refresh the /sites sidebar
+		invalidateSiteExcerptsQuery();
+	}, [ dispatch, invalidateSiteExcerptsQuery, site.ID ] );
 
 	useEffect( () => {
 		if ( isCancellationSuccess ) {

--- a/client/hosting/overview/components/migration-overview/components/migration-pending/test/index.tsx
+++ b/client/hosting/overview/components/migration-overview/components/migration-pending/test/index.tsx
@@ -7,6 +7,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import React from 'react';
+import { useSiteExcerptsQueryInvalidator } from 'calypso/data/sites/use-site-excerpts-query';
 import { useDispatch } from 'calypso/state';
 import { requestSite } from 'calypso/state/sites/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
@@ -20,8 +21,13 @@ const site = {
 jest.mock( 'calypso/state', () => ( {
 	useDispatch: jest.fn(),
 } ) );
+
 jest.mock( 'calypso/state/sites/actions', () => ( {
 	requestSite: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/data/sites/use-site-excerpts-query', () => ( {
+	useSiteExcerptsQueryInvalidator: jest.fn(),
 } ) );
 
 describe( 'MigrationPending', () => {
@@ -31,7 +37,9 @@ describe( 'MigrationPending', () => {
 
 	it( 'cancels the migration', async () => {
 		const mockedDispatch = jest.fn();
+		const invalidator = jest.fn();
 		jest.mocked( useDispatch ).mockReturnValue( mockedDispatch );
+		jest.mocked( useSiteExcerptsQueryInvalidator ).mockReturnValue( invalidator );
 		renderWithProvider( <MigrationPending site={ site } /> );
 
 		nock( 'https://public-api.wordpress.com' )
@@ -42,6 +50,7 @@ describe( 'MigrationPending', () => {
 
 		await waitFor( () => {
 			expect( requestSite ).toHaveBeenCalledWith( site.ID );
+			expect( invalidator ).toHaveBeenCalled();
 		} );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes
* Introduce a new hook to invalidate the dashboard site list query
* Use the hook to reload the list after the migration is canceled. 


## Why are these changes being made?
* When the user cancels a migration, we need to ensure the whole screen reloads the site data to show the proper state.

https://github.com/user-attachments/assets/b98d8460-d726-48e1-b382-760627067708


## Testing Instructions
* Create a pending migration following the steps above
* Go to /sites
* Select your site
* Click on the cancel migration button
* Check if the left bar is updated (It may take some seconds) and does not show the "Incoming migration"  site name.


# How to create a pending migration
* Go to any migration flow (e.g./setup/migration)
* Enable the feature flag sessionStorage.setItem('flags', 'automated-migration/pending-status') and reload the page
* Follow all migration steps until you see the credential or setup instructions steps.
( Close the tab


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?