### PR TITLE
Fixes Yoast SEO icon

### DIFF
--- a/client/components/spotlight/docs/example.jsx
+++ b/client/components/spotlight/docs/example.jsx
@@ -1,6 +1,6 @@
 import Spotlight from 'calypso/components/spotlight';
 
-const illustrationSrc = 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png?rev=1550389';
+const illustrationSrc = 'https://ps.w.org/wordpress-seo/assets/icon-256x256.gif';
 const url = '/';
 const taglineText = 'tagline text';
 const titleText = 'title text';

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -357,7 +357,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 			{
 				slug: 'wordpress-seo-premium',
 				name: __( 'Yoast SEO Premium' ),
-				icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png',
+				icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.gif',
 				short_description: __( 'Optimize your site for search engines' ),
 			},
 			{
@@ -402,7 +402,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 			{
 				slug: 'wordpress-seo-premium',
 				name: __( 'Yoast SEO Premium' ),
-				icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png',
+				icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.gif',
 				short_description: __( 'Optimize your site for search engines' ),
 			},
 			{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1731946112589419-slack-C029JEQRVRT
Additional diff for the Spotlight section D166515-code

## Proposed Changes

* Switch from png icon to gif as the png is 404 now

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /plugins
* Check that Yoast SEO Premium icons work

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?