### PR TITLE
Router: trim leading slashes to avoid interpreting path as external link

### DIFF
--- a/packages/calypso-router/src/index.js
+++ b/packages/calypso-router/src/index.js
@@ -1051,7 +1051,7 @@ function Context( path, state, pageInstance ) {
 	const hashbang = this.page._hashbang;
 
 	// merge multiple leading slashes into one, to avoid misinterpreting the path as scheme-relative URL
-	path = path.replace( /^\/+/, '/' );
+	path = path.replace( /^[/\\]+/, '/' );
 
 	const pageBase = this.page._getBase();
 	if ( '/' === path[ 0 ] && 0 !== path.indexOf( pageBase ) ) {

--- a/packages/calypso-router/src/index.js
+++ b/packages/calypso-router/src/index.js
@@ -1050,6 +1050,9 @@ function Context( path, state, pageInstance ) {
 	const window = this.page._window;
 	const hashbang = this.page._hashbang;
 
+	// merge multiple leading slashes into one, to avoid misinterpreting the path as scheme-relative URL
+	path = path.replace( /^\/+/, '/' );
+
 	const pageBase = this.page._getBase();
 	if ( '/' === path[ 0 ] && 0 !== path.indexOf( pageBase ) ) {
 		path = pageBase + ( hashbang ? '#!' : '' ) + path;


### PR DESCRIPTION
Fixes a bug where link in Calypso UI like:
```
<a href="https://wordpress.com//jetpack.com">Navigate</a>
```
is incorrectly interpreted by the Calypso router and causes navigation to `https://jetpack.com`.

The Calypso router has a `clickHandler` that captures all clicks on `a href` elements and tries to do an SPA navigation. The `pathname` of the offending URL is `//jetpack.com`, and because no matching route is registered in Calypso for this path, eventually the router does a full-page navigation by assigning to `window.location.href`:
```js
window.location.href = '//jetpack.com';
```
But here the path is not interpreted as a relative `pathname`, but as a scheme-relative URL to `jetpack.com`.

This is a counterintutitive behavior of URLs because when parsing and composing an URL with the native `URL` class is not "symmetrical":
```js
new URL( 'https://wordpress.com//jetpack.com' )
```
produces a parsed object with `{ host: 'wordpress.com', pathname: '//jetpack.com' }`. But trying to use the pathname as a relative URL leads to something different:
```js
new URL( '//jetpack.com', 'https://wordpress.com' /* base url */ )
```
produces a parsed object with `{ host: 'jetpack.com' }`. Only the `https` scheme is used from the base URL.

I'm fixing this by removing extra leading slashes from the `path` when producing a router `Context` object. This way the offending path is never assigned to `window.location` and is also never passed to `window.history.pushState`.

**How to test:**
Put a `<a href>` element somewhere in Calypso React UI and click on it. Unpatched Calypso will navigate to `http://jetpack.com`. Patched Calypso will navigate to local `/jetpack.com`.