### PR TITLE
Stats: Traffic page header refresh - sticky header

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -402,8 +402,8 @@ class StatsSite extends Component {
 					<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				) }
 				{ isNewDateFilteringEnabled && (
-					// moves date range block into new location
-					<StatsPeriodHeader>
+					// moves date range block into new location + adds sticky header
+					<StatsPeriodHeader className="is-sticky">
 						<StatsPeriodNavigation
 							date={ date }
 							period={ period }

--- a/client/my-sites/stats/stats-period-header/index.jsx
+++ b/client/my-sites/stats/stats-period-header/index.jsx
@@ -1,7 +1,13 @@
+import PropTypes from 'prop-types';
 import './style.scss';
 
-const StatsPeriodHeader = ( { children, className } ) => {
-	return <div className={ `stats__period-header ${ className || '' }` }>{ children }</div>;
+const StatsPeriodHeader = ( { children, className = '' } ) => {
+	return <div className={ `stats__period-header ${ className }`.trim() }>{ children }</div>;
+};
+
+StatsPeriodHeader.propTypes = {
+	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
 };
 
 export default StatsPeriodHeader;

--- a/client/my-sites/stats/stats-period-header/index.jsx
+++ b/client/my-sites/stats/stats-period-header/index.jsx
@@ -1,7 +1,7 @@
 import './style.scss';
 
-const StatsPeriodHeader = ( { children } ) => {
-	return <div className="stats__period-header">{ children }</div>;
+const StatsPeriodHeader = ( { children, className } ) => {
+	return <div className={ `stats__period-header ${ className || '' }` }>{ children }</div>;
 };
 
 export default StatsPeriodHeader;

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -226,6 +226,20 @@ $stats-card-min-width: 390px;
 	&.color-scheme.is-classic-dark {
 		@include apply-improved-classic-dark-colors();
 	}
+
+	// Sticky header styling
+	.layout__content {
+		&:has(.stats__period-header.is-sticky) {
+			overflow: clip;
+		}
+	}
+
+	.stats__period-header.is-sticky {
+		position: sticky;
+		top: 32px;
+		z-index: 20;
+		background-color: var(--studio-white);
+	}
 }
 
 .list-emails {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/217

## Proposed Changes

* Makes the header on the traffic page sticky

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
* Part of the Date filtering for the traffic page project (header refresh section)

## Important Notes

* Initially explored by @a8ck3n in https://github.com/Automattic/wp-calypso/pull/95573 - it's important to note that this requires a change to the `layout__content` DIV which effects the entire viewport. However I have added in `&:has(.stats__period-header.is-sticky)` to the selector, which hopefully will prevent unintended issues when the sticky header is not being used. But we do want to be really thorough in testing this. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link.
* Visit the Stats → Traffic page and confirm it loads normally.
* Manually enable the feature flag: ?flags=stats/new-date-filtering
* Scroll the page and confirm the header sticks to the top of the page.
* Keep an eye out for unintended layout changes.

| Design Image | Second Header |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/c0e759da-d652-456c-a895-0ffba2593b4c)  | Content Cell  |
| Content Cell  | Content Cell  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
