### PR TITLE
Global Styles on Personal: Enable feature on Calypso

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -39,7 +39,7 @@
 		"external-media/openverse": true,
 		"cookie-banner": true,
 		"google-my-business": false,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"help": true,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,

--- a/config/production.json
+++ b/config/production.json
@@ -51,7 +51,7 @@
 		"external-media/openverse": true,
 		"cookie-banner": true,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
 		"help-center-experience": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,7 +51,7 @@
 		"external-media/openverse": true,
 		"cookie-banner": false,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
 		"help-center-experience": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -57,7 +57,7 @@
 		"external-media/openverse": true,
 		"cookie-banner": true,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
 		"help-center-experience": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/9839

## Proposed Changes

* Enabled the feature on all Calypso envs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To enable Global Styles on Personal plans.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* You should see all the GS upsells referring to the Personal plan instead of the Premium plan.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
