### PR TITLE
Checkout: Show introductory offer details in sidebar for quantity upgrades

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -86,9 +86,6 @@ function LineItemIntroOfferCostOverrideDetail( {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const translate = useTranslate();
-	if ( ! product.introductory_offer_terms?.enabled ) {
-		return null;
-	}
 
 	if ( ! isOverrideCodeIntroductoryOffer( costOverride.overrideCode ) ) {
 		return false;

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -515,8 +515,6 @@ export function isOverrideCodeIntroductoryOffer( overrideCode: string ): boolean
 	switch ( overrideCode ) {
 		case 'introductory-offer':
 			return true;
-		case 'prorated-introductory-offer':
-			return true;
 		case 'quantity-upgrade-introductory-offer':
 			return true;
 	}

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -218,7 +218,10 @@ function makeIntroductoryOfferCostOverrideUnique(
 	translate: ReturnType< typeof useTranslate >,
 	allowFreeText: boolean
 ): ResponseCartCostOverride {
-	if ( 'introductory-offer' !== costOverride.override_code || ! product.introductory_offer_terms ) {
+	if (
+		! isOverrideCodeIntroductoryOffer( costOverride.override_code ) ||
+		! product.introductory_offer_terms
+	) {
 		return costOverride;
 	}
 	const isPriceIncrease = costOverride.old_subtotal_integer < costOverride.new_subtotal_integer;

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -281,7 +281,7 @@ export function doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
 	) {
 		return false;
 	}
-	if ( ! introductoryOfferTerms?.enabled ) {
+	if ( ! introductoryOfferTerms ) {
 		return false;
 	}
 	if (
@@ -300,7 +300,7 @@ function doesIntroductoryOfferCostOverrideHavePriceIncrease(
 	if ( ! isOverrideCodeIntroductoryOffer( costOverride.override_code ) ) {
 		return false;
 	}
-	if ( ! product.introductory_offer_terms?.enabled ) {
+	if ( ! product.introductory_offer_terms ) {
 		return false;
 	}
 
@@ -322,7 +322,7 @@ function doesIntroductoryOfferCostOverrideHavePriceIncrease(
 }
 
 export function doesIntroductoryOfferHavePriceIncrease( product: ResponseCartProduct ): boolean {
-	if ( ! product.introductory_offer_terms?.enabled ) {
+	if ( ! product.introductory_offer_terms ) {
 		return false;
 	}
 	const hasIntroOfferOverrideWithPriceIncrease = product.cost_overrides?.some( ( override ) =>


### PR DESCRIPTION
## Proposed Changes

In this PR we include special introductory offer text in the sidebar for quantity upgrades affected by an introductory offer.

Fixes https://github.com/Automattic/wp-calypso/issues/96414

Before             |  After
:-------------------------:|:-------------------------:
![Image](https://github.com/user-attachments/assets/2fd19793-4a8c-48e3-acbc-729ee06a7ee1) | ![Image](https://github.com/user-attachments/assets/eb9caff1-5940-45b8-8083-ff5dec9aff4c)

## Why are these changes being made?

There are different types of cost overrides used to apply the pricing for introductory offers. There is a special type of override used for introductory offers as they apply to quantity upgrades, like adding a new mailbox to a Professional Email subscription when the original purchase is within the introductory offer period.

Since introductory offer discounts can be hard to understand when the offer's term length differs from the product's regular term length, like Professional Email subscriptions which have a discount of 3 months free, https://github.com/Automattic/wp-calypso/pull/87732 added special introductory offer text in the sidebar discount list to help clarify what's going on.

However, when performing a quantity upgrade for a product still covered by an introductory offer, it is not clear why the pricing is what it is.

## To do

This is still confusing for two reasons:

1. If two months have already passed by the time you're adding the new mailbox, it's actually only 1 month free. I believe that's why we are just displaying "Introductory offer" currently. We need a better way to communicate what is going on to the user.
2. The "Billed November..." and "Billed every year" are still a little confusing since it seems that they would refer to this specific mailbox, when they actually apply to all the mailboxes. We probably need a way to communicate that.

## Testing Instructions

- Purchase a Professional Email subscription.
- While the subscription is still within the introductory offer period, add a new mailbox to your shopping cart.
- Verify that the pricing calculation displayed in the sidebar for the new mailbox makes sense.