### PR TITLE
Design picker default selection based on goal selection

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -1,8 +1,14 @@
+import { Onboard } from '@automattic/data-stores';
 import { Category } from '@automattic/design-picker';
 
 const CATEGORY_BLOG = 'blog';
 const CATEGORY_STORE = 'store';
 const CATEGORY_BUSINESS = 'business';
+const CATEGORY_COMMUNITY_NON_PROFIT = 'community-non-profit';
+const CATEGORY_PORTFOLIO = 'portfolio';
+const CATEGORY_AUTHORS_WRITERS = 'authors-writers';
+const CATEGORY_EDUCATION = 'education';
+const CATEGORY_ENTERTAINMENT = 'entertainment';
 
 /**
  * Ensures the category appears at the top of the design category list
@@ -25,7 +31,18 @@ const sortBlogToTop = makeSortCategoryToTop( CATEGORY_BLOG );
 const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
 const sortBusinessToTop = makeSortCategoryToTop( CATEGORY_BUSINESS );
 
-export function getCategorizationOptions( intent: string ) {
+export function getCategorizationOptions(
+	intent: string,
+	goals: Onboard.SiteGoal[],
+	useGoals: boolean
+) {
+	if ( useGoals ) {
+		return getCategorizationFromGoals( goals );
+	}
+	return getCategorizationFromIntent( intent );
+}
+
+function getCategorizationFromIntent( intent: string ) {
 	const result = {
 		defaultSelection: null,
 	} as {
@@ -57,5 +74,84 @@ export function getCategorizationOptions( intent: string ) {
 				...result,
 				sort: sortBlogToTop,
 			};
+	}
+}
+
+function getCategorizationFromGoals( goals: Onboard.SiteGoal[] ) {
+	// Sorted according to which theme category makes the most consequential impact
+	// on the user's site e.g. if you want a store, then choosing a Woo compatible
+	// theme is more important than choosing a theme that is good for blogging.
+	// Missing categories are treated as equally inconsequential.
+	const mostConsequentialDesignCategories = [
+		CATEGORY_STORE,
+		CATEGORY_EDUCATION,
+		CATEGORY_COMMUNITY_NON_PROFIT,
+		CATEGORY_ENTERTAINMENT,
+		CATEGORY_PORTFOLIO,
+		CATEGORY_BLOG,
+		CATEGORY_AUTHORS_WRITERS,
+	];
+
+	const defaultSelection =
+		goals
+			.map( getGoalsPreferredCategory )
+			.sort( ( a, b ) => {
+				let aIndex = mostConsequentialDesignCategories.indexOf( a );
+				let bIndex = mostConsequentialDesignCategories.indexOf( b );
+
+				// If the category is not in the list, it should be sorted to the end.
+				if ( aIndex === -1 ) {
+					aIndex = mostConsequentialDesignCategories.length;
+				}
+				if ( bIndex === -1 ) {
+					bIndex = mostConsequentialDesignCategories.length;
+				}
+
+				return aIndex - bIndex;
+			} )
+			.shift() ?? CATEGORY_BUSINESS;
+
+	return {
+		defaultSelection,
+		sort: makeSortCategoryToTop( defaultSelection ),
+	};
+}
+
+function getGoalsPreferredCategory( goal: Onboard.SiteGoal ): string {
+	switch ( goal ) {
+		case Onboard.SiteGoal.Write:
+			return CATEGORY_BLOG;
+
+		case Onboard.SiteGoal.CollectDonations:
+		case Onboard.SiteGoal.BuildNonprofit:
+			return CATEGORY_COMMUNITY_NON_PROFIT;
+
+		case Onboard.SiteGoal.Porfolio:
+			return CATEGORY_PORTFOLIO;
+
+		case Onboard.SiteGoal.Newsletter:
+		case Onboard.SiteGoal.PaidSubscribers:
+			return CATEGORY_AUTHORS_WRITERS;
+
+		case Onboard.SiteGoal.SellDigital:
+		case Onboard.SiteGoal.SellPhysical:
+		case Onboard.SiteGoal.Sell:
+			return CATEGORY_STORE;
+
+		case Onboard.SiteGoal.Courses:
+			return CATEGORY_EDUCATION;
+
+		case Onboard.SiteGoal.Videos:
+		case Onboard.SiteGoal.AnnounceEvents:
+			return CATEGORY_ENTERTAINMENT;
+
+		case Onboard.SiteGoal.Engagement:
+		case Onboard.SiteGoal.Promote:
+		case Onboard.SiteGoal.ContactForm:
+		case Onboard.SiteGoal.Import:
+		case Onboard.SiteGoal.ImportSubscribers:
+		case Onboard.SiteGoal.Other:
+		case Onboard.SiteGoal.DIFM:
+			return CATEGORY_BUSINESS;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/96325

## Proposed Changes

* The default design picker selection is dependent on the goals selected (not the inferred "intent")
* When multiple goals are selected, the default category will be the more "consequential" one i.e. `store > blog`
* Sorts the default selection to the front of the categories, which is the existing behaviour
* Retains old "intent" driven behaviour for users not in the `calypso_onboarding_goals_step_added_goals` experiment.

https://github.com/user-attachments/assets/3993d6f3-e0c8-4b7f-8f91-0665ad723900

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As we make our onboarding more "goal" centric, the design picker should support filtering by multiple goals: p9Jlb4-emx-p2#design-picker

In the interim, while the design picker still only supports filtering by a single goal, we need to decide which goals should align with which design categories.

See more discussion here
p1731454668413339-slack-C07H21B2W59

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to the `control` variant at 22097-explat-experiment
* `/setup/site-setup/goals?siteSlug={{ site slug }}`
* Make your goal selection and advance to the design picker
* Ensure that the category selected by default in this PR is the same that would have been selected in production
* Assign yourself to the `treatment` variant
* Refresh the goals screen
* Make your goal selection and advance to the design picker
* Ensure that the category selected by default aligns with the onboarding goals spreadsheet (see https://github.com/Automattic/wp-calypso/issues/96325#issue-2653701471) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?