### PR TITLE
Logged-in Profiler: Public sites with missing launch status should be able to run performance test

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -4,6 +4,7 @@ import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
@@ -139,9 +140,13 @@ export const SitePerformance = () => {
 	const dispatch = useDispatch();
 	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID;
-
+	const { getSiteSetting } = useSiteSettings( site?.slug );
+	const blog_public = getSiteSetting( 'blog_public' );
 	const isSitePublic =
-		site && ! site.is_coming_soon && ! site.is_private && site.launch_status === 'launched';
+		site &&
+		! site.is_coming_soon &&
+		! site.is_private &&
+		( site.launch_status === 'launched' || ( site.launch_status === '' && blog_public === 1 ) );
 
 	const stats = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, statsQuery )

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -142,11 +142,7 @@ export const SitePerformance = () => {
 	const siteId = site?.ID;
 	const { getSiteSetting } = useSiteSettings( site?.slug );
 	const blog_public = getSiteSetting( 'blog_public' );
-	const isSitePublic =
-		site &&
-		! site.is_coming_soon &&
-		! site.is_private &&
-		( site.launch_status === 'launched' || ( site.launch_status === '' && blog_public === 1 ) );
+	const isSitePublic = site && blog_public === 1;
 
 	const stats = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, statsQuery )


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/96533

## Proposed Changes
Some sites which are older or have uses external domains may not have the `launch_status` property set. This prevents them from running performance tests. This PR fixes that by also checking if the blog is public when the `launch_status` is missing.

* check if `blog_public=1` when launch status is missing

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that these particular sites can run the test from the sites dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure you have a site with `launch_status` empty and `public_blog=1` 
* Go to `/sites/performance/siteSlug`
* Verify you are able to run performance test on the site and the `Launch site` CTA is not shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
