### PR TITLE
Stats: Avoid restricting access for Growth plan owners

### DIFF
--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -81,10 +81,6 @@ export const hasSecurityPlan = ( ownedPurchases: Purchase[] ) => {
 	return areProductsOwned( ownedPurchases, [ ...JETPACK_SECURITY_PLANS ] );
 };
 
-export const hasGrowthPlan = ( ownedPurchases: Purchase[] ) => {
-	return areProductsOwned( ownedPurchases, [ ...JETPACK_GROWTH_PLANS ] );
-};
-
 export const hasSupportedCommercialUse = ( state: object, siteId: number | null ) => {
 	const sitePurchases = getSitePurchases( state, siteId );
 

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -59,8 +59,8 @@ const isCommercialPurchaseOwned = ( ownedPurchases: Purchase[] ) => {
 const supportCommercialPurchaseUse = ( ownedPurchases: Purchase[] ) => {
 	return (
 		isCommercialPurchaseOwned( ownedPurchases ) ||
-		[ ...JETPACK_BUSINESS_PLANS, ...JETPACK_COMPLETE_PLANS ].some( ( plan ) =>
-			isProductOwned( ownedPurchases, plan )
+		[ ...JETPACK_BUSINESS_PLANS, ...JETPACK_COMPLETE_PLANS, ...JETPACK_GROWTH_PLANS ].some(
+			( plan ) => isProductOwned( ownedPurchases, plan )
 		)
 	);
 };

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -12,7 +12,12 @@ import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purch
 import { useSelector } from 'calypso/state';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { hasBusinessPlan, hasCompletePlan, hasSecurityPlan } from '../hooks/use-stats-purchases';
+import {
+	hasBusinessPlan,
+	hasCompletePlan,
+	hasSecurityPlan,
+	hasGrowthPlan,
+} from '../hooks/use-stats-purchases';
 import usePurchasedProducts from './use-purchased-products';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
@@ -33,8 +38,9 @@ function shouldHideUpsellSection( purchases: Purchase[] ) {
 
 	const hasBusiness = hasBusinessPlan( purchases );
 	const hasComplete = hasCompletePlan( purchases );
+	const hasGrowth = hasGrowthPlan( purchases );
 
-	return hasBusiness || hasComplete;
+	return hasBusiness || hasComplete || hasGrowth;
 }
 
 function bundledProductsFromPurchases( purchases: Purchase[] ) {

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -12,12 +12,7 @@ import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purch
 import { useSelector } from 'calypso/state';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import {
-	hasBusinessPlan,
-	hasCompletePlan,
-	hasSecurityPlan,
-	hasGrowthPlan,
-} from '../hooks/use-stats-purchases';
+import { hasBusinessPlan, hasCompletePlan, hasSecurityPlan } from '../hooks/use-stats-purchases';
 import usePurchasedProducts from './use-purchased-products';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
@@ -38,9 +33,8 @@ function shouldHideUpsellSection( purchases: Purchase[] ) {
 
 	const hasBusiness = hasBusinessPlan( purchases );
 	const hasComplete = hasCompletePlan( purchases );
-	const hasGrowth = hasGrowthPlan( purchases );
 
-	return hasBusiness || hasComplete || hasGrowth;
+	return hasBusiness || hasComplete;
 }
 
 function bundledProductsFromPurchases( purchases: Purchase[] ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/1986

## Proposed Changes

* Show all Stats modules for Growth plan owners

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Setting up Stats to work with the Growth plan owners

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* follow Oyssey testing instructions PCYsg-Pp7-p2 (Option 2)
* crate a JN site
* connect Jetpack and the user
* use the free plan and go to stats. Verify that UTM module requires a plan upgrade
* purchase the new Growth plan for this JN site
* verify that when you navigate to Stats, all modules are unrestricted like on the screenshot below (sandboxed store might take some time to apply the purchase information, so use the real one)

| Before | After |
| --- | --- |
| ![SCR-20241115-lwwq](https://github.com/user-attachments/assets/aab60b16-dd04-4fdb-814a-864b1dff7334) | ![SCR-20241115-lzpe](https://github.com/user-attachments/assets/74044373-7aeb-4353-86be-e964234c0dfb) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?