### PR TITLE
Update free domain blurn on /start/free

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -7,7 +7,7 @@ import './style.scss';
 
 class ReskinSideExplainer extends Component {
 	getStrings() {
-		const { flowName, translate, type, isFreeFlow } = this.props;
+		const { flowName, translate, type, isFreePlan } = this.props;
 
 		let title;
 		let subtitle;
@@ -40,7 +40,7 @@ class ReskinSideExplainer extends Component {
 				);
 				subtitle2 = translate( 'You can claim your custom domain name later when you’re ready.' );
 				ctaText = translate( 'Check paid plans »' );
-				if ( isFreeFlow ) {
+				if ( isFreePlan ) {
 					ctaText2 = translate( 'Choose my domain later' );
 				}
 				break;

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -10,70 +10,29 @@ class ReskinSideExplainer extends Component {
 		const { flowName, translate, type } = this.props;
 
 		let title;
-		let freeTitle;
-		let paidTitle;
 		let subtitle;
-		let freeSubtitle;
-		let paidSubtitle;
 		let subtitle2;
 		let ctaText;
-
-		const isPaidPlan = [
-			'starter',
-			'pro',
-			'personal',
-			'premium',
-			'business',
-			'ecommerce',
-			'domain',
-		].includes( flowName );
 
 		const hideChooseDomainLater = [ 'launch-site', 'onboarding-with-email' ].includes( flowName );
 
 		switch ( type ) {
-			case 'free-domain-explainer':
-				freeTitle = translate(
-					'Get a {{b}}free{{/b}} one-year domain registration with any paid annual plan.',
-					{
-						components: { b: <strong /> },
-					}
-				);
+			case 'free-domain-explainer-paid-plans':
+				title = translate( 'Get a {{b}}free{{/b}} one-year domain registration with your plan.', {
+					components: { b: <strong /> },
+				} );
 
-				paidTitle = translate(
-					'Get a {{b}}free{{/b}} one-year domain registration with your plan.',
-					{
-						components: { b: <strong /> },
-					}
-				);
-
-				title = isPaidPlan ? paidTitle : freeTitle;
-
-				freeSubtitle = (
-					<span>
-						{ translate(
-							'Use the search tool on this page to find a domain you love, then select any paid annual plan.'
-						) }
-					</span>
-				);
-
-				paidSubtitle = translate( 'Use the search tool on this page to find a domain you love.' );
-
-				subtitle = isPaidPlan ? paidSubtitle : freeSubtitle;
+				subtitle = translate( 'Use the search tool on this page to find a domain you love.' );
 
 				subtitle2 = translate(
 					'We’ll pay the first year’s domain registration fees for you, simple as that!'
 				);
 
-				if ( ! subtitle ) {
-					subtitle = subtitle2;
-					subtitle2 = null;
-				}
-
 				ctaText = hideChooseDomainLater ? null : (
 					<span>{ translate( 'Choose my domain later' ) }</span>
 				);
 				break;
-			case 'free-domain-explainer-check-paid-plans':
+			case 'free-domain-explainer':
 				title = translate( 'Not ready to choose a domain just yet?' );
 				subtitle = translate(
 					'Select any annual paid plan and we’ll pay the first year’s domain registration fees for you.'

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -7,12 +7,13 @@ import './style.scss';
 
 class ReskinSideExplainer extends Component {
 	getStrings() {
-		const { flowName, translate, type } = this.props;
+		const { flowName, translate, type, isFreeFlow } = this.props;
 
 		let title;
 		let subtitle;
 		let subtitle2;
 		let ctaText;
+		let ctaText2;
 
 		const hideChooseDomainLater = [ 'launch-site', 'onboarding-with-email' ].includes( flowName );
 
@@ -39,6 +40,9 @@ class ReskinSideExplainer extends Component {
 				);
 				subtitle2 = translate( 'You can claim your custom domain name later when you’re ready.' );
 				ctaText = translate( 'Check paid plans »' );
+				if ( isFreeFlow ) {
+					ctaText2 = translate( 'Choose my domain later' );
+				}
 				break;
 
 			case 'free-domain-explainer-treatment-search':
@@ -73,11 +77,11 @@ class ReskinSideExplainer extends Component {
 				break;
 		}
 
-		return { title, subtitle, subtitle2, ctaText };
+		return { title, subtitle, subtitle2, ctaText, ctaText2 };
 	}
 
 	render() {
-		const { title, subtitle, subtitle2, ctaText } = this.getStrings();
+		const { title, subtitle, subtitle2, ctaText, ctaText2 } = this.getStrings();
 
 		return (
 			/* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -91,10 +95,20 @@ class ReskinSideExplainer extends Component {
 					<div className="reskin-side-explainer__cta">
 						<button
 							className="reskin-side-explainer__cta-text"
-							onClick={ this.props.onClick }
+							onClick={ this.props.primaryCtaClick }
 							tabIndex="0"
 						>
 							{ ctaText }
+						</button>
+					</div>
+				) }
+				{ ctaText2 && (
+					<div className="reskin-side-explainer__cta">
+						<button
+							className="reskin-side-explainer__cta-text"
+							onClick={ this.props.secondaryCtaClick }
+						>
+							{ ctaText2 }
 						</button>
 					</div>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -129,7 +129,7 @@ export function DomainFormControl( {
 
 		const useYourDomain = (
 			<div className="domains__domain-side-content">
-				<ReskinSideExplainer onClick={ handleUseYourDomainClick } type="use-your-domain" />
+				<ReskinSideExplainer primaryCtaClick={ handleUseYourDomainClick } type="use-your-domain" />
 			</div>
 		);
 
@@ -137,7 +137,7 @@ export function DomainFormControl( {
 			<div className="domains__domain-side-content-container">
 				<div className="domains__domain-side-content domains__free-domain">
 					<ReskinSideExplainer
-						onClick={ handleDomainExplainerClick }
+						primaryCtaClick={ handleDomainExplainerClick }
 						type="free-domain-explainer"
 						flowName={ flow }
 					/>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -353,14 +353,13 @@ export class RenderDomainsStep extends Component {
 	};
 
 	handleDomainExplainerClick = () => {
-		const navigate = this.props.page || page;
-		if ( this.props.flowName === 'free' ) {
-			navigate( '/start/plans-first' );
-			return;
-		}
-
 		const hideFreePlan = true;
 		this.handleSkip( undefined, hideFreePlan, SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER );
+	};
+
+	navigateToPlansFirstFlow = () => {
+		const navigate = this.props.page || page;
+		navigate( '/start/plans-first' );
 	};
 
 	handleUseYourDomainClick = () => {
@@ -925,7 +924,10 @@ export class RenderDomainsStep extends Component {
 						( domainsInCart.length > 0 || this.state.wpcomSubdomainSelected ),
 				} ) }
 			>
-				<ReskinSideExplainer onClick={ this.handleUseYourDomainClick } type="use-your-domain" />
+				<ReskinSideExplainer
+					primaryCtaClick={ this.handleUseYourDomainClick }
+					type="use-your-domain"
+				/>
 			</div>
 		) : null;
 
@@ -958,9 +960,13 @@ export class RenderDomainsStep extends Component {
 					hasSearchedDomains && (
 						<div className="domains__domain-side-content domains__free-domain">
 							<ReskinSideExplainer
-								onClick={ this.handleDomainExplainerClick }
+								primaryCtaClick={
+									isFreeFlow ? this.navigateToPlansFirstFlow : this.handleDomainExplainerClick
+								}
 								type={ explainerType }
 								flowName={ flowName }
+								isFreeFlow={ isFreeFlow }
+								secondaryCtaClick={ isFreeFlow && this.handleDomainExplainerClick }
 							/>
 						</div>
 					)
@@ -969,7 +975,7 @@ export class RenderDomainsStep extends Component {
 				{ this.shouldDisplayDomainOnlyExplainer() && (
 					<div className="domains__domain-side-content">
 						<ReskinSideExplainer
-							onClick={ this.handleDomainExplainerClick }
+							primaryCtaClick={ this.handleDomainExplainerClick }
 							type="free-domain-only-explainer"
 						/>
 					</div>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -353,6 +353,12 @@ export class RenderDomainsStep extends Component {
 	};
 
 	handleDomainExplainerClick = () => {
+		const navigate = this.props.page || page;
+		if ( this.props.flowName === 'free' ) {
+			navigate( '/start/plans-first' );
+			return;
+		}
+
 		const hideFreePlan = true;
 		this.handleSkip( undefined, hideFreePlan, SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER );
 	};
@@ -925,6 +931,16 @@ export class RenderDomainsStep extends Component {
 
 		const hasSearchedDomains = Array.isArray( this.props.step?.domainForm?.searchResults );
 
+		const isPaidPlan = [
+			'starter',
+			'pro',
+			'personal',
+			'premium',
+			'business',
+			'ecommerce',
+			'domain',
+		].includes( flowName );
+
 		return (
 			<div className="domains__domain-side-content-container">
 				{ domainsInCart.length > 0 || this.state.wpcomSubdomainSelected ? (
@@ -947,11 +963,7 @@ export class RenderDomainsStep extends Component {
 						<div className="domains__domain-side-content domains__free-domain">
 							<ReskinSideExplainer
 								onClick={ this.handleDomainExplainerClick }
-								type={
-									this.props.isPlanSelectionAvailableLaterInFlow
-										? 'free-domain-explainer-check-paid-plans'
-										: 'free-domain-explainer'
-								}
+								type={ isPaidPlan ? 'free-domain-explainer-paid-plans' : 'free-domain-explainer' }
 								flowName={ flowName }
 							/>
 						</div>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -934,8 +934,11 @@ export class RenderDomainsStep extends Component {
 		const hasSearchedDomains = Array.isArray( this.props.step?.domainForm?.searchResults );
 
 		const isFreeFlow = flowName === 'free';
+		const isPlansFirstFlow = flowName === 'plans-first';
+		const isFreePlan = isFreeFlow || ( isPlansFirstFlow && ! this.props.hasAddedPlanToCart );
+
 		const explainerType =
-			this.props.isPlanSelectionAvailableLaterInFlow || isFreeFlow
+			this.props.isPlanSelectionAvailableLaterInFlow || isFreePlan
 				? 'free-domain-explainer'
 				: 'free-domain-explainer-paid-plans';
 
@@ -961,12 +964,12 @@ export class RenderDomainsStep extends Component {
 						<div className="domains__domain-side-content domains__free-domain">
 							<ReskinSideExplainer
 								primaryCtaClick={
-									isFreeFlow ? this.navigateToPlansFirstFlow : this.handleDomainExplainerClick
+									isFreePlan ? this.navigateToPlansFirstFlow : this.handleDomainExplainerClick
 								}
 								type={ explainerType }
 								flowName={ flowName }
-								isFreeFlow={ isFreeFlow }
-								secondaryCtaClick={ isFreeFlow && this.handleDomainExplainerClick }
+								isFreePlan={ isFreePlan }
+								secondaryCtaClick={ isFreePlan && this.handleDomainExplainerClick }
 							/>
 						</div>
 					)
@@ -1490,7 +1493,7 @@ export const submitDomainStepSelection = ( suggestion, section ) => {
 };
 
 const RenderDomainsStepConnect = connect(
-	( state, { steps, flowName, stepName, previousStepName } ) => {
+	( state, { steps, flowName, stepName, previousStepName, progress } ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
 		const isPlanStepSkipped = isPlanStepExistsAndSkipped( state );
@@ -1512,6 +1515,7 @@ const RenderDomainsStepConnect = connect(
 			userLoggedIn,
 			multiDomainDefaultPlan,
 			previousStepName: previousStepName || getPreviousStepName( flowName, stepName, userLoggedIn ),
+			hasAddedPlanToCart: !! progress?.plans?.cartItems?.length,
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -931,15 +931,11 @@ export class RenderDomainsStep extends Component {
 
 		const hasSearchedDomains = Array.isArray( this.props.step?.domainForm?.searchResults );
 
-		const isPaidPlan = [
-			'starter',
-			'pro',
-			'personal',
-			'premium',
-			'business',
-			'ecommerce',
-			'domain',
-		].includes( flowName );
+		const isFreeFlow = flowName === 'free';
+		const explainerType =
+			this.props.isPlanSelectionAvailableLaterInFlow || isFreeFlow
+				? 'free-domain-explainer'
+				: 'free-domain-explainer-paid-plans';
 
 		return (
 			<div className="domains__domain-side-content-container">
@@ -963,7 +959,7 @@ export class RenderDomainsStep extends Component {
 						<div className="domains__domain-side-content domains__free-domain">
 							<ReskinSideExplainer
 								onClick={ this.handleDomainExplainerClick }
-								type={ isPaidPlan ? 'free-domain-explainer-paid-plans' : 'free-domain-explainer' }
+								type={ explainerType }
 								flowName={ flowName }
 							/>
 						</div>


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/95576

## Proposed Changes

Accessing https://wordpress.com/start/free will trigger a **Free** site creation.
Unlike the `/start`, the `/start/{plan}` does not ask which plan to be used. Among other things, it sets the free domain blurb 

![image](https://github.com/user-attachments/assets/801e0b21-80ee-4b3a-88bc-b8ca064eccd0)

The current message for **Free** plans states:

> Use the search tool on this page to find a domain you love, then select any paid annual plan.
We’ll pay the first year’s domain registration fees for you, simple as that!

That is not true. On the current flow, users are not be presented with the plans page. If they choose an payed domain, they will be directed to checkout page and pay for the domain. Our users are assuming that, after upgrading the site to a payed plan, the amount payed on domain will be reimbursed. That does not happen, because the domain is purchased before the plan.

As discussed on the issue, we are proposing present to the user the same blurb from the plain `/start`.

![image](https://github.com/user-attachments/assets/4f80a345-4b98-4844-ad1b-e0af8532487b)

This keeps the event orders very clear, paid plan first then get free domain. Also presents an opportunity to convert the user with Check paid plans » call to action.

## Testing Instructions

Run this branch locally.
Check that http://calypso.localhost:3000/start/free shows the new blurb.
Check that the `Check paid plans` directs the user to `/start/plans-first`.
Check that there are no regression on http://calypso.localhost:3000/start/business and http://calypso.localhost:3000/start

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
