### PR TITLE
Stats: Add list quick action to view generated URL on UTM modal

### DIFF
--- a/client/my-sites/stats/stats-list/action-utm-builder.jsx
+++ b/client/my-sites/stats/stats-list/action-utm-builder.jsx
@@ -1,0 +1,41 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import { Icon, link } from '@wordpress/icons';
+import { localize } from 'i18n-calypso';
+import { PureComponent } from 'react';
+
+class StatsActionUTMBuilder extends PureComponent {
+	clickHandler = ( event ) => {
+		event.stopPropagation();
+		event.preventDefault();
+
+		// Click handler is provided by the UTMBuilder component
+		this.props.onClick?.();
+	};
+
+	render() {
+		return (
+			<li className="module-content-list-item-action">
+				<a
+					href="#"
+					onClick={ this.clickHandler }
+					className="module-content-list-item-action-wrapper"
+					title={ this.props.translate( 'View in UTM URL builder', {
+						textOnly: true,
+						context: 'Stats action tooltip: View in UTM URL builder',
+					} ) }
+					aria-label={ this.props.translate( 'View in UTM URL builder', {
+						textOnly: true,
+						context: 'Stats ARIA label: View in UTM URL builder',
+					} ) }
+				>
+					<Icon className="stats-icon" icon={ link } size={ 18 } />
+					<span className="module-content-list-item-action-label">
+						{ this.props.translate( 'URL' ) }
+					</span>
+				</a>
+			</li>
+		);
+	}
+}
+
+export default localize( StatsActionUTMBuilder );

--- a/client/my-sites/stats/stats-list/stats-list-actions.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-actions.jsx
@@ -4,11 +4,13 @@ import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 import titlecase from 'to-title-case';
+import UTMBuilder from '../stats-module-utm-builder/stats-module-utm-builder';
 import Follow from './action-follow';
 import OpenLink from './action-link';
 import Page from './action-page';
 import Promote from './action-promote';
 import Spam from './action-spam';
+import OpenUTMBuilder from './action-utm-builder';
 
 function useActionItems( { data, moduleName } ) {
 	return useMemo( () => {
@@ -51,6 +53,15 @@ function useActionItems( { data, moduleName } ) {
 					case 'link':
 						actionItem = (
 							<OpenLink href={ action.data } key={ action.type } moduleName={ moduleNameTitle } />
+						);
+						break;
+					case 'url-builder':
+						actionItem = (
+							<UTMBuilder
+								initialData={ action.data }
+								trigger={ <OpenUTMBuilder /> }
+								key={ action.type }
+							/>
 						);
 						break;
 				}

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -20,6 +20,15 @@ type InputFieldProps = {
 	ariaDescribedBy?: string;
 };
 
+export type UtmBuilderProps = {
+	initialData?: {
+		url?: string;
+		utm_source?: string;
+		utm_medium?: string;
+		utm_campaign?: string;
+	};
+};
+
 const utmKeys = [ 'url', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term' ];
 
 type UtmKeyType = ( typeof utmKeys )[ number ];
@@ -109,13 +118,13 @@ const InputField: React.FC< InputFieldProps > = ( {
 	);
 };
 
-const UtmBuilder: React.FC = () => {
+const UtmBuilder: React.FC< UtmBuilderProps > = ( { initialData } ) => {
 	const translate = useTranslate();
-	const [ url, setUrl ] = useState( '' );
+	const [ url, setUrl ] = useState( initialData?.url || '' );
 	const [ inputValues, setInputValues ] = useState< inputValuesType >( {
-		utm_source: '',
-		utm_medium: '',
-		utm_campaign: '',
+		utm_source: initialData?.utm_source || '',
+		utm_medium: initialData?.utm_medium || '',
+		utm_campaign: initialData?.utm_campaign || '',
 	} );
 	// Focus the initial input field when rendered.
 	const initialFieldReference = useRef< HTMLLabelElement >( null );

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -5,14 +5,15 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useRef } from 'react';
 import { trackStatsAnalyticsEvent } from '../utils';
-import StatsUtmBuilderForm from './stats-module-utm-builder-form';
+import StatsUtmBuilderForm, { type UtmBuilderProps } from './stats-module-utm-builder-form';
 
 interface Props {
 	modalClassName: string;
 	trigger?: React.ReactElement;
+	initialData?: UtmBuilderProps[ 'initialData' ];
 }
 
-const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger } ) => {
+const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData } ) => {
 	const [ isOpen, setOpen ] = useState< boolean | null >( null );
 	const scrollY = useRef( { y: 0, mobile: false } );
 
@@ -77,7 +78,7 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger } ) => {
 							<div className="stats-utm-builder__description">
 								{ translate( 'Generate URLs to share and track UTM parameters.' ) }
 							</div>
-							<StatsUtmBuilderForm />
+							<StatsUtmBuilderForm initialData={ initialData } />
 						</div>
 						<div className="stats-utm-builder__help">
 							<div className="stats-utm-builder__help-bg"></div>

--- a/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
+++ b/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
@@ -62,12 +62,12 @@ registerHandlers( 'state/data-layer/wpcom/sites/stats/utm-metrics/index.js', {
 	[ STATS_UTM_METRICS_REQUEST ]: [
 		dispatchRequest( {
 			fetch,
-			onSuccess: ( { siteId, postId, siteSlug }: AnyAction, data: object ) => {
+			onSuccess: ( { siteId, postId, siteSlug, utmParam }: AnyAction, data: object ) => {
 				if ( postId ) {
 					return receiveMetricsByPost( siteId, postId, data );
 				}
 
-				return receiveMetrics( siteId, data, siteSlug );
+				return receiveMetrics( siteId, data, siteSlug, utmParam );
 			},
 			onError: ( { siteId }: AnyAction ) => requestMetricsFail( siteId ),
 			// fromApi,

--- a/client/state/stats/utm-metrics/actions.ts
+++ b/client/state/stats/utm-metrics/actions.ts
@@ -47,12 +47,13 @@ export function requestMetricsFail( siteId: number ) {
  * @param {Object} data   API response
  * @returns {Object}  Action object
  */
-export function receiveMetrics( siteId: number, data: object, siteSlug: string ) {
+export function receiveMetrics( siteId: number, data: object, siteSlug: string, utmParam: string ) {
 	return {
 		type: STATS_UTM_METRICS_RECEIVE,
 		siteId,
 		data,
 		siteSlug,
+		utmParam,
 	};
 }
 

--- a/client/state/stats/utm-metrics/types.ts
+++ b/client/state/stats/utm-metrics/types.ts
@@ -18,5 +18,5 @@ export interface UTMMetricItemTopPost {
 	value: number;
 	href: string;
 	page: string | null;
-	actions: Array< { data: string; type: string } >;
+	actions: Array< { data: string | { [ key: string ]: string }; type: string } >;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/263
Closes https://github.com/Automattic/red-team/issues/263

## Proposed Changes

* Adds a quick action to open the UTM URL modal with pre-filled data so the user can copy the generated URL again or modify it as necessary
* Modified the UTM modal to allow initial data

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* UX improvements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the UTM card with some visits data
* If you don't have any, generate a UTM URL with the modal tool, visit it, wait around 5 minutes and refresh
* Click on a UTM data combination to open the top posts list
* Check that on the post entry there is a new quick action to view it in the URL builder:

![2024-11-20_19-26](https://github.com/user-attachments/assets/eae2a86f-3aa6-4c4f-a353-2afab9c490cd)

* Click it and check that the available data is pre-loaded on the modal (in this case, only source and medium):

![Screenshot from 2024-11-20 19-43-35](https://github.com/user-attachments/assets/119f6e65-e02a-419b-9952-9f44f2038148)

* Change the UTM data filter to another combination, like "Campaign / Source / Medium" or just "Medium" and click on the action link again
* Check that only the selected data is pre-loaded

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
