### PR TITLE
A4A > Migrations: Implement loading indicator for commissions

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -11,6 +11,7 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MIGRATIONS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import MigrationsCommissionsList from '../../commissions-list';
@@ -34,15 +35,27 @@ export default function MigrationsCommissions() {
 		setShowAddSitesModal( true );
 	}, [ dispatch ] );
 
-	const { data: migrationCommissions, isFetching: isFetchingCommissions } =
-		useFetchMigrationCommissions();
-
-	if ( isFetchingCommissions ) {
-		// TODO: Add a loading state
-		return null;
-	}
+	const { data: migrationCommissions, isFetched } = useFetchMigrationCommissions();
 
 	const showEmptyState = ! migrationCommissions?.length;
+
+	let content = (
+		<>
+			<TextPlaceholder />
+			<TextPlaceholder />
+		</>
+	);
+
+	if ( isFetched ) {
+		content = showEmptyState ? (
+			<MigrationsCommissionsEmptyState setShowAddSitesModal={ setShowAddSitesModal } />
+		) : (
+			<div className="migrations-commissions__content">
+				<MigrationsConsolidatedCommissions items={ migrationCommissions } />
+				<MigrationsCommissionsList items={ migrationCommissions } />
+			</div>
+		);
+	}
 
 	return (
 		<Layout
@@ -77,14 +90,7 @@ export default function MigrationsCommissions() {
 
 			<LayoutBody>
 				<>
-					{ showEmptyState ? (
-						<MigrationsCommissionsEmptyState setShowAddSitesModal={ setShowAddSitesModal } />
-					) : (
-						<div className="migrations-commissions__content">
-							<MigrationsConsolidatedCommissions items={ migrationCommissions } />
-							<MigrationsCommissionsList items={ migrationCommissions } />
-						</div>
-					) }
+					{ content }
 					{ showAddSitesModal && (
 						<MigrationsTagSitesModal onClose={ () => setShowAddSitesModal( false ) } />
 					) }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -39,15 +39,17 @@ export default function MigrationsCommissions() {
 
 	const showEmptyState = ! migrationCommissions?.length;
 
-	let content = (
-		<>
-			<TextPlaceholder />
-			<TextPlaceholder />
-		</>
-	);
+	const content = useMemo( () => {
+		if ( ! isFetched ) {
+			return (
+				<>
+					<TextPlaceholder />
+					<TextPlaceholder />
+				</>
+			);
+		}
 
-	if ( isFetched ) {
-		content = showEmptyState ? (
+		return showEmptyState ? (
 			<MigrationsCommissionsEmptyState setShowAddSitesModal={ setShowAddSitesModal } />
 		) : (
 			<div className="migrations-commissions__content">
@@ -55,7 +57,7 @@ export default function MigrationsCommissions() {
 				<MigrationsCommissionsList items={ migrationCommissions } />
 			</div>
 		);
-	}
+	}, [ isFetched, showEmptyState, migrationCommissions, setShowAddSitesModal ] );
 
 	return (
 		<Layout

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/style.scss
@@ -6,6 +6,19 @@
 		max-width: 900px;
 	}
 
+	.a4a-text-placeholder {
+		height: 100px;
+		margin: 16px;
+
+		&:nth-child(2) {
+			height: 200px;
+		}
+
+		@include break-large {
+			margin: 16px 64px 48px;
+		}
+	}
+
 	.step-section-item__content {
 		max-width: none;
 


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1470

## Proposed Changes

This PR adds a loading indicator for commissions on the Migrations page.

* To show a loading indicator when the commissions are loading.

## Testing Instructions

To test these changes, you need to use the local environment and make some changes to the code as we don't have the API endpoint ready.

* Switch to this branch locally and start the server
* Go to `client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx` file and update the code:

```
// const { data: migrationCommissions, isFetched } = useFetchMigrationCommissions();
const { data: migrationCommissions } = useFetchMigrationCommissions();
const isFetched = false;
```

* Go to `client/a8c-for-agencies/sections/migrations/hooks/use-fetch-migration-commissions.ts` and update the code:

```
queryFn: () =>
	isAPIEnabled
		? wpcom.req.get( {
			apiNamespace: 'wpcom/v2',
			path: `/agency/${ agencyId }/migrations/commissions`, // FIXME: Replace with the correct API path
		   } )
		: [], // Remove this line once the API is implemented
```

* Go to Migrations: Commissions > Verify the loading indicator is displayed as shown below:


<img width="1725" alt="Screenshot 2024-11-14 at 10 51 15 AM" src="https://github.com/user-attachments/assets/0df495d0-c14f-4fe0-88d6-49fa17f5b8c3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
