### PR TITLE
Help Center: Switch to check if elapsed time less than 15 minutes

### DIFF
--- a/packages/odie-client/src/hooks/use-send-chat-message.ts
+++ b/packages/odie-client/src/hooks/use-send-chat-message.ts
@@ -38,7 +38,7 @@ export const useSendChatMessage = () => {
 					const elapsedTime = getHelpCenterZendeskConversationStartedElapsedTime();
 					if ( elapsedTime ) {
 						trackEvent( 'first_answer_to_human_support', {
-							elapsed_time: elapsedTime,
+							elapsed_time_less_than_900s: elapsedTime < 900 * 1000,
 							role: message.role,
 							user_id: chat?.wpcomUserId,
 						} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1732093892596739/1732093791.902089-slack-C07D72S1135

## Proposed Changes

Instead of tracking the elapsed time, we just track if the answer from the user happened in less than 15 minutes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

ExPlat p1732054589211009/1732020069.327289-slack-CNTD4G117 doesn't support the <= operator for the elapsed_time property.
We’ll need to incorporate that logic directly into the event. After analyzing historical data we agreed that 15 minutes (900 seconds) would be the most suitable threshold.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test new Help Center
* Clear the chat
* Ask to talk with an human
* Answer the message in less than 15 minutes
* Check that (with Tracks Vigilante for example) the event `calypso_odie_first_answer_to_human_support` has been fired with the prop `elapsed_time_less_than_900s` set to true
