### PR TITLE
Subscriber importer: move Substack button icon to right

### DIFF
--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -104,6 +104,7 @@ export default function Content( {
 						target="_blank"
 						rel="noreferrer noopener"
 						icon={ external }
+						iconPosition="right"
 						variant="primary"
 					>
 						{ __( 'Open Substack settings' ) }

--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -59,6 +59,7 @@ export default function StepInitial( {
 				target="_blank"
 				rel="noreferrer noopener"
 				icon={ external }
+				iconPosition="right"
 				variant="primary"
 			>
 				{ __( 'Open Substack subscribers' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


Before
<img width="291" alt="Screenshot 2024-11-13 at 18 58 52" src="https://github.com/user-attachments/assets/016d71ed-f54e-4b8a-be1f-4ed8020eb906">

After

<img width="281" alt="Screenshot 2024-11-13 at 18 59 11" src="https://github.com/user-attachments/assets/e2cead78-6b39-4aea-a0fe-fd52518b0aef">


## Proposed Changes


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
 
* The icon in this type of button should be on the right side, as it's an external link.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
