### PR TITLE
Update copy for delete account confirmation modal

### DIFF
--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -121,7 +121,7 @@ class AccountCloseConfirmDialog extends Component {
 		const deleteButtons = [
 			<Button onClick={ this.handleCancel }>{ translate( 'Cancel' ) }</Button>,
 			<Button primary scary disabled={ isDeleteButtonDisabled } onClick={ this.handleConfirm }>
-				{ translate( 'Close your account' ) }
+				{ translate( 'Delete account' ) }
 			</Button>,
 		];
 
@@ -134,7 +134,7 @@ class AccountCloseConfirmDialog extends Component {
 				<h1 className="account-close__confirm-dialog-header">
 					{ this.state.displayAlternativeOptions
 						? translate( 'Are you sure?' )
-						: translate( 'Confirm account closure' ) }
+						: translate( 'Confirm account deletion' ) }
 				</h1>
 				{ ! this.state.displayAlternativeOptions && (
 					<>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9500

> [!WARNING]  
> Merge after translations are done

## Proposed Changes

![delete@2x](https://github.com/user-attachments/assets/c20c216e-1db3-44e2-ba0d-ed4afa176c7a)

* Align copy to use delete/deletion

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Terminology consistency

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me/account/close
* Check the copy of the confirmation dialog right before deletion

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
