### PR TITLE
Copy Site: Navigate to business checkout to add the plan when copying a site

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -130,7 +130,7 @@ const copySite: Flow = {
 					setSignupCompleteFlowName( flowName );
 					const returnUrl = encodeURIComponent( destination );
 					return window.location.assign(
-						`/checkout/${ encodeURIComponent(
+						`/checkout/business/${ encodeURIComponent(
 							( siteSlug as string ) ?? ''
 						) }?redirect_to=${ returnUrl }&signup=1`
 					);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96590

## Proposed Changes

* Quick fix to add business plan to the cart when copying a site

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Copy Site stepper flow is broken and the cart appears empty

Not sure if this is the best solution. We may want to add the plan calling the right function, or displaying the Business+ plans for the user to select them.


| Before | After |
|--------|--------|
|  <img width="1279" alt="Screenshot 2024-11-20 at 18 00 07" src="https://github.com/user-attachments/assets/3b0fd7d1-ad06-49f5-b624-36e9f201e131"> | <img width="1519" alt="Screenshot 2024-11-20 at 17 59 40" src="https://github.com/user-attachments/assets/b6febbb6-bcd5-4376-aecd-03b8a8fcb5eb"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On your localhost or calypso live, access `/sites`
* Select a atomic site and click the three dots
* Select `Copy site` to start the flow
* Enter some domain name and select a free domain to finish the flow. You can also try selecting a domain to purchase.
* Complete the process
* Observe you land in your new site and a banner displays the site was successfully copied.
* Access the frontend and confirm the site was indeed copied


![image](https://github.com/user-attachments/assets/c5aa876b-db1d-4c9c-a8c4-cdfc4523d03e)



https://github.com/user-attachments/assets/6e2ef981-8e3d-4017-bb83-59608094b8d9



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?