### PR TITLE
Email Upsell: Improve CSS to avoid input field focus being cut-off

### DIFF
--- a/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/style.scss
@@ -135,6 +135,7 @@ $width-left-panel-card: 55%;
 
 		.action-panel__body {
 			color: var(--color-text);
+			overflow: visible;
 
 			p {
 				margin-bottom: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94932

## Proposed Changes

| Before | After |
| --- | --- |
| ![Screenshot 2024-11-14 at 9 34 30 AM](https://github.com/user-attachments/assets/e383d4e7-5d62-4273-b2af-9695a4698e79) |  ![Screenshot 2024-11-14 at 9 34 07 AM](https://github.com/user-attachments/assets/b09703dc-07f3-41af-badb-53d2cc4f7a91) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WordPress.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Head to /domains/add/:domain
2. Select any domain
3. In the email upsell step, focus on any input field
4. Ensure that the left side of the input field focus state is not cut off

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
