### PR TITLE
A4A: Show a4a branding on email confirmation screen

### DIFF
--- a/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
+++ b/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
@@ -104,7 +104,7 @@ const HandleEmailedLinkFormJetpackConnect: FC< Props > = ( { emailAddress, token
 	return (
 		<EmptyContent className="magic-login__handle-link jetpack" title={ null } illustration={ null }>
 			{ ! isWooFlow && ! isFromAutomatticForAgenciesPlugin && <JetpackLogo size={ 74 } full /> }
-			{ isFromAutomatticForAgenciesPlugin && <A4ALogo size={ 74 } fullA4A /> }
+			{ isFromAutomatticForAgenciesPlugin && <A4ALogo fullA4A size={ 58 } /> }
 
 			<h2 className="magic-login__title empty-content__title">
 				{ translate( 'Email confirmed!' ) }

--- a/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
+++ b/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useCallback, useEffect, useState } from 'react';
+import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import EmptyContent from 'calypso/components/empty-content';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { login } from 'calypso/lib/paths';
@@ -49,6 +50,9 @@ const HandleEmailedLinkFormJetpackConnect: FC< Props > = ( { emailAddress, token
 	const isFetching = useSelector( isFetchingMagicLoginAuth );
 	const twoFactorEnabled = useSelector( isTwoFactorEnabled );
 	const twoFactorNotificationSent = useSelector( getTwoFactorNotificationSent );
+	const isFromAutomatticForAgenciesPlugin =
+		new URLSearchParams( redirectToOriginal.split( '?' )[ 1 ] ).get( 'from' ) ===
+		'automattic-for-agencies-client';
 
 	useEffect( () => {
 		if ( ! emailAddress || ! token ) {
@@ -99,7 +103,8 @@ const HandleEmailedLinkFormJetpackConnect: FC< Props > = ( { emailAddress, token
 
 	return (
 		<EmptyContent className="magic-login__handle-link jetpack" title={ null } illustration={ null }>
-			{ ! isWooFlow && <JetpackLogo size={ 74 } full /> }
+			{ ! isWooFlow && ! isFromAutomatticForAgenciesPlugin && <JetpackLogo size={ 74 } full /> }
+			{ isFromAutomatticForAgenciesPlugin && <A4ALogo size={ 74 } fullA4A /> }
 
 			<h2 className="magic-login__title empty-content__title">
 				{ translate( 'Email confirmed!' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: 1417-gh-Automattic/automattic-for-agencies-dev
Discussion: pfunGA-3vP-p2

## Proposed Changes

* When coming from the A4A plugin, show the A4A logo on the email confirmation screen.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Brand consistency and to minimize confusion for users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Setup
* Checkout this branch locally
* Point `wordpress.com` to `127.0.0.1` in your hosts file
* Start Calypso using `yarn start-mock-wordpress-com` (press any key to continue when prompted)

#### Test A4A plugin
* While **logged-in** to wpcom, create [jurassic ninja](https://jurassic.ninja/) site.
* On the new site, in wp-admin go to plugins > add new plugin, search for "automattic for agencies"
* Install now > Activate the plugin
* From A4A settings page in wp-admin, click "Connect this site"
<img width="1395" alt="Screenshot 2024-11-13 at 10 50 02 AM" src="https://github.com/user-attachments/assets/156f00ca-1588-4749-ac8a-bf760bfac04c">

* On the wordpress.com auth page, click "Sign in as different user" (might need to type `thisisunsafe` in chrome)
<img width="1112" alt="Screenshot 2024-11-13 at 4 53 24 PM" src="https://github.com/user-attachments/assets/f208ae56-5860-4ed7-b8db-f2fbb11e6efc">

* Enter an email address that's not already registered on wpcom, click "Continue"
<img width="1227" alt="Screenshot 2024-11-13 at 10 52 47 AM" src="https://github.com/user-attachments/assets/52f7602b-6021-48b3-bfa0-17682f72fa28">

* You should receive an email with the subject "Create WordPress.com account"
* Watch closely as you do the next step, as it changes quickly...
* Copy the "Finish your Jetpack setup" link in the email and paste it in a **logged-out** browser window.
* For a few seconds you should see the "Email Confirmed" confirmed screen.
* It should have the A4A logo and not the Jetpack one.
<img width="1328" alt="Screenshot 2024-11-13 at 4 59 17 PM" src="https://github.com/user-attachments/assets/ca15df16-a4e5-4383-b8a4-d23c8b340b84">

#### Test normal Jetpack flow
* Repeat the steps above but with the Jetpack plugin.
* Go through the normal connection flow to connect your user.
* The screen mentioned above should continue to show the Jetpack logo.
<img width="1255" alt="Screenshot 2024-11-13 at 5 07 48 PM" src="https://github.com/user-attachments/assets/01885eb0-9d4e-4551-b249-5396c50e5325">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
