### PR TITLE
Subscriber import: translate "active subscribers"

### DIFF
--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -52,7 +52,7 @@ export interface Product {
 }
 
 export interface Plan {
-	active_subscriptions: boolean;
+	active_subscriptions: number;
 	is_active: boolean;
 	name: string;
 	plan_amount_decimal: number;

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plan.tsx
@@ -1,7 +1,7 @@
 import { formatCurrency } from '@automattic/format-currency';
 import { DropdownMenu, MenuGroup, MenuItem, MenuItemsChoice, Button } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import { chevronDown, Icon, arrowRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState, KeyboardEvent } from 'react';
@@ -66,12 +66,7 @@ export function MapPlan( {
 	tierToAdd,
 	selectedProductId,
 }: MapPlanProps ) {
-	const { __ } = useI18n();
-	let active_subscriptions = '';
-	if ( plan.active_subscriptions ) {
-		active_subscriptions = ` • ${ plan.active_subscriptions } active subscribers`;
-	}
-
+	const { __, _n } = useI18n();
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const selectedProduct = products.find(
@@ -91,7 +86,14 @@ export function MapPlan( {
 						isSmallestUnit: true,
 						stripZeros: true,
 					} ) }
-					/{ plan.plan_interval } { active_subscriptions }
+					/{ plan.plan_interval }
+					{ plan.active_subscriptions &&
+						' • ' +
+							sprintf(
+								// Translators: %d is number of subscribers
+								_n( '%d active subscriber', '%d active subscribers', plan.active_subscriptions ),
+								plan.active_subscriptions
+							) }
 				</p>
 			</div>
 			<div className="map-plan__arrow">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



<img width="1047" alt="Screenshot 2024-11-13 at 15 06 15" src="https://github.com/user-attachments/assets/fa11fb51-b371-455b-bb9f-345641742c9c">

## Proposed Changes

* Translate "% active subscribers".
* Update type

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
