### PR TITLE
Domains: Limit TLDs of domain suggestions in the 100-year plan flow

### DIFF
--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -5,6 +5,7 @@ import {
 	WOOEXPRESS_FLOW,
 	DOMAIN_FOR_GRAVATAR_FLOW,
 	isDomainForGravatarFlow,
+	isHundredYearPlanFlow,
 	isHundredYearDomainFlow,
 } from '@automattic/onboarding';
 import type { DomainSuggestions } from '@automattic/data-stores';
@@ -66,7 +67,7 @@ export function getDomainSuggestionsVendor(
 	if ( isDomainForGravatarFlow( options.flowName ) ) {
 		return 'gravatar';
 	}
-	if ( isHundredYearDomainFlow( options.flowName ) ) {
+	if ( isHundredYearPlanFlow( options.flowName ) || isHundredYearDomainFlow( options.flowName ) ) {
 		return '100-year-domains';
 	}
 	if ( options.flowName === LINK_IN_BIO_TLD_FLOW ) {

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -209,6 +209,10 @@ export const isDomainForGravatarFlow = ( flowName: string | null | undefined ) =
 	return Boolean( flowName && [ DOMAIN_FOR_GRAVATAR_FLOW ].includes( flowName ) );
 };
 
+export const isHundredYearPlanFlow = ( flowName: string | null | undefined ) => {
+	return Boolean( flowName && [ HUNDRED_YEAR_PLAN_FLOW ].includes( flowName ) );
+};
+
 export const isHundredYearDomainFlow = ( flowName: string | null | undefined ) => {
 	return Boolean( flowName && [ HUNDRED_YEAR_DOMAIN_FLOW ].includes( flowName ) );
 };


### PR DESCRIPTION
## Proposed Changes

This PR limits the TLDs of domains that are suggested in the 100-year plan flow to `com`, `net`, `org` and `blog`.

| Before | After |
| --- | --- |
| <img width="720" alt="Screenshot 2024-11-19 at 16 33 14" src="https://github.com/user-attachments/assets/27c1d754-3bb8-47c1-9611-391ad497897c"> | <img width="753" alt="Screenshot 2024-11-19 at 16 33 03" src="https://github.com/user-attachments/assets/5f6e9d47-0e8e-4673-9e7b-c01c3a729fa6"> |

## Why are these changes being made?

Standardization with the 100-year domain flow: these 4 TLDs are the same as the ones offered in that flow.

## Testing Instructions

- Build this branch locally or open the live Calypso link
- Go to the 100-year plan flow (`/setup/hundred-year-plan`)
  - Select "I'll create my site on my own" and then "Start a new site"
  - Pick any name for the new site
- In the domain search page, ensure only `com`, `net`, `org` and `blog` domain suggestions are shown
  - In your browser's network tab, ensure that the `suggestions` API call has the `100-year-domains` vendor string

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?