### PR TITLE
Help Center: Prevent line breaks on Enter key press in ResizableTextarea component

### DIFF
--- a/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
+++ b/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
@@ -29,6 +29,16 @@ export const ResizableTextarea: React.FC< {
 		[ inputRef, sendMessageHandler, keyUpHandle, setSubmitDisabled ]
 	);
 
+	const onKeyDown = useCallback(
+		async ( event: KeyboardEvent< HTMLTextAreaElement > ) => {
+			// Prevent line break when user sends a message
+			if ( event.key === 'Enter' && ! event.shiftKey && inputRef.current?.value.trim() !== '' ) {
+				event.preventDefault();
+			}
+		},
+		[ inputRef ]
+	);
+
 	useEffect( () => {
 		// Set's back the textarea height after sending messages, it is needed for long messages.
 		if ( inputRef.current ) {
@@ -54,6 +64,7 @@ export const ResizableTextarea: React.FC< {
 			rows={ 1 }
 			className={ className }
 			onKeyUp={ onKeyUp }
+			onKeyDown={ onKeyDown }
 			placeholder={ __( 'Type a message…', __i18n_text_domain__ ) }
 			style={ { transition: 'none' } }
 		/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/9778

## Proposed Changes

* Removes line break when user types a message and presses the "Enter" to submit it

Watch video in comment here to see issue: pdDR7T-1X1-p2#comment-2405

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout out branch or use live link
* Navigate to `/home?flags=help-center-experience`, open the Help Center, and start a new chat (use go to an existing chat).
* Type a message and click enter to send it. Verify that a line break does not appear in textarea component before the message is sent.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?