### PR TITLE
Rename sites/marketing/sharing route to /sharing-buttons

### DIFF
--- a/client/sites/components/site-preview-pane/constants.ts
+++ b/client/sites/components/site-preview-pane/constants.ts
@@ -47,7 +47,7 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ MARKETING_TOOLS ]: 'sites/marketing/tools/:site',
 	[ MARKETING_CONNECTIONS ]: 'sites/marketing/connections/:site',
 	[ MARKETING_TRAFFIC ]: 'sites/marketing/traffic/:site',
-	[ MARKETING_SHARING ]: 'sites/marketing/sharing/:site',
+	[ MARKETING_SHARING ]: 'sites/marketing/sharing-buttons/:site',
 	[ TOOLS_STAGING_SITE ]: 'sites/tools/staging-site/:site',
 	[ TOOLS_DEPLOYMENTS ]: 'sites/tools/deployments/:site',
 	[ TOOLS_MONITORING ]: 'sites/tools/monitoring/:site',

--- a/client/sites/marketing/controller.tsx
+++ b/client/sites/marketing/controller.tsx
@@ -24,7 +24,9 @@ export function MarketingSidebar() {
 				{ __( 'Connections' ) }
 			</SidebarItem>
 			<SidebarItem href={ `/sites/marketing/traffic/${ slug }` }>{ __( 'Traffic' ) }</SidebarItem>
-			<SidebarItem href={ `/sites/marketing/sharing/${ slug }` }>{ __( 'Sharing' ) }</SidebarItem>
+			<SidebarItem href={ `/sites/marketing/sharing-buttons/${ slug }` }>
+				{ __( 'Sharing' ) }
+			</SidebarItem>
 		</Sidebar>
 	);
 }

--- a/client/sites/marketing/index.tsx
+++ b/client/sites/marketing/index.tsx
@@ -49,9 +49,9 @@ export default function () {
 		clientRender
 	);
 
-	page( '/sites/marketing/sharing', siteSelection, sites, makeLayout, clientRender );
+	page( '/sites/marketing/sharing-buttons', siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/sites/marketing/sharing/:site',
+		'/sites/marketing/sharing-buttons/:site',
 		siteSelection,
 		navigation,
 		marketingSharing,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/9868

## Proposed Changes

* rename the sharing route back to sharing-buttons

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because the route `/sites/marketing/sharing` conflicts with existing routes on dotcom, which returns a 302 redirect.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/sites/marketing/sharing-buttons/:site` in browser. it should load the sharing content.
* Also, try switching between different tabs on the left nav. It should load all tabs and update route in the url bar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
