### PR TITLE
Improve padding between icon and text in FormInputValidation

### DIFF
--- a/packages/components/src/forms/form-input-validation/style.scss
+++ b/packages/components/src/forms/form-input-validation/style.scss
@@ -19,7 +19,7 @@
 	}
 
 	&.has-icon {
-		padding-left: 34px;
+		padding-left: 26px;
 	}
 
 	&.is-hidden {
@@ -35,6 +35,6 @@
 	svg {
 		fill: currentcolor;
 		float: left;
-		margin-left: -34px;
+		margin-left: -26px;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR fixes the padding between the icon and text regarding FormInputValidation.

Close https://github.com/Automattic/wp-calypso/issues/95814
Related https://github.com/Automattic/wp-calypso/pull/91216

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See https://github.com/Automattic/wp-calypso/issues/95814

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to WP Admin ➡ Hosting ➡ Domains
- Add a domain
- Select any domain
- Click Purchase without completing any fields

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
