### PR TITLE
A4A: Hide the Dataview actions on the Referrals table.

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -236,3 +236,7 @@ $data-view-border-color: #f1f1f1;
 	flex-direction: column;
 	height: calc(100vh - 32px);
 }
+
+.referrals-layout .redesigned-a8c-table .dataviews__view-actions {
+	display: none;
+}


### PR DESCRIPTION
This PR hides the Dataview actions from the Referrals page's table since they are not being utilized at this time.
<img width="701" alt="Screenshot 2024-11-15 at 11 37 08 PM" src="https://github.com/user-attachments/assets/061df6fa-6e29-4ee3-bd15-bec942bb3829">
<img width="618" alt="Screenshot 2024-11-15 at 11 37 31 PM" src="https://github.com/user-attachments/assets/819f5e4f-faa0-4cdb-adf9-d3a7430c22cd">



## Proposed Changes

* Implement a CSS rule to conceal the data view actions, since the DataView interface lacks this option.

## Why are these changes being made?

* This causes confusion among users, so we should eliminate it if it’s not working.

## Testing Instructions

* Use the A4A live link and go to the `/referrals/dashboard` page.
* Confirm that the Gear icons are no longer visible in the page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
