### PR TITLE
Theme Showcase: Fix gradient on search input

### DIFF
--- a/client/components/search-themes/style.scss
+++ b/client/components/search-themes/style.scss
@@ -170,6 +170,10 @@ $search-border-radius: 4px;
 			}
 			.keyed-suggestions__value-description {
 				height: auto;
+
+				&::before {
+					display: none;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

Fixes a regression introduced in https://github.com/Automattic/wp-calypso/pull/96349 which caused the search themes component to display a weird gradient.

Before | After
--- | ---
<img width="724" alt="Screenshot 2024-11-14 at 11 20 02" src="https://github.com/user-attachments/assets/098ebaef-605f-4ca2-a88e-9aaefeaee168"> | <img width="732" alt="Screenshot 2024-11-14 at 11 28 08" src="https://github.com/user-attachments/assets/029910fa-e45a-4485-a21d-2f7fccc9af60">
<img width="725" alt="Screenshot 2024-11-14 at 11 26 18" src="https://github.com/user-attachments/assets/f787a236-fdc5-4cd1-8b4b-ffc650ed2133"> | <img width="689" alt="Screenshot 2024-11-14 at 11 27 34" src="https://github.com/user-attachments/assets/b19107bd-fa72-439a-9558-13cc4aaef538">



## Why are these changes being made?

Because the search input in the Theme Showcase displays a weird-looking gradient.

## Testing Instructions
- Use the Calypso live link below
- Go to `/themes`
- Open the search
- Make sure the gradient does not show up in the right side of the items

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
