### PR TITLE
Help Center: Parse user's message to markdown

### DIFF
--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
 import Markdown from 'react-markdown';
 import { useOdieAssistantContext } from '../../context';
-import { Message } from '../../types';
+import { ZendeskMessage, Message } from '../../types';
+import { zendeskMessageConverter } from '../../utils';
 import ChatWithSupportLabel from '../chat-with-support';
 import CustomALink from './custom-a-link';
 import DislikeFeedbackMessage from './dislike-feedback-message';
@@ -41,6 +42,20 @@ export const MessageContent = ( {
 		message.context?.flags?.hide_disclaimer_content ||
 		message.context?.question_tags?.inquiry_type === 'user-is-greeting';
 
+	// This will parse text messages sent from users to Zendesk.
+	const parseTextMessage = ( message: Message ): Message => {
+		const zendeskMessage = {
+			type: 'text',
+			text: message.content,
+			role: message.role,
+		} as ZendeskMessage;
+		return zendeskMessageConverter( zendeskMessage );
+	};
+
+	// message type === message are messages being sent from users to zendesk.
+	// They need to be parsed to markdown to appear nicely.
+	const markdownMessageContent = message.type !== 'message' ? message : parseTextMessage( message );
+
 	return (
 		<>
 			<div className={ containerClasses } data-is-message="true">
@@ -50,7 +65,7 @@ export const MessageContent = ( {
 					{ ( [ 'message', 'image', 'file', 'text' ].includes( message.type ) ||
 						! message.type ) && (
 						<UserMessage
-							message={ message }
+							message={ markdownMessageContent }
 							isDisliked={ isDisliked }
 							isMessageWithoutEscalationOption={ isMessageWithOnlyText }
 						/>

--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import Markdown from 'react-markdown';
 import { useOdieAssistantContext } from '../../context';
-import { ZendeskMessage, Message } from '../../types';
 import { zendeskMessageConverter } from '../../utils';
 import ChatWithSupportLabel from '../chat-with-support';
 import CustomALink from './custom-a-link';
@@ -10,6 +9,7 @@ import ErrorMessage from './error-message';
 import Sources from './sources';
 import { uriTransformer } from './uri-transformer';
 import { UserMessage } from './user-message';
+import type { ZendeskMessage, Message } from '../../types';
 
 export const MessageContent = ( {
 	isDisliked = false,
@@ -52,9 +52,13 @@ export const MessageContent = ( {
 		return zendeskMessageConverter( zendeskMessage );
 	};
 
+	const shouldParseMessage = () => {
+		return message.type === 'message' && message.role !== 'bot';
+	};
+
 	// message type === message are messages being sent from users to zendesk.
 	// They need to be parsed to markdown to appear nicely.
-	const markdownMessageContent = message.type !== 'message' ? message : parseTextMessage( message );
+	const markdownMessageContent = shouldParseMessage() ? parseTextMessage( message ) : message;
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9879
Fixes https://github.com/Automattic/dotcom-forge/issues/9879

## Proposed Changes

* Parse message to markdown if a message is being sent from the user to Zendesk

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is necessary to make messages appear nicely in the chat and keep the content of the message just as before.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and add this flag `?flags=help-center-experience`
* Start a chat with yourself by asking Wapuu to talk to a human
* Send links and make sure they appear nicely in the message thread
* Check production and compare.
* Images are not being changed, it should work fine

Before: www.google.com is not a link
<img width="418" alt="image" src="https://github.com/user-attachments/assets/2a07c07b-290a-4d22-ab8f-1c29c41a4f88">


After:  www.wordpress.com is a link
<img width="412" alt="image" src="https://github.com/user-attachments/assets/ae36c9ea-7b3a-4c0f-ade6-be8e1e4ea9a8">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
