### PR TITLE
Add password application strings to trigger translations.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, Title, SubTitle, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -149,6 +150,50 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 			</div>
 			{ hasTranslationsForAllItems && (
 				<HostingDetails items={ Object.values( hostingDetailItems ) } />
+			) }
+			{ isEnabled( 'automated-migration/application-password' ) && (
+				<>
+					<p>{ translate( 'Current WordPress site address' ) }</p>
+					<p>{ translate( 'WordPress site address' ) }</p>
+					<p>
+						{ translate(
+							'Help us get started by providing some basic details about your current website.'
+						) }
+					</p>
+					<p>{ translate( 'Verifying your site' ) }</p>
+					<p>{ translate( 'Get ready for blazing fast speeds' ) }</p>
+					<p>{ translate( 'Authorize access' ) }</p>
+					<p>{ translate( 'Share credentials instead' ) }</p>
+					<p>{ translate( 'Here’s what else you’re getting' ) }</p>
+					<p>
+						{ translate( 'Uninterrupted service throughout the entire migration experience.' ) }
+					</p>
+					<p>{ translate( 'Unmatched reliability with 99.999% uptime and unmetered traffic.' ) }</p>
+					<p>{ translate( 'Round-the-clock security monitoring and DDoS protection.' ) }</p>
+					<p>{ translate( 'Securely share your credentials' ) }</p>
+					<p>
+						{ translate(
+							'Enter your login details for a WordPress Admin so we can temporarily access {{b}}%(siteURL){{/b}} and start migrating it to WordPress.com.',
+							{ components: { b: <strong /> }, args: { siteURL: 'areallylongdomainname.com' } }
+						) }
+					</p>
+					<p>
+						{ translate(
+							'We’re ready to migrate {{b}}%(siteURL){{/b}} to WordPress.com. To make sure everything goes smoothly, we need you to authorize us for access in your WordPress admin.',
+							{ components: { b: <strong /> }, args: { siteURL: 'areallylongdomainname.com' } }
+						) }
+					</p>
+					<p>
+						{ translate(
+							'We can’t start your migration without your authorization. Please authorize WordPress.com in your WP Admin or share your credentials.'
+						) }
+					</p>
+					<p>
+						{ translate(
+							'Upload your full site backup as a zip file containing the database backup and wp-content folder, or use a backup created by a plugin.'
+						) }
+					</p>
+				</>
 			) }
 		</div>
 	);


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/96564

**Do not merge this**

## Proposed Changes

Trigger the translations for new texts based on F8foKv974Gc5dTHSh0i0Wo-fi-680_6511

## Why are these changes being made?


## Testing Instructions



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?