### PR TITLE
Enable Bulk Plugin Management: Fix mobile layout and title alignment

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -529,7 +529,12 @@ export class PluginsMain extends Component {
 					<QueryJetpackSitesFeatures />
 				) }
 				{ this.renderPageViewTracking() }
-				<div className="plugin-management-wrapper">
+				<div
+					className={ clsx(
+						'plugin-management-wrapper',
+						this.props.newBulkPluginManagement && 'is-bulk-plugin-management'
+					) }
+				>
 					{ ! isJetpackCloud && (
 						<NavigationHeader
 							navigationItems={ [] }

--- a/client/my-sites/plugins/plugins-list/style-compatibilty.scss
+++ b/client/my-sites/plugins/plugins-list/style-compatibilty.scss
@@ -57,12 +57,3 @@
 	padding: 0;
 }
 
-.is-section-jetpack-cloud-plugin-management {
-    .layout__content {
-        padding: 79px 32px 32px calc(var(--sidebar-width-max) + 32px);
-    }
-
-	.plugins__top-container-jc {
-        padding-left: 50px;
-    }
-}

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -2,6 +2,11 @@ body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management {
 	.navigation-header {
 		border-block-end: 1px solid var(--color-border-secondary);
 		padding-inline: 48px;
+
+        .navigation-header__main {
+            max-width: 1400px;
+            margin: auto;
+        }
 	}
 }
 

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -1,13 +1,12 @@
-body.is-section-plugins .plugin-management-wrapper {
+body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management {
 	.navigation-header {
 		border-block-end: 1px solid var(--color-border-secondary);
 		padding-inline: 48px;
 	}
 }
 
-body.is-section-plugins .plugin-management-wrapper,
-.is-section-jetpack-cloud-plugin-management {
-
+body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management,
+.is-section-jetpack-cloud-plugin-management .plugin-management-wrapper.is-bulk-plugin-management {
     .dataviews-wrapper .dataviews-view-table {
         .dataviews-view-table__row {
             .plugin-icon {
@@ -25,6 +24,12 @@ body.is-section-plugins .plugin-management-wrapper,
 .is-section-jetpack-cloud-plugin-management {
     --wp-admin-theme-color: var(--studio-jetpack-green-50);
 
+	.plugin-management-wrapper {
+		display: flex;
+		flex-direction: column;
+		min-height: calc(100vh - 64px);
+	}
+
     .select-partner-key {
         padding: 0 40px;
     }
@@ -33,7 +38,7 @@ body.is-section-plugins .plugin-management-wrapper,
         button {
             border: none;
             background-color: transparent;
-    
+
             &:hover {
                 background-color: var(--color-background-alt);
             }
@@ -46,13 +51,16 @@ body.is-section-plugins .plugin-management-wrapper,
         }
     }
 
-    .layout__content {
-        padding: 79px 0 32px calc(var(--sidebar-width-max));
-    }
+	.plugins__top-container-jc,
+	.plugins__main-content-jc {
+		margin-inline: -32px;
+	}
 
-    .plugins__top-container-jc {
-        padding-left: 80px;
-    }
+	.plugin-management-wrapper.is-bulk-plugin-management {
+		.plugins__page-title-container {
+			padding-inline: 48px;
+		}
+	}
 }
 
 .sites-manage-plugin-status-button {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -599,6 +599,16 @@ body.is-section-plugins #primary {
 	}
 }
 
+.plugin-management-wrapper.is-bulk-plugin-management {
+  .plugins__top-container-jc {
+      padding: 4px 0 0;
+
+      @include break-large() {
+          padding: 6px 0 0;
+      }
+  }
+}
+
 .plugins__content-wrapper {
 	max-width: 1500px;
 	margin: auto;
@@ -608,7 +618,8 @@ body.is-section-plugins #primary {
 }
 .plugins__main-content {
 	margin: 0;
-	padding: 0 16px;
+	padding: 0;
+	// padding: 0 16px;
 	flex: 1 1 100%;
 	@media (min-width: $break-small) {
 		padding: 16px 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9742
Related to https://github.com/Automattic/wp-calypso/pull/96437 (it's an alternative fix)


## Proposed Changes

- Adds a `is-bulk-plugin-management` class to the UI wrapper
- Removes the custom `layout__content` rule used to adjust the width of the primary content area
   - I believe it was there so the custom background colour would stretch all the way to the edge of the primary area
   - However the custom rule, without any media queries, broke mobile layout
   - I instead made the custom background stretch all the way to the edges by introducing `margin-inline: -32px`, which I believe is how the other dashboards do it
- Adjusted rules to ensure titles stayed aligned with page content
- Ensured the custom background colour extended to the bottom of the screen (like on other dashboards) by using a vertical flex layout with a minimum height of `calc(100vh - 64px)`

I had to add a `is-bulk-plugin-management` class because, in my testing at least, the strategy of loading different CSS files based on features flags wasn't working. i.e. the code imported with `import('style.scss')` was being included, even when the feature flag was disabled. I'm not sure why, maybe webpack statically analyses the file while bundling and so you can't load CSS on demand?

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The mobile layout was broken on the plugin screen on Jetpack Cloud. Titles weren't aligned. The background colour used to differentiate between the top and bottom section wasn't right.
We want our page to look noice 💅

I think we should accept this fix (instead of #96437) because it's a smaller change which doesn't need to rearrange too much DOM. And it also is resilient to the presence of scrollbars.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You might need this info to get set up with the Jetpack Cloud dashboard pet6gk-1Gs-p2

Access Jetpack Cloud at `jetpack.cloud.localhost:3001/plugins/manage`
Access Calypso screen at `calypso.localhost:3000/plugins/manage`

Test with the feature flag enabled and disabled:
- `?flags=bulk-plugin-management`
- `?flags=-bulk-plugin-management`

**Calypso without feature flag**

https://github.com/user-attachments/assets/00b47710-3e42-4bc3-8621-0dd3e69527fc

**Calypso with feature flag**


https://github.com/user-attachments/assets/c31d38f7-0bfb-4c4b-a4fd-e6549a2b420d



**Jetpack Cloud without feature flag**


https://github.com/user-attachments/assets/d402ebac-92ee-494d-a70a-ddb260c5ebed



**Jetpack Cloud with feature flag**


https://github.com/user-attachments/assets/d3fd34c5-c6f1-4e40-a13d-a90a64b8191c



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?