### PR TITLE
Send Cart Key in Setup Intent Request

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -28,6 +28,9 @@ import type { LocalizeProps } from 'i18n-calypso';
  *
  * NOTE: if countryCode is not provided, geolocation will be used to determine
  * which Stripe account to use to create the Payment Method.
+ * The cartKey is optional and is only used in the Checkout flow to create
+ * the SetupIntent using information from the cart - for special cases like
+ * Indian Payments Methods with e-mandates.
  */
 async function createStripeSetupIntent(
 	countryCode?: string,

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -4,6 +4,7 @@ import {
 	makeSuccessResponse,
 	makeErrorResponse,
 } from '@automattic/composite-checkout';
+import { CartKey } from '@automattic/shopping-cart';
 import { ManagedContactDetails } from '@automattic/wpcom-checkout';
 import { addQueryArgs } from '@wordpress/url';
 import wp from 'calypso/lib/wp';
@@ -28,9 +29,13 @@ import type { LocalizeProps } from 'i18n-calypso';
  * NOTE: if countryCode is not provided, geolocation will be used to determine
  * which Stripe account to use to create the Payment Method.
  */
-async function createStripeSetupIntent( countryCode?: string ): Promise< StripeSetupIntentId > {
+async function createStripeSetupIntent(
+	countryCode?: string,
+	cartKey?: CartKey
+): Promise< StripeSetupIntentId > {
 	const configuration = await wp.req.post( '/me/stripe-setup-intent', {
 		country: countryCode,
+		cart_key: cartKey,
 	} );
 	const intentId: string | undefined =
 		configuration?.setup_intent_id && typeof configuration.setup_intent_id === 'string'
@@ -90,6 +95,7 @@ export async function assignNewCardProcessor(
 		cardNumberElement,
 		reduxDispatch,
 		eventSource,
+		cartKey,
 	}: {
 		purchase: Purchase | undefined;
 		translate: LocalizeProps[ 'translate' ];
@@ -98,6 +104,7 @@ export async function assignNewCardProcessor(
 		cardNumberElement: StripeCardNumberElement | undefined;
 		reduxDispatch: CalypsoDispatch;
 		eventSource?: string;
+		cartKey?: CartKey;
 	},
 	submitData: unknown
 ): Promise< PaymentProcessorResponse > {
@@ -178,7 +185,7 @@ export async function assignNewCardProcessor(
 		// but since `prepareAndConfirmStripeSetupIntent()` uses the `stripe`
 		// object created by `StripeHookProvider`, that object must also be
 		// created with the same countryCode, and right now it is not.
-		const stripeSetupIntentId = await createStripeSetupIntent();
+		const stripeSetupIntentId = await createStripeSetupIntent( undefined, cartKey );
 		const formFieldValues = {
 			country: countryCode,
 			postal_code: postalCode ?? '',

--- a/client/my-sites/checkout/src/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/src/lib/multi-partner-card-processor.ts
@@ -309,6 +309,7 @@ export default async function multiPartnerCardProcessor(
 				cardNumberElement: submitData.cardNumberElement,
 				reduxDispatch: dataForProcessor.reduxDispatch,
 				eventSource: '/checkout',
+				cartKey: dataForProcessor.responseCart.cart_key,
 			},
 			submitDataWithContactInfo
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

In this PR, we add a new parameter to the `createStripeSetupIntent` endpoint call, the `cart_key`  parameter, which will help us create a SetupIntent based on the Shopping Cart information. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For Indian e-mandates, we need to establish a maximum amount that the user will be charged in a single transaction without requiring 3DS authentication. To do this we're using ShoppingCart amount to establish the amount when creating the SetupIntent.
D166642-code introduces the `cart_key` parameter to the `/me/stripe-setup-intent` endpoint.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply `D166642` to your sandbox and point `public-api.wordpress.com`
* Add a plan upgrade to your cart and go to checkout
* Apply the `SETUPTEST` discount code to get a 100% discount
* Open up the Network Tab on your browser, we'll verify the requests being made
* Add a new payment method, use `4000003560000123` simulates successful mandate setup
* Complete checkout
* Assert that the call to the `/stripe-setup-intent` endpoint has the `cart_key` parameter and that it is a numeric value.
* Inspect the `confirm` call and copy the `id` from the response. It should look something like this: `seti_1QMzbu...`
* Complete the 3DS auth screen
* Head over to the Stripe Dashboard and search for your setup intent using the `id` you copied earlier (make sure you're on test mode)
* Inspect the Log that created the SetupIntent and assert that the Request POST Body contains the `payment_method_options` key. It should look similar to this:
```
  "payment_method_options": {
    "card": {
      "mandate_options": {
        "supported_types": {
          "0": "india"
        },
        "description": "WordPress.com (ignaciodob)",
        "currency": "USD",
        "interval": "sporadic",
        "amount_type": "maximum",
        "reference": "#215662688-229264679",
        "amount": "17772",
        "start_date": "1732054166"
      }
    }
  },
```
Testing the Add a Payment Method Screen:
- Visit /me/purchases/add-payment-method and add a new credit card.
- Verify that the card is added successfully.

<br class="Apple-interchange-newline">

<!--
## Pre-merge Checklist

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

-->