### PR TITLE
A4A > Tier: Temporary hide the "Download your badges" button

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -38,9 +38,15 @@ export default function AgencyTierOverview() {
 
 	const ALL_TIERS: AgencyTier[] = [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ];
 
+	// todo: Restore this. We have to hide temporary the 'Download your badges' button until the WooCommerce ones are ready
+	// A4A GH issue: 1500
+	const temporaryHideDownloadBadges = true;
+
 	// Show download badges button for Agency Partner and Pro Agency Partner tiers
 	const showDownloadBadges =
-		currentAgencyTier && [ 'agency-partner', 'pro-agency-partner' ].includes( currentAgencyTier );
+		! temporaryHideDownloadBadges &&
+		currentAgencyTier &&
+		[ 'agency-partner', 'pro-agency-partner' ].includes( currentAgencyTier );
 
 	return (
 		<Layout className="agency-tier-overview" title={ title } wide>


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/1500

## Proposed Changes

This PR hides the `Download your badges` button from the Tiers section until the WooCommerce ones are ready.

![image](https://github.com/user-attachments/assets/dacd096e-0e26-452d-ae75-6406e0d2b0bb)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code.
- In trunk: 
   - Go to the Agency Tier section
   - Check that the `Download your badges` button is displayed.
   - If not, you have to list your agency in one of the PDs, go to the MC tool, and mark it as visible in one of the Partner Directory, for example, the Jetpack one, because it's small.
   - Reload the page and you will see the button.
   - Hide again your testing agency from that directory.
- Launch a Horizon live site:
   - Do the same as the previous step.
   - This time, you won't see the `Download your badges` button.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
