### PR TITLE
Add more contrast to Plugins details border.

### DIFF
--- a/client/my-sites/plugins/plugin-details-sidebar/style.scss
+++ b/client/my-sites/plugins/plugin-details-sidebar/style.scss
@@ -16,6 +16,7 @@
 	border-width: 1px;
 	border-color: #eee;
 	border-bottom: none;
+	border-top: 2px solid var(--studio-gray-5);
 
 	.title {
 		color: var(--studio-gray-60);


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/96359

## Proposed Changes

![image](https://github.com/user-attachments/assets/49558b31-dfd0-462c-8d6d-7f73673ab19d)

![image](https://github.com/user-attachments/assets/427a385f-89db-48e4-ae0a-5d307995f4e8)

In the plugin details screen, the sections separator in the right-hand sidebar is barely visible.
We are just adding some contrast to it.

## Testing Instructions

Navigate to a plugin details screen, e.g. `https://wordpress.com/plugins/wordpress-seo-premium/:siteId`
The line between upper and lower section should be visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
