### PR TITLE
Removed custom CSS for DataViews pagination

### DIFF
--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -838,12 +838,3 @@
 		justify-content: center;
 	}
 }
-
-.dataviews-pagination {
-	box-sizing: border-box;
-	width: 100%;
-
-	.components-input-control__container > div.components-input-control__backdrop {
-		border-color: var(--color-border-subtle);
-	}
-}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9840


## Proposed Changes

* We want to prevent CSS leaking while navigating in /sites and /plugins/manage

| Before | After |
|--------|--------|
| <img width="1300" alt="image" src="https://github.com/user-attachments/assets/fdfd2645-d942-43d4-9a09-c9a3caaa5fd6"> | <img width="1304" alt="image" src="https://github.com/user-attachments/assets/5521b2ed-e2a3-4513-be9c-d2988e94f33d"> | 

* We're also removing a custom border, which isn't available at [the core component](https://wordpress.github.io/gutenberg/?path=/docs/dataviews-dataviews--docs):

| Header | Header |
|--------|--------|
| <img width="403" alt="image" src="https://github.com/user-attachments/assets/ced65d1b-83f9-43a2-98bf-8d56894aaa47"> |  <img width="372" alt="image" src="https://github.com/user-attachments/assets/2288a0bf-95fb-4b9b-94a6-5ab8adf094e8">  | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're removing custom CSS as we can. This will fix a bug and also remove an unnecessary CSS customomization

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [/sites](http://calypso.localhost:3000/sites)
* Ensure the pagination works well on desktop|mobile|tablet (the mobile navigation [motivated the addition of the code](https://github.com/Automattic/wp-calypso/pull/90015) we're removing)
* Go to [/plugins/manage](http://calypso.localhost:3000/plugins/manage) and ensure the pagination looks good and not broken anymore.




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
