### PR TITLE
Substack importer: translate success message

### DIFF
--- a/client/my-sites/importer/newsletter/subscribers/step-done.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-done.tsx
@@ -1,20 +1,29 @@
 import { Card } from '@automattic/components';
 import { Notice } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 import { SubscribersStepProps } from '../types';
 
 export default function StepDone( { cardData, nextStepUrl }: SubscribersStepProps ) {
-	const { __ } = useI18n();
+	const { __, _n } = useI18n();
 	const subscribedCount = parseInt( cardData?.meta?.email_count || '0' );
 
 	return (
 		<Card>
 			<h2>{ __( 'Import your subscribers to WordPress.com' ) }</h2>
 			<Notice status="success" className="importer__notice" isDismissible={ false }>
-				Success! { subscribedCount } subscribers have been added!
+				{ sprintf(
+					// Translators: %d is number of subscribers.
+					_n(
+						'Success! %d subscriber has been added!',
+						'Success! %d subscribers have been added!',
+						subscribedCount
+					),
+					subscribedCount
+				) }
 			</Notice>
-			<ImporterActionButton href={ nextStepUrl }>{ __( 'View Summary' ) }</ImporterActionButton>
+			<ImporterActionButton href={ nextStepUrl }>{ __( 'View summary' ) }</ImporterActionButton>
 		</Card>
 	);
 }

--- a/client/my-sites/importer/newsletter/subscribers/step-importing.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-importing.tsx
@@ -22,7 +22,7 @@ export default function StepImporting( { nextStepUrl }: SubscribersStepProps ) {
 			<p>
 				<ProgressBar className="is-larger-progress-bar" />
 			</p>
-			<ImporterActionButton href={ nextStepUrl }>{ __( 'View Summary' ) }</ImporterActionButton>
+			<ImporterActionButton href={ nextStepUrl }>{ __( 'View summary' ) }</ImporterActionButton>
 		</Card>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Translate success message
* Use sentence case, not title case for CTAs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
