### PR TITLE
Plans: Enable term savings price display - as a grid feature

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -838,6 +838,7 @@ const PlansFeaturesMain = ( {
 										enableReducedFeatureGroupSpacing={ showSimplifiedFeatures }
 										enableLogosOnlyForEnterprisePlan={ showSimplifiedFeatures }
 										hideFeatureGroupTitles={ showSimplifiedFeatures }
+										enableTermSavingsPriceDisplay
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import {
 	chooseDefaultCustomerType,
 	getPlan,
@@ -838,7 +838,9 @@ const PlansFeaturesMain = ( {
 										enableReducedFeatureGroupSpacing={ showSimplifiedFeatures }
 										enableLogosOnlyForEnterprisePlan={ showSimplifiedFeatures }
 										hideFeatureGroupTitles={ showSimplifiedFeatures }
-										enableTermSavingsPriceDisplay
+										enableTermSavingsPriceDisplay={ isEnabled(
+											'plans/term-savings-price-display'
+										) }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }
@@ -898,6 +900,9 @@ const PlansFeaturesMain = ( {
 													}
 													enableFeatureTooltips
 													featureGroupMap={ featureGroupMapForComparisonGrid }
+													enableTermSavingsPriceDisplay={ isEnabled(
+														'plans/term-savings-price-display'
+													) }
 												/>
 											) }
 											<ComparisonGridToggle

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -1153,6 +1153,7 @@ const WrappedComparisonGrid = ( {
 	hideUnsupportedFeatures,
 	enableFeatureTooltips,
 	featureGroupMap,
+	enableTermSavingsPriceDisplay,
 	...otherProps
 }: ComparisonGridExternalProps ) => {
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -1186,6 +1187,7 @@ const WrappedComparisonGrid = ( {
 				enableFeatureTooltips={ enableFeatureTooltips }
 				featureGroupMap={ featureGroupMap }
 				hideUnsupportedFeatures={ hideUnsupportedFeatures }
+				enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 			>
 				<ComparisonGrid
 					intervalType={ intervalType }

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -385,6 +385,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		featureGroupMap = {},
 		hideFeatureGroupTitles,
 		enterpriseFeaturesList,
+		enableTermSavingsPriceDisplay,
 	} = props;
 
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -430,6 +431,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 				hideFeatureGroupTitles={ hideFeatureGroupTitles }
 				featureGroupMap={ featureGroupMap }
 				enterpriseFeaturesList={ enterpriseFeaturesList }
+				enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 			>
 				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />
 			</PlansGridContextProvider>

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -21,13 +21,18 @@ interface HeaderPriceProps {
 	visibleGridPlans: GridPlan[];
 }
 
-const getTermVariantPlanSlugForSavings = ( {
+/**
+ * Returns the term variant plan slug for savings calculation.
+ * This currently resolves to the monthly plan slug for annual/biennial/triennial plans.
+ */
+const useTermVariantPlanSlugForSavings = ( {
 	planSlug,
 	billingPeriod,
 }: {
 	planSlug: PlanSlug;
 	billingPeriod?: -1 | ( typeof PERIOD_LIST )[ number ];
 } ) => {
+	// If the billing period is yearly or above, we return the monthly variant's plan slug
 	if ( billingPeriod && 365 <= billingPeriod ) {
 		return getPlanSlugForTermVariant( planSlug, TERM_MONTHLY );
 	}
@@ -68,7 +73,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	} );
 
 	const storageAddOns = AddOns.useStorageAddOns( { siteId } );
-	const termVariantPlanSlug = getTermVariantPlanSlugForSavings( { planSlug, billingPeriod } );
+	const termVariantPlanSlug = useTermVariantPlanSlugForSavings( { planSlug, billingPeriod } );
 	const termVariantPricing = Plans.usePricingMetaForGridPlans( {
 		planSlugs: termVariantPlanSlug ? [ termVariantPlanSlug ] : [],
 		storageAddOns,

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -2,8 +2,6 @@ import {
 	getPlanSlugForTermVariant,
 	isWpcomEnterpriseGridPlan,
 	PERIOD_LIST,
-	TERM_ANNUALLY,
-	TERM_BIENNIALLY,
 	TERM_MONTHLY,
 	type PlanSlug,
 } from '@automattic/calypso-products';
@@ -30,12 +28,8 @@ const getTermVariantPlanSlugForSavings = ( {
 	planSlug: PlanSlug;
 	billingPeriod?: -1 | ( typeof PERIOD_LIST )[ number ];
 } ) => {
-	if ( 365 === billingPeriod ) {
+	if ( billingPeriod && 365 <= billingPeriod ) {
 		return getPlanSlugForTermVariant( planSlug, TERM_MONTHLY );
-	} else if ( 730 === billingPeriod ) {
-		return getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
-	} else if ( 1095 === billingPeriod ) {
-		return getPlanSlugForTermVariant( planSlug, TERM_BIENNIALLY );
 	}
 
 	return null;
@@ -161,10 +155,23 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		);
 	}
 
-	if ( enableTermSavingsPriceDisplay && termVariantPricing ) {
+	const termVariantPrice =
+		termVariantPricing?.discountedPrice.monthly ?? termVariantPricing?.originalPrice.monthly ?? 0;
+	const planPrice = discountedPrice.monthly ?? originalPrice.monthly ?? 0;
+	const savings =
+		termVariantPrice > planPrice
+			? Math.floor( ( ( termVariantPrice - planPrice ) / termVariantPrice ) * 100 )
+			: 0;
+
+	if ( enableTermSavingsPriceDisplay && termVariantPricing && savings ) {
 		return (
 			<div className="plans-grid-next-header-price">
-				<div className="plans-grid-next-header-price__badge">{ `Save from ${ termVariantPricing.originalPrice.monthly }` }</div>
+				<div className="plans-grid-next-header-price__badge">
+					{ translate( 'Save %(savings)d%%', {
+						args: { savings },
+						comment: 'Example: Save 35%',
+					} ) }
+				</div>
 				<div
 					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
 						'is-large-currency': isLargeCurrency,

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -1,5 +1,14 @@
-import { isWpcomEnterpriseGridPlan, type PlanSlug } from '@automattic/calypso-products';
+import {
+	getPlanSlugForTermVariant,
+	isWpcomEnterpriseGridPlan,
+	PERIOD_LIST,
+	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
+	TERM_MONTHLY,
+	type PlanSlug,
+} from '@automattic/calypso-products';
 import { PlanPrice } from '@automattic/components';
+import { AddOns, Plans } from '@automattic/data-stores';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
@@ -14,12 +23,31 @@ interface HeaderPriceProps {
 	visibleGridPlans: GridPlan[];
 }
 
+const getTermVariantPlanSlugForSavings = ( {
+	planSlug,
+	billingPeriod,
+}: {
+	planSlug: PlanSlug;
+	billingPeriod?: -1 | ( typeof PERIOD_LIST )[ number ];
+} ) => {
+	if ( 365 === billingPeriod ) {
+		return getPlanSlugForTermVariant( planSlug, TERM_MONTHLY );
+	} else if ( 730 === billingPeriod ) {
+		return getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
+	} else if ( 1095 === billingPeriod ) {
+		return getPlanSlugForTermVariant( planSlug, TERM_BIENNIALLY );
+	}
+
+	return null;
+};
+
 const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	const translate = useTranslate();
-	const { gridPlansIndex } = usePlansGridContext();
+	const { gridPlansIndex, enableTermSavingsPriceDisplay, siteId, coupon, helpers } =
+		usePlansGridContext();
 	const {
 		current,
-		pricing: { currencyCode, originalPrice, discountedPrice, introOffer },
+		pricing: { currencyCode, originalPrice, discountedPrice, introOffer, billingPeriod },
 	} = gridPlansIndex[ planSlug ];
 	const isPricedPlan = null !== originalPrice.monthly;
 
@@ -44,6 +72,16 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		currencyCode: currencyCode || 'USD',
 		ignoreWhitespace: true,
 	} );
+
+	const storageAddOns = AddOns.useStorageAddOns( { siteId } );
+	const termVariantPlanSlug = getTermVariantPlanSlugForSavings( { planSlug, billingPeriod } );
+	const termVariantPricing = Plans.usePricingMetaForGridPlans( {
+		planSlugs: termVariantPlanSlug ? [ termVariantPlanSlug ] : [],
+		storageAddOns,
+		coupon,
+		siteId,
+		useCheckPlanAvailabilityForPurchase: helpers?.useCheckPlanAvailabilityForPurchase,
+	} )?.[ termVariantPlanSlug ?? '' ];
 
 	if ( isWpcomEnterpriseGridPlan( planSlug ) || ! isPricedPlan ) {
 		return null;
@@ -123,7 +161,43 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		);
 	}
 
-	if ( isAnyVisibleGridPlanOneTimeDiscounted || isAnyVisibleGridPlanOnIntroOffer ) {
+	if ( enableTermSavingsPriceDisplay && termVariantPricing ) {
+		return (
+			<div className="plans-grid-next-header-price">
+				<div className="plans-grid-next-header-price__badge">{ `Save from ${ termVariantPricing.originalPrice.monthly }` }</div>
+				<div
+					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
+						'is-large-currency': isLargeCurrency,
+					} ) }
+				>
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ termVariantPricing.originalPrice.monthly }
+						displayPerMonthNotation={ false }
+						isLargeCurrency={ isLargeCurrency }
+						isSmallestUnit
+						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
+						original
+					/>
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ discountedPrice.monthly ?? originalPrice.monthly }
+						displayPerMonthNotation={ false }
+						isLargeCurrency={ isLargeCurrency }
+						isSmallestUnit
+						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
+						discounted
+					/>
+				</div>
+			</div>
+		);
+	}
+
+	if (
+		isAnyVisibleGridPlanOneTimeDiscounted ||
+		isAnyVisibleGridPlanOnIntroOffer ||
+		enableTermSavingsPriceDisplay
+	) {
 		return (
 			<div className="plans-grid-next-header-price">
 				<div className="plans-grid-next-header-price__badge is-hidden">' '</div>

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -13,6 +13,15 @@ jest.mock( 'react-redux', () => ( {
 	useSelector: jest.fn(),
 } ) );
 jest.mock( '../../grid-context', () => ( { usePlansGridContext: jest.fn() } ) );
+jest.mock( '@automattic/data-stores', () => ( {
+	...jest.requireActual( '@automattic/data-stores' ),
+	AddOns: {
+		useStorageAddOns: jest.fn(),
+	},
+	Plans: {
+		usePricingMetaForGridPlans: jest.fn(),
+	},
+} ) );
 
 import {
 	type PlanSlug,
@@ -20,10 +29,17 @@ import {
 	PLAN_ENTERPRISE_GRID_WPCOM,
 	PLAN_PERSONAL,
 } from '@automattic/calypso-products';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { usePlansGridContext } from '../../grid-context';
 import HeaderPrice from '../shared/header-price';
+
+const Wrapper = ( { children } ) => {
+	const queryClient = useMemo( () => new QueryClient(), [] );
+
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+};
 
 describe( 'HeaderPrice', () => {
 	const defaultProps = {
@@ -53,7 +69,7 @@ describe( 'HeaderPrice', () => {
 			},
 		} ) );
 
-		const { container } = render( <HeaderPrice { ...defaultProps } /> );
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
 		const rawPrice = container.querySelector( '.plan-price.is-original' );
 		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
 
@@ -78,7 +94,7 @@ describe( 'HeaderPrice', () => {
 			},
 		} ) );
 
-		const { container } = render( <HeaderPrice { ...defaultProps } /> );
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
 		const rawPrice = container.querySelector( '.plan-price' );
 		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
 
@@ -104,7 +120,8 @@ describe( 'HeaderPrice', () => {
 		} ) );
 
 		const { container } = render(
-			<HeaderPrice { ...defaultProps } planSlug={ PLAN_ENTERPRISE_GRID_WPCOM } />
+			<HeaderPrice { ...defaultProps } planSlug={ PLAN_ENTERPRISE_GRID_WPCOM } />,
+			{ wrapper: Wrapper }
 		);
 
 		expect( container ).toBeEmptyDOMElement();
@@ -134,7 +151,7 @@ describe( 'HeaderPrice', () => {
 			},
 		} ) );
 
-		const { container } = render( <HeaderPrice { ...defaultProps } /> );
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
 		const badge = container.querySelector( '.plans-grid-next-header-price__badge' );
 
 		expect( badge ).toHaveTextContent( 'Special Offer' );
@@ -157,7 +174,7 @@ describe( 'HeaderPrice', () => {
 			},
 		} ) );
 
-		const { container } = render( <HeaderPrice { ...defaultProps } /> );
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
 		const badge = container.querySelector( '.plans-grid-next-header-price__badge' );
 
 		expect( badge ).toHaveTextContent( 'One time discount' );

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -25,6 +25,7 @@ interface PlansGridContext {
 	enableStorageAsBadge?: boolean;
 	enableReducedFeatureGroupSpacing?: boolean;
 	enableLogosOnlyForEnterprisePlan?: boolean;
+	enableTermSavingsPriceDisplay?: boolean;
 	featureGroupMap: Partial< FeatureGroupMap >;
 	hideUnsupportedFeatures?: boolean;
 	hideFeatureGroupTitles?: boolean;
@@ -48,6 +49,7 @@ const PlansGridContextProvider = ( {
 	enableStorageAsBadge,
 	enableReducedFeatureGroupSpacing,
 	enableLogosOnlyForEnterprisePlan,
+	enableTermSavingsPriceDisplay,
 	featureGroupMap,
 	hideUnsupportedFeatures,
 	hideFeatureGroupTitles,
@@ -80,6 +82,7 @@ const PlansGridContextProvider = ( {
 				enableStorageAsBadge,
 				enableReducedFeatureGroupSpacing,
 				enableLogosOnlyForEnterprisePlan,
+				enableTermSavingsPriceDisplay,
 				featureGroupMap,
 				hideUnsupportedFeatures,
 				hideFeatureGroupTitles,

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -227,6 +227,13 @@ export type GridContextProps = {
 	 * Hide the titles for feature groups in the features grid
 	 */
 	hideFeatureGroupTitles?: boolean;
+
+	/**
+	 * Enable the display of the term savings in plan prices.
+	 * Prices will display crossed out with the savings from shorter term accentuated in a label.
+	 * This carries lower precedence than promo/coupon and introductory pricing, irrespective of whether set or not.
+	 */
+	enableTermSavingsPriceDisplay?: boolean;
 };
 
 export type ComparisonGridExternalProps = Omit<


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3403, https://github.com/Automattic/wp-calypso/pull/96174

## Proposed Changes

Enables the term savings price display as a grid feature that can be enabled/disabled, as needed. This is now behind a feature flag.

- See media below
- It applies to all the grid terms - from yearly onward. 
- It takes lower precedence than intro offers and coupon discounts (so if an intro offer exists, then that discount variation will display instead)

### Media

<img width="800" alt="Screenshot 2024-11-15 at 3 57 16 PM" src="https://github.com/user-attachments/assets/25b73dc0-2707-4982-9417-3dd693f64315">


### Caveats

The interplay with introductory offers and coupon/promos may create ambiguity/confusion, as the pricing discounts are based off different origins -> intro offers are a comparison between standard plan price and discounted plan price, for term saving the comparison is between two separate plans (the current term's and the lower terms). These two living next to each other in the grid:

<img width="800" alt="Screenshot 2024-11-15 at 3 49 39 PM" src="https://github.com/user-attachments/assets/d50e45a4-4bce-436e-a2e5-52b81e8577fd">

Also see comment below regarding the validity of this display/UI if everything appears as discounted in the grid (TLDR will this nullify the presence of a promo/intro offer?): https://github.com/Automattic/wp-calypso/pull/96357#issuecomment-2486183234

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/martech/issues/3403

## TODO

- [x] Decide the base term for computing the savings. See comment: https://github.com/Automattic/wp-calypso/pull/96357#discussion_r1842493952
- [x] Some cleanup in the Header Price component will happen in a follow-up.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/plans/:site?flags=plans/term-savings-price-display` and `/start/plans?flags=plans/term-savings-price-display`
- Ensure for yearly and above the savings are displayed as per media above
- Try the same with a coupon (need to find one) or active intro offer (need to mock/code it) and ensure those discounts render instead for the respective plans

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
