### PR TITLE
Check `isChatLoaded` before loading conversation

### DIFF
--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -12,10 +12,11 @@ import type { Chat, Message } from '../types';
  * @returns The combined chat.
  */
 export const useGetCombinedChat = ( shouldUseHelpCenterExperience: boolean | undefined ) => {
-	const { currentSupportInteraction } = useSelect( ( select ) => {
+	const { currentSupportInteraction, isChatLoaded } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
 			currentSupportInteraction: store.getCurrentSupportInteraction(),
+			isChatLoaded: store.getIsChatLoaded(),
 		};
 	}, [] );
 
@@ -45,7 +46,7 @@ export const useGetCombinedChat = ( shouldUseHelpCenterExperience: boolean | und
 				} );
 			}
 		} else if ( odieId && conversationId && shouldUseHelpCenterExperience ) {
-			if ( odieChat ) {
+			if ( odieChat && isChatLoaded ) {
 				getZendeskConversation( {
 					chatId: odieChat.odieId,
 					conversationId: conversationId.toString(),
@@ -75,7 +76,14 @@ export const useGetCombinedChat = ( shouldUseHelpCenterExperience: boolean | und
 				status: 'loaded',
 			} ) );
 		}
-	}, [ isOdieChatLoading, odieChat, conversationId, odieId, currentSupportInteraction ] );
+	}, [
+		isOdieChatLoading,
+		isChatLoaded,
+		odieChat,
+		conversationId,
+		odieId,
+		currentSupportInteraction,
+	] );
 
 	return { mainChatState, setMainChatState };
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9744

## Proposed Changes

* Add checks for smooch

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Ensure that you use the flag `help-center-experience`
* Talk to support 
* Reload the page
* Quickly click `Still need help?` while smooch is loading
* No errors should be thrown, and the chat should load
