### PR TITLE
A4A > Contact sales & support: Send contact form for Pressable Sales via Zendesk

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/index.tsx
@@ -124,6 +124,7 @@ export default function MigrationContactSupportForm( { show, onClose }: Props ) 
 			name,
 			email,
 			product,
+			agency_id: agency?.id,
 			no_of_sites: site,
 			...( pressableContactType && { contact_type: pressableContactType } ),
 			...( pressable_id && { pressable_id } ),

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -130,6 +130,7 @@ export default function UserContactSupportModalForm( {
 			name,
 			email,
 			product,
+			agency_id: agency?.id,
 			...( site && { site } ),
 			...( pressableContactType && { contact_type: pressableContactType } ),
 			...( pressable_id && { pressable_id } ),

--- a/client/a8c-for-agencies/data/support/types.ts
+++ b/client/a8c-for-agencies/data/support/types.ts
@@ -10,6 +10,7 @@ export interface SubmitContactSupportParams {
 	email: string;
 	message: string;
 	product: string;
+	agency_id: number | undefined;
 	site?: string;
 	no_of_sites?: number;
 	contact_type?: string;

--- a/client/a8c-for-agencies/data/support/use-submit-support-form-mutation.ts
+++ b/client/a8c-for-agencies/data/support/use-submit-support-form-mutation.ts
@@ -9,7 +9,7 @@ interface APIResponse {
 function mutationSubmitSupportForm( params: SubmitContactSupportParams ): Promise< APIResponse > {
 	let path = '/agency/help/zendesk/create-ticket';
 
-	if ( params.product === 'pressable' ) {
+	if ( params.product === 'pressable' && params.contact_type === 'support' ) {
 		path = '/agency/help/pressable/support';
 	}
 


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/1479

## Proposed Changes

This PR updates the Contact sales & support path for Pressable Sales, sending the contact form to Zendesk instead of Intercom.

<img width="765" alt="image" src="https://github.com/user-attachments/assets/37552022-8b97-4f73-8634-5e6c59aa8e48">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

_See the issue_

## Testing Instructions

- Check the code
- Click on `Contact sales & support` menu and fill out it.
- Select `Pressable` Automattic product and then `Sales`.
- Send it.
- Go to Zendesk and check that you see the ticket.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
