### PR TITLE
A4A: Fix the 'free' unit price bug on client checkout.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/hooks/use-total-invoice-value.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/hooks/use-total-invoice-value.ts
@@ -44,6 +44,16 @@ export const useGetProductPricingInfo = () => {
 			};
 		}
 
+		// If we don't have userProducts, we just pull the price from the product and not calculate the discount
+		if ( ! Object.keys( userProducts ).length ) {
+			const actualCost = Number( product?.price_per_unit_display?.replace( /,/g, '' ) ) ?? 0;
+			return {
+				actualCost,
+				discountedCost: actualCost,
+				discountPercentage: 0,
+			};
+		}
+
 		const bundle = product?.supported_bundles?.find( ( bundle ) => bundle.quantity === quantity );
 		const bundleAmount = bundle && bundle.amount ? bundle.amount.replace( ',', '' ) : '';
 

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -108,6 +108,7 @@ export interface APIProductFamilyProduct {
 	currency: string;
 	amount: string;
 	price_interval: string;
+	price_per_unit_display?: string;
 	family_slug: string;
 	supported_bundles: APIProductFamilyProductBundlePrice[];
 }


### PR DESCRIPTION
This PR resolves an issue where the Client checkout incorrectly displays a 'Free' unit price for all products, with the exception of **WordPress.com sites**.

| Before | After |
|--------|--------|
| <img width="526" alt="Screenshot 2024-11-18 at 10 55 01 PM" src="https://github.com/user-attachments/assets/1402c53a-9845-4ca1-a6e5-54d7779046cf"> | <img width="508" alt="Screenshot 2024-11-18 at 10 55 09 PM" src="https://github.com/user-attachments/assets/0b01ebc4-f830-4ab6-ba92-b5c53f988cc8"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1455

## Proposed Changes

* Correct the logic used to compute actual and discounted costs when `userProducts` data is absent. This information is inaccessible to the Client UI (API) hence the cause of the bug.

## Why are these changes being made?

* Displaying accurate information during Checkout is crucial, as inaccuracies can harm our brand image.

## Testing Instructions

* Set up this branch locally and log in using your agency account.
* Generate a referral order (Ensure you have a few different products, including Pressable, WPCOM site, Woocommerce, and Jetpack licenses).
* Continue to request payment.
* Log in with your client account and access the payment link sent to your email.
* Remember to change https://agencies.automattic.com to http://agencies.localhost:3000. 
* Confirm that the Unit price for each product does not show a Free price.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
