### PR TITLE
Stats: Use moment object with site offset

### DIFF
--- a/client/components/date-control/index.tsx
+++ b/client/components/date-control/index.tsx
@@ -4,6 +4,7 @@ import { Moment } from 'moment';
 import { RefObject } from 'react';
 import DateRange from 'calypso/components/date-range';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import useMomentSiteZone from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { DateControlProps } from './types';
 import './style.scss';
 
@@ -19,12 +20,13 @@ const DateControl = ( {
 	overlay,
 }: DateControlProps ) => {
 	const moment = useLocalizedMoment();
+	const siteToday = useMomentSiteZone();
 
 	const getShortcutForRange = () => {
 		// Search the shortcut array for something matching the current date range.
 		// Returns shortcut or null;
-		const today = moment().format( 'YYYY-MM-DD' );
-		const yesterday = moment().subtract( 1, 'days' ).format( 'YYYY-MM-DD' );
+		const today = siteToday.format( 'YYYY-MM-DD' );
+		const yesterday = siteToday.clone().subtract( 1, 'days' ).format( 'YYYY-MM-DD' );
 		const shortcut = shortcutList.find( ( element ) => {
 			if (
 				yesterday === dateRange.chartEnd &&
@@ -50,6 +52,12 @@ const DateControl = ( {
 		// Generate a full date range for the label.
 		const startDate = moment( dateRange.chartStart ).format( 'LL' );
 		const endDate = moment( dateRange.chartEnd ).format( 'LL' );
+
+		// If start and end are the same, then just show one date.
+		if ( startDate === endDate ) {
+			return startDate;
+		}
+
 		return `${ startDate } - ${ endDate }`;
 	};
 
@@ -58,7 +66,7 @@ const DateControl = ( {
 			<DateRange
 				selectedStartDate={ moment( dateRange.chartStart ) }
 				selectedEndDate={ moment( dateRange.chartEnd ) }
-				lastSelectableDate={ moment() }
+				lastSelectableDate={ siteToday }
 				firstSelectableDate={ moment( '2010-01-01' ) }
 				onDateCommit={ ( startDate: Moment, endDate: Moment ) =>
 					startDate && endDate && onApplyButtonClick( startDate, endDate )

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import moment, { Moment } from 'moment';
 import PropTypes from 'prop-types';
+import useMomentSiteZone from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 
 const DATERANGE_PERIOD = {
 	DAY: 'day',
@@ -29,6 +30,7 @@ const DateRangePickerShortcuts = ( {
 	endDate?: MomentOrNull;
 } ) => {
 	const translate = useTranslate();
+	const siteToday = useMomentSiteZone();
 
 	const normalizeDate = ( date: MomentOrNull ) => {
 		return date ? date.startOf( 'day' ) : date;
@@ -87,7 +89,7 @@ const DateRangePickerShortcuts = ( {
 		}
 		// Search the shortcut array for something matching the current date range.
 		// Returns shortcut or null;
-		const today = moment().startOf( 'day' );
+		const today = siteToday.clone().startOf( 'day' );
 		const daysInRange = Math.abs( endDate.diff( startDate, 'days' ) );
 		const shortcut = shortcutList.find( ( element ) => {
 			if ( endDate.isSame( today ) && daysInRange === element.range ) {
@@ -99,8 +101,9 @@ const DateRangePickerShortcuts = ( {
 	};
 
 	const handleClick = ( { id, offset, range }: { id?: string; offset: number; range: number } ) => {
-		const newToDate = moment().startOf( 'day' ).subtract( offset, 'days' );
-		const newFromDate = moment()
+		const newToDate = siteToday.clone().startOf( 'day' ).subtract( offset, 'days' );
+		const newFromDate = siteToday
+			.clone()
 			.startOf( 'day' )
 			.subtract( offset + range, 'days' );
 		onClick( newFromDate, newToDate, id || '' );

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -210,6 +210,7 @@ export function site( context, next ) {
 				chartTab={ chartTab }
 				context={ context }
 				period={ rangeOfPeriod( activeFilter.period, date ) }
+				momentSiteZone={ momentSiteZone }
 			/>
 		</StatsPageLoader>
 	);

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -210,7 +210,6 @@ export function site( context, next ) {
 				chartTab={ chartTab }
 				context={ context }
 				period={ rangeOfPeriod( activeFilter.period, date ) }
-				momentSiteZone={ momentSiteZone }
 			/>
 		</StatsPageLoader>
 	);

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -1,0 +1,23 @@
+import moment, { Moment } from 'moment';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useSelector } from 'calypso/state';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export function getMomentSiteZone(
+	state: object,
+	siteId: number | null,
+	localizedMoment?: () => Moment
+) {
+	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' ) as number;
+	return ( localizedMoment || moment )().utcOffset( gmtOffset ?? 0 );
+}
+
+/**
+ * Get moment object based on site timezone.
+ */
+export default function useMomentSiteZone() {
+	const siteId = useSelector( getSelectedSiteId );
+	const localizedMoment = useLocalizedMoment();
+	return useSelector( ( state ) => getMomentSiteZone( state, siteId, localizedMoment ) );
+}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -27,6 +27,7 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS } from 'calypso/my-sites/stats/constants';
+import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import {
 	recordGoogleEvent,
 	recordTracksEvent,
@@ -823,6 +824,7 @@ export default connect(
 			supportUserFeedback,
 			isOldJetpack,
 			shouldForceDefaultDateRange,
+			momentSiteZone: getMomentSiteZone( state, siteId ),
 		};
 	},
 	{

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -248,6 +248,7 @@ class StatsSite extends Component {
 			isOldJetpack,
 			shouldForceDefaultDateRange,
 			supportUserFeedback,
+			momentSiteZone,
 		} = this.props;
 		const isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' );
 		let defaultPeriod = PAST_SEVEN_DAYS;
@@ -276,7 +277,7 @@ class StatsSite extends Component {
 		if ( chartEnd ) {
 			customChartRange = { chartEnd };
 		} else {
-			customChartRange = { chartEnd: moment().format( 'YYYY-MM-DD' ) };
+			customChartRange = { chartEnd: momentSiteZone.format( 'YYYY-MM-DD' ) };
 		}
 
 		// Find the quantity of bars for the chart.
@@ -291,7 +292,8 @@ class StatsSite extends Component {
 		} else {
 			// if start date is missing let the frequency of data take over to avoid showing one bar
 			// (e.g. months defaulting to 30 days and showing one point)
-			customChartRange.chartStart = moment()
+			customChartRange.chartStart = momentSiteZone
+				.clone()
 				.subtract( daysInRange - 1, 'days' )
 				.format( 'YYYY-MM-DD' );
 		}
@@ -321,8 +323,11 @@ class StatsSite extends Component {
 
 			// For StatsDateControl
 			customChartRange.daysInRange = 7;
-			customChartRange.chartEnd = moment().format( 'YYYY-MM-DD' );
-			customChartRange.chartStart = moment().subtract( 7, 'days' ).format( 'YYYY-MM-DD' );
+			customChartRange.chartEnd = momentSiteZone.format( 'YYYY-MM-DD' );
+			customChartRange.chartStart = momentSiteZone
+				.clone()
+				.subtract( 7, 'days' )
+				.format( 'YYYY-MM-DD' );
 		}
 
 		const query = isNewDateFilteringEnabled


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/76912

## Proposed Changes

* Add hook `useMomentSiteZone` and use it for site dates, especially the relevant dates, like today / yesterday.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Unify timezone across front end / back end

## Testing Instructions

* Open a site that is still at yesterday like`https://wordpress.com/stats/day/jetpack.com`
  * jetpack.com is on UTC, so if it's already passed the time, you could change your local site to for example -12 zone. 
* You should be seeing empty today data
<img width="611" alt="image" src="https://github.com/user-attachments/assets/2db874ff-9746-456f-8099-3f758a574fa3">


* Open Calypso live on `/stats/day/jetpack.com`
* Ensure the today you see matches the site timezone
![image](https://github.com/user-attachments/assets/4d78e18b-e508-4d6c-ade2-c7c1680069ad)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
