### PR TITLE
update upgrades > add-ons card styles

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -44,6 +44,7 @@ const Container = styled.div`
 			display: flex;
 			flex-direction: column;
 			box-sizing: border-box;
+			padding: 8px 0;
 		}
 	}
 
@@ -83,6 +84,8 @@ const Container = styled.div`
 
 	.add-ons-card__body {
 		font-size: 0.875rem;
+		padding-top: 0;
+		padding-bottom: 0;
 	}
 
 	.add-ons-card__footer {

--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -1,7 +1,7 @@
 import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
-import { Badge, Button, Gridicon, Spinner } from '@automattic/components';
+import { Badge, Gridicon, Spinner } from '@automattic/components';
 import styled from '@emotion/styled';
-import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
+import { Card, CardBody, CardFooter, CardHeader, Button } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -43,7 +43,6 @@ const Container = styled.div`
 			width: 100%;
 			display: flex;
 			flex-direction: column;
-			padding: 18px 10px; // Card sections have 16x24 inner padding
 			box-sizing: border-box;
 		}
 	}
@@ -60,7 +59,7 @@ const Container = styled.div`
 		.add-ons-card__name-and-billing {
 			.add-ons-card__billing {
 				color: var( --studio-gray-60 );
-				font-weight: 500;
+				font-size: 0.75rem;
 			}
 
 			.add-ons-card__name-tag {
@@ -75,14 +74,26 @@ const Container = styled.div`
 
 				.add-ons-card__featured-badge {
 					border-radius: 4px;
+					font-size: 0.75rem;
+					font-weight: 500;
 				}
 			}
 		}
 	}
 
+	.add-ons-card__body {
+		font-size: 0.875rem;
+	}
+
 	.add-ons-card__footer {
 		display: flex;
 		margin-top: auto;
+
+		.add-ons-card__action-button {
+			font-weight: 600;
+			text-decoration: none;
+			padding: 0;
+		}
 
 		.add-ons-card__selected-tag {
 			display: flex;
@@ -154,7 +165,9 @@ const AddOnCard = ( {
 					{ shouldRenderSecondaryAction && (
 						<>
 							{ actionSecondary && (
-								<Button onClick={ onActionSecondary }>{ actionSecondary.text }</Button>
+								<Button onClick={ onActionSecondary } variant="secondary">
+									{ actionSecondary.text }
+								</Button>
 							) }
 							{ availabilityStatus?.text && (
 								<div className="add-ons-card__selected-tag">
@@ -165,7 +178,14 @@ const AddOnCard = ( {
 						</>
 					) }
 					{ shouldRenderPrimaryAction && actionPrimary && (
-						<Button onClick={ onActionPrimary } primary>
+						<Button
+							className="add-ons-card__action-button"
+							onClick={ onActionPrimary }
+							variant="link"
+							icon={ <Gridicon icon="chevron-right" /> }
+							iconPosition="right"
+							iconSize={ 16 }
+						>
 							{ actionPrimary.text }
 						</Button>
 					) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

fixes https://github.com/Automattic/dotcom-forge/issues/9685

## Proposed Changes

* Update card content styles such as font-size, font-weight
* Update button to link variant
* Update @automattic/components/button to @wordpress/components/button
* Update font styles of the badge

Before:
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/65a1ed04-8fad-4979-a4ea-57c1763fe670">

After:
<img width="1076" alt="image" src="https://github.com/user-attachments/assets/639cafda-c67c-4430-81f4-00a580be0ac0">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match the UI of Marketing pages

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify UI, it should match the new designs. Reference: pIiTEGIxHIzKfHv1KHOUM5-fi-3130_24771

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?