### PR TITLE
Calypso Green: minor update to cloud.jetpack.com/pricing page layout

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -1,9 +1,7 @@
-import { ExternalLinkWithTracking } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
-import { JETPACK_COM_A4A_LANDING_PAGE } from 'calypso/jetpack-cloud/sections/manage/pricing/constants';
 import CloudCart from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar/cloud-cart';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -19,7 +17,6 @@ import { isJetpackCloudCartEnabled } from 'calypso/state/sites/selectors';
 import guaranteeBadge from './14-day-badge.svg';
 import useBoundingClientRect from './hooks/use-bounding-client-rect';
 import { usePrevious } from './hooks/use-previous';
-import people from './people.svg';
 import rocket from './rocket.svg';
 
 const CALYPSO_MASTERBAR_HEIGHT = 47;
@@ -106,22 +103,6 @@ const IntroPricingBanner: React.FC = () => {
 								} )
 							) }
 						</span>
-					</div>
-					<div className="intro-pricing-banner__item is-agencies">
-						<img className="intro-pricing-banner__item-icon" src={ people } alt="" />
-						<ExternalLinkWithTracking
-							className="intro-pricing-banner__item-label is-link"
-							tracksEventName="calypso_jpcom_agencies_page_intro_banner_link_click"
-							// The JETPACK_COM_A4A_LANDING_PAGE is only available in English at this time, so we
-							// won't worry about localizing the link for now. Although we may want to localize it
-							// in the future when/if the page gets translated & posted to other languages/locales.
-							href={ JETPACK_COM_A4A_LANDING_PAGE }
-							icon
-							iconClassName="intro-pricing-banner__external-link-icon"
-							iconSize={ 15 }
-						>
-							{ preventWidows( translate( 'Jetpack for Agencies' ) ) }
-						</ExternalLinkWithTracking>
 					</div>
 					{ shouldShowCart && hasCrossed && (
 						<CloudCart cartStyle={ isSmallScreen ? {} : { left: clientRect.left } } />

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -22,7 +22,7 @@ export const jetpackPricingContext: Callback = ( context, next ) => {
 		return (
 			<Header
 				urlQueryArgs={ urlQueryArgs }
-				title={ translate( 'Best-in-class products for your WordPress site' ) }
+				title={ translate( 'Security, performance, and marketing tools by the WordPress experts' ) }
 			/>
 		);
 	};

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector } from 'calypso/state';
 import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
 
@@ -29,9 +28,10 @@ const Header: React.FC< Props > = ( { title } ) => {
 			<div className={ clsx( 'header', { 'has-sale-banner': hasSaleBanner } ) }>
 				<FormattedHeader
 					className="header__main-title"
-					headerText={ preventWidows(
+					disablePreventWidows
+					headerText={
 						title ?? translate( 'Security, performance, and marketing tools made for WordPress' )
-					) }
+					}
 					align="center"
 				/>
 			</div>

--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -8,7 +8,6 @@ import { useState } from 'react';
 import JetpackPluginUpdateWarning from 'calypso/blocks/jetpack-plugin-update-warning';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Notice from 'calypso/components/notice';
-import { preventWidows } from 'calypso/lib/formatting';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import { useSelector } from 'calypso/state';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
@@ -39,9 +38,7 @@ const StandardPlansHeader = ( { shouldShowPlanRecommendation, siteId }: Standard
 		) }
 		{ ! shouldShowPlanRecommendation && (
 			<h2 className="jetpack-plans__pricing-header">
-				{ preventWidows(
-					translate( 'Security, performance, and marketing tools by the WordPress experts' )
-				) }
+				{ translate( 'Security, performance, and marketing tools by the WordPress experts' ) }
 			</h2>
 		) }
 	</>

--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -39,7 +39,9 @@ const StandardPlansHeader = ( { shouldShowPlanRecommendation, siteId }: Standard
 		) }
 		{ ! shouldShowPlanRecommendation && (
 			<h2 className="jetpack-plans__pricing-header">
-				{ preventWidows( translate( 'Best-in-class products for your WordPress site' ) ) }
+				{ preventWidows(
+					translate( 'Security, performance, and marketing tools by the WordPress experts' )
+				) }
 			</h2>
 		) }
 	</>

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -65,11 +65,11 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 				/>
 			) }
 
-			<PricingBanner />
-
 			<StoreItemInfoContext.Provider value={ storeItemInfo }>
 				<ItemsList duration={ duration } siteId={ siteId } />
 			</StoreItemInfoContext.Provider>
+
+			<PricingBanner />
 
 			<NeedMoreInfo />
 

--- a/client/my-sites/plans/jetpack-plans/product-store/pricing-banner/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/pricing-banner/style.scss
@@ -3,7 +3,7 @@
 
 .jetpack-product-store__pricing-banner {
 	height: auto;
-	margin-bottom: 0;
+	margin-top: rem(64px);
 
 	@include break-large {
 		height: 32px;

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -77,10 +77,6 @@
 	}
 }
 
-.jetpack-product-store__items-list {
-	margin-top: rem(48px);
-}
-
 /* Tabs */
 
 @mixin jetpack-product-store__tab-focus {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR changes the title of the pricing page on Calypso Green, and updates the layout so the banner with the pricing information appears before the "Need more info?" section

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/67346709-b588-4f16-a8e1-17e22371fbf8) | ![image](https://github.com/user-attachments/assets/1d8394b8-dc24-4503-bd54-c9da459a55c2)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This change is being made to make the pricing page simpler.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Jetpack Cloud live link
* Go to /pricing
* Confirm it looks like the screenshot above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
