### PR TITLE
Site Migration flows should redirect to home instead of /start

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -21,7 +21,7 @@ import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, SITE_STORE, ONBOARD_STORE } from '../stores';
 import { goToCheckout } from '../utils/checkout';
 import { STEPS } from './internals/steps';
-import { getSiteIdParam, redirect } from './internals/steps-repository/import/util';
+import { getSiteIdParam } from './internals/steps-repository/import/util';
 import { type SiteMigrationIdentifyAction } from './internals/steps-repository/site-migration-identify';
 import { AssertConditionState } from './internals/types';
 import { goToImporter } from './migration/helpers';
@@ -80,7 +80,7 @@ const siteMigration: Flow = {
 		}, [ isAdmin ] );
 
 		if ( userIsLoggedIn && ! siteSlug && ! siteId && ! isHostedSiteMigrationFlow( flowPath ) ) {
-			redirect( '/' );
+			window.location.assign( '/' );
 			return {
 				state: AssertConditionState.FAILURE,
 				message: 'site-migration does not have the site slug or site id.',

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -21,7 +21,7 @@ import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, SITE_STORE, ONBOARD_STORE } from '../stores';
 import { goToCheckout } from '../utils/checkout';
 import { STEPS } from './internals/steps';
-import { getSiteIdParam } from './internals/steps-repository/import/util';
+import { getSiteIdParam, redirect } from './internals/steps-repository/import/util';
 import { type SiteMigrationIdentifyAction } from './internals/steps-repository/site-migration-identify';
 import { AssertConditionState } from './internals/types';
 import { goToImporter } from './migration/helpers';
@@ -79,24 +79,8 @@ const siteMigration: Flow = {
 			}
 		}, [ isAdmin ] );
 
-		useEffect( () => {
-			// We don't need to do anything if the user isn't logged in.
-			if ( ! userIsLoggedIn ) {
-				return;
-			}
-
-			if ( siteSlug || siteId ) {
-				return;
-			}
-
-			if ( isHostedSiteMigrationFlow( flowPath ) ) {
-				return;
-			}
-
-			window.location.assign( '/start' );
-		}, [ flowPath, siteId, siteSlug, userIsLoggedIn, isAdmin ] );
-
-		if ( ! siteSlug && ! siteId && ! isHostedSiteMigrationFlow( flowPath ) ) {
+		if ( userIsLoggedIn && ! siteSlug && ! siteId && ! isHostedSiteMigrationFlow( flowPath ) ) {
+			redirect( '/' );
 			return {
 				state: AssertConditionState.FAILURE,
 				message: 'site-migration does not have the site slug or site id.',

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -56,7 +56,7 @@ describe( 'Site Migration Flow', () => {
 	} );
 
 	describe( 'useAssertConditions', () => {
-		it( 'redirects the user to the start page when there is not siteSlug and SiteID', () => {
+		it( 'redirects the user to home when there is not siteSlug and SiteID', () => {
 			const { runUseAssertionCondition } = renderFlow( siteMigrationFlow );
 
 			runUseAssertionCondition( {
@@ -64,7 +64,7 @@ describe( 'Site Migration Flow', () => {
 				currentURL: `/setup/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }?siteSlug=&siteId=`,
 			} );
 
-			expect( window.location.assign ).toHaveBeenCalledWith( '/start' );
+			expect( window.location.assign ).toHaveBeenCalledWith( '/' );
 		} );
 
 		it( 'redirects the user to the start page when the user is not the site admin', () => {

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -38,14 +38,6 @@ describe( 'Site Migration Flow', () => {
 
 	beforeEach( () => {
 		( window.location.assign as jest.Mock ).mockClear();
-
-		delete global.window.location;
-		global.window.location = {
-			href: 'http://wwww.example.com',
-			origin: 'http://www.example.com',
-			assign: jest.fn(),
-		};
-
 		( isCurrentUserLoggedIn as jest.Mock ).mockReturnValue( true );
 		( useIsSiteAdmin as jest.Mock ).mockReturnValue( {
 			isAdmin: true,
@@ -72,7 +64,7 @@ describe( 'Site Migration Flow', () => {
 				currentURL: `/setup/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }?siteSlug=&siteId=`,
 			} );
 
-			expect( global.window.location.href ).toBe( '/' );
+			expect( window.location.assign ).toHaveBeenCalledWith( '/' );
 		} );
 
 		it( 'redirects the user to the start page when the user is not the site admin', () => {

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -38,6 +38,14 @@ describe( 'Site Migration Flow', () => {
 
 	beforeEach( () => {
 		( window.location.assign as jest.Mock ).mockClear();
+
+		delete global.window.location;
+		global.window.location = {
+			href: 'http://wwww.example.com',
+			origin: 'http://www.example.com',
+			assign: jest.fn(),
+		};
+
 		( isCurrentUserLoggedIn as jest.Mock ).mockReturnValue( true );
 		( useIsSiteAdmin as jest.Mock ).mockReturnValue( {
 			isAdmin: true,
@@ -64,7 +72,7 @@ describe( 'Site Migration Flow', () => {
 				currentURL: `/setup/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }?siteSlug=&siteId=`,
 			} );
 
-			expect( window.location.assign ).toHaveBeenCalledWith( '/' );
+			expect( global.window.location.href ).toBe( '/' );
 		} );
 
 		it( 'redirects the user to the start page when the user is not the site admin', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9709#issuecomment-2488150145

## Proposed Changes

Instead of redirecting the users to /start, when there is not site id or site slug, we redirect them to /home as it is done in the `site-setup` flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When you remove the siteSlug/siteId in the /setup/site-setup steps, you get redirected to the primary site.
However, when you remove the siteSlug/siteId in the /setup/site-migration/site-migration-identify step, you get redirected to the Domains step, and potentially create a new site if you continue the flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through onboarding (/start)
* After domains and plans, select "Import existing content or website"
* Try to remove the site slug from the url
* You should land in /home
