### PR TITLE
Increase padding on email login link for it locale

### DIFF
--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -47,6 +47,7 @@
 						margin-bottom: 0;
 						padding: 4px 16px;
 						border-color: #ccc;
+						text-wrap: balance;
 
 						& > svg.social-icons {
 							border: 0;

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -42,7 +42,7 @@
 						border: 1px solid var(--studio-gray-50, #646970);
 						border-radius: 4px;
 						display: flex;
-						height: 40px;
+						height: 44px;
 						justify-content: center;
 						margin-bottom: 0;
 						padding: 4px 16px;
@@ -67,7 +67,7 @@
 							max-width: 240px;
 							text-align: center;
 							margin-right: auto;
-							margin-left: -20px;
+							margin-left: -10px;
 						}
 					}
 				}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/96280

## Proposed Changes

* Increases padding around login link text

## Testing Instructions

* Compare desktop and mobile login screen at http://calypso.localhost:3000/log-in/it
* Observer extra spacing for the email login link text
* Confirm text is still center aligned on mobile

Before

<img src="https://github.com/user-attachments/assets/85e2db13-0e8d-4474-8dc7-e1f7e934808a" width=300 />
<img src="https://github.com/user-attachments/assets/f80df181-2f96-4c25-aae3-394b62146b40" />


After

<img src="https://github.com/user-attachments/assets/aeb46d2d-fddf-42c0-a38d-f3645cae9942" width=300 />
<img src="https://github.com/user-attachments/assets/9557bda4-8bdc-481b-8b37-75927d91bb63" />
