### PR TITLE
A4A > Agency Tier: Enable feature flag/section agency tier on production

### DIFF
--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -36,6 +36,7 @@
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,
+		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": false
 	},
 	"enable_all_sections": false,
@@ -54,7 +55,8 @@
 		"a8c-for-agencies-partner-directory": true,
 		"a8c-for-agencies-migrations": true,
 		"a8c-for-agencies-client": true,
-		"a8c-for-agencies-team": true
+		"a8c-for-agencies-team": true,
+		"a8c-for-agencies-agency-tier": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
## Proposed Changes

* Enable Agency Tier feature flag & section on production.

## Why are these changes being made?

* To enable Agency Tier on production.

## Testing Instructions

* Make sure the feature flag & section are set to true in production env (a8c-for-agencies-production.json)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
