### PR TITLE
Substack importer: account for user skipping both steps

### DIFF
--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -47,6 +47,14 @@ $newsletter_importer_line-height: 20px;
 		clear: both;
 		margin-bottom: 12px;
 	}
+	.summary__content-skipped {
+		p {
+			margin-bottom: 6px;
+		}
+		.summary__content-stats-label {
+			color: var(--studio-gray-50);
+		}
+	}
 
 	/**
 	 * Summary table of numbers of posts/pages/subscribers imported

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -54,6 +54,9 @@ $newsletter_importer_line-height: 20px;
 		.summary__content-stats-label {
 			color: var(--studio-gray-50);
 		}
+		svg {
+			fill: var( --studio-gray-50 );
+		}
 	}
 
 	/**

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -100,8 +100,8 @@ export default function Summary( {
 	if ( importerStatus === 'skipped' ) {
 		return (
 			<Card>
-				<h2>{ __( 'Uh oh!' ) }</h2>
-				<p>
+				<h2>{ __( 'Summary' ) }</h2>
+				<div className="summary__content summary__content-skipped">
 					{ steps.content.content && (
 						<ContentSummary stepContent={ steps.content.content } status={ steps.content.status } />
 					) }
@@ -111,7 +111,7 @@ export default function Summary( {
 							status={ steps.subscribers.status }
 						/>
 					) }
-				</p>
+				</div>
 				<ImporterActionButtonContainer noSpacing>
 					<ImporterActionButton
 						href={ `/import/newsletter/substack/${ selectedSite.slug }/content?from=${ fromSite }` }

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -71,102 +71,134 @@ export default function Summary( {
 	// Combined status of subscriber & content importer
 	const importerStatus = getImporterStatus( steps.content.status, steps.subscribers.status );
 
-	return (
-		<Card>
-			{ importerStatus === 'done' ? (
-				<>
-					{ showConfetti && <ConfettiAnimation trigger={ ! prefersReducedMotion } /> }
-					<h2>{ __( 'Success!' ) } 🎉</h2>
-
-					<p>
-						{ sprintf(
-							// translators: %s the site name
-							__( 'Here’s a summary of the imported data to %s:' ),
-							selectedSite.name
-						) }
-					</p>
-					<div className="summary__content">
-						{ steps.content.content && (
-							<ContentSummary
-								stepContent={ steps.content.content }
-								status={ steps.content.status }
-							/>
-						) }
-						{ steps.subscribers.content && (
-							<SubscribersSummary
-								stepContent={ steps.subscribers.content }
-								status={ steps.subscribers.status }
-							/>
-						) }
-					</div>
-					{ showPauseSubstackBillingWarning && (
-						<Notice status="warning" className="importer__notice" isDismissible={ false }>
-							<h2>{ __( 'Action required' ) }</h2>
-							{ createInterpolateElement(
-								__(
-									'To prevent any charges from Substack, go to your <substackPaymentsSettingsLink>Substack Payments Settings</substackPaymentsSettingsLink>, select "Pause billing" and click "<strong>Pause indefinitely</strong>".'
-								),
-								{
-									strong: <strong />,
-									substackPaymentsSettingsLink: (
-										// @ts-expect-error Used in createInterpolateElement doesn't need children.
-										<ExternalLink
-											href={ `https://${ normalizeFromSite(
-												fromSite
-											) }/publish/settings?search=Pause%20subscription` }
-										/>
-									),
-								}
-							) }
-							<img
-								src={ pauseSubstackBillingImg }
-								alt={ __( 'Pause Substack billing' ) }
-								className="pause-billing"
-							/>
-						</Notice>
+	// Skipped both steps...
+	if ( importerStatus === 'skipped' ) {
+		return (
+			<Card>
+				<h2>{ __( "You skipped importing your site's content or subscribers." ) }</h2>
+				<p>
+					{ steps.content.content && (
+						<ContentSummary stepContent={ steps.content.content } status={ steps.content.status } />
 					) }
-					<hr />
-					<p>{ __( 'What would you like to do next?' ) }</p>
-					<ImporterActionButtonContainer noSpacing>
-						<ImporterActionButton
-							href={ '/settings/newsletter/' + selectedSite.slug }
-							onClick={ onButtonClick }
-							primary
-						>
-							{ __( 'Customize your newsletter' ) }
-						</ImporterActionButton>
-						<ImporterActionButton href={ '/posts/' + selectedSite.slug } onClick={ onButtonClick }>
-							{ __( 'View content' ) }
-						</ImporterActionButton>
-						<ImporterActionButton
-							href={ '/subscribers/' + selectedSite.slug }
-							onClick={ onButtonClick }
-						>
-							{ __( 'Check subscribers' ) }
-						</ImporterActionButton>
-					</ImporterActionButtonContainer>
-				</>
-			) : (
-				<>
-					<h2>{ __( 'Almost there…' ) }</h2>
-					<div className="summary__content">
-						<p>
-							<strong>
-								{ getSummaryDescription( steps.content.status, steps.subscribers.status ) }
-							</strong>
-							<br />
-						</p>
-					</div>
+					{ steps.subscribers.content && (
+						<SubscribersSummary
+							stepContent={ steps.subscribers.content }
+							status={ steps.subscribers.status }
+						/>
+					) }
+				</p>
+				<hr />
+				<p>{ __( 'What would you like to do next?' ) }</p>
+				<ImporterActionButtonContainer noSpacing>
+					<ImporterActionButton
+						href={ '/import/newsletter/' + selectedSite.slug }
+						onClick={ onButtonClick }
+						primary
+					>
+						{ __( 'Start over' ) }
+					</ImporterActionButton>
+				</ImporterActionButtonContainer>
+			</Card>
+		);
+	}
+
+	// Either content- or subscriber-import is still in progress
+	if ( importerStatus === 'importing' ) {
+		return (
+			<Card>
+				<h2>{ __( 'Almost there…' ) }</h2>
+				<div className="summary__content">
 					<p>
-						{ __(
-							"This may take a few minutes. Feel free to leave this window – we'll let you know when it's done."
+						<strong>
+							{ getSummaryDescription( steps.content.status, steps.subscribers.status ) }
+						</strong>
+						<br />
+					</p>
+				</div>
+				<p>
+					{ __(
+						"This may take a few minutes. Feel free to leave this window – we'll let you know when it's done."
+					) }
+				</p>
+				<p>
+					<ProgressBar className="is-larger-progress-bar" />
+				</p>
+			</Card>
+		);
+	}
+
+	// Both done!
+	if ( importerStatus === 'done' ) {
+		return (
+			<Card>
+				{ showConfetti && <ConfettiAnimation trigger={ ! prefersReducedMotion } /> }
+				<h2>{ __( 'Success!' ) } 🎉</h2>
+
+				<p>
+					{ sprintf(
+						// translators: %s the site name
+						__( 'Here’s a summary of the imported data to %s:' ),
+						selectedSite.name
+					) }
+				</p>
+				<div className="summary__content">
+					{ steps.content.content && (
+						<ContentSummary stepContent={ steps.content.content } status={ steps.content.status } />
+					) }
+					{ steps.subscribers.content && (
+						<SubscribersSummary
+							stepContent={ steps.subscribers.content }
+							status={ steps.subscribers.status }
+						/>
+					) }
+				</div>
+				{ showPauseSubstackBillingWarning && (
+					<Notice status="warning" className="importer__notice" isDismissible={ false }>
+						<h2>{ __( 'Action required' ) }</h2>
+						{ createInterpolateElement(
+							__(
+								'To prevent any charges from Substack, go to your <substackPaymentsSettingsLink>Substack Payments Settings</substackPaymentsSettingsLink>, select "Pause billing" and click "<strong>Pause indefinitely</strong>".'
+							),
+							{
+								strong: <strong />,
+								substackPaymentsSettingsLink: (
+									// @ts-expect-error Used in createInterpolateElement doesn't need children.
+									<ExternalLink
+										href={ `https://${ normalizeFromSite(
+											fromSite
+										) }/publish/settings?search=Pause%20subscription` }
+									/>
+								),
+							}
 						) }
-					</p>
-					<p>
-						<ProgressBar className="is-larger-progress-bar" />
-					</p>
-				</>
-			) }
-		</Card>
-	);
+						<img
+							src={ pauseSubstackBillingImg }
+							alt={ __( 'Pause Substack billing' ) }
+							className="pause-billing"
+						/>
+					</Notice>
+				) }
+				<hr />
+				<p>{ __( 'What would you like to do next?' ) }</p>
+				<ImporterActionButtonContainer noSpacing>
+					<ImporterActionButton
+						href={ '/settings/newsletter/' + selectedSite.slug }
+						onClick={ onButtonClick }
+						primary
+					>
+						{ __( 'Customize your newsletter' ) }
+					</ImporterActionButton>
+					<ImporterActionButton href={ '/posts/' + selectedSite.slug } onClick={ onButtonClick }>
+						{ __( 'View content' ) }
+					</ImporterActionButton>
+					<ImporterActionButton
+						href={ '/subscribers/' + selectedSite.slug }
+						onClick={ onButtonClick }
+					>
+						{ __( 'Check subscribers' ) }
+					</ImporterActionButton>
+				</ImporterActionButtonContainer>
+			</Card>
+		);
+	}
 }

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -71,6 +71,31 @@ export default function Summary( {
 	// Combined status of subscriber & content importer
 	const importerStatus = getImporterStatus( steps.content.status, steps.subscribers.status );
 
+	// Either content- or subscriber-import is still in progress
+	if ( importerStatus === 'importing' || importerStatus === 'initial' ) {
+		return (
+			<Card>
+				<h2>{ __( 'Almost there…' ) }</h2>
+				<div className="summary__content">
+					<p>
+						<strong>
+							{ getSummaryDescription( steps.content.status, steps.subscribers.status ) }
+						</strong>
+						<br />
+					</p>
+				</div>
+				<p>
+					{ __(
+						"This may take a few minutes. Feel free to leave this window – we'll let you know when it's done."
+					) }
+				</p>
+				<p>
+					<ProgressBar className="is-larger-progress-bar" />
+				</p>
+			</Card>
+		);
+	}
+
 	// Skipped both steps...
 	if ( importerStatus === 'skipped' ) {
 		return (
@@ -96,31 +121,6 @@ export default function Summary( {
 						{ __( 'Start over' ) }
 					</ImporterActionButton>
 				</ImporterActionButtonContainer>
-			</Card>
-		);
-	}
-
-	// Either content- or subscriber-import is still in progress
-	if ( importerStatus === 'importing' ) {
-		return (
-			<Card>
-				<h2>{ __( 'Almost there…' ) }</h2>
-				<div className="summary__content">
-					<p>
-						<strong>
-							{ getSummaryDescription( steps.content.status, steps.subscribers.status ) }
-						</strong>
-						<br />
-					</p>
-				</div>
-				<p>
-					{ __(
-						"This may take a few minutes. Feel free to leave this window – we'll let you know when it's done."
-					) }
-				</p>
-				<p>
-					<ProgressBar className="is-larger-progress-bar" />
-				</p>
 			</Card>
 		);
 	}

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -75,7 +75,7 @@ export default function Summary( {
 	if ( importerStatus === 'skipped' ) {
 		return (
 			<Card>
-				<h2>{ __( "You skipped importing your site's content or subscribers." ) }</h2>
+				<h2>{ __( 'Uh oh!' ) }</h2>
 				<p>
 					{ steps.content.content && (
 						<ContentSummary stepContent={ steps.content.content } status={ steps.content.status } />
@@ -87,11 +87,9 @@ export default function Summary( {
 						/>
 					) }
 				</p>
-				<hr />
-				<p>{ __( 'What would you like to do next?' ) }</p>
 				<ImporterActionButtonContainer noSpacing>
 					<ImporterActionButton
-						href={ '/import/newsletter/substack/' + selectedSite.slug }
+						href={ `/import/${ selectedSite.slug }` }
 						onClick={ onButtonClick }
 						primary
 					>

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -56,7 +56,7 @@ export default function Summary( {
 	const { resetPaidNewsletter } = useResetMutation();
 	const prefersReducedMotion = useReducedMotion();
 
-	const onButtonClick = () => resetPaidNewsletter( selectedSite.ID, engine, 'content' );
+	const resetImporter = () => resetPaidNewsletter( selectedSite.ID, engine, 'content' );
 	const paidSubscribersCount = parseInt(
 		steps.subscribers.content?.meta?.paid_subscribed_count || '0'
 	);
@@ -115,7 +115,7 @@ export default function Summary( {
 				<ImporterActionButtonContainer noSpacing>
 					<ImporterActionButton
 						href={ `/import/newsletter/substack/${ selectedSite.slug }/content?from=${ fromSite }` }
-						onClick={ onButtonClick }
+						onClick={ resetImporter }
 						primary
 					>
 						{ __( 'Start over' ) }
@@ -181,17 +181,17 @@ export default function Summary( {
 				<ImporterActionButtonContainer noSpacing>
 					<ImporterActionButton
 						href={ '/settings/newsletter/' + selectedSite.slug }
-						onClick={ onButtonClick }
+						onClick={ resetImporter }
 						primary
 					>
 						{ __( 'Customize your newsletter' ) }
 					</ImporterActionButton>
-					<ImporterActionButton href={ '/posts/' + selectedSite.slug } onClick={ onButtonClick }>
+					<ImporterActionButton href={ '/posts/' + selectedSite.slug } onClick={ resetImporter }>
 						{ __( 'View content' ) }
 					</ImporterActionButton>
 					<ImporterActionButton
 						href={ '/subscribers/' + selectedSite.slug }
-						onClick={ onButtonClick }
+						onClick={ resetImporter }
 					>
 						{ __( 'Check subscribers' ) }
 					</ImporterActionButton>

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -114,7 +114,7 @@ export default function Summary( {
 				</p>
 				<ImporterActionButtonContainer noSpacing>
 					<ImporterActionButton
-						href={ `/import/${ selectedSite.slug }` }
+						href={ `/import/newsletter/substack/${ selectedSite.slug }/content?from=${ fromSite }` }
 						onClick={ onButtonClick }
 						primary
 					>

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -91,7 +91,7 @@ export default function Summary( {
 				<p>{ __( 'What would you like to do next?' ) }</p>
 				<ImporterActionButtonContainer noSpacing>
 					<ImporterActionButton
-						href={ '/import/newsletter/' + selectedSite.slug }
+						href={ '/import/newsletter/substack/' + selectedSite.slug }
 						onClick={ onButtonClick }
 						primary
 					>

--- a/client/my-sites/importer/newsletter/summary/content.tsx
+++ b/client/my-sites/importer/newsletter/summary/content.tsx
@@ -1,5 +1,5 @@
 import { createInterpolateElement } from '@wordpress/element';
-import { verse, page, post, file } from '@wordpress/icons';
+import { verse, page, file, postFeaturedImage } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import {
 	ContentStepContent,
@@ -18,7 +18,7 @@ export default function ContentSummary( { status, stepContent }: ContentSummaryP
 		return (
 			<p>
 				<SummaryStat
-					icon={ post }
+					icon={ postFeaturedImage }
 					label={ createInterpolateElement(
 						__( 'You <strong>skipped</strong> content importing.' ),
 						{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Adds a summary state when both content and subscriber importing were skipped. I don't think many people will end up at this screen, but if they do, now it's not a dead end at least.

<img width="758" alt="image" src="https://github.com/user-attachments/assets/683a177e-a20f-4406-8797-dd986b65330a">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test Substack importer
* Skip both content and subscriber importers
* Start over

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
