### PR TITLE
Purchase Management: Replace getUserPurchases with React Hook useUserPurchases

### DIFF
--- a/client/me/purchases/hooks/use-user-purchases.tsx
+++ b/client/me/purchases/hooks/use-user-purchases.tsx
@@ -1,0 +1,52 @@
+import { Purchases } from '@automattic/data-stores';
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import type { Purchase, RawPurchase } from 'calypso/lib/purchases/types';
+import type { ComponentType } from 'react';
+
+export interface UserPurchasesState {
+	purchases: Purchase[];
+	isFetching: boolean;
+	isError: boolean;
+	error: Error | undefined | null;
+}
+
+export interface WithUserPurchasesProps {
+	userPurchasesState: UserPurchasesState;
+}
+
+async function fetchUserPurchases(): Promise< RawPurchase[] > {
+	return await wpcom.req.get( {
+		path: '/me/purchases',
+	} );
+}
+
+async function fetchAndTransformUserPurchases(): Promise< Purchase[] > {
+	const rawPurchases = await fetchUserPurchases();
+	return rawPurchases.map( Purchases.utils.createPurchaseObject );
+}
+
+export function useUserPurchases(): UserPurchasesState {
+	const queryKey = [ 'user-purchases' ];
+	const result = useQuery< Purchase[] >( {
+		queryKey,
+		queryFn: fetchAndTransformUserPurchases,
+		meta: {
+			persist: false,
+		},
+		refetchOnWindowFocus: false,
+	} );
+	return {
+		purchases: result.data ?? [],
+		isFetching: result.isFetching || result.isLoading,
+		isError: result.isError,
+		error: result.error,
+	};
+}
+
+export function withUserPurchases< P >( Component: ComponentType< P > ) {
+	return function UserPurchasesWrapper( props: Omit< P, keyof WithUserPurchasesProps > ) {
+		const state = useUserPurchases();
+		return <Component { ...( props as P ) } userPurchasesState={ state } />;
+	};
+}

--- a/client/me/purchases/payment-methods/main.tsx
+++ b/client/me/purchases/payment-methods/main.tsx
@@ -1,6 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -19,7 +18,6 @@ function PaymentMethods() {
 		<Main wideLayout className="payment-methods__main">
 			<DocumentHead title={ titles.paymentMethods } />
 			<PageViewTracker path="/me/purchases/payment-methods" title="Me > Payment Methods" />
-			<QueryUserPurchases />
 			<NavigationHeader
 				navigationItems={ [] }
 				title={ titles.sectionTitle }

--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -5,10 +5,8 @@ import { FunctionComponent, useState, useCallback } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isPaymentAgreement, PaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PaymentMethodDeleteDialog from './payment-method-delete-dialog';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 
@@ -25,8 +23,6 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	const reduxDispatch = useDispatch();
 	const [ isDialogVisible, setIsDialogVisible ] = useState( false );
 	const closeDialog = useCallback( () => setIsDialogVisible( false ), [] );
-	const siteId = useSelector( getSelectedSiteId );
-	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
 	const { purchases: userPurchases } = Purchases.useUserPurchases();
 
 	const handleDelete = useCallback( () => {
@@ -84,7 +80,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 				onClose={ closeDialog }
 				onConfirm={ handleDelete }
 				card={ card }
-				purchases={ userPurchases || sitePurchases }
+				purchases={ userPurchases }
 			/>
 			{ renderDeleteButton() }
 		</div>

--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -6,8 +6,9 @@ import { isPaymentAgreement, PaymentMethodSummary } from 'calypso/lib/checkout/p
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import { getSitePurchases, getUserPurchases } from 'calypso/state/purchases/selectors';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useUserPurchases } from '../hooks/use-user-purchases';
 import PaymentMethodDeleteDialog from './payment-method-delete-dialog';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 
@@ -26,7 +27,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	const closeDialog = useCallback( () => setIsDialogVisible( false ), [] );
 	const siteId = useSelector( getSelectedSiteId );
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
-	const userPurchases = useSelector( ( state ) => getUserPurchases( state ) );
+	const { purchases: userPurchases } = useUserPurchases();
 
 	const handleDelete = useCallback( () => {
 		closeDialog();

--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { Purchases } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useState, useCallback } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -8,7 +9,6 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { useUserPurchases } from '../hooks/use-user-purchases';
 import PaymentMethodDeleteDialog from './payment-method-delete-dialog';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 
@@ -27,7 +27,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	const closeDialog = useCallback( () => setIsDialogVisible( false ), [] );
 	const siteId = useSelector( getSelectedSiteId );
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
-	const { purchases: userPurchases } = useUserPurchases();
+	const { purchases: userPurchases } = Purchases.useUserPurchases();
 
 	const handleDelete = useCallback( () => {
 		closeDialog();

--- a/client/me/purchases/payment-methods/payment-method-list.tsx
+++ b/client/me/purchases/payment-methods/payment-method-list.tsx
@@ -11,10 +11,8 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import PaymentMethod from 'calypso/me/purchases/payment-methods/payment-method';
 import { withStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
-import {
-	hasLoadedSitePurchasesFromServer,
-	hasLoadedUserPurchasesFromServer,
-} from 'calypso/state/purchases/selectors';
+import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/selectors';
+import { WithUserPurchasesProps, withUserPurchases } from '../hooks/use-user-purchases';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import type { WithStoredPaymentMethodsProps } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import type { IAppState } from 'calypso/state/types';
@@ -26,17 +24,17 @@ interface PaymentMethodListProps {
 	translate: typeof translate;
 	isAgencyUser: boolean;
 	hasLoadedSitePurchasesFromServer: boolean;
-	hasLoadedUserPurchasesFromServer: boolean;
 }
 
 class PaymentMethodList extends Component<
-	PaymentMethodListProps & WithStoredPaymentMethodsProps
+	PaymentMethodListProps & WithStoredPaymentMethodsProps & WithUserPurchasesProps
 > {
 	renderPaymentMethods( paymentMethods: StoredPaymentMethod[] ) {
-		const hasLoadedPurchases =
-			this.props.hasLoadedUserPurchasesFromServer || this.props.hasLoadedSitePurchasesFromServer;
-
-		if ( this.props.paymentMethodsState.isLoading || ! hasLoadedPurchases ) {
+		if (
+			this.props.paymentMethodsState.isLoading ||
+			this.props.userPurchasesState.isFetching ||
+			! this.props.hasLoadedSitePurchasesFromServer
+		) {
 			return (
 				<CompactCard className="payment-method-list__loader">
 					<div className="payment-method-list__loading-placeholder-card loading-placeholder__content" />
@@ -113,5 +111,8 @@ class PaymentMethodList extends Component<
 export default connect( ( state: IAppState ) => ( {
 	isAgencyUser: isAgencyUser( state ),
 	hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
-	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-} ) )( withStoredPaymentMethods( localize( PaymentMethodList ), { type: 'all', expired: true } ) );
+} ) )(
+	withUserPurchases(
+		withStoredPaymentMethods( localize( PaymentMethodList ), { type: 'all', expired: true } )
+	)
+);

--- a/client/me/purchases/payment-methods/payment-method-list.tsx
+++ b/client/me/purchases/payment-methods/payment-method-list.tsx
@@ -12,7 +12,6 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import PaymentMethod from 'calypso/me/purchases/payment-methods/payment-method';
 import { withStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
-import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/selectors';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import type { WithStoredPaymentMethodsProps } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import type { IAppState } from 'calypso/state/types';
@@ -23,18 +22,16 @@ interface PaymentMethodListProps {
 	addPaymentMethodUrl: string;
 	translate: typeof translate;
 	isAgencyUser: boolean;
-	hasLoadedSitePurchasesFromServer: boolean;
 }
 
 class PaymentMethodList extends Component<
 	PaymentMethodListProps & WithStoredPaymentMethodsProps & Purchases.WithUserPurchasesProps
 > {
 	renderPaymentMethods( paymentMethods: StoredPaymentMethod[] ) {
-		if (
-			this.props.paymentMethodsState.isLoading ||
-			this.props.userPurchasesState.isFetching ||
-			! this.props.hasLoadedSitePurchasesFromServer
-		) {
+		// NOTE: we wait for user purchases to load because they are needed by
+		// some sub-components of PaymentMethod (eg: PaymentMethodDelete) and
+		// those components don't have their own loading states.
+		if ( this.props.paymentMethodsState.isLoading || this.props.userPurchasesState.isFetching ) {
 			return (
 				<CompactCard className="payment-method-list__loader">
 					<div className="payment-method-list__loading-placeholder-card loading-placeholder__content" />
@@ -110,7 +107,6 @@ class PaymentMethodList extends Component<
 
 export default connect( ( state: IAppState ) => ( {
 	isAgencyUser: isAgencyUser( state ),
-	hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
 } ) )(
 	Purchases.withUserPurchases(
 		withStoredPaymentMethods( localize( PaymentMethodList ), { type: 'all', expired: true } )

--- a/client/me/purchases/payment-methods/payment-method-list.tsx
+++ b/client/me/purchases/payment-methods/payment-method-list.tsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Button, CompactCard } from '@automattic/components';
 import { CheckoutProvider } from '@automattic/composite-checkout';
+import { Purchases } from '@automattic/data-stores';
 import { localize, translate } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -12,7 +13,6 @@ import PaymentMethod from 'calypso/me/purchases/payment-methods/payment-method';
 import { withStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/selectors';
-import { WithUserPurchasesProps, withUserPurchases } from '../hooks/use-user-purchases';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import type { WithStoredPaymentMethodsProps } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import type { IAppState } from 'calypso/state/types';
@@ -27,7 +27,7 @@ interface PaymentMethodListProps {
 }
 
 class PaymentMethodList extends Component<
-	PaymentMethodListProps & WithStoredPaymentMethodsProps & WithUserPurchasesProps
+	PaymentMethodListProps & WithStoredPaymentMethodsProps & Purchases.WithUserPurchasesProps
 > {
 	renderPaymentMethods( paymentMethods: StoredPaymentMethod[] ) {
 		if (
@@ -112,7 +112,7 @@ export default connect( ( state: IAppState ) => ( {
 	isAgencyUser: isAgencyUser( state ),
 	hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
 } ) )(
-	withUserPurchases(
+	Purchases.withUserPurchases(
 		withStoredPaymentMethods( localize( PaymentMethodList ), { type: 'all', expired: true } )
 	)
 );

--- a/client/me/purchases/payment-methods/payment-method-list.tsx
+++ b/client/me/purchases/payment-methods/payment-method-list.tsx
@@ -31,7 +31,7 @@ class PaymentMethodList extends Component<
 		// NOTE: we wait for user purchases to load because they are needed by
 		// some sub-components of PaymentMethod (eg: PaymentMethodDelete) and
 		// those components don't have their own loading states.
-		if ( this.props.paymentMethodsState.isLoading || this.props.userPurchasesState.isFetching ) {
+		if ( this.props.paymentMethodsState.isLoading || this.props.userPurchasesState.isLoading ) {
 			return (
 				<CompactCard className="payment-method-list__loader">
 					<div className="payment-method-list__loading-placeholder-card loading-placeholder__content" />

--- a/client/me/purchases/payment-methods/test/payment-method.tsx
+++ b/client/me/purchases/payment-methods/test/payment-method.tsx
@@ -7,15 +7,20 @@ import { render, screen, waitForElementToBeRemoved } from '@testing-library/reac
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
+import wpcomRequest from 'wpcom-proxy-request';
 import { createReduxStore } from 'calypso/state';
+import { RawPurchase } from '../../../../lib/purchases/types';
 import PaymentMethodList from '../payment-method-list';
 import type {
 	StoredPaymentMethodCard,
 	StoredPaymentMethodPayPal,
 } from '../../../../lib/checkout/payment-methods';
 
+jest.mock( 'wpcom-proxy-request', () => jest.fn() );
+
 const card: StoredPaymentMethodCard = {
 	stored_details_id: '1234',
+	display_brand: null,
 	user_id: '5432',
 	name: 'Card Person',
 	country_code: 'US',
@@ -75,6 +80,17 @@ const mockPurchases = [
 	},
 ];
 
+const mockRawPurchases: Partial< RawPurchase >[] = [
+	{
+		product_name: 'WordPress.com Business Plan',
+		domain: 'associatedsubscription.wordpress.com',
+		meta: 'associatedsubscription.wordpress.com',
+		stored_details_id: '1234',
+		auto_renew: '1',
+		renew_date: '2080-12-31',
+	},
+];
+
 jest.mock( 'calypso/state/purchases/selectors', () => ( {
 	getUserPurchases: jest.fn( () => mockPurchases ),
 	getSitePurchases: jest.fn( () => mockPurchases ),
@@ -102,6 +118,12 @@ describe( 'PaymentMethod', () => {
 	const currentData = { cards: [] };
 	beforeEach( () => {
 		nock.cleanAll();
+		( wpcomRequest as jest.Mock ).mockImplementation( ( args ) => {
+			if ( args.path === '/me/purchases' ) {
+				return Promise.resolve( mockRawPurchases );
+			}
+			return Promise.reject( `Unknown endpoint in test ${ args.path }` );
+		} );
 		currentData.cards = [ card, payPalAgreement ];
 		nock( 'https://public-api.wordpress.com' )
 			.persist()
@@ -164,7 +186,7 @@ describe( 'PaymentMethod', () => {
 		const store = createMockReduxStoreForPurchase();
 		const queryClient = new QueryClient();
 
-		mockPurchases[ 0 ].payment.storedDetailsId = '5678';
+		mockRawPurchases[ 0 ].stored_details_id = '5678';
 
 		render(
 			<ReduxProvider store={ store }>

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import noSitesIllustration from 'calypso/assets/images/illustrations/illustration-nosites.svg';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -26,11 +25,6 @@ import {
 	withStoredPaymentMethods,
 } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { getAllSubscriptions } from 'calypso/state/memberships/subscriptions/selectors';
-import {
-	getUserPurchases,
-	hasLoadedUserPurchasesFromServer,
-	isFetchingUserPurchases,
-} from 'calypso/state/purchases/selectors';
 import getAvailableConciergeSessions from 'calypso/state/selectors/get-available-concierge-sessions';
 import getConciergeNextAppointment, {
 	NextAppointment,
@@ -39,6 +33,7 @@ import getConciergeUserBlocked from 'calypso/state/selectors/get-concierge-user-
 import getSites from 'calypso/state/selectors/get-sites';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { AppState } from 'calypso/types';
+import { withUserPurchases } from '../hooks/use-user-purchases';
 import MembershipSite from '../membership-site';
 import PurchasesSite from '../purchases-site';
 import PurchasesListHeader from './purchases-list-header';
@@ -63,7 +58,7 @@ class PurchasesList extends Component<
 	PurchasesListProps & PurchasesListConnectedProps & WithStoredPaymentMethodsProps & LocalizeProps
 > {
 	isDataLoading() {
-		if ( this.props.isFetchingUserPurchases && ! this.props.hasLoadedUserPurchasesFromServer ) {
+		if ( this.props.userPurchasesState.isFetching ) {
 			return true;
 		}
 
@@ -94,7 +89,8 @@ class PurchasesList extends Component<
 	}
 
 	render() {
-		const { purchases, sites, translate, subscriptions } = this.props;
+		const { sites, translate, subscriptions } = this.props;
+		const { purchases } = this.props.userPurchasesState;
 		const commonEventProps = { context: 'me' };
 		let content;
 
@@ -165,7 +161,6 @@ class PurchasesList extends Component<
 
 		return (
 			<Main wideLayout className="purchases-list">
-				<QueryUserPurchases />
 				<QueryMembershipsSubscriptions />
 				<PageViewTracker path="/me/purchases" title="Purchases" />
 
@@ -191,13 +186,14 @@ class PurchasesList extends Component<
 }
 
 export default connect( ( state: AppState ) => ( {
-	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-	isFetchingUserPurchases: isFetchingUserPurchases( state ),
-	purchases: getUserPurchases( state ),
 	subscriptions: getAllSubscriptions( state ),
 	sites: getSites( state ).filter( isValueTruthy ),
 	nextAppointment: getConciergeNextAppointment( state ),
 	isUserBlocked: getConciergeUserBlocked( state ),
 	availableSessions: getAvailableConciergeSessions( state ),
 	siteId: getSiteId( state, null ),
-} ) )( withStoredPaymentMethods( localize( PurchasesList ), { type: 'card', expired: true } ) );
+} ) )(
+	withUserPurchases(
+		withStoredPaymentMethods( localize( PurchasesList ), { type: 'card', expired: true } )
+	)
+);

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CompactCard } from '@automattic/components';
-import { SiteDetails } from '@automattic/data-stores';
+import { SiteDetails, Purchases } from '@automattic/data-stores';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { LocalizeProps, localize } from 'i18n-calypso';
 import { Component } from 'react';
@@ -34,7 +34,6 @@ import getConciergeUserBlocked from 'calypso/state/selectors/get-concierge-user-
 import getSites from 'calypso/state/selectors/get-sites';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { AppState } from 'calypso/types';
-import { WithUserPurchasesProps, withUserPurchases } from '../hooks/use-user-purchases';
 import MembershipSite from '../membership-site';
 import PurchasesSite from '../purchases-site';
 import PurchasesListHeader from './purchases-list-header';
@@ -58,7 +57,7 @@ export interface PurchasesListConnectedProps {
 class PurchasesList extends Component<
 	PurchasesListProps &
 		PurchasesListConnectedProps &
-		WithUserPurchasesProps &
+		Purchases.WithUserPurchasesProps &
 		LocalizeProps &
 		WithStoredPaymentMethodsProps
 > {
@@ -199,7 +198,7 @@ export default connect( ( state: AppState ) => ( {
 	availableSessions: getAvailableConciergeSessions( state ),
 	siteId: getSiteId( state, null ),
 } ) )(
-	withUserPurchases(
+	Purchases.withUserPurchases(
 		withStoredPaymentMethods( localize( PurchasesList ), { type: 'card', expired: true } )
 	)
 );

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -102,7 +102,7 @@ class PurchasesList extends Component<
 			content = <PurchasesSite isPlaceholder />;
 		}
 
-		if ( purchases && purchases.length ) {
+		if ( ! this.isDataLoading() && purchases.length ) {
 			content = (
 				<>
 					{ this.renderConciergeBanner() }
@@ -124,7 +124,7 @@ class PurchasesList extends Component<
 			);
 		}
 
-		if ( purchases && ! purchases.length && ! subscriptions.length ) {
+		if ( ! this.isDataLoading() && ! purchases.length && ! subscriptions.length ) {
 			if ( ! sites.length ) {
 				return (
 					<Main wideLayout className="purchases-list">

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -62,7 +62,7 @@ class PurchasesList extends Component<
 		WithStoredPaymentMethodsProps
 > {
 	isDataLoading() {
-		if ( this.props.userPurchasesState.isFetching ) {
+		if ( this.props.userPurchasesState.isLoading ) {
 			return true;
 		}
 

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import noSitesIllustration from 'calypso/assets/images/illustrations/illustration-nosites.svg';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -165,6 +166,7 @@ class PurchasesList extends Component<
 
 		return (
 			<Main wideLayout className="purchases-list">
+				<QueryUserPurchases />
 				<QueryMembershipsSubscriptions />
 				<PageViewTracker path="/me/purchases" title="Purchases" />
 

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -33,7 +33,7 @@ import getConciergeUserBlocked from 'calypso/state/selectors/get-concierge-user-
 import getSites from 'calypso/state/selectors/get-sites';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { AppState } from 'calypso/types';
-import { withUserPurchases } from '../hooks/use-user-purchases';
+import { WithUserPurchasesProps, withUserPurchases } from '../hooks/use-user-purchases';
 import MembershipSite from '../membership-site';
 import PurchasesSite from '../purchases-site';
 import PurchasesListHeader from './purchases-list-header';
@@ -55,7 +55,11 @@ export interface PurchasesListConnectedProps {
 }
 
 class PurchasesList extends Component<
-	PurchasesListProps & PurchasesListConnectedProps & WithStoredPaymentMethodsProps & LocalizeProps
+	PurchasesListProps &
+		PurchasesListConnectedProps &
+		WithUserPurchasesProps &
+		LocalizeProps &
+		WithStoredPaymentMethodsProps
 > {
 	isDataLoading() {
 		if ( this.props.userPurchasesState.isFetching ) {

--- a/client/me/purchases/purchases-list/purchase-list-concierge-banner.tsx
+++ b/client/me/purchases/purchases-list/purchase-list-concierge-banner.tsx
@@ -4,7 +4,7 @@ import {
 } from 'calypso/me/concierge/constants';
 import ConciergeBanner from 'calypso/me/purchases/concierge-banner/index';
 
-type Props = {
+export type PurchaseListConciergeBannerProps = {
 	nextAppointment?: {
 		id: number;
 		siteId: number;
@@ -15,7 +15,7 @@ type Props = {
 	isUserBlocked: boolean;
 };
 
-export function PurchaseListConciergeBanner( props: Props ) {
+export function PurchaseListConciergeBanner( props: PurchaseListConciergeBannerProps ) {
 	const { nextAppointment, availableSessions, siteId, isUserBlocked } = props;
 
 	if ( isUserBlocked ) {

--- a/packages/data-stores/src/purchases/index.ts
+++ b/packages/data-stores/src/purchases/index.ts
@@ -2,6 +2,7 @@ import { createPurchaseObject, createPurchasesArray } from './lib/assembler';
 
 /** Queries */
 export { default as useSitePurchases } from './queries/use-site-purchases';
+export * from './queries/use-user-purchases';
 
 /** Hooks/Selectors */
 export { default as useSitePurchaseById } from './hooks/use-site-purchase-by-id';

--- a/packages/data-stores/src/purchases/queries/use-site-purchases.ts
+++ b/packages/data-stores/src/purchases/queries/use-site-purchases.ts
@@ -12,24 +12,38 @@ interface Props {
 	siteId?: string | number | null;
 }
 
+async function fetchSitePurchases( siteId: string | number ): Promise< RawPurchase[] > {
+	return await wpcomRequest( {
+		path: `/sites/${ encodeURIComponent( siteId ) }/purchases`,
+		apiVersion: '1.1',
+	} );
+}
+
+async function fetchAndTransformSitePurchases(
+	siteId: string | number
+): Promise< PurchasesIndex > {
+	const rawPurchases = await fetchSitePurchases( siteId );
+	return Object.fromEntries(
+		rawPurchases.map( ( rawPurchase ) => {
+			const purchase = createPurchaseObject( rawPurchase );
+			return [ purchase.id, purchase ];
+		} )
+	);
+}
+
 export function getUseSitePurchasesOptions(
 	{ siteId }: Props,
 	queryKey: ( string | number | null | undefined )[]
 ) {
 	return {
+		// The queryKey should be hopefully generated with the siteId included.
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
 		queryKey,
 		queryFn: async (): Promise< PurchasesIndex > => {
-			const purchases: RawPurchase[] = await wpcomRequest( {
-				path: `/sites/${ encodeURIComponent( siteId as string ) }/purchases`,
-				apiVersion: '1.1',
-			} );
-
-			return Object.fromEntries(
-				purchases.map( ( rawPurchase ) => {
-					const purchase = createPurchaseObject( rawPurchase );
-					return [ purchase.id, purchase ];
-				} )
-			);
+			if ( ! siteId ) {
+				return Promise.resolve( {} );
+			}
+			return await fetchAndTransformSitePurchases( siteId );
 		},
 		enabled: !! siteId,
 	};
@@ -37,16 +51,11 @@ export function getUseSitePurchasesOptions(
 
 /**
  * Fetches all purchases for a given site, transformed into a map of purchaseId => Purchase
- * @param {Object} props - The properties for the function
- * @param props.siteId Site ID
- * @returns Query result
  */
-function useSitePurchases( { siteId }: Props ) {
+export default function useSitePurchases( { siteId }: Props ) {
 	const queryKeys = useQueryKeysFactory();
 
-	return useQuery< any, unknown, PurchasesIndex >(
+	return useQuery< PurchasesIndex, Error, PurchasesIndex >(
 		getUseSitePurchasesOptions( { siteId }, queryKeys.sitePurchases( siteId ) )
 	);
 }
-
-export default useSitePurchases;

--- a/packages/data-stores/src/purchases/queries/use-site-purchases.tsx
+++ b/packages/data-stores/src/purchases/queries/use-site-purchases.tsx
@@ -1,15 +1,22 @@
-import { useQuery } from '@tanstack/react-query';
+import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import { createPurchaseObject } from '../lib/assembler';
 import useQueryKeysFactory from './lib/use-query-keys-factory';
 import type { RawPurchase, Purchase } from '../types';
+import type { ComponentType } from 'react';
 
 export interface PurchasesIndex {
 	[ purchaseId: number ]: Purchase;
 }
 
-interface Props {
+export interface GetUseSitePurchasesOptionsProps {
 	siteId?: string | number | null;
+}
+
+export type SitePurchasesState = UseQueryResult< Purchase[], Error >;
+
+export interface WithSitePurchasesProps {
+	sitePurchasesState: SitePurchasesState;
 }
 
 async function fetchSitePurchases( siteId: string | number ): Promise< RawPurchase[] > {
@@ -32,7 +39,7 @@ async function fetchAndTransformSitePurchases(
 }
 
 export function getUseSitePurchasesOptions(
-	{ siteId }: Props,
+	{ siteId }: GetUseSitePurchasesOptionsProps,
 	queryKey: ( string | number | null | undefined )[]
 ) {
 	return {
@@ -52,10 +59,20 @@ export function getUseSitePurchasesOptions(
 /**
  * Fetches all purchases for a given site, transformed into a map of purchaseId => Purchase
  */
-export default function useSitePurchases( { siteId }: Props ) {
+export default function useSitePurchases( { siteId }: GetUseSitePurchasesOptionsProps ) {
 	const queryKeys = useQueryKeysFactory();
 
 	return useQuery< PurchasesIndex, Error, PurchasesIndex >(
 		getUseSitePurchasesOptions( { siteId }, queryKeys.sitePurchases( siteId ) )
 	);
+}
+
+export function withSitePurchases< P >(
+	Component: ComponentType< P >,
+	siteId: GetUseSitePurchasesOptionsProps[ 'siteId' ]
+) {
+	return function UserPurchasesWrapper( props: Omit< P, keyof WithSitePurchasesProps > ) {
+		const state = useSitePurchases( { siteId } );
+		return <Component { ...( props as P ) } sitePurchasesState={ state } />;
+	};
 }

--- a/packages/data-stores/src/purchases/queries/use-user-purchases.tsx
+++ b/packages/data-stores/src/purchases/queries/use-user-purchases.tsx
@@ -6,7 +6,7 @@ import type { ComponentType } from 'react';
 
 export interface UserPurchasesState {
 	purchases: Purchase[];
-	isFetching: boolean;
+	isLoading: boolean;
 	isError: boolean;
 	error: Error | undefined | null;
 }
@@ -18,6 +18,7 @@ export interface WithUserPurchasesProps {
 async function fetchUserPurchases(): Promise< RawPurchase[] > {
 	return await wpcomRequest( {
 		path: '/me/purchases',
+		apiVersion: '1.1',
 	} );
 }
 
@@ -38,7 +39,7 @@ export function useUserPurchases(): UserPurchasesState {
 	} );
 	return {
 		purchases: result.data ?? [],
-		isFetching: result.isFetching || result.isLoading,
+		isLoading: result.isLoading,
 		isError: result.isError,
 		error: result.error,
 	};

--- a/packages/data-stores/src/purchases/queries/use-user-purchases.tsx
+++ b/packages/data-stores/src/purchases/queries/use-user-purchases.tsx
@@ -1,7 +1,7 @@
-import { Purchases } from '@automattic/data-stores';
 import { useQuery } from '@tanstack/react-query';
-import wpcom from 'calypso/lib/wp';
-import type { Purchase, RawPurchase } from 'calypso/lib/purchases/types';
+import wpcomRequest from 'wpcom-proxy-request';
+import { createPurchaseObject } from '../lib/assembler';
+import type { Purchase, RawPurchase } from '../types';
 import type { ComponentType } from 'react';
 
 export interface UserPurchasesState {
@@ -16,14 +16,14 @@ export interface WithUserPurchasesProps {
 }
 
 async function fetchUserPurchases(): Promise< RawPurchase[] > {
-	return await wpcom.req.get( {
+	return await wpcomRequest( {
 		path: '/me/purchases',
 	} );
 }
 
 async function fetchAndTransformUserPurchases(): Promise< Purchase[] > {
 	const rawPurchases = await fetchUserPurchases();
-	return rawPurchases.map( Purchases.utils.createPurchaseObject );
+	return rawPurchases.map( createPurchaseObject );
 }
 
 export function useUserPurchases(): UserPurchasesState {

--- a/packages/data-stores/src/purchases/queries/use-user-purchases.tsx
+++ b/packages/data-stores/src/purchases/queries/use-user-purchases.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import { createPurchaseObject } from '../lib/assembler';
 import type { Purchase, RawPurchase } from '../types';
@@ -22,16 +22,57 @@ async function fetchUserPurchases(): Promise< RawPurchase[] > {
 	} );
 }
 
+async function fetchSitePurchases( siteId: number ): Promise< RawPurchase[] > {
+	return await wpcomRequest( {
+		path: `/sites/${ encodeURIComponent( siteId ) }/purchases`,
+		apiVersion: '1.1',
+	} );
+}
+
+async function fetchAndTransformSitePurchases( siteId: number ): Promise< Purchase[] > {
+	const rawPurchases = await fetchSitePurchases( siteId );
+	return rawPurchases.map( createPurchaseObject );
+}
+
 async function fetchAndTransformUserPurchases(): Promise< Purchase[] > {
 	const rawPurchases = await fetchUserPurchases();
 	return rawPurchases.map( createPurchaseObject );
 }
 
-export function useUserPurchases(): UserPurchasesState {
-	const queryKey = [ 'user-purchases' ];
+function getUserPurchasesQueryKey() {
+	return [ 'user-purchases' ];
+}
+
+function getSitePurchasesQueryKey( siteId: number ) {
+	return [ 'site-purchases', siteId ];
+}
+
+export function useUserPurchases( siteId?: number ): UserPurchasesState {
+	const queryClient = useQueryClient();
 	const result = useQuery< Purchase[] >( {
-		queryKey,
-		queryFn: fetchAndTransformUserPurchases,
+		// eslint can't tell that we are providing the siteId when it is needed
+		// so we must disable the rule.
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
+		queryKey: siteId ? getSitePurchasesQueryKey( siteId ) : getUserPurchasesQueryKey(),
+		queryFn: async () => {
+			// If we are looking for all user purchases, fetch them.
+			if ( ! siteId ) {
+				return fetchAndTransformUserPurchases();
+			}
+			// If we are looking for just the user purchases for a site, return
+			// site purchases from user-purchases state if they exist.
+			const userPurchases = queryClient.getQueryData< Purchase[] >( getUserPurchasesQueryKey() );
+			const sitePurchasesFromUser =
+				userPurchases?.filter( ( purchase ) => purchase.siteId === siteId ) ?? [];
+			if ( sitePurchasesFromUser.length > 0 ) {
+				return sitePurchasesFromUser;
+			}
+			// If no site purchases exist in the user-purchases state, fetch
+			// them and store them in the user-purchases state for later.
+			const sitePurchases = await fetchAndTransformSitePurchases( siteId );
+			queryClient.setQueryData( getUserPurchasesQueryKey(), sitePurchases );
+			return sitePurchases;
+		},
 		meta: {
 			persist: false,
 		},

--- a/packages/data-stores/src/purchases/queries/use-user-purchases.tsx
+++ b/packages/data-stores/src/purchases/queries/use-user-purchases.tsx
@@ -29,6 +29,20 @@ async function fetchSitePurchases( siteId: number ): Promise< RawPurchase[] > {
 	} );
 }
 
+async function fetchSinglePurchase( purchaseId: number ): Promise< RawPurchase > {
+	return await wpcomRequest( {
+		path: `/me/purchases/${ encodeURIComponent( purchaseId ) }`,
+		apiVersion: '1.1',
+	} );
+}
+
+async function fetchAndTransformPurchaseById(
+	purchaseId: number
+): Promise< Purchase | undefined > {
+	const rawPurchase = await fetchSinglePurchase( purchaseId );
+	return rawPurchase ? createPurchaseObject( rawPurchase ) : undefined;
+}
+
 async function fetchAndTransformSitePurchases( siteId: number ): Promise< Purchase[] > {
 	const rawPurchases = await fetchSitePurchases( siteId );
 	return rawPurchases.map( createPurchaseObject );
@@ -39,39 +53,63 @@ async function fetchAndTransformUserPurchases(): Promise< Purchase[] > {
 	return rawPurchases.map( createPurchaseObject );
 }
 
-function getUserPurchasesQueryKey() {
+function getPurchasesQueryKey( { siteId, purchaseId }: { siteId?: number; purchaseId?: number } ) {
+	if ( purchaseId ) {
+		return [ 'single-purchase', purchaseId ];
+	}
+	if ( siteId ) {
+		return [ 'site-purchases', siteId ];
+	}
 	return [ 'user-purchases' ];
 }
 
-function getSitePurchasesQueryKey( siteId: number ) {
-	return [ 'site-purchases', siteId ];
-}
-
-export function useUserPurchases( siteId?: number ): UserPurchasesState {
+export function useUserPurchases( params?: {
+	siteId?: number;
+	purchaseId?: number;
+} ): UserPurchasesState {
+	const { siteId, purchaseId } = params ?? {};
 	const queryClient = useQueryClient();
 	const result = useQuery< Purchase[] >( {
-		// eslint can't tell that we are providing the siteId when it is needed
-		// so we must disable the rule.
-		// eslint-disable-next-line @tanstack/query/exhaustive-deps
-		queryKey: siteId ? getSitePurchasesQueryKey( siteId ) : getUserPurchasesQueryKey(),
+		queryKey: getPurchasesQueryKey( { siteId, purchaseId } ),
 		queryFn: async () => {
+			if ( purchaseId ) {
+				// If we are looking for just a single purchase, return it from
+				// the user-purchases state, if it exists there already.
+				const userPurchases = queryClient.getQueryData< Purchase[] >( getPurchasesQueryKey( {} ) );
+				const purchasesMatchingId =
+					userPurchases?.filter( ( purchase ) => purchase.id === purchaseId ) ?? [];
+				if ( purchasesMatchingId.length > 0 ) {
+					return purchasesMatchingId;
+				}
+				// If the user-purchases state does not contain this purchase,
+				// fetch it and store it in the user-purchases state for later.
+				const purchaseForId = await fetchAndTransformPurchaseById( purchaseId );
+				if ( purchaseForId ) {
+					queryClient.setQueryData( getPurchasesQueryKey( {} ), [ purchaseForId ] );
+					return [ purchaseForId ];
+				}
+				return [];
+			}
+
+			if ( siteId ) {
+				// If we are looking for just the user purchases for a site, return
+				// site purchases from user-purchases state if they exist there already.
+				const userPurchases = queryClient.getQueryData< Purchase[] >( getPurchasesQueryKey( {} ) );
+				const sitePurchasesFromUser =
+					userPurchases?.filter( ( purchase ) => purchase.siteId === siteId ) ?? [];
+				if ( sitePurchasesFromUser.length > 0 ) {
+					return sitePurchasesFromUser;
+				}
+				// If no site purchases exist in the user-purchases state for
+				// this site, fetch them and store them in the user-purchases
+				// state for later.
+				const sitePurchases = await fetchAndTransformSitePurchases( siteId );
+				queryClient.setQueryData( getPurchasesQueryKey( {} ), sitePurchases );
+				return sitePurchases;
+			}
+
 			// If we are looking for all user purchases, fetch them.
-			if ( ! siteId ) {
-				return fetchAndTransformUserPurchases();
-			}
-			// If we are looking for just the user purchases for a site, return
-			// site purchases from user-purchases state if they exist.
-			const userPurchases = queryClient.getQueryData< Purchase[] >( getUserPurchasesQueryKey() );
-			const sitePurchasesFromUser =
-				userPurchases?.filter( ( purchase ) => purchase.siteId === siteId ) ?? [];
-			if ( sitePurchasesFromUser.length > 0 ) {
-				return sitePurchasesFromUser;
-			}
-			// If no site purchases exist in the user-purchases state, fetch
-			// them and store them in the user-purchases state for later.
-			const sitePurchases = await fetchAndTransformSitePurchases( siteId );
-			queryClient.setQueryData( getUserPurchasesQueryKey(), sitePurchases );
-			return sitePurchases;
+			return fetchAndTransformUserPurchases();
 		},
 		meta: {
 			persist: false,


### PR DESCRIPTION
## Proposed Changes

This PR creates a new React Hook using useQuery called `useUserPurchases()` which fetches all of a user's purchases and returns them. This takes the place of the `getUserPurchases()` Redux function and its associated state.

This PR then uses the new Hook in the purchase management pages.

> [!NOTE]
> This does not remove the `QueryUserPurchases` component in the purchase list because other sub-components of the page might still rely on the Redux store being populated. 

> [!NOTE]
> There are a few other places that use `getUserPurchases()` within other parts of calypso but to keep this PR easy to review and test, I've limited it to only the main purchase list page. Follow-up PRs can migrate the other consumers and then eventually remove the Redux state itself.

## To do

The main issue with this approach currently is that the Redux store is a single place where three different mechanisms can populate the local cache with purchase data: fetching user purchases, fetching site purchases, and fetching a single purchase. By changing these components to use a hook, we no longer share that cache and instead will potentially have three separate caches that may all contain the same data.

- [ ] Replace some uses of `hasLoadedUserPurchasesFromServer` in `client/me/purchases` that may be affected by this change if they also depended on the query component.
- [ ] Make sure nothing in `client/me/purchases` uses the main `isDataLoading()` function.
- [ ] Replace some (all?) uses of `getByPurchaseId` in `client/me/purchases`.

## Why are these changes being made?

Using Redux is overkill for fetching a list of purchases and it limits these components to be used only within the main calypso package. useQuery (aka: React Query/Tanstack Query) is the main replacement for Redux currently used by calypso and this migration allows removing a lot of state from our Redux tree.

There is already a hook like this for site purchases (`useSitePurchases` added in https://github.com/Automattic/wp-calypso/pull/84761). This PR adds `useUserPurchases` alongside it in the `@automattic/data-stores` package.

## Testing Instructions

- Visit `/me/purchases` for an account with multiple purchases and verify that they show up and operate the same before and after this PR.