### PR TITLE
Reader Recent Feed Overhaul: Add an empty state for feed and post view

### DIFF
--- a/client/reader/components/skeleton/index.tsx
+++ b/client/reader/components/skeleton/index.tsx
@@ -1,0 +1,30 @@
+import clsx from 'clsx';
+import React from 'react';
+
+import './style.scss';
+
+interface Props extends React.HTMLAttributes< HTMLDivElement > {
+	shape?: 'circle' | 'rect';
+	height?: string;
+	width?: string;
+}
+
+const Skeleton = ( { shape = 'rect', height, width, style, className, ...rest }: Props ) => {
+	const classes = clsx(
+		'skeleton',
+		{
+			'skeleton--circle': shape === 'circle',
+		},
+		className
+	);
+
+	const styles = {
+		...style,
+		...( height && { height } ),
+		...( width && { width } ),
+	};
+
+	return <div { ...rest } className={ classes } style={ styles }></div>;
+};
+
+export default Skeleton;

--- a/client/reader/components/skeleton/style.scss
+++ b/client/reader/components/skeleton/style.scss
@@ -1,0 +1,22 @@
+.skeleton {
+	box-sizing: border-box;
+	background-color: var( --studio-gray-5 );
+	animation: pulse 1.5s infinite;
+	border-radius: 4px;
+
+	&--circle {
+		border-radius: 50%;
+	}
+
+	@keyframes pulse {
+		0% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.5;
+		}
+		100% {
+			opacity: 1;
+		}
+	}
+}

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -8,6 +8,7 @@ import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import AsyncLoad from 'calypso/components/async-load';
+import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPaginatedStream } from 'calypso/state/reader/streams/actions';
@@ -221,7 +222,7 @@ const Recent = () => {
 			</div>
 			{ ! isEmpty && (
 				<div className={ `recent-feed__post-column ${ selectedItem ? 'overlay' : '' }` }>
-					{ selectedItem && getPostFromItem( selectedItem ) && (
+					{ selectedItem && getPostFromItem( selectedItem ) ? (
 						<>
 							<AsyncLoad
 								require="calypso/blocks/reader-full-post"
@@ -232,6 +233,13 @@ const Recent = () => {
 							/>
 							<EngagementBar feedId={ selectedItem?.feedId } postId={ selectedItem?.postId } />
 						</>
+					) : (
+						<EmptyContent
+							title={ translate( 'Nothing Posted Yet' ) }
+							line={ translate( 'This feed is currently empty.' ) }
+							illustration="/calypso/images/illustrations/illustration-empty-results.svg"
+							illustrationWidth={ 400 }
+						/>
 					) }
 				</div>
 			) }

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -3,7 +3,7 @@ import { WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { DataViews, filterSortAndPaginate, SupportedLayouts, View } from '@wordpress/dataviews';
 import { translate } from 'i18n-calypso';
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useLayoutEffect } from 'react';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
@@ -16,6 +16,7 @@ import { viewStream } from 'calypso/state/reader-ui/actions';
 import ReaderOnboarding from '../onboarding';
 import EngagementBar from './engagement-bar';
 import RecentPostField from './recent-post-field';
+import RecentPostSkeleton from './recent-post-skeleton';
 import RecentSeenField from './recent-seen-field';
 import type { PostItem, ReaderPost } from './types';
 import type { AppState } from 'calypso/types';
@@ -26,6 +27,7 @@ const Recent = () => {
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, AnyAction > >();
 	const [ selectedItem, setSelectedItem ] = useState< ReaderPost | null >( null );
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
+	const [ isLoading, setIsLoading ] = useState( false );
 
 	const [ view, setView ] = useState< View >( {
 		type: 'table',
@@ -167,6 +169,10 @@ const Recent = () => {
 		} ) );
 	}, [ selectedRecentSidebarFeedId ] );
 
+	useLayoutEffect( () => {
+		setIsLoading( data?.isRequesting );
+	}, [ data?.isRequesting ] );
+
 	const { data: subscriptionsCount } = SubscriptionManager.useSubscriptionsCountQuery();
 	const hasSubscriptions = subscriptionsCount?.blogs && subscriptionsCount.blogs > 0;
 
@@ -215,15 +221,17 @@ const Recent = () => {
 							}
 							paginationInfo={ paginationInfo }
 							defaultLayouts={ defaultLayouts as SupportedLayouts }
-							isLoading={ data?.isRequesting }
+							isLoading={ isLoading }
 						/>
 					) }
 				</div>
 			</div>
 			{ hasSubscriptions && (
 				<div className={ `recent-feed__post-column ${ selectedItem ? 'overlay' : '' }` }>
-					{ data?.isRequesting && 'Loading...' }
-					{ ! data?.isRequesting && data?.items.length === 0 && (
+					{ ! ( selectedItem && getPostFromItem( selectedItem ) ) && isLoading && (
+						<RecentPostSkeleton />
+					) }
+					{ ! isLoading && data?.items.length === 0 && (
 						<EmptyContent
 							title={ translate( 'Nothing Posted Yet' ) }
 							line={ translate( 'This feed is currently empty.' ) }

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -127,14 +127,6 @@ const Recent = () => {
 				perPage: view.perPage,
 			} ) as AnyAction
 		);
-		// Fetch the next page in advance.
-		dispatch(
-			requestPaginatedStream( {
-				streamKey,
-				page: view?.page ? view.page + 1 : undefined,
-				perPage: view.perPage,
-			} ) as AnyAction
-		);
 	}, [ dispatch, view, streamKey ] );
 
 	const paginationInfo = useMemo( () => {

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -222,18 +222,8 @@ const Recent = () => {
 			</div>
 			{ ! isEmpty && (
 				<div className={ `recent-feed__post-column ${ selectedItem ? 'overlay' : '' }` }>
-					{ selectedItem && getPostFromItem( selectedItem ) ? (
-						<>
-							<AsyncLoad
-								require="calypso/blocks/reader-full-post"
-								feedId={ selectedItem.feedId }
-								postId={ selectedItem.postId }
-								onClose={ () => setSelectedItem( null ) }
-								layout="recent"
-							/>
-							<EngagementBar feedId={ selectedItem?.feedId } postId={ selectedItem?.postId } />
-						</>
-					) : (
+					{ data?.isRequesting && 'Loading...' }
+					{ ! data?.isRequesting && data?.items.length === 0 && (
 						<EmptyContent
 							title={ translate( 'Nothing Posted Yet' ) }
 							line={ translate( 'This feed is currently empty.' ) }
@@ -241,6 +231,21 @@ const Recent = () => {
 							illustrationWidth={ 400 }
 						/>
 					) }
+					{ ! data?.isRequesting &&
+						data?.items.length > 0 &&
+						selectedItem &&
+						getPostFromItem( selectedItem ) && (
+							<>
+								<AsyncLoad
+									require="calypso/blocks/reader-full-post"
+									feedId={ selectedItem.feedId }
+									postId={ selectedItem.postId }
+									onClose={ () => setSelectedItem( null ) }
+									layout="recent"
+								/>
+								<EngagementBar feedId={ selectedItem?.feedId } postId={ selectedItem?.postId } />
+							</>
+						) }
 				</div>
 			) }
 		</div>

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -168,20 +168,20 @@ const Recent = () => {
 	}, [ selectedRecentSidebarFeedId ] );
 
 	const { data: subscriptionsCount } = SubscriptionManager.useSubscriptionsCountQuery();
-	const isEmpty = subscriptionsCount?.blogs === 0;
+	const hasSubscriptions = subscriptionsCount?.blogs && subscriptionsCount.blogs > 0;
 
 	return (
 		<div className="recent-feed">
 			<div
-				className={ `recent-feed__list-column ${ selectedItem && ! isEmpty ? 'has-overlay' : '' } ${
-					isEmpty ? 'recent-feed-empty' : ''
-				}` }
+				className={ `recent-feed__list-column ${
+					selectedItem && hasSubscriptions ? 'has-overlay' : ''
+				} ${ ! hasSubscriptions ? 'recent-feed--no-subscriptions' : '' }` }
 			>
 				<div className="recent-feed__list-column-header">
 					<FormattedHeader align="left" headerText={ translate( 'Recent' ) } />
 				</div>
 				<div className="recent-feed__list-column-content">
-					{ isEmpty ? (
+					{ ! hasSubscriptions ? (
 						<>
 							<p>
 								{ translate(
@@ -220,7 +220,7 @@ const Recent = () => {
 					) }
 				</div>
 			</div>
-			{ ! isEmpty && (
+			{ hasSubscriptions && (
 				<div className={ `recent-feed__post-column ${ selectedItem ? 'overlay' : '' }` }>
 					{ data?.isRequesting && 'Loading...' }
 					{ ! data?.isRequesting && data?.items.length === 0 && (
@@ -231,21 +231,18 @@ const Recent = () => {
 							illustrationWidth={ 400 }
 						/>
 					) }
-					{ ! data?.isRequesting &&
-						data?.items.length > 0 &&
-						selectedItem &&
-						getPostFromItem( selectedItem ) && (
-							<>
-								<AsyncLoad
-									require="calypso/blocks/reader-full-post"
-									feedId={ selectedItem.feedId }
-									postId={ selectedItem.postId }
-									onClose={ () => setSelectedItem( null ) }
-									layout="recent"
-								/>
-								<EngagementBar feedId={ selectedItem?.feedId } postId={ selectedItem?.postId } />
-							</>
-						) }
+					{ data?.items.length > 0 && selectedItem && getPostFromItem( selectedItem ) && (
+						<>
+							<AsyncLoad
+								require="calypso/blocks/reader-full-post"
+								feedId={ selectedItem.feedId }
+								postId={ selectedItem.postId }
+								onClose={ () => setSelectedItem( null ) }
+								layout="recent"
+							/>
+							<EngagementBar feedId={ selectedItem?.feedId } postId={ selectedItem?.postId } />
+						</>
+					) }
 				</div>
 			) }
 		</div>

--- a/client/reader/recent/recent-post-skeleton.tsx
+++ b/client/reader/recent/recent-post-skeleton.tsx
@@ -1,0 +1,41 @@
+import Skeleton from '../components/skeleton';
+
+const RecentPostSkeleton = () => (
+	<div className="recent-post-skeleton">
+		<div className="recent-post-skeleton__header">
+			<Skeleton height="80px" width="80px" shape="circle" />
+			<div className="recent-post-skeleton__header-content">
+				<Skeleton height="36px" className="recent-post-skeleton__title" />
+				<Skeleton height="36px" width="80%" className="recent-post-skeleton__title" />
+				<div className="recent-post-skeleton__header-meta">
+					<Skeleton height="24px" width="100px" />
+					<Skeleton height="24px" width="100px" />
+					<Skeleton height="24px" width="100px" />
+				</div>
+			</div>
+		</div>
+		<Skeleton height="400px" className="recent-post-skeleton__img" />
+		<div className="recent-post-skeleton__p">
+			<Skeleton height="24px" width="100%" />
+			<Skeleton height="24px" width="100%" />
+			<Skeleton height="24px" width="75%" />
+		</div>
+		<div className="recent-post-skeleton__p">
+			<Skeleton height="24px" width="100%" />
+			<Skeleton height="24px" width="100%" />
+			<Skeleton height="24px" width="75%" />
+		</div>
+		<div className="recent-post-skeleton__p">
+			<Skeleton height="24px" width="100%" />
+			<Skeleton height="24px" width="100%" />
+			<Skeleton height="24px" width="75%" />
+		</div>
+		<div className="recent-post-skeleton__p">
+			<Skeleton height="24px" width="100%" />
+			<Skeleton height="24px" width="100%" />
+			<Skeleton height="24px" width="75%" />
+		</div>
+	</div>
+);
+
+export default RecentPostSkeleton;

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -126,7 +126,7 @@
 			}
 		}
 
-		&.recent-feed-empty {
+		&.recent-feed--no-subscriptions {
 			max-width: none;
 
 			.recent-feed__list-column-header {

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -219,4 +219,41 @@
 			flex: 3;
 		}
 	}
+
+	.recent-post-skeleton {
+		max-width: 720px;
+		padding: 32px 24px;
+		margin: 0 auto;
+
+		&__header {
+			display: flex;
+			gap: 2rem;
+			align-items: center;
+			margin-bottom: 2rem;
+		}
+
+		&__header-content {
+			flex-grow: 1;
+		}
+
+		&__title {
+			margin-bottom: 1rem;
+		}
+
+		&__header-meta {
+			display: flex;
+			gap: 1rem;
+		}
+
+		&__img {
+			margin-bottom: 2rem;
+		}
+
+		&__p {
+			display: flex;
+			gap: 1rem;
+			margin-bottom: 2rem;
+			flex-wrap: wrap;
+		}
+	}
 }

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -52,6 +52,10 @@
 			padding: 0 12px;
 		}
 
+		.dataviews-no-results {
+			padding: 0 12px;
+		}
+
 		table {
 			border-collapse: collapse;
 			margin-top: 16px;

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -53,7 +53,7 @@ const ReaderSidebarRecent = ( {
 	const dispatch = useDispatch();
 
 	let sitesToShow = showAllSites ? sites : sites.slice( 0, SITE_DISPLAY_CUTOFF );
-	const totalUnseenCount = sites.reduce( ( total, site ) => total + site.unseen_count, 0 );
+	// const totalUnseenCount = sites.reduce( ( total, site ) => total + site.unseen_count, 0 );
 
 	const selectedSite = sites.find( ( site ) => site.feed_ID === selectedSiteFeedId );
 	if ( selectedSite && ! sitesToShow.includes( selectedSite ) ) {
@@ -102,8 +102,8 @@ const ReaderSidebarRecent = ( {
 					) }
 					onClick={ () => selectSite( null ) }
 				>
-					<span className="reader-sidebar-recent__site-name">{ translate( 'All' ) }</span>{ ' ' }
-					<span className="reader-sidebar-recent__site-count">{ totalUnseenCount }</span>
+					<span className="reader-sidebar-recent__site-name">{ translate( 'All' ) }</span>
+					{ /* <span className="reader-sidebar-recent__site-count">{ totalUnseenCount }</span> */ }
 				</button>
 			</li>
 			{ sitesToShow.map( ( site ) => (
@@ -118,7 +118,7 @@ const ReaderSidebarRecent = ( {
 						<span title={ site.name } className="reader-sidebar-recent__site-name">
 							{ site.name }
 						</span>
-						<span className="reader-sidebar-recent__site-count">{ site.unseen_count }</span>
+						{ /* <span className="reader-sidebar-recent__site-count">{ site.unseen_count }</span> */ }
 					</button>
 				</li>
 			) ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/loop#193

## Proposed Changes

* Shows an empty state in the post view and styles the post feed
* Show a loading skeleton when new post data is being fetched
* Clean up flickering when switching feeds.

https://github.com/user-attachments/assets/2e7fe161-4429-49a8-a1ef-5249f7d472f0


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2iv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you follow a feed with no posts
* Navigate to `/read?flags=reader/recent-feed-overhaul`
* Select the feed with no posts
* Click around different feeds. Loading skeleton should show on first request of the feed but subsequent visits should feel close to instant.
* You might need to throttle your network to make sure a slower connection feels good too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
