### PR TITLE
Dynamically change color scheme from color_scheme query param

### DIFF
--- a/client/jetpack-connect/schema.js
+++ b/client/jetpack-connect/schema.js
@@ -43,5 +43,6 @@ export const authorizeQueryDataSchema = {
 		allow_site_connection: { type: 'string' }, // '1' if true
 		installed_ext_success: { type: 'string' }, // '1' if true
 		plugin_name: { type: 'string' },
+		color_scheme: { type: 'string' },
 	},
 };

--- a/client/layout/color-scheme/index.jsx
+++ b/client/layout/color-scheme/index.jsx
@@ -16,10 +16,20 @@ export function getColorScheme( { state, isGlobalSidebarVisible, sectionName } )
 	return siteColorScheme ?? calypsoColorScheme;
 }
 
-export function getColorSchemeFromCurrentQuery( currentQuery ) {
-	return currentQuery?.color_scheme
-		? currentQuery?.color_scheme
-		: new URLSearchParams( currentQuery?.redirect_to ).get( 'color_scheme' );
+export function getColorSchemeFromCurrentQuery( currentQuery, defaultColorScheme = 'default' ) {
+	if ( currentQuery?.color_scheme ) {
+		return currentQuery.color_scheme;
+	}
+
+	if ( currentQuery?.redirect_to ) {
+		try {
+			return new URLSearchParams( currentQuery.redirect_to ).get( 'color_scheme' );
+		} catch ( error ) {
+			return defaultColorScheme;
+		}
+	}
+
+	return defaultColorScheme;
 }
 
 export function refreshColorScheme( prevColorScheme, nextColorScheme ) {

--- a/client/layout/color-scheme/index.jsx
+++ b/client/layout/color-scheme/index.jsx
@@ -16,6 +16,12 @@ export function getColorScheme( { state, isGlobalSidebarVisible, sectionName } )
 	return siteColorScheme ?? calypsoColorScheme;
 }
 
+export function getColorSchemeFromCurrentQuery( currentQuery ) {
+	return currentQuery?.color_scheme
+		? currentQuery?.color_scheme
+		: new URLSearchParams( currentQuery?.redirect_to ).get( 'color_scheme' );
+}
+
 export function refreshColorScheme( prevColorScheme, nextColorScheme ) {
 	if ( typeof document === 'undefined' ) {
 		return;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -504,21 +504,13 @@ export default withCurrentRoute(
 		const userAllowedToHelpCenter =
 			config.isEnabled( 'calypso/help-center' ) && ! getIsOnboardingAffiliateFlow( state );
 
-		let colorScheme = null;
-
-		// Try to get the color scheme from `color_scheme` query param if we're in the WooCommerce Passwordless JPC flow.
-		if ( isWooPasswordlessJPC ) {
-			colorScheme = getColorSchemeFromCurrentQuery( currentQuery );
-		}
-
-		// if the value is still null, get the color scheme from the state.
-		if ( ! colorScheme ) {
-			colorScheme = getColorScheme( {
-				state,
-				isGlobalSidebarVisible,
-				sectionName,
-			} );
-		}
+		const colorScheme = isWooPasswordlessJPC
+			? getColorSchemeFromCurrentQuery( currentQuery )
+			: getColorScheme( {
+					state,
+					isGlobalSidebarVisible,
+					sectionName,
+			  } );
 
 		return {
 			masterbarIsHidden,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -61,7 +61,7 @@ import {
 	masterbarIsVisible,
 } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
-import { getColorScheme, refreshColorScheme } from './color-scheme';
+import { getColorScheme, getColorSchemeFromCurrentQuery, refreshColorScheme } from './color-scheme';
 import GlobalNotifications from './global-notifications';
 import LayoutLoader from './loader';
 import { shouldLoadInlineHelp, handleScroll } from './utils';
@@ -504,11 +504,21 @@ export default withCurrentRoute(
 		const userAllowedToHelpCenter =
 			config.isEnabled( 'calypso/help-center' ) && ! getIsOnboardingAffiliateFlow( state );
 
-		const colorScheme = getColorScheme( {
-			state,
-			sectionName,
-			isGlobalSidebarVisible,
-		} );
+		let colorScheme = null;
+
+		// Try to get the color scheme from `color_scheme` query param if we're in the WooCommerce Passwordless JPC flow.
+		if ( isWooPasswordlessJPC ) {
+			colorScheme = getColorSchemeFromCurrentQuery( currentQuery );
+		}
+
+		// if the value is still null, get the color scheme from the state.
+		if ( ! colorScheme ) {
+			colorScheme = getColorScheme( {
+				state,
+				isGlobalSidebarVisible,
+				sectionName,
+			} );
+		}
 
 		return {
 			masterbarIsHidden,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -5,6 +5,7 @@ import { UniversalNavbarHeader, UniversalNavbarFooter } from '@automattic/wpcom-
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { useEffect } from 'react';
 import { connect, useSelector } from 'react-redux';
 import { CookieBannerContainerSSR } from 'calypso/blocks/cookie-banner';
 import ReaderJoinConversationDialog from 'calypso/blocks/reader-join-conversation/dialog';
@@ -48,6 +49,7 @@ import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isWooPasswordlessJPCFlow from 'calypso/state/selectors/is-woo-passwordless-jpc-flow';
 import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
+import { refreshColorScheme } from './color-scheme';
 
 import './style.scss';
 
@@ -81,6 +83,7 @@ const LayoutLoggedOut = ( {
 	twoFactorEnabled,
 	/* eslint-disable no-shadow */
 	clearLastActionRequiresLogin,
+	colorScheme,
 } ) => {
 	const localizeUrl = useLocalizeUrl();
 	const isLoggedIn = useSelector( isUserLoggedIn );
@@ -152,6 +155,10 @@ const LayoutLoggedOut = ( {
 	};
 
 	let masterbar = null;
+
+	useEffect( () => {
+		refreshColorScheme( 'default', colorScheme );
+	}, [] ); // Empty dependency array ensures it runs only once on mount
 
 	// Open new window to create account page when a logged in action was triggered on the Reader tag embed page and the user is not logged in
 	if ( ! isLoggedIn && loggedInAction && isReaderTagEmbed ) {
@@ -365,6 +372,7 @@ export default withCurrentRoute(
 				noMasterbarForSection ||
 				noMasterbarForRoute;
 			const twoFactorEnabled = isTwoFactorEnabled( state );
+			const colorScheme = currentQuery?.color_scheme;
 
 			return {
 				isJetpackLogin,
@@ -389,6 +397,7 @@ export default withCurrentRoute(
 				isWooPasswordless: getIsWooPasswordless( state ),
 				isBlazePro: getIsBlazePro( state ),
 				twoFactorEnabled,
+				colorScheme,
 			};
 		},
 		{ clearLastActionRequiresLogin }

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -157,7 +157,7 @@ const LayoutLoggedOut = ( {
 	let masterbar = null;
 
 	useEffect( () => {
-		refreshColorScheme( 'default', colorScheme );
+		this.props.isWooPasswordlessJPC && refreshColorScheme( 'default', colorScheme );
 	}, [] ); // Empty dependency array ensures it runs only once on mount
 
 	// Open new window to create account page when a logged in action was triggered on the Reader tag embed page and the user is not logged in

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -157,7 +157,7 @@ const LayoutLoggedOut = ( {
 	let masterbar = null;
 
 	useEffect( () => {
-		this.props.isWooPasswordlessJPC && refreshColorScheme( 'default', colorScheme );
+		isWooPasswordlessJPC && refreshColorScheme( 'default', colorScheme );
 	}, [] ); // Empty dependency array ensures it runs only once on mount
 
 	// Open new window to create account page when a logged in action was triggered on the Reader tag embed page and the user is not logged in

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -49,7 +49,7 @@ import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isWooPasswordlessJPCFlow from 'calypso/state/selectors/is-woo-passwordless-jpc-flow';
 import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
-import { refreshColorScheme } from './color-scheme';
+import { refreshColorScheme, getColorSchemeFromCurrentQuery } from './color-scheme';
 
 import './style.scss';
 
@@ -372,7 +372,10 @@ export default withCurrentRoute(
 				noMasterbarForSection ||
 				noMasterbarForRoute;
 			const twoFactorEnabled = isTwoFactorEnabled( state );
-			const colorScheme = currentQuery?.color_scheme;
+
+			const colorScheme = isWooPasswordlessJPC
+				? getColorSchemeFromCurrentQuery( currentQuery )
+				: null;
 
 			return {
 				isJetpackLogin,

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -185,7 +185,7 @@ $breakpoint-mobile: 660px;
 
 		.progress-bar__progress {
 			border-radius: 0;
-			background-color: var(--wp-admin-theme-color);
+			background-color: var(--color-primary);
 		}
 	}
 
@@ -964,7 +964,7 @@ $breakpoint-mobile: 660px;
 			height: 48px;
 			padding: 10px 16px;
 			font-weight: 500;
-			background-color: var(--wp-admin-theme-color);
+			background-color: var(--color-primary);
 		}
 
 		.two-factor-authentication__actions.card button.button {
@@ -1927,11 +1927,11 @@ $breakpoint-mobile: 660px;
 		}
 
 		button.button.is-primary {
-			background-color: var(--wp-admin-theme-color);
+			background-color: var(--color-primary);
 			font-family: inherit;
 			border-radius: 2px;
 			&:hover:not(:disabled) {
-				background-color: var(--wp-admin-theme-color);
+				background-color: var(--color-primary);
 			}
 		}
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -2120,19 +2120,3 @@ $breakpoint-mobile: 660px;
 		}
 	}
 }
-
-// Color scheme 'blue' fix
-// The 'blue' theme color from wp-calypso does not match the 'blue' color from the local WordPress admin color scheme.
-// Fix the color scheme 'blue' to match the local WordPress admin color scheme on the new JPC page.
-body.is-blue {
-	.is-woocommerce-core-profiler-flow.is-woo-passwordless {
-		button.button.is-primary {
-			background: #52accc;
-		}
-		.masterbar__progress-bar {
-			.progress-bar__progress {
-				background-color: #52accc;
-			}
-		}
-	}
-}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -2120,3 +2120,19 @@ $breakpoint-mobile: 660px;
 		}
 	}
 }
+
+// Color scheme 'blue' fix
+// The 'blue' theme color from wp-calypso does not match the 'blue' color from the local WordPress admin color scheme.
+// Fix the color scheme 'blue' to match the local WordPress admin color scheme on the new JPC page.
+body.is-blue {
+	.is-woocommerce-core-profiler-flow.is-woo-passwordless {
+		button.button.is-primary {
+			background: #52accc;
+		}
+		.masterbar__progress-bar {
+			.progress-bar__progress {
+				background-color: #52accc;
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/woocommerce/woocommerce/issues/52875

## Proposed Changes

* Support changing the color scheme based on the `color_scheme` query parameter when the user is using the new passwordless Jetpack connection



## Testing Instructions

1. Checkout this branch locally and run `yarn start`
2. Once the build is ready, visit this [link](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=239172539&redirect_uri=https%3A%2F%2Fpink-piccolo.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3Df3099546f0%26redirect%3Dhttps%253A%252F%252Fpink-piccolo.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A1a2e2b51282f8ac685ca15e67964f8f4&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=14.1-a.3&secret=QYBTIYTgqLIIMcpg68zLcFnH8pyT9Jmf&blogname=Pink%20Piccolo&site_url=https%3A%2F%2Fpink-piccolo.jurassic.ninja&home_url=https%3A%2F%2Fpink-piccolo.jurassic.ninja&site_icon=&site_lang=en_US&site_created=2024-11-19%2018%3A10%3A55&allow_site_connection=1&calypso_env=production&source=&_as=wp-cli&locale=en&from=woocommerce-core-profiler&plugin_name=woocommerce-payments&color_scheme=sunrise&_ui=189042142&_ut=wpcom%3Auser_id&purchase_nonce=3UiGhvFH&_wp_nonce=d1d5864992&redirect_after_auth=https%3A%2F%2Fpink-piccolo.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fpink-piccolo.jurassic.ninja)
3. Confirm the color scheme is `sunrise`
4. Copy the link and search for `color_scheme`
5. Change it to one of the supported color schemes and revisit the link.
6. Confirm the color scheme change.

Supported color schemes:

- default
- light
- modern
- blue
- coffee
- ectoplasm
- midnight
- ocean
- sunrise

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
