### PR TITLE
Subscriber importer: wrap steps in translation functions

### DIFF
--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -1,4 +1,5 @@
 import { Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { ReactNode } from 'react';
@@ -32,7 +33,7 @@ export function getStepsProgress(
 
 	const result: ClickHandler[] = [
 		{
-			message: 'Content',
+			message: __( 'Content' ),
 			onClick: () => {
 				navigate(
 					addQueryArgs( `/import/newsletter/${ engine }/${ selectedSiteSlug }/content`, {
@@ -44,7 +45,7 @@ export function getStepsProgress(
 			indicator: getStepProgressIndicator( paidNewsletterData?.steps.content.status ),
 		},
 		{
-			message: 'Subscribers',
+			message: __( 'Subscribers' ),
 			onClick: () => {
 				navigate(
 					addQueryArgs( `/import/newsletter/${ engine }/${ selectedSiteSlug }/subscribers`, {
@@ -56,7 +57,7 @@ export function getStepsProgress(
 			indicator: getStepProgressIndicator( paidNewsletterData?.steps.subscribers.status ),
 		},
 		{
-			message: 'Summary',
+			message: __( 'Summary' ),
 			onClick: () => {
 				navigate(
 					addQueryArgs( `/import/newsletter/${ engine }/${ selectedSiteSlug }/summary`, {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

<img width="751" alt="Screenshot 2024-11-13 at 15 51 08" src="https://github.com/user-attachments/assets/667a76ab-fb25-4c1d-a0fa-29ccb6bb1f40">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
