### PR TITLE
Blaze location charts

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -759,6 +759,17 @@ export default function CampaignItemDetails( props: Props ) {
 									</div>
 								</div>
 
+								<div className="campaign-item-details__secondary-stats-interests-mobile">
+									<>
+										<span className="campaign-item-details__label">
+											{ translate( 'Interests' ) }
+										</span>
+										<span className="campaign-item-details__details">
+											{ ! isLoading ? topicsListFormatted : <FlexibleSkeleton /> }
+										</span>
+									</>
+								</div>
+
 								<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
 									<div>
 										<div className="campaign-item-page__graph">
@@ -771,18 +782,11 @@ export default function CampaignItemDetails( props: Props ) {
 										</div>
 									</div>
 								</div>
+							</div>
+						</div>
 
-								<div className="campaign-item-details__secondary-stats-interests-mobile">
-									<>
-										<span className="campaign-item-details__label">
-											{ translate( 'Interests' ) }
-										</span>
-										<span className="campaign-item-details__details">
-											{ ! isLoading ? topicsListFormatted : <FlexibleSkeleton /> }
-										</span>
-									</>
-								</div>
-
+						<div className="campaign-item-details__main-stats-container">
+							<div className="campaign-item-details__secondary-stats">
 								<div className="campaign-item-details__secondary-stats-row">
 									{ objective && objectiveFormatted && (
 										<div>
@@ -853,6 +857,7 @@ export default function CampaignItemDetails( props: Props ) {
 								</div>
 							</div>
 						</div>
+
 						{ canDisplayPaymentSection ? (
 							<div className="campaign-item-details__payment-container">
 								<div className="campaign-item-details__payment">

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, chevronLeft, chevronDown } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment/moment';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -28,6 +28,7 @@ import useCancelCampaignMutation from 'calypso/data/promote-post/use-promote-pos
 import AdPreview from 'calypso/my-sites/promote-post-i2/components/ad-preview';
 import AdPreviewModal from 'calypso/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal';
 import CampaignStatsLineChart from 'calypso/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart';
+import LocationChart from 'calypso/my-sites/promote-post-i2/components/location-charts';
 import useOpenPromoteWidget from 'calypso/my-sites/promote-post-i2/hooks/use-open-promote-widget';
 import {
 	campaignStatus,
@@ -628,44 +629,59 @@ export default function CampaignItemDetails( props: Props ) {
 								</div>
 
 								{ ! campaignsStatsIsLoading && campaignStats && (
-									<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
-										<div>
-											<div className="campaign-item-page__graph">
-												<DropdownMenu
-													class="campaign-item-page__graph-selector"
-													controls={ [
-														{
-															onClick: () => setChartSource( ChartSourceOptions.Clicks ),
-															title: __( 'Clicks' ),
-															isDisabled: chartSource === ChartSourceOptions.Clicks,
-														},
-														{
-															onClick: () => setChartSource( ChartSourceOptions.Impressions ),
-															title: __( 'Impressions' ),
-															isDisabled: chartSource === ChartSourceOptions.Impressions,
-														},
-													] }
-													icon={ chevronDown }
-													text={
-														chartSource === ChartSourceOptions.Clicks
-															? __( 'Clicks' )
-															: __( 'Impressions' )
-													}
-													label={ chartSource }
-												/>
-												{ ChartSourceOptions.Clicks === chartSource &&
-													getCampaignStatsChart(
-														campaignStats?.series.clicks,
-														ChartSourceOptions.Clicks
+									<>
+										<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
+											<div>
+												<div className="campaign-item-page__graph">
+													<DropdownMenu
+														class="campaign-item-page__graph-selector"
+														controls={ [
+															{
+																onClick: () => setChartSource( ChartSourceOptions.Clicks ),
+																title: __( 'Clicks' ),
+																isDisabled: chartSource === ChartSourceOptions.Clicks,
+															},
+															{
+																onClick: () => setChartSource( ChartSourceOptions.Impressions ),
+																title: __( 'Impressions' ),
+																isDisabled: chartSource === ChartSourceOptions.Impressions,
+															},
+														] }
+														icon={ chevronDown }
+														text={
+															chartSource === ChartSourceOptions.Clicks
+																? __( 'Clicks' )
+																: __( 'Impressions' )
+														}
+														label={ chartSource }
+													/>
+													{ getCampaignStatsChart(
+														campaignStats?.series[ chartSource ],
+														chartSource
 													) }
-												{ ChartSourceOptions.Impressions === chartSource &&
-													getCampaignStatsChart(
-														campaignStats?.series.impressions,
-														ChartSourceOptions.Impressions
-													) }
+												</div>
 											</div>
 										</div>
-									</div>
+
+										<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
+											<div>
+												<div className="campaign-item-page__locaton-charts">
+													<span className="campaign-item-details__label">
+														{ chartSource === ChartSourceOptions.Clicks
+															? __( 'Clicks by location' )
+															: __( 'Impressions by location' ) }
+													</span>
+													<div>
+														<LocationChart
+															stats={ campaignStats?.total_stats.countryStats[ chartSource ] }
+															total={ campaignStats.total_stats.total[ chartSource ] }
+															source={ chartSource }
+														/>
+													</div>
+												</div>
+											</div>
+										</div>
+									</>
 								) }
 							</div>
 						) }

--- a/client/my-sites/promote-post-i2/components/location-charts/index.tsx
+++ b/client/my-sites/promote-post-i2/components/location-charts/index.tsx
@@ -1,0 +1,80 @@
+import { Tooltip } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import React, { useState } from 'react';
+import './style.scss';
+import { CampaignChartCountryData } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+import useCountryList from 'calypso/my-sites/checkout/src/hooks/use-country-list';
+import { ChartSourceOptions } from 'calypso/my-sites/promote-post-i2/components/campaign-item-details';
+import { formatNumber } from 'calypso/my-sites/promote-post-i2/utils';
+
+type Props = {
+	stats: CampaignChartCountryData[];
+	total: number;
+	source: ChartSourceOptions;
+};
+
+const LocationChart = ( { stats, total, source }: Props ) => {
+	// Filter out the 'unknown' country from stats, we show this as a message at the end
+	const filteredStats = stats.filter( ( stat ) => stat.country.toLowerCase() !== 'unknown' );
+	const unknownStat = stats.find( ( stat ) => stat.country.toLowerCase() === 'unknown' );
+	const [ showAll, setShowAll ] = useState( false );
+
+	// We only show the top 5 countries by default, but allow the user to show more to see the rest
+	const displayedStats = showAll ? filteredStats : filteredStats.slice( 0, 5 );
+
+	// The item with the largest percentages will have the bar at 100% width
+	// The other bars will be displayed relative to (this rather than 100%)
+	const maxPercentage = Math.max( ...filteredStats.map( ( stat ) => stat.percentage ) );
+
+	const countryList = useCountryList();
+
+	return (
+		<div className="location-chart__country-stats-container">
+			{ displayedStats.map( ( stat, index ) => {
+				// Calculate the filled bar width, relative to the most popular country
+				const normalisedPercentage = ( stat.percentage / maxPercentage ) * 100;
+
+				// Convert the ISO country code to a country name
+				const country = countryList.find( ( country ) => country.code === stat.country );
+
+				// Used to show the user abreakdown of the data by country
+				const tooltipText = `${ formatNumber( stat.total ) } of ${ formatNumber(
+					total
+				) } ${ source }`;
+				return (
+					<Tooltip text={ tooltipText } key={ index }>
+						<div className="location-chart__country-stat">
+							<div className="location-chart__country-info">
+								<span>{ country?.name || stat.country }</span>
+								<span className="location-chart__percentage">{ stat.percentage }%</span>
+							</div>
+							<div className="location-chart__progress-bar">
+								<div
+									className="location-chart__progress-bar-filled"
+									style={ { width: `${ normalisedPercentage }%` } }
+								></div>
+								{ /* not needed ont the first item (since it is full width already) */ }
+								{ index > 0 && <div className="location-chart__progress-bar-unfilled"></div> }
+							</div>
+						</div>
+					</Tooltip>
+				);
+			} ) }
+			{ unknownStat && showAll && (
+				<div className="location-chart__unknown-stats-message">
+					{ `${ unknownStat.percentage }% of data is from visitors whose location cannot be determined` }
+				</div>
+			) }
+			{ filteredStats.length > 5 && (
+				<button
+					className="location-chart__show-more-button"
+					onClick={ () => setShowAll( ! showAll ) }
+				>
+					{ showAll ? __( 'Show Less' ) : __( 'Show More' ) }
+				</button>
+			) }
+		</div>
+	);
+};
+
+export default LocationChart;

--- a/client/my-sites/promote-post-i2/components/location-charts/index.tsx
+++ b/client/my-sites/promote-post-i2/components/location-charts/index.tsx
@@ -3,7 +3,7 @@ import { Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import React, { useState } from 'react';
 import './style.scss';
-import { CampaignChartCountryData } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+import { CampaignChartCountryData } from 'calypso/data/promote-post/use-campaign-chart-stats-query';
 import { ChartSourceOptions } from 'calypso/my-sites/promote-post-i2/components/campaign-item-details';
 import { formatNumber } from 'calypso/my-sites/promote-post-i2/utils';
 
@@ -45,13 +45,17 @@ const LocationChart = ( { stats, total, source }: Props ) => {
 						<div className="location-chart__country-stat">
 							<div className="location-chart__country-info">
 								<span>{ regionNames.of( stat.country ) }</span>
-								<span className="location-chart__percentage">{ stat.percentage }%</span>
+								<span className="location-chart__percentage">
+									{ stat.percentage > 0 ? stat.percentage : `~0` }%
+								</span>
 							</div>
 							<div className="location-chart__progress-bar">
-								<div
-									className="location-chart__progress-bar-filled"
-									style={ { width: `${ normalisedPercentage }%` } }
-								></div>
+								{ stat.percentage > 0 && (
+									<div
+										className="location-chart__progress-bar-filled"
+										style={ { width: `${ normalisedPercentage }%` } }
+									></div>
+								) }
 								{ /* not needed ont the first item (since it is full width already) */ }
 								{ index > 0 && <div className="location-chart__progress-bar-unfilled"></div> }
 							</div>

--- a/client/my-sites/promote-post-i2/components/location-charts/index.tsx
+++ b/client/my-sites/promote-post-i2/components/location-charts/index.tsx
@@ -1,9 +1,9 @@
+import { useLocale } from '@automattic/i18n-utils';
 import { Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import React, { useState } from 'react';
 import './style.scss';
 import { CampaignChartCountryData } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
-import useCountryList from 'calypso/my-sites/checkout/src/hooks/use-country-list';
 import { ChartSourceOptions } from 'calypso/my-sites/promote-post-i2/components/campaign-item-details';
 import { formatNumber } from 'calypso/my-sites/promote-post-i2/utils';
 
@@ -19,6 +19,10 @@ const LocationChart = ( { stats, total, source }: Props ) => {
 	const unknownStat = stats.find( ( stat ) => stat.country.toLowerCase() === 'unknown' );
 	const [ showAll, setShowAll ] = useState( false );
 
+	// Translation of countries
+	const locale = useLocale();
+	const regionNames = new Intl.DisplayNames( [ locale ], { type: 'region' } );
+
 	// We only show the top 5 countries by default, but allow the user to show more to see the rest
 	const displayedStats = showAll ? filteredStats : filteredStats.slice( 0, 5 );
 
@@ -26,18 +30,13 @@ const LocationChart = ( { stats, total, source }: Props ) => {
 	// The other bars will be displayed relative to (this rather than 100%)
 	const maxPercentage = Math.max( ...filteredStats.map( ( stat ) => stat.percentage ) );
 
-	const countryList = useCountryList();
-
 	return (
 		<div className="location-chart__country-stats-container">
 			{ displayedStats.map( ( stat, index ) => {
 				// Calculate the filled bar width, relative to the most popular country
 				const normalisedPercentage = ( stat.percentage / maxPercentage ) * 100;
 
-				// Convert the ISO country code to a country name
-				const country = countryList.find( ( country ) => country.code === stat.country );
-
-				// Used to show the user abreakdown of the data by country
+				// Used to show the user a breakdown of the data by country
 				const tooltipText = `${ formatNumber( stat.total ) } of ${ formatNumber(
 					total
 				) } ${ source }`;
@@ -45,7 +44,7 @@ const LocationChart = ( { stats, total, source }: Props ) => {
 					<Tooltip text={ tooltipText } key={ index }>
 						<div className="location-chart__country-stat">
 							<div className="location-chart__country-info">
-								<span>{ country?.name || stat.country }</span>
+								<span>{ regionNames.of( stat.country ) }</span>
 								<span className="location-chart__percentage">{ stat.percentage }%</span>
 							</div>
 							<div className="location-chart__progress-bar">

--- a/client/my-sites/promote-post-i2/components/location-charts/style.scss
+++ b/client/my-sites/promote-post-i2/components/location-charts/style.scss
@@ -15,7 +15,7 @@
 		&__country-info {
 			display: flex;
 			justify-content: space-between;
-			margin-bottom: 8px;
+			margin-bottom: 10px;
 			font-size: .875rem;
 			color: var( --studio-gray-60 );
 		}
@@ -29,6 +29,7 @@
 			height: 3px;
 			overflow: hidden;
 			display: flex;
+			gap: 10px;
 		}
 
 		&__progress-bar-filled {
@@ -39,7 +40,6 @@
 
 		&__progress-bar-unfilled {
 			height: 100%;
-			margin-left: 10px;
 			background-color: var(--studio-gray-5);
 			border-radius: 4px;
 			flex-grow: 1;

--- a/client/my-sites/promote-post-i2/components/location-charts/style.scss
+++ b/client/my-sites/promote-post-i2/components/location-charts/style.scss
@@ -1,0 +1,57 @@
+.promote-post-i2 {
+	.location-chart {
+
+		&__country-stats-container {
+			margin-top: 24px;
+			width: 100%;
+			display: flex;
+			flex-direction: column;
+		}
+
+		&__country-stat {
+			margin-bottom: 12px;
+		}
+
+		&__country-info {
+			display: flex;
+			justify-content: space-between;
+			margin-bottom: 8px;
+			font-size: .875rem;
+			color: var( --studio-gray-60 );
+		}
+
+		&__percentage {
+			color: var( --studio-gray-100 );
+			font-weight: 500;
+		}
+
+		&__progress-bar {
+			height: 3px;
+			overflow: hidden;
+			display: flex;
+		}
+
+		&__progress-bar-filled {
+			height: 100%;
+			background-color: var(--color-primary);
+			border-radius: 4px;
+		}
+
+		&__progress-bar-unfilled {
+			height: 100%;
+			margin-left: 10px;
+			background-color: var(--studio-gray-5);
+			border-radius: 4px;
+			flex-grow: 1;
+		}
+
+		&__show-more-button {
+			color: var(--color-primary);
+			font-weight: 500;
+			text-align: center;
+			margin-top: 12px;
+		}
+	}
+
+}
+


### PR DESCRIPTION
Related to 2728-gh-org/a8c-dsp

## Proposed Changes

New charts to give the user a breakdown of their impressions or clicks by Country

See an example at: `/advertising/campaigns/{campaignId}/{domain}`

https://github.com/user-attachments/assets/d6804a9b-7a09-4648-99f0-9a1c1c14ed2e


## Testing Instructions

* View one of your campaigns  `/advertising/campaigns/{campaignId}/{domain}`
* You should see the new charts
* Try changing your locale - the countries should be translated.  There are some edge cases (generally small autonomous regions) (https://wordpress.com/me/account)
* Try changing your colour scheme, it should update the chart colours.

**Default View**
![Screenshot 2024-11-18 at 18 58 28](https://github.com/user-attachments/assets/8f3ae995-c430-49fa-bd8c-e75d9ffbc059)

**Expanded**
![Screenshot 2024-11-18 at 18 58 23](https://github.com/user-attachments/assets/54d30f6d-1fc5-4ce4-9fee-5bd330f0f6e3)

**Colour scheme**
![Screenshot 2024-11-18 at 19 34 38](https://github.com/user-attachments/assets/af3ca1ee-60b0-4776-9e20-22cffacf7c69)

**Locale translation**
![Screenshot 2024-11-18 at 19 36 22](https://github.com/user-attachments/assets/d62292e6-6243-41ee-96ba-b1ed095d3d76)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
