### PR TITLE
A4A: Fix Pressable referrals UI issues.

### DIFF
--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
@@ -1,4 +1,6 @@
 import { formatCurrency } from '@automattic/format-currency';
+import { Button } from '@wordpress/components';
+import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
@@ -10,8 +12,34 @@ interface Props {
 	isFetching: boolean;
 }
 
-export function SubscriptionPurchase( { isFetching, name }: Props & { name?: string } ) {
-	return isFetching ? <TextPlaceholder /> : name;
+export function SubscriptionPurchase( {
+	isFetching,
+	name,
+	isPressable,
+}: Props & { name?: string; isPressable?: boolean } ) {
+	const translate = useTranslate();
+
+	if ( isFetching ) {
+		return <TextPlaceholder />;
+	}
+
+	return (
+		<div className="subscription-purchase">
+			{ name }
+			{ isPressable && (
+				<Button
+					className="manage-pressable-link"
+					target="_blank"
+					rel="norefferer nooppener"
+					href="https://my.pressable.com/agency/auth"
+					variant="link"
+				>
+					{ translate( 'Manage in Pressable' ) }
+					<Icon icon={ external } size={ 18 } />
+				</Button>
+			) }
+		</div>
+	);
 }
 
 export function SubscriptionPrice( { isFetching, amount }: Props & { amount?: string } ) {

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
@@ -49,7 +49,14 @@ export default function SubscriptionsList() {
 				getValue: () => '-',
 				render: ( { item }: { item: Subscription } ): ReactNode => {
 					const product = products?.find( ( product ) => product.product_id === item.product_id );
-					return <SubscriptionPurchase isFetching={ isFetchingProducts } name={ product?.name } />;
+					const isPressable = product?.slug.startsWith( 'pressable' );
+					return (
+						<SubscriptionPurchase
+							isFetching={ isFetchingProducts }
+							name={ product?.name }
+							isPressable={ isPressable }
+						/>
+					);
 				},
 				enableHiding: false,
 				enableSorting: false,

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
@@ -26,6 +26,7 @@ const SubscriptionItem = ( {
 	const translate = useTranslate();
 
 	const product = products?.find( ( product ) => product.product_id === subscription.product_id );
+	const isPressable = product?.slug.startsWith( 'pressable' );
 
 	return (
 		<div className="subscriptions-mobile">
@@ -34,7 +35,11 @@ const SubscriptionItem = ( {
 					<h3>{ translate( 'PURCHASE' ).toUpperCase() }</h3>
 				</div>
 				<p className="subscriptions-mobile__product-name">
-					<SubscriptionPurchase isFetching={ isFetching } name={ product?.name } />
+					<SubscriptionPurchase
+						isFetching={ isFetching }
+						name={ product?.name }
+						isPressable={ isPressable }
+					/>
 				</p>
 			</div>
 			<div className="subscriptions-mobile__content">

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/style.scss
@@ -19,3 +19,9 @@
 		}
 	}
 }
+
+.subscription-purchase {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
@@ -11,7 +11,9 @@ export default function CommissionsInfo( { items }: { items: ShoppingCartItem[] 
 	const totalCommissions = items.reduce( ( acc, item ) => {
 		const product = item;
 		const commissionPercentage = getProductCommissionPercentage( product.family_slug );
-		const totalCommissions = product?.amount ? Number( product.amount ) * commissionPercentage : 0;
+		const totalCommissions = product?.amount
+			? Number( product.amount.replace( /,/g, '' ) ) * commissionPercentage
+			: 0;
 		return acc + totalCommissions;
 	}, 0 );
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/referral-mode/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/referral-mode/index.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import useProductAndPlans from '../../../hooks/use-product-and-plans';
-import usePressableOwnershipType from '../../../hosting-overview/hooks/use-pressable-ownership-type';
 import PlanSelectionDetails from './../details';
 import PlanSelectionFilter from './../filter';
 
@@ -53,32 +52,25 @@ export default function ReferralPressableOverviewPlanSelection( { onAddToCart }:
 		}
 	}, [ dispatch, onAddToCart, selectedPlan ] );
 
-	const pressableOwnership = usePressableOwnershipType();
-
 	return (
 		<div
 			className={ clsx( 'pressable-overview-plan-selection', {
 				'is-new-hosting-page': isNewHostingPage,
-				'is-slider-hidden': pressableOwnership === 'regular',
 			} ) }
 		>
-			{ pressableOwnership !== 'regular' && (
-				<>
-					<div className="pressable-overview-plan-selection__upgrade-title narrow">
-						{ translate( 'Choose plan to refer' ) }
-					</div>
-					<PlanSelectionFilter
-						selectedPlan={ selectedPlan }
-						plans={ pressablePlans }
-						onSelectPlan={ onSelectPlan }
-					/>
-				</>
-			) }
+			<div className="pressable-overview-plan-selection__upgrade-title narrow">
+				{ translate( 'Choose plan to refer' ) }
+			</div>
+			<PlanSelectionFilter
+				selectedPlan={ selectedPlan }
+				plans={ pressablePlans }
+				onSelectPlan={ onSelectPlan }
+			/>
 
 			<PlanSelectionDetails
 				selectedPlan={ selectedPlan }
 				onSelectPlan={ onPlanAddToCart }
-				pressableOwnership={ pressableOwnership }
+				pressableOwnership="agency"
 			/>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -94,7 +94,9 @@ export default function LicenseDetails( {
 						<h4 className="license-details__label">
 							{ translate( 'Manage your Pressable licenses' ) }
 						</h4>
-						{ pressablePlan && <PressableUsageDetails existingPlan={ pressablePlan } /> }
+						{ ! referral && pressablePlan && (
+							<PressableUsageDetails existingPlan={ pressablePlan } />
+						) }
 					</div>
 				) }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -257,7 +257,14 @@ export default function LicensePreview( {
 			>
 				<div>
 					<span className="license-preview__product">
-						{ productTitle }
+						<div className="license-preview__product-title">
+							{ productTitle }
+							{ isClientLicense && (
+								<Badge className="license-preview__client-badge" type="info">
+									{ translate( 'Referral' ) }
+								</Badge>
+							) }
+						</div>
 						{ isClientLicense && (
 							<div className="license-preview__client-email">
 								<ClientSite referral={ referral } />

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -194,6 +194,13 @@ button.button.is-borderless.license-bundle-dropdown__button {
 	}
 }
 
+.license-preview__product-title {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
 .license-preview__client-email {
 	font-size: 0.75rem;
 	line-height: 1.3;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -34,6 +34,7 @@ function getPurchaseStatus(
 const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props ) => {
 	const translate = useTranslate();
 	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
+	const isPressable = product?.slug.startsWith( 'pressable' );
 	const isWPCOMLicense = product?.family_slug === 'wpcom-hosting';
 	const redirectUrl =
 		purchase.license &&
@@ -54,15 +55,26 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 			: translate( 'When your client pays, you can assign this product to a site.' );
 	}
 
-	return purchase.site_assigned ? (
-		<Button
-			className="referrals-purchases__assign-button"
-			borderless
-			href={ `/sites/overview/${ urlToSlug( purchase.site_assigned ) }` }
-		>
-			{ urlToSlug( purchase.site_assigned ) }
-		</Button>
-	) : (
+	if ( purchase.site_assigned ) {
+		return isPressable ? (
+			<StatusBadge
+				statusProps={ {
+					children: translate( 'Pressable' ),
+					type: 'success',
+				} }
+			/>
+		) : (
+			<Button
+				className="referrals-purchases__assign-button"
+				borderless
+				href={ `/sites/overview/${ urlToSlug( purchase.site_assigned ) }` }
+			>
+				{ urlToSlug( purchase.site_assigned ) }
+			</Button>
+		);
+	}
+
+	return (
 		<>
 			<StatusBadge
 				statusProps={ {


### PR DESCRIPTION
This PR closes a couple of issues related to Pressable referrals.


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1472
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1486
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1481
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1474
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1471

## Proposed Changes

| Issue | Before | After |
|--------|--------|--------|
| 1. Add a 'Managed in Pressable' link on the Client subscription page for the Pressable subscription. https://github.com/Automattic/automattic-for-agencies-dev/issues/1472 | <img width="639" alt="Screenshot 2024-11-18 at 9 31 33 PM" src="https://github.com/user-attachments/assets/f1bed0ad-01ab-4006-8c90-3d4583727442"> | <img width="855" alt="Screenshot 2024-11-18 at 8 06 54 PM" src="https://github.com/user-attachments/assets/3000b59e-a2db-4df6-9f71-5d19553bced1">  |
| 2. Display the 'Pressable' badge rather than the assigned site for active Pressable licenses on the Referrals overview page. https://github.com/Automattic/automattic-for-agencies-dev/issues/1481 | <img width="1012" alt="Screenshot 2024-11-18 at 9 35 21 PM" src="https://github.com/user-attachments/assets/623568e2-2825-4400-af09-b2502544a380"> | <img width="551" alt="Screenshot 2024-11-18 at 8 19 12 PM" src="https://github.com/user-attachments/assets/cdc98a51-25ae-4721-a853-34cc5d2fc4a1"> |
| 3. Display a 'Referral' badge for client-owned licenses on the Licenses page. https://github.com/Automattic/automattic-for-agencies-dev/issues/1474 | <img width="341" alt="Screenshot 2024-11-18 at 9 37 14 PM" src="https://github.com/user-attachments/assets/6c7cf4c0-a390-4fb6-b255-35b2bc58dd77"> | <img width="320" alt="Screenshot 2024-11-18 at 9 37 28 PM" src="https://github.com/user-attachments/assets/1bd577bd-532c-44bb-9d6c-31b34ae000ff"> |
| 4. Resolve calculation errors for commissions on products with a total cost of over $1k. https://github.com/Automattic/automattic-for-agencies-dev/issues/1486 | <img width="535" alt="Screenshot 2024-11-18 at 9 41 19 PM" src="https://github.com/user-attachments/assets/c329af7f-68f2-466e-8447-e73eafef77a9"> | <img width="561" alt="Screenshot 2024-11-18 at 9 39 53 PM" src="https://github.com/user-attachments/assets/ab779dc4-c57b-4a45-b654-33945bafa999"> | 
| 5. Hide Pressable usage for client-owned Pressable licenses. https://github.com/Automattic/automattic-for-agencies-dev/issues/1471 | <img width="1524" alt="Screenshot 2024-11-18 at 10 02 16 PM" src="https://github.com/user-attachments/assets/ddde4eab-0504-458f-8789-bd37ab432946"> | <img width="1530" alt="Screenshot 2024-11-18 at 10 02 02 PM" src="https://github.com/user-attachments/assets/e21f2c33-a264-4c7e-a782-3618c4763ced"> |


## Why are these changes being made?

* This is part of the Pressable Referrals project.

## Testing Instructions

For proper testing, it is essential to test the branch locally.

### Issue 1 
* Navigate to the `http://agencies.localhost:3000/marketplace/hosting/pressable` page, and activate **'Refer mode'**.
* Continue to checkout and request payment from your client account.
* Log in using your client account and finalize the payment.
* In your client's account, head to the http://agencies.localhost:3000/client/subscriptions page.
* Verify that you see the 'Managed in Pressable' link for the subscription.

### Issue 2
* Access the referrals dashboard using your agency account at http://agencies.localhost:3000/referrals/dashboard.
* Locate the Client with an active Pressable paid license and expand the details.
* Ensure that the **'Pressable'** badge is visible instead of the assigned site.

### Issue 3
* Access the licenses page using your agency account at http://agencies.localhost:3000/purchases/licenses
* Ensure that all licenses that are owned by clients has the 'Referral' badge.

### Issue 4
* Go to the `http://agencies.localhost:3000/marketplace/hosting/pressable` page and enable **'Refer mode'**.
* Choose the **'Pressable 150'** plan and click on **'Select this plan'**.
* Ensure the Shopping cart displays the accurate commission.


### Issue 5
* Go to the http://agencies.localhost:3000/purchases/licenses page.
* Look for any client-owned Pressable licenses and expand the row.
* Confirm that you no longer see the usage information.


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
