### PR TITLE
Reader Recent Overhaul: Enable back button on mobile

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -492,7 +492,7 @@ export class FullPostView extends Component {
 					) }
 					{ referral && ! referralPost && <QueryReaderPost postKey={ referral } /> }
 					{ ! post || ( isLoading && <QueryReaderPost postKey={ postKey } /> ) }
-					{ isDefaultLayout && <BackButton onClick={ this.handleBack } /> }
+					<BackButton onClick={ this.handleBack } />
 					<div className="reader-full-post__visit-site-container">
 						<ExternalLink
 							icon

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -203,10 +203,10 @@
 			padding-bottom: 132px;
 		}
 
-		.reader-full-post__sidebar,
-		.reader-full-post__author-block,
 		.back-button {
-			display: none;
+			@media ( min-width: $break-wide ) {
+				display: none;
+			}
 		}
 
 		@media ( min-width: $break-wide ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/218

## Proposed Changes

* This PR enables the "Back" button on mobile to close the full-screen post and reshow the feed list.


https://github.com/user-attachments/assets/9424bab2-53d6-4cfa-a44a-7a456b2179e5



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Push the Reader /recent overhaul project forward.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read?flags=reader/recent-feed-overhaul in Calypso Live
* Switch to mobile view and various screen widths and use the Back button to close the full post view and get back to the posts list view.
* Wide screens should not have a Back button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
