### PR TITLE
Help Center: Do not call Support Interaction APIs in old version

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -243,22 +243,29 @@ const HelpCenterFooterButton = ( {
 };
 
 export const HelpCenterContactButton: FC = () => {
+	const shouldUseHelpCenterExperience = config.isEnabled( 'help-center-experience' );
 	const { __ } = useI18n();
 	const { data: supportInteractionsResolved } = useGetSupportInteractions(
 		'zendesk',
 		100,
-		'resolved'
+		'resolved',
+		undefined,
+		shouldUseHelpCenterExperience
 	);
-	const { data: supportInteractionsOpen } = useGetSupportInteractions( 'zendesk', 10, 'open' );
+	const { data: supportInteractionsOpen } = useGetSupportInteractions(
+		'zendesk',
+		10,
+		'open',
+		undefined,
+		shouldUseHelpCenterExperience
+	);
 
 	const supportInteractions = [
 		...( supportInteractionsResolved || [] ),
 		...( supportInteractionsOpen || [] ),
 	];
 
-	return config.isEnabled( 'help-center-experience' ) &&
-		supportInteractions &&
-		supportInteractions?.length > 0 ? (
+	return shouldUseHelpCenterExperience && supportInteractions && supportInteractions?.length > 0 ? (
 		<>
 			<HelpCenterFooterButton
 				icon={ comment }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -248,17 +248,9 @@ export const HelpCenterContactButton: FC = () => {
 	const { data: supportInteractionsResolved } = useGetSupportInteractions(
 		'zendesk',
 		100,
-		'resolved',
-		undefined,
-		shouldUseHelpCenterExperience
+		'resolved'
 	);
-	const { data: supportInteractionsOpen } = useGetSupportInteractions(
-		'zendesk',
-		10,
-		'open',
-		undefined,
-		shouldUseHelpCenterExperience
-	);
+	const { data: supportInteractionsOpen } = useGetSupportInteractions( 'zendesk', 10, 'open' );
 
 	const supportInteractions = [
 		...( supportInteractionsResolved || [] ),

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -248,9 +248,17 @@ export const HelpCenterContactButton: FC = () => {
 	const { data: supportInteractionsResolved } = useGetSupportInteractions(
 		'zendesk',
 		100,
-		'resolved'
+		'resolved',
+		undefined,
+		shouldUseHelpCenterExperience
 	);
-	const { data: supportInteractionsOpen } = useGetSupportInteractions( 'zendesk', 10, 'open' );
+	const { data: supportInteractionsOpen } = useGetSupportInteractions(
+		'zendesk',
+		10,
+		'open',
+		undefined,
+		shouldUseHelpCenterExperience
+	);
 
 	const supportInteractions = [
 		...( supportInteractionsResolved || [] ),

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -3,6 +3,7 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { useManageSupportInteraction } from '@automattic/odie-client/src/data';
 import { useGetSupportInteractions } from '@automattic/odie-client/src/data/use-get-support-interactions';
 import { CardBody, Disabled } from '@wordpress/components';
@@ -56,7 +57,13 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const { startNewInteraction } = useManageSupportInteraction();
 	const { data } = useSupportStatus();
 	const { data: openSupportInteraction, isLoading: isLoadingOpenSupportInteractions } =
-		useGetSupportInteractions( 'help-center' );
+		useGetSupportInteractions(
+			'help-center',
+			undefined,
+			undefined,
+			undefined,
+			config.isEnabled( 'help-center-experience' )
+		);
 	const isUserEligibleForPaidSupport = data?.eligibility.is_user_eligible ?? false;
 
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -3,7 +3,6 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
 import { useManageSupportInteraction } from '@automattic/odie-client/src/data';
 import { useGetSupportInteractions } from '@automattic/odie-client/src/data/use-get-support-interactions';
 import { CardBody, Disabled } from '@wordpress/components';
@@ -57,13 +56,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const { startNewInteraction } = useManageSupportInteraction();
 	const { data } = useSupportStatus();
 	const { data: openSupportInteraction, isLoading: isLoadingOpenSupportInteractions } =
-		useGetSupportInteractions(
-			'help-center',
-			undefined,
-			undefined,
-			undefined,
-			config.isEnabled( 'help-center-experience' )
-		);
+		useGetSupportInteractions( 'help-center' );
 	const isUserEligibleForPaidSupport = data?.eligibility.is_user_eligible ?? false;
 
 	useEffect( () => {

--- a/packages/odie-client/src/data/use-get-support-interactions.ts
+++ b/packages/odie-client/src/data/use-get-support-interactions.ts
@@ -10,7 +10,8 @@ export const useGetSupportInteractions = (
 	provider: SupportProvider | null = null,
 	per_page = 10,
 	status = 'open',
-	page = 1
+	page = 1,
+	enabled = true
 ) => {
 	const path = `?per_page=${ per_page }&page=${ page }&status=${ status }`;
 
@@ -32,5 +33,6 @@ export const useGetSupportInteractions = (
 
 			return response;
 		},
+		enabled,
 	} );
 };

--- a/packages/odie-client/src/data/use-get-support-interactions.ts
+++ b/packages/odie-client/src/data/use-get-support-interactions.ts
@@ -10,8 +10,7 @@ export const useGetSupportInteractions = (
 	provider: SupportProvider | null = null,
 	per_page = 10,
 	status = 'open',
-	page = 1,
-	enabled = true
+	page = 1
 ) => {
 	const path = `?per_page=${ per_page }&page=${ page }&status=${ status }`;
 
@@ -33,6 +32,5 @@ export const useGetSupportInteractions = (
 
 			return response;
 		},
-		enabled,
 	} );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Avoid calling the Support Interaction APIs in the old version, since we're not using them there.



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that everything is working with the flag (`?flags=help-center-experience`) and without.
* On the old version, you shouldn't see any call to /support-interaction