### PR TITLE
Domains: Do not query subdomain suggestions on all 100-year related flows

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -147,6 +147,9 @@ class RegisterDomainStep extends Component {
 		 * It will be removed if there is still no need of it once the test concludes.
 		 */
 		hasPendingRequests: PropTypes.bool,
+
+		// Whether subdomains (.wordpress.com, .blog subdomains) should be queried - used for hiding free subdomains in specific cases
+		shouldQuerySubdomains: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -169,6 +172,7 @@ class RegisterDomainStep extends Component {
 		otherManagedSubdomains: null,
 		hasPendingRequests: false,
 		forceExactSuggestion: false,
+		shouldQuerySubdomains: true,
 	};
 
 	constructor( props ) {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -222,9 +222,10 @@ class RegisterDomainStep extends Component {
 
 	isSubdomainResultsVisible() {
 		return (
-			this.props.includeWordPressDotCom ||
-			this.props.includeDotBlogSubdomain ||
-			this.props.otherManagedSubdomains?.length > 0
+			this.props.shouldQuerySubdomains &&
+			( this.props.includeWordPressDotCom ||
+				this.props.includeDotBlogSubdomain ||
+				this.props.otherManagedSubdomains?.length > 0 )
 		);
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1431,7 +1431,7 @@ class RegisterDomainStep extends Component {
 					.catch( () => [] ) // handle the error and return an empty list
 					.then( this.handleDomainSuggestions( domain ) );
 
-				if ( this.props.shouldQuerySubdomains && this.isSubdomainResultsVisible() ) {
+				if ( this.isSubdomainResultsVisible() ) {
 					this.getSubdomainSuggestions( domain, timestamp );
 				}
 			}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -834,7 +834,7 @@ class RegisterDomainStep extends Component {
 		} );
 	};
 
-	repeatSearch = ( stateOverride = {}, { shouldQuerySubdomains = true } = {} ) => {
+	repeatSearch = ( stateOverride = {} ) => {
 		this.save();
 
 		const { lastQuery } = this.state;
@@ -858,7 +858,7 @@ class RegisterDomainStep extends Component {
 		};
 		debug( 'Repeating a search with the following input for setState', nextState );
 		this.setState( nextState, () => {
-			loadingResults && this.onSearch( lastQuery, { shouldQuerySubdomains } );
+			loadingResults && this.onSearch( lastQuery );
 		} );
 	};
 
@@ -1382,7 +1382,7 @@ class RegisterDomainStep extends Component {
 		} );
 	};
 
-	onSearch = async ( searchQuery, { shouldQuerySubdomains = true } = {} ) => {
+	onSearch = async ( searchQuery ) => {
 		debug( 'onSearch handler was triggered with query', searchQuery );
 
 		const domain = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
@@ -1427,7 +1427,7 @@ class RegisterDomainStep extends Component {
 					.catch( () => [] ) // handle the error and return an empty list
 					.then( this.handleDomainSuggestions( domain ) );
 
-				if ( shouldQuerySubdomains && this.isSubdomainResultsVisible() ) {
+				if ( this.props.shouldQuerySubdomains && this.isSubdomainResultsVisible() ) {
 					this.getSubdomainSuggestions( domain, timestamp );
 				}
 			}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -221,11 +221,14 @@ class RegisterDomainStep extends Component {
 	}
 
 	isSubdomainResultsVisible() {
+		if ( ! this.props.shouldQuerySubdomains ) {
+			return false;
+		}
+
 		return (
-			this.props.shouldQuerySubdomains &&
-			( this.props.includeWordPressDotCom ||
-				this.props.includeDotBlogSubdomain ||
-				this.props.otherManagedSubdomains?.length > 0 )
+			this.props.includeWordPressDotCom ||
+			this.props.includeDotBlogSubdomain ||
+			this.props.otherManagedSubdomains?.length > 0
 		);
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -74,7 +74,7 @@ export function DomainFormControl( {
 	let showExampleSuggestions: boolean | undefined = undefined;
 	let includeWordPressDotCom: boolean | undefined = undefined;
 	let showSkipButton: boolean | undefined = undefined;
-	let shouldQuerySubdomains: boolean | undefined = undefined;
+	let shouldQuerySubdomains: boolean = true;
 
 	// Checks if the user entered the signup flow via browser back from checkout page,
 	// and if they did, we'll show a modified domain step to prevent creating duplicate sites,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -74,6 +74,7 @@ export function DomainFormControl( {
 	let showExampleSuggestions: boolean | undefined = undefined;
 	let includeWordPressDotCom: boolean | undefined = undefined;
 	let showSkipButton: boolean | undefined = undefined;
+	let shouldQuerySubdomains: boolean | undefined = undefined;
 
 	// Checks if the user entered the signup flow via browser back from checkout page,
 	// and if they did, we'll show a modified domain step to prevent creating duplicate sites,
@@ -102,10 +103,12 @@ export function DomainFormControl( {
 
 	if ( flow === HUNDRED_YEAR_PLAN_FLOW ) {
 		includeWordPressDotCom = false;
+		shouldQuerySubdomains = false;
 	}
 
 	if ( flow === HUNDRED_YEAR_DOMAIN_FLOW ) {
 		includeWordPressDotCom = false;
+		shouldQuerySubdomains = false;
 	}
 
 	const domainsWithPlansOnly = true;
@@ -265,6 +268,7 @@ export function DomainFormControl( {
 					selectedSite={ selectedSite }
 					showExampleSuggestions={ showExampleSuggestions }
 					showSkipButton={ showSkipButton }
+					shouldQuerySubdomains={ shouldQuerySubdomains }
 					suggestion={ initialQuery }
 					handleClickUseYourDomain={ onUseYourDomainClick }
 					vendor={ getSuggestionsVendor( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
We're currently querying subdomains (free `.blog` and `.wordpress.com` subdomains) on the 100-year domain and 100-year plan flows. 
This is causing some UI issues in both, as these were not expected to be displayed in those flows - we should only be offering paid domains, even for the 100-year plan one, so we shouldn't query these subdomains on those particular flows. This PR fixes it.

## Proposed Changes
It reuses the `shouldQuerySubdomain` logic (already added back in #23871 and currently unused, apparently), switching it from a function argument to a prop, which is `false` for the 100-year domain and 100-year plan flows, and `true` for every other case — also some minor adjustments.

## Why are these changes being made?
To fix the UI (looks broken) and avoid unnecessary requests.

## Testing Instructions
- Apply this branch locally or use its `calypso.live` link;
- Visit the 100-year domain flow (`/setup/hundred-year-domain`) or the 100-year plan flow;
- On the domain search section, try querying an FQDN, or any term, and ensure the `/suggestions` request is fired only once
  - Currently, on `trunk`, there are two requests: one for the suggestions and another one for the free subdomain (even though these are ignored on the 100-year domain flow);
- Ensure you don't get the same UI bugs as in the "Before" video preview below.

## Preview

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/cea92270-e9ea-4786-a78f-154c3fac6df3"/> | <video src="https://github.com/user-attachments/assets/27822dc6-9a35-4ae8-8af8-7a4e714143cb"/> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
