### PR TITLE
Subscribers List: Fix Plan display for users who have turned off auto-renew.

### DIFF
--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -171,7 +171,9 @@ function Subscription( { translate, subscription, moment, stoppingStatus, updati
 								</div>
 								{ ! isProduct && (
 									<div className="memberships__subscription-inner-detail">
-										Auto-renew is { subscription.renew_interval ? 'ON' : 'OFF' }
+										{ subscription.renew_interval
+											? translate( 'Auto-renew is ON' )
+											: translate( 'Auto-renew is OFF' ) }
 									</div>
 								) }
 							</li>

--- a/client/my-sites/subscribers/hooks/use-subscription-plans.ts
+++ b/client/my-sites/subscribers/hooks/use-subscription-plans.ts
@@ -26,7 +26,11 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 	const translate = useTranslate();
 	const freePlan = translate( 'Free' );
 
-	const getPaymentInterval = ( renew_interval: string ): string => {
+	const getPaymentInterval = (
+		renew_interval: string,
+		inactive_renew_interval: string
+	): string => {
+		renew_interval = renew_interval || inactive_renew_interval;
 		if ( renew_interval === null ) {
 			return translate( 'one time' );
 		} else if ( renew_interval === PLAN_MONTHLY_FREQUENCY ) {
@@ -61,10 +65,17 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 
 		if ( subscriptions ) {
 			const result = subscriptions.map( ( subscription: SubscriptionPlan ) => {
-				const { is_gift, currency, renewal_price, renew_interval, start_date, title } =
-					subscription;
+				const {
+					is_gift,
+					currency,
+					renewal_price,
+					renew_interval,
+					inactive_renew_interval,
+					start_date,
+					title,
+				} = subscription;
 				const renewalPrice = formatRenewalPrice( renewal_price, currency );
-				const when = getPaymentInterval( renew_interval );
+				const when = getPaymentInterval( renew_interval, inactive_renew_interval );
 
 				return { is_gift, renewalPrice, when, start_date, title };
 			} );

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -19,6 +19,7 @@ export type SubscriptionPlan = {
 	renewal_period: string;
 	renewal_price: number;
 	renew_interval: string;
+	inactive_renew_interval: string;
 	start_date: string;
 	end_date: string;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

 * Fix the plan display in the subscriber list for users who have turned off auto-renew.
 
 Before: 
<img width="314" alt="Screenshot 2024-11-12 at 3 28 35 PM" src="https://github.com/user-attachments/assets/ff5bfa0a-7ceb-4331-8728-c4efd2a811f2">

After: 
<img width="316" alt="Screenshot 2024-11-12 at 3 27 59 PM" src="https://github.com/user-attachments/assets/b630135a-baee-4cc5-b497-d4736b5647ce">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Sandbox the API and apply D166096-code
* Subscribe as a paid subscriber to your test site.
* Turn off auto-renew.
* Check that your user still shows the plan on your test site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?