### PR TITLE
Photos picker: Update the message in case when connection upgrade is required

### DIFF
--- a/client/sites/marketing/connections/google-photos-migration.jsx
+++ b/client/sites/marketing/connections/google-photos-migration.jsx
@@ -6,7 +6,7 @@ const GooglePhotosMigration = ( { translate } ) => (
 		<h3>{ translate( 'Your Google Photos connection is being upgraded!' ) }</h3>
 		<p>
 			{ translate(
-				'We are moving to a new Google Photos Picker service. You will need to disconnect and reconnect to continue accessing your photos.'
+				"We've updated our Google Photos service. You will need to disconnect and reconnect to continue accessing your photos."
 			) }
 		</p>
 	</Fragment>

--- a/client/sites/marketing/connections/google-photos-migration.jsx
+++ b/client/sites/marketing/connections/google-photos-migration.jsx
@@ -3,7 +3,7 @@ import { Fragment } from 'react';
 
 const GooglePhotosMigration = ( { translate } ) => (
 	<Fragment>
-		<h3>{ translate( 'Your Google Photos connection is being upgraded!' ) }</h3>
+		<h3>{ translate( 'Your Google Photos connection is being updated!' ) }</h3>
 		<p>
 			{ translate(
 				"We've updated our Google Photos service. You will need to disconnect and reconnect to continue accessing your photos."


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/96061

## Proposed Changes

* Update the message in case when connection upgrade is required

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, the message is specific for Google Photos Picker, now we update content to support both ways; upgrade Google Photos <-> Google Photos Picker upgrade

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure that you don't have Google Photos connection established
* Whitelist your user ID
* Establish connection
* Remove your user ID from the whitelist array
* Go to the "Tools/Marketing" page and check the message

<img width="1068" alt="Screenshot 2024-11-20 at 12 45 45" src="https://github.com/user-attachments/assets/d6fc103f-df46-4ccf-82ac-4b37344c0e65">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
