### PR TITLE
Stats: Make UTM Builder modal more accessible

### DIFF
--- a/client/my-sites/stats/components/empty-state-action/empty-state-action.tsx
+++ b/client/my-sites/stats/components/empty-state-action/empty-state-action.tsx
@@ -26,11 +26,19 @@ const EmptyStateAction: React.FC< EmptyStateActionProps > = ( {
 		onClick();
 	};
 
+	const handleKeyPress = ( event: React.KeyboardEvent< HTMLDivElement > ) => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			handleClick();
+		}
+	};
+
 	return (
 		<Card
 			className="stats-empty-action__cta stats-empty-action__cta-parent"
 			size="small"
 			onClick={ handleClick }
+			onKeyDown={ handleKeyPress }
+			tabIndex={ 0 }
 		>
 			<CardBody className="stats-empty-action__card-body">
 				<Icon className="stats-empty-action__cta-link-icon" icon={ icon } size={ 20 } />

--- a/client/my-sites/stats/components/empty-state-action/styles.scss
+++ b/client/my-sites/stats/components/empty-state-action/styles.scss
@@ -22,6 +22,10 @@
 		&:last-child {
 			margin-bottom: 0;
 		}
+
+		&:focus {
+			border: 1px solid var( --color-primary-light );
+		}
 	}
 
 	.stats-empty-action__card-body {

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -16,7 +16,8 @@ type InputFieldProps = {
 	placeholder: string;
 	value: string;
 	onChange: ( e: React.ChangeEvent< HTMLInputElement > ) => void;
-	inputReference?: React.RefObject< HTMLInputElement >;
+	labelReference?: React.RefObject< HTMLLabelElement >;
+	ariaDescribedBy?: string;
 };
 
 const utmKeys = [ 'url', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term' ];
@@ -24,7 +25,10 @@ const utmKeys = [ 'url', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_conten
 type UtmKeyType = ( typeof utmKeys )[ number ];
 
 type inputValuesType = Record< UtmKeyType, string >;
-type formLabelsType = Record< UtmKeyType, { label: string; placeholder: string } >;
+type formLabelsType = Record<
+	UtmKeyType,
+	{ label: string; placeholder: string; describedBy?: string }
+>;
 
 const useConfirmationMessage = ( visibleDuration = 2000, fadeOutDuration = 500 ) => {
 	const [ showConfirmation, setShowConfirmation ] = useState( false );
@@ -83,11 +87,14 @@ const InputField: React.FC< InputFieldProps > = ( {
 	placeholder,
 	value,
 	onChange,
-	inputReference,
+	labelReference,
+	ariaDescribedBy,
 } ) => {
 	return (
 		<div className="stats-utm-builder__form-field">
-			<FormLabel htmlFor={ id }>{ label }</FormLabel>
+			<FormLabel htmlFor={ id } id={ `${ id }-label` } ref={ labelReference }>
+				{ label }
+			</FormLabel>
 			<FormTextInput
 				type="text"
 				id={ id }
@@ -95,7 +102,8 @@ const InputField: React.FC< InputFieldProps > = ( {
 				value={ value }
 				onChange={ onChange }
 				placeholder={ placeholder }
-				inputRef={ inputReference }
+				aria-describedby={ ariaDescribedBy }
+				aria-labelledby={ `${ id }-label` }
 			/>
 		</div>
 	);
@@ -110,26 +118,33 @@ const UtmBuilder: React.FC = () => {
 		utm_campaign: '',
 	} );
 	// Focus the initial input field when rendered.
-	const initialInputReference = useRef< HTMLInputElement >( null );
+	const initialFieldReference = useRef< HTMLLabelElement >( null );
 	const { showConfirmation, fadeOut, triggerConfirmation } = useConfirmationMessage();
 
 	useEffect( () => {
-		initialInputReference.current!.focus();
+		initialFieldReference.current!.focus();
 	}, [] );
 
 	const fromLabels: formLabelsType = {
 		url: {
 			label: translate( 'Site or post URL' ),
 			placeholder: '',
+			describedBy: 'stats-utm-builder-help-section-url',
 		},
-		utm_source: { label: translate( 'UTM source' ), placeholder: translate( 'e.g. newsletter' ) },
+		utm_source: {
+			label: translate( 'UTM source' ),
+			placeholder: translate( 'e.g. newsletter' ),
+			describedBy: 'stats-utm-builder-help-section-campaign-source',
+		},
 		utm_medium: {
 			label: translate( 'UTM medium' ),
 			placeholder: translate( 'e.g. email, social' ),
+			describedBy: 'stats-utm-builder-help-section-campaign-medium',
 		},
 		utm_campaign: {
 			label: translate( 'UTM campaign' ),
 			placeholder: translate( 'e.g. promotion' ),
+			describedBy: 'stats-utm-builder-help-section-campaign-name',
 		},
 	};
 
@@ -175,7 +190,8 @@ const UtmBuilder: React.FC = () => {
 						placeholder={ fromLabels.url.placeholder }
 						value={ url }
 						onChange={ ( e ) => setUrl( e.target.value ) }
-						inputReference={ initialInputReference }
+						ariaDescribedBy={ fromLabels.url.describedBy }
+						labelReference={ initialFieldReference }
 					/>
 					{ Object.keys( inputValues ).map( ( key ) => (
 						<InputField
@@ -186,6 +202,7 @@ const UtmBuilder: React.FC = () => {
 							placeholder={ fromLabels[ key ].placeholder }
 							value={ inputValues[ key ] }
 							onChange={ handleInputChange }
+							ariaDescribedBy={ fromLabels[ key ].describedBy }
 						/>
 					) ) }
 				</FormFieldset>

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -122,7 +122,9 @@ const UtmBuilder: React.FC = () => {
 	const { showConfirmation, fadeOut, triggerConfirmation } = useConfirmationMessage();
 
 	useEffect( () => {
-		initialFieldReference.current!.focus();
+		setTimeout( () => {
+			initialFieldReference.current!.focus();
+		}, 100 );
 	}, [] );
 
 	const fromLabels: formLabelsType = {

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -75,7 +75,7 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger } ) => {
 					<div className={ clsx( modalClassName, 'stats-utm-builder-modal' ) }>
 						<div className="stats-utm-builder__fields">
 							<div className="stats-utm-builder__description">
-								{ translate( 'Generate URLs to share and track UTM prameters.' ) }
+								{ translate( 'Generate URLs to share and track UTM parameters.' ) }
 							</div>
 							<StatsUtmBuilderForm />
 						</div>
@@ -84,7 +84,14 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger } ) => {
 							<div className="stats-utm-builder__description">
 								{ translate( 'Parameter descriptions and examples.' ) }
 							</div>
-							<section>
+							<section id="stats-utm-builder-help-section-url">
+								<div className="stats-utm-builder__label">{ translate( 'URL' ) }</div>
+								<div>{ translate( 'The full URL of the site or post you want to track.' ) }</div>
+								<div className="stats-utm-builder__help-section-parameter-example">
+									{ translate( 'Example: https://www.my-site.com/2024/11/18/my-post' ) }
+								</div>
+							</section>
+							<section id="stats-utm-builder-help-section-campaign-source">
 								<div className="stats-utm-builder__label">{ translate( 'Campaign Source' ) }</div>
 								<div className="stats-utm-builder__help-section-parameter">utm_source</div>
 								<div>
@@ -96,7 +103,7 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger } ) => {
 									{ translate( 'Example: newsletter, X, Google' ) }
 								</div>
 							</section>
-							<section>
+							<section id="stats-utm-builder-help-section-campaign-medium">
 								<div className="stats-utm-builder__label">{ translate( 'Campaign Medium' ) }</div>
 								<div className="stats-utm-builder__help-section-parameter">utm_medium</div>
 								<div>
@@ -108,7 +115,7 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger } ) => {
 									{ translate( 'Example: cpc, banner, email' ) }
 								</div>
 							</section>
-							<section>
+							<section id="stats-utm-builder-help-section-campaign-name">
 								<div className="stats-utm-builder__label">{ translate( 'Campaign Name' ) }</div>
 								<div className="stats-utm-builder__help-section-parameter">utm_campaign</div>
 								<div>

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -1,4 +1,4 @@
-import { Modal, Button } from '@wordpress/components';
+import { Modal, Button, VisuallyHidden } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { link } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -84,13 +84,15 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger } ) => {
 							<div className="stats-utm-builder__description">
 								{ translate( 'Parameter descriptions and examples.' ) }
 							</div>
-							<section id="stats-utm-builder-help-section-url">
-								<div className="stats-utm-builder__label">{ translate( 'URL' ) }</div>
-								<div>{ translate( 'The full URL of the site or post you want to track.' ) }</div>
-								<div className="stats-utm-builder__help-section-parameter-example">
-									{ translate( 'Example: https://www.my-site.com/2024/11/18/my-post' ) }
-								</div>
-							</section>
+							<VisuallyHidden>
+								<section id="stats-utm-builder-help-section-url">
+									<div className="stats-utm-builder__label">{ translate( 'URL' ) }</div>
+									<div>{ translate( 'The full URL of the site or post you want to track.' ) }</div>
+									<div className="stats-utm-builder__help-section-parameter-example">
+										{ translate( 'Example: https://www.my-site.com/2024/11/18/my-post' ) }
+									</div>
+								</section>
+							</VisuallyHidden>
 							<section id="stats-utm-builder-help-section-campaign-source">
 								<div className="stats-utm-builder__label">{ translate( 'Campaign Source' ) }</div>
 								<div className="stats-utm-builder__help-section-parameter">utm_source</div>

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -157,3 +157,15 @@ $modal-content-padding: 32px;
 		border-radius: 4px;
 	}
 }
+
+// Hide the URL help section visually, but keep it accessible for screen readers
+#stats-utm-builder-help-section-url {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+}

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -157,15 +157,3 @@ $modal-content-padding: 32px;
 		border-radius: 4px;
 	}
 }
-
-// Hide the URL help section visually, but keep it accessible for screen readers
-#stats-utm-builder-help-section-url {
-	border: 0;
-	clip: rect(0 0 0 0);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
-	padding: 0;
-	position: absolute;
-	width: 1px;
-}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/red-team/issues/77
Closes #https://github.com/Automattic/red-team/issues/77

## Proposed Changes

* Links the form fields to the sidebar descriptions via `aria-describedby` for screenreaders
* Adds a visually hidden entry for the URL with an example
* Makes the EmptyStateAction component keyboard-friendly by allowing focus on tab, changing the border color on focus and allowing trigger on Enter and Space keydown events

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A11y improvements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the UTM URL builder modal using only your keyboard
* Activate a screen reader if not done already
* Check that when focusing a field, its description and example from the right side of the modal are spoken
* Check that the first field, the URL, also has a spoken description, but it is not visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
