### PR TITLE
Domain settings update for 100y domains

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -127,9 +127,15 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 			isUpdatingPrivacy,
 			privacyAvailable,
 			privateDomain,
+			isHundredYearDomain,
 		} = props;
 
-		if ( ! privacyAvailable || ! contactInfoDisclosureAvailable || privateDomain ) {
+		if (
+			! privacyAvailable ||
+			! contactInfoDisclosureAvailable ||
+			privateDomain ||
+			isHundredYearDomain
+		) {
 			return false;
 		}
 
@@ -176,7 +182,8 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 		);
 	};
 
-	const { selectedDomainName, canManageConsent, currentRoute, readOnly } = props;
+	const { selectedDomainName, canManageConsent, currentRoute, readOnly, isHundredYearDomain } =
+		props;
 
 	return (
 		<div>
@@ -185,20 +192,22 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 					{ props.registeredViaTrustee && renderTrusteeNotice() }
 					<ContactDisplay selectedDomainName={ selectedDomainName } />
 					<div className="contact-information__button-container">
-						<Button
-							disabled={ disableEdit || readOnly || pendingContactUpdate }
-							href={
-								disableEdit || readOnly || pendingContactUpdate
-									? ''
-									: domainManagementEditContactInfo(
-											props.selectedSite.slug,
-											props.selectedDomainName,
-											currentRoute
-									  )
-							}
-						>
-							{ translate( 'Edit' ) }
-						</Button>
+						{ !! isHundredYearDomain && (
+							<Button
+								disabled={ disableEdit || readOnly || pendingContactUpdate }
+								href={
+									disableEdit || readOnly || pendingContactUpdate
+										? ''
+										: domainManagementEditContactInfo(
+												props.selectedSite.slug,
+												props.selectedDomainName,
+												currentRoute
+										  )
+								}
+							>
+								{ translate( 'Edit' ) }
+							</Button>
+						) }
 
 						{ canManageConsent && (
 							<Button
@@ -227,11 +236,13 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 						</p>
 					) }
 				</div>
-				<div className="contact-information__toggle-container">
-					{ getPrivacyProtection() }
-					{ getContactInfoDisclosed() }
-					{ getPrivacyProtectionRecommendationText() }
-				</div>
+				{ ! isHundredYearDomain && (
+					<div className="contact-information__toggle-container">
+						{ getPrivacyProtection() }
+						{ getContactInfoDisclosed() }
+						{ getPrivacyProtectionRecommendationText() }
+					</div>
+				) }
 			</Card>
 		</div>
 	);

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -192,7 +192,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 					{ props.registeredViaTrustee && renderTrusteeNotice() }
 					<ContactDisplay selectedDomainName={ selectedDomainName } />
 					<div className="contact-information__button-container">
-						{ !! isHundredYearDomain && (
+						{ ! isHundredYearDomain && (
 							<Button
 								disabled={ disableEdit || readOnly || pendingContactUpdate }
 								href={

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-privacy-info.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-privacy-info.tsx
@@ -26,6 +26,7 @@ const ContactsPrivacy = ( props: ContactsInfoProps ): null | JSX.Element => {
 			registeredViaTrustee,
 			registeredViaTrusteeUrl,
 			supportsGdprConsentManagement,
+			isHundredYearDomain,
 		} = domain;
 
 		return (
@@ -42,6 +43,7 @@ const ContactsPrivacy = ( props: ContactsInfoProps ): null | JSX.Element => {
 				readOnly={ readonly }
 				registeredViaTrustee={ registeredViaTrustee }
 				registeredViaTrusteeUrl={ registeredViaTrusteeUrl }
+				isHundredYearDomain={ isHundredYearDomain }
 			/>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/types.ts
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/types.ts
@@ -35,6 +35,7 @@ export type ContactsCardPassedProps = {
 	readOnly: boolean | undefined;
 	registeredViaTrustee: boolean;
 	registeredViaTrusteeUrl: string;
+	isHundredYearDomain: boolean;
 };
 
 export type ContactsCardConnectedProps = {

--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -27,11 +27,12 @@ const RegisteredDomainDetails = ( {
 	);
 
 	const renderDates = () => {
-		const untilDateLabel = domain.expired
-			? // translators: this is followed by a date, e.g. Expired on December 15, 2021
-			  translate( 'Expired on' )
-			: // translators: this is followed by a date, e.g. Registered until January 21, 2023
-			  translate( 'Registered until' );
+		let untilDateLabel = translate( 'Registered until' );
+		if ( domain.expired ) {
+			untilDateLabel = translate( 'Expired on' );
+		} else if ( domain.isHundredYearDomain ) {
+			untilDateLabel = translate( 'Paid until' );
+		}
 
 		return (
 			<>

--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -27,10 +27,13 @@ const RegisteredDomainDetails = ( {
 	);
 
 	const renderDates = () => {
+		// translators: this is followed by a date, e.g. Registered until December 15, 2021
 		let untilDateLabel = translate( 'Registered until' );
 		if ( domain.expired ) {
+			// translators: this is followed by a date, e.g. Expired on December 15, 2021
 			untilDateLabel = translate( 'Expired on' );
 		} else if ( domain.isHundredYearDomain ) {
+			// translators: this is followed by a date, e.g. Paid until December 15, 2021
 			untilDateLabel = translate( 'Paid until' );
 		}
 

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -539,7 +539,7 @@ const Settings = ( {
 			></ContactsPrivacyInfo>
 		);
 
-		const { privateDomain } = domain;
+		const { privateDomain, isHundredYearDomain } = domain;
 		const titleLabel = translate( 'Contact information', { textOnly: true } );
 		const privacyProtectionLabel = privateDomain
 			? translate( 'Privacy protection on', { textOnly: true } )
@@ -566,7 +566,11 @@ const Settings = ( {
 		return (
 			<Accordion
 				title={ titleLabel }
-				subtitle={ `${ contactInfoFullName }, ${ privacyProtectionLabel.toLowerCase() }` }
+				subtitle={
+					isHundredYearDomain
+						? 'WordPress.com'
+						: `${ contactInfoFullName }, ${ privacyProtectionLabel.toLowerCase() }`
+				}
 				isDisabled={ domain.isMoveToNewSitePending }
 			>
 				{ getContactsPrivacyInfo() }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -215,10 +215,13 @@ const Settings = ( {
 			return null;
 		}
 		if ( domain.type === domainTypes.REGISTERED ) {
+			const subtitle = domain.isHundredYearDomain
+				? translate( 'Registration details', { textOnly: true } )
+				: translate( 'Registration and auto-renew', { textOnly: true } );
 			return (
 				<Accordion
 					title={ translate( 'Details', { textOnly: true } ) }
-					subtitle={ translate( 'Registration and auto-renew', { textOnly: true } ) }
+					subtitle={ subtitle }
 					key="main"
 					expanded={ ! selectedSite?.options?.is_domain_only && ! domain.isMoveToNewSitePending }
 					isDisabled={ domain.isMoveToNewSitePending }


### PR DESCRIPTION
## Proposed Changes

This PR adds some UX/copy updates in the domain settings page for a 100 year domain.

## Why are these changes being made?
This updates is one of the step we are taking to improve the overall user experience for the 100 year domains registrations.

![100 year domain ux updates](https://github.com/user-attachments/assets/cde45049-0fc5-498e-96a1-fd5791f2eb52)

![contact editing disabled](https://github.com/user-attachments/assets/3f495bf4-28e4-4280-b216-3eaaada161b8)


## Testing Instructions

- Apply this patch locally (or use the Calypso image below) and D166404-code.
- Enable Store Sanbox the register a new 100 year domain starting from the 100y domain flow (/setup/hundred-year-domain)
- Once registered the domain, open its management page and verify:
   - In the details card, the subtitle changed from `Registration and auto-renew` to `Registration details`
   - In the details card, `Registered until` changed to `Paid until`
   - In the contact information card, there is a message that shows that the contact info are managed by WordPress.com
   - In the contact information card, Privacy toggle and Edit button are hided
- Verify that the contact info editing page (/domains/manage/all/[DOMAIN]/edit-contact-info/[DOMAIN]) is disabled too

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?