### PR TITLE
A4A > Migrations: Implement the self migration tool

### DIFF
--- a/client/a8c-for-agencies/components/task-steps/index.tsx
+++ b/client/a8c-for-agencies/components/task-steps/index.tsx
@@ -23,7 +23,7 @@ export interface TaskStepItem {
 
 interface TaskStepProps {
 	step: TaskStepItem;
-	markAsDone: ( step: TaskStepItem ) => void;
+	toggleTaskStatus: ( step: TaskStepItem ) => void;
 }
 
 interface TaskStepsProps {
@@ -33,7 +33,7 @@ interface TaskStepsProps {
 	sessionStorageKey: string;
 }
 
-export function TaskStep( { step, markAsDone }: TaskStepProps ) {
+export function TaskStep( { step, toggleTaskStatus }: TaskStepProps ) {
 	const translate = useTranslate();
 
 	return (
@@ -64,12 +64,8 @@ export function TaskStep( { step, markAsDone }: TaskStepProps ) {
 							{ step.buttonProps.icon && <Icon icon={ step.buttonProps.icon } size={ 24 } /> }
 						</Button>
 					) }
-					<Button
-						onClick={ () => markAsDone( step ) }
-						variant="secondary"
-						disabled={ step.isCompleted }
-					>
-						{ translate( 'Mark as done' ) }
+					<Button onClick={ () => toggleTaskStatus( step ) } variant="secondary">
+						{ step.isCompleted ? translate( 'Reset task' ) : translate( 'Mark as done' ) }
 					</Button>
 				</div>
 			</>
@@ -90,13 +86,15 @@ export function TaskSteps( { heading, subheading, steps, sessionStorageKey }: Ta
 		};
 	} );
 
-	const markAsDone = ( step: TaskStepItem ) => {
-		const updatedStepIds = [ ...completedStepIds, step.stepId ];
+	const toggleTaskStatus = ( step: TaskStepItem ) => {
+		const updatedStepIds = completedStepIds.includes( step.stepId )
+			? completedStepIds.filter( ( id ) => id !== step.stepId )
+			: [ ...completedStepIds, step.stepId ];
 		setCompletedStepIds( updatedStepIds );
 		sessionStorage.setItem( sessionStorageKey, JSON.stringify( updatedStepIds ) );
 	};
 
-	const resetTasks = () => {
+	const resetAllTasks = () => {
 		setCompletedStepIds( [] );
 		sessionStorage.removeItem( sessionStorageKey );
 	};
@@ -108,13 +106,13 @@ export function TaskSteps( { heading, subheading, steps, sessionStorageKey }: Ta
 					<div className="task-steps__heading">{ preventWidows( heading ) }</div>
 					<div className="task-steps__subheading">{ preventWidows( subheading ) }</div>
 				</div>
-				<Button variant="secondary" onClick={ resetTasks }>
-					{ translate( 'Reset tasks' ) }
+				<Button variant="secondary" onClick={ resetAllTasks }>
+					{ translate( 'Reset all tasks' ) }
 				</Button>
 			</div>
 			<div className="task-steps__steps">
 				{ updatedSteps.map( ( step ) => (
-					<TaskStep key={ step.count } step={ step } markAsDone={ markAsDone } />
+					<TaskStep key={ step.count } step={ step } toggleTaskStatus={ toggleTaskStatus } />
 				) ) }
 			</div>
 		</div>

--- a/client/a8c-for-agencies/components/task-steps/index.tsx
+++ b/client/a8c-for-agencies/components/task-steps/index.tsx
@@ -1,0 +1,122 @@
+import { FoldableCard } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { Icon, check } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { preventWidows } from 'calypso/lib/formatting';
+
+import './style.scss';
+
+export interface TaskStepItem {
+	stepId: string;
+	count: number;
+	title: string;
+	description: string;
+	isCompleted: boolean;
+	buttonProps: {
+		label: string;
+		href: string;
+		variant: 'primary' | 'secondary';
+		icon?: JSX.Element;
+	};
+}
+
+interface TaskStepProps {
+	step: TaskStepItem;
+	markAsDone: ( step: TaskStepItem ) => void;
+}
+
+interface TaskStepsProps {
+	heading: string;
+	subheading: string;
+	steps: TaskStepItem[];
+	sessionStorageKey: string;
+}
+
+export function TaskStep( { step, markAsDone }: TaskStepProps ) {
+	const translate = useTranslate();
+
+	return (
+		<FoldableCard
+			className="task-step"
+			header={
+				<div className="task-step__header">
+					{ step.isCompleted ? (
+						<div className="task-step__completed">
+							<Icon icon={ check } size={ 24 } />
+						</div>
+					) : (
+						<div className="task-step__count">{ step.count }</div>
+					) }
+					<div className="task-step__title">{ step.title }</div>
+				</div>
+			}
+			expanded
+			clickableHeader
+			summary={ false }
+		>
+			<>
+				<div className="task-step__description">{ step.description }</div>
+				<div className="task-step__button-container">
+					{ step.buttonProps && (
+						<Button variant={ step.buttonProps.variant } href={ step.buttonProps.href }>
+							{ step.buttonProps.label }
+							{ step.buttonProps.icon && <Icon icon={ step.buttonProps.icon } size={ 24 } /> }
+						</Button>
+					) }
+					<Button
+						onClick={ () => markAsDone( step ) }
+						variant="secondary"
+						disabled={ step.isCompleted }
+					>
+						{ translate( 'Mark as done' ) }
+					</Button>
+				</div>
+			</>
+		</FoldableCard>
+	);
+}
+
+export function TaskSteps( { heading, subheading, steps, sessionStorageKey }: TaskStepsProps ) {
+	const translate = useTranslate();
+
+	const updatedStepIds = JSON.parse( sessionStorage.getItem( sessionStorageKey ) || '[]' );
+	const [ completedStepIds, setCompletedStepIds ] = useState< string[] >( updatedStepIds );
+
+	const updatedSteps = steps.map( ( step ) => {
+		return {
+			...step,
+			isCompleted: completedStepIds.includes( step.stepId ),
+		};
+	} );
+
+	const markAsDone = ( step: TaskStepItem ) => {
+		const updatedStepIds = [ ...completedStepIds, step.stepId ];
+		setCompletedStepIds( updatedStepIds );
+		sessionStorage.setItem( sessionStorageKey, JSON.stringify( updatedStepIds ) );
+	};
+
+	const resetTasks = () => {
+		setCompletedStepIds( [] );
+		sessionStorage.removeItem( sessionStorageKey );
+	};
+
+	return (
+		<div className="task-steps">
+			<div className="task-steps__header">
+				<div className="task-steps__heading-container">
+					<div className="task-steps__heading">{ preventWidows( heading ) }</div>
+					<div className="task-steps__subheading">{ preventWidows( subheading ) }</div>
+				</div>
+				<Button variant="secondary" onClick={ resetTasks }>
+					{ translate( 'Reset tasks' ) }
+				</Button>
+			</div>
+			<div className="task-steps__steps">
+				{ updatedSteps.map( ( step ) => (
+					<TaskStep key={ step.count } step={ step } markAsDone={ markAsDone } />
+				) ) }
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/task-steps/index.tsx
+++ b/client/a8c-for-agencies/components/task-steps/index.tsx
@@ -55,20 +55,18 @@ export function TaskStep( { step, toggleTaskStatus }: TaskStepProps ) {
 			clickableHeader
 			summary={ false }
 		>
-			<>
-				<div className="task-step__description">{ step.description }</div>
-				<div className="task-step__button-container">
-					{ step.buttonProps && (
-						<Button variant={ step.buttonProps.variant } href={ step.buttonProps.href }>
-							{ step.buttonProps.label }
-							{ step.buttonProps.icon && <Icon icon={ step.buttonProps.icon } size={ 24 } /> }
-						</Button>
-					) }
-					<Button onClick={ () => toggleTaskStatus( step ) } variant="secondary">
-						{ step.isCompleted ? translate( 'Reset task' ) : translate( 'Mark as done' ) }
+			<div className="task-step__description">{ step.description }</div>
+			<div className="task-step__button-container">
+				{ step.buttonProps && (
+					<Button variant={ step.buttonProps.variant } href={ step.buttonProps.href }>
+						{ step.buttonProps.label }
+						{ step.buttonProps.icon && <Icon icon={ step.buttonProps.icon } size={ 24 } /> }
 					</Button>
-				</div>
-			</>
+				) }
+				<Button onClick={ () => toggleTaskStatus( step ) } variant="secondary">
+					{ step.isCompleted ? translate( 'Reset task' ) : translate( 'Mark as done' ) }
+				</Button>
+			</div>
 		</FoldableCard>
 	);
 }

--- a/client/a8c-for-agencies/components/task-steps/style.scss
+++ b/client/a8c-for-agencies/components/task-steps/style.scss
@@ -1,0 +1,120 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.task-steps {
+	.task-steps__steps {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.task-steps__header {
+		display: flex;
+		justify-content: space-between;
+		padding-block-end: 24px;
+		flex-direction: column;
+		gap: 24px;
+
+		.task-steps__heading-container {
+			display: flex;
+			flex-direction: column;
+			gap: 8px;
+		}
+
+		@include break-large {
+			flex-direction: row;
+		}
+	}
+
+	.task-steps__heading {
+		@include a4a-font-heading-xl;
+	}
+
+	.task-steps__subheading {
+		@include a4a-font-body-lg;
+	}
+
+	.task-step {
+		width: 100%;
+		border-radius: 8px; /* stylelint-disable-line scales/radii */
+
+		.foldable-card__main {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 16px;
+		}
+
+		.foldable-card__content {
+			padding-block-start: 16px;
+			border-top: none;
+
+			@include break-large {
+				padding: 20px 56px 16px 56px;
+			}
+		}
+
+		.task-step__button-container {
+			display: flex;
+			gap: 10px;
+			flex-direction: row;
+			flex-wrap: wrap;
+
+			.components-button {
+				flex: 1 1 auto;
+
+				@include break-large {
+					flex: unset;
+				}
+			}
+
+			svg {
+				margin-inline-start: 4px;
+			}
+		}
+
+		.task-step__header{
+			display: flex;
+			align-items: center;
+			gap: 24px;
+		}
+
+		.task-step__title {
+			@include a4a-font-heading-lg
+		}
+
+		.task-step__description {
+			@include a4a-font-body-lg;
+			padding-block-end: 20px;
+		}
+
+		.step-icon {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			height: 30px;
+			border-radius: 50%;
+			min-width: 30px;
+			max-width: 30px;
+			font-size: rem(16px);
+			font-weight: 600;
+			text-align: center;
+		}
+
+		.task-step__count {
+			@extend .step-icon;
+			border: 1px solid var(--color-accent-5);
+		}
+
+		.task-step__completed {
+			@extend .step-icon;
+			background-color: var(--color-primary);
+			border: 1px solid var(--color-primary);
+			fill: var(--color-text-white);
+		}
+	}
+}
+
+
+
+

--- a/client/a8c-for-agencies/components/task-steps/style.scss
+++ b/client/a8c-for-agencies/components/task-steps/style.scss
@@ -1,49 +1,52 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.task-steps {
-	.task-steps__steps {
+
+.task-steps__steps {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.task-steps__header {
+	display: flex;
+	justify-content: space-between;
+	padding-block-end: 24px;
+	flex-direction: column;
+	gap: 24px;
+
+	.task-steps__heading-container {
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
 	}
 
-	.task-steps__header {
+	@include break-large {
+		flex-direction: row;
+	}
+}
+
+.task-steps__heading {
+	@include a4a-font-heading-xl;
+}
+
+.task-steps__subheading {
+	@include a4a-font-body-lg;
+}
+
+.task-step {
+	width: 100%;
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+
+	.foldable-card__main {
 		display: flex;
+		align-items: center;
 		justify-content: space-between;
-		padding-block-end: 24px;
-		flex-direction: column;
-		gap: 24px;
-
-		.task-steps__heading-container {
-			display: flex;
-			flex-direction: column;
-			gap: 8px;
-		}
-
-		@include break-large {
-			flex-direction: row;
-		}
+		gap: 16px;
 	}
 
-	.task-steps__heading {
-		@include a4a-font-heading-xl;
-	}
-
-	.task-steps__subheading {
-		@include a4a-font-body-lg;
-	}
-
-	.task-step {
-		width: 100%;
-		border-radius: 8px; /* stylelint-disable-line scales/radii */
-
-		.foldable-card__main {
-			display: flex;
-			align-items: center;
-			justify-content: space-between;
-			gap: 16px;
-		}
+	&.card.foldable-card.is-expanded  {
+		margin: 0 0 16px 0;
 
 		.foldable-card__content {
 			padding-block-start: 16px;
@@ -53,68 +56,65 @@
 				padding: 20px 56px 16px 56px;
 			}
 		}
-
-		.task-step__button-container {
-			display: flex;
-			gap: 10px;
-			flex-direction: row;
-			flex-wrap: wrap;
-
-			.components-button {
-				flex: 1 1 auto;
-
-				@include break-large {
-					flex: unset;
-				}
-			}
-
-			svg {
-				margin-inline-start: 4px;
-			}
-		}
-
-		.task-step__header{
-			display: flex;
-			align-items: center;
-			gap: 24px;
-		}
-
-		.task-step__title {
-			@include a4a-font-heading-lg
-		}
-
-		.task-step__description {
-			@include a4a-font-body-lg;
-			padding-block-end: 20px;
-		}
-
-		.step-icon {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			height: 30px;
-			border-radius: 50%;
-			min-width: 30px;
-			max-width: 30px;
-			font-size: rem(16px);
-			font-weight: 600;
-			text-align: center;
-		}
-
-		.task-step__count {
-			@extend .step-icon;
-			border: 1px solid var(--color-accent-5);
-		}
-
-		.task-step__completed {
-			@extend .step-icon;
-			background-color: var(--color-primary);
-			border: 1px solid var(--color-primary);
-			fill: var(--color-text-white);
-		}
 	}
 }
 
+.task-step__button-container {
+	display: flex;
+	gap: 10px;
+	flex-direction: row;
+	flex-wrap: wrap;
 
+	.components-button {
+		flex: 1 1 auto;
 
+		@include break-large {
+			flex: unset;
+		}
+	}
+
+	svg {
+		margin-inline-start: 4px;
+	}
+}
+
+.task-step__header{
+	display: flex;
+	align-items: center;
+	gap: 24px;
+}
+
+.task-step__title {
+	@include a4a-font-heading-lg
+}
+
+.task-step__description {
+	@include a4a-font-body-lg;
+	padding-block-end: 20px;
+}
+
+.task-step__icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 30px;
+	border-radius: 50%;
+	min-width: 30px;
+	max-width: 30px;
+	font-size: rem(16px);
+	font-weight: 600;
+	text-align: center;
+}
+
+.task-step__count {
+	@extend .task-step__icon;
+	border: 1px solid var(--color-accent-5);
+}
+
+.task-step__completed {
+	@extend .task-step__icon;
+	background-color: var(--color-primary);
+	border: 1px solid var(--color-primary);
+	fill: var(--color-text-white);
+}
 

--- a/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/index.tsx
@@ -37,9 +37,6 @@ const SelfMigrationTool = ( { type }: { type: 'pressable' | 'wpcom' } ) => {
 								href: A4A_MIGRATIONS_LINK,
 							},
 							{
-								label: translate( 'Overview' ),
-							},
-							{
 								label: heading,
 							},
 						] }

--- a/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/index.tsx
@@ -8,6 +8,7 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MIGRATIONS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { TaskSteps, TaskStepItem } from 'calypso/a8c-for-agencies/components/task-steps';
 import { getMigrationInfo } from './migration-info';
 
 const SelfMigrationTool = ( { type }: { type: 'pressable' | 'wpcom' } ) => {
@@ -15,11 +16,14 @@ const SelfMigrationTool = ( { type }: { type: 'pressable' | 'wpcom' } ) => {
 
 	const stepInfo = getMigrationInfo( type, translate );
 
-	if ( ! stepInfo ) {
-		return null;
-	}
+	const { pageTitle, heading, pageHeading, pageSubheading, steps, sessionStorageKey } = stepInfo;
 
-	const { pageTitle, heading } = stepInfo;
+	const stepsWithCompletion = steps.map( ( step ) => {
+		return {
+			...step,
+			isCompleted: false,
+		};
+	} ) as TaskStepItem[];
 
 	return (
 		<Layout className="self-migration-tool" title={ pageTitle } wide>
@@ -47,7 +51,12 @@ const SelfMigrationTool = ( { type }: { type: 'pressable' | 'wpcom' } ) => {
 			</LayoutTop>
 
 			<LayoutBody>
-				<></>
+				<TaskSteps
+					heading={ pageHeading }
+					subheading={ pageSubheading }
+					steps={ stepsWithCompletion }
+					sessionStorageKey={ sessionStorageKey }
+				/>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/migration-info.ts
+++ b/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/migration-info.ts
@@ -57,9 +57,8 @@ export const getMigrationInfo = (
 			pageTitle: translate( 'Migrations: Migrate to Pressable' ),
 			heading: translate( 'Migrate to Pressable' ),
 			pageHeading: translate( 'Transfer your WordPress website to Pressable on your own.' ),
-			pageSubheading: translate(
-				"Move your site and tag it for potential earnings by following these steps. If you need help finishing the transfer, don't hesitate to contact us."
-			),
+			pageSubheading:
+				"Move your site and tag it for potential earnings by following these steps. If you need help finishing the transfer, don't hesitate to contact us.",
 			steps: dummySteps,
 			sessionStorageKey: 'a4a_self_migrate_to_pressable_steps',
 		},
@@ -67,9 +66,8 @@ export const getMigrationInfo = (
 			pageTitle: translate( 'Migrations: Migrate to WordPress.com' ),
 			heading: translate( 'Migrate to WordPress.com' ),
 			pageHeading: translate( 'Transfer your WordPress website to WordPress.com on your own.' ),
-			pageSubheading: translate(
-				"Move your site and tag it for potential earnings by following these steps. If you need help finishing the transfer, don't hesitate to contact us."
-			),
+			pageSubheading:
+				"Move your site and tag it for potential earnings by following these steps. If you need help finishing the transfer, don't hesitate to contact us.",
 			steps: dummySteps,
 			sessionStorageKey: 'a4a_self_migrate_to_wpcom_steps',
 		},

--- a/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/migration-info.ts
+++ b/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/migration-info.ts
@@ -1,3 +1,53 @@
+const dummySteps = [
+	{
+		stepId: 'step-1',
+		count: 1,
+		title: 'Dummy Title 1',
+		description:
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+		buttonProps: {
+			variant: 'primary',
+			label: 'Dummy Label 1',
+			href: '',
+		},
+	},
+	{
+		stepId: 'step-2',
+		count: 2,
+		title: 'Dummy Title 2',
+		description:
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+		buttonProps: {
+			variant: 'primary',
+			label: 'Dummy Label 2',
+			href: '',
+		},
+	},
+	{
+		stepId: 'step-3',
+		count: 3,
+		title: 'Dummy Title 3',
+		description:
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+		buttonProps: {
+			variant: 'primary',
+			label: 'Dummy Label 3',
+			href: '',
+		},
+	},
+	{
+		stepId: 'step-4',
+		count: 4,
+		title: 'Dummy Title 4',
+		description:
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+		buttonProps: {
+			variant: 'primary',
+			label: 'Dummy Label 4',
+			href: '',
+		},
+	},
+];
 export const getMigrationInfo = (
 	type: 'pressable' | 'wpcom',
 	translate: ( key: string ) => string
@@ -6,10 +56,22 @@ export const getMigrationInfo = (
 		pressable: {
 			pageTitle: translate( 'Migrations: Migrate to Pressable' ),
 			heading: translate( 'Migrate to Pressable' ),
+			pageHeading: translate( 'Transfer your WordPress website to Pressable on your own.' ),
+			pageSubheading: translate(
+				"Move your site and tag it for potential earnings by following these steps. If you need help finishing the transfer, don't hesitate to contact us."
+			),
+			steps: dummySteps,
+			sessionStorageKey: 'a4a_self_migrate_to_pressable_steps',
 		},
 		wpcom: {
 			pageTitle: translate( 'Migrations: Migrate to WordPress.com' ),
 			heading: translate( 'Migrate to WordPress.com' ),
+			pageHeading: translate( 'Transfer your WordPress website to WordPress.com on your own.' ),
+			pageSubheading: translate(
+				"Move your site and tag it for potential earnings by following these steps. If you need help finishing the transfer, don't hesitate to contact us."
+			),
+			steps: dummySteps,
+			sessionStorageKey: 'a4a_self_migrate_to_wpcom_steps',
 		},
 	};
 	return steps?.[ type ];


### PR DESCRIPTION

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1477
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1478

## Proposed Changes

This PR

- Implements a self migration tool for A4A. 
- Adds TaskSteps component that stores the state using session storage.

Note: The actual steps will be added in another PR. These are just dummy steps. 

## Why are these changes being made?

* To allow users to track the progress of self migrating a site. 

@madebynoam: Do you think we should collapse the completed steps when the user visits this page again?

## Testing Instructions

* Open the A4A live link 
* Go to Migrations: Overview: Click the `Migrate your site` button > Select the `Self migrate to WordPress.com` option > Verify the below is displayed. Play around with the tool. Clicking on `Mark as done` should set the step as completed and `Reset task` should reset the status. Refreshing the page should restore the previous state as we are storing it in session storage. Clicking on the `Reset task` should reset the state to default. 

<img width="1728" alt="Screenshot 2024-11-15 at 3 30 29 PM" src="https://github.com/user-attachments/assets/70f3e240-d6fd-499f-9265-6e742be4c9ff">

* Repeat the same for the `Self migrate to Pressable` option

<img width="1728" alt="Screenshot 2024-11-15 at 3 30 33 PM" src="https://github.com/user-attachments/assets/81934d4f-b221-48c4-ad32-92066e1c37db">

* Verify it looks good across different screen sizes.

<img width="768" alt="Screenshot 2024-11-15 at 3 30 58 PM" src="https://github.com/user-attachments/assets/fc85da9b-9528-460c-af55-94da8dc21f67">

<img width="372" alt="Screenshot 2024-11-15 at 3 33 25 PM" src="https://github.com/user-attachments/assets/4e91268b-1af6-4ac7-873b-f9e43f28ea85">


When a few steps are completed:

<img width="1728" alt="Screenshot 2024-11-15 at 3 30 24 PM" src="https://github.com/user-attachments/assets/e8555015-45bc-404f-b873-dfa9a9ff8953">


When all the steps are collapsed: 

<img width="1728" alt="Screenshot 2024-11-15 at 3 33 47 PM" src="https://github.com/user-attachments/assets/d3cbd766-fb07-4fcd-b79c-f09e4b05ce64">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
