### PR TITLE
Passwordless Auth Core Profiler - copy updates

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -634,7 +634,7 @@ class Login extends Component {
 					headerText = (
 						<h3>
 							{ config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
-								? translate( 'Connect your account' )
+								? translate( 'Log in to your account' )
 								: translate( 'One last step' ) }
 						</h3>
 					);

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -640,7 +640,7 @@ class Login extends Component {
 					);
 					if ( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
 						subtitle = translate(
-							'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. {{br}}{{/br}}For more information, please {{doc}}review our documentation{{/doc}}.',
+							'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. For more information, please {{doc}}review our documentation{{/doc}}.',
 							{
 								components: {
 									signupLink,

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -107,7 +107,7 @@ export class AuthFormHeader extends Component {
 		}
 
 		if ( isWooPasswordlessJPC ) {
-			return translate( 'Connect your account' );
+			return translate( 'Create an account' );
 		}
 
 		if ( isWpcomMigration ) {
@@ -191,7 +191,7 @@ export class AuthFormHeader extends Component {
 				switch ( currentState ) {
 					case 'logged-out':
 						return translate(
-							'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Please create one now, or {{a}}log in{{/a}}. {{br}}{{/br}}For more information, please {{doc}}review our documentation{{/doc}}.',
+							'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Please create one now, or {{a}}log in{{/a}}. For more information, please {{doc}}review our documentation{{/doc}}.',
 							{
 								...translateParams,
 								components: {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -799,10 +799,6 @@ export class JetpackAuthorize extends Component {
 			}
 			return translate( 'Connect your account' );
 		}
-		// eslint-disable-next-line no-lonely-if
-		if ( this.isWooPasswordlessJPC() ) {
-			return translate( 'Connect your account' );
-		}
 
 		if ( ! this.retryingAuth ) {
 			return translate( 'Approve' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/woocommerce/woocommerce/issues/52742

This PR updates copy on the passwordless auth pages.

## Proposed Changes

* Updated copy


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch locally and open `config/development.json`.
2. Enable `woocommerce/core-profiler-passwordless-auth` feature flag and run `yarn start`
3. Once the build is ready, visit this [link](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=236381464&redirect_uri=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D32ab4c9508%26redirect%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A2ca8ea2582da1c066074563a12cc8b22&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=13.7&secret=QFoaAXaOIPZTr9p6Z5Hqf6RWkCboPylJ&blogname=Noisily+Fortunate+Toucan&site_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&home_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&site_icon&site_lang=en_US&site_created=2024-08-26+19%3A40%3A51&allow_site_connection=1&calypso_env=production&source&_as=search-term&_ak=jetpack&from=woocommerce-core-profiler&installed_ext_success=1&_ui=254662545&_ut=wpcom%3Auser_id&purchase_nonce=lbtPaOlO&_wp_nonce=69744335dc&redirect_after_auth=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja) in an incognito session.
4. The title should be `Create an account`
5. Click on `Log in` link.
6. The title should be `Log in to your account`
7. Open `client/lib/login/index.js` and locate `getPluginTitle` function.
8. Add `return "WooCommerce Order Attribution";`
9. Refresh the page
10. Confirm  "For more information, please review our documentation" is not on the new line.

![Screenshot 2024-11-12 at 12 30 47 PM](https://github.com/user-attachments/assets/24e5951d-df85-4d26-8098-cd8e3394f309)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
