### PR TITLE
Sites dashboard doesn't need DataViewState from the A4A project

### DIFF
--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -163,7 +163,7 @@ const SitesDashboard = ( {
 	};
 
 	// Create the DataViews state based on initial values
-	const defaultDataViewsState = {
+	const defaultDataViewsState: View = {
 		sort: {
 			field: '',
 			direction: 'asc',
@@ -183,30 +183,34 @@ const SitesDashboard = ( {
 					],
 			  }
 			: {} ),
-		type: selectedSite ? 'list' : 'table',
-		layout: {
-			styles: {
-				site: {
-					width: getSiteNameColWidth( isDesktop, isWide ),
-				},
-				plan: {
-					width: '126px',
-				},
-				status: {
-					width: '142px',
-				},
-				'last-publish': {
-					width: '146px',
-				},
-				stats: {
-					width: '106px',
-				},
-				actions: {
-					width: '74px',
-				},
-			},
-		},
-	} as View;
+		...( selectedSite
+			? { type: 'list', layout: {} }
+			: {
+					type: 'table',
+					layout: {
+						styles: {
+							site: {
+								width: getSiteNameColWidth( isDesktop, isWide ),
+							},
+							plan: {
+								width: '126px',
+							},
+							status: {
+								width: '142px',
+							},
+							'last-publish': {
+								width: '146px',
+							},
+							stats: {
+								width: '106px',
+							},
+							actions: {
+								width: '74px',
+							},
+						},
+					},
+			  } ),
+	};
 	const [ dataViewsState, setDataViewsState ] = useState< View >( defaultDataViewsState );
 
 	useEffect( () => {
@@ -225,28 +229,19 @@ const SitesDashboard = ( {
 			dataViewsState.type === 'table' &&
 			dataViewsState.layout?.styles?.site?.width !== siteNameColumnWidth
 		) {
-			// @ts-expect-error -- Need to fix the layout type upstream in @wordpress/dataviews to support styles.
-			setDataViewsState( ( prevState ) => ( {
-				...prevState,
+			setDataViewsState( {
+				...dataViewsState,
 				layout: {
 					styles: {
-						// @ts-expect-error -- Need to fix the layout type upstream in @wordpress/dataviews to support styles.
-						...prevState.layout?.styles,
+						...dataViewsState.layout?.styles,
 						site: {
 							width: siteNameColumnWidth,
 						},
 					},
 				},
-			} ) );
+			} );
 		}
-	}, [
-		isDesktop,
-		isWide,
-		dataViewsState.type,
-		dataViewsState?.fields,
-		// @ts-expect-error -- Need to fix the layout type upstream in @wordpress/dataviews to support styles.
-		dataViewsState?.layout?.styles?.site?.width,
-	] );
+	}, [ isDesktop, isWide, dataViewsState ] );
 
 	// Ensure site sort preference is applied when it loads in. This isn't always available on
 	// initial mount.

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -1,5 +1,5 @@
 import { usePrevious } from '@wordpress/compose';
-import { DataViews, View, Field } from '@wordpress/dataviews';
+import { DataViews, Field } from '@wordpress/dataviews';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo, useRef, useLayoutEffect } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -12,6 +12,7 @@ import SiteField from './dataviews-fields/site-field';
 import { SiteStats } from './sites-site-stats';
 import { SiteStatus } from './sites-site-status';
 import type { SiteExcerptData } from '@automattic/sites';
+import type { View } from '@wordpress/dataviews';
 
 import './style.scss';
 import './dataview-style.scss';
@@ -211,7 +212,7 @@ const DotcomSitesDataViews = ( {
 			<DataViews
 				data={ sites }
 				fields={ fields }
-				onChangeView={ ( newView: View ) => setDataViewsState( () => newView ) }
+				onChangeView={ ( newView ) => setDataViewsState( () => newView ) }
 				view={ dataViewsState }
 				search
 				searchLabel={ __( 'Search sites…' ) }

--- a/client/sites/hooks/use-initialize-dataviews-page.ts
+++ b/client/sites/hooks/use-initialize-dataviews-page.ts
@@ -1,17 +1,17 @@
 import { usePrevious } from '@wordpress/compose';
 import { useEffect, useRef } from 'react';
-import type { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import type { View } from '@wordpress/dataviews';
 
 // DataViews' pagination always resets when the search component is mounted, even though the search term has not changed.
 // This is a bug which has a fix in https://github.com/WordPress/gutenberg/pull/61307.
 // This is a workaround until the above fix is released.
 // Here, we restore the page to the previous page if it is unintentionally changed by the above bug.
-export function useInitializeDataViewsPage(
-	dataViewsState: DataViewsState,
-	setDataViewsState: ( state: DataViewsState ) => void
+export function useInitializeDataViewsPage< V extends View >(
+	dataViewsState: V,
+	setDataViewsState: ( state: V ) => void
 ) {
-	const prevPage = usePrevious( dataViewsState.page ) as number;
-	const prevSearch = usePrevious( dataViewsState.search ) as string;
+	const prevPage = usePrevious( dataViewsState.page );
+	const prevSearch = usePrevious( dataViewsState.search );
 
 	const done = useRef( false );
 
@@ -30,5 +30,5 @@ export function useInitializeDataViewsPage(
 			} );
 			done.current = true;
 		}
-	}, [ dataViewsState.page, dataViewsState.search ] );
+	}, [ dataViewsState, prevPage, prevSearch, setDataViewsState ] );
 }


### PR DESCRIPTION
It doesn't use the "selected item" attribute and so the sites dashboard can use the vanilla `View` interface directly.

Related to https://github.com/Automattic/wp-calypso/pull/96326

## Proposed Changes

* Fixes dataview typing after https://github.com/Automattic/wp-calypso/pull/96326 made it possible to drop the a4a typing in `useInitializeDataViewsPage`

## Testing Instructions

* Smoke test /sites, see https://github.com/Automattic/wp-calypso/pull/96326 for a checklist of things to watch for