### PR TITLE
Help Center: Remove disclaimer when asking for a human

### DIFF
--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -100,6 +100,7 @@
 
 		.chat-feedback-wrapper {
 			padding-top: 24px;
+			width: 100%;
 		}
 
 		.disclaimer {

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -42,6 +42,9 @@ export const UserMessage = ( {
 		return shouldUseHelpCenterExperience ? <GetSupport /> : extraContactOptions;
 	};
 
+	const isMessageShowingDisclaimer =
+		message.context?.question_tags?.inquiry_type !== 'request-for-human-support';
+
 	const renderDisclaimers = () => (
 		<>
 			<WasThisHelpfulButtons message={ message } isDisliked={ isDisliked } />
@@ -61,7 +64,7 @@ export const UserMessage = ( {
 			isBot && (
 				<div className="chat-feedback-wrapper">
 					{ showExtraContactOptions && renderExtraContactOptions() }
-					{ renderDisclaimers() }
+					{ isMessageShowingDisclaimer && renderDisclaimers() }
 				</div>
 			)
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9814

## Proposed Changes

Remove the disclaimer when the user asks for a human.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There is no need for a thumbs up or down survey in the middle of this line of communication.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Launch Help
- Select to Still Need Help?
- Type, "Can I speak to a human?"
- There should be the button but not disclaimer