### PR TITLE
Fix "Sign in as a different user" bug with passwordless account

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -510,6 +510,16 @@ export class JetpackAuthorize extends Component {
 				window.location.href = e.target.href;
 				break;
 			case this.isWooPasswordlessJPC():
+				// Logout user before redirecting to login page.
+				try {
+					await this.props.logoutUser();
+					disablePersistence();
+					await clearStore();
+				} catch ( error ) {
+					// The logout endpoint might fail if the nonce has expired.
+					// Clear wordpress_logged_in cookie to force logout.
+					document.cookie = 'wordpress_logged_in=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/';
+				}
 				recordTracksEvent( 'calypso_jpc_wc_coreprofiler_different_user_click' );
 				window.location.href = e.target.href;
 				break;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #96408 

## Proposed Changes

* Fixes a bug where the 'Sign in as a different user' flow renders the logged-in user instead.

When logging in with a passwordless account, the function at https://github.com/Automattic/wp-calypso/blob/trunk/client/login/controller.js#L141 redirects the user back to the logged-in page if they are already logged in. This effectively blocks the "Sign in as a different user" flow.

This PR addresses the issue by logging out the current user when they click "Sign in as a different user".

## Testing Instructions

1. Setup [woocommerce-start-dev-env](https://github.com/woocommerce/woocommerce-start-dev-env) with this branch. Make sure all hosts are configured. You should be able to access https://wordpress.com locally.
2. Run `yarn start`
3. Make sure you're signed-in on WPCOM.
4. Once the build is ready, visit this [link](https://wordpress.com/jetpack/connect/authorize?client_id=236381464&redirect_uri=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D32ab4c9508%26redirect%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A2ca8ea2582da1c066074563a12cc8b22&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=13.7&secret=QFoaAXaOIPZTr9p6Z5Hqf6RWkCboPylJ&blogname=Noisily+Fortunate+Toucan&site_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&home_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&site_icon&site_lang=en_US&site_created=2024-08-26+19%3A40%3A51&allow_site_connection=1&calypso_env=production&source&_as=search-term&_ak=jetpack&from=woocommerce-core-profiler&installed_ext_success=1&_ui=254662545&_ut=wpcom%3Auser_id&purchase_nonce=lbtPaOlO&_wp_nonce=69744335dc&redirect_after_auth=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja)
5. Click on "Sign in as a different" user.
6. Enter a passwordless account and click on "Continue"
7. You should see "Check your email" page.
8. Check your email for the magic login email.
9. Click on "Log in to WooCommerce"
10. You should be logged-in successfully. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
