### PR TITLE
Goals Step: Add `is_goals_big_sky_eligible` prop to goals selection event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -5,6 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
@@ -26,6 +27,7 @@ type TracksGoalsSelectEventProperties = {
 	total: number;
 	ref?: string;
 	intent: string;
+	is_goals_big_sky_eligible: boolean;
 } & {
 	[ key in Onboard.SiteGoal as KebabToSnakeCase< key > ]?: number;
 };
@@ -75,15 +77,16 @@ const GoalsStep: Step = ( { navigation } ) => {
 		intent: Onboard.SiteIntent
 	) => {
 		const commonEventProps = {
-			intent,
 			ref: refParameter ?? null,
 		};
 
 		const goalsSelectProperties: TracksGoalsSelectEventProperties = {
 			...commonEventProps,
+			intent,
 			goals: serializeGoals( goals ),
 			combo: goals.sort().join( ',' ),
 			total: goals.length,
+			is_goals_big_sky_eligible: isGoalsBigSkyEligible( goals ),
 		};
 
 		goals.forEach( ( goal, i ) => {
@@ -92,8 +95,8 @@ const GoalsStep: Step = ( { navigation } ) => {
 			goalsSelectProperties[ snakeCaseGoal ] = i + 1;
 
 			recordTracksEvent( 'calypso_signup_goals_single_select', {
+				...commonEventProps,
 				goal,
-				ref: commonEventProps.ref,
 			} );
 		} );
 

--- a/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
@@ -31,12 +31,17 @@ export function useIsBigSkyEligible() {
 		[ site ]
 	);
 
-	const hasInvalidGoal = goals.some( ( value ) => invalidGoals.includes( value ) );
+	const isEligibleGoals = isGoalsBigSkyEligible( goals );
 	const isEligiblePlan = isPremiumPlan( product_slug ) || isBusinessPlan( product_slug );
 
 	const eligibilityResult =
-		( featureFlagEnabled && isOwner && isEligiblePlan && ! hasInvalidGoal && onSupportedDevice ) ||
+		( featureFlagEnabled && isOwner && isEligiblePlan && isEligibleGoals && onSupportedDevice ) ||
 		false;
 
 	return { isLoading: false, isEligible: eligibilityResult };
+}
+
+export function isGoalsBigSkyEligible( goals: Onboard.SiteGoal[] ) {
+	const hasInvalidGoal = goals.some( ( value ) => invalidGoals.includes( value ) );
+	return ! hasInvalidGoal;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Adds a `is_goals_big_sky_eligible` prop to the `calypso_signup_goals_select` event, which signifies whether the client believed this goal selection made the user eligible/ineligible for Big Sky

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

A request from @isatuncman-auto to make analysing Big Sky usage easier. It's easier to send this prop than to filter by eligible goals selection later, and it would be hard to ensure the logic stays in sync.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to the `/setup/site-setup?siteSlug={{ site slug }}`
- Make a selection of goals and submit the step
- Observe the `calypso_signup_goals_select` event that gets sent, and confirm it has the correct `is_goals_big_sky_eligible` prop value based on the ineligible goals documented here: peGwbA-2BZ-p2#comment-3986

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?