### PR TITLE
Stats: Prevent scroll to top on UTM modal open

### DIFF
--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -65,6 +65,7 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger } ) => {
 					title={ translate( 'URL Builder' ) }
 					onRequestClose={ closeModal }
 					overlayClassName="stats-utm-builder__overlay"
+					bodyOpenClassName="stats-utm-builder__body-modal-open"
 				>
 					<div className={ clsx( modalClassName, 'stats-utm-builder-modal' ) }>
 						<div className="stats-utm-builder__fields">

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger } ) => {
-	const [ isOpen, setOpen ] = useState( false );
+	const [ isOpen, setOpen ] = useState< boolean | null >( null );
 	const scrollY = useRef( { y: 0, mobile: false } );
 
 	const openModal = () => {
@@ -26,6 +26,11 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger } ) => {
 
 	// Prevent scroll to top when modal is opened
 	useEffect( () => {
+		// Do not scroll on initial render
+		if ( isOpen === null ) {
+			return;
+		}
+
 		if ( isOpen && ! scrollY.current.mobile ) {
 			document.body.scrollTo( 0, scrollY.current.y );
 		} else if ( ! isOpen ) {

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -3,7 +3,7 @@ import { useState } from '@wordpress/element';
 import { link } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { trackStatsAnalyticsEvent } from '../utils';
 import StatsUtmBuilderForm from './stats-module-utm-builder-form';
 
@@ -14,7 +14,26 @@ interface Props {
 
 const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger } ) => {
 	const [ isOpen, setOpen ] = useState( false );
-	const openModal = () => setOpen( true );
+	const scrollY = useRef( { y: 0, mobile: false } );
+
+	const openModal = () => {
+		const isMobile = document.body.scrollTop > 0;
+		scrollY.current.mobile = isMobile;
+		scrollY.current.y = isMobile ? document.body.scrollTop : window.scrollY;
+
+		setOpen( true );
+	};
+
+	// Prevent scroll to top when modal is opened
+	useEffect( () => {
+		if ( isOpen && ! scrollY.current.mobile ) {
+			document.body.scrollTo( 0, scrollY.current.y );
+		} else if ( ! isOpen ) {
+			const element = scrollY.current.mobile ? document.body : window;
+			element.scrollTo( 0, scrollY.current.y );
+		}
+	}, [ isOpen ] );
+
 	const closeModal = () => setOpen( false );
 	const translate = useTranslate();
 

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -8,6 +8,11 @@ $stats-utm-builder-help-padding: 38px;
 $stats-utm-builder-vertical-spacing: 24px;
 $modal-content-padding: 32px;
 
+.stats-utm-builder__body-modal-open {
+	// Not added by default on Calypso
+	overflow: hidden;
+}
+
 .stats-utm-builder__overlay {
 	@media (min-width: $break-large) {
 		.components-modal__frame {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #https://github.com/Automattic/red-team/issues/255

## Proposed Changes

* Prevents the scroll to the top when opening the modal by immediately scrolling back
* Locks the background on Calypso as well

![Screenshot from 2024-11-13 18-12-21](https://github.com/user-attachments/assets/ebbbba4b-c75b-464f-9ac1-c4bbbf5bd2c9)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* UX enhancements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the UTM button and click it
* Check that the page is not scrolled to the top, remaining exactly where it was
* Check that it is not possible to scroll the background
* Close the modal
* Check that the scroll position remains unchanged and scrolling is available again
* Check on mobile, Jetpack and Calypso. To test on Calypso you'll need to run Calypso locally to be able to enable the feature by changing [the code](https://github.com/Automattic/wp-calypso/blob/a53c506111658b38f62ed8ce0e64799bf6d9da86/client/state/sites/selectors/get-env-stats-feature-supports.ts#L48-L50).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
