### PR TITLE
Site Migration: Remove english restriction

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Onboard, type SiteSelect, type UserSelect } from '@automattic/data-stores';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { isHostedSiteMigrationFlow } from '@automattic/onboarding';
 import { SiteExcerptData } from '@automattic/sites';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -123,7 +122,6 @@ const siteMigration: Flow = {
 			true
 		);
 		const isFromSiteWordPress = ! isLoadingFromData && urlData?.platform === 'wordpress';
-		const isEnglishLocale = useIsEnglishLocale();
 
 		const exitFlow = ( to: string ) => {
 			window.location.assign( to );
@@ -441,7 +439,7 @@ const siteMigration: Flow = {
 						);
 					}
 
-					if ( isEnglishLocale && action === 'already-wpcom' ) {
+					if ( action === 'already-wpcom' ) {
 						return navigate(
 							addQueryArgs(
 								{ siteId, from: from || fromQueryParam, siteSlug },
@@ -450,7 +448,7 @@ const siteMigration: Flow = {
 						);
 					}
 
-					if ( isEnglishLocale && action === 'site-is-not-using-wordpress' ) {
+					if ( action === 'site-is-not-using-wordpress' ) {
 						return navigate(
 							addQueryArgs(
 								{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Show the steps "site-migration/already-wpcom` and  `other-platform-detected` for all languages, removing the english restriction.


## Why are these changes being made?
* The translation is ready, so the restriction is not necessary

## Testing Instructions
* Set any language different from english 
* Go to the credential steps using the `/setup/hosted-site-migration` flow + DIFM
* Use a non-WordPress site on the source site field, check if you can see the `/other-platform-detected` step
* Back and use a site that is already hosted by WordPress.com and check if you can see the `setup/already-wpcom` step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
