### PR TITLE
Help Center: Improve dislike message for non eligible users

### DIFF
--- a/packages/odie-client/src/components/message/dislike-feedback-message.tsx
+++ b/packages/odie-client/src/components/message/dislike-feedback-message.tsx
@@ -6,7 +6,42 @@ import { useOdieAssistantContext } from '../../context';
 import { GetSupport } from './get-support';
 
 export const DislikeFeedbackMessage = () => {
-	const { shouldUseHelpCenterExperience, extraContactOptions, botName } = useOdieAssistantContext();
+	const {
+		shouldUseHelpCenterExperience,
+		extraContactOptions,
+		botName,
+		isUserEligibleForPaidSupport,
+	} = useOdieAssistantContext();
+
+	const renderEligibleUserMessage = () => {
+		return (
+			<Markdown>
+				{ __(
+					'Let’s get the information you need. Would you like to contact our support team?',
+					__i18n_text_domain__
+				) }
+			</Markdown>
+		);
+	};
+
+	const renderNotEligibleUserMessage = () => {
+		return (
+			<>
+				<Markdown>
+					{ __(
+						'Sorry about that! Here is another way to get in-depth help.',
+						__i18n_text_domain__
+					) }
+				</Markdown>
+				<Markdown>
+					{ __(
+						'Share your questions in our forums. Since posts are public, avoid sharing personal or financial details.',
+						__i18n_text_domain__
+					) }
+				</Markdown>
+			</>
+		);
+	};
 
 	const renderRedesignedComponent = () => {
 		return (
@@ -16,13 +51,11 @@ export const DislikeFeedbackMessage = () => {
 					<strong className="message-header-name"></strong>
 				</div>
 				<div className="odie-chatbox-dislike-feedback-message">
-					<Markdown>
-						{ __(
-							'Let’s get the information you need. Would you like to contact our support team?',
-							__i18n_text_domain__
-						) }
-					</Markdown>
+					{ isUserEligibleForPaidSupport
+						? renderEligibleUserMessage()
+						: renderNotEligibleUserMessage() }
 				</div>
+
 				<GetSupport />
 			</>
 		);

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -43,6 +43,10 @@
 				border-radius: 8px 8px 8px 0;
 				font-size: 0.875rem;
 				margin-bottom: 0;
+
+			}
+			p:nth-of-type(2) {
+				margin-top:	8px;
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9892
Fixes https://github.com/Automattic/dotcom-forge/issues/9892

## Proposed Changes

* Improve support message for non-eligible users when disliking Wapuu's message

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Before: 
<img width="413" alt="image" src="https://github.com/user-attachments/assets/b33cad4f-a7e5-41fd-8eb3-4f4c25f8dbba">


After:
<img width="408" alt="image" src="https://github.com/user-attachments/assets/c0f201b1-0f66-476f-b320-d45737177c6c">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link with the flag `?flags=help-center-experience`
* With a free user, start a conversation with Wapuu and ask anything
* Give it a 'bad' feedback by clicking on thumbs down
* You should get a tailored message like the screenshot above.
* Check with paid user and make sure it renders the proper message


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
