### PR TITLE
Stats Notice: use site feature checks for Jetpack sites too

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -90,13 +90,13 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		( state ) => getSelectedSite( state )?.site_owner === TEAM51_OWNER_ID
 	);
 
-	const wpcomSiteHasPaidStatsFeature = useSelector(
-		( state ) => isWpcom && siteHasFeature( state, siteId, FEATURE_STATS_PAID )
+	const siteHasPaidStatsFeature = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, FEATURE_STATS_PAID )
 	);
 
 	const hasPaidStats =
 		useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) ) ||
-		wpcomSiteHasPaidStatsFeature;
+		siteHasPaidStatsFeature;
 	const hasFreeStats = useSelector( ( state ) => hasSiteProductJetpackStatsFree( state, siteId ) );
 
 	const { isRequestingSitePurchases, isCommercialOwned, supportCommercialUse } =
@@ -145,6 +145,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		showPaywallNotice,
 		isNearLimit,
 		isOverLimit,
+		supportCommercialUse,
 	};
 
 	const { isLoading, isError, data: serverNoticesVisibility } = useNoticesVisibilityQuery( siteId );

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -145,7 +145,6 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		showPaywallNotice,
 		isNearLimit,
 		isOverLimit,
-		supportCommercialUse,
 	};
 
 	const { isLoading, isError, data: serverNoticesVisibility } = useNoticesVisibilityQuery( siteId );


### PR DESCRIPTION

Related to p1731530921199019-slack-C82FZ5T4G

## Proposed Changes

* Check site feature for Jetpack sites too

## Why are these changes being made?

* Leverage feature checks

## Testing Instructions


* Purchase and assign a Growth bundle `https://wordpress.com/checkout/jetpack/jetpack_growth_monthly` and assign it to a site
* Remove other plans from the site
* Toggle the site to Commercial from JP Tools
* Open Calypso Live `/stats/day/:slug`
* Ensure you don't see a commercial upgrade notice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?