### PR TITLE
Plugin Marketplace: Remove Rating Number For 0 Ratings

### DIFF
--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -106,10 +106,11 @@ export const ReviewsModal = ( props: Props ) => {
 					<div className="marketplace-reviews-modal__summary">
 						<div className="marketplace-reviews-modal__stats">
 							<div className="marketplace-reviews-modal__ratings-average">
-								{ averageRating.toLocaleString( getLocaleSlug() ?? 'default', {
-									minimumFractionDigits: 1,
-									maximumFractionDigits: 1,
-								} ) }
+								{ numberOfReviews > 0 &&
+									averageRating.toLocaleString( getLocaleSlug() ?? 'default', {
+										minimumFractionDigits: 1,
+										maximumFractionDigits: 1,
+									} ) }
 							</div>
 							<div className="marketplace-reviews-modal__ratings">
 								<Rating rating={ normalizedRating } />


### PR DESCRIPTION
Fixes #96360

## Proposed Changes

* Removes the rating number when it shows "0.0" for plugin reviews.

## Why are these changes being made?

See original issue - basically, it looks odd. 

## Testing Instructions

* Go to `/plugins/sensei-pro/`
* Select "Write review"
* Confirm 0.0 no longer appears
* Verify that the rating number still shows when there are reviews - eg. `/plugins/wordpress-seo-premium`

| Before | After |
|--------|--------|
| <img width="884" alt="Screenshot 2024-11-13 at 18 35 47" src="https://github.com/user-attachments/assets/6cb2eaa4-cb45-4f1d-a3a5-eafbd28f45a5"> | <img width="881" alt="Screenshot 2024-11-13 at 18 35 39" src="https://github.com/user-attachments/assets/bdb4ac2b-5572-4b33-9a0b-8c89ed3cda40"> | 
