### PR TITLE
Update getPluginTitle to accept plugin names separated by ,

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -616,7 +616,10 @@ class Login extends Component {
 		} else if ( isWooPasswordlessJPC ) {
 			const isLostPasswordFlow = currentQuery.lostpassword_flow === 'true';
 			const isTwoFactorAuthFlow = this.props.twoFactorEnabled;
-			const pluginName = getPluginTitle( this.props.authQuery?.plugin_name, translate );
+			const pluginName = getPluginTitle(
+				new URLSearchParams( this.props.initialQuery?.redirect_to ).get( 'plugin_name' ),
+				translate
+			);
 			let subtitle = null;
 
 			switch ( true ) {

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
-import { localize } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import { capitalize, get, isEmpty, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -618,7 +618,8 @@ class Login extends Component {
 			const isTwoFactorAuthFlow = this.props.twoFactorEnabled;
 			const pluginName = getPluginTitle(
 				new URLSearchParams( this.props.initialQuery?.redirect_to ).get( 'plugin_name' ),
-				translate
+				translate,
+				getLocaleSlug()
 			);
 			let subtitle = null;
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { capitalize, get, isEmpty, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -618,8 +618,7 @@ class Login extends Component {
 			const isTwoFactorAuthFlow = this.props.twoFactorEnabled;
 			const pluginName = getPluginTitle(
 				new URLSearchParams( this.props.initialQuery?.redirect_to ).get( 'plugin_name' ),
-				translate,
-				getLocaleSlug()
+				translate
 			);
 			let subtitle = null;
 

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { safeImageUrl } from '@automattic/calypso-url';
 import { CompactCard } from '@automattic/components';
 import { Icon, globe } from '@wordpress/icons';
-import { localize } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -171,7 +171,11 @@ export class AuthFormHeader extends Component {
 		}
 
 		if ( isWooPasswordlessJPC ) {
-			const pluginName = getPluginTitle( this.props.authQuery?.plugin_name, translate );
+			const pluginName = getPluginTitle(
+				this.props.authQuery?.plugin_name,
+				translate,
+				getLocaleSlug()
+			);
 			const reviewDocLink = (
 				<a
 					href="https://woocommerce.com/document/connect-your-store-to-a-wordpress-com-account/"

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { safeImageUrl } from '@automattic/calypso-url';
 import { CompactCard } from '@automattic/components';
 import { Icon, globe } from '@wordpress/icons';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -171,11 +171,7 @@ export class AuthFormHeader extends Component {
 		}
 
 		if ( isWooPasswordlessJPC ) {
-			const pluginName = getPluginTitle(
-				this.props.authQuery?.plugin_name,
-				translate,
-				getLocaleSlug()
-			);
+			const pluginName = getPluginTitle( this.props.authQuery?.plugin_name, translate );
 			const reviewDocLink = (
 				<a
 					href="https://woocommerce.com/document/connect-your-store-to-a-wordpress-com-account/"

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -256,5 +256,22 @@ export const getPluginTitle = ( pluginName, translate ) => {
 		default: translate( 'Jetpack' ),
 	};
 
-	return pluginNames[ pluginName ] || pluginNames.default;
+	if ( ! pluginName ) {
+		// Handle null, undefined, or empty strings
+		return pluginNames.default;
+	}
+
+	// Handle multiple plugin names separated by commas
+	const titles = pluginName
+		.split( ',' )
+		.map( ( name ) => pluginNames[ name.trim() ] || pluginNames.default );
+
+	// Combine titles with a serial comma before "and"
+	if ( titles.length > 1 ) {
+		return `${ titles.slice( 0, -1 ).join( ', ' ) }, ${ translate( 'and' ) } ${
+			titles[ titles.length - 1 ]
+		}`;
+	}
+
+	return titles[ 0 ];
 };

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -263,11 +263,12 @@ export const getPluginTitle = ( pluginName, translate, langSlug = getLocaleSlug(
 	}
 
 	// Handle multiple plugin names separated by commas
-	const titles = pluginName
-		.split( ',' )
-		.map( ( name ) => allowedPluginNames[ name.trim() ] || allowedPluginNames.default );
+	const titles = pluginName.split( ',' ).map( ( name ) => allowedPluginNames[ name.trim() ] );
+	const uniqueTitles = Array.from( new Set( titles ) ).filter( ( title ) => title );
 
-	const uniqueTitles = Array.from( new Set( titles ) );
+	if ( uniqueTitles.length === 0 ) {
+		return allowedPluginNames.default;
+	}
 
 	// Use Intl.ListFormat for proper localized list formatting
 	const formatter = new Intl.ListFormat( langSlug, { style: 'long', type: 'conjunction' } );

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { addLocaleToPath, isDefaultLocale } from '@automattic/i18n-utils';
 import cookie from 'cookie';
+import { getLocaleSlug } from 'i18n-calypso';
 import { get, includes, startsWith } from 'lodash';
 import {
 	isAkismetOAuth2Client,
@@ -248,12 +249,12 @@ export const getLoginLinkPageUrl = ( {
 	return login( loginParameters );
 };
 
-export const getPluginTitle = ( pluginName, translate, langSlug = 'en' ) => {
+export const getPluginTitle = ( pluginName, translate, langSlug = getLocaleSlug() ) => {
 	const allowedPluginNames = {
 		'jetpack-ai': translate( 'Jetpack' ),
 		'woocommerce-payments': translate( 'WooPayments' ),
 		'order-attribution': translate( 'Order Attribution' ),
-		default: translate( 'Jetpack' ),
+		default: translate( 'WooCommerce' ),
 	};
 
 	if ( ! pluginName ) {

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -254,12 +254,18 @@ export const getPluginTitle = ( pluginName, translate, langSlug = getLocaleSlug(
 		'jetpack-ai': translate( 'Jetpack' ),
 		'woocommerce-payments': translate( 'WooPayments' ),
 		'order-attribution': translate( 'Order Attribution' ),
-		default: translate( 'WooCommerce' ),
 	};
+
+	const listFormatter = new Intl.ListFormat( langSlug, {
+		style: 'long',
+		type: 'conjunction',
+	} );
+
+	const defaultTitle = listFormatter.format( Object.values( allowedPluginNames ) );
 
 	if ( ! pluginName ) {
 		// Handle null, undefined, or empty strings
-		return allowedPluginNames.default;
+		return defaultTitle;
 	}
 
 	// Handle multiple plugin names separated by commas
@@ -267,11 +273,8 @@ export const getPluginTitle = ( pluginName, translate, langSlug = getLocaleSlug(
 	const uniqueTitles = Array.from( new Set( titles ) ).filter( ( title ) => title );
 
 	if ( uniqueTitles.length === 0 ) {
-		return allowedPluginNames.default;
+		return defaultTitle;
 	}
 
-	// Use Intl.ListFormat for proper localized list formatting
-	const formatter = new Intl.ListFormat( langSlug, { style: 'long', type: 'conjunction' } );
-
-	return formatter.format( uniqueTitles );
+	return listFormatter.format( uniqueTitles );
 };

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -249,7 +249,7 @@ export const getLoginLinkPageUrl = ( {
 };
 
 export const getPluginTitle = ( pluginName, translate ) => {
-	const pluginNames = {
+	const allowedPluginNames = {
 		'jetpack-ai': translate( 'Jetpack' ),
 		'woocommerce-payments': translate( 'WooPayments' ),
 		'order-attribution': translate( 'Order Attribution' ),
@@ -258,13 +258,13 @@ export const getPluginTitle = ( pluginName, translate ) => {
 
 	if ( ! pluginName ) {
 		// Handle null, undefined, or empty strings
-		return pluginNames.default;
+		return allowedPluginNames.default;
 	}
 
 	// Handle multiple plugin names separated by commas
 	const titles = pluginName
 		.split( ',' )
-		.map( ( name ) => pluginNames[ name.trim() ] || pluginNames.default );
+		.map( ( name ) => allowedPluginNames[ name.trim() ] || allowedPluginNames.default );
 
 	const uniqueTitles = Array.from( new Set( titles ) );
 

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -266,8 +266,10 @@ export const getPluginTitle = ( pluginName, translate ) => {
 		.split( ',' )
 		.map( ( name ) => pluginNames[ name.trim() ] || pluginNames.default );
 
-	// Combine titles with a serial comma before "and"
-	if ( titles.length > 1 ) {
+	// Adjust formatting for two vs more than two plugins
+	if ( titles.length === 2 ) {
+		return `${ titles[ 0 ] } ${ translate( 'and' ) } ${ titles[ 1 ] }`;
+	} else if ( titles.length > 2 ) {
 		return `${ titles.slice( 0, -1 ).join( ', ' ) }, ${ translate( 'and' ) } ${
 			titles[ titles.length - 1 ]
 		}`;

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -248,7 +248,7 @@ export const getLoginLinkPageUrl = ( {
 	return login( loginParameters );
 };
 
-export const getPluginTitle = ( pluginName, translate ) => {
+export const getPluginTitle = ( pluginName, translate, langSlug = 'en' ) => {
 	const allowedPluginNames = {
 		'jetpack-ai': translate( 'Jetpack' ),
 		'woocommerce-payments': translate( 'WooPayments' ),
@@ -268,14 +268,8 @@ export const getPluginTitle = ( pluginName, translate ) => {
 
 	const uniqueTitles = Array.from( new Set( titles ) );
 
-	// Adjust formatting for two vs more than two plugins
-	if ( uniqueTitles.length === 2 ) {
-		return `${ uniqueTitles[ 0 ] } ${ translate( 'and' ) } ${ uniqueTitles[ 1 ] }`;
-	} else if ( uniqueTitles.length > 2 ) {
-		return `${ uniqueTitles.slice( 0, -1 ).join( ', ' ) }, ${ translate( 'and' ) } ${
-			uniqueTitles[ uniqueTitles.length - 1 ]
-		}`;
-	}
+	// Use Intl.ListFormat for proper localized list formatting
+	const formatter = new Intl.ListFormat( langSlug, { style: 'long', type: 'conjunction' } );
 
-	return titles[ 0 ];
+	return formatter.format( uniqueTitles );
 };

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -266,12 +266,14 @@ export const getPluginTitle = ( pluginName, translate ) => {
 		.split( ',' )
 		.map( ( name ) => pluginNames[ name.trim() ] || pluginNames.default );
 
+	const uniqueTitles = Array.from( new Set( titles ) );
+
 	// Adjust formatting for two vs more than two plugins
-	if ( titles.length === 2 ) {
-		return `${ titles[ 0 ] } ${ translate( 'and' ) } ${ titles[ 1 ] }`;
-	} else if ( titles.length > 2 ) {
-		return `${ titles.slice( 0, -1 ).join( ', ' ) }, ${ translate( 'and' ) } ${
-			titles[ titles.length - 1 ]
+	if ( uniqueTitles.length === 2 ) {
+		return `${ uniqueTitles[ 0 ] } ${ translate( 'and' ) } ${ uniqueTitles[ 1 ] }`;
+	} else if ( uniqueTitles.length > 2 ) {
+		return `${ uniqueTitles.slice( 0, -1 ).join( ', ' ) }, ${ translate( 'and' ) } ${
+			uniqueTitles[ uniqueTitles.length - 1 ]
 		}`;
 	}
 

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -251,7 +251,7 @@ describe( 'getPluginTitle', () => {
 
 	it( 'should handle a mix of valid and invalid plugin names', () => {
 		const result = getPluginTitle( 'jetpack-ai,unknown-plugin,woocommerce-payments', translate );
-		expect( result ).toBe( 'Jetpack, Jetpack, and WooPayments' ); // Default for invalid names
+		expect( result ).toBe( 'Jetpack and WooPayments' ); // Default for invalid names
 	} );
 
 	it( 'should handle extra whitespace in plugin names', () => {

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -216,43 +216,46 @@ describe( 'getSignupUrl', () => {
 } );
 
 describe( 'getPluginTitle', () => {
+	const translate = ( str ) => {
+		return str;
+	};
 	it( 'should return the title for a single valid plugin name', () => {
-		const result = getPluginTitle( 'jetpack-ai' );
+		const result = getPluginTitle( 'jetpack-ai', translate );
 		expect( result ).toBe( 'Jetpack' );
 	} );
 
 	it( 'should return titles joined with "and" for two plugin names', () => {
-		const result = getPluginTitle( 'jetpack-ai,woocommerce-payments' );
+		const result = getPluginTitle( 'jetpack-ai,woocommerce-payments', translate );
 		expect( result ).toBe( 'Jetpack and WooPayments' );
 	} );
 
 	it( 'should return titles joined with a serial comma and "and" for three plugin names', () => {
-		const result = getPluginTitle( 'jetpack-ai,woocommerce-payments,order-attribution' );
+		const result = getPluginTitle( 'jetpack-ai,woocommerce-payments,order-attribution', translate );
 		expect( result ).toBe( 'Jetpack, WooPayments, and Order Attribution' );
 	} );
 
 	it( 'should return the default title for an invalid plugin name', () => {
-		const result = getPluginTitle( 'unknown-plugin' );
+		const result = getPluginTitle( 'unknown-plugin', translate );
 		expect( result ).toBe( 'Jetpack' ); // Default value
 	} );
 
 	it( 'should return the default title for null input', () => {
-		const result = getPluginTitle( null );
+		const result = getPluginTitle( null, translate );
 		expect( result ).toBe( 'Jetpack' ); // Default value
 	} );
 
 	it( 'should return the default title for an empty string', () => {
-		const result = getPluginTitle( '' );
+		const result = getPluginTitle( '', translate );
 		expect( result ).toBe( 'Jetpack' ); // Default value
 	} );
 
 	it( 'should handle a mix of valid and invalid plugin names', () => {
-		const result = getPluginTitle( 'jetpack-ai,unknown-plugin,woocommerce-payments' );
+		const result = getPluginTitle( 'jetpack-ai,unknown-plugin,woocommerce-payments', translate );
 		expect( result ).toBe( 'Jetpack, Jetpack, and WooPayments' ); // Default for invalid names
 	} );
 
 	it( 'should handle extra whitespace in plugin names', () => {
-		const result = getPluginTitle( ' jetpack-ai , woocommerce-payments ' );
+		const result = getPluginTitle( ' jetpack-ai , woocommerce-payments ', translate );
 		expect( result ).toBe( 'Jetpack and WooPayments' );
 	} );
 } );

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -236,17 +236,17 @@ describe( 'getPluginTitle', () => {
 
 	it( 'should return the default title for an invalid plugin name', () => {
 		const result = getPluginTitle( 'unknown-plugin', translate );
-		expect( result ).toBe( 'Jetpack' ); // Default value
+		expect( result ).toBe( 'WooCommerce' ); // Default value
 	} );
 
 	it( 'should return the default title for null input', () => {
 		const result = getPluginTitle( null, translate );
-		expect( result ).toBe( 'Jetpack' ); // Default value
+		expect( result ).toBe( 'WooCommerce' ); // Default value
 	} );
 
 	it( 'should return the default title for an empty string', () => {
 		const result = getPluginTitle( '', translate );
-		expect( result ).toBe( 'Jetpack' ); // Default value
+		expect( result ).toBe( 'WooCommerce' ); // Default value
 	} );
 
 	it( 'should handle a mix of valid and invalid plugin names', () => {

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -236,17 +236,17 @@ describe( 'getPluginTitle', () => {
 
 	it( 'should return the default title for an invalid plugin name', () => {
 		const result = getPluginTitle( 'unknown-plugin', translate );
-		expect( result ).toBe( 'WooCommerce' ); // Default value
+		expect( result ).toBe( 'Jetpack, WooPayments, and Order Attribution' ); // Default value
 	} );
 
 	it( 'should return the default title for null input', () => {
 		const result = getPluginTitle( null, translate );
-		expect( result ).toBe( 'WooCommerce' ); // Default value
+		expect( result ).toBe( 'Jetpack, WooPayments, and Order Attribution' ); // Default value
 	} );
 
 	it( 'should return the default title for an empty string', () => {
 		const result = getPluginTitle( '', translate );
-		expect( result ).toBe( 'WooCommerce' ); // Default value
+		expect( result ).toBe( 'Jetpack, WooPayments, and Order Attribution' ); // Default value
 	} );
 
 	it( 'should handle a mix of valid and invalid plugin names', () => {

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -1,4 +1,4 @@
-import { pathWithLeadingSlash, getSignupUrl } from 'calypso/lib/login';
+import { pathWithLeadingSlash, getSignupUrl, getPluginTitle } from 'calypso/lib/login';
 
 describe( 'pathWithLeadingSlash', () => {
 	test( 'should add leading slash', () => {
@@ -212,5 +212,47 @@ describe( 'getSignupUrl', () => {
 		).toEqual(
 			'/start/account?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Fpublic.api%2Fconnect%2F%3Faction%3Dverify'
 		);
+	} );
+} );
+
+describe( 'getPluginTitle', () => {
+	it( 'should return the title for a single valid plugin name', () => {
+		const result = getPluginTitle( 'jetpack-ai' );
+		expect( result ).toBe( 'Jetpack' );
+	} );
+
+	it( 'should return titles joined with "and" for two plugin names', () => {
+		const result = getPluginTitle( 'jetpack-ai,woocommerce-payments' );
+		expect( result ).toBe( 'Jetpack and WooPayments' );
+	} );
+
+	it( 'should return titles joined with a serial comma and "and" for three plugin names', () => {
+		const result = getPluginTitle( 'jetpack-ai,woocommerce-payments,order-attribution' );
+		expect( result ).toBe( 'Jetpack, WooPayments, and Order Attribution' );
+	} );
+
+	it( 'should return the default title for an invalid plugin name', () => {
+		const result = getPluginTitle( 'unknown-plugin' );
+		expect( result ).toBe( 'Jetpack' ); // Default value
+	} );
+
+	it( 'should return the default title for null input', () => {
+		const result = getPluginTitle( null );
+		expect( result ).toBe( 'Jetpack' ); // Default value
+	} );
+
+	it( 'should return the default title for an empty string', () => {
+		const result = getPluginTitle( '' );
+		expect( result ).toBe( 'Jetpack' ); // Default value
+	} );
+
+	it( 'should handle a mix of valid and invalid plugin names', () => {
+		const result = getPluginTitle( 'jetpack-ai,unknown-plugin,woocommerce-payments' );
+		expect( result ).toBe( 'Jetpack, Jetpack, and WooPayments' ); // Default for invalid names
+	} );
+
+	it( 'should handle extra whitespace in plugin names', () => {
+		const result = getPluginTitle( ' jetpack-ai , woocommerce-payments ' );
+		expect( result ).toBe( 'Jetpack and WooPayments' );
 	} );
 } );

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -258,4 +258,13 @@ describe( 'getPluginTitle', () => {
 		const result = getPluginTitle( ' jetpack-ai ,, woocommerce-payments ', translate );
 		expect( result ).toBe( 'Jetpack and WooPayments' );
 	} );
+
+	it( 'should handle French formatting for three plugin names', () => {
+		const result = getPluginTitle(
+			'jetpack-ai,woocommerce-payments,order-attribution',
+			translate,
+			'fr'
+		);
+		expect( result ).toBe( 'Jetpack, WooPayments et Order Attribution' );
+	} );
 } );

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -255,7 +255,7 @@ describe( 'getPluginTitle', () => {
 	} );
 
 	it( 'should handle extra whitespace in plugin names', () => {
-		const result = getPluginTitle( ' jetpack-ai , woocommerce-payments ', translate );
+		const result = getPluginTitle( ' jetpack-ai ,, woocommerce-payments ', translate );
 		expect( result ).toBe( 'Jetpack and WooPayments' );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Partially fixes https://github.com/woocommerce/woocommerce/issues/52875

## Proposed Changes

* Updated getPluginTitle function to accept plugin names separated by ,

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support multiple plugin names

## Testing Instructions

1. Checkout this branch locally and run `yarn start`
2. Once the build is ready, visit this [link](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=236381464&redirect_uri=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D32ab4c9508%26redirect%3Dhttps%253A%252F%252Fnoisily-fortunate-toucan.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A2ca8ea2582da1c066074563a12cc8b22&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=13.7&secret=QFoaAXaOIPZTr9p6Z5Hqf6RWkCboPylJ&blogname=Noisily+Fortunate+Toucan&site_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&home_url=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja&site_icon&site_lang=en_US&site_created=2024-08-26+19%3A40%3A51&allow_site_connection=1&calypso_env=production&source&_as=search-term&_ak=jetpack&from=woocommerce-core-profiler&installed_ext_success=1&_ui=254662545&_ut=wpcom%3Auser_id&purchase_nonce=lbtPaOlO&_wp_nonce=69744335dc&redirect_after_auth=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fnoisily-fortunate-toucan.jurassic.ninja)
3. Confirm the subtitle reads "To access all of the features and functionality in Jetpack..."
4. Copy the link and add `&plugin_name=woocommerce-payments,jetpack-ai` and open it again.
5. Confirm the subtitle reads "To access all of the features and functionality in WooCommerce Payments and Jetpack"
6. Take a look at the tests and make sure they make sense.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
