### PR TITLE
Performance Profiler: Update shared events to have the `version` prop

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -227,6 +227,7 @@ export const SitePerformance = () => {
 		if ( performanceReport.isBasicMetricsFetched && performanceReport.url ) {
 			recordTracksEvent( 'calypso_performance_profiler_test_started', {
 				url: performanceReport.url,
+				version: profilerVersion(),
 			} );
 		}
 	}, [ performanceReport.isBasicMetricsFetched, performanceReport.url ] );

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -9,6 +9,7 @@ import {
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { LLMMessage } from 'calypso/performance-profiler/components/llm-message';
 import { ThumbsUpIcon, ThumbsDownIcon } from 'calypso/performance-profiler/icons/thumbs';
+import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
 import { InsightDetailedContent } from './insight-detailed-content';
 
 interface InsightContentProps {
@@ -31,6 +32,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 			rating,
 			description,
 			...( userFeedback && { user_feedback: userFeedback } ),
+			version: profilerVersion(),
 		} );
 
 		setFeedbackSent( true );

--- a/client/performance-profiler/components/tip/index.tsx
+++ b/client/performance-profiler/components/tip/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
 
 export type TipProps = {
 	title: string;
@@ -15,6 +16,7 @@ export const Tip = ( { title, content, link, linkText }: TipProps ) => {
 	const handleLearnMoreClick = () => {
 		recordTracksEvent( 'calypso_performance_profiler_tip_learn_more_clicked', {
 			link: link,
+			version: profilerVersion(),
 		} );
 	};
 

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -13,6 +13,7 @@ import {
 	MessageDisplay,
 	ErrorSecondLine,
 } from 'calypso/performance-profiler/components/message-display';
+import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
 import { updateQueryParams } from 'calypso/performance-profiler/utils/query-params';
 import { LoadingScreen } from '../loading-screen';
 
@@ -50,6 +51,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 	if ( isFetched && finalUrl ) {
 		recordTracksEvent( 'calypso_performance_profiler_test_started', {
 			url: finalUrl,
+			version: profilerVersion(),
 		} );
 		testStartTime.current = Date.now();
 	}

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -87,6 +87,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 			duration: Date.now() - testStartTime.current,
 			mobile_score: mobileReport?.overall_score,
 			desktop_score: desktopReport?.overall_score,
+			version: profilerVersion(),
 		} );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9834

## Proposed Changes

* Add `version` props to shared events

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To easily track events executed from both versions of the performance profiler

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* None

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
