### PR TITLE
Shopping Cart: add default HTTP requests to shopping-cart package with wpcom-proxy-request, take 2

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -2,13 +2,17 @@
  * @jest-environment jsdom
  */
 
+import { getEmptyResponseCart } from '@automattic/shopping-cart';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
+import wpcomRequest from 'wpcom-proxy-request';
 import DomainUpsell from '../';
+
+jest.mock( 'wpcom-proxy-request', () => jest.fn() );
 
 const initialState = {
 	sites: {
@@ -107,13 +111,17 @@ describe( 'index', () => {
 
 	test( 'Should test the purchase button link on Free and Monthly plans', async () => {
 		nock.cleanAll();
-		nock( 'https://public-api.wordpress.com' )
-			.persist()
-			.post( '/rest/v1.1/me/shopping-cart/1' )
-			.reply( 200 );
+		wpcomRequest.mockReset();
 
 		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( initialState );
+
+		wpcomRequest.mockImplementation( ( args ) => {
+			if ( args.path.startsWith( '/me/shopping-cart' ) ) {
+				return Promise.resolve( getEmptyResponseCart() );
+			}
+			return Promise.reject( `Unknown endpoint in test ${ args.path }:${ args.method }` );
+		} );
 
 		render(
 			<Provider store={ store }>
@@ -132,10 +140,14 @@ describe( 'index', () => {
 
 	test( 'Should test the purchase button link on Yearly plans', async () => {
 		nock.cleanAll();
-		nock( 'https://public-api.wordpress.com' )
-			.persist()
-			.post( '/rest/v1.1/me/shopping-cart/1' )
-			.reply( 200 );
+		wpcomRequest.mockReset();
+
+		wpcomRequest.mockImplementation( ( args ) => {
+			if ( args.path.startsWith( '/me/shopping-cart' ) ) {
+				return Promise.resolve( getEmptyResponseCart() );
+			}
+			return Promise.reject( `Unknown endpoint in test ${ args.path }:${ args.method }` );
+		} );
 
 		const newInitialState = {
 			...initialState,

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -111,6 +111,10 @@ describe( 'index', () => {
 
 	test( 'Should test the purchase button link on Free and Monthly plans', async () => {
 		nock.cleanAll();
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/me/shopping-cart/1' )
+			.reply( 200 );
 		wpcomRequest.mockReset();
 
 		const mockStore = configureStore( [ thunk ] );
@@ -140,6 +144,10 @@ describe( 'index', () => {
 
 	test( 'Should test the purchase button link on Yearly plans', async () => {
 		nock.cleanAll();
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/me/shopping-cart/1' )
+			.reply( 200 );
 		wpcomRequest.mockReset();
 
 		wpcomRequest.mockImplementation( ( args ) => {

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/test/index.jsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { getEmptyResponseCart } from '@automattic/shopping-cart';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -9,7 +10,10 @@ import nock from 'nock';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
+import wpcomRequest from 'wpcom-proxy-request';
 import DomainUpsell from '../';
+
+jest.mock( 'wpcom-proxy-request', () => jest.fn() );
 
 const initialState = {
 	sites: {
@@ -112,10 +116,14 @@ describe( 'index', () => {
 
 	test( 'Should test the purchase button link on Free and Monthly plans', async () => {
 		nock.cleanAll();
-		nock( 'https://public-api.wordpress.com' )
-			.persist()
-			.post( '/rest/v1.1/me/shopping-cart/1' )
-			.reply( 200 );
+		wpcomRequest.mockReset();
+
+		wpcomRequest.mockImplementation( ( args ) => {
+			if ( args.path.startsWith( '/me/shopping-cart' ) ) {
+				return Promise.resolve( getEmptyResponseCart() );
+			}
+			return Promise.reject( `Unknown endpoint in test ${ args.path }:${ args.method }` );
+		} );
 
 		const queryClient = new QueryClient();
 		const mockStore = configureStore( [ thunk ] );
@@ -140,10 +148,14 @@ describe( 'index', () => {
 
 	test( 'Should test the purchase button link on Yearly plans', async () => {
 		nock.cleanAll();
-		nock( 'https://public-api.wordpress.com' )
-			.persist()
-			.post( '/rest/v1.1/me/shopping-cart/1' )
-			.reply( 200 );
+		wpcomRequest.mockReset();
+
+		wpcomRequest.mockImplementation( ( args ) => {
+			if ( args.path.startsWith( '/me/shopping-cart' ) ) {
+				return Promise.resolve( getEmptyResponseCart() );
+			}
+			return Promise.reject( `Unknown endpoint in test ${ args.path }:${ args.method }` );
+		} );
 
 		const newInitialState = {
 			...initialState,

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/test/index.jsx
@@ -116,6 +116,10 @@ describe( 'index', () => {
 
 	test( 'Should test the purchase button link on Free and Monthly plans', async () => {
 		nock.cleanAll();
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/me/shopping-cart/1' )
+			.reply( 200 );
 		wpcomRequest.mockReset();
 
 		wpcomRequest.mockImplementation( ( args ) => {
@@ -148,6 +152,10 @@ describe( 'index', () => {
 
 	test( 'Should test the purchase button link on Yearly plans', async () => {
 		nock.cleanAll();
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/me/shopping-cart/1' )
+			.reply( 200 );
 		wpcomRequest.mockReset();
 
 		wpcomRequest.mockImplementation( ( args ) => {

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -32,6 +32,7 @@
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
+		"@automattic/shopping-cart": "workspace:^",
 		"@wordpress/components": "^28.8.0",
 		"@wordpress/data": "^10.8.0",
 		"@wordpress/icons": "^10.8.0",

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -86,10 +86,10 @@ A function that converts a `ResponseCart` to a `RequestCart`. Usually this shoul
 
 A function to create a `ShoppingCartManagerClient` which is the state management system used by the `shopping-cart` package. It's recommended to create this as a singleton and share it across your entire application.
 
-It requires an object to be passed in with the following properties:
+An options object can be passed in with the following optional properties:
 
-- `getCart: ( cartKey: number | 'no-site' | 'no-user' ) => Promise< ResponseCart >`. This is an async function that will fetch the cart from the server.
-- `setCart: ( cartKey: number | 'no-site' | 'no-user', requestCart: RequestCart ) => Promise< ResponseCart >`. This is an async function that will send an updated cart to the server.
+- `getCart?: ( cartKey: number | 'no-site' | 'no-user' ) => Promise< ResponseCart >`. This is an async function that will fetch the cart from the server.
+- `setCart?: ( cartKey: number | 'no-site' | 'no-user', requestCart: RequestCart ) => Promise< ResponseCart >`. This is an async function that will send an updated cart to the server.
 
 Once created, the `ShoppingCartManagerClient` has the properties:
 

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -35,7 +35,8 @@
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/shopping-cart#readme",
 	"dependencies": {
-		"debug": "^4.3.3"
+		"debug": "^4.3.3",
+		"wpcom-proxy-request": "workspace:^"
 	},
 	"peerDependencies": {
 		"react": "^18.3.1",

--- a/packages/shopping-cart/src/shopping-cart-endpoint-interface.ts
+++ b/packages/shopping-cart/src/shopping-cart-endpoint-interface.ts
@@ -1,0 +1,18 @@
+import wpcomRequest from 'wpcom-proxy-request';
+import { GetCart, SetCart } from './types';
+
+export const getCart: GetCart = ( cartKey ) => {
+	return wpcomRequest( {
+		path: `/me/shopping-cart/${ cartKey }`,
+		apiVersion: '1.1',
+	} );
+};
+
+export const setCart: SetCart = ( cartKey, cartData ) => {
+	return wpcomRequest( {
+		path: `/me/shopping-cart/${ cartKey }`,
+		apiVersion: '1.1',
+		method: 'POST',
+		body: cartData,
+	} );
+};

--- a/packages/shopping-cart/src/shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/shopping-cart-manager.ts
@@ -178,6 +178,20 @@ function createShoppingCartManager(
 	};
 }
 
+/**
+ * A function to create a `ShoppingCartManagerClient` which is the state
+ * management system used by the `shopping-cart` package. It's recommended to
+ * create this as a singleton and share it across your entire application.
+ *
+ * Once created, a `ShoppingCartManagerClient` can use its `forCartKey()`
+ * method to return a `ShoppingCartManager` which is used to fetch and update a
+ * shopping cart.
+ *
+ * An optional options object can be provided if you want to override the
+ * default behavior of fetching or updating the shopping cart, but this should
+ * rarely be needed unless you have an unusual situation where regular HTTP
+ * calls (via the `wpcom-proxy-request` package) will not work.
+ */
 export function createShoppingCartManagerClient(
 	options?: ShoppingCartManagerClientOptions
 ): ShoppingCartManagerClient {

--- a/packages/shopping-cart/src/shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/shopping-cart-manager.ts
@@ -8,6 +8,7 @@ import {
 	noopManager,
 } from './managers';
 import { createActions } from './shopping-cart-actions';
+import { getCart, setCart } from './shopping-cart-endpoint-interface';
 import {
 	getInitialShoppingCartState,
 	isStatePendingUpdateOrQueuedAction,
@@ -28,6 +29,7 @@ import type {
 	ActionPromises,
 	ShoppingCartState,
 	CartKey,
+	ShoppingCartManagerClientOptions,
 } from './types';
 
 const debug = debugFactory( 'shopping-cart:shopping-cart-manager' );
@@ -176,13 +178,9 @@ function createShoppingCartManager(
 	};
 }
 
-export function createShoppingCartManagerClient( {
-	getCart,
-	setCart,
-}: {
-	getCart: GetCart;
-	setCart: SetCart;
-} ): ShoppingCartManagerClient {
+export function createShoppingCartManagerClient(
+	options?: ShoppingCartManagerClientOptions
+): ShoppingCartManagerClient {
 	const managersByCartKey = new Map< CartKey, ShoppingCartManager >();
 
 	function forCartKey( cartKey: CartKey | undefined ): ShoppingCartManager {
@@ -193,7 +191,9 @@ export function createShoppingCartManagerClient( {
 		let manager = managersByCartKey.get( cartKey );
 		if ( typeof manager === 'undefined' ) {
 			debug( `creating cart manager for "${ cartKey }"` );
-			manager = createShoppingCartManager( cartKey, getCart, setCart );
+			const getCartFromServer = options?.getCart ?? getCart;
+			const setCartOnServer = options?.setCart ?? setCart;
+			manager = createShoppingCartManager( cartKey, getCartFromServer, setCartOnServer );
 			managersByCartKey.set( cartKey, manager );
 		}
 		return manager;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -18,6 +18,11 @@ export type CartKey = number | 'no-user' | 'no-site';
 export type GetCart = ( cartKey: CartKey ) => Promise< ResponseCart >;
 export type SetCart = ( cartKey: CartKey, requestCart: RequestCart ) => Promise< ResponseCart >;
 
+export interface ShoppingCartManagerClientOptions {
+	getCart?: GetCart;
+	setCart?: SetCart;
+}
+
 export interface ShoppingCartManagerOptions {
 	refetchOnWindowFocus?: boolean;
 	defaultCartKey?: CartKey;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -19,7 +19,22 @@ export type GetCart = ( cartKey: CartKey ) => Promise< ResponseCart >;
 export type SetCart = ( cartKey: CartKey, requestCart: RequestCart ) => Promise< ResponseCart >;
 
 export interface ShoppingCartManagerClientOptions {
+	/**
+	 * This is an async function that will fetch the cart from the server.
+	 *
+	 * This should rarely be needed unless you have an unusual situation where
+	 * regular HTTP calls (via the `wpcom-proxy-request` package) will not
+	 * work.
+	 */
 	getCart?: GetCart;
+
+	/**
+	 * This is an async function that will send an updated cart to the server.
+	 *
+	 * This should rarely be needed unless you have an unusual situation where
+	 * regular HTTP calls (via the `wpcom-proxy-request` package) will not
+	 * work.
+	 */
 	setCart?: SetCart;
 }
 

--- a/packages/shopping-cart/test/utils/mock-cart-api.ts
+++ b/packages/shopping-cart/test/utils/mock-cart-api.ts
@@ -84,7 +84,7 @@ export async function getCart( cartKey: CartKey ): Promise< ResponseCart > {
 			cart_key: cartKey,
 		};
 	}
-	throw new Error( 'Unknown cart key' );
+	throw new Error( `Unknown cart key: ${ cartKey }` );
 }
 
 function createProduct( productProps: RequestCartProduct ): ResponseCartProduct {
@@ -112,5 +112,5 @@ export async function setCart( cartKey: CartKey, newCart: RequestCart ): Promise
 			},
 		};
 	}
-	throw new Error( 'Unknown cart key' );
+	throw new Error( `Unknown cart key: ${ cartKey }` );
 }

--- a/packages/shopping-cart/test/utils/mock-components.tsx
+++ b/packages/shopping-cart/test/utils/mock-components.tsx
@@ -14,8 +14,14 @@ import type {
 	CartKey,
 } from '../../src/types';
 
-export function ProductList( { initialProducts }: { initialProducts?: RequestCartProduct[] } ) {
-	const { isPendingUpdate, responseCart, addProductsToCart } = useShoppingCart( undefined );
+export function ProductList( {
+	initialProducts,
+	cartKey,
+}: {
+	initialProducts?: RequestCartProduct[];
+	cartKey?: CartKey;
+} ) {
+	const { isPendingUpdate, responseCart, addProductsToCart } = useShoppingCart( cartKey );
 	useEffect( () => {
 		initialProducts && addProductsToCart( initialProducts );
 	}, [ addProductsToCart, initialProducts ] );
@@ -69,6 +75,11 @@ export function ProductListWithoutHook( {
 			<button onClick={ onClick }>Click me</button>
 		</ul>
 	);
+}
+
+export function MockProviderWithDefaultGetterSetter( { children } ) {
+	const managerClient = createShoppingCartManagerClient();
+	return <ShoppingCartProvider managerClient={ managerClient }>{ children }</ShoppingCartProvider>;
 }
 
 export function MockProvider( {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,6 +1593,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
+    "@automattic/shopping-cart": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@automattic/viewport": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"
@@ -1829,6 +1830,7 @@ __metadata:
     "@testing-library/react": "npm:^15.0.7"
     debug: "npm:^4.3.3"
     typescript: "npm:^5.3.3"
+    wpcom-proxy-request: "workspace:^"
   peerDependencies:
     react: ^18.3.1
     react-dom: ^18.3.1


### PR DESCRIPTION
## Proposed Changes

In this PR, we update the `@automattic/shopping-cart` package's `createShoppingCartManagerClient()` function to make its `getCart` and `setCart` arguments optional. When not provided, it will default to using the `wpcom-proxy-request` package to contact the shopping cart endpoint on its own.

> [!NOTE]
> This is the second attempt after the first (https://github.com/Automattic/wp-calypso/pull/96482) was reverted due to an issue with authentication in signup (https://github.com/Automattic/wp-calypso/pull/96482#issuecomment-2483812891). In this PR we no longer make any changes to calypso or onboarding. Those can be made as their own separate PRs.

## Why are these changes being made?

When the `@automattic/shopping-cart` package was created to encapsulate interactions with the `/me/shopping-cart` HTTP API endpoint, there was no way for a separate npm package to authenticate with the WPCOM HTTP API; it had to be done inside of calypso (the `client/` directory of the monorepo). Therefore we made it a requirement to inject two methods into the package, one for calling the `GET` endpoint to fetch a shopping cart and one for calling the `POST` endpoint to modify the cart. 

However, since then it's become possible to use the `wpcom-proxy-request` npm package directly to make authenticated calls. By removing the requirement for the consumer to provide these API functions, using the shopping cart package becomes much simpler and easier to implement in more places.

## Testing Instructions

Try adding or removing products from the shopping cart in calypso. If it works at all, then this is safe.