### PR TITLE
Substack subscriber importer: add translation function

### DIFF
--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/success-notice.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/success-notice.tsx
@@ -1,15 +1,20 @@
 import { Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 
 export default function SuccessNotice( { allEmailsCount }: { allEmailsCount: number } ) {
+	const { _n } = useI18n();
 	return (
 		<Notice status="success" className="importer__notice" isDismissible={ false }>
 			{ createInterpolateElement(
 				sprintf(
-					// @TODO: add _n() translation function once we finalize this copy.
 					// translators: %d is the number of subscribers
-					'All set! We’ve found <strong>%d subscribers</strong> to import.',
+					_n(
+						'All set! We’ve found <strong>%d subscriber</strong> to import.',
+						'All set! We’ve found <strong>%d subscribers</strong> to import.',
+						allEmailsCount
+					),
 					allEmailsCount
 				),
 				{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Wrap "All set..." in translation function.

## Proposed Changes

<img width="1047" alt="Screenshot 2024-11-13 at 15 06 15" src="https://github.com/user-attachments/assets/14783758-5ba6-4799-a322-d333558978e6">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
