### PR TITLE
A4A: Show an 'Early Access' banner on the Agency Tier and benefits page.

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/early-access-banner/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/early-access-banner/index.tsx
@@ -1,0 +1,34 @@
+import { useTranslate } from 'i18n-calypso';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+
+const EARLY_ACCESS_BANNER_DISMISSED = 'a4a-agency-tier-early-access-banner-dismissed';
+
+export default function EarlyAccessBanner() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const bannerDismissed = useSelector( ( state ) =>
+		getPreference( state, EARLY_ACCESS_BANNER_DISMISSED )
+	);
+
+	const handleDismiss = () => {
+		dispatch( savePreference( EARLY_ACCESS_BANNER_DISMISSED, true ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_early_access_banner_dismissed' ) );
+	};
+
+	if ( bannerDismissed ) {
+		return null;
+	}
+
+	return (
+		<LayoutBanner level="warning" onClose={ handleDismiss }>
+			{ translate(
+				"You've been granted early access to our new Agency Tier experience! While the official launch of our tiers is set for January 2025, you have the opportunity to explore and progress on your tier today."
+			) }
+		</LayoutBanner>
+	);
+}

--- a/client/a8c-for-agencies/sections/agency-tier/early-access-banner/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/early-access-banner/index.tsx
@@ -17,7 +17,7 @@ export default function EarlyAccessBanner() {
 
 	const handleDismiss = () => {
 		dispatch( savePreference( EARLY_ACCESS_BANNER_DISMISSED, true ) );
-		dispatch( recordTracksEvent( 'calypso_a4a_early_access_banner_dismiss_click' ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_agency_tier_early_access_banner_dismiss_click' ) );
 	};
 
 	if ( bannerDismissed ) {

--- a/client/a8c-for-agencies/sections/agency-tier/early-access-banner/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/early-access-banner/index.tsx
@@ -17,7 +17,7 @@ export default function EarlyAccessBanner() {
 
 	const handleDismiss = () => {
 		dispatch( savePreference( EARLY_ACCESS_BANNER_DISMISSED, true ) );
-		dispatch( recordTracksEvent( 'calypso_a4a_early_access_banner_dismissed' ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_early_access_banner_dismiss_click' ) );
 	};
 
 	if ( bannerDismissed ) {

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -14,6 +14,7 @@ import { useSelector, useDispatch } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import DownloadBadges from '../../download-badges';
+import EarlyAccessBanner from '../../early-access-banner';
 import getAgencyTierInfo from '../../lib/get-agency-tier-info';
 import getTierBenefits from '../../lib/get-tier-benefits';
 import { AgencyTier } from '../../types';
@@ -54,6 +55,8 @@ export default function AgencyTierOverview() {
 			</LayoutTop>
 
 			<LayoutBody>
+				<EarlyAccessBanner />
+
 				{ currentAgencyTierInfo && (
 					<div className="agency-tier-overview__top-content">
 						<div className="agency-tier-overview__top-content-left">


### PR DESCRIPTION
This PR adds a disclaimer on the Agency Tier and benefits page that clarifies the early access experience.
<img width="1469" alt="Screenshot 2024-11-13 at 4 22 10 PM" src="https://github.com/user-attachments/assets/d24a0051-d7d2-4001-9243-6d8fe91b5e62">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1468

## Proposed Changes

* Create an `EarlyAccessBanner` component based from the `LayoutBanner` component. This component can be dismissed, and its dismiss state will be saved as a preference.

## Why are these changes being made?

* This is part of the Agency Tier project and needed before the launch.

## Testing Instructions

* Use the A4A live link and go to the `/agency-tier` page.
* Please confirm if the banner is visible. If it isn’t, reset the `a4a-agency-tier-early-access-banner-dismissed` preference with the Calypso debug tool.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
