### PR TITLE
Create automated-migration/application-password feature flag.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -34,6 +34,7 @@
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
+		"automated-migration/application-password": true,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,6 +13,7 @@
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
+		"automated-migration/application-password": false,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/production.json
+++ b/config/production.json
@@ -24,6 +24,7 @@
 		"ad-tracking": true,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
+		"automated-migration/application-password": false,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"bulk-plugin-management": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -23,6 +23,7 @@
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
+		"automated-migration/application-password": false,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"bulk-plugin-management": false,

--- a/config/test.json
+++ b/config/test.json
@@ -25,6 +25,7 @@
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
+		"automated-migration/application-password": false,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"calypsoify/plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -22,6 +22,7 @@
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
+		"automated-migration/application-password": false,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/96561

## Proposed Changes

Just adds `automated-migration/application-password` feature flag on Calypso development environment.

## Testing Instructions

Just code review is enough. This flag does not impact any feature at the moment.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
