### PR TITLE
Domains: Prevent premium domain names suggestion/selection for all 100-year flows

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1138,7 +1138,7 @@ class RegisterDomainStep extends Component {
 							'hundred_year_domain_premium_name_restriction',
 							{}
 						);
-						return resolve( null );
+						resolve( null );
 					}
 
 					this.setState( {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1,7 +1,11 @@
 import { isBlogger, isFreeWordPressComDomain } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, CompactCard, ResponsiveToolbarGroup } from '@automattic/components';
-import { isHundredYearDomainFlow } from '@automattic/onboarding';
+import {
+	HUNDRED_YEAR_DOMAIN_FLOW,
+	HUNDRED_YEAR_PLAN_FLOW,
+	isHundredYearDomainFlow,
+} from '@automattic/onboarding';
 import Search from '@automattic/search';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { Icon } from '@wordpress/icons';
@@ -1122,6 +1126,19 @@ class RegisterDomainStep extends Component {
 						status !== MAPPED_SAME_SITE_REGISTRABLE
 					) {
 						availabilityStatus = mappable;
+					}
+
+					if (
+						[ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( this.props.flowName ) &&
+						isAvailablePremiumDomain
+					) {
+						this.removeUnavailablePremiumDomain( domain );
+						this.showSuggestionErrorMessage(
+							domain,
+							'hundred_year_domain_premium_name_restriction',
+							{}
+						);
+						return resolve( null );
 					}
 
 					this.setState( {

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -652,6 +652,19 @@ function getAvailabilityNotice(
 			severity = 'info';
 			break;
 
+		case 'hundred_year_domain_premium_name_restriction':
+			message = translate(
+				'{{strong}}%(domain)s{{/strong}} is premium and is still not supported for the 100-year domain registration.',
+				{
+					args: { domain },
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+			severity = 'info';
+			break;
+
 		default:
 			message = translate(
 				'Sorry, there was a problem processing your request. Please try again in a few minutes.'


### PR DESCRIPTION
## Proposed Changes
Prevents premium domain names suggestion/selection for all 100-year related flows.

## Testing Instructions
- Build this branch locally or access its calypso.live link;
- Go to any 100-year related flow (100-year plan, 100-year domain, e.g. `/setup/hundred-year-domain/domains`);
- Try entering a premium domain name (e.g. `meat.blog`) and ensure you see the same error message as in the screenshot below.

## Preview

| Before                                                                                    | After                                                                                     |
|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| ![image](https://github.com/user-attachments/assets/5db70668-1a2b-46ee-bf4b-78ad08514426) | ![image](https://github.com/user-attachments/assets/daa7ae9e-0b65-4b63-a0ea-c00a1c7d6180) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
