### PR TITLE
Domains: Update the purchase settings page for 100-year domains

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -38,6 +38,7 @@ import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isMarketplaceTemporarySitePurchase } from 'calypso/me/purchases/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { ResponseDomain } from '../domains/types';
 import type { Purchase } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -877,7 +878,10 @@ export function isAgencyPartnerType( partnerType: string ) {
 	return [ 'agency', 'a4a_agency' ].includes( partnerType );
 }
 
-export function purchaseType( purchase: Purchase ) {
+export function purchaseType(
+	purchase: Purchase,
+	domainDetails: ResponseDomain | null | undefined
+) {
 	if ( isThemePurchase( purchase ) ) {
 		return i18n.translate( 'Premium Theme' );
 	}
@@ -899,6 +903,10 @@ export function purchaseType( purchase: Purchase ) {
 	}
 
 	if ( isDomainRegistration( purchase ) ) {
+		if ( domainDetails?.isHundredYearDomain ) {
+			return i18n.translate( '100-Year Domain Registration' );
+		}
+
 		return purchase.productName;
 	}
 

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -38,7 +38,6 @@ import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isMarketplaceTemporarySitePurchase } from 'calypso/me/purchases/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
-import { ResponseDomain } from '../domains/types';
 import type { Purchase } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -878,10 +877,7 @@ export function isAgencyPartnerType( partnerType: string ) {
 	return [ 'agency', 'a4a_agency' ].includes( partnerType );
 }
 
-export function purchaseType(
-	purchase: Purchase,
-	domainDetails: ResponseDomain | null | undefined
-) {
+export function purchaseType( purchase: Purchase ) {
 	if ( isThemePurchase( purchase ) ) {
 		return i18n.translate( 'Premium Theme' );
 	}
@@ -903,10 +899,6 @@ export function purchaseType(
 	}
 
 	if ( isDomainRegistration( purchase ) ) {
-		if ( domainDetails?.isHundredYearDomain ) {
-			return i18n.translate( '100-Year Domain Registration' );
-		}
-
 		return purchase.productName;
 	}
 

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -1,6 +1,7 @@
 import { Purchases } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { ResponseDomain } from '../domains/types';
 
 export type Purchase = Purchases.Purchase;
 export type PurchasePriceTier = Purchases.PurchasePriceTier;
@@ -57,5 +58,6 @@ export type RenderRenewsOrExpiresOn = ( args: {
 
 export type RenderRenewsOrExpiresOnLabel = ( args: {
 	purchase: Purchase;
+	domainDetails: ResponseDomain | null | undefined;
 	translate: ReturnType< typeof useTranslate >;
 } ) => string | null;

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -58,6 +58,6 @@ export type RenderRenewsOrExpiresOn = ( args: {
 
 export type RenderRenewsOrExpiresOnLabel = ( args: {
 	purchase: Purchase;
-	domainDetails: ResponseDomain | null | undefined;
+	domainDetails?: ResponseDomain | null;
 	translate: ReturnType< typeof useTranslate >;
 } ) => string | null;

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1281,7 +1281,9 @@ class ManagePurchase extends Component<
 						{ this.renderPurchaseIcon() }
 						<h2 className="manage-purchase__title">{ this.getProductDisplayName() }</h2>
 						<div className="manage-purchase__description">
-							{ purchaseType( purchase, domainDetails ) }
+							{ domainDetails?.isHundredYearDomain
+								? translate( '100-Year Domain Registration' )
+								: purchaseType( purchase ) }
 						</div>
 						<div className="manage-purchase__price">
 							{ isPartnerPurchase( purchase ) ? (

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -886,10 +886,8 @@ class ManagePurchase extends Component<
 
 		// If it's a 100-year domain, don't show the cancel button
 		if ( isDomainRegistration( purchase ) ) {
-			const domain = this.props.domainsDetails?.[ purchase.siteId ]?.find(
-				( domain ) => domain.domain === purchase.meta
-			);
-			if ( domain?.isHundredYearDomain ) {
+			const domainDetails = this.getDomainDetailsFromPurchase( purchase );
+			if ( domainDetails?.isHundredYearDomain ) {
 				return null;
 			}
 		}
@@ -934,10 +932,8 @@ class ManagePurchase extends Component<
 			);
 		}
 
-		const domain = this.props.domainsDetails?.[ purchase.siteId ]?.find(
-			( domain ) => domain.domain === purchase.meta
-		);
-		if ( domain?.isHundredYearDomain ) {
+		const domainDetails = this.getDomainDetailsFromPurchase( purchase );
+		if ( domainDetails?.isHundredYearDomain ) {
 			return (
 				<div className="manage-purchase__plan-icon">
 					<HundredYearPlanLogo width={ 50 } />
@@ -1024,9 +1020,7 @@ class ManagePurchase extends Component<
 		if ( isDomainTransfer( purchase ) ) {
 			const { currentRoute, site, translate, dispatch } = this.props;
 
-			const transferDomain = this.props.domainsDetails?.[ purchase.siteId ]?.find(
-				( domain ) => domain.domain === purchase.meta
-			);
+			const transferDomain = this.getDomainDetailsFromPurchase( purchase );
 
 			if ( transferDomain ) {
 				const { noticeText } = resolveDomainStatus( transferDomain, null, translate, dispatch, {

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -71,6 +71,7 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import reinstallPlugins from 'calypso/data/marketplace/reinstall-plugins-api';
+import HundredYearPlanLogo from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/hundred-year-plan-logo';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { resolveDomainStatus } from 'calypso/lib/domains';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -634,6 +635,13 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
+		const domainDetails = this.props.domainsDetails?.[ purchase.siteId ]?.find(
+			( domain ) => domain.domain === purchase.meta
+		);
+		if ( domainDetails?.isHundredYearDomain ) {
+			return null;
+		}
+
 		if ( canEditPaymentDetails( purchase ) ) {
 			const path = ( getChangePaymentMethodUrlFor ?? getChangePaymentMethodPath )(
 				siteSlug,
@@ -922,6 +930,17 @@ class ManagePurchase extends Component<
 			);
 		}
 
+		const domain = this.props.domainsDetails?.[ purchase.siteId ]?.find(
+			( domain ) => domain.domain === purchase.meta
+		);
+		if ( domain?.isHundredYearDomain ) {
+			return (
+				<div className="manage-purchase__plan-icon">
+					<HundredYearPlanLogo width={ 50 } />
+				</div>
+			);
+		}
+
 		if ( isDomainProduct( purchase ) || isDomainTransfer( purchase ) ) {
 			return (
 				<div className="manage-purchase__plan-icon">
@@ -976,6 +995,16 @@ class ManagePurchase extends Component<
 		}
 
 		if ( isDomainMapping( purchase ) || isDomainRegistration( purchase ) ) {
+			const domainDetails = this.props.domainsDetails?.[ purchase.siteId ]?.find(
+				( domain ) => domain.domain === purchase.meta
+			);
+
+			if ( domainDetails?.isHundredYearDomain ) {
+				return translate(
+					'Your stories, achievements, and memories preserved for generations to come. One payment. One hundred years of legacy.'
+				);
+			}
+
 			return translate(
 				"When used with a paid plan, your custom domain can replace your site's free address, {{strong}}%(wpcom_url)s{{/strong}}, " +
 					'with {{strong}}%(domain)s{{/strong}}, making it easier to remember and easier to share.',
@@ -1092,6 +1121,11 @@ class ManagePurchase extends Component<
 		const domainTransferDuration = translate(
 			'Domain transfers can take anywhere from five to seven days to complete.'
 		);
+
+		const domainDetails = this.props.domainsDetails?.[ purchase.siteId ]?.find(
+			( domain ) => domain.domain === purchase.meta
+		);
+
 		return (
 			<div className="manage-purchase__content">
 				<span className="manage-purchase__description">
@@ -1155,6 +1189,7 @@ class ManagePurchase extends Component<
 						getChangePaymentMethodUrlFor={
 							getChangePaymentMethodUrlFor ?? getChangePaymentMethodPath
 						}
+						domainDetails={ null }
 					/>
 				</Card>
 				<PurchasePlanDetails isPlaceholder />
@@ -1238,6 +1273,10 @@ class ManagePurchase extends Component<
 
 		const renderMonthlyRenewalOption = shouldRenderMonthlyRenewalOption( purchase );
 
+		const domainDetails = this.props.domainsDetails?.[ purchase.siteId ]?.find(
+			( domain ) => domain.domain === purchase.meta
+		);
+
 		return (
 			<Fragment>
 				{ ( this.props.showHeader ?? true ) && (
@@ -1247,7 +1286,9 @@ class ManagePurchase extends Component<
 					<header className="manage-purchase__header">
 						{ this.renderPurchaseIcon() }
 						<h2 className="manage-purchase__title">{ this.getProductDisplayName() }</h2>
-						<div className="manage-purchase__description">{ purchaseType( purchase ) }</div>
+						<div className="manage-purchase__description">
+							{ purchaseType( purchase, domainDetails ) }
+						</div>
 						<div className="manage-purchase__price">
 							{ isPartnerPurchase( purchase ) ? (
 								<div className="manage-purchase__contact-partner">
@@ -1282,6 +1323,7 @@ class ManagePurchase extends Component<
 							getChangePaymentMethodUrlFor={
 								getChangePaymentMethodUrlFor ?? getChangePaymentMethodPath
 							}
+							domainDetails={ domainDetails }
 						/>
 					) }
 					{ isProductOwner && ! purchase.isLocked && (

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -617,6 +617,12 @@ class ManagePurchase extends Component<
 		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
 	};
 
+	getDomainDetailsFromPurchase = ( purchase: Purchase ) => {
+		return this.props.domainsDetails?.[ purchase.siteId ]?.find(
+			( domain ) => domain.domain === purchase.meta
+		);
+	};
+
 	renderEditPaymentMethodNavItem() {
 		const { purchase, translate, siteSlug, getChangePaymentMethodUrlFor } = this.props;
 		if ( ! purchase ) {
@@ -635,9 +641,7 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		const domainDetails = this.props.domainsDetails?.[ purchase.siteId ]?.find(
-			( domain ) => domain.domain === purchase.meta
-		);
+		const domainDetails = this.getDomainDetailsFromPurchase( purchase );
 		if ( domainDetails?.isHundredYearDomain ) {
 			return null;
 		}
@@ -995,10 +999,7 @@ class ManagePurchase extends Component<
 		}
 
 		if ( isDomainMapping( purchase ) || isDomainRegistration( purchase ) ) {
-			const domainDetails = this.props.domainsDetails?.[ purchase.siteId ]?.find(
-				( domain ) => domain.domain === purchase.meta
-			);
-
+			const domainDetails = this.getDomainDetailsFromPurchase( purchase );
 			if ( domainDetails?.isHundredYearDomain ) {
 				return translate(
 					'Your stories, achievements, and memories preserved for generations to come. One payment. One hundred years of legacy.'
@@ -1120,10 +1121,6 @@ class ManagePurchase extends Component<
 
 		const domainTransferDuration = translate(
 			'Domain transfers can take anywhere from five to seven days to complete.'
-		);
-
-		const domainDetails = this.props.domainsDetails?.[ purchase.siteId ]?.find(
-			( domain ) => domain.domain === purchase.meta
 		);
 
 		return (
@@ -1272,10 +1269,7 @@ class ManagePurchase extends Component<
 		const siteId = purchase.siteId;
 
 		const renderMonthlyRenewalOption = shouldRenderMonthlyRenewalOption( purchase );
-
-		const domainDetails = this.props.domainsDetails?.[ purchase.siteId ]?.find(
-			( domain ) => domain.domain === purchase.meta
-		);
+		const domainDetails = this.getDomainDetailsFromPurchase( purchase );
 
 		return (
 			<Fragment>

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -617,10 +617,15 @@ class ManagePurchase extends Component<
 		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
 	};
 
-	getDomainDetailsFromPurchase = ( purchase: Purchase ) => {
+	getDomainDetailsFromPurchase = ( purchase: Purchase ): ResponseDomain | undefined => {
 		return this.props.domainsDetails?.[ purchase.siteId ]?.find(
 			( domain ) => domain.domain === purchase.meta
 		);
+	};
+
+	isHundredYearDomain = ( purchase: Purchase ): boolean | undefined => {
+		const domainDetails = this.getDomainDetailsFromPurchase( purchase );
+		return domainDetails?.isHundredYearDomain;
 	};
 
 	renderEditPaymentMethodNavItem() {
@@ -641,8 +646,7 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		const domainDetails = this.getDomainDetailsFromPurchase( purchase );
-		if ( domainDetails?.isHundredYearDomain ) {
+		if ( this.isHundredYearDomain( purchase ) ) {
 			return null;
 		}
 
@@ -885,11 +889,8 @@ class ManagePurchase extends Component<
 		}
 
 		// If it's a 100-year domain, don't show the cancel button
-		if ( isDomainRegistration( purchase ) ) {
-			const domainDetails = this.getDomainDetailsFromPurchase( purchase );
-			if ( domainDetails?.isHundredYearDomain ) {
-				return null;
-			}
+		if ( this.isHundredYearDomain( purchase ) ) {
+			return null;
 		}
 
 		const onClick = ( event: { preventDefault: () => void } ) => {
@@ -932,8 +933,7 @@ class ManagePurchase extends Component<
 			);
 		}
 
-		const domainDetails = this.getDomainDetailsFromPurchase( purchase );
-		if ( domainDetails?.isHundredYearDomain ) {
+		if ( this.isHundredYearDomain( purchase ) ) {
 			return (
 				<div className="manage-purchase__plan-icon">
 					<HundredYearPlanLogo width={ 50 } />
@@ -995,8 +995,7 @@ class ManagePurchase extends Component<
 		}
 
 		if ( isDomainMapping( purchase ) || isDomainRegistration( purchase ) ) {
-			const domainDetails = this.getDomainDetailsFromPurchase( purchase );
-			if ( domainDetails?.isHundredYearDomain ) {
+			if ( this.isHundredYearDomain( purchase ) ) {
 				return translate(
 					'Your stories, achievements, and memories preserved for generations to come. One payment. One hundred years of legacy.'
 				);
@@ -1262,7 +1261,7 @@ class ManagePurchase extends Component<
 		const siteId = purchase.siteId;
 
 		const renderMonthlyRenewalOption = shouldRenderMonthlyRenewalOption( purchase );
-		const domainDetails = this.getDomainDetailsFromPurchase( purchase );
+		const isHundredYearDomain = this.isHundredYearDomain( purchase );
 
 		return (
 			<Fragment>
@@ -1274,7 +1273,7 @@ class ManagePurchase extends Component<
 						{ this.renderPurchaseIcon() }
 						<h2 className="manage-purchase__title">{ this.getProductDisplayName() }</h2>
 						<div className="manage-purchase__description">
-							{ domainDetails?.isHundredYearDomain
+							{ isHundredYearDomain
 								? translate( '100-Year Domain Registration' )
 								: purchaseType( purchase ) }
 						</div>

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1180,7 +1180,6 @@ class ManagePurchase extends Component<
 						getChangePaymentMethodUrlFor={
 							getChangePaymentMethodUrlFor ?? getChangePaymentMethodPath
 						}
-						domainDetails={ null }
 					/>
 				</Card>
 				<PurchasePlanDetails isPlaceholder />
@@ -1313,7 +1312,6 @@ class ManagePurchase extends Component<
 							getChangePaymentMethodUrlFor={
 								getChangePaymentMethodUrlFor ?? getChangePaymentMethodPath
 							}
-							domainDetails={ domainDetails }
 						/>
 					) }
 					{ isProductOwner && ! purchase.isLocked && (

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -11,6 +11,7 @@ import { useTranslate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { ResponseDomain } from 'calypso/lib/domains/types';
 import {
 	hasPaymentMethod,
 	isRechargeable,
@@ -61,8 +62,8 @@ function PurchaseMetaExpiration( {
 		isJetpackPurchase && config.isEnabled( 'jetpack/cancel-through-main-flow' );
 
 	const allDomains = useSelector( getAllDomains );
-	const selectedDomain = allDomains?.[ purchase.siteId ]?.find(
-		( domain ) => domain.domain === purchase.meta
+	const domainDetails = allDomains?.[ purchase.siteId ]?.find(
+		( domain: ResponseDomain ) => domain.domain === purchase.meta
 	);
 
 	if (
@@ -209,7 +210,7 @@ function PurchaseMetaExpiration( {
 	return (
 		<li>
 			<em className="manage-purchase__detail-label">
-				{ renderRenewsOrExpiresOnLabel( { purchase, domainDetails: selectedDomain, translate } ) }
+				{ renderRenewsOrExpiresOnLabel( { purchase, domainDetails, translate } ) }
 			</em>
 			<span className="manage-purchase__detail">
 				{ renderRenewsOrExpiresOn( {

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -21,6 +21,7 @@ import {
 import { isAkismetTemporarySitePurchase } from 'calypso/me/purchases/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getAllDomains } from 'calypso/state/sites/domains/selectors';
 import AutoRenewToggle from './auto-renew-toggle';
 import type { SiteDetails } from '@automattic/data-stores';
 import type {
@@ -58,6 +59,11 @@ function PurchaseMetaExpiration( {
 	const isAutorenewalEnabled = purchase?.isAutoRenewEnabled ?? false;
 	const isJetpackPurchaseUsingPrimaryCancellationFlow =
 		isJetpackPurchase && config.isEnabled( 'jetpack/cancel-through-main-flow' );
+
+	const allDomains = useSelector( getAllDomains );
+	const selectedDomain = allDomains?.[ purchase.siteId ]?.find(
+		( domain ) => domain.domain === purchase.meta
+	);
 
 	if (
 		! purchase ||
@@ -203,7 +209,7 @@ function PurchaseMetaExpiration( {
 	return (
 		<li>
 			<em className="manage-purchase__detail-label">
-				{ renderRenewsOrExpiresOnLabel( { purchase, translate } ) }
+				{ renderRenewsOrExpiresOnLabel( { purchase, domainDetails: selectedDomain, translate } ) }
 			</em>
 			<span className="manage-purchase__detail">
 				{ renderRenewsOrExpiresOn( {

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -15,6 +15,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useAkismetKeyQuery from 'calypso/data/akismet/use-akismet-key-query';
 import useUserLicenseBySubscriptionQuery from 'calypso/data/jetpack-licensing/use-user-license-by-subscription-query';
+import { ResponseDomain } from 'calypso/lib/domains/types';
 import {
 	getName,
 	isExpired,
@@ -49,6 +50,7 @@ export interface PurchaseMetaProps {
 	siteSlug: string;
 	getChangePaymentMethodUrlFor: GetChangePaymentMethodUrlFor;
 	getManagePurchaseUrlFor?: GetManagePurchaseUrlFor;
+	domainDetails: ResponseDomain | null | undefined;
 }
 
 export default function PurchaseMeta( {
@@ -57,6 +59,7 @@ export default function PurchaseMeta( {
 	siteSlug,
 	getChangePaymentMethodUrlFor,
 	getManagePurchaseUrlFor = managePurchase,
+	domainDetails,
 }: PurchaseMetaProps ) {
 	const translate = useTranslate();
 
@@ -78,7 +81,10 @@ export default function PurchaseMeta( {
 	const showJetpackUserLicense = isJetpackProduct( purchase ) || isJetpackPlan( purchase );
 	const isAkismetPurchase = isAkismetTemporarySitePurchase( purchase );
 
-	const renewalPriceHeader = translate( 'Renewal Price' );
+	// 100-year domains will only show a "Price" label since their renewal date is a long time in the future
+	const renewalPriceHeader = domainDetails?.isHundredYearDomain
+		? translate( 'Price' )
+		: translate( 'Renewal Price' );
 
 	const hideRenewalPriceSection = isOneTimePurchase( purchase );
 	const hideTaxString = isIncludedWithPlan( purchase );
@@ -148,9 +154,11 @@ export default function PurchaseMeta( {
 
 function renderRenewsOrExpiresOnLabel( {
 	purchase,
+	domainDetails,
 	translate,
 }: {
 	purchase: Purchase;
+	domainDetails: ResponseDomain | null | undefined;
 	translate: ReturnType< typeof useTranslate >;
 } ): string | null {
 	if ( isExpiring( purchase ) ) {
@@ -186,6 +194,9 @@ function renderRenewsOrExpiresOnLabel( {
 	}
 
 	if ( isDomainRegistration( purchase ) ) {
+		if ( domainDetails?.isHundredYearDomain ) {
+			return translate( 'Paid until' );
+		}
 		return translate( 'Domain renews on' );
 	}
 

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -28,6 +28,7 @@ import {
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
+import { getAllDomains } from 'calypso/state/sites/domains/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { managePurchase } from '../paths';
 import { isAkismetTemporarySitePurchase, isTemporarySitePurchase } from '../utils';
@@ -48,9 +49,9 @@ export interface PurchaseMetaProps {
 	purchaseId: number | false;
 	hasLoadedPurchasesFromServer: boolean;
 	siteSlug: string;
+	domainDetails?: ResponseDomain | null;
 	getChangePaymentMethodUrlFor: GetChangePaymentMethodUrlFor;
 	getManagePurchaseUrlFor?: GetManagePurchaseUrlFor;
-	domainDetails: ResponseDomain | null | undefined;
 }
 
 export default function PurchaseMeta( {
@@ -59,7 +60,6 @@ export default function PurchaseMeta( {
 	siteSlug,
 	getChangePaymentMethodUrlFor,
 	getManagePurchaseUrlFor = managePurchase,
-	domainDetails,
 }: PurchaseMetaProps ) {
 	const translate = useTranslate();
 
@@ -74,12 +74,18 @@ export default function PurchaseMeta( {
 
 	const isDataLoading = useSelector( isRequestingSites ) || ! hasLoadedPurchasesFromServer;
 
+	const allDomains = useSelector( getAllDomains );
+
 	if ( isDataLoading || ! purchaseId || ! purchase ) {
 		return <PurchaseMetaPlaceholder />;
 	}
 
 	const showJetpackUserLicense = isJetpackProduct( purchase ) || isJetpackPlan( purchase );
 	const isAkismetPurchase = isAkismetTemporarySitePurchase( purchase );
+
+	const domainDetails = allDomains?.[ purchase.siteId ]?.find(
+		( domain: ResponseDomain ) => domain.domain === purchase.meta
+	);
 
 	// 100-year domains will only show a "Price" label since their renewal date is a long time in the future
 	const renewalPriceHeader = domainDetails?.isHundredYearDomain
@@ -158,7 +164,7 @@ function renderRenewsOrExpiresOnLabel( {
 	translate,
 }: {
 	purchase: Purchase;
-	domainDetails: ResponseDomain | null | undefined;
+	domainDetails?: ResponseDomain | null;
 	translate: ReturnType< typeof useTranslate >;
 } ): string | null {
 	if ( isExpiring( purchase ) ) {

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -49,7 +49,6 @@ export interface PurchaseMetaProps {
 	purchaseId: number | false;
 	hasLoadedPurchasesFromServer: boolean;
 	siteSlug: string;
-	domainDetails?: ResponseDomain | null;
 	getChangePaymentMethodUrlFor: GetChangePaymentMethodUrlFor;
 	getManagePurchaseUrlFor?: GetManagePurchaseUrlFor;
 }

--- a/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
+++ b/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
@@ -42,6 +42,9 @@ function createReduxStoreWithPurchase( purchase ) {
 			},
 			sites: {
 				requestingAll: false,
+				domains: {
+					items: [],
+				},
 			},
 			currentUser: {
 				id: 1,

--- a/client/me/purchases/manage-purchase/test/purchase-meta.js
+++ b/client/me/purchases/manage-purchase/test/purchase-meta.js
@@ -10,6 +10,20 @@ import PurchaseMeta from '../purchase-meta';
 
 describe( 'PurchaseMeta', () => {
 	const queryClient = new QueryClient();
+	const commonStoreAttributes = {
+		sites: {
+			requestingAll: false,
+			domains: {
+				items: [],
+			},
+		},
+		currentUser: {
+			id: 1,
+			user: {
+				primary_blog: 'example',
+			},
+		},
+	};
 
 	it( 'does render "Free with Plan"', () => {
 		const store = createReduxStore(
@@ -22,18 +36,7 @@ describe( 'PurchaseMeta', () => {
 						},
 					],
 				},
-				sites: {
-					requestingAll: false,
-					domains: {
-						items: [],
-					},
-				},
-				currentUser: {
-					id: 1,
-					user: {
-						primary_blog: 'example',
-					},
-				},
+				...commonStoreAttributes,
 			},
 			( state ) => state
 		);
@@ -64,18 +67,7 @@ describe( 'PurchaseMeta', () => {
 						},
 					],
 				},
-				sites: {
-					requestingAll: false,
-					domains: {
-						items: [],
-					},
-				},
-				currentUser: {
-					id: 1,
-					user: {
-						primary_blog: 'example',
-					},
-				},
+				...commonStoreAttributes,
 			},
 			( state ) => state
 		);
@@ -106,18 +98,7 @@ describe( 'PurchaseMeta', () => {
 						},
 					],
 				},
-				sites: {
-					requestingAll: false,
-					domains: {
-						items: [],
-					},
-				},
-				currentUser: {
-					id: 1,
-					user: {
-						primary_blog: 'example',
-					},
-				},
+				...commonStoreAttributes,
 			},
 			( state ) => state
 		);
@@ -148,18 +129,7 @@ describe( 'PurchaseMeta', () => {
 						},
 					],
 				},
-				sites: {
-					requestingAll: false,
-					domains: {
-						items: [],
-					},
-				},
-				currentUser: {
-					id: 1,
-					user: {
-						primary_blog: 'example',
-					},
-				},
+				...commonStoreAttributes,
 			},
 			( state ) => state
 		);
@@ -190,18 +160,7 @@ describe( 'PurchaseMeta', () => {
 						},
 					],
 				},
-				sites: {
-					requestingAll: false,
-					domains: {
-						items: [],
-					},
-				},
-				currentUser: {
-					id: 1,
-					user: {
-						primary_blog: 'example',
-					},
-				},
+				...commonStoreAttributes,
 			},
 			( state ) => state
 		);
@@ -232,18 +191,7 @@ describe( 'PurchaseMeta', () => {
 						},
 					],
 				},
-				sites: {
-					requestingAll: false,
-					domains: {
-						items: [],
-					},
-				},
-				currentUser: {
-					id: 1,
-					user: {
-						primary_blog: 'example',
-					},
-				},
+				...commonStoreAttributes,
 			},
 			( state ) => state
 		);
@@ -274,18 +222,7 @@ describe( 'PurchaseMeta', () => {
 						},
 					],
 				},
-				sites: {
-					requestingAll: false,
-					domains: {
-						items: [],
-					},
-				},
-				currentUser: {
-					id: 1,
-					user: {
-						primary_blog: 'example',
-					},
-				},
+				...commonStoreAttributes,
 			},
 			( state ) => state
 		);
@@ -317,18 +254,7 @@ describe( 'PurchaseMeta', () => {
 						},
 					],
 				},
-				sites: {
-					requestingAll: false,
-					domains: {
-						items: [],
-					},
-				},
-				currentUser: {
-					id: 1,
-					user: {
-						primary_blog: 'example',
-					},
-				},
+				...commonStoreAttributes,
 			},
 			( state ) => state
 		);
@@ -360,18 +286,7 @@ describe( 'PurchaseMeta', () => {
 						},
 					],
 				},
-				sites: {
-					requestingAll: false,
-					domains: {
-						items: [],
-					},
-				},
-				currentUser: {
-					id: 1,
-					user: {
-						primary_blog: 'example',
-					},
-				},
+				...commonStoreAttributes,
 			},
 			( state ) => state
 		);
@@ -405,18 +320,7 @@ describe( 'PurchaseMeta', () => {
 						},
 					],
 				},
-				sites: {
-					requestingAll: false,
-					domains: {
-						items: [],
-					},
-				},
-				currentUser: {
-					id: 1,
-					user: {
-						primary_blog: 'example',
-					},
-				},
+				...commonStoreAttributes,
 			},
 			( state ) => state
 		);

--- a/client/me/purchases/manage-purchase/test/purchase-meta.js
+++ b/client/me/purchases/manage-purchase/test/purchase-meta.js
@@ -24,6 +24,9 @@ describe( 'PurchaseMeta', () => {
 				},
 				sites: {
 					requestingAll: false,
+					domains: {
+						items: [],
+					},
 				},
 				currentUser: {
 					id: 1,
@@ -63,6 +66,9 @@ describe( 'PurchaseMeta', () => {
 				},
 				sites: {
 					requestingAll: false,
+					domains: {
+						items: [],
+					},
 				},
 				currentUser: {
 					id: 1,
@@ -102,6 +108,9 @@ describe( 'PurchaseMeta', () => {
 				},
 				sites: {
 					requestingAll: false,
+					domains: {
+						items: [],
+					},
 				},
 				currentUser: {
 					id: 1,
@@ -141,6 +150,9 @@ describe( 'PurchaseMeta', () => {
 				},
 				sites: {
 					requestingAll: false,
+					domains: {
+						items: [],
+					},
 				},
 				currentUser: {
 					id: 1,
@@ -180,6 +192,9 @@ describe( 'PurchaseMeta', () => {
 				},
 				sites: {
 					requestingAll: false,
+					domains: {
+						items: [],
+					},
 				},
 				currentUser: {
 					id: 1,
@@ -219,6 +234,9 @@ describe( 'PurchaseMeta', () => {
 				},
 				sites: {
 					requestingAll: false,
+					domains: {
+						items: [],
+					},
 				},
 				currentUser: {
 					id: 1,
@@ -258,6 +276,9 @@ describe( 'PurchaseMeta', () => {
 				},
 				sites: {
 					requestingAll: false,
+					domains: {
+						items: [],
+					},
 				},
 				currentUser: {
 					id: 1,
@@ -298,6 +319,9 @@ describe( 'PurchaseMeta', () => {
 				},
 				sites: {
 					requestingAll: false,
+					domains: {
+						items: [],
+					},
 				},
 				currentUser: {
 					id: 1,
@@ -338,6 +362,9 @@ describe( 'PurchaseMeta', () => {
 				},
 				sites: {
 					requestingAll: false,
+					domains: {
+						items: [],
+					},
 				},
 				currentUser: {
 					id: 1,
@@ -380,6 +407,9 @@ describe( 'PurchaseMeta', () => {
 				},
 				sites: {
 					requestingAll: false,
+					domains: {
+						items: [],
+					},
 				},
 				currentUser: {
 					id: 1,


### PR DESCRIPTION
## Proposed Changes

This PR updates the purchase settings page for 100-year domains. These are the updates that were done:

- Change the globe icon by the 100-year badge
- Update "Domain Registration" label to "100-Year Domain Registration"
- Update product description
- Change "Renewal Price" label to "Price"
- Change "Domain renews on" label to "Paid until"
- Remove "Change payment method" option

| Before | After |
| --- | --- |
| <img width="1069" alt="Screenshot 2024-11-19 at 18 56 33" src="https://github.com/user-attachments/assets/225783dc-911a-465a-ab3f-ae0e30d6e2e8"> | <img width="1070" alt="Screenshot 2024-11-19 at 18 56 19" src="https://github.com/user-attachments/assets/3574aa84-2434-45bb-9157-4249082d5843"> |

## Why are these changes being made?

This is part of the 100-year domains: UX updates project (pcYYhz-2q8-p2) to update Calypso for 100-year domains.

## Testing Instructions

- Build this branch locally or open the live Calypso link
- Go to the purchase settings page for a 100-year domain
- Ensure it looks like the updated screenshot shown above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?