### PR TITLE
Help Center: Check user eligibility for support

### DIFF
--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -1,7 +1,7 @@
 
 
-.help-center__container-chat .chatbox-messages .odie__transfer-to-human,
-.help-center-article-content .help-center-feedback__form .odie__transfer-to-human {
+.help-center__container-chat .chatbox-messages .odie__transfer-chat,
+.help-center-article-content .help-center-feedback__form .odie__transfer-chat {
 	display: flex;
 	width: 100%;
 	padding-bottom: 16px;
@@ -30,6 +30,6 @@
 	}
 }
 
-.help-center__container-chat .chatbox-messages .odie__transfer-to-human {
+.help-center__container-chat .chatbox-messages .odie__transfer-chat {
 	margin-left: 46px;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9881
Fixes https://github.com/Automattic/dotcom-forge/issues/9881

## Proposed Changes

* Add check whether the user should talk to a human or get support in forums

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Only eligible users can talk to a human, this PR addresses it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and add the flag `?flags=help-center-experience`
* Create a free account and open the Helpcenter
* Start a conversation with Wapuu and ask to "talk to a human"
* You should see this
<img width="418" alt="image" src="https://github.com/user-attachments/assets/f5d96998-6cb4-4081-b797-92b013e5b570">

When clicking on the "Ask in our forums" button, you should be redirected to
<img width="412" alt="image" src="https://github.com/user-attachments/assets/0902cdce-a3b1-4312-89d9-d80728835ddc">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
