### PR TITLE
Stats: Fix logic error determining outdated jetpack

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -624,7 +624,7 @@ class StatsSite extends Component {
 							/>
 						) }
 
-						{ ! supportsDevicesStats && isOldJetpack && (
+						{ supportsDevicesStats && isOldJetpack && (
 							<StatsModuleUpgradeDevicesOverlay
 								className={ halfWidthModuleClasses }
 								siteId={ siteId }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -530,7 +530,7 @@ class StatsSite extends Component {
 						/>
 
 						{ /* If UTM if supported display the module or update Jetpack plugin card */ }
-						{ supportsUTMStats && isOldJetpack === false && (
+						{ supportsUTMStats && ! isOldJetpack && (
 							<StatsModuleUTM
 								siteId={ siteId }
 								period={ this.props.period }
@@ -615,7 +615,7 @@ class StatsSite extends Component {
 							)
 						}
 
-						{ supportsDevicesStats && isOldJetpack === false && (
+						{ supportsDevicesStats && ! isOldJetpack && (
 							<StatsModuleDevices
 								siteId={ siteId }
 								period={ this.props.period }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -530,7 +530,7 @@ class StatsSite extends Component {
 						/>
 
 						{ /* If UTM if supported display the module or update Jetpack plugin card */ }
-						{ supportsUTMStats && ! isOldJetpack && (
+						{ supportsUTMStats && isOldJetpack === false && (
 							<StatsModuleUTM
 								siteId={ siteId }
 								period={ this.props.period }
@@ -615,7 +615,7 @@ class StatsSite extends Component {
 							)
 						}
 
-						{ supportsDevicesStats && ! isOldJetpack && (
+						{ supportsDevicesStats && isOldJetpack === false && (
 							<StatsModuleDevices
 								siteId={ siteId }
 								period={ this.props.period }

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -12,7 +12,7 @@ const version_greater_than_or_equal = (
 	return !! ( ! isOdysseyStats || ( version && version_compare( version, compareVersion, '>=' ) ) );
 };
 
-function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ): boolean | null {
+function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
 	const isSiteJetpackNotAtomic = isJetpackSite( state, siteId, {

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -68,7 +68,7 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 		),
 		isOldJetpack:
 			isSiteJetpackNotAtomic &&
-			statsAdminVersion &&
+			!! statsAdminVersion &&
 			! version_greater_than_or_equal( statsAdminVersion, '0.19.0-alpha', isOdysseyStats ),
 	};
 }

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -12,7 +12,7 @@ const version_greater_than_or_equal = (
 	return !! ( ! isOdysseyStats || ( version && version_compare( version, compareVersion, '>=' ) ) );
 };
 
-function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ) {
+function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ): boolean | null {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
 	const isSiteJetpackNotAtomic = isJetpackSite( state, siteId, {
@@ -66,7 +66,8 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 		),
 		isOldJetpack:
 			isSiteJetpackNotAtomic &&
-			statsAdminVersion &&
+			// Returns null when the version is not available.
+			( statsAdminVersion || null ) &&
 			! version_greater_than_or_equal( statsAdminVersion, '0.19.0-alpha', isOdysseyStats ),
 	};
 }

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -66,6 +66,7 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 		),
 		isOldJetpack:
 			isSiteJetpackNotAtomic &&
+			statsAdminVersion &&
 			! version_greater_than_or_equal( statsAdminVersion, '0.19.0-alpha', isOdysseyStats ),
 	};
 }

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -47,8 +47,8 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 		),
 		supportsUTMStats:
 			// UTM stats are only available for Jetpack sites for now.
-			isSiteJetpackNotAtomic,
-		supportsDevicesStats: isSiteJetpackNotAtomic,
+			isSiteJetpackNotAtomic && !! statsAdminVersion,
+		supportsDevicesStats: isSiteJetpackNotAtomic && !! statsAdminVersion,
 		supportsOnDemandCommercialClassification: version_greater_than_or_equal(
 			statsAdminVersion,
 			'0.18.0-alpha',
@@ -66,8 +66,7 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 		),
 		isOldJetpack:
 			isSiteJetpackNotAtomic &&
-			// Returns null when the version is not available.
-			( statsAdminVersion || null ) &&
+			statsAdminVersion &&
 			! version_greater_than_or_equal( statsAdminVersion, '0.19.0-alpha', isOdysseyStats ),
 	};
 }

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -48,7 +48,9 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 		supportsUTMStats:
 			// UTM stats are only available for Jetpack sites for now.
 			isSiteJetpackNotAtomic && !! statsAdminVersion,
-		supportsDevicesStats: isSiteJetpackNotAtomic && !! statsAdminVersion,
+		supportsDevicesStats:
+			// UTM stats are only available for Jetpack sites for now.
+			isSiteJetpackNotAtomic && !! statsAdminVersion,
 		supportsOnDemandCommercialClassification: version_greater_than_or_equal(
 			statsAdminVersion,
 			'0.18.0-alpha',


### PR DESCRIPTION
Related to p1731459493443339-slack-C0CMN0V97

## Proposed Changes

- Fix the logic error when Jetpack Upgrade CTA is shown.
- Only show UTM module when stats package version number is not empty 

## Why are these changes being made?

* Bugfix

## Testing Instructions

* Build Odyssey Stats and Jetpack locally
* Set the version [here](https://github.com/Automattic/jetpack/blob/8a1dca0e1384560683fc19658602bf77a1691d5e/projects/packages/stats-admin/src/class-odyssey-config-data.php#L97) to `0.17.0`
* Open `/wp-admin/admin.php?page=stats#!/stats/day/193141071?page=stats`
* Ensure you see update plugin CTA for UTM and Devices modules

<img width="796" alt="image" src="https://github.com/user-attachments/assets/e9504c0a-c4d3-49bc-a8bd-d82ee02cdc2c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?