### PR TITLE
Devdocs: Make the color scheme picker working again

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -9,6 +9,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 // This is a custom AsyncLoad component for devdocs that includes a
 // `props.component`-aware placeholder. It still needs to be imported as
 // `AsyncLoad` though–see https://github.com/Automattic/babel-plugin-transform-wpcalypso-async/blob/HEAD/index.js#L12
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import AsyncLoad from './devdocs-async-load';
 import SingleDocComponent from './doc';
 import DocsComponent from './main';
@@ -26,6 +27,7 @@ const devdocs = {
 			path: context.path,
 		} );
 
+		context.store.dispatch( setSelectedSiteId( null ) );
 		next();
 	},
 


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/wp-calypso/issues/96350

## Proposed Changes

This PR brought back the "temporary color scheme picker" functionality in Calypso's devdocs.

Currently, it does not work because it always tries to show the color scheme of the most recently selected site. This PR clears the selected site prior to loading devdocs route.


https://github.com/user-attachments/assets/a37c6491-c3fb-43bf-b989-63d9d64c7d43



## Testing Instructions

1. Go to `/devdocs/blocks/upsell-nudge`
1. Click around the color schemes.
1. Verify that the blocks change color (see above video)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?