### PR TITLE
[POC] Domain Revamp i1: Layout, routing, details, swtiching

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -26,6 +26,7 @@ import {
 } from 'calypso/my-sites/domains/paths';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import DomainPreviewPane from './domain-overview';
 import DomainManagement from '.';
 
 export default {
@@ -44,6 +45,81 @@ export default {
 			<DomainManagement.BulkAllDomains
 				analyticsPath={ domainManagementRoot() }
 				analyticsTitle="Domain Management > All Domains"
+			/>
+		);
+		next();
+	},
+
+	domainDashboard( feature ) {
+		return ( pageContext, next ) => {
+			const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
+
+			pageContext.primary = (
+				<DomainManagement.TwoColumnDomainManagement
+					searchComponent={
+						<DomainManagement.BulkAllDomains
+							analyticsPath={ domainManagementRoot() }
+							analyticsTitle="Domain Management > All Domains"
+							sidebarMode
+						/>
+					}
+					initialFeature={ feature }
+					detailsComponent={
+						<DomainPreviewPane
+							selectedDomain={ selectedDomainName }
+							selectedDomainPreview={ pageContext.primary }
+						/>
+					}
+				/>
+			);
+
+			next();
+		};
+	},
+
+	domainManagementV2( pageContext, next ) {
+		const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
+
+		pageContext.primary = (
+			<DomainManagementData
+				analyticsPath={ domainManagementRoot( ':domain' ) }
+				analyticsTitle="Domain Management"
+				component={ DomainManagement.Settings }
+				context={ pageContext }
+				selectedDomainName={ selectedDomainName }
+				needsDomains
+			/>
+		);
+		next();
+	},
+
+	domainManagementDashboard( pageContext, next ) {
+		const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
+
+		pageContext.primary = (
+			<DomainManagement.TwoColumnDomainManagement
+				searchComponent={
+					<DomainManagement.BulkAllDomains
+						analyticsPath={ domainManagementRoot() }
+						analyticsTitle="Domain Management > All Domains"
+						sidebarMode
+					/>
+				}
+				detailsComponent={
+					<DomainPreviewPane
+						selectedDomain={ selectedDomainName }
+						selectedDomainPreview={
+							<DomainManagementData
+								analyticsPath={ domainManagementRoot( ':domain' ) }
+								analyticsTitle="Domain Management"
+								component={ DomainManagement.Settings }
+								context={ pageContext }
+								selectedDomainName={ selectedDomainName }
+								needsDomains
+							/>
+						}
+					/>
+				}
 			/>
 		);
 		next();

--- a/client/my-sites/domains/domain-management/domain-overview/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview/index.tsx
@@ -1,0 +1,102 @@
+import { Button } from '@wordpress/components';
+import { useMergeRefs } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { useMemo, useRef, useState } from 'react';
+import ItemPreviewPane from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
+import type {
+	ItemData,
+	FeaturePreviewInterface,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
+
+interface Props {
+	selectedDomainPreview: React.ReactNode;
+	selectedDomain: string;
+}
+
+const DomainPreviewPane = ( { selectedDomainPreview, selectedDomain }: Props ) => {
+	const itemData: ItemData = {
+		title: selectedDomain,
+		subtitle: selectedDomain,
+		blogId: 12435645646456468,
+		isDotcomSite: true,
+		adminUrl: `testdomain.com/wp-admin`,
+		withIcon: false,
+		hideEnvDataInHeader: true,
+	};
+
+	type BtnProps = {
+		focusRef: React.RefObject< HTMLButtonElement >;
+		itemData: ItemData;
+		closeSitePreviewPane?: () => void;
+	};
+
+	const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane }: BtnProps ) => {
+		const adminButtonRef = useRef< HTMLButtonElement | null >( null );
+
+		return (
+			<>
+				<Button onClick={ closeSitePreviewPane } className="item-preview__close-preview-button">
+					Close
+				</Button>
+				<Button
+					variant="primary"
+					className="item-preview__admin-button"
+					ref={ useMergeRefs( [ adminButtonRef, focusRef ] ) }
+				>
+					Manage Site
+				</Button>
+			</>
+		);
+	};
+
+	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( 'domain-overview' );
+
+	const features: FeaturePreviewInterface[] = useMemo( () => {
+		const siteFeatures = [
+			{
+				label: __( 'Overview' ),
+				enabled: true,
+				featureIds: [ 'domain-overview' ],
+			},
+			{
+				label: __( 'Email' ),
+				enabled: true,
+				featureIds: [ 'email' ],
+			},
+		];
+
+		return siteFeatures.map( ( { label, enabled, featureIds } ) => {
+			const selected = enabled && featureIds.includes( selectedSiteFeature );
+			const defaultFeatureId = featureIds[ 0 ];
+			return {
+				id: defaultFeatureId,
+				tab: {
+					label,
+					visible: enabled,
+					selected,
+					onTabClick: () => {
+						if ( enabled && ! selected ) {
+							setSelectedSiteFeature( defaultFeatureId );
+						}
+					},
+				},
+				enabled,
+				preview: enabled ? selectedDomainPreview : null,
+			};
+		} );
+	}, [ __, selectedDomain, selectedSiteFeature ] );
+
+	return (
+		<ItemPreviewPane
+			itemData={ itemData }
+			closeItemPreviewPane={ () => {} }
+			features={ features }
+			enforceTabsView
+			itemPreviewPaneHeaderExtraProps={ {
+				headerButtons: PreviewPaneHeaderButtons,
+			} }
+		/>
+	);
+};
+
+export default DomainPreviewPane;

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -1,5 +1,7 @@
 import BulkAllDomains from 'calypso/my-sites/domains/domain-management/list/bulk-all-domains';
-import BulkSiteDomains from 'calypso/my-sites/domains/domain-management/list/bulk-site-domains';
+import BulkSiteDomains, {
+	TwoColumnDomainManagement,
+} from 'calypso/my-sites/domains/domain-management/list/bulk-site-domains';
 import AddDnsRecord from './dns/add-dns-record';
 import DnsRecords from './dns/dns-records';
 import DomainConnectMapping from './domain-connect-mapping';
@@ -32,4 +34,5 @@ export default {
 	TransferDomainToAnyUser,
 	BulkAllDomains,
 	BulkSiteDomains,
+	TwoColumnDomainManagement,
 };

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -27,6 +27,7 @@ import './style.scss';
 interface BulkAllDomainsProps {
 	analyticsPath: string;
 	analyticsTitle: string;
+	sidebarMode?: boolean;
 }
 
 export default function BulkAllDomains( props: BulkAllDomainsProps ) {
@@ -383,6 +384,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						createBulkAction={ createBulkAction }
 						fetchBulkActionStatus={ fetchBulkActionStatus }
 						deleteBulkActionStatus={ deleteBulkActionStatus }
+						sidebarMode={ props.sidebarMode }
 					/>
 				) : (
 					<EmptyState />

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -3,6 +3,8 @@ import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable, ResponseDomain } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import SiteAddressChanger from 'calypso/blocks/site-address-changer';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -43,6 +45,17 @@ import './style.scss';
 interface BulkSiteDomainsProps {
 	analyticsPath: string;
 	analyticsTitle: string;
+}
+
+export function TwoColumnDomainManagement( props: any ) {
+	return (
+		<Layout title="Domain Management" wide className="domains-overview">
+			<LayoutColumn className="domains-overview__list">{ props.searchComponent }</LayoutColumn>
+			<LayoutColumn className="domains-overview__details" wide>
+				{ props.detailsComponent }
+			</LayoutColumn>
+		</Layout>
+	);
 }
 
 export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -30,6 +30,10 @@
 	}
 }
 
+.domains-overview .main.domains-overview_list {
+	max-width: 400px;
+}
+
 .domain-management__all-domains-section {
 	display: flex;
 	flex-direction: column;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -30,7 +30,7 @@
 	}
 }
 
-.domains-overview .main.domains-overview_list {
+.domains-overview .main.domains-overview__list {
 	max-width: 400px;
 }
 

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -150,6 +150,16 @@ export default function () {
 	);
 
 	page(
+		paths.domainManagementRoot() + '-overview/:domain',
+		noSite,
+		navigation,
+		domainManagementController.domainManagementV2,
+		domainManagementController.domainDashboard( 'domain-management' ),
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		paths.domainManagementList( ':site' ),
 		...getCommonHandlers(),
 		domainManagementController.domainManagementList,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -9,6 +9,7 @@ import {
 	stagingSiteNotSupportedRedirect,
 	noSite,
 } from 'calypso/my-sites/controller';
+import emailController from 'calypso/my-sites/email/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
 import * as paths from './paths';
@@ -150,10 +151,20 @@ export default function () {
 	);
 
 	page(
-		paths.domainManagementRoot() + '-overview/:domain',
-		noSite,
+		paths.domainManagementRoot() + '/overview/:domain/:site',
+		siteSelection,
 		navigation,
 		domainManagementController.domainManagementV2,
+		domainManagementController.domainDashboard( 'domain-management' ),
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.domainManagementRoot() + '/email/:domain',
+		noSite,
+		navigation,
+		emailController.emailManagementPurchaseNewEmailAccount,
 		domainManagementController.domainDashboard( 'domain-management' ),
 		makeLayout,
 		clientRender

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -24,7 +24,8 @@ const SITE_DASHBOARD_ROUTES = {
 	'site-settings': '/sites/settings',
 
 	// Domain Management
-	'domain-management': '/domains/manage-overview',
+	'domain-management': '/domains/manage/overview',
+	'email-management': '/domains/manage-email',
 };
 
 function isInSection( sectionName: string, sectionNames: string[] ) {

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -22,6 +22,9 @@ const SITE_DASHBOARD_ROUTES = {
 	'site-marketing': '/sites/marketing',
 	'site-tools': '/sites/tools',
 	'site-settings': '/sites/settings',
+
+	// Domain Management
+	'domain-management': '/domains/manage-overview',
 };
 
 function isInSection( sectionName: string, sectionNames: string[] ) {

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -99,7 +99,7 @@ export const DomainsTableHeader = ( {
 	return (
 		<thead className={ listHeaderClasses }>
 			<tr>
-				{ canSelectAnyDomains && (
+				{ canSelectAnyDomains ? (
 					<th className="domains-table-checkbox-th">
 						<CheckboxControl
 							data-testid="domains-select-all-checkbox"
@@ -113,6 +113,8 @@ export const DomainsTableHeader = ( {
 							) }
 						/>
 					</th>
+				) : (
+					<th></th>
 				) }
 
 				{ columns.map( ( column ) => {

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,4 +1,5 @@
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
 import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
@@ -89,7 +90,8 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	};
 
 	const handleSelect = () => {
-		window.location.href = domainManagementLink;
+		page.show( domainManagementLink );
+		//window.location.href = domainManagementLink;
 	};
 
 	return (
@@ -98,7 +100,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 			className="domains-table__row"
 			onClick={ domainManagementLink ? handleSelect : undefined }
 		>
-			{ canSelectAnyDomains && (
+			{ canSelectAnyDomains ? (
 				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
 				<td
 					className="domains-table-checkbox-td"
@@ -115,6 +117,8 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 						disabled={ ! canBulkUpdate( domain ) }
 					/>
 				</td>
+			) : (
+				<td></td>
 			) }
 
 			{ domainsTableColumns.map( ( column ) => {

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -68,6 +68,7 @@ interface BaseDomainsTableProps {
 	fetchBulkActionStatus?: () => Promise< BulkDomainUpdateStatusQueryFnData >;
 	deleteBulkActionStatus?: () => Promise< void >;
 	currentUserCanBulkUpdateContactInfo?: boolean;
+	sidebarMode?: boolean;
 }
 
 export type DomainsTableProps =
@@ -144,6 +145,7 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		userCanSetPrimaryDomains,
 		isLoadingDomains,
 		currentUserCanBulkUpdateContactInfo = false,
+		sidebarMode = false,
 	} = props;
 
 	const [ { sortKey, sortDirection }, setSort ] = useState< {
@@ -240,6 +242,19 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		domainsTableColumns = removeColumns( domainsTableColumns, 'owner' );
 	}
 
+	if ( sidebarMode ) {
+		// Remove all columns except for domain and action.
+		domainsTableColumns = removeColumns(
+			domainsTableColumns,
+			'site',
+			'owner',
+			'ssl',
+			'expire_renew',
+			'status',
+			'status_action'
+		);
+	}
+
 	const sortedDomains = useMemo( () => {
 		if ( ! domains ) {
 			return;
@@ -305,7 +320,7 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 
 	const hasSelectedDomains = selectedDomains.size > 0;
 	const selectableDomains = ( domains ?? [] ).filter( canBulkUpdate );
-	const canSelectAnyDomains = selectableDomains.length > 1;
+	const canSelectAnyDomains = selectableDomains.length > 1 && ! sidebarMode;
 	const areAllDomainsSelected = selectableDomains.length === selectedDomains.size;
 
 	const getBulkSelectionStatus = () => {

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -19,7 +19,7 @@ export function domainManagementLink(
 	}
 
 	if ( isAllSitesView ) {
-		return `${ domainManagementAllRoot() }/${ domain }/${ viewSlug }/${ siteSlug }`;
+		return `${ domainManagementRoot() }-overview/${ domain }`;
 	}
 
 	return `${ domainManagementRoot() }/${ domain }/${ viewSlug }/${ siteSlug }`;

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -19,7 +19,7 @@ export function domainManagementLink(
 	}
 
 	if ( isAllSitesView ) {
-		return `${ domainManagementRoot() }-overview/${ domain }`;
+		return `${ domainManagementRoot() }/overview/${ domain }/${ siteSlug }`;
 	}
 
 	return `${ domainManagementRoot() }/${ domain }/${ viewSlug }/${ siteSlug }`;


### PR DESCRIPTION
**POC** rough barebone implementation of the revamped domain. **NOT FOR MERGE**. Just for the concept and references during development.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

- Creating components
- Implements the layout for the domain view
- Included tabs structure (not implemented yet)
- Modify domains table for sidebar view
- Create middlewares for processing partial views
- Add routing for domain views

I'll implement the Email view and the tab switching once done.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/domains/manage`
* Click on a domain

## Pre-merge Checklist [ Nope - Nothing was followed :p ]

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
