### PR TITLE
Help Center: Update transfer to support

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { EllipsisMenu } from '@automattic/odie-client';
 import { useManageSupportInteraction } from '@automattic/odie-client/src/data';
+import { useSmooch } from '@automattic/zendesk-client/src/use-smooch';
 import { CardHeader, Button, Flex } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useMemo, useCallback } from '@wordpress/element';
@@ -12,6 +13,7 @@ import clsx from 'clsx';
 import { Route, Routes, useLocation, useSearchParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { matchSupportInteractionId } from '../components/utils';
 import { usePostByUrl } from '../hooks';
 import { useResetSupportInteraction } from '../hooks/use-reset-support-interaction';
 import { DragIcon } from '../icons';
@@ -94,22 +96,39 @@ const ChatEllipsisMenu = () => {
 	);
 };
 
-const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
+const GetHeaderText = () => {
 	const { __ } = useI18n();
 	const { pathname } = useLocation();
+	const { getConversations } = useSmooch();
+	const { currentSupportInteraction, isChatLoaded } = useSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		return {
+			isChatLoaded: store.getIsChatLoaded(),
+			currentSupportInteraction: store.getCurrentSupportInteraction(),
+		};
+	}, [] );
 
 	const shouldUseHelpCenterExperience = config.isEnabled( 'help-center-experience' );
-	const shouldDisplayClearChatButton =
-		shouldUseHelpCenterExperience && pathname.startsWith( '/odie' );
-	const isHelpCenterHome = pathname === '/';
+
+	const foundMatchingSupportConversation = matchSupportInteractionId(
+		getConversations,
+		isChatLoaded,
+		currentSupportInteraction
+	);
 
 	const headerText = useMemo( () => {
-		if ( pathname.startsWith( '/odie' ) ) {
-			return shouldUseHelpCenterExperience
-				? __( 'Support Assistant', __i18n_text_domain__ )
-				: __( 'Wapuu', __i18n_text_domain__ );
-		}
+		const odieHeader = () => {
+			if ( shouldUseHelpCenterExperience ) {
+				return foundMatchingSupportConversation
+					? __( 'Support Team', __i18n_text_domain__ )
+					: __( 'Support Assistant', __i18n_text_domain__ );
+			}
+			return __( 'Wapuu', __i18n_text_domain__ );
+		};
+
 		switch ( pathname ) {
+			case '/odie':
+				return odieHeader();
 			case '/contact-form':
 				return shouldUseHelpCenterExperience
 					? __( 'Support Assistant', __i18n_text_domain__ )
@@ -119,7 +138,21 @@ const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
 			default:
 				return __( 'Help Center', __i18n_text_domain__ );
 		}
-	}, [ __, pathname ] );
+	}, [ __, foundMatchingSupportConversation, pathname, shouldUseHelpCenterExperience ] );
+
+	return headerText;
+};
+
+const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
+	const { __ } = useI18n();
+	const { pathname } = useLocation();
+
+	const shouldUseHelpCenterExperience = config.isEnabled( 'help-center-experience' );
+	const shouldDisplayClearChatButton =
+		shouldUseHelpCenterExperience && pathname.startsWith( '/odie' );
+	const isHelpCenterHome = pathname === '/';
+
+	const headerText = GetHeaderText();
 
 	return (
 		<>

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -3,17 +3,16 @@ import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { EllipsisMenu } from '@automattic/odie-client';
 import { useManageSupportInteraction } from '@automattic/odie-client/src/data';
-import { useSmooch } from '@automattic/zendesk-client/src/use-smooch';
+import { clearHelpCenterZendeskConversationStarted } from '@automattic/odie-client/src/utils/storage-utils';
 import { CardHeader, Button, Flex } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useCallback, useEffect, useState } from '@wordpress/element';
 import { closeSmall, chevronUp, lineSolid, commentContent, page, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { Route, Routes, useLocation, useSearchParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { matchSupportInteractionId } from '../components/utils';
 import { usePostByUrl } from '../hooks';
 import { useResetSupportInteraction } from '../hooks/use-reset-support-interaction';
 import { DragIcon } from '../icons';
@@ -78,6 +77,7 @@ const ChatEllipsisMenu = () => {
 			event_source: 'help-center',
 			event_external_id: uuidv4(),
 		} );
+		clearHelpCenterZendeskConversationStarted();
 	};
 
 	return (
@@ -96,11 +96,11 @@ const ChatEllipsisMenu = () => {
 	);
 };
 
-const GetHeaderText = () => {
+const HeaderText = () => {
 	const { __ } = useI18n();
 	const { pathname } = useLocation();
-	const { getConversations } = useSmooch();
-	const { currentSupportInteraction, isChatLoaded } = useSelect( ( select ) => {
+	const [ isConversationWithZendesk, setIsConversationWithZendesk ] = useState< boolean >( false );
+	const { currentSupportInteraction } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
 			isChatLoaded: store.getIsChatLoaded(),
@@ -110,16 +110,23 @@ const GetHeaderText = () => {
 
 	const shouldUseHelpCenterExperience = config.isEnabled( 'help-center-experience' );
 
-	const foundMatchingSupportConversation = matchSupportInteractionId(
-		getConversations,
-		isChatLoaded,
-		currentSupportInteraction
-	);
+	useEffect( () => {
+		if ( currentSupportInteraction ) {
+			const zendeskEvent = currentSupportInteraction?.events.find(
+				( event ) => event.event_source === 'zendesk'
+			);
+			if ( zendeskEvent ) {
+				setIsConversationWithZendesk( true );
+			} else {
+				setIsConversationWithZendesk( false );
+			}
+		}
+	}, [ currentSupportInteraction ] );
 
 	const headerText = useMemo( () => {
 		const getOdieHeader = () => {
 			if ( shouldUseHelpCenterExperience ) {
-				return foundMatchingSupportConversation
+				return isConversationWithZendesk
 					? __( 'Support Team', __i18n_text_domain__ )
 					: __( 'Support Assistant', __i18n_text_domain__ );
 			}
@@ -138,9 +145,13 @@ const GetHeaderText = () => {
 			default:
 				return __( 'Help Center', __i18n_text_domain__ );
 		}
-	}, [ __, foundMatchingSupportConversation, pathname, shouldUseHelpCenterExperience ] );
+	}, [ __, isConversationWithZendesk, pathname, shouldUseHelpCenterExperience ] );
 
-	return headerText;
+	return (
+		<span id="header-text" role="presentation" className="help-center-header__text">
+			{ headerText }
+		</span>
+	);
 };
 
 const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
@@ -152,14 +163,10 @@ const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
 		shouldUseHelpCenterExperience && pathname.startsWith( '/odie' );
 	const isHelpCenterHome = pathname === '/';
 
-	const headerText = GetHeaderText();
-
 	return (
 		<>
 			{ isHelpCenterHome ? <DragIcon /> : <BackButton /> }
-			<span id="header-text" role="presentation" className="help-center-header__text">
-				{ headerText }
-			</span>
+			<HeaderText />
 			{ shouldDisplayClearChatButton && <ChatEllipsisMenu /> }
 			<Button
 				className="help-center-header__minimize"

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -117,7 +117,7 @@ const GetHeaderText = () => {
 	);
 
 	const headerText = useMemo( () => {
-		const odieHeader = () => {
+		const getOdieHeader = () => {
 			if ( shouldUseHelpCenterExperience ) {
 				return foundMatchingSupportConversation
 					? __( 'Support Team', __i18n_text_domain__ )
@@ -128,7 +128,7 @@ const GetHeaderText = () => {
 
 		switch ( pathname ) {
 			case '/odie':
-				return odieHeader();
+				return getOdieHeader();
 			case '/contact-form':
 				return shouldUseHelpCenterExperience
 					? __( 'Support Assistant', __i18n_text_domain__ )

--- a/packages/help-center/src/components/utils.tsx
+++ b/packages/help-center/src/components/utils.tsx
@@ -115,3 +115,21 @@ export const getConversationsFromSupportInteractions = (
 		)
 	);
 };
+
+export const matchSupportInteractionId = (
+	getConversations: () => ZendeskConversation[],
+	isChatLoaded: boolean,
+	currentSupportInteraction: SupportInteraction | undefined
+) => {
+	if ( currentSupportInteraction && isChatLoaded && getConversations ) {
+		const conversations = getConversations();
+		const getCurrentSupportInteractionId = currentSupportInteraction?.events.find(
+			( event ) => event.event_source === 'zendesk'
+		)?.event_external_id;
+		const foundMatch = conversations.find( ( conversation ) => {
+			return conversation.id === getCurrentSupportInteractionId;
+		} );
+
+		return foundMatch;
+	}
+};

--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -31,5 +31,5 @@
 }
 
 .help-center__container-chat .chatbox-messages .odie__transfer-to-human {
-	margin-left: 11%;
+	margin-left: 46px;
 }

--- a/packages/odie-client/src/components/message/index.tsx
+++ b/packages/odie-client/src/components/message/index.tsx
@@ -108,7 +108,12 @@ const MessageAvatarHeader = ( {
 	);
 };
 
-const ChatMessage = ( { message, currentUser, displayChatWithSupportLabel }: ChatMessageProps ) => {
+const ChatMessage = ( {
+	message,
+	currentUser,
+	displayChatWithSupportLabel,
+	isNextMessageFromSameSender,
+}: ChatMessageProps ) => {
 	const isBot = message.role === 'bot';
 	const { botName } = useOdieAssistantContext();
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
@@ -165,6 +170,7 @@ const ChatMessage = ( { message, currentUser, displayChatWithSupportLabel }: Cha
 				messageHeader={ messageHeader }
 				isDisliked={ isDisliked }
 				displayChatWithSupportLabel={ displayChatWithSupportLabel }
+				isNextMessageFromSameSender={ isNextMessageFromSameSender }
 			/>
 			{ isFullscreen && ReactDOM.createPortal( fullscreenContent, document.body ) }
 		</>

--- a/packages/odie-client/src/components/message/index.tsx
+++ b/packages/odie-client/src/components/message/index.tsx
@@ -108,7 +108,7 @@ const MessageAvatarHeader = ( {
 	);
 };
 
-const ChatMessage = ( { message, currentUser }: ChatMessageProps ) => {
+const ChatMessage = ( { message, currentUser, displayChatWithSupportLabel }: ChatMessageProps ) => {
 	const isBot = message.role === 'bot';
 	const { botName } = useOdieAssistantContext();
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
@@ -164,6 +164,7 @@ const ChatMessage = ( { message, currentUser }: ChatMessageProps ) => {
 				message={ message }
 				messageHeader={ messageHeader }
 				isDisliked={ isDisliked }
+				displayChatWithSupportLabel={ displayChatWithSupportLabel }
 			/>
 			{ isFullscreen && ReactDOM.createPortal( fullscreenContent, document.body ) }
 		</>

--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -27,7 +27,10 @@ export const MessageContent = ( {
 	const messageClasses = clsx(
 		'odie-chatbox-message',
 		`odie-chatbox-message-${ message.role }`,
-		`odie-chatbox-message-${ message.type ?? 'message' }`
+		`odie-chatbox-message-${ message.type ?? 'message' }`,
+		shouldUseHelpCenterExperience &&
+			message?.context?.flags?.show_ai_avatar === false &&
+			`odie-chatbox-message-no-avatar`
 	);
 	const containerClasses = clsx(
 		'odie-chatbox-message-sources-container',
@@ -42,7 +45,7 @@ export const MessageContent = ( {
 		<>
 			<div className={ containerClasses } data-is-message="true">
 				<div className={ messageClasses }>
-					{ messageHeader }
+					{ message?.context?.flags?.show_ai_avatar !== false && messageHeader }
 					{ message.type === 'error' && <ErrorMessage message={ message } /> }
 					{ ( [ 'message', 'image', 'file', 'text' ].includes( message.type ) ||
 						! message.type ) && (

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -81,6 +81,12 @@
 			list-style: initial;
 		}
 
+		&.odie-chatbox-message-no-avatar {
+			.odie-chatbox-message__content {
+				margin-left: 46px;
+			}
+		}
+
 		&.odie-chatbox-message-bot {
 			.odie-chatbox-message__content {
 				background-color: var(--studio-gray-0);

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -99,7 +99,6 @@
 		}
 
 		.chat-feedback-wrapper {
-			padding-top: 24px;
 			width: 100%;
 		}
 

--- a/packages/odie-client/src/constants.ts
+++ b/packages/odie-client/src/constants.ts
@@ -49,76 +49,59 @@ export const ODIE_FORWARD_TO_ZENDESK_MESSAGE = __(
 	__i18n_text_domain__
 );
 
-export const ODIE_TRANSFER_MESSAGE = (
-	shouldUseHelpCenterExperience: boolean | undefined
-): Message => ( {
-	content: shouldUseHelpCenterExperience
-		? __( "Help's on the way!", __i18n_text_domain__ )
-		: __( "We're connecting you to our support team.", __i18n_text_domain__ ),
-	role: 'bot',
-	type: 'message',
-	context: {
-		flags: {
-			hide_disclaimer_content: true,
-			show_contact_support_msg: true,
+export const ODIE_TRANSFER_MESSAGE: Message[] = [
+	{
+		content: __( "We're connecting you to our support team.", __i18n_text_domain__ ),
+		role: 'bot',
+		type: 'message',
+		context: {
+			flags: {
+				hide_disclaimer_content: true,
+				show_contact_support_msg: true,
+			},
+			site_id: null,
 		},
-		site_id: null,
 	},
-} );
+];
 
-export const ODIE_TRANSFER_MESSAGE_NEW = (
+export const ODIE_TRANSFER_MESSAGE_NEW: Message[] = [
+	{
+		content: __( "We're connecting you to our support team.", __i18n_text_domain__ ),
+		role: 'bot',
+		type: 'message',
+		context: {
+			flags: {
+				hide_disclaimer_content: true,
+				show_contact_support_msg: false,
+				show_ai_avatar: false,
+			},
+			site_id: null,
+		},
+	},
+	{
+		content: __(
+			"Meanwhile, feel free to include any additional information like screenshots or a detailed explanation of what's going wrong.",
+			__i18n_text_domain__
+		),
+		role: 'bot',
+		type: 'message',
+		context: {
+			flags: {
+				hide_disclaimer_content: true,
+				show_contact_support_msg: true,
+			},
+			site_id: null,
+		},
+	},
+];
+
+export const getOdieTransferMessageConstant = (
 	shouldUseHelpCenterExperience: boolean | undefined
-): Message[] => {
-	let transferMessage: Message[] = [];
+) => {
 	if ( shouldUseHelpCenterExperience ) {
-		transferMessage = [
-			{
-				content: __( "We're connecting you to our support team.", __i18n_text_domain__ ),
-				role: 'bot',
-				type: 'message',
-				context: {
-					flags: {
-						hide_disclaimer_content: true,
-						show_contact_support_msg: false,
-						show_ai_avatar: false,
-					},
-					site_id: null,
-				},
-			},
-			{
-				content: __(
-					"Meanwhile, feel free to include any additional information like screenshots or a detailed explanation of what's going wrong.",
-					__i18n_text_domain__
-				),
-				role: 'bot',
-				type: 'message',
-				context: {
-					flags: {
-						hide_disclaimer_content: true,
-						show_contact_support_msg: true,
-					},
-					site_id: null,
-				},
-			},
-		];
-	} else {
-		transferMessage = [
-			{
-				content: __( "We're connecting you to our support team.", __i18n_text_domain__ ),
-				role: 'bot',
-				type: 'message',
-				context: {
-					flags: {
-						hide_disclaimer_content: true,
-						show_contact_support_msg: true,
-					},
-					site_id: null,
-				},
-			},
-		];
+		return ODIE_TRANSFER_MESSAGE_NEW;
 	}
-
-	return transferMessage;
+	return ODIE_TRANSFER_MESSAGE;
 };
 
 export const ODIE_THUMBS_DOWN_RATING_VALUE = 0;

--- a/packages/odie-client/src/constants.ts
+++ b/packages/odie-client/src/constants.ts
@@ -66,7 +66,7 @@ export const ODIE_TRANSFER_MESSAGE: Message[] = [
 
 export const ODIE_TRANSFER_MESSAGE_NEW: Message[] = [
 	{
-		content: __( "We're connecting you to our support team.", __i18n_text_domain__ ),
+		content: __( "Help's on the way!", __i18n_text_domain__ ),
 		role: 'bot',
 		type: 'message',
 		context: {
@@ -80,7 +80,7 @@ export const ODIE_TRANSFER_MESSAGE_NEW: Message[] = [
 	},
 	{
 		content: __(
-			"Meanwhile, feel free to include any additional information like screenshots or a detailed explanation of what's going wrong.",
+			'Feel free to share more details while we connect you to support.',
 			__i18n_text_domain__
 		),
 		role: 'bot',

--- a/packages/odie-client/src/constants.ts
+++ b/packages/odie-client/src/constants.ts
@@ -66,6 +66,61 @@ export const ODIE_TRANSFER_MESSAGE = (
 	},
 } );
 
+export const ODIE_TRANSFER_MESSAGE_NEW = (
+	shouldUseHelpCenterExperience: boolean | undefined
+): Message[] => {
+	let transferMessage: Message[] = [];
+	if ( shouldUseHelpCenterExperience ) {
+		transferMessage = [
+			{
+				content: __( "We're connecting you to our support team.", __i18n_text_domain__ ),
+				role: 'bot',
+				type: 'message',
+				context: {
+					flags: {
+						hide_disclaimer_content: true,
+						show_contact_support_msg: false,
+						show_ai_avatar: false,
+					},
+					site_id: null,
+				},
+			},
+			{
+				content: __(
+					"Meanwhile, feel free to include any additional information like screenshots or a detailed explanation of what's going wrong.",
+					__i18n_text_domain__
+				),
+				role: 'bot',
+				type: 'message',
+				context: {
+					flags: {
+						hide_disclaimer_content: true,
+						show_contact_support_msg: true,
+					},
+					site_id: null,
+				},
+			},
+		];
+	} else {
+		transferMessage = [
+			{
+				content: __( "We're connecting you to our support team.", __i18n_text_domain__ ),
+				role: 'bot',
+				type: 'message',
+				context: {
+					flags: {
+						hide_disclaimer_content: true,
+						show_contact_support_msg: true,
+					},
+					site_id: null,
+				},
+			},
+		];
+	}
+
+	return transferMessage;
+};
+
 export const ODIE_THUMBS_DOWN_RATING_VALUE = 0;
 export const ODIE_THUMBS_UP_RATING_VALUE = 1;
 export const ODIE_ALLOWED_BOTS = [ 'wpcom-support-chat', 'wpcom-plan-support' ];

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -3,7 +3,7 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useUpdateZendeskUserFields } from '@automattic/zendesk-client';
 import { useSelect } from '@wordpress/data';
 import Smooch from 'smooch';
-import { ODIE_TRANSFER_MESSAGE } from '../constants';
+import { ODIE_TRANSFER_MESSAGE_NEW } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
 import { setHelpCenterZendeskConversationStarted } from '../utils';
@@ -34,7 +34,10 @@ export const useCreateZendeskConversation = (): ( () => Promise< void > ) => {
 
 		setChat( ( prevChat ) => ( {
 			...prevChat,
-			messages: [ ...prevChat.messages, ODIE_TRANSFER_MESSAGE( shouldUseHelpCenterExperience ) ],
+			messages: [
+				...prevChat.messages,
+				...ODIE_TRANSFER_MESSAGE_NEW( shouldUseHelpCenterExperience ),
+			],
 			status: 'transfer',
 		} ) );
 

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -3,7 +3,7 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useUpdateZendeskUserFields } from '@automattic/zendesk-client';
 import { useSelect } from '@wordpress/data';
 import Smooch from 'smooch';
-import { ODIE_TRANSFER_MESSAGE_NEW } from '../constants';
+import { getOdieTransferMessageConstant } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
 import { setHelpCenterZendeskConversationStarted } from '../utils';
@@ -36,7 +36,7 @@ export const useCreateZendeskConversation = (): ( () => Promise< void > ) => {
 			...prevChat,
 			messages: [
 				...prevChat.messages,
-				...ODIE_TRANSFER_MESSAGE_NEW( shouldUseHelpCenterExperience ),
+				...getOdieTransferMessageConstant( shouldUseHelpCenterExperience ),
 			],
 			status: 'transfer',
 		} ) );

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -2,7 +2,7 @@ import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import { ODIE_TRANSFER_MESSAGE } from '../constants';
+import { ODIE_TRANSFER_MESSAGE_NEW } from '../constants';
 import { emptyChat } from '../context';
 import { getZendeskConversation, useOdieChat } from '../data';
 import type { Chat, Message } from '../types';
@@ -58,7 +58,7 @@ export const useGetCombinedChat = ( shouldUseHelpCenterExperience: boolean | und
 							conversationId: conversation.id,
 							messages: [
 								...odieChat.messages,
-								ODIE_TRANSFER_MESSAGE( true ),
+								...ODIE_TRANSFER_MESSAGE_NEW( true ),
 								...( conversation.messages as Message[] ),
 							],
 							provider: 'zendesk',
@@ -83,6 +83,7 @@ export const useGetCombinedChat = ( shouldUseHelpCenterExperience: boolean | und
 		conversationId,
 		odieId,
 		currentSupportInteraction,
+		shouldUseHelpCenterExperience,
 	] );
 
 	return { mainChatState, setMainChatState };

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -2,7 +2,7 @@ import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import { ODIE_TRANSFER_MESSAGE_NEW } from '../constants';
+import { getOdieTransferMessageConstant } from '../constants';
 import { emptyChat } from '../context';
 import { getZendeskConversation, useOdieChat } from '../data';
 import type { Chat, Message } from '../types';
@@ -58,7 +58,7 @@ export const useGetCombinedChat = ( shouldUseHelpCenterExperience: boolean | und
 							conversationId: conversation.id,
 							messages: [
 								...odieChat.messages,
-								...ODIE_TRANSFER_MESSAGE_NEW( true ),
+								...getOdieTransferMessageConstant( true ),
 								...( conversation.messages as Message[] ),
 							],
 							provider: 'zendesk',

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -115,6 +115,7 @@ export type Context = {
 		canned_response?: boolean;
 		hide_disclaimer_content?: boolean;
 		show_contact_support_msg?: boolean;
+		show_ai_avatar?: boolean;
 	};
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9746

## Proposed Changes

* Update header text to `Support Team` when chatting with support.
* DIsplay `Chatting with support` message before the user is transferred to support chat.
* Update AI message before transferring the user to Support.

<img width="416" alt="CleanShot 2024-11-14 at 17 40 59@2x" src="https://github.com/user-attachments/assets/bf8adda2-cb2f-4f9f-8b40-7b9be0adf5cc">


https://github.com/user-attachments/assets/90dd4ca3-3017-46b8-9f91-dd8ef8e82098

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Update experience and improve clarity when the user is transferred from AI chat to Support chat.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Navigate to `/home?flags=help-center-experience`
* Open a new chat and verify the header text is `Support Assistant`
* Send a message `Support` and click the `Get instant support` from the AI response.
* Verify the header changes to `Support Team` and the `Chatting with support now` text appears above the initial support message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
