### PR TITLE
A4A: Convert Site dashboard URLs into clickable links.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -28,25 +28,31 @@
 }
 
 .sites-dataviews__site-url {
-	display: block;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	white-space: nowrap;
-	font-size: rem(12px);
-	font-weight: 400;
+	display: flex;
+	flex-direction: row;
+	gap: 2px;
 
-	&,
-	&:focus,
-	&:hover,
-	&:visited {
-		color: var(--color-neutral-60);
-		outline: none;
-	}
+	a {
+		display: block;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		white-space: nowrap;
+		font-size: rem(12px);
+		font-weight: 400;
 
-	&:focus,
-	&:hover {
-		color: var(--color-primary);
-		fill: var(--color-primary);
+		&,
+		&:focus,
+		&:hover,
+		&:visited {
+			color: var(--color-neutral-60);
+			outline: none;
+		}
+
+		&:focus,
+		&:hover {
+			color: var(--color-primary);
+			fill: var(--color-primary);
+		}
 	}
 
 	svg {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -28,12 +28,29 @@
 }
 
 .sites-dataviews__site-url {
+	display: block;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
 	font-size: rem(12px);
-	color: var(--color-neutral-60);
 	font-weight: 400;
+
+	&,
+	&:focus,
+	&:hover,
+	&:visited {
+		color: var(--color-neutral-60);
+		outline: none;
+	}
+
+	&:focus,
+	&:hover {
+		text-decoration: underline;
+	}
+
+	svg {
+		margin-block-end: -4px;
+	}
 }
 
 .sites-dataviews__site-error-indicator {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -45,7 +45,8 @@
 
 	&:focus,
 	&:hover {
-		text-decoration: underline;
+		color: var(--color-primary);
+		fill: var(--color-primary);
 	}
 
 	svg {

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -1,4 +1,5 @@
 import { Badge, Button } from '@automattic/components';
+import { Icon, external } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import SiteFavicon from 'calypso/a8c-for-agencies/components/items-dashboard/site-favicon';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
@@ -39,7 +40,18 @@ const SiteDataField = ( {
 			/>
 			<div className="sites-dataviews__site-name">
 				<div>{ site.blogname }</div>
-				{ ! migrationInProgress && <div className="sites-dataviews__site-url">{ site.url }</div> }
+				{ ! migrationInProgress && (
+					<a
+						className="sites-dataviews__site-url"
+						href={ site.url_with_scheme }
+						title={ site.url_with_scheme }
+						target="_blank"
+						rel="noreferrer"
+						onClick={ ( e ) => e.stopPropagation() }
+					>
+						{ site.url } <Icon icon={ external } size={ 16 } />
+					</a>
+				) }
 				{ migrationInProgress && (
 					<Badge className="status-badge" type="info-blue">
 						{ translate( 'Migration in progress' ) }

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -41,16 +41,18 @@ const SiteDataField = ( {
 			<div className="sites-dataviews__site-name">
 				<div>{ site.blogname }</div>
 				{ ! migrationInProgress && (
-					<a
-						className="sites-dataviews__site-url"
-						href={ site.url_with_scheme }
-						title={ site.url_with_scheme }
-						target="_blank"
-						rel="noreferrer"
-						onClick={ ( e ) => e.stopPropagation() }
-					>
-						{ site.url } <Icon icon={ external } size={ 16 } />
-					</a>
+					<span className="sites-dataviews__site-url">
+						<a
+							href={ site.url_with_scheme }
+							title={ site.url_with_scheme }
+							target="_blank"
+							rel="noreferrer"
+							onClick={ ( e ) => e.stopPropagation() }
+						>
+							{ site.url }
+						</a>
+						<Icon icon={ external } size={ 18 } />
+					</span>
 				) }
 				{ migrationInProgress && (
 					<Badge className="status-badge" type="info-blue">


### PR DESCRIPTION
This PR implements a small enhancement to the Site dashboard by converting Site URLs into clickable links.

| Before | After |
|--------|--------|
| <img width="425" alt="Screenshot 2024-11-15 at 10 51 22 PM" src="https://github.com/user-attachments/assets/dec15ef7-7d3c-48bd-a81e-b4938b7a75e3"> | <img width="496" alt="Screenshot 2024-11-15 at 10 51 04 PM" src="https://github.com/user-attachments/assets/1817bdc5-3c74-4355-82c9-a9f55ec29d3b"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/596

## Proposed Changes

* Convert the Site URL (display only) to clickable links similar to how the WPCOM site dashboard works.

## Why are these changes being made?

* This ensures that when hovering over the site URL, a small tooltip will display the full site name.

## Testing Instructions

* Use the A4A live link and go to the `/sites` page
* Confirm that the Site URLs are now clickable links.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
