### PR TITLE
A4A: Hide the Dataview actions on the 'Import site from WPCOM' modal.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
@@ -30,6 +30,10 @@
 	flex-direction: column;
 	height: 680px;
 
+	.dataviews__view-actions {
+		display: none;
+	}
+
 	@include break-large {
 		width: 800px;
 		padding: 40px;


### PR DESCRIPTION
This PR conceals the Dataview actions in the 'Import site from WPCOM' modal.

| Before | After |
|--------|--------|
| <img width="847" alt="Screenshot 2024-11-15 at 9 21 53 PM" src="https://github.com/user-attachments/assets/6c7017a8-719c-47f6-b0c7-3b35073006e6"> | <img width="851" alt="Screenshot 2024-11-15 at 9 22 16 PM" src="https://github.com/user-attachments/assets/10cef792-94ad-45b0-a34a-b739776f19ed"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1393

## Proposed Changes

* Utilize a CSS rule to force hide the dataview actions, as they cannot be hidden through any properties of the Dataview component.

## Why are these changes being made?

* We can omit the dataview actions in the modal since we only intend to show it as a simple table.

## Testing Instructions

* Use the A4A live link and go to the `/overview` page.
* Click the `Add sites` dropdown button > Select **Via WordPress.com**.
* Confirm that the table in the modal no longer shows the gear icon.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
