### PR TITLE
Login: Display password recovery link below input only in Woo flows

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -939,8 +939,7 @@ export class LoginForm extends Component {
 			isGravatarFlowWithEmail;
 
 		const shouldRenderForgotPasswordLink =
-			( ! isPasswordHidden && isWoo && ! isPartnerSignup && ! isWooPasswordless ) ||
-			! isPasswordHidden;
+			! isPasswordHidden && isWoo && ! isPartnerSignup && ! isWooPasswordless;
 
 		return (
 			<form


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/96285#top.

## Proposed Changes

Only display the "Forgot password?" link within the Woo flows. We've introduced a regression where all flows were seeing this link below the password input.

@moon0326 is this logic correct? I vaguely remember seeing something related to Jetpack Connect, but couldn't connect (pun intended) the dots in my brain properly.

## Why are these changes being made?

To fix a regression.

## Testing Instructions

Check that [WPCOM login](https://container-nostalgic-hypatia.calypso.live/log-in) doesn't include the "Forgot password?" link below the input password, while the [Woo login](https://container-nostalgic-hypatia.calypso.live/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db619bf885d5c3bdbd46a1a66ea64f94c670474617a86395365c12699fd779073%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26authorize%3D1%26wccom-from%3D%26calypso_env%3Dproduction) does.

### WPCOM

<img width="528" alt="image" src="https://github.com/user-attachments/assets/7ff26ba5-abd6-4184-bb3f-013b9a19aaee">

### Woo

<img width="627" alt="image" src="https://github.com/user-attachments/assets/2d198be3-e41f-4c48-a4a8-599062ea330c">
