### PR TITLE
Stats:  Make header on traffic page sticky

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -25,6 +25,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import StickyPanel from 'calypso/components/sticky-panel';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS } from 'calypso/my-sites/stats/constants';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
@@ -469,36 +470,38 @@ class StatsSite extends Component {
 				) }
 				{ isNewDateFilteringEnabled && (
 					// moves date range block into new location
-					<StatsPeriodHeader>
-						<StatsPeriodNavigation
-							date={ date }
-							period={ period }
-							url={ `/stats/${ period }/${ slug }` }
-							queryParams={ context.query }
-							pathTemplate={ pathTemplate }
-							charts={ CHARTS }
-							availableLegend={ this.getAvailableLegend() }
-							activeTab={ getActiveTab( this.props.chartTab ) }
-							activeLegend={ this.state.activeLegend }
-							onChangeLegend={ this.onChangeLegend }
-							isWithNewDateFiltering // @TODO:remove this prop once we release new date filtering
-							isWithNewDateControl
-							showArrows
-							slug={ slug }
-							dateRange={ customChartRange }
-						>
-							{ ' ' }
-							<DatePicker
-								period={ period }
+					<StickyPanel>
+						<StatsPeriodHeader>
+							<StatsPeriodNavigation
 								date={ date }
-								query={ query }
-								statsType="statsTopPosts"
-								showQueryDate
-								isShort
+								period={ period }
+								url={ `/stats/${ period }/${ slug }` }
+								queryParams={ context.query }
+								pathTemplate={ pathTemplate }
+								charts={ CHARTS }
+								availableLegend={ this.getAvailableLegend() }
+								activeTab={ getActiveTab( this.props.chartTab ) }
+								activeLegend={ this.state.activeLegend }
+								onChangeLegend={ this.onChangeLegend }
+								isWithNewDateFiltering // @TODO:remove this prop once we release new date filtering
+								isWithNewDateControl
+								showArrows
+								slug={ slug }
 								dateRange={ customChartRange }
-							/>
-						</StatsPeriodNavigation>
-					</StatsPeriodHeader>
+							>
+								{ ' ' }
+								<DatePicker
+									period={ period }
+									date={ date }
+									query={ query }
+									statsType="statsTopPosts"
+									showQueryDate
+									isShort
+								dateRange={ customChartRange }
+								/>
+							</StatsPeriodNavigation>
+						</StatsPeriodHeader>
+					</StickyPanel>
 				) }
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -497,7 +497,7 @@ class StatsSite extends Component {
 									statsType="statsTopPosts"
 									showQueryDate
 									isShort
-								dateRange={ customChartRange }
+									dateRange={ customChartRange }
 								/>
 							</StatsPeriodNavigation>
 						</StatsPeriodHeader>

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -54,12 +54,11 @@ $stats-card-min-width: 390px;
 	.stats-period-navigation {
 		margin: 9px 0;
 	}
-
-	.stats-date-picker__refresh-status {
-		display: none;
-	}
 }
 
+.stats__period-header {
+	padding: 0 32px;
+}
 
 .stats-card {
 	@media (max-width: $break-medium) {
@@ -228,6 +227,9 @@ $stats-card-min-width: 390px;
 		@include apply-improved-classic-dark-colors();
 	}
 
+	.sticky-panel.is-sticky {
+		padding: 0;
+	}
 
 }
 

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -47,7 +47,7 @@ $stats-card-min-width: 390px;
 	}
 }
 
-.stats__sticky-navigation.is-sticky .sticky-panel__content {
+.stats__sticky-navigation.is-sticky .sticky-panel__content, .sticky-panel.is-sticky .sticky-panel__content {
 	background: var(--studio-white);
 	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1), 0 0 56px rgba(0, 0, 0, 0.075);
 
@@ -59,6 +59,7 @@ $stats-card-min-width: 390px;
 		display: none;
 	}
 }
+
 
 .stats-card {
 	@media (max-width: $break-medium) {
@@ -226,6 +227,8 @@ $stats-card-min-width: 390px;
 	&.color-scheme.is-classic-dark {
 		@include apply-improved-classic-dark-colors();
 	}
+
+
 }
 
 .list-emails {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/217

## Proposed Changes

* Makes the header on the traffic page sticky

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
* Part of the Date filtering for the traffic page project (header refresh section)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link.
* Visit the Stats → Traffic page and confirm it loads normally.
* Manually enable the feature flag: ?flags=stats/new-date-filtering
* Scroll the page and confirm the header sticks to the top of the page.
* Keep an eye out for unintended layout changes.

| Design Image | Screenshot from branch |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/c0e759da-d652-456c-a895-0ffba2593b4c)  | ![image](https://github.com/user-attachments/assets/345536cb-a5ae-4a18-87f6-ea55e3e70ce0)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
