### PR TITLE
A4A: Fix checkbox text alignment on the Site configuration modal.

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/style.scss
+++ b/client/a8c-for-agencies/components/site-configurations-modal/style.scss
@@ -17,6 +17,8 @@
 		color: var(--color-neutral-50);
 		font-size: rem(14px);
 		line-height: 1.5;
+		align-items: center;
+
 
 		.dev-sites-label {
 			margin-top: 15px;


### PR DESCRIPTION
This fixes misalignment on the checkbox label found in the Site configuration modal.

| Before | After |
|--------|--------|
| <img width="692" alt="Screenshot 2024-11-15 at 9 11 47 PM" src="https://github.com/user-attachments/assets/25d0e612-4196-4bce-bf6a-62f2c04917f5"> | <img width="653" alt="Screenshot 2024-11-15 at 9 13 12 PM" src="https://github.com/user-attachments/assets/57f7528a-2fda-4089-85e6-eb2ccd992597"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1396

## Proposed Changes

* Set flex alignment of items to `center`.

## Why are these changes being made?


* Makes our page more polished.

## Testing Instructions

* Use the A4A live link
* Create a WPCOM site to show the Site configuration modal.
* Confirm that the checkbox text is now aligned properly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
