### PR TITLE
Help Center: Fix wapuu full screen content broken styles

### DIFF
--- a/packages/odie-client/src/components/message/index.tsx
+++ b/packages/odie-client/src/components/message/index.tsx
@@ -152,13 +152,15 @@ const ChatMessage = ( {
 	);
 
 	const fullscreenContent = (
-		<div className="odie-fullscreen" onClick={ handleBackdropClick }>
-			<div className="odie-fullscreen-backdrop" onClick={ handleContentClick }>
-				<MessageContent
-					message={ message }
-					messageHeader={ messageHeader }
-					isDisliked={ isDisliked }
-				/>
+		<div className="help-center-experience-disabled">
+			<div className="odie-fullscreen" onClick={ handleBackdropClick }>
+				<div className="odie-fullscreen-backdrop" onClick={ handleContentClick }>
+					<MessageContent
+						message={ message }
+						messageHeader={ messageHeader }
+						isDisliked={ isDisliked }
+					/>
+				</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96494
Fixes https://github.com/Automattic/wp-calypso/issues/96494

## Proposed Changes

* Wapuu's full-screen content is broken, this PR addresses it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* With a recent change, we have wrapped all the new changes into a class to keep the changes isolated, but it accidentally broke Wapuu's full-screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and open help center
* Start a conversation with Wapuu by asking anything
* When Wapuu answers, click on full-screen icon and make sure it opens nicely

Full-screen option
<img width="383" alt="image" src="https://github.com/user-attachments/assets/66716164-bf6e-432f-a07e-6162007b2997">

Full-screen content
<img width="1184" alt="image" src="https://github.com/user-attachments/assets/8bd6f03c-253b-4f88-847a-8c45ee7143c1">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
