### PR TITLE
Fix processing of the `odyssey-stats` changes during since last build

### DIFF
--- a/bin/did-calypso-app-change.mjs
+++ b/bin/did-calypso-app-change.mjs
@@ -34,7 +34,7 @@ export default async function didCalypsoAppChange( { slug, dir, artifactDir } ) 
 	try {
 		await exec(
 			`diff -r --exclude="*.js.map" --exclude="*.asset.php" --exclude="build_meta.json" --exclude="README.md" ${ artifactDir } ${ prevReleaseDir }`,
-			{ cwd: dir, maxBuffer: 1024 * 1024 * 16 } // 16MB buffer for large diffs.
+			{ cwd: dir, maxBuffer: 1024 * 1024 * 32 } // 32MB buffer for large diffs.
 		);
 		return false;
 	} catch ( { code, stdout, stderr } ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

TeamCity build was failing with the error
`Unexpected error code ERR_CHILD_PROCESS_STDIO_MAXBUFFER while diffing odyssey-stats build`

This increases the buffer size used by the diff script.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I started having this error occurring while the #96386 PR tried to build.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TeamCity build should run
