### PR TITLE
Stats: fix UTM upsell overlay link

### DIFF
--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
@@ -6,6 +6,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { SUPPORT_URL, INSIGHTS_SUPPORT_URL } from 'calypso/my-sites/stats/const';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
@@ -53,13 +54,32 @@ const insightsSupportLinkWithAnchor = ( anchor: string ) => {
 	);
 };
 
-const useUpsellCopy = ( statType: string ) => {
+const utmLearnMoreLink = ( isOdysseyStats: boolean ) => {
+	return isOdysseyStats ? (
+		<a
+			href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
+			target="_blank"
+			rel="noopenner noreferrer"
+		/>
+	) : (
+		<InlineSupportLink supportContext="stats" showIcon={ false } />
+	);
+};
+
+const useUpsellCopy = ( statType: string, isOdysseyStats: boolean ) => {
 	const translate = useTranslate();
 	switch ( statType ) {
 		case STATS_FEATURE_DATE_CONTROL:
 			return translate( 'Compare different time periods to analyze your site’s growth.' );
 		case STATS_FEATURE_UTM_STATS:
-			return translate( 'Generate UTM parameters and track your campaign performance data.' );
+			return translate(
+				'Generate UTM parameters and track your campaign performance data. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: utmLearnMoreLink( isOdysseyStats ),
+					},
+				}
+			);
 		case STATS_TYPE_DEVICE_STATS:
 			return translate( 'See which devices your visitors are using.' );
 		case STAT_TYPE_TOP_POSTS:
@@ -144,7 +164,7 @@ const useUpsellCopy = ( statType: string ) => {
 const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteId, statType } ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	const copyText = useUpsellCopy( statType );
+	const copyText = useUpsellCopy( statType, isOdysseyStats );
 
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
@@ -62,7 +62,7 @@ const utmLearnMoreLink = ( isOdysseyStats: boolean ) => {
 			rel="noopenner noreferrer"
 		/>
 	) : (
-		<InlineSupportLink supportContext="stats" showIcon={ false } />
+		<InlineSupportLink supportContext="utm-upsell-overlay" showIcon={ false } />
 	);
 };
 

--- a/client/my-sites/stats/stats-details-navigation/index.tsx
+++ b/client/my-sites/stats/stats-details-navigation/index.tsx
@@ -33,14 +33,17 @@ function StatsDetailsNavigation( { postId, period, statType, givenSiteId }: prop
 					? `email/${ item }/${ period }`
 					: `post`;
 				const attr = {
-					key: item,
 					path: `/stats/${ pathParam }/${ postId }/${ givenSiteId }`,
 					selected,
 				};
 				const label = tabs[ item as keyof typeof tabs ];
 
 				// uppercase first character of item
-				return <NavItem { ...attr }>{ label }</NavItem>;
+				return (
+					<NavItem key={ item } { ...attr }>
+						{ label }
+					</NavItem>
+				);
 			} );
 		},
 		[ tabs, selectedTab ]


### PR DESCRIPTION
Related to #87925 

## Proposed Changes
Implement "Learn more" link on the UTM upsell overlay. Odyssey won't render Calypso components, so we choose between the InlineSupportLink or a simple link to support page depending on the case.

## Why are these changes being made?
Ref: https://github.com/Automattic/red-team/issues/194
Ref: pe4Cmx-2SM-p2

Part of the PT/tasks assigned to Agora team https://github.com/Automattic/red-team/issues/203#event-15156617447

## Testing Instructions
The UTM card shows an overlay when no upgrade/plan is purchased. The overlay should now show a "Learn more" link.

On Calypso, it should open the floating support popup:
<img width="883" alt="image" src="https://github.com/user-attachments/assets/ca9ce631-ad3a-48b2-bdaf-87ecce962737">

On Jetpack Odyssey Stats it should open the support page in a new tab (see link address at the bottom):
<img width="641" alt="image" src="https://github.com/user-attachments/assets/1f084d24-b4a9-42b2-80d6-38e7860c6b51">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?