### PR TITLE
Fix error when clicking on link

### DIFF
--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -53,8 +53,8 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 					element.setAttribute( 'href', new URL( hash, link ).href );
 					element.onclick = ( event: Event ) => {
 						event.preventDefault();
-
-						const target = node?.querySelector( hash );
+						// We need to use CSS.escape since we can have non latin chars in the hash
+						const target = node?.querySelector( `#${ CSS.escape( hash.slice( 1 ) ) }` );
 						if ( target ) {
 							target.scrollIntoView();
 						}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9032

Sentry errors brought to our attention that navigation can break when clicking on a link via the help center.

https://github.com/user-attachments/assets/86076287-11e3-4293-9aeb-507ed525b62b

## Proposed Changes

* Use CSS.escape when selecting the element

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix navigation in special cases

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Change the language to `fr`
* Follow the same steps from the videos
* Navigation should work after clicking the link

