### PR TITLE
Reader Recent Feed Overhaul: Filter by selected sidebar feed

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -33,8 +33,9 @@ const Recent = () => {
 	const selectedRecentSidebarFeedId = useSelector< AppState, number | null >(
 		( state ) => state.readerUi.sidebar.selectedRecentSite
 	);
+
 	const streamKey =
-		selectedRecentSidebarFeedId !== null ? `feed:${ selectedRecentSidebarFeedId }` : 'recent';
+		selectedRecentSidebarFeedId !== null ? `recent:${ selectedRecentSidebarFeedId }` : 'recent';
 
 	const data = useSelector( ( state: AppState ) => state.reader?.streams?.[ streamKey ] );
 

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -152,6 +152,11 @@ const Recent = () => {
 		}
 	}, [ isWide, data?.items, selectedItem ] );
 
+	// When the selected feed changes, clear the selected item.
+	useEffect( () => {
+		setSelectedItem( null );
+	}, [ selectedRecentSidebarFeedId ] );
+
 	return (
 		<div className="recent-feed">
 			<div className={ `recent-feed__list-column ${ selectedItem ? 'has-overlay' : '' }` }>

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -153,9 +153,13 @@ const Recent = () => {
 		}
 	}, [ isWide, data?.items, selectedItem ] );
 
-	// When the selected feed changes, clear the selected item.
+	// When the selected feed changes, clear the selected item and reset the page to 1.
 	useEffect( () => {
 		setSelectedItem( null );
+		setView( ( prevView ) => ( {
+			...prevView,
+			page: 1,
+		} ) );
 	}, [ selectedRecentSidebarFeedId ] );
 
 	return (

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -30,7 +30,13 @@ const Recent = () => {
 		page: 1,
 	} );
 
-	const data = useSelector( ( state: AppState ) => state.reader?.streams?.recent );
+	const selectedRecentSidebarFeedId = useSelector< AppState, number | null >(
+		( state ) => state.readerUi.sidebar.selectedRecentSite
+	);
+	const streamKey =
+		selectedRecentSidebarFeedId !== null ? `feed:${ selectedRecentSidebarFeedId }` : 'recent';
+
+	const data = useSelector( ( state: AppState ) => state.reader?.streams?.[ streamKey ] );
 
 	const posts = useSelector( ( state: AppState ) => {
 		const items = data?.items;
@@ -105,10 +111,10 @@ const Recent = () => {
 	];
 
 	const fetchData = useCallback( () => {
-		dispatch( viewStream( 'recent', window.location.pathname ) as AnyAction );
+		dispatch( viewStream( streamKey, window.location.pathname ) as AnyAction );
 		dispatch(
 			requestPaginatedStream( {
-				streamKey: 'recent',
+				streamKey,
 				page: view.page,
 				perPage: view.perPage,
 			} ) as AnyAction
@@ -116,12 +122,12 @@ const Recent = () => {
 		// Fetch the next page in advance.
 		dispatch(
 			requestPaginatedStream( {
-				streamKey: 'recent',
+				streamKey,
 				page: view?.page ? view.page + 1 : undefined,
 				perPage: view.perPage,
 			} ) as AnyAction
 		);
-	}, [ dispatch, view ] );
+	}, [ dispatch, view, streamKey ] );
 
 	const paginationInfo = useMemo( () => {
 		return {

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -198,7 +198,11 @@ const streamApis = {
 		path: () => '/read/streams/following',
 		dateProperty: 'date',
 		apiNamespace: 'wpcom/v2',
-		query: ( extras ) => getQueryString( extras ),
+		query: ( extras, { streamKey } ) => {
+			const feedId = streamKeySuffix( streamKey );
+			const queryParams = feedId !== 'recent' ? { ...extras, feed_id: feedId } : { ...extras };
+			return getQueryString( { queryParams } );
+		},
 	},
 	search: {
 		path: () => '/read/search',

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -200,8 +200,12 @@ const streamApis = {
 		apiNamespace: 'wpcom/v2',
 		query: ( extras, { streamKey } ) => {
 			const feedId = streamKeySuffix( streamKey );
-			const queryParams = feedId !== 'recent' ? { ...extras, feed_id: feedId } : { ...extras };
-			return getQueryString( { queryParams } );
+			const queryParams = { ...extras };
+			if ( feedId !== 'recent' ) {
+				// 'recent' without a suffix means don't filter by feedId
+				queryParams.feed_id = feedId;
+			}
+			return getQueryString( queryParams );
 		},
 	},
 	search: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/loop#193

## Proposed Changes

* Enables filtering the posts by the selected feed in the sidebar

**Note:** This is dependent on D166025-code

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2iv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/read?flags=reader/recent-feed-overhaul`
* Select a site in the sidebar under "Recent"
* Posts should be filtered by that feed in middle column

**Note:** The pagination and sorting is still wonky and will be addressed in another PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
