### PR TITLE
Bulk Plugin Management: Show sites modal when clicking sites counter or plugin status

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -493,12 +493,7 @@ function GetStartedButton( { onClick, plugin, isMarketplaceProduct, startFreeTri
 	);
 }
 
-export function ManageSitesButton( {
-	className = 'plugin-details-cta__manage-button',
-	plugin,
-	installedOnSitesQuantity = 0,
-	children,
-} ) {
+function ManageSitesButton( { plugin, installedOnSitesQuantity } ) {
 	const translate = useTranslate();
 	const [ displayManageSitePluginsModal, setDisplayManageSitePluginsModal ] = useState( false );
 	const isRequestingPlugins = useSelector( ( state ) => isRequestingForAllSites( state ) );
@@ -531,11 +526,11 @@ export function ManageSitesButton( {
 				</div>
 			) }
 			<Button
-				className={ className }
+				className="plugin-details-cta__manage-button"
 				onClick={ toggleDisplayManageSitePluginsModal }
 				busy={ isRequestingPlugins }
 			>
-				{ children ?? translate( 'Manage sites' ) }
+				{ translate( 'Manage sites' ) }
 			</Button>
 		</>
 	);

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -493,7 +493,12 @@ function GetStartedButton( { onClick, plugin, isMarketplaceProduct, startFreeTri
 	);
 }
 
-function ManageSitesButton( { plugin, installedOnSitesQuantity } ) {
+export function ManageSitesButton( {
+	className = 'plugin-details-cta__manage-button',
+	plugin,
+	installedOnSitesQuantity = 0,
+	children,
+} ) {
 	const translate = useTranslate();
 	const [ displayManageSitePluginsModal, setDisplayManageSitePluginsModal ] = useState( false );
 	const isRequestingPlugins = useSelector( ( state ) => isRequestingForAllSites( state ) );
@@ -526,11 +531,11 @@ function ManageSitesButton( { plugin, installedOnSitesQuantity } ) {
 				</div>
 			) }
 			<Button
-				className="plugin-details-cta__manage-button"
+				className={ className }
 				onClick={ toggleDisplayManageSitePluginsModal }
 				busy={ isRequestingPlugins }
 			>
-				{ translate( 'Manage sites' ) }
+				{ children ?? translate( 'Manage sites' ) }
 			</Button>
 		</>
 	);

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -141,7 +141,7 @@ export default function PluginsListDataViews( {
 				defaultLayouts={ defaultLayouts }
 				header={ header }
 			/>
-			{ sitesDialog && sitesDialog }
+			{ sitesDialog }
 		</>
 	);
 }

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -10,7 +10,7 @@ import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants
 import { Plugin } from 'calypso/state/plugins/installed/types';
 import { useActions } from './use-actions';
 import { useFields } from './use-fields';
-
+import { useSitesDialog } from './use-sites-dialog';
 import './style.scss';
 
 interface Props {
@@ -34,7 +34,8 @@ export default function PluginsListDataViews( {
 	const pluginUpdateCount = currentPlugins.filter(
 		( plugin ) => plugin.status?.includes( PLUGINS_STATUS.UPDATE )
 	).length;
-	const fields = useFields( bulkActionDialog );
+	const { sitesDialog, toggleDialogForPlugin } = useSitesDialog();
+	const fields = useFields( bulkActionDialog, toggleDialogForPlugin );
 	const actions = useActions( bulkActionDialog );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( () => ( {
@@ -140,6 +141,7 @@ export default function PluginsListDataViews( {
 				defaultLayouts={ defaultLayouts }
 				header={ header }
 			/>
+			{ sitesDialog && sitesDialog }
 		</>
 	);
 }

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -54,3 +54,10 @@ body.is-section-plugins .plugin-management-wrapper,
         padding-left: 80px;
     }
 }
+
+.sites-manage-plugin-button {
+    border: none;
+    padding: 0;
+    font-size: inherit;
+    color: inherit;
+}

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -58,10 +58,6 @@ body.is-section-plugins .plugin-management-wrapper,
 .sites-manage-plugin-status-button {
     padding: 0;
     display: contents;
-    &:focus:not(:disabled) {
-        outline: none;
-        box-shadow: none;
-    }
 }
 
 .sites-manage-plugin-button {
@@ -69,8 +65,4 @@ body.is-section-plugins .plugin-management-wrapper,
     font-size: inherit;
     color: inherit;
     cursor: pointer;
-    &:focus:not(:disabled) {
-     outline: none;
-     box-shadow: none;
-    }
 }

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -55,9 +55,22 @@ body.is-section-plugins .plugin-management-wrapper,
     }
 }
 
-.sites-manage-plugin-button {
-    border: none;
+.sites-manage-plugin-status-button {
     padding: 0;
+    display: contents;
+    &:focus:not(:disabled) {
+        outline: none;
+        box-shadow: none;
+    }
+}
+
+.sites-manage-plugin-button {
+    margin-left: -12px;
     font-size: inherit;
     color: inherit;
+    cursor: pointer;
+    &:focus:not(:disabled) {
+     outline: none;
+     box-shadow: none;
+    }
 }

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -6,11 +6,11 @@ import { useMemo } from 'react';
 import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
 import { Plugin } from 'calypso/state/plugins/installed/types';
 import { PluginActions } from '../hooks/types';
-import { ManageSitesButton } from '../plugin-details-CTA';
 import PluginActionStatus from '../plugin-management-v2/plugin-action-status';
 
 export function useFields(
-	bulkActionDialog: ( action: string, plugins: Array< Plugin > ) => void
+	bulkActionDialog: ( action: string, plugins: Array< Plugin > ) => void,
+	toggleDialogForPlugin: ( plugin: Plugin | null ) => void
 ) {
 	const fields = useMemo(
 		() => [
@@ -52,12 +52,15 @@ export function useFields(
 
 					if ( item.allStatuses?.length ) {
 						pluginActionStatus = (
-							<ManageSitesButton className="sites-manage-plugin-button" plugin={ item }>
+							<Button
+								className="sites-manage-plugin-status-button"
+								onClick={ () => toggleDialogForPlugin( item ) }
+							>
 								<PluginActionStatus
 									currentSiteStatuses={ item.allStatuses }
 									selectedSite={ undefined }
 								/>
-							</ManageSitesButton>
+							</Button>
 						);
 					}
 
@@ -83,9 +86,12 @@ export function useFields(
 				render: ( { item }: { item: Plugin } ) => {
 					const numberOfSites = item.sites && Object.keys( item.sites ).length;
 					return (
-						<ManageSitesButton className="sites-manage-plugin-button" plugin={ item }>
+						<Button
+							className="sites-manage-plugin-button"
+							onClick={ () => toggleDialogForPlugin( item ) }
+						>
 							{ numberOfSites }
-						</ManageSitesButton>
+						</Button>
 					);
 				},
 			},
@@ -117,7 +123,7 @@ export function useFields(
 				},
 			},
 		],
-		[ bulkActionDialog ]
+		[ bulkActionDialog, toggleDialogForPlugin ]
 	);
 
 	return fields;

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
 import { Plugin } from 'calypso/state/plugins/installed/types';
 import { PluginActions } from '../hooks/types';
+import { ManageSitesButton } from '../plugin-details-CTA';
 import PluginActionStatus from '../plugin-management-v2/plugin-action-status';
 
 export function useFields(
@@ -51,10 +52,12 @@ export function useFields(
 
 					if ( item.allStatuses?.length ) {
 						pluginActionStatus = (
-							<PluginActionStatus
-								currentSiteStatuses={ item.allStatuses }
-								selectedSite={ undefined }
-							/>
+							<ManageSitesButton className="sites-manage-plugin-button" plugin={ item }>
+								<PluginActionStatus
+									currentSiteStatuses={ item.allStatuses }
+									selectedSite={ undefined }
+								/>
+							</ManageSitesButton>
 						);
 					}
 
@@ -78,7 +81,12 @@ export function useFields(
 					return item.sites && Object.keys( item.sites ).length;
 				},
 				render: ( { item }: { item: Plugin } ) => {
-					return <span>{ item.sites && Object.keys( item.sites ).length }</span>;
+					const numberOfSites = item.sites && Object.keys( item.sites ).length;
+					return (
+						<ManageSitesButton className="sites-manage-plugin-button" plugin={ item }>
+							{ numberOfSites }
+						</ManageSitesButton>
+					);
 				},
 			},
 			{

--- a/client/my-sites/plugins/plugins-list/use-sites-dialog.tsx
+++ b/client/my-sites/plugins/plugins-list/use-sites-dialog.tsx
@@ -1,0 +1,23 @@
+import { useCallback, useState } from 'react';
+import { Plugin } from 'calypso/state/plugins/installed/types';
+import { ManageSitePluginsDialog } from '../manage-site-plugins-dialog';
+
+export function useSitesDialog() {
+	const [ displayManageSitePluginsModal, setDisplayManageSitePluginsModal ] = useState( false );
+	const [ plugin, setPlugin ] = useState< Plugin | null >( null );
+
+	const toggleDialogForPlugin = useCallback( ( plugin: Plugin | null = null ) => {
+		setPlugin( plugin );
+		setDisplayManageSitePluginsModal( ( value ) => ! value );
+	}, [] );
+
+	const sitesDialog = plugin ? (
+		<ManageSitePluginsDialog
+			plugin={ plugin }
+			isVisible={ displayManageSitePluginsModal }
+			onClose={ () => setDisplayManageSitePluginsModal( false ) }
+		/>
+	) : null;
+
+	return { sitesDialog, toggleDialogForPlugin };
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9850

## Proposed Changes

* Clicking the sites counter or plugin status will show the sites modal

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that users can easily find list of sites a plugin might failed on.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/manage`
* Click the counter in the `sites` column and verify the modal is shown
* Try updating a plugin and let it fail or if there is a plugin status available, click on it and verify it opens the modal.
* 
![image](https://github.com/user-attachments/assets/16153595-d3c8-49b5-885d-368b3f411cbf)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
