### PR TITLE
Fix renewal messaging position

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
@@ -127,7 +127,7 @@ function PurchaseMetaIntroductoryOfferDetail( {
 function RenewalSubtext( { text }: { text: ReactNode } ): JSX.Element {
 	return (
 		<>
-			<br /> <br /> <small> { text } </small>{ ' ' }
+			<br /> <br /> <small className="manage-purchase__renewal-text"> { text } </small>{ ' ' }
 		</>
 	);
 }

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -112,7 +112,6 @@ export default function PurchaseMeta( {
 						<em className="manage-purchase__detail-label">{ renewalPriceHeader }</em>
 						<span className="manage-purchase__detail">
 							<PurchaseMetaPrice purchase={ purchase } />
-							<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />
 						</span>
 						{ ! hideTaxString && (
 							<span>
@@ -120,6 +119,7 @@ export default function PurchaseMeta( {
 							</span>
 						) }
 						<PurchaseMetaAutoRenewCouponDetail purchase={ purchase } />
+						<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />
 					</li>
 				) }
 				<PurchaseMetaExpiration

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -359,6 +359,10 @@
 	}
 }
 
+.manage-purchase__renewal-text {
+	display: inline-block;		
+}
+
 .manage-purchase__detail .user__name {
 	margin-right: 0;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/88425

## Proposed Changes

This PR fixes an issue with the information on our purchase details screen being displayed incorrectly.

**Before**
<img width="1752" alt="image" src="https://github.com/user-attachments/assets/cbd87195-3c6e-4cdc-9d35-11f8e4adc747">



**After**
<img width="1753" alt="image" src="https://github.com/user-attachments/assets/a432714e-ceec-4d75-8f04-f43cd629be38">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To improve readability and fix what appears to be a visual bug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a new Professional email subscription.
* View the purchase details for Professional email subscription.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
