### PR TITLE
Fix "unavailable tld" message in Gravatar domain flow

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1044,8 +1044,8 @@ class RegisterDomainStep extends Component {
 		// available but not eligible for Gravatar won't be displayed
 		if ( this.props.flowName === 'domain-for-gravatar' ) {
 			// Also, we want to error messages for unavailable TLDs in Gravatar.
-			// Since only .link is enabled for now, we show the message for all other TLDs.
-			if ( getTld( domain ) !== 'link' ) {
+			// Since only a limited number of tlds is enabled for now, we show the message for all other TLDs.
+			if ( ! this.state.availableTlds.includes( getTld( domain ) ) ) {
 				this.showSuggestionErrorMessage( domain, 'gravatar_tld_restriction', {} );
 			}
 			return;

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -642,7 +642,7 @@ function getAvailabilityNotice(
 
 		case 'gravatar_tld_restriction':
 			message = translate(
-				'Gravatar is currently offering .link domains. Additional domain extensions may become available for a fee in the future.'
+				'The domain extension you are looking for is currently not supported. Additional domain extensions may become available for a fee in the future.'
 			);
 			severity = 'info';
 			break;


### PR DESCRIPTION
## Proposed Changes

We recently update the number of supported domain extensions in the domains Gravatar flow. This PR updates the message that we shows if the user search for an unsupported tld using a fqdn in the search field.

Depends on D166507-code

![gravatar message](https://github.com/user-attachments/assets/64181b84-9373-4166-af92-51253465f0c6)

## Why are these changes being made?
The message we are currently showing is wrong, since it's say that we are supporting only .link domains.

## Testing Instructions

Apply this patch and the corresponding back one (D166507-code), the visit the Gravatar flow at `/start/domain-for-gravatar/domain-only`.

- Put an unsupported FQDN (i.e.`test-gravatar-tld.me`) in the search field and verify that the info message is: `The domain extension you are looking for is currently not supported. Additional domain extensions may become available for a fee in the future.`
- Put a supported FQDN (not .link, ie `test-gravatar-tld.world` and verify that no error messages are showed


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?