### PR TITLE
Site Migration: Add openapi spec for the new migration api

### DIFF
--- a/docs/api/migration.yaml
+++ b/docs/api/migration.yaml
@@ -23,16 +23,16 @@ paths:
             type: integer
             enum: [1]
       responses:
-        '200': 
+        '200':
           description: |
             Return the list of migrations by site
           content:
-            application/json:    
+            application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Migration'
-        '400':  
+        '400':
           description: "Missing or invalid required params"
           content:
             application/json:
@@ -42,7 +42,7 @@ paths:
                   error:
                     type: string
                     example: "Missing or invalid parameters"
-        
+
         '404':
           description: No migration found
           content:
@@ -58,8 +58,18 @@ paths:
         Create an entity "migration"
       description: |
         It automatically sets a migration as "pending" as "in-progress" if all required information were provided. For example DIY migration doesn't require  credentials or file, so there is no depedency to start without more information.
-        If there are missing information, the status will be "pending"
-        It also can return "cancelled" if the source site is not using wordpress or is already wpcom.
+        This endpoint holds the responsibility of:
+        - Validating the input data
+        - Creating the migration entity
+        - Return the migration status based on the input data provided
+        - Returning the available options to start the migration
+        - Returning the hosting details
+        - Cancelling the migration if the source site is not using wordpress or is already wpcom
+        - Returning the cancel details
+        - Schedule the migration async job to run the migration as soon as all the required information is provided
+        - Set as pending if there is missing information to start a migration (E.g. credentials for "DIFM" migration)
+        - Returning the migration entity with its status
+        - Doesn't create new migration if the latest migration is still in pending or in-progress
       parameters:
         - in: path
           name: siteSlug
@@ -101,9 +111,15 @@ paths:
                     type: string
                     example: "Internal server error"
     patch:
-      summary: Update the lastest migration entity from a site
+      summary: Update the latest migration entity from a site
       description: |
-        It automatically starts a migration if all required fields are provided
+        This endpoint holds the responsibility of:
+        - Validating the input data
+        - Updating the migration entity
+        - Returning the migration entity with its status
+        - Move from pending to in-progress if all required information was provided
+        - Returning the migration entity with its status
+        - Store the migration notes, credentials, backup_file_url, etc.
       parameters:
         - in: path
           name: siteSlug
@@ -173,7 +189,7 @@ components:
   schemas:
     MigrationStatus:
       type: string
-      enum: 
+      enum:
         - "pending"
         - "in-progress"
         - "completed"
@@ -187,26 +203,26 @@ components:
 
     MigrationType:
       type: string
-      enum: 
+      enum:
         - "DIY"
         - "DIFM"
-  
+
     MigrationStrategy:
       type: string
       description: |
         * credentials: Requires user and password
         * backup_file: Requires the backup_file_url
-      enum: 
+      enum:
         - "credentials"
         - "backup_file"
-    
+
     AvailableStrategies:
       type: array
       description: "Possible migration options for the site."
       example: ['credentials', 'backup_file', 'application_password']
       items:
         type: string
-        enum: 
+        enum:
           - "credentials"
           - "backup_file"
           - "application_password"
@@ -214,7 +230,7 @@ components:
     Migration:
       type: object
       properties:
-        status: 
+        status:
           $ref: "#/components/schemas/MigrationStatus"
         pending_details:
           type: string
@@ -222,7 +238,7 @@ components:
           description: "Describe what is missing to start a migration"
         progress_details:
           type: object
-          properties: 
+          properties:
             step:
               type: integer
               example: 1
@@ -255,7 +271,7 @@ components:
               type: string
             application_password:
               type: string
-              example: "https://test-vanilla-wp.godaddy.test-wpcom-migrations.net/wp-admin/authorize-application.php" 
+              example: "https://test-vanilla-wp.godaddy.test-wpcom-migrations.net/wp-admin/authorize-application.php"
               nullable: true
         available_options:
           $ref: "#/components/schemas/AvailableStrategies"
@@ -263,7 +279,7 @@ components:
     MigrationUpdate:
       type: object
       properties:
-        status: 
+        status:
           $ref: "#/components/schemas/MigrationStatus"
         source_site:
           $ref: "#/components/schemas/Migration/properties/status"
@@ -296,7 +312,7 @@ components:
           properties:
             strategy:
               enum: ["backup_file"]
-    
+
     MigrationInput:
       type: object
       properties:
@@ -330,12 +346,11 @@ components:
         - required: [backup_file_url]
           properties:
             strategy:
-              enum: ["backup_file"]         
-              
-              
-              
-              
-              
-              
-              
-              
+              enum: ["backup_file"]
+
+
+
+
+
+
+

--- a/docs/api/migration.yaml
+++ b/docs/api/migration.yaml
@@ -1,0 +1,341 @@
+openapi: 3.0.3
+info:
+  title: Migration API
+  version: 0.0.1
+  description: API for managing website migrations to WPCOM platform
+
+paths:
+  /sites/{siteSlug}/migrations:
+    get:
+      summary: |
+        List migrations related to the WPCOM site slug. It also returns the the hosting details and the available options E.g application_password, credentials, backup_file.
+      parameters:
+        - in: path
+          name: siteSlug
+          description: The WPCOM site slug
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: latest
+          description: 'Returns only the latest migration'
+          schema:
+            type: integer
+            enum: [1]
+      responses:
+        '200': 
+          description: |
+            Return the list of migrations by site
+          content:
+            application/json:    
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Migration'
+        '400':  
+          description: "Missing or invalid required params"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Missing or invalid parameters"
+        
+        '404':
+          description: No migration found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "No migration found for siteSlug."
+    post:
+      summary: |
+        Create an entity "migration"
+      description: |
+        It automatically sets a migration as "pending" as "in-progress" if all required information were provided. For example DIY migration doesn't require  credentials or file, so there is no depedency to start without more information.
+        If there are missing information, the status will be "pending"
+        It also can return "cancelled" if the source site is not using wordpress or is already wpcom.
+      parameters:
+        - in: path
+          name: siteSlug
+          required: true
+          description: The WPCOM site slug
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MigrationInput'
+      responses:
+        '201':
+          description: The created migration with its status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Migration'
+        '400':
+          description: Invalid input data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Invalid input data"
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Internal server error"
+    patch:
+      summary: Update the lastest migration entity from a site
+      description: |
+        It automatically starts a migration if all required fields are provided
+      parameters:
+        - in: path
+          name: siteSlug
+          required: true
+          description: The WPCOM site slug
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MigrationUpdate'
+      responses:
+        '201':
+          description: The created migration with its status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Migration'
+        '400':
+          description: Invalid input data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Invalid input data"
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Internal server error"
+    delete:
+      summary: Cancels pending migration
+      description: |
+        Updates the migration status to cancelled. It should only be used by manually cancelletion when the status is pending
+      parameters:
+        - in: path
+          name: siteSlug
+          required: true
+          description: The WPCOM site slug
+          schema:
+            type: string
+
+      responses:
+        '200':
+          description: The created migration with its status
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Internal server error"
+components:
+  schemas:
+    MigrationStatus:
+      type: string
+      enum: 
+        - "pending"
+        - "in-progress"
+        - "completed"
+        - "failed"
+        - "cancelled"
+      description: |
+        * PENDING - Only when there is missing information to start a migration
+        * IN_PROGRESS - Represents the migration automated or the HE started the migration progress
+        * COMPLETED - All migration and post-migration tasks were finished
+        * FAILED - Migration attempt failed
+
+    MigrationType:
+      type: string
+      enum: 
+        - "DIY"
+        - "DIFM"
+  
+    MigrationStrategy:
+      type: string
+      description: |
+        * credentials: Requires user and password
+        * backup_file: Requires the backup_file_url
+      enum: 
+        - "credentials"
+        - "backup_file"
+    
+    AvailableStrategies:
+      type: array
+      description: "Possible migration options for the site."
+      example: ['credentials', 'backup_file', 'application_password']
+      items:
+        type: string
+        enum: 
+          - "credentials"
+          - "backup_file"
+          - "application_password"
+
+    Migration:
+      type: object
+      properties:
+        status: 
+          $ref: "#/components/schemas/MigrationStatus"
+        pending_details:
+          type: string
+          example: "missing-credentials"
+          description: "Describe what is missing to start a migration"
+        progress_details:
+          type: object
+          properties: 
+            step:
+              type: integer
+              example: 1
+            total:
+              type: integer
+              example: 2
+        cancel_details:
+          type: string
+          example: "non-wordpress"
+        origin:
+          type: string
+          example: "/setup/flow"
+        type:
+          $ref: "#/components/schemas/MigrationType"
+        strategy:
+          $ref: "#/components/schemas/MigrationStrategy"
+        notes:
+          type: string
+          example: "My migration requires plugin X"
+        source_site:
+          type: string
+          format: uri
+        backup_file_url:
+          type: string
+          format: uri
+        source_details:
+          type: object
+          properties:
+            platform:
+              type: string
+            application_password:
+              type: string
+              example: "https://test-vanilla-wp.godaddy.test-wpcom-migrations.net/wp-admin/authorize-application.php" 
+              nullable: true
+        available_options:
+          $ref: "#/components/schemas/AvailableStrategies"
+
+    MigrationUpdate:
+      type: object
+      properties:
+        status: 
+          $ref: "#/components/schemas/MigrationStatus"
+        source_site:
+          $ref: "#/components/schemas/Migration/properties/status"
+        origin:
+          $ref: "#/components/schemas/Migration/properties/origin"
+        type:
+          $ref: "#/components/schemas/MigrationType"
+        notes:
+          $ref: "#/components/schemas/Migration/properties/notes"
+        strategy:
+          $ref: "#/components/schemas/MigrationStrategy"
+        backup_file_url:
+          $ref: "#/components/schemas/Migration/properties/backup_file_url"
+        credentials:
+          type: object
+          properties:
+            user:
+              type: string
+            password:
+              type: string
+          required: [user, password]
+          nullable: true
+      required: [source_site, origin, type, strategy]
+      oneOf:
+        - required: [credentials]
+          properties:
+            strategy:
+              enum: ["credentials"]
+        - required: [backup_file_url]
+          properties:
+            strategy:
+              enum: ["backup_file"]
+    
+    MigrationInput:
+      type: object
+      properties:
+        source_site:
+          $ref: "#/components/schemas/Migration/properties/status"
+        origin:
+          $ref: "#/components/schemas/Migration/properties/origin"
+        type:
+          $ref: "#/components/schemas/MigrationType"
+        notes:
+          $ref: "#/components/schemas/Migration/properties/notes"
+        strategy:
+          $ref: "#/components/schemas/MigrationStrategy"
+        backup_file_url:
+           $ref: "#/components/schemas/Migration/properties/backup_file_url"
+        credentials:
+          type: object
+          properties:
+            user:
+              type: string
+            password:
+              type: string
+          required: [user, password]
+          nullable: true
+      required: [source_site, origin, type, strategy]
+      oneOf:
+        - required: [credentials]
+          properties:
+            strategy:
+              enum: ["credentials"]
+        - required: [backup_file_url]
+          properties:
+            strategy:
+              enum: ["backup_file"]         
+              
+              
+              
+              
+              
+              
+              
+              


### PR DESCRIPTION
> [!IMPORTANT]  
> I am using this PR only to store easily and update an Open API definition. It should not be merged.


<img width="1516" alt="image" src="https://github.com/user-attachments/assets/882d4bf1-c750-4be9-a118-46058a9c4f7e">



## Usage

* run ` npx @redocly/cli preview-docs  docs/api/migration.yaml -p 8888` 
* Open a browser and access ` http://127.0.0.1:8888`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
