### PR TITLE
Stats: Set date range default to 7 days

### DIFF
--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -92,7 +92,7 @@ const DateRangePickerShortcuts = ( {
 		const today = siteToday.clone().startOf( 'day' );
 		const daysInRange = Math.abs( endDate.diff( startDate, 'days' ) );
 		const shortcut = shortcutList.find( ( element ) => {
-			if ( endDate.isSame( today ) && daysInRange === element.range ) {
+			if ( endDate.isSame( today, 'day' ) && daysInRange === element.range ) {
 				return element;
 			}
 			return null;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -203,9 +203,14 @@ class StatsSite extends Component {
 
 	// Return a default amount of days to subtracts from the present day depending on the period selected.
 	// Used in case no starting date is present in the URL.
-	getDefaultDaysForPeriod( period ) {
+	getDefaultDaysForPeriod( period, defaultSevenDaysForPeriodDay = false ) {
 		switch ( period ) {
 			case 'day':
+				// TODO: Temporary fix for the new date filtering feature.
+				if ( defaultSevenDaysForPeriodDay ) {
+					return 7;
+				}
+
 				return 30;
 			case 'week':
 				return 12 * 7; // ~last 3 months
@@ -282,7 +287,7 @@ class StatsSite extends Component {
 		}
 
 		// Find the quantity of bars for the chart.
-		let daysInRange = this.getDefaultDaysForPeriod( period );
+		let daysInRange = this.getDefaultDaysForPeriod( period, isNewDateFilteringEnabled );
 		const chartStart = this.getValidDateOrNullFromInput( context.query?.chartStart );
 		const isSameOrBefore = moment( chartStart ).isSameOrBefore( moment( chartEnd ) );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/229

## Proposed Changes

* Set the default date range to 7 days for date filtering on the Traffic page.
* Fix the date range shortcut selection.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We plan to default `Last 7 Days` to set the view for the alternative past `7-day highlights` section.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Ensure the default date range is still `Last 30 Days`.
* Append the feature flag to the URL: `?flags=stats/new-date-filtering`.
* Ensure the default date range is replaced with `Last 7 Days`.
* Click on the date range picker.
* Ensure the shortcut selection is correctly set to `Last 7 Days`.

|Before|After|
|-|-|
|<img width="749" alt="截圖 2024-11-19 晚上9 36 22" src="https://github.com/user-attachments/assets/c4bbccec-9033-4ccb-9967-624cd4727e7a">|<img width="755" alt="截圖 2024-11-19 晚上9 35 11" src="https://github.com/user-attachments/assets/670cc4dc-2e4d-43a2-a854-ce22167d52e0">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
