### PR TITLE
Substack importer: show correct summary "status" while in progress

### DIFF
--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -7,11 +7,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import pauseSubstackBillingImg from 'calypso/assets/images/importer/pause-substack-billing.png';
-import {
-	Steps,
-	SubscribersStepContent,
-	ContentStepContent,
-} from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import { Steps, StepStatus } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import { useResetMutation } from 'calypso/data/paid-newsletter/use-reset-mutation';
 import ImporterActionButton from '../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../importer-action-buttons/container';
@@ -29,19 +25,19 @@ interface SummaryProps {
 	shouldShownConfetti: Dispatch< SetStateAction< boolean > >;
 }
 
-function getSummaryDescription(
-	contentStepContent: ContentStepContent | undefined,
-	subscribersStepContent: SubscribersStepContent | undefined
-) {
-	if ( contentStepContent && subscribersStepContent ) {
+function getSummaryDescription( contentStepStatus: StepStatus, subscribersStepStatus: StepStatus ) {
+	const skippedContent = contentStepStatus === 'skipped';
+	const skippedSubscribers = subscribersStepStatus === 'skipped';
+
+	if ( ! skippedContent && ! skippedSubscribers ) {
 		return __( 'We’re importing your content and subscribers' );
 	}
 
-	if ( contentStepContent ) {
+	if ( ! skippedContent ) {
 		return __( 'We’re importing your content' );
 	}
 
-	if ( subscribersStepContent ) {
+	if ( ! skippedSubscribers ) {
 		return __( 'We’re importing your subscribers' );
 	}
 
@@ -156,7 +152,7 @@ export default function Summary( {
 					<div className="summary__content">
 						<p>
 							<strong>
-								{ getSummaryDescription( steps.content.content, steps.subscribers.content ) }
+								{ getSummaryDescription( steps.content.status, steps.subscribers.status ) }
 							</strong>
 							<br />
 						</p>

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -1,12 +1,15 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { verse, page, post, file } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { ContentStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import {
+	ContentStepContent,
+	StepStatus,
+} from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import SummaryStat from './SummaryStat';
 
 interface ContentSummaryProps {
 	stepContent: ContentStepContent;
-	status: string;
+	status: StepStatus;
 }
 
 export default function ContentSummary( { status, stepContent }: ContentSummaryProps ) {

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,12 +1,15 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { people } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import {
+	SubscribersStepContent,
+	StepStatus,
+} from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import SummaryStat from './SummaryStat';
 
 interface SubscriberSummaryProps {
 	stepContent: SubscribersStepContent;
-	status: string;
+	status: StepStatus;
 }
 
 export default function SubscriberSummary( { stepContent, status }: SubscriberSummaryProps ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

I noticed that I saw "_We’re importing your content and subscribers_" summary status even if I skipped subscriber importing.

## Proposed Changes

* Switch `string` type to actual `StepStatus` type
* Ensures correct status message is shown, depending if user skipped content or subscriber importer:
    - _We’re importing your content and subscribers_
    - _We’re importing your content_
    - _We’re importing your subscribers_


Before
<img width="910" alt="Screenshot 2024-11-14 at 15 49 33" src="https://github.com/user-attachments/assets/5588e02d-d1da-4251-ae6a-f2168f1c2212">


After
<img width="1046" alt="Screenshot 2024-11-14 at 15 49 51" src="https://github.com/user-attachments/assets/3dd654c7-ea5c-49fd-bf10-bea4a587fabf">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through Substack importer, but skip either content or subscriber import.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
