### PR TITLE
Substack importer: reset state properly after import is finished

### DIFF
--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -72,7 +72,7 @@ export default function Summary( {
 
 		// Reset importer state entirely when leaving summary state and everything is done
 		return () => {
-			if ( importerStatus === 'done' ) {
+			if ( importerStatus === 'done' || importerStatus === 'skipped' ) {
 				resetPaidNewsletter( selectedSite.ID, engine, 'content' );
 			}
 		};

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -62,14 +62,28 @@ export default function Summary( {
 	);
 	const showPauseSubstackBillingWarning = paidSubscribersCount > 0;
 
+	// Combined status of subscriber & content importer
+	const importerStatus = getImporterStatus( steps.content.status, steps.subscribers.status );
+
 	useEffect( () => {
 		if ( showConfetti ) {
 			shouldShownConfetti( false );
 		}
-	}, [ showConfetti, shouldShownConfetti ] );
 
-	// Combined status of subscriber & content importer
-	const importerStatus = getImporterStatus( steps.content.status, steps.subscribers.status );
+		// Reset importer state entirely when leaving summary state and everything is done
+		return () => {
+			if ( importerStatus === 'done' ) {
+				resetPaidNewsletter( selectedSite.ID, engine, 'content' );
+			}
+		};
+	}, [
+		engine,
+		importerStatus,
+		resetPaidNewsletter,
+		selectedSite.ID,
+		shouldShownConfetti,
+		showConfetti,
+	] );
 
 	// Either content- or subscriber-import is still in progress
 	if ( importerStatus === 'importing' || importerStatus === 'initial' ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Previously, state would not get reset/end up in weird state if you would right-click copy the URL from any of the summary CTAs (`onClick` wouldn't run), OR click anything else around calypso sidebar.

This ensures state gets reset.

## Proposed Changes

* Resets the importer engine state on leaving the summary step IF the importer is finished. Otherwise should let leaving and not rest the state, and allow returning to see the state progressing.
* Removes clearing state on clicking summary CTAs.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
