### PR TITLE
Calypso environment badge: remove color scheme from account settings

### DIFF
--- a/client/lib/account-settings-helper/index.jsx
+++ b/client/lib/account-settings-helper/index.jsx
@@ -2,12 +2,10 @@ import languages from '@automattic/languages';
 import ReactDom from 'react-dom';
 import { useInView } from 'react-intersection-observer';
 import { Provider, useDispatch, useSelector } from 'react-redux';
-import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import LanguagePicker from 'calypso/components/language-picker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
-import { getPreference } from 'calypso/state/preferences/selectors';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import { setUserSetting } from 'calypso/state/user-settings/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
@@ -19,7 +17,6 @@ export function AccountSettingsHelper() {
 	const dispatch = useDispatch();
 	const userSettings = useSelector( getUserSettings ) ?? {};
 	const isFetching = useSelector( isFetchingUserSettings );
-	const colorSchemePreference = useSelector( ( state ) => getPreference( state, 'colorScheme' ) );
 	const { ref, inView } = useInView( { triggerOnce: true } );
 
 	const updateLanguage = ( event ) => {
@@ -59,8 +56,6 @@ export function AccountSettingsHelper() {
 					useFallbackForIncompleteLanguages={ userSettings?.use_fallback_for_incomplete_languages }
 					onChange={ updateLanguage }
 				/>
-				<div>Dashboard color scheme</div>
-				<ColorSchemePicker defaultSelection={ colorSchemePreference } />
 			</div>
 		</>
 	);


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/wp-calypso/issues/96327

## Proposed Changes

This PR removes the admin color scheme picker from the Calypso env badge:

<img width="731" alt="image" src="https://github.com/user-attachments/assets/e0dbb297-7032-47fa-ace1-5ed5f6c6a6c8">

## Why are these changes being made?

We cannot update the admin color scheme at user level anymore after pbxlJb-63Y-p2.

## Testing Instructions

1. Open the Calypso live link.
2. Click the "bug" icon at the bottom right corner.
3. Verify that the admin color scheme picker is not there anymore (see screenshot above).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?