### PR TITLE
A4A: Show a4a logo on magic login screens

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -1114,7 +1114,9 @@ export default connect(
 		linkingSocialService: getSocialAccountLinkService( state ),
 		partnerSlug: getPartnerSlugFromQuery( state ),
 		isFromAutomatticForAgenciesPlugin:
-			'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ),
+			'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ) ||
+			'automattic-for-agencies-client' ===
+				new URLSearchParams( getRedirectToOriginal( state ).split( '?' )[ 1 ] ).get( 'from' ),
 		isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 		isJetpackWooCommerceFlow:
 			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -1116,7 +1116,7 @@ export default connect(
 		isFromAutomatticForAgenciesPlugin:
 			'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ) ||
 			'automattic-for-agencies-client' ===
-				new URLSearchParams( getRedirectToOriginal( state ).split( '?' )[ 1 ] ).get( 'from' ),
+				new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
 		isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 		isJetpackWooCommerceFlow:
 			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -363,7 +363,6 @@ export class LoginForm extends Component {
 			addQueryArgs(
 				{
 					email_address: this.state.usernameOrEmail,
-					...( this.props.isFromAutomatticForAgenciesPlugin ? { a4a: '1' } : {} ),
 				},
 				'/log-in/jetpack/link'
 			)

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -5,7 +5,6 @@ import { addLocaleToPath, localizeUrl, getLanguage } from '@automattic/i18n-util
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -48,6 +47,7 @@ import {
 	getTwoFactorNotificationSent,
 	isTwoFactorEnabled,
 	getRedirectToSanitized,
+	getRedirectToOriginal,
 } from 'calypso/state/login/selectors';
 import {
 	infoNotice,
@@ -1294,9 +1294,13 @@ class MagicLogin extends Component {
 
 		return (
 			<Main className="magic-login magic-login__request-link is-white-login">
-				{ this.props.isJetpackLogin && ! this.props.isA4A && <JetpackHeader /> }
+				{ this.props.isJetpackLogin && ! this.props.isFromAutomatticForAgenciesPlugin && (
+					<JetpackHeader />
+				) }
 				{ this.renderGutenboardingLogo() }
-				{ this.props.isA4A && <A4ALogo fullA4A size={ 58 } className="magic-login__a4a-logo" /> }
+				{ this.props.isFromAutomatticForAgenciesPlugin && (
+					<A4ALogo fullA4A size={ 58 } className="magic-login__a4a-logo" />
+				) }
 
 				{ this.renderLocaleSuggestions() }
 
@@ -1330,7 +1334,9 @@ const mapState = ( state ) => ( {
 	twoFactorEnabled: isTwoFactorEnabled( state ),
 	twoFactorNotificationSent: getTwoFactorNotificationSent( state ),
 	redirectToSanitized: getRedirectToSanitized( state ),
-	isA4A: '1' === get( getCurrentQueryArguments( state ), 'a4a' ),
+	isFromAutomatticForAgenciesPlugin:
+		'automattic-for-agencies-client' ===
+		new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
 } );
 
 const mapDispatch = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: 1417-gh-Automattic/automattic-for-agencies-dev
Discussion: pfunGA-3vP-p2

## Proposed Changes

* When going through the Jetpack connect flow when coming from the A4A plugin, show A4A branding instead of Jetpack.
* Undo a change made in https://github.com/Automattic/wp-calypso/pull/96368 to determine A4A another way without passing an additional URL param.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To give A4A customer better consistency and avoid confusion with mismatched branding

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Setup
* Checkout this branch locally
* Point `wordpress.com` to `127.0.0.1` in your hosts file
* Start Calypso using `yarn start-mock-wordpress-com` (press any key to continue when prompted)

#### Test A4A plugin
* While **logged-in** to wpcom, create [jurassic ninja](https://jurassic.ninja/) site.
* On the new site, in wp-admin go to plugins > add new plugin, search for "automattic for agencies"
* Install now > Activate the plugin
* From A4A settings page in wp-admin, click "Connect this site"
<img width="1395" alt="Screenshot 2024-11-13 at 10 50 02 AM" src="https://github.com/user-attachments/assets/156f00ca-1588-4749-ac8a-bf760bfac04c">

* On the wordpress.com auth page, click "Sign in as different user" (might need to type `thisisunsafe` in chrome)
<img width="1112" alt="Screenshot 2024-11-13 at 4 53 24 PM" src="https://github.com/user-attachments/assets/f208ae56-5860-4ed7-b8db-f2fbb11e6efc">

* Enter an email address (not already registered on wpcom), click "Continue"
<img width="1227" alt="Screenshot 2024-11-13 at 10 52 47 AM" src="https://github.com/user-attachments/assets/52f7602b-6021-48b3-bfa0-17682f72fa28">

* On the next screen, you should see an A4A logo instead of Jetpack.
<img width="1245" alt="Screenshot 2024-11-13 at 10 53 43 AM" src="https://github.com/user-attachments/assets/37682047-54cb-4d42-9685-9acb0d5bd7e0">

* Click back and enter an email address of an existing wpcom user (not the currently signed-in user)

* On the next screen, you should see an A4A logo instead of Jetpack.
<img width="1245" alt="Screenshot 2024-11-13 at 10 53 43 AM" src="https://github.com/user-attachments/assets/37682047-54cb-4d42-9685-9acb0d5bd7e0">

#### Test normal Jetpack flow
* Repeat the steps above but with the Jetpack plugin.
* Go through the normal connection flow to connect your user.
* You should continue to see the Jetpack logo on the screen mentioned above.
<img width="1193" alt="Screenshot 2024-11-13 at 11 03 48 AM" src="https://github.com/user-attachments/assets/4d50c319-a52c-4de7-8b3e-e21d28766349">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
