### PR TITLE
Update long-content-fade usage from rgb to hex

### DIFF
--- a/client/assets/stylesheets/shared/mixins/_long-content-fade.scss
+++ b/client/assets/stylesheets/shared/mixins/_long-content-fade.scss
@@ -10,13 +10,13 @@
 //
 // Usage:
 // @include long-content-fade();
-// @include long-content-fade( $color: var( --color-sidebar-background-rgb ) );
+// @include long-content-fade( $color: var( --color-sidebar-background ) );
 // ==========================================================================
 
 @mixin long-content-fade(
 	$direction: right,
 	$size: 20%,
-	$color: var( --color-surface-rgb ),
+	$color: var( --color-surface ),
 	$edge: 0,
 	$z-index: false
 ) {

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -197,7 +197,7 @@
 .reader-share__site-selector .site__title,
 .reader-share__site-selector .site__domain {
 	&::after {
-		@include long-content-fade( $color: var( --color-surface-rgb ) );
+		@include long-content-fade();
 		border-radius: 50%;
 	}
 }

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -183,7 +183,7 @@
 	text-overflow: ellipsis;
 
 	&::after {
-		@include long-content-fade( $color: var( --color-surface-rgb ) );
+		@include long-content-fade();
 	}
 }
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -461,7 +461,7 @@ $y-axis-padding: 0 20px;
 			min-width: 0;
 
 			&::before {
-				@include long-content-fade( $color: var( --color-neutral-60-rgb ) );
+				@include long-content-fade( $color: var( --color-neutral-60 ) );
 				position: relative;
 				left: -30px;
 				width: 30px;

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -36,7 +36,7 @@ $date-picker_nav_button_size: 20px;
 	width: 100%;
 
 	&::after {
-		@include long-content-fade( $color: var( --color-neutral-60-rgb ) );
+		@include long-content-fade( $color: var( --color-neutral-60 ) );
 	}
 }
 

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -94,7 +94,7 @@
 		@include long-content-fade();
 
 		.is-selected & {
-			@include long-content-fade( $color: var( --color-primary-rgb ) );
+			@include long-content-fade( $color: var( --color-primary ) );
 		}
 	}
 }

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -87,6 +87,6 @@
 	white-space: nowrap;
 
 	&::after {
-		@include long-content-fade( $color: var( --color-surface-rgb ) );
+		@include long-content-fade();
 	}
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -44,7 +44,7 @@
 		.site__domain {
 			color: var(--color-sidebar-menu-selected-text);
 			&::after {
-				@include long-content-fade( $color: var( --color-sidebar-menu-selected-background-rgb ) );
+				@include long-content-fade( $color: var( --color-sidebar-menu-selected-background ) );
 			}
 		}
 
@@ -78,7 +78,7 @@
 	.site__title,
 	.site__domain {
 		&::after {
-			@include long-content-fade( $color: var( --color-neutral-5-rgb ) );
+			@include long-content-fade( $color: var( --color-neutral-5 ) );
 		}
 	}
 }
@@ -110,7 +110,7 @@
 	.site__domain {
 		color: var(--color-sidebar-menu-hover-text);
 		&::after {
-			@include long-content-fade( $color: var( --color-sidebar-menu-hover-background-rgb ) );
+			@include long-content-fade( $color: var( --color-sidebar-menu-hover-background ) );
 		}
 	}
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -211,7 +211,7 @@ body.is-mobile-app-view {
 
 	.site__title::after,
 	.site__domain::after {
-		@include long-content-fade( $color: var( --color-sidebar-background-rgb ) );
+		@include long-content-fade( $color: var( --color-sidebar-background ) );
 	}
 
 	.site-selector {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -150,7 +150,7 @@ $image-height: 47px;
 	white-space: nowrap;
 
 	&::after {
-		@include long-content-fade($color: var(--color-neutral-0-rgb));
+		@include long-content-fade( $color: var( --color-neutral-0 ) );
 	}
 }
 

--- a/client/my-sites/media-library/list-item-file-details.scss
+++ b/client/my-sites/media-library/list-item-file-details.scss
@@ -25,7 +25,7 @@
 	color: var(--color-neutral-60);
 
 	&::after {
-		@include long-content-fade( $color: var( --color-neutral-10-rgb ) );
+		@include long-content-fade( $color: var( --color-neutral-10 ) );
 	}
 }
 

--- a/client/post-editor/media-modal/dialog.scss
+++ b/client/post-editor/media-modal/dialog.scss
@@ -146,6 +146,6 @@
 
 .editor-media-modal .media-library__list-item-file-name {
 	&::after {
-		@include long-content-fade( $color: var( --color-neutral-0-rgb ) );
+		@include long-content-fade( $color: var( --color-neutral-0 ) );
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/83974

## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/65598, the long-content-fade mixin was updated to match core's implementation. The change introduced a regression where the color in passed to the mixin was no longer wrapped in `rgba()`. As a result, if the color passed was formatted as rgb, then the output is no longer valid.

This PR updates the instances rgb colors to hex colors instead. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Since this PR updates many components, this can be tested by going to any of the affected components, use dev tools to make the content longer, and ensuring that the fade effect takes place.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
