### PR TITLE
Help Center: Fix minimized content

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -93,6 +93,20 @@
 		}
 	}
 
+	&.is-minimized {
+		.help-center__container-header {
+			cursor: pointer;
+		}
+
+		.help-center__container-content {
+			display: none;
+		}
+
+		.help-center-header__text {
+			cursor: pointer;
+		}
+	}
+
 	/**
 	 * Desktop
 	 */
@@ -109,18 +123,6 @@
 			top: unset;
 			right: 50px;
 			bottom: calc(#{$header-height} + 16px);
-
-			.help-center__container-header {
-				cursor: pointer;
-			}
-
-			.help-center__container-content {
-				display: none;
-			}
-			
-			.help-center-header__text {
-				cursor: pointer;
-			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
| Before  | After |
| ------------- | ------------- |
| <img width="395" alt="Screenshot 2024-11-13 at 17 26 32" src="https://github.com/user-attachments/assets/71199408-1fc0-4de7-8048-13dab33a0d3e">  |  <img width="895" alt="Screenshot 2024-11-13 at 17 26 03" src="https://github.com/user-attachments/assets/97d19a8b-f38b-4f3b-95fc-398aa9a61418">  |

Fixes https://github.com/Automattic/dotcom-forge/issues/9803

## Proposed Changes

* Ensure that content is hidden both on desktop and mobile if the help center is minimized

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We were still showing the content card when the help center is minimized on mobile

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Use the `help-center-experience` flag
* Chat with odie
* Using a mobile viewport minimize the help center
* The header should display and the content should be hidden

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
