### PR TITLE
Stepper: Don't record user registration if signing up with existing social account

### DIFF
--- a/client/lib/signup/api/account.tsx
+++ b/client/lib/signup/api/account.tsx
@@ -125,16 +125,16 @@ export async function createAccount( {
 	let isNewAccountCreated = true;
 	if ( service && response && 'created_account' in response && ! response?.created_account ) {
 		isNewAccountCreated = false;
+	} else {
+		const username = response?.signup_sandbox_username || response?.username;
+
+		recordNewAccountCreation( {
+			response,
+			flowName,
+			username,
+			signupType: service ? 'social' : 'default',
+		} );
 	}
-
-	const username = response?.signup_sandbox_username || response?.username;
-
-	recordNewAccountCreation( {
-		response,
-		flowName,
-		username,
-		signupType: service ? 'social' : 'default',
-	} );
 
 	return { ...response, isNewAccountCreated };
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

There are cases where users sign up using a social method, but the user already exists and so we log them in. We're currently triggering the `calypso_user_registration_complete` event in this case.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Don't record user registration if signing up with existing social account

