### PR TITLE
Substack Subscribers importer: release

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -48,7 +48,7 @@
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,
 		"importer/unified": true,
-		"importers/newsletter": false,
+		"importers/newsletter": true,
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/ai-assistant-request-limit": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -39,6 +39,7 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"i18n/community-translator": false,
+		"importers/newsletter": false,
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,

--- a/config/production.json
+++ b/config/production.json
@@ -61,7 +61,7 @@
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,
 		"importer/unified": true,
-		"importers/newsletter": false,
+		"importers/newsletter": true,
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"is_running_in_jetpack_site": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -60,7 +60,7 @@
 		"i18n/empathy-mode": true,
 		"importer/site-backups": true,
 		"importer/unified": true,
-		"importers/newsletter": false,
+		"importers/newsletter": true,
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Releases easy, guided subscriber (free & paid!) importing from Substack alongside their content.

Current entry to the importer is only at **Tools -> Import -> Substack**:

<img width="909" alt="Screenshot 2024-11-19 at 12 28 15" src="https://github.com/user-attachments/assets/50698d30-3f86-464d-ba47-3ec63434f3e2">


Next up, we'll add to other flows as well:

- Subscribers -> Add ([PR](https://github.com/Automattic/wp-calypso/pull/96143))
- Onboarding -> Content only -> Substack

<img width="744" alt="Screenshot 2024-11-19 at 11 15 03" src="https://github.com/user-attachments/assets/f24ba42f-1ab0-475a-8fa2-68a79e381e5b">


## Proposed Changes

### Before

<img width="876" alt="Screenshot 2024-11-19 at 12 28 19" src="https://github.com/user-attachments/assets/d6fad4ff-ba20-4ab6-8ad2-3dea10de0297">

### After

<img width="927" alt="Screenshot 2024-11-14 at 14 18 52" src="https://github.com/user-attachments/assets/77e528fc-8425-4eb5-917b-be6eb0e20ed2">

<img width="1143" alt="Screenshot 2024-11-19 at 12 40 17" src="https://github.com/user-attachments/assets/76943b3a-0763-4850-92a8-7eabf78c497b">

<img width="1026" alt="Screenshot 2024-11-19 at 12 40 22" src="https://github.com/user-attachments/assets/436be096-1391-46fd-a727-948e34b68519">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Project thread peKye1-Z1-p2


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tools -> Import
* Substack importer
* Go through the flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
