### PR TITLE
Business tax: Remove feature flag and update support doc link

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -316,8 +316,8 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/posts/tags/',
 		post_id: 8586,
 	},
-	'tax-exempt-customers': {
-		link: 'https://wordpress.com/support/vat-gst-other-taxes/#other-tax-exempt-customers',
+	'state-based-business-use-tax': {
+		link: 'https://wordpress.com/support/vat-gst-other-taxes/#state-based-business-use-tax',
 		post_id: 234670,
 	},
 	team: {

--- a/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
+++ b/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
@@ -1,6 +1,6 @@
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart, convertTaxLocationToLocationUpdate } from '@automattic/shopping-cart';
-import { hasCheckoutVersion, styled } from '@automattic/wpcom-checkout';
+import { styled } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -43,7 +43,7 @@ export function IsForBusinessCheckbox() {
 	const isChecked = responseCart.tax.location.is_for_business ?? false;
 	const isDisabled = formStatus !== FormStatus.READY || isLoading || isPendingUpdate;
 
-	if ( ! isUnitedStateWithBusinessOption || ! hasCheckoutVersion( 'business-use-tax' ) ) {
+	if ( ! isUnitedStateWithBusinessOption ) {
 		return null;
 	}
 
@@ -59,7 +59,7 @@ export function IsForBusinessCheckbox() {
 								link: (
 									<InlineSupportLink
 										id="checkout-is-business-checkbox"
-										supportContext="tax-exempt-customers"
+										supportContext="state-based-business-use-tax"
 										showIcon={ false }
 									/>
 								),


### PR DESCRIPTION
This PR will effectively launch the business use tax checkbox in Checkout for Ohio and Connecticut.

Frontend features added for this project can be found here https://github.com/Automattic/wp-calypso/pull/88737

Related to https://github.com/Automattic/payments-shilling/issues/1914

## Testing Instructions

* Before removing this feature flag, make sure that the backend changes have been deployed https://github.com/Automattic/payments-shilling/issues/3226
* Then, to test that everything is working, follow the testing steps found in the backend differential