### PR TITLE
Performance Profiler: Add chatId to track events for LLM survey

### DIFF
--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -140,11 +140,16 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 					fullPageScreenshot={ fullPageScreenshot }
 					data={ {
 						...insight,
-						...( isEnabled( 'performance-profiler/llm' ) ? { description: llmAnswer } : {} ),
+						...( isEnabled( 'performance-profiler/llm' )
+							? { description: llmAnswer?.messages }
+							: {} ),
 					} }
 					secondaryArea={ tip && <Tip { ...tip } /> }
 					isLoading={ isEnabled( 'performance-profiler/llm' ) && isLoadingLlmAnswer }
 					AIGenerated={ isEnabled( 'performance-profiler/llm' ) }
+					hash={ hash }
+					url={ props.url }
+					chatId={ llmAnswer?.chatId }
 				/>
 			</Content>
 		</Card>

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -18,17 +18,23 @@ interface InsightContentProps {
 	secondaryArea?: React.ReactNode;
 	isLoading?: boolean;
 	AIGenerated: boolean;
+	hash: string;
+	url?: string;
+	chatId?: number;
 }
 
 export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 	const translate = useTranslate();
-	const { data, fullPageScreenshot, isLoading, AIGenerated } = props;
+	const { data, fullPageScreenshot, isLoading, AIGenerated, hash, url, chatId } = props;
 	const { description = '' } = data ?? {};
 	const [ feedbackSent, setFeedbackSent ] = useState( false );
 	const [ feedbackOpen, setFeedbackOpen ] = useState( false );
 	const [ userFeedback, setUserFeedback ] = useState( '' );
 	const onSurveyClick = ( rating: string ) => {
 		recordTracksEvent( 'calypso_performance_profiler_llm_survey_click', {
+			hash,
+			url,
+			chatId,
 			rating,
 			description,
 			...( userFeedback && { user_feedback: userFeedback } ),

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -3,7 +3,12 @@ import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/
 import wp from 'calypso/lib/wp';
 
 function mapResult( response: WPComSupportQueryResponse ) {
-	return response.messages?.[ 0 ]?.content ?? '';
+	const messages = response.messages?.[ 0 ]?.content ?? '';
+	const chatId = response.chat_id;
+	return {
+		messages,
+		chatId,
+	};
 }
 
 export const useSupportChatLLMQuery = (
@@ -37,6 +42,7 @@ export const useSupportChatLLMQuery = (
 };
 
 type WPComSupportQueryResponse = {
+	chat_id: number;
 	messages: Array< WPComSupportMessageQueryResponse >;
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9873

## Proposed Changes

* Adds `url`, `hash` and `chatId` to `calypso_performance_profiler_llm_survey_click` track event

**Please note:** I didn't add the `message_id` to the track event because with the `chat_id`, the messages are very easy to identify (currently there is only one message), and I don't think it is necessary. But if required, it would be straightforward to add it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It will allow to identify chats that are rated to further analyse the responses

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch and run a test using the speed test tool, or navigate to an existing report, e.g. `/speed-test-tool?hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzA3MX0.m3-63iGZmpJOpOfkZ4ww184EoKd8P3UHzTYwv1VLQUo&url=https%3A%2F%2Fwordpress.com%2F&tab=mobile`
* Open the developer tools, select the Network tab and filter the requests for `t.gif`, additionally, use the Tracks Vigilante or any other tool to inspect the Tracks events.
* Expand an insight and wait for the result to appear
* Click on the Survey, either `good` or `bad`
* Check that the `calypso_performance_profiler_llm_survey_click` track event is sent and it contains the proper `url`, `hash` and `chatId`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
