### PR TITLE
A4A > Agency Tier: Show emerging tier celebration modal only after first purchase

### DIFF
--- a/client/a8c-for-agencies/constants/index.ts
+++ b/client/a8c-for-agencies/constants/index.ts
@@ -6,3 +6,5 @@ export const JETPACK_CONNECT_A4A_LINK =
 	'https://wordpress.com/jetpack/connect?source=a8c-for-agencies';
 
 export const REFERRAL_EMAIL_QUERY_PARAM_KEY = 'referral_email';
+
+export const AGENCY_FIRST_PURCHASE_SESSION_STORAGE_KEY = 'a4a-first-purchase';

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
@@ -7,6 +7,7 @@ import {
 	A4A_SITES_LINK,
 	A4A_SITES_LINK_NEEDS_SETUP,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { AGENCY_FIRST_PURCHASE_SESSION_STORAGE_KEY } from 'calypso/a8c-for-agencies/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { useDispatch, useSelector } from 'calypso/state';
 import { fetchAgencies } from 'calypso/state/a8c-for-agencies/agency/actions';
@@ -134,6 +135,8 @@ function useIssueAndAssignLicenses(
 
 			// Refresh the list of agencies if we don't have the tier to get the updated tier
 			if ( ! agency?.tier ) {
+				// We need to show the agency tier celebration modal after the first purchase
+				sessionStorage.setItem( AGENCY_FIRST_PURCHASE_SESSION_STORAGE_KEY, 'true' );
 				dispatch( fetchAgencies() );
 			}
 


### PR DESCRIPTION
## Proposed Changes

This PR changes the logic to show the emerging tier celebration modal only after the first purchase. 

## Why are these changes being made?

* To show emerging tier celebration modal only after the first purchase

## Testing Instructions

* Open the A4A live link
* Update your agency tier to Agency Partner or Pro Agency Partner until a celebration modal is shown on the Overview page > Dismiss it. This is to make sure the preference is saved.
* Set your agency tier to "Emerging Partner" using the MC tool > Refresh the page and verify no modal is shown.
* Use the MC tool to set your agency tier to undefined. Then, Go to Marketplace, Purchase any license > Go to the Overview page, and verify that the modal below is shown > Dismiss the modal > Refresh the page and verify it is not shown again.

<img width="800" alt="Screenshot 2024-11-18 at 12 36 59 PM" src="https://github.com/user-attachments/assets/7cf70872-6657-47c5-b3ca-c2e5dda220ef">

* Update your agency tier to Agency Partner or Pro Agency Partner until a celebration modal is shown on the Overview page > Dismiss it. This is to make sure the preference is saved.
*  Set your agency tier to "Emerging Partner" using the MC tool > Refresh the page and verify no modal is shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
