### PR TITLE
Redirect back to media page post checkout

### DIFF
--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -23,7 +23,9 @@ export const MediaLibraryUpgradeNudge = ( { translate, filter = 'video', site } 
 
 	const handleClick = () => {
 		const planSlug = 'audio' === filter ? PLAN_PERSONAL : PLAN_PREMIUM;
-		const checkoutUrl = addQueryArgs( `/checkout/${ site.slug }/${ planSlug }` );
+		const checkoutUrl = addQueryArgs( `/checkout/${ site.slug }/${ planSlug }`, {
+			redirect_to: `/media/${ filter }/${ site.slug }`,
+		} );
 
 		recordTracksEvent( 'calypso_upgrade_nudge_cta_click', commonEventProps );
 		page.redirect( checkoutUrl );

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -24,7 +24,7 @@ export const MediaLibraryUpgradeNudge = ( { translate, filter = 'video', site } 
 	const handleClick = () => {
 		const planSlug = 'audio' === filter ? PLAN_PERSONAL : PLAN_PREMIUM;
 		const checkoutUrl = addQueryArgs( `/checkout/${ site.slug }/${ planSlug }`, {
-			redirect_to: `/media/${ filter }/${ site.slug }`,
+			redirect_to: `/media/${ filter }/${ site.slug }?upgrade=success`,
 		} );
 
 		recordTracksEvent( 'calypso_upgrade_nudge_cta_click', commonEventProps );

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -364,7 +364,7 @@ class Media extends Component {
 		if ( filter === 'audio' ) {
 			message = translate( 'Audio upload has been enabled.' );
 		} else if ( filter === 'videos' ) {
-			translate( 'Video upload has been enabled.' );
+			message = translate( 'Video upload has been enabled.' );
 		}
 
 		if ( status === 'success' && message ) {

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -22,6 +22,7 @@ import { EditorMediaModalDetail } from 'calypso/post-editor/media-modal/detail';
 import EditorMediaModalDialog from 'calypso/post-editor/media-modal/dialog';
 import { withJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
 import { selectMediaItems, changeMediaSource, clearSite } from 'calypso/state/media/actions';
+import { successNotice } from 'calypso/state/notices/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
 import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
@@ -57,6 +58,12 @@ class Media extends Component {
 		this.setState( {
 			containerWidth: this.containerRef.current.clientWidth,
 		} );
+
+		const params = new URLSearchParams( window.location.search );
+		const upgradeStatus = params.get( 'upgrade' );
+		if ( upgradeStatus ) {
+			this.showUpgradeStatusNotice( upgradeStatus );
+		}
 	}
 
 	onFilterChange = ( filter ) => {
@@ -351,6 +358,20 @@ class Media extends Component {
 		);
 	};
 
+	showUpgradeStatusNotice = ( status ) => {
+		const { translate, filter, successNotice: showSuccessNotice } = this.props;
+		let message = '';
+		if ( filter === 'audio' ) {
+			message = translate( 'Audio upload has been enabled.' );
+		} else if ( filter === 'videos' ) {
+			translate( 'Video upload has been enabled.' );
+		}
+
+		if ( status === 'success' && message ) {
+			showSuccessNotice( message );
+		}
+	};
+
 	render() {
 		const {
 			selectedSite: site,
@@ -472,6 +493,9 @@ const mapStateToProps = ( state, { mediaId } ) => {
 	};
 };
 
-export default connect( mapStateToProps, { selectMediaItems, changeMediaSource, clearSite } )(
-	localize( withJetpackConnectionProblem( withDeleteMedia( withEditMedia( Media ) ) ) )
-);
+export default connect( mapStateToProps, {
+	selectMediaItems,
+	changeMediaSource,
+	clearSite,
+	successNotice,
+} )( localize( withJetpackConnectionProblem( withDeleteMedia( withEditMedia( Media ) ) ) ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9683

## Proposed Changes

* Add `redirect_to` pointing back to media page after checkout
* set the checkout status as query param to redirect link
* Add a status notice in the media page

<img width="821" alt="image" src="https://github.com/user-attachments/assets/964d48c5-ec49-48e0-89c2-6d65c91e6051">
<img width="821" alt="image" src="https://github.com/user-attachments/assets/b528482c-31ab-4194-94bc-f5119a3bc0df">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To enhance media plan upgrade experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Media page in admin
* Choose to upgrade videos or audio
* Complete the checkout
* It should redirect back to media page and show upgrade status message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
