### PR TITLE
Improve plugin details performance

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -8,6 +8,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
+import QueryJetpackSitesFeatures from 'calypso/components/data/query-jetpack-sites-features';
 import QueryPlugins from 'calypso/components/data/query-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
@@ -366,7 +367,11 @@ function PluginDetails( props ) {
 			/>
 			<QueryPlugins siteId={ selectedSite?.ID } />
 			<QueryEligibility siteId={ selectedSite?.ID } />
-			<QuerySiteFeatures siteIds={ selectedOrAllSites.map( ( site ) => site.ID ) } />
+			{ selectedOrAllSites && 1 === selectedOrAllSites.length ? (
+				<QuerySiteFeatures siteIds={ selectedOrAllSites.map( ( site ) => site.ID ) } />
+			) : (
+				<QueryJetpackSitesFeatures />
+			) }
 			<QueryProductsList persist={ ! wporgPluginNotFound } />
 			<QueryUserPurchases />
 			<QuerySitePurchases siteId={ selectedSite?.ID } />

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -78,7 +78,6 @@ export default function PluginRowFormatter( {
 		};
 
 	const moment = useLocalizedMoment();
-	const state = useSelector( ( state ) => state );
 
 	const ago = ( date: MomentInput ) => {
 		return moment.utc( date, 'YYYY-MM-DD hh:mma' ).fromNow();
@@ -92,8 +91,11 @@ export default function PluginRowFormatter( {
 			selectedSite && isPluginActionInProgress( state, selectedSite.ID, pluginId, INSTALL_PLUGIN )
 	);
 
+	const { activation, autoupdate } = useSelector( ( state ) =>
+		getAllowedPluginActions( item, state, selectedSite )
+	);
+
 	if ( selectedSite ) {
-		const { activation, autoupdate } = getAllowedPluginActions( item, state, selectedSite );
 		canActivate = activation;
 		canUpdate = autoupdate;
 	}
@@ -104,7 +106,8 @@ export default function PluginRowFormatter( {
 
 	const siteCount = item?.sites && Object.keys( item.sites ).length;
 
-	const allStatuses = getPluginActionStatuses( state );
+	const isFromMarketplace = useSelector( ( state ) => isMarketplaceProduct( state, item?.slug ) );
+	const allStatuses = useSelector( ( state ) => getPluginActionStatuses( state ) );
 
 	let currentSiteStatuses = allStatuses.filter(
 		( status ) => status.pluginId === pluginId && status.action !== UPDATE_PLUGIN
@@ -224,7 +227,7 @@ export default function PluginRowFormatter( {
 						plugin={ pluginOnSite }
 						site={ selectedSite }
 						wporg={ !! item.wporg }
-						isMarketplaceProduct={ isMarketplaceProduct( state, item?.slug ) }
+						isMarketplaceProduct={ isFromMarketplace }
 						disabled={ !! item?.isSelectable }
 					/>
 				</div>

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-common-card.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-common-card.test.tsx
@@ -41,6 +41,7 @@ const initialState = {
 			interval: 'yearly',
 		},
 	},
+	productsList: [],
 };
 
 const props = {

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-common-table.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-common-table.test.tsx
@@ -41,6 +41,7 @@ const initialState = {
 			interval: 'yearly',
 		},
 	},
+	productsList: [],
 };
 
 const props = {

--- a/client/my-sites/plugins/plugin-management-v2/test/update-plugin.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/update-plugin.test.tsx
@@ -168,6 +168,11 @@ describe( '<UpdatePlugin>', () => {
 
 	test( 'should render correctly and show auto-managed', () => {
 		site.jetpack = false;
+		const updatedInitialState = {
+			...initialState,
+		};
+
+		const store = mockStore( updatedInitialState );
 		const { getAllByText } = render(
 			<Provider store={ store }>
 				<UpdatePlugin { ...props } />

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
@@ -1,4 +1,5 @@
 import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
+import { createSelector } from '@wordpress/data';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -6,22 +7,20 @@ import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { AppState } from 'calypso/types';
 
-export const getAllowedPluginActions = (
-	plugin: PluginComponentProps,
-	state: AppState,
-	selectedSite?: SiteDetails
-) => {
-	const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
-	const siteIsAtomic = selectedSite && isSiteAutomatedTransfer( state, selectedSite?.ID );
-	const siteIsJetpack = selectedSite && isJetpackSite( state, selectedSite?.ID );
-	const hasManagePlugins =
-		selectedSite && siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
-	const isManagedPlugin = siteIsAtomic && autoManagedPlugins.includes( plugin.slug );
-	const canManagePlugins =
-		! selectedSite || ( siteIsJetpack && ! siteIsAtomic ) || ( siteIsAtomic && hasManagePlugins );
+export const getAllowedPluginActions = createSelector(
+	( plugin: PluginComponentProps, state: AppState, selectedSite?: SiteDetails ) => {
+		const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
+		const siteIsAtomic = selectedSite && isSiteAutomatedTransfer( state, selectedSite?.ID );
+		const siteIsJetpack = selectedSite && isJetpackSite( state, selectedSite?.ID );
+		const hasManagePlugins =
+			selectedSite && siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
+		const isManagedPlugin = siteIsAtomic && autoManagedPlugins.includes( plugin.slug );
+		const canManagePlugins =
+			! selectedSite || ( siteIsJetpack && ! siteIsAtomic ) || ( siteIsAtomic && hasManagePlugins );
 
-	return {
-		autoupdate: ! isManagedPlugin && canManagePlugins,
-		activation: ! isManagedPlugin && canManagePlugins,
-	};
-};
+		return {
+			autoupdate: ! isManagedPlugin && canManagePlugins,
+			activation: ! isManagedPlugin && canManagePlugins,
+		};
+	}
+);

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-statuses.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-statuses.ts
@@ -1,10 +1,11 @@
+import { createSelector } from '@wordpress/data';
 import { getPluginStatusesByType } from 'calypso/state/plugins/installed/selectors';
 import type { AppState } from 'calypso/types';
 
 /**
  * Returns an array of all plugin action statuses(inProgress, completed, error)
  */
-export const getPluginActionStatuses = ( state: AppState ) => {
+export const getPluginActionStatuses = createSelector( ( state: AppState ) => {
 	const inProgressStatuses = getPluginStatusesByType( state, 'inProgress' );
 	const completedStatuses = getPluginStatusesByType( state, 'completed' );
 	const incompletedStatuses = getPluginStatusesByType( state, 'incompleted' );
@@ -18,4 +19,4 @@ export const getPluginActionStatuses = ( state: AppState ) => {
 		...incompletedStatuses,
 		...uptoDateStatuses,
 	];
-};
+} );

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -124,11 +124,7 @@ function getPluginsSelector( state, siteIds, pluginFilter ) {
 
 export const getPlugins = createSelector(
 	getPluginsSelector,
-	( state, siteIds ) => [
-		state.plugins.installed.plugins,
-		isRequestingForAllSites( state ),
-		...siteIds.map( ( siteId ) => isRequesting( state, siteId ) ),
-	],
+	( state ) => state.plugins.installed.plugins,
 	( state, siteIds, pluginFilter ) => {
 		return [ siteIds, pluginFilter ].flat().join( '-' );
 	}

--- a/client/state/sites/features/reducer.js
+++ b/client/state/sites/features/reducer.js
@@ -37,7 +37,7 @@ function updateBulkFeatures( state, features ) {
 		newState[ siteId ] = {
 			...initialSiteState,
 			hasLoadedFromServer: true,
-			data: features,
+			data: features[ siteId ],
 		};
 	}
 	return { ...state, ...newState };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9731


## Proposed Changes

* We're increasing the plugin's global marketplace navigation speed by:
  - Modifying `getPlugins` to not return empty results when loading plugins.
  - Using site features bulk update
  - Fixing a bug that didn't properly store bulk features for a site
  - Avoiding unnecessary re-renders by misusage of state

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Project related: pet6gk-1CP-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate through [the new /plugins/manage](https://wordpress.com/plugins/manage?flags=bulk-plugin-management) and ensure it's faster than the previous version.
* Test the normal plugin navigation (outside the /plugins/manage scope) to ensure everything is fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?