### PR TITLE
Untangling: apply new design to Marketing -> {Traffic, Sharing}

### DIFF
--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -7,9 +7,9 @@ import {
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import {
-	CompactCard,
 	FormInputValidation as FormTextValidation,
 	FormLabel,
+	Button,
 } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { pick } from 'lodash';
@@ -19,7 +19,7 @@ import cloudflareIllustration from 'calypso/assets/images/illustrations/cloudfla
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { PanelHeading, PanelSection } from 'calypso/sites/components/panel';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -144,29 +144,17 @@ export function CloudflareAnalyticsSettings( {
 		);
 		return (
 			<form id="analytics" onSubmit={ handleSubmitForm }>
-				<SettingsSectionHeader
-					disabled={ isSubmitButtonDisabled }
-					isSaving={ isSavingSettings }
-					onButtonClick={ handleSubmitForm }
-					showButton
-					title={ translate( 'Cloudflare' ) }
-				/>
-
-				<CompactCard>
+				<>
+					<PanelHeading>{ translate( 'Cloudflare Web Analytics' ) }</PanelHeading>
 					<div className="analytics site-settings__analytics">
 						<div className="analytics site-settings__analytics-illustration">
 							<img src={ cloudflareIllustration } alt="" />
 						</div>
 						<div className="analytics site-settings__analytics-text">
-							<p className="analytics site-settings__analytics-title">
-								{ translate( 'Cloudflare Web Analytics' ) }
-							</p>
 							<p>
 								{ translate(
 									"Privacy-first metrics with unmatched accuracy that won't track your visitors."
-								) }
-							</p>
-							<p>
+								) }{ ' ' }
 								<a
 									onClick={ recordSupportLinkClick }
 									href="https://www.cloudflare.com/pg-lp/cloudflare-for-wordpress-dot-com?utm_source=wordpress.com&utm_medium=affiliate&utm_campaign=paygo_2021-02_a8_pilot&utm_content=traffic"
@@ -207,11 +195,11 @@ export function CloudflareAnalyticsSettings( {
 							) }
 						</FormFieldset>
 					) }
-				</CompactCard>
+				</>
 				{ showUpgradeNudge && site && site.plan ? (
 					nudge
 				) : (
-					<CompactCard>
+					<>
 						<div className="analytics site-settings__analytics">
 							<ToggleControl
 								checked={ isCloudflareEnabled }
@@ -220,9 +208,16 @@ export function CloudflareAnalyticsSettings( {
 								label={ translate( 'Add Cloudflare' ) }
 							/>
 						</div>
-					</CompactCard>
+						<Button
+							className="is-primary"
+							disabled={ isSubmitButtonDisabled }
+							busy={ isSavingSettings }
+							onClick={ handleSubmitForm }
+						>
+							{ translate( 'Save' ) }
+						</Button>
+					</>
 				) }
-				<div className="analytics site-settings__analytics-spacer" />
 			</form>
 		);
 	};
@@ -232,7 +227,7 @@ export function CloudflareAnalyticsSettings( {
 	if ( ! site ) {
 		return null;
 	}
-	return renderForm();
+	return <PanelSection>{ renderForm() }</PanelSection>;
 }
 
 const mapStateToProps = ( state ) => {

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -3,9 +3,9 @@ import {
 	PLAN_JETPACK_SECURITY_DAILY,
 } from '@automattic/calypso-products';
 import {
-	CompactCard,
 	FormInputValidation as FormTextValidation,
 	FormLabel,
+	Button,
 } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
@@ -22,7 +22,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import SupportInfo from 'calypso/components/support-info';
 import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { PanelHeading, PanelSection } from 'calypso/sites/components/panel';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSiteSettings } from 'calypso/state/site-settings/actions';
@@ -133,29 +133,17 @@ const GoogleAnalyticsJetpackForm = ( {
 			>
 				<QueryJetpackModules siteId={ siteId } />
 
-				<SettingsSectionHeader
-					disabled={ isSubmitButtonDisabled }
-					isSaving={ isSavingSettings }
-					onButtonClick={ handleSubmitFormCustom }
-					showButton
-					title={ translate( 'Google' ) }
-				/>
-
-				<CompactCard>
+				<>
+					<PanelHeading>{ translate( 'Google Analytics' ) }</PanelHeading>
 					<div className="analytics site-settings__analytics">
 						<div className="analytics site-settings__analytics-illustration">
 							<img src={ googleIllustration } alt="" />
 						</div>
 						<div className="analytics site-settings__analytics-text">
-							<p className="analytics site-settings__analytics-title">
-								{ translate( 'Google Analytics' ) }
-							</p>
 							<p>
 								{ translate(
 									'A free analytics tool that offers additional insights into your site.'
-								) }
-							</p>
-							<p>
+								) }{ ' ' }
 								<a
 									onClick={ recordSupportLinkClick }
 									href={ analyticsSupportUrl }
@@ -246,7 +234,7 @@ const GoogleAnalyticsJetpackForm = ( {
 							</p>
 						</div>
 					) }
-				</CompactCard>
+				</>
 				{ showUpgradeNudge && site && site.plan ? (
 					<UpsellNudge
 						description={ translate(
@@ -260,7 +248,7 @@ const GoogleAnalyticsJetpackForm = ( {
 						title={ nudgeTitle }
 					/>
 				) : (
-					<CompactCard>
+					<>
 						<div className="analytics site-settings__analytics">
 							<FormFieldset>
 								<SupportInfo
@@ -284,9 +272,17 @@ const GoogleAnalyticsJetpackForm = ( {
 								) }
 							</FormFieldset>
 						</div>
-					</CompactCard>
+
+						<Button
+							className="is-primary"
+							disabled={ isSubmitButtonDisabled }
+							busy={ isSavingSettings }
+							onClick={ handleSubmitFormCustom }
+						>
+							{ translate( 'Save' ) }
+						</Button>
+					</>
 				) }
-				<div className="analytics site-settings__analytics-spacer" />
 			</form>
 		);
 	};
@@ -296,6 +292,6 @@ const GoogleAnalyticsJetpackForm = ( {
 	if ( ! site ) {
 		return null;
 	}
-	return renderForm();
+	return <PanelSection>{ renderForm() }</PanelSection>;
 };
 export default GoogleAnalyticsJetpackForm;

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -6,9 +6,9 @@ import {
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import {
-	CompactCard,
 	FormInputValidation as FormTextValidation,
 	FormLabel,
+	Button,
 } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
@@ -18,7 +18,7 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { PanelHeading, PanelSection } from 'calypso/sites/components/panel';
 
 import './style.scss';
 
@@ -89,29 +89,17 @@ const GoogleAnalyticsSimpleForm = ( {
 				id="analytics"
 				onSubmit={ handleSubmitForm }
 			>
-				<SettingsSectionHeader
-					disabled={ isSubmitButtonDisabled }
-					isSaving={ isSavingSettings }
-					onButtonClick={ handleSubmitForm }
-					showButton
-					title={ translate( 'Google' ) }
-				/>
-
-				<CompactCard>
+				<>
+					<PanelHeading>{ translate( 'Google Analytics' ) }</PanelHeading>
 					<div className="analytics site-settings__analytics">
 						<div className="analytics site-settings__analytics-illustration">
 							<img src={ googleIllustration } alt="" />
 						</div>
 						<div className="analytics site-settings__analytics-text">
-							<p className="analytics site-settings__analytics-title">
-								{ translate( 'Google Analytics' ) }
-							</p>
 							<p>
 								{ translate(
 									'A free analytics tool that offers additional insights into your site.'
-								) }
-							</p>
-							<p>
+								) }{ ' ' }
 								<a
 									onClick={ recordSupportLinkClick }
 									href={ analyticsSupportUrl }
@@ -177,11 +165,11 @@ const GoogleAnalyticsSimpleForm = ( {
 							</p>
 						</div>
 					) }
-				</CompactCard>
+				</>
 				{ showUpgradeNudge && site && site.plan ? (
 					nudge
 				) : (
-					<CompactCard>
+					<>
 						<div className="analytics site-settings__analytics">
 							<ToggleControl
 								checked={ displayForm }
@@ -190,9 +178,16 @@ const GoogleAnalyticsSimpleForm = ( {
 								label={ translate( 'Add Google' ) }
 							/>
 						</div>
-					</CompactCard>
+						<Button
+							className="is-primary"
+							disabled={ isSubmitButtonDisabled }
+							busy={ isSavingSettings }
+							onClick={ handleSubmitForm }
+						>
+							{ translate( 'Save' ) }
+						</Button>
+					</>
 				) }
-				<div className="analytics site-settings__analytics-spacer" />
 			</form>
 		);
 	};
@@ -202,7 +197,7 @@ const GoogleAnalyticsSimpleForm = ( {
 	if ( ! site ) {
 		return null;
 	}
-	return renderForm();
+	return <PanelSection>{ renderForm() }</PanelSection>;
 };
 
 export default GoogleAnalyticsSimpleForm;

--- a/client/my-sites/site-settings/analytics/style.scss
+++ b/client/my-sites/site-settings/analytics/style.scss
@@ -1,7 +1,20 @@
+#analytics {
+	button {
+		float: unset;
+		margin-top: 10px;
+	}
+
+	.form-fieldset {
+		margin-top: 16px;
+	}
+}
+
 .site-settings__analytics {
 	display: flex;
 	flex-direction: row;
 	align-items: flex-start;
+	margin-bottom: 12px;
+	margin-top: 16px;
 	.support-info {
 		position: absolute;
 		right: 24px;
@@ -11,16 +24,10 @@
 .site-settings__analytics-text {
 	margin-left: 20px;
 	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 2rem;
+	line-height: 1rem;
 }
 .site-settings__analytics-text p {
 	margin: 0;
-}
-
-.site-settings__analytics-title {
-	font-weight: 600;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 1rem;
 }
 
 .site-settings__analytics-illustration {

--- a/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
+++ b/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
@@ -8,7 +8,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const JetpackDevModeNotice = ( { isJetpackSiteInDevMode, siteId, siteIsJetpack, translate } ) => {
-	if ( ! siteIsJetpack ) {
+	if ( ! siteIsJetpack || ! isJetpackSiteInDevMode ) {
 		return null;
 	}
 

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -1,11 +1,10 @@
 import { FEATURE_ADVANCED_SEO } from '@automattic/calypso-products';
-import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { PanelHeading, PanelSection } from 'calypso/sites/components/panel';
 import getJetpackModules from 'calypso/state/selectors/get-jetpack-modules';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -23,10 +22,10 @@ export const SeoSettingsHelpCard = ( {
 		: 'https://wpbizseo.wordpress.com/';
 
 	return (
-		<div id="seo">
-			<SettingsSectionHeader title={ translate( 'Search engine optimization' ) } />
+		<PanelSection>
+			<PanelHeading>{ translate( 'Search engine optimization' ) }</PanelHeading>
 			{ hasAdvancedSEOFeature && (
-				<Card className="seo-settings__help">
+				<>
 					<p>
 						{ translate(
 							'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
@@ -50,9 +49,9 @@ export const SeoSettingsHelpCard = ( {
 							disabled={ disabled }
 						/>
 					) }
-				</Card>
+				</>
 			) }
-		</div>
+		</PanelSection>
 	);
 };
 

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -1,4 +1,4 @@
-import { Card, FormInputValidation } from '@automattic/components';
+import { Button, FormInputValidation } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get, omit } from 'lodash';
 import { Component } from 'react';
@@ -13,7 +13,7 @@ import SupportInfo from 'calypso/components/support-info';
 import { protectForm } from 'calypso/lib/protect-form';
 import versionCompare from 'calypso/lib/version-compare';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { PanelHeading, PanelSection } from 'calypso/sites/components/panel';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
@@ -271,26 +271,26 @@ class SiteVerification extends Component {
 		} );
 
 		return (
-			<div className="seo-settings__site-verification">
+			<PanelSection className="seo-settings__site-verification">
 				<QuerySiteSettings siteId={ siteId } />
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
-				<SettingsSectionHeader
-					disabled={ isSaveDisabled || isVerificationDisabled }
-					isSaving={ isSubmittingForm }
-					onButtonClick={ this.handleFormSubmit }
-					showButton
-					title={ translate( 'Site verification services' ) }
-				/>
-				<Card>
+				<PanelHeading>
+					{ translate( 'Site verification services' ) }
 					{ siteIsJetpack && (
-						<FormFieldset>
+						<>
 							<SupportInfo
 								text={ translate(
 									'Provides the necessary hidden tags needed to verify your WordPress site with various services.'
 								) }
 								link="https://jetpack.com/support/site-verification-tools/"
 							/>
+						</>
+					) }
+				</PanelHeading>
+				<>
+					{ siteIsJetpack && (
+						<FormFieldset>
 							<JetpackModuleToggle
 								siteId={ siteId }
 								moduleSlug="verification-tools"
@@ -299,7 +299,6 @@ class SiteVerification extends Component {
 							/>
 						</FormFieldset>
 					) }
-
 					<p>
 						{ translate(
 							'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order' +
@@ -347,9 +346,17 @@ class SiteVerification extends Component {
 								{ this.hasError( service.slug ) && this.getVerificationError( showPasteError ) }
 							</FormFieldset>
 						) ) }
+						<Button
+							className="is-primary"
+							disabled={ isSaveDisabled || isVerificationDisabled }
+							busy={ isSubmittingForm }
+							onClick={ this.handleFormSubmit }
+						>
+							{ translate( 'Save' ) }
+						</Button>
 					</form>
-				</Card>
-			</div>
+				</>
+			</PanelSection>
 		);
 	}
 }

--- a/client/my-sites/site-settings/seo-settings/style.scss
+++ b/client/my-sites/site-settings/seo-settings/style.scss
@@ -1,5 +1,5 @@
 .seo-settings__seo-upsell.upsell-nudge {
-	margin-top: -18px;
+	margin-top: -30px;
 	margin-left: 1px;
 	margin-right: 1px;
 	margin-bottom: 16px;

--- a/client/my-sites/site-settings/seo-settings/style.scss
+++ b/client/my-sites/site-settings/seo-settings/style.scss
@@ -1,3 +1,20 @@
+.seo-settings__seo-upsell.upsell-nudge {
+	margin-top: -18px;
+	margin-left: 1px;
+	margin-right: 1px;
+	margin-bottom: 16px;
+}
+
+.seo-settings__seo-form {
+	button.is-primary {
+		float: unset !important;
+	}
+
+	.panel-section {
+		margin-bottom: 16px;
+	}
+}
+
 .seo-settings__page-title-header {
 	display: flex;
 	justify-content: center;

--- a/client/my-sites/site-settings/shortlinks.jsx
+++ b/client/my-sites/site-settings/shortlinks.jsx
@@ -1,4 +1,3 @@
-import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -6,7 +5,7 @@ import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { PanelHeading, PanelSection } from 'calypso/sites/components/panel';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
@@ -36,18 +35,18 @@ class Shortlinks extends Component {
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div>
-				<SettingsSectionHeader title={ translate( 'WP.me Shortlinks' ) } />
-
-				<Card className="shortlinks__card site-settings site-settings__traffic-settings">
-					<FormFieldset>
+			<PanelSection>
+				<>
+					<PanelHeading>
+						{ translate( 'WP.me Shortlinks' ) }
 						<SupportInfo
 							text={ translate(
 								'Generates shorter links so you can have more space to write on social media sites.'
 							) }
 							link="https://jetpack.com/support/wp-me-shortlinks/"
 						/>
-
+					</PanelHeading>
+					<FormFieldset>
 						<JetpackModuleToggle
 							siteId={ selectedSiteId }
 							moduleSlug="shortlinks"
@@ -55,8 +54,8 @@ class Shortlinks extends Component {
 							disabled={ formPending }
 						/>
 					</FormFieldset>
-				</Card>
-			</div>
+				</>
+			</PanelSection>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -1,4 +1,4 @@
-import { Card } from '@automattic/components';
+import { isEnabled } from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -10,7 +10,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { PanelHeading, PanelSection } from 'calypso/sites/components/panel';
 import getJetpackModule from 'calypso/state/selectors/get-jetpack-module';
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -42,7 +42,12 @@ class Sitemaps extends Component {
 	renderSitemapLink( sitemapUrl ) {
 		return (
 			<div key={ sitemapUrl }>
-				<ExternalLink href={ sitemapUrl } icon target="_blank">
+				<ExternalLink
+					href={ sitemapUrl }
+					icon
+					target="_blank"
+					style={ { overflowWrap: 'anywhere' } }
+				>
 					{ sitemapUrl }
 				</ExternalLink>
 			</div>
@@ -85,7 +90,15 @@ class Sitemaps extends Component {
 						'You must set your {{a}}privacy settings{{/a}} to "public".',
 					{
 						components: {
-							a: <a href={ '/settings/general/' + siteSlug } />,
+							a: (
+								<a
+									href={
+										isEnabled( 'untangling/hosting-menu' )
+											? '/sites/settings/site/' + siteSlug
+											: '/settings/general/' + siteSlug
+									}
+								/>
+							),
 						},
 					}
 				) }
@@ -99,8 +112,6 @@ class Sitemaps extends Component {
 
 		return (
 			<div>
-				{ this.renderInfoLink( localizeUrl( 'https://wordpress.com/support/sitemaps/' ), false ) }
-
 				{ this.isSitePublic() ? (
 					<div>
 						{ this.renderSitemapExplanation() }
@@ -161,8 +172,6 @@ class Sitemaps extends Component {
 
 		return (
 			<FormFieldset>
-				{ this.renderInfoLink( 'https://jetpack.com/support/sitemaps/' ) }
-
 				<JetpackModuleToggle
 					siteId={ siteId }
 					moduleSlug="sitemaps"
@@ -179,15 +188,21 @@ class Sitemaps extends Component {
 		const { siteId, siteIsJetpack, translate } = this.props;
 
 		return (
-			<div>
+			<PanelSection>
 				{ siteId && <QueryJetpackConnection siteId={ siteId } /> }
 
-				<SettingsSectionHeader title={ translate( 'Sitemaps' ) } />
+				<PanelHeading>
+					{ translate( 'Sitemaps' ) }
+					{ siteIsJetpack
+						? this.renderInfoLink( 'https://jetpack.com/support/sitemaps/' )
+						: this.renderInfoLink(
+								localizeUrl( 'https://wordpress.com/support/sitemaps/' ),
+								false
+						  ) }
+				</PanelHeading>
 
-				<Card className="sitemaps__card site-settings__traffic-settings">
-					{ siteIsJetpack ? this.renderJetpackSettings() : this.renderWpcomSettings() }
-				</Card>
-			</div>
+				{ siteIsJetpack ? this.renderJetpackSettings() : this.renderWpcomSettings() }
+			</PanelSection>
 		);
 	}
 }

--- a/client/sites/components/panel-sidebar/style.scss
+++ b/client/sites/components/panel-sidebar/style.scss
@@ -17,7 +17,8 @@
 		font-size: 0.875rem;
 	}
 
-	> div:not(:first-child) {
+	> div:not(:first-child),
+	> main:not(:first-child) {
 		width: 100%;
 	}
 

--- a/client/sites/components/panel/style.scss
+++ b/client/sites/components/panel/style.scss
@@ -5,6 +5,10 @@
 	font-size: 0.875rem;
 	align-items: flex-start;
 
+	&.main {
+		margin: 0;
+	}
+
 	.header-cake__back {
 		padding: 0;
 	}
@@ -13,6 +17,7 @@
 .panel-section {
 	box-sizing: border-box;
 	background-color: #fff;
+	width: 100%;
 
 	&.panel-section--borderless{
 		margin-top: 24px;
@@ -39,5 +44,9 @@
 	.form-text-input,
 	.form-select {
 		font-size: rem(14px) !important;
+	}
+
+	.upsell-nudge {
+		margin: 0 -22px -22px -22px !important;
 	}
 }

--- a/client/sites/marketing/sharing/appearance.jsx
+++ b/client/sites/marketing/sharing/appearance.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import SupportInfo from 'calypso/components/support-info';
+import { PanelSection } from 'calypso/sites/components/panel';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
@@ -157,7 +158,7 @@ class SharingButtonsAppearance extends Component {
 		// Disable classname namespace because `sharing-buttons` makes the most sense here
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div className="sharing-buttons__panel sharing-buttons-appearance">
+			<PanelSection className="sharing-buttons-appearance">
 				<p className="sharing-buttons-appearance__description">
 					{ this.props.translate(
 						'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.'
@@ -184,7 +185,7 @@ class SharingButtonsAppearance extends Component {
 						? this.props.translate( 'Saving…' )
 						: this.props.translate( 'Save changes' ) }
 				</button>
-			</div>
+			</PanelSection>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}

--- a/client/sites/marketing/sharing/components/buttons-block-appearance.jsx
+++ b/client/sites/marketing/sharing/components/buttons-block-appearance.jsx
@@ -1,9 +1,11 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import ExternalLink from 'calypso/components/external-link';
+import { PanelSection } from 'calypso/sites/components/panel';
 import { useSelector } from 'calypso/state';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import SharingButtonsPreviewButtons from '../preview-buttons';
+
 import './style.scss';
 
 const buttons = [
@@ -23,7 +25,7 @@ const ButtonsBlockAppearance = ( { isJetpack, translate, siteId } ) => {
 	);
 
 	return (
-		<div className="sharing-buttons__panel sharing-buttons-appearance">
+		<PanelSection>
 			<p className="sharing-buttons-appearance__description">
 				{ translate(
 					'Allow readers to easily share your posts with others by adding a sharing buttons block anywhere in one of your site’s templates.'
@@ -40,7 +42,7 @@ const ButtonsBlockAppearance = ( { isJetpack, translate, siteId } ) => {
 			</div>
 			<p className="sharing-buttons__example-text">{ translate( 'Sharing Buttons example:' ) }</p>
 			<SharingButtonsPreviewButtons buttons={ buttons } style="icon-text" />
-		</div>
+		</PanelSection>
 	);
 };
 

--- a/client/sites/marketing/sharing/index.tsx
+++ b/client/sites/marketing/sharing/index.tsx
@@ -1,17 +1,24 @@
 import { useTranslate } from 'i18n-calypso';
+import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
+import { Panel } from 'calypso/sites/components/panel';
+import { useSelector } from 'calypso/state';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import {
 	getSiteAdminUrl,
 	isAdminInterfaceWPAdmin,
 	isJetpackSite,
 } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SharingButtons from './buttons';
+
+import './style.scss';
 
 export default function MarketingSharing() {
 	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
 	const isJetpack = useSelectedSiteSelector( isJetpackSite );
 	const adminInterfaceIsWPAdmin = useSelectedSiteSelector( isAdminInterfaceWPAdmin );
 	const siteAdminUrl = useSelectedSiteSelector( getSiteAdminUrl );
@@ -29,7 +36,8 @@ export default function MarketingSharing() {
 	};
 
 	return (
-		<div className="marketing-sharing">
+		<Panel className="marketing-sharing">
+			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 			<NavigationHeader
 				title={ translate( 'Sharing' ) }
 				subtitle={ translate(
@@ -44,6 +52,6 @@ export default function MarketingSharing() {
 				) }
 			/>
 			{ isJetpack && adminInterfaceIsWPAdmin ? renderNotice() : <SharingButtons /> }
-		</div>
+		</Panel>
 	);
 }

--- a/client/sites/marketing/sharing/options.jsx
+++ b/client/sites/marketing/sharing/options.jsx
@@ -11,6 +11,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import MultiCheckbox from 'calypso/components/forms/multi-checkbox';
 import SupportInfo from 'calypso/components/support-info';
+import { PanelSection } from 'calypso/sites/components/panel';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPostTypes } from 'calypso/state/post-types/selectors';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
@@ -259,7 +260,7 @@ class SharingButtonsOptions extends Component {
 
 		return (
 			<Fragment>
-				<div className="sharing-buttons__panel">
+				<PanelSection className="sharing-buttons__panel">
 					{ siteId && <QueryPostTypes siteId={ siteId } /> }
 					<div className="sharing-buttons__fieldset-group">
 						{ this.getSharingShowOptionsElement() }
@@ -274,7 +275,7 @@ class SharingButtonsOptions extends Component {
 					>
 						{ saving ? translate( 'Saving…' ) : translate( 'Save changes' ) }
 					</button>
-				</div>
+				</PanelSection>
 			</Fragment>
 		);
 	}

--- a/client/sites/marketing/sharing/style.scss
+++ b/client/sites/marketing/sharing/style.scss
@@ -1,0 +1,5 @@
+.marketing-sharing {
+	form {
+		width: 100%;
+	}
+}

--- a/client/sites/marketing/traffic/index.tsx
+++ b/client/sites/marketing/traffic/index.tsx
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
+import { Panel } from 'calypso/sites/components/panel';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import {
 	getSiteAdminUrl,
@@ -29,7 +30,7 @@ export default function MarketingTraffic() {
 	};
 
 	return (
-		<div className="marketing-traffic">
+		<Panel className="marketing-traffic">
 			<NavigationHeader
 				title={ translate( 'Traffic' ) }
 				subtitle={ translate(
@@ -44,6 +45,6 @@ export default function MarketingTraffic() {
 				) }
 			/>
 			{ isJetpack && adminInterfaceIsWPAdmin ? renderNotice() : <Traffic /> }
-		</div>
+		</Panel>
 	);
 }

--- a/client/sites/marketing/traffic/style.scss
+++ b/client/sites/marketing/traffic/style.scss
@@ -285,12 +285,20 @@
 }
 
 .settings-traffic {
+	.promo-card-block {
+		margin-top: 0;
+	}
+
 	.promo-card-block .button {
 		float: none;
 	}
 
 	.promo-card-block img {
 		max-width: 170px;
+	}
+
+	.panel-section {
+		margin-bottom: 16px;
 	}
 
 	#analytics {

--- a/client/sites/marketing/traffic/traffic.js
+++ b/client/sites/marketing/traffic/traffic.js
@@ -7,7 +7,6 @@ import blazeIllustration from 'calypso/assets/images/customer-home/illustration-
 import PromoCardBlock from 'calypso/blocks/promo-card-block';
 import AsyncLoad from 'calypso/components/async-load';
 import EmptyContent from 'calypso/components/empty-content';
-import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
 import CloudflareAnalyticsSettings from 'calypso/my-sites/site-settings/analytics/form-cloudflare-analytics';
@@ -52,7 +51,7 @@ const SiteSettingsTraffic = ( {
 
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-		<Main className="settings-traffic site-settings" wideLayout>
+		<div className="settings-traffic site-settings">
 			<PageViewTracker path="/marketing/traffic/:site" title="Marketing > Traffic" />
 			{ ! isAdmin && (
 				<EmptyContent
@@ -115,7 +114,7 @@ const SiteSettingsTraffic = ( {
 				/>
 			) }
 			{ isAdmin && <SiteVerification /> }
-		</Main>
+		</div>
 	);
 };
 

--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -66,7 +66,7 @@ export class MarketingPage {
 	 *
 	 */
 	async saveSettings() {
-		await this.page.getByRole( 'button', { name: 'Save settings' } ).first().click();
+		await this.page.getByRole( 'button', { name: 'Save' } ).first().click();
 
 		await this.page.waitForResponse( /settings/ );
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9858
Fixes https://github.com/Automattic/dotcom-forge/issues/9859

## Proposed Changes

This PR applies the new global view design (almost) to Marketing -> {Traffic, Sharing}.

### Traffic

|Before|After|
|-|-|
|<img width="418" alt="image" src="https://github.com/user-attachments/assets/beec0827-c1e1-42b7-8a9c-ef991646becd">|<img width="415" alt="image" src="https://github.com/user-attachments/assets/eccd86c2-ac25-49b6-a281-8a51840bf375">

#### NOTE!!

I didn't touch this "component". Will do it when updating the Connections subtab, because it's a shared component.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/a59c9a5c-1dc8-428e-8c6a-37051e631967">


### Sharing

Almost no visible visual changes except border radius...

## Why are these changes being made?

pbxlJb-6ye-p2

## Testing Instructions

1. Go to /sites
2. Select a Simple site
3. Go to Marketing -> Traffic and Marketing -> Sharing, try to break them
4. Select an Atomic Default site
5. Go to Marketing -> Traffic and Marketing -> Sharing, try to break them
6. Select an Atomic Classic site
7. Go to Marketing -> Traffic and Marketing -> Sharing, verify that only the Jetpack links are shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?