### PR TITLE
A4A > Migrations: Implement card view for commissions & mobile fixes

### DIFF
--- a/client/a8c-for-agencies/components/layout/header.tsx
+++ b/client/a8c-for-agencies/components/layout/header.tsx
@@ -7,6 +7,7 @@ type Props = {
 	showStickyContent?: boolean;
 	children: ReactNode;
 	className?: string;
+	useColumnAlignment?: boolean;
 };
 
 export function LayoutHeaderTitle( { children }: Props ) {
@@ -17,14 +18,26 @@ export function LayoutHeaderSubtitle( { children }: Props ) {
 	return <h2 className="a4a-layout__header-subtitle">{ children }</h2>;
 }
 
-export function LayoutHeaderActions( { children, className }: Props ) {
-	const wrapperClass = clsx( className, 'a4a-layout__header-actions' );
+export function LayoutHeaderActions( { children, className, useColumnAlignment }: Props ) {
+	const wrapperClass = clsx( className, 'a4a-layout__header-actions', {
+		'is-column-flex-align': useColumnAlignment,
+	} );
 	return <div className={ wrapperClass }>{ children }</div>;
 }
 
-export function LayoutHeaderBreadcrumb( { items }: { items: BreadcrumbItem[] } ) {
+export function LayoutHeaderBreadcrumb( {
+	items,
+	hideOnMobile,
+}: {
+	items: BreadcrumbItem[];
+	hideOnMobile?: boolean;
+} ) {
 	return (
-		<div className="a4a-layout__header-breadcrumb">
+		<div
+			className={ clsx( 'a4a-layout__header-breadcrumb', {
+				'is-hidden-on-mobile': hideOnMobile,
+			} ) }
+		>
 			<Breadcrumb items={ items } />
 		</div>
 	);

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -139,6 +139,13 @@ html,
 		flex-grow: 1;
 	}
 
+	&.is-column-flex-align {
+		display: flex;
+		flex-direction: column;
+		align-items: normal;
+		justify-content: normal;
+	}
+
 	@include break-medium {
 		width: auto;
 		> * {
@@ -213,6 +220,12 @@ html,
 
 .a4a-layout__header-breadcrumb {
 	margin-block-end: 4px;
+
+	&.is-hidden-on-mobile {
+		@include breakpoint-deprecated( "<660px" ) {
+			display: none;
+		}
+	}
 }
 
 .a4a-layout__header-title {

--- a/client/a8c-for-agencies/components/list-item-cards/index.tsx
+++ b/client/a8c-for-agencies/components/list-item-cards/index.tsx
@@ -1,0 +1,26 @@
+import './style.scss';
+
+export function ListItemCardContent( {
+	title,
+	children,
+}: {
+	title: string;
+	children: React.ReactNode;
+} ) {
+	return (
+		<div className="list-item-card-content">
+			<div className="list-item-card-content__header">
+				<div className="list-item-card-content__header-title">{ title.toUpperCase() }</div>
+			</div>
+			{ children }
+		</div>
+	);
+}
+
+export function ListItemCard( { children }: { children: React.ReactNode } ) {
+	return <div className="list-item-card">{ children }</div>;
+}
+
+export function ListItemCards( { children }: { children: React.ReactNode } ) {
+	return <div className="list-item-cards">{ children }</div>;
+}

--- a/client/a8c-for-agencies/components/list-item-cards/style.scss
+++ b/client/a8c-for-agencies/components/list-item-cards/style.scss
@@ -1,0 +1,31 @@
+.list-item-cards {
+	overflow-y: auto;
+
+	.list-item-card {
+		border: 1px solid var(--color-border-subtle);
+		border-radius: 4px;
+		margin-block-end: 1rem;
+		padding: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+
+		.list-item-card-content {
+			display: flex;
+			flex-direction: column;
+			gap: 6px;
+
+			.list-item-card-content__header {
+				display: flex;
+				justify-content: space-between;
+
+				.list-item-card-content__header-title {
+					@include a4a-font-body-sm($font-weight: 500);
+					color: var(--color-gray-80);
+				}
+			}
+		}
+	}
+}
+
+

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
@@ -9,7 +9,7 @@ export const SiteColumn = ( { site }: { site: string } ) => {
 	return site;
 };
 
-export const MigratedOnColumn = ( { migratedOn }: { migratedOn: string } ) => {
+export const MigratedOnColumn = ( { migratedOn }: { migratedOn: Date } ) => {
 	return <FormattedDate date={ migratedOn } format={ DETAILS_DATE_FORMAT_SHORT } />;
 };
 

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -1,9 +1,11 @@
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, ReactNode, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { MigratedOnColumn, ReviewStatusColumn, SiteColumn } from './commission-columns';
+import MigrationsCommissionsListMobileView from './mobile-view';
 import type { MigrationCommissionItem } from '../types';
 import type { Field } from '@wordpress/dataviews';
 
@@ -13,6 +15,8 @@ export default function MigrationsCommissionsList( {
 	items: MigrationCommissionItem[];
 } ) {
 	const translate = useTranslate();
+
+	const isDesktop = useDesktopBreakpoint();
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
@@ -54,6 +58,10 @@ export default function MigrationsCommissionsList( {
 		],
 		[ translate ]
 	);
+
+	if ( ! isDesktop ) {
+		return <MigrationsCommissionsListMobileView commissions={ items } />;
+	}
 
 	return (
 		<div className="redesigned-a8c-table full-width">

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/mobile-view.tsx
@@ -1,0 +1,42 @@
+import { useTranslate } from 'i18n-calypso';
+import {
+	ListItemCards,
+	ListItemCard,
+	ListItemCardContent,
+} from 'calypso/a8c-for-agencies/components/list-item-cards';
+import { MigratedOnColumn, ReviewStatusColumn, SiteColumn } from './commission-columns';
+import type { MigrationCommissionItem } from '../types';
+
+import './style.scss';
+
+export default function MigrationsCommissionsListMobileView( {
+	commissions,
+}: {
+	commissions: MigrationCommissionItem[];
+} ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="migrations-commissions-list-mobile-view">
+			<ListItemCards>
+				{ commissions.map( ( commission ) => (
+					<ListItemCard key={ commission.id }>
+						<ListItemCardContent title={ translate( 'Site' ) }>
+							<div className="migrations-commissions-list-mobile-view__column">
+								<SiteColumn site={ commission.siteUrl } />
+							</div>
+						</ListItemCardContent>
+						<ListItemCardContent title={ translate( 'Migrated on' ) }>
+							<div className="migrations-commissions-list-mobile-view__column">
+								<MigratedOnColumn migratedOn={ commission.migratedOn } />
+							</div>
+						</ListItemCardContent>
+						<ListItemCardContent title={ translate( 'Review status' ) }>
+							<ReviewStatusColumn reviewStatus={ commission.reviewStatus } />
+						</ListItemCardContent>
+					</ListItemCard>
+				) ) }
+			</ListItemCards>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/style.scss
@@ -1,0 +1,7 @@
+.migrations-commissions-list-mobile-view {
+	padding: 16px;
+}
+
+.migrations-commissions-list-mobile-view__column {
+	@include a4a-font-body-md;
+}

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -27,7 +27,7 @@ export default function MigrationsCommissions() {
 
 	const [ showAddSitesModal, setShowAddSitesModal ] = useState( false );
 
-	const title = translate( 'Migrations' );
+	const title = translate( 'Migrations: Commissions' );
 
 	const onTagSitesClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a8c_migrations_commissions_tag_sites_click' ) );
@@ -55,6 +55,7 @@ export default function MigrationsCommissions() {
 			<LayoutTop>
 				<LayoutHeader>
 					<Breadcrumb
+						hideOnMobile
 						items={ [
 							{
 								label: translate( 'Migrations' ),
@@ -65,9 +66,8 @@ export default function MigrationsCommissions() {
 							},
 						] }
 					/>
-					<Actions>
+					<Actions useColumnAlignment>
 						<MobileSidebarNavigation />
-
 						<Button variant="primary" onClick={ onTagSitesClick }>
 							{ translate( 'Tag sites for commission' ) }
 						</Button>

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -45,7 +45,7 @@ export default function ReferralsBankDetails( {
 	if ( isMigrations ) {
 		title = isDesktop
 			? translate( 'Migrations: Set up secure payments' )
-			: translate( 'Payment Settings' );
+			: translate( 'Migrations: Payment Settings' );
 	}
 
 	const { data, isFetching } = useGetTipaltiIFrameURL();

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -43,7 +43,9 @@ export default function ReferralsBankDetails( {
 		: translate( 'Referrals: Add bank details' );
 
 	if ( isMigrations ) {
-		title = translate( 'Migrations: Payment Settings' );
+		title = isDesktop
+			? translate( 'Migrations: Set up secure payments' )
+			: translate( 'Payment Settings' );
 	}
 
 	const { data, isFetching } = useGetTipaltiIFrameURL();
@@ -82,15 +84,16 @@ export default function ReferralsBankDetails( {
 	return (
 		<Layout
 			className={ clsx( 'bank-details__layout', {
-				'bank-details__layout--automated': isAutomatedReferral,
+				'bank-details__layout--automated': isAutomatedReferral && ! isMigrations,
 			} ) }
 			title={ title }
 			wide
-			sidebarNavigation={ <MobileSidebarNavigation /> }
+			sidebarNavigation={ ! isMigrations ? <MobileSidebarNavigation /> : undefined }
 		>
 			<LayoutTop>
 				<LayoutHeader>
 					<Breadcrumb
+						hideOnMobile={ isMigrations }
 						items={ [
 							mainPageBreadCrumb,
 							{
@@ -101,7 +104,8 @@ export default function ReferralsBankDetails( {
 						] }
 					/>
 					{ accountStatus && (
-						<Actions>
+						<Actions useColumnAlignment={ isMigrations }>
+							{ isMigrations && <MobileSidebarNavigation /> }
 							<div className="bank-details__status">
 								{ translate( 'Payment status: {{badge}}%(status)s{{/badge}}', {
 									args: {

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
@@ -71,7 +71,12 @@ const ReferralPurchasesMobile = ( { purchases }: { purchases: ReferralPurchase[]
 	return (
 		<div className="referral-purchases-mobile__wrapper">
 			{ purchases.map( ( purchase ) => (
-				<PurchaseItem purchase={ purchase } data={ data } isFetching={ isFetching } />
+				<PurchaseItem
+					key={ `${ purchase.product_id }-${ purchase.referral_id }` }
+					purchase={ purchase }
+					data={ data }
+					isFetching={ isFetching }
+				/>
 			) ) }
 		</div>
 	);


### PR DESCRIPTION

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1463

## Proposed Changes

This PR:

- Implements a card view for commissions on mobile screens.
- Creates component for card view
- Updates the Layout components to support mobile screens.

Note: Clicking on the `Tag sites for commissions` button does nothing. It is being implemented here: https://github.com/Automattic/wp-calypso/pull/96273

## Why are these changes being made?

* To provide a better mobile experience on the Migrations page.

## Testing Instructions

* Open the A4A live link
* Go to Migrations: Commissions > Switch to any mobile screen > Verify everything looks good.
* Go to Migrations: Payment Setting > Verify everything looks good. 

<img width="375" alt="Screenshot 2024-11-13 at 10 32 00 AM" src="https://github.com/user-attachments/assets/9d0f2693-e950-4f92-a769-959ea2f8114d">

<img width="375" alt="Screenshot 2024-11-13 at 1 16 36 PM" src="https://github.com/user-attachments/assets/d792277e-21ff-4cc3-bd62-212265f97713">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
