### PR TITLE
A4A > Migrations: Add event tracking

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
@@ -4,22 +4,35 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
 import { preventWidows } from 'calypso/lib/formatting';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import MigrationsAddSitesTable from './add-sites-table';
 
 import './style.scss';
 
 export default function MigrationsTagSitesModal( { onClose }: { onClose: () => void } ) {
 	const translate = useTranslate();
-
-	const handleAddSites = () => {
-		// TODO: Implement this
-	};
+	const dispatch = useDispatch();
 
 	const [ selectedSites, setSelectedSites ] = useState< number[] | [] >( [] );
 
+	const handleAddSites = () => {
+		// TODO: Implement this
+		dispatch(
+			recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_add_sites_click', {
+				count: selectedSites.length,
+			} )
+		);
+	};
+
+	const handleOnClose = () => {
+		onClose();
+		dispatch( recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_close' ) );
+	};
+
 	return (
 		<A4AModal
-			onClose={ onClose }
+			onClose={ handleOnClose }
 			extraActions={
 				<Button variant="primary" onClick={ handleAddSites }>
 					{ selectedSites.length > 0


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1439

## Proposed Changes

This PR adds the event tracking to the new migration changes.

## Why are these changes being made?

* To be able to track the events.

## Testing Instructions

- Open the A4A live link > Open the network tab on the browser dev tool > Filter `Img` and `a8c-for-agencies-horizon` text.

<img width="835" alt="Screenshot 2024-10-25 at 1 53 16 PM" src="https://github.com/user-attachments/assets/f0fdb22e-57e8-48e4-be15-10b44e65f713">

- Verify the below tracking events are being captured along with the props mentioned:

**Migrations: Overview > Click the `Tag sites for commission` button**

<img width="820" alt="Screenshot 2024-11-14 at 10 32 03 AM" src="https://github.com/user-attachments/assets/7177472f-0098-427b-afbf-03c3f8993871">

1) Select all/deselect all

```
Event: calypso_a8c_migrations_tag_sites_modal_select_all_sites_click
Props: type: select | deselect
```

2) Select/deselect one

```
Event: calypso_a8c_migrations_tag_sites_modal_select_site_click
Props: type: select | deselect
```

3) Cancel/Close modal

```
Event: calypso_a8c_migrations_tag_sites_modal_close
```

4) Add Sites

```
Event: calypso_a8c_migrations_tag_sites_modal_add_sites_click
Props: count
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
