### PR TITLE
Checkout: Always display non-zero discount in checkout footer

### DIFF
--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -111,7 +111,7 @@ export default function BeforeSubmitCheckoutHeader() {
 	const subTotalLineItemWithoutCoupon: LineItemType = {
 		id: 'subtotal-without-coupon',
 		type: 'subtotal',
-		label: totalDiscount > 0 ? translate( 'Subtotal before discounts' ) : translate( 'Subtotal' ),
+		label: totalDiscount !== 0 ? translate( 'Subtotal before discounts' ) : translate( 'Subtotal' ),
 		formattedAmount: formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
@@ -126,7 +126,7 @@ export default function BeforeSubmitCheckoutHeader() {
 			<WPOrderReviewSection>
 				<NonTotalPrices>
 					<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
-					{ totalDiscount > 0 && <NonProductLineItem subtotal lineItem={ discountLineItem } /> }
+					{ totalDiscount !== 0 && <NonProductLineItem subtotal lineItem={ discountLineItem } /> }
 					{ taxLineItems.map( ( taxLineItem ) => (
 						<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
 					) ) }


### PR DESCRIPTION
## Proposed Changes

This fixes a regression caused by https://github.com/Automattic/wp-calypso/pull/94454/ where the "Discounts" line item in the checkout footer was not being displayed. That PR changed the discount total to be a negative number, which meant that when comparing it to 0, it was always less than 0.

Before             |  After
:-------------------------:|:-------------------------:
<img width="595" alt="Screenshot 2024-11-12 at 3 22 23 PM" src="https://github.com/user-attachments/assets/8307447b-544c-4c3f-9ed8-7517a12c5897"> | <img width="582" alt="Screenshot 2024-11-12 at 3 25 54 PM" src="https://github.com/user-attachments/assets/654c4787-2d68-41ce-98e4-0b9988485c7c">
<img width="587" alt="Screenshot 2024-11-12 at 3 44 22 PM" src="https://github.com/user-attachments/assets/7747eb19-aaf6-4648-a6c9-7447ca022ce4"> | <img width="581" alt="Screenshot 2024-11-12 at 3 39 17 PM" src="https://github.com/user-attachments/assets/7950d43f-8a7c-448b-85b6-dc9be33d4bce">

Fixes https://github.com/Automattic/wp-calypso/issues/96309

Props to @jjchrisdiehl for figuring out what was wrong!

## Testing Instructions

- Add a product to the cart which has no discount.
- Verify that the "Subtotal" and "Total" in the checkout footer make sense.
- Add a product to the cart with a discount.
- Verify that the "Subtotal before discounts", "Discounts", and "Total" in the checkout footer make sense.

Repeat the test instructions for https://github.com/Automattic/wp-calypso/pull/94454/ to make sure that bug is still fixed.

Here's how it looks when an introductory offer increases the price (the bug fix from that PR which prevented showing the price increase as a discount):

Before             |  After
:-------------------------:|:-------------------------:
<img width="590" alt="Screenshot 2024-11-12 at 3 53 44 PM" src="https://github.com/user-attachments/assets/979edf30-1141-41ff-8d9a-346975366de8"> | <img width="595" alt="Screenshot 2024-11-12 at 3 52 42 PM" src="https://github.com/user-attachments/assets/ffab586a-eaf6-4cb2-99c8-973efbde346c">
