### PR TITLE
Reader Recent: Shrink site icon

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -499,29 +499,10 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 }
 
 .reader-full-post__header-meta {
-	width: 100%;
-	padding-top: 10px;
 	display: flex;
-	flex-wrap: wrap;
-
-	@media ( min-width: $break-wide ) {
-		display: block;
-		grid-column: 2;
-		grid-row: 2;
-		width: auto;
-		padding-top: 0;
-	}
-
-	span {
-		line-height: 1.6;
-		margin-right: 20px;
-		color: var( --color-text-subtle );
-		display: inline-block;
-	}
-
-	.reader-full-post__header-date {
-		margin-right: 0;
-	}
+	flex-direction: row;
+	font-size: $font-body;
+	max-width: 750px;
 }
 
 .reader-full-post__header-follow-count,
@@ -685,37 +666,37 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 .reader-full-post {
 	.reader-full-post__header--recent {
-		display: flex;
-		flex-wrap: wrap;
+		display: grid;
+		grid-template-columns: auto 1fr;
+		grid-template-rows: auto auto;
+		align-items: start;
 
-		@media ( min-width: $break-wide ) {
-			display: grid;
-			grid-template-columns: auto 1fr;
-			grid-template-rows: auto auto;
-			align-items: start;
+		@media ( max-width: ($break-wide - 1) ) {
+			display: flex;
+			flex-wrap: wrap;
 		}
 
 		.reader-full-post__header-site-icon {
-			flex-shrink: 0;
-			width: 40px;
-			margin-right: 15px;
+			grid-column: 1;
+			margin-right: 30px;
+			grid-row: 1 / 3;
+			align-self: center;
+			width: 80px;
 
-			@media ( min-width: $break-wide ) {
-				grid-column: 1;
-				margin-right: 30px;
-				grid-row: 1 / 3;
-				align-self: center;
-				width: 80px;
+			@media ( max-width: ($break-wide - 1) ) {
+				flex-shrink: 0;
+				width: 40px;
+				margin-right: 15px;
 			}
 
 			.reader-full-post__site-icon {
 				border-radius: 50%;
-				height: 40px;
-				width: 40px;
+				height: 80px;
+				width: 80px;
 
-				@media ( min-width: $break-wide ) {
-					height: 80px;
-					width: 80px;
+				@media ( max-width: ($break-wide - 1) ) {
+					height: 40px;
+					width: 40px;
 				}
 
 				&.is-missing-icon {
@@ -725,25 +706,23 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		}
 
 		.reader-full-post__header-title {
-			flex: 1;
-			min-width: 0;
+			grid-column: 2;
+			grid-row: 1;
 
-			@media ( min-width: $break-wide ) {
-				grid-column: 2;
-				grid-row: 1;
+			@media ( max-width: ($break-wide - 1) ) {
+				flex: 1;
+				min-width: 0;
 			}
 		}
 
 		.reader-full-post__header-meta {
-			width: 100%;
-			padding-top: 10px;
+			display: block;
+			grid-column: 2;
+			grid-row: 2;
 
-			@media ( min-width: $break-wide ) {
-				display: block;
-				grid-column: 2;
-				grid-row: 2;
-				width: auto;
-				padding-top: 0;
+			@media ( max-width: ($break-wide - 1) ) {
+				width: 100%;
+				padding-top: 10px;
 			}
 
 			span {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -671,6 +671,11 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		grid-template-rows: auto auto;
 		align-items: start;
 
+		@media ( max-width: $break-wide ) {
+			display: flex;
+			flex-wrap: wrap;
+		}
+
 		.reader-full-post__header-site-icon {
 			grid-column: 1;
 			margin-right: 30px;
@@ -678,25 +683,47 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 			align-self: center;
 			width: 80px;
 
+			@media ( max-width: $break-wide ) {
+				flex-shrink: 0;
+				width: 40px;
+				margin-right: 15px;
+			}
+
 			.reader-full-post__site-icon {
 				border-radius: 50%;
 				height: 80px;
 				width: 80px;
+
+				@media ( max-width: $break-wide ) {
+					height: 40px;
+					width: 40px;
+				}
 
 				&.is-missing-icon {
 					color: var( --color-neutral-70 );
 				}
 			}
 		}
+
 		.reader-full-post__header-title {
 			grid-column: 2;
 			grid-row: 1;
+
+			@media ( max-width: $break-wide ) {
+				flex: 1;
+				min-width: 0;
+			}
 		}
 
 		.reader-full-post__header-meta {
 			display: block;
 			grid-column: 2;
 			grid-row: 2;
+
+			@media ( max-width: $break-wide ) {
+				width: 100%;
+				padding-top: 10px;
+			}
 
 			span {
 				line-height: 1.6;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -682,11 +682,17 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 			grid-row: 1 / 3;
 			align-self: center;
 			width: 80px;
+			height: 80px;
 
 			@media ( max-width: ($break-wide - 1) ) {
 				flex-shrink: 0;
 				width: 40px;
+				height: 40px;
 				margin-right: 15px;
+			}
+
+			.reader-full-post__header-site-icon-link {
+				line-height: 0;
 			}
 
 			.reader-full-post__site-icon {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -499,10 +499,29 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 }
 
 .reader-full-post__header-meta {
+	width: 100%;
+	padding-top: 10px;
 	display: flex;
-	flex-direction: row;
-	font-size: $font-body;
-	max-width: 750px;
+	flex-wrap: wrap;
+
+	@media ( min-width: $break-wide ) {
+		display: block;
+		grid-column: 2;
+		grid-row: 2;
+		width: auto;
+		padding-top: 0;
+	}
+
+	span {
+		line-height: 1.6;
+		margin-right: 20px;
+		color: var( --color-text-subtle );
+		display: inline-block;
+	}
+
+	.reader-full-post__header-date {
+		margin-right: 0;
+	}
 }
 
 .reader-full-post__header-follow-count,
@@ -666,37 +685,37 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 .reader-full-post {
 	.reader-full-post__header--recent {
-		display: grid;
-		grid-template-columns: auto 1fr;
-		grid-template-rows: auto auto;
-		align-items: start;
+		display: flex;
+		flex-wrap: wrap;
 
-		@media ( max-width: $break-wide ) {
-			display: flex;
-			flex-wrap: wrap;
+		@media ( min-width: $break-wide ) {
+			display: grid;
+			grid-template-columns: auto 1fr;
+			grid-template-rows: auto auto;
+			align-items: start;
 		}
 
 		.reader-full-post__header-site-icon {
-			grid-column: 1;
-			margin-right: 30px;
-			grid-row: 1 / 3;
-			align-self: center;
-			width: 80px;
+			flex-shrink: 0;
+			width: 40px;
+			margin-right: 15px;
 
-			@media ( max-width: $break-wide ) {
-				flex-shrink: 0;
-				width: 40px;
-				margin-right: 15px;
+			@media ( min-width: $break-wide ) {
+				grid-column: 1;
+				margin-right: 30px;
+				grid-row: 1 / 3;
+				align-self: center;
+				width: 80px;
 			}
 
 			.reader-full-post__site-icon {
 				border-radius: 50%;
-				height: 80px;
-				width: 80px;
+				height: 40px;
+				width: 40px;
 
-				@media ( max-width: $break-wide ) {
-					height: 40px;
-					width: 40px;
+				@media ( min-width: $break-wide ) {
+					height: 80px;
+					width: 80px;
 				}
 
 				&.is-missing-icon {
@@ -706,23 +725,25 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		}
 
 		.reader-full-post__header-title {
-			grid-column: 2;
-			grid-row: 1;
+			flex: 1;
+			min-width: 0;
 
-			@media ( max-width: $break-wide ) {
-				flex: 1;
-				min-width: 0;
+			@media ( min-width: $break-wide ) {
+				grid-column: 2;
+				grid-row: 1;
 			}
 		}
 
 		.reader-full-post__header-meta {
-			display: block;
-			grid-column: 2;
-			grid-row: 2;
+			width: 100%;
+			padding-top: 10px;
 
-			@media ( max-width: $break-wide ) {
-				width: 100%;
-				padding-top: 10px;
+			@media ( min-width: $break-wide ) {
+				display: block;
+				grid-column: 2;
+				grid-row: 2;
+				width: auto;
+				padding-top: 0;
 			}
 
 			span {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/218

## Proposed Changes

* This PR shrinks the site icon so the header takes up less space on mobile.


Before | After
--|--
<img width="388" alt="Screenshot 2024-11-14 at 3 42 31 PM" src="https://github.com/user-attachments/assets/ec8609fc-353a-4484-bbe6-a7e9f7e1a70e">  |  <img width="385" alt="Screenshot 2024-11-14 at 3 41 49 PM" src="https://github.com/user-attachments/assets/a0cf406d-5744-4d2b-9543-2327cc86d8fd">


Demo


https://github.com/user-attachments/assets/18104e23-c948-490f-b901-f56031b9b19b


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve mobile view.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live and go to /read?flags=reader/recent-feed-overhaul
* Click on a post
* View that the site icon decreases in size on mobile and smaller widths
* View various posts and confirm the full-page post header looks ok.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
