### PR TITLE
Improved Bulk Plugin Management DataViews usability

### DIFF
--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -42,6 +42,23 @@ export default function PluginsListDataViews( {
 		perPage: 15,
 		search: initialSearch,
 		fields: [ 'plugins', 'sites', 'update' ],
+		layout: {
+			styles: {
+				plugins: {
+					width: '60%',
+					minWidth: '300px',
+				},
+				sites: {
+					width: '70px',
+				},
+				update: {
+					minWidth: '200px',
+				},
+				actions: {
+					width: '50px',
+				},
+			},
+		},
 	} ) );
 
 	const [ isFilteringUpdates, setIsFilteringUpdates ] = useState( false );
@@ -80,7 +97,6 @@ export default function PluginsListDataViews( {
 		</>
 	);
 
-	// When search changes, notify the parent component
 	useEffect( () => {
 		if ( dataViewsState.search !== initialSearch ) {
 			onSearch && onSearch( dataViewsState.search || '' );
@@ -91,7 +107,7 @@ export default function PluginsListDataViews( {
 		if (
 			dataViewsState.filters?.length === 1 &&
 			dataViewsState.filters[ 0 ].field === 'status' &&
-			dataViewsState.filters[ 0 ].value.includes( PLUGINS_STATUS.UPDATE )
+			dataViewsState.filters[ 0 ].value?.includes( PLUGINS_STATUS.UPDATE )
 		) {
 			setIsFilteringUpdates( true );
 		} else {

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -14,6 +14,10 @@ body.is-section-plugins .plugin-management-wrapper,
                 max-width: 35px;
                 max-height: 35px;
             }
+
+            td:nth-child(2) {
+                white-space: break-spaces;
+            }
         }
     }
 }

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -36,7 +36,7 @@ export function useFields(
 				],
 				filterBy: {
 					operators: [ 'isAny' as Operator ],
-					isPrimary: true,
+					isPrimary: false,
 				},
 				enableHiding: false,
 				enableSorting: false,


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to issues:
- https://github.com/Automattic/dotcom-forge/issues/9849
- https://github.com/Automattic/dotcom-forge/issues/9851
- https://github.com/Automattic/dotcom-forge/issues/9852

## Proposed Changes

- Column with min-width and fixed width
- Hide status filter by default
- Reset filter hides when necessary

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
