### PR TITLE
Login: Remove lost password link from lost password page

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -462,6 +462,7 @@ export class Login extends Component {
 			isBlazePro,
 			currentQuery,
 			isWooPasswordlessJPC,
+			currentRoute,
 		} = this.props;
 
 		if ( isGravPoweredLoginPage ) {
@@ -469,9 +470,11 @@ export class Login extends Component {
 		}
 
 		if (
-			currentQuery.lostpassword_flow === 'true' &&
-			isWooPasswordlessJPC &&
-			config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
+			( currentQuery.lostpassword_flow === 'true' &&
+				isWooPasswordlessJPC &&
+				config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) ||
+			// We don't want to show lost password option if the user is already on lost password's page
+			( isSocialFirst && currentRoute === '/log-in/lostpassword' )
 		) {
 			return null;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96290
Fixes https://github.com/Automattic/wp-calypso/issues/96290

## Proposed Changes

* Hide the lost password link on last password page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Addresses this issue https://github.com/Automattic/wp-calypso/issues/96290

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link
* Write your email and click on lost password
* Make sure you don't see the lost password link on the lost passwords page

<img width="651" alt="image" src="https://github.com/user-attachments/assets/403d4d4a-ce22-466f-a8ee-14bd978c52e8">

Before
<img width="811" alt="image" src="https://github.com/user-attachments/assets/4f5d4e6e-c553-4721-8f08-503578b1c021">

After
<img width="998" alt="image" src="https://github.com/user-attachments/assets/64c9dbb5-6e40-45b0-85d4-c53157e3ec1c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
