### PR TITLE
Passwordless Auth Core Profiler - Add `source` param when sending an email

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -104,6 +104,7 @@ class Login extends Component {
 		emailRequested: PropTypes.bool,
 		isSendingEmail: PropTypes.bool,
 		isWooPasswordlessJPC: PropTypes.bool,
+		from: PropTypes.string,
 	};
 
 	state = {
@@ -1139,6 +1140,7 @@ export default connect(
 		isSendingEmail: isFetchingMagicLoginEmail( state ),
 		emailRequested: isMagicLoginEmailRequested( state ),
 		isLoggedIn: isUserLoggedIn( state ),
+		from: get( getCurrentQueryArguments( state ), 'from' ),
 	} ),
 	{
 		rebootAfterLogin,
@@ -1151,16 +1153,20 @@ export default connect(
 		...ownProps,
 		...stateProps,
 		...dispatchProps,
-		sendEmailLogin: ( options = {} ) =>
+		sendEmailLogin: ( options = {} ) => {
 			dispatchProps.sendEmailLogin( stateProps.usernameOrEmail, {
 				redirectTo: stateProps.redirectTo,
 				loginFormFlow: true,
 				showGlobalNotices: false,
+				source: stateProps.isWooPasswordlessJPC
+					? 'woo-passwordless-jpc' + '-' + get( getCurrentQueryArguments( stateProps ), 'from' )
+					: '',
 				flow:
 					( ownProps.isJetpack && 'jetpack' ) ||
 					( ownProps.isGravPoweredClient && getGravatarOAuth2Flow( ownProps.oauth2Client ) ) ||
 					null,
 				...options,
-			} ),
+			} );
+		},
 	} )
 )( localize( Login ) );

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -1154,12 +1154,12 @@ export default connect(
 		...stateProps,
 		...dispatchProps,
 		sendEmailLogin: ( options = {} ) => {
-			dispatchProps.sendEmailLogin( stateProps.usernameOrEmail, {
+			return dispatchProps.sendEmailLogin( stateProps.usernameOrEmail, {
 				redirectTo: stateProps.redirectTo,
 				loginFormFlow: true,
 				showGlobalNotices: false,
 				source: stateProps.isWooPasswordlessJPC
-					? 'woo-passwordless-jpc' + '-' + get( getCurrentQueryArguments( stateProps ), 'from' )
+					? 'woo-passwordless-jpc' + '-' + get( stateProps, 'from' )
 					: '',
 				flow:
 					( ownProps.isJetpack && 'jetpack' ) ||

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -1181,7 +1181,7 @@ export class LoginForm extends Component {
 							shouldRenderToS={ isWoo && ! isPartnerSignup && ! isWooPasswordless }
 							isWoo={ isWoo && isWooPasswordless }
 							isSocialFirst={ isSocialFirst }
-							magicLoginLink={ this.getMagicLoginPageLink() }
+							magicLoginLink={ ! isWooPasswordlessJPC ? this.getMagicLoginPageLink() : null }
 							qrLoginLink={ this.getQrLoginLink() }
 						/>
 					</Fragment>

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -44,7 +44,6 @@ import {
 	warningNotice as warningNoticeAction,
 } from 'calypso/state/notices/actions';
 import isWooPasswordlessJPCFlow from 'calypso/state/selectors/is-woo-passwordless-jpc-flow';
-import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import AuthFormHeader from './auth-form-header';
 import HelpButton from './help-button';
 import MainWrapper from './main-wrapper';
@@ -574,7 +573,6 @@ const connectComponent = connect(
 		usernameOrEmail: getLastCheckedUsernameOrEmail( state ),
 		isFullLoginFormVisible: !! getAuthAccountType( state ),
 		redirectTo: getRedirectToOriginal( state ),
-		isWooCoreProfiler: isWooCommerceCoreProfilerFlow( state ),
 		isWooPasswordlessJPC: isWooPasswordlessJPCFlow( state ),
 	} ),
 	{

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -44,6 +44,7 @@ import {
 	warningNotice as warningNoticeAction,
 } from 'calypso/state/notices/actions';
 import isWooPasswordlessJPCFlow from 'calypso/state/selectors/is-woo-passwordless-jpc-flow';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import AuthFormHeader from './auth-form-header';
 import HelpButton from './help-button';
 import MainWrapper from './main-wrapper';
@@ -171,6 +172,9 @@ export class JetpackSignup extends Component {
 					extra: {
 						...userData.extra,
 						jpc: true,
+						source: this.props.isWooPasswordlessJPC
+							? 'woo-passwordless-jpc' + '-' + this.props.authQuery.from
+							: '',
 					},
 				} )
 				.then( this.handleUserCreationSuccess, this.handleUserCreationError )
@@ -570,6 +574,7 @@ const connectComponent = connect(
 		usernameOrEmail: getLastCheckedUsernameOrEmail( state ),
 		isFullLoginFormVisible: !! getAuthAccountType( state ),
 		redirectTo: getRedirectToOriginal( state ),
+		isWooCoreProfiler: isWooCommerceCoreProfilerFlow( state ),
 		isWooPasswordlessJPC: isWooPasswordlessJPCFlow( state ),
 	} ),
 	{

--- a/client/state/auth/actions.js
+++ b/client/state/auth/actions.js
@@ -15,6 +15,7 @@ import 'calypso/state/data-layer/wpcom/auth/send-login-email';
  * @param {boolean} options.showGlobalNotices - if true, displays global notices to user about the email
  * @param {string} options.flow - name of the login flow
  * @param {boolean} options.createAccount - if true, instructs the API to create a WPCOM account associated with email
+ * @param {boolean} options.source - source of the login request (optional)
  * @returns {Object} action object
  */
 export const sendEmailLogin = (
@@ -28,6 +29,7 @@ export const sendEmailLogin = (
 		isMobileAppLogin = false,
 		flow = null,
 		createAccount = false,
+		source = '',
 	}
 ) => {
 	const locale = getLocaleSlug();
@@ -46,5 +48,6 @@ export const sendEmailLogin = (
 		requestLoginEmailFormFlow,
 		flow,
 		createAccount,
+		source,
 	};
 };

--- a/client/state/data-layer/wpcom/auth/send-login-email/index.js
+++ b/client/state/data-layer/wpcom/auth/send-login-email/index.js
@@ -32,6 +32,7 @@ export const sendLoginEmail = ( action ) => {
 		isMobileAppLogin,
 		flow,
 		createAccount,
+		source,
 	} = action;
 	const noticeAction = showGlobalNotices
 		? infoNotice( translate( 'Sending email' ), { duration: 4000 } )
@@ -72,6 +73,7 @@ export const sendLoginEmail = ( action ) => {
 					...( flow && { flow } ),
 					create_account: createAccount,
 					tos: getToSAcceptancePayload(),
+					source,
 					calypso_env:
 						window?.location?.host === 'wordpress.com' ? 'production' : config( 'env_id' ),
 				},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR adds `source` param to `sendEmailLogin` function.

This is needed in WPCOM to identify the JPC flow and its product (Jetpack, Woo Payments, and Woo Order Attribution). We use this value to use a different email template for the signup and magic link. I'll open a WPCOM PR soon.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To identify JPC flow in WPCOM so we can use a different email template for the sign up and magic link.

## Testing Instructions


1. Checkout this branch locally and open `config/development.json`.
2. Enable `woocommerce/core-profiler-passwordless-auth` feature flag and run `yarn start`
3. Once the build is ready, visit this [link](http://calypso.localhost:3000/log-in/jetpack?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D236381464%26redirect_uri%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253D32ab4c9508%2526redirect%253Dhttps%25253A%25252F%25252Fnoisily-fortunate-toucan.jurassic.ninja%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-admin%26state%3D1%26scope%3Dadministrator%253A2ca8ea2582da1c066074563a12cc8b22%26user_email%3Dmoon.kyong%2540automattic.com%26user_login%3Dmoon0326%26jp_version%3D13.7%26secret%3DQFoaAXaOIPZTr9p6Z5Hqf6RWkCboPylJ%26blogname%3DNoisily%2520Fortunate%2520Toucan%26site_url%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%26home_url%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%26site_icon%3D%26site_lang%3Den_US%26site_created%3D2024-08-26%252019%253A40%253A51%26allow_site_connection%3D1%26calypso_env%3Dproduction%26source%3D%26_as%3Dsearch-term%26_ak%3Djetpack%26from%3Dwoocommerce-core-profiler%26_ui%3D254662545%26_ut%3Dwpcom%253Auser_id%26purchase_nonce%3DlbtPaOlO%26_wp_nonce%3D69744335dc%26redirect_after_auth%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin%26site%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja&from=woocommerce-core-profiler) in an incognito session.
4. Open your browser's inspector -> Network
5. Enter a passwordless auth enabled email and click on `Continue` button.
6. Search for `send-login-email` request and check the payload.
7. Confirm the payload has `source` value.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
