### PR TITLE
Plans: Remove references to `withDiscount` in favor of `coupon`

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -21,7 +21,7 @@ export type PlanNoticeProps = {
 	showLegacyStorageFeature?: boolean;
 	mediaStorage?: SiteMediaStorage;
 	discountInformation?: {
-		withDiscount: string;
+		coupon: string;
 		discountEndDate: Date;
 	};
 };
@@ -60,7 +60,7 @@ function useResolveNoticeType(
 	);
 	const activeDiscount =
 		discountInformation &&
-		getDiscountByName( discountInformation.withDiscount, discountInformation.discountEndDate );
+		getDiscountByName( discountInformation.coupon, discountInformation.discountEndDate );
 	const planUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable( siteId, visiblePlans );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const sitePlanSlug = sitePlan?.product_slug ?? '';
@@ -98,7 +98,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 	const handleDismissNotice = () => setIsNoticeDismissed( true );
 	let activeDiscount =
 		discountInformation &&
-		getDiscountByName( discountInformation.withDiscount, discountInformation.discountEndDate );
+		getDiscountByName( discountInformation.coupon, discountInformation.discountEndDate );
 
 	switch ( noticeType ) {
 		case NO_NOTICE:

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -28,11 +28,11 @@ import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 function useUpgradeHandler( {
 	siteSlug,
-	withDiscount,
+	coupon,
 	cartHandler,
 }: {
 	siteSlug?: string | null;
-	withDiscount?: string;
+	coupon?: string;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
 } ) {
 	const processCartItems = useCallback(
@@ -62,15 +62,12 @@ function useUpgradeHandler( {
 				? `/checkout/${ siteSlug }/${ planPath },${ cartItemForStorageAddOn.product_slug }:-q-${ cartItemForStorageAddOn.quantity }`
 				: `/checkout/${ siteSlug }/${ planPath }`;
 
-			const checkoutUrlWithArgs = addQueryArgs(
-				{ ...( withDiscount && { coupon: withDiscount } ) },
-				checkoutUrl
-			);
+			const checkoutUrlWithArgs = addQueryArgs( { ...( coupon && { coupon } ) }, checkoutUrl );
 
 			page( checkoutUrlWithArgs );
 			return;
 		},
-		[ siteSlug, withDiscount, cartHandler ]
+		[ siteSlug, coupon, cartHandler ]
 	);
 
 	return useCallback(
@@ -154,7 +151,7 @@ function useGenerateActionCallback( {
 	showModalAndExit,
 	sitePlanSlug,
 	siteId,
-	withDiscount,
+	coupon,
 }: {
 	currentPlan: Plans.SitePlan | undefined;
 	eligibleForFreeHostingTrial: boolean;
@@ -164,7 +161,7 @@ function useGenerateActionCallback( {
 	showModalAndExit?: ( planSlug: PlanSlug ) => boolean;
 	sitePlanSlug?: PlanSlug | null;
 	siteId?: number | null;
-	withDiscount?: string;
+	coupon?: string;
 } ): UseActionCallback {
 	const siteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
@@ -177,7 +174,7 @@ function useGenerateActionCallback( {
 			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
 			: null
 	);
-	const handleUpgradeClick = useUpgradeHandler( { siteSlug, withDiscount, cartHandler } );
+	const handleUpgradeClick = useUpgradeHandler( { siteSlug, coupon, cartHandler } );
 	const handleDowngradeClick = useDowngradeHandler( {
 		siteSlug,
 		currentPlan,

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -63,7 +63,7 @@ export default function useGenerateActionHook( {
 	isInSignup,
 	isLaunchPage,
 	showModalAndExit,
-	withDiscount,
+	coupon,
 }: {
 	siteId?: number | null;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
@@ -72,7 +72,7 @@ export default function useGenerateActionHook( {
 	isInSignup: boolean;
 	isLaunchPage: boolean | null;
 	showModalAndExit?: ( planSlug: PlanSlug ) => boolean;
-	withDiscount?: string;
+	coupon?: string;
 } ): UseAction {
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
@@ -102,7 +102,7 @@ export default function useGenerateActionHook( {
 		showModalAndExit,
 		sitePlanSlug,
 		siteId,
-		withDiscount,
+		coupon,
 	} );
 
 	const useActionHook = ( {

--- a/client/my-sites/plans-features-main/hooks/use-plan-type-destination-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-type-destination-callback.ts
@@ -17,7 +17,7 @@ const usePlanTypeDestinationCallback = () => {
 			const { intervalType = '' } = additionalArgs;
 			const defaultArgs = {
 				customerType: undefined,
-				discount: props.withDiscount,
+				coupon: props.coupon,
 				feature: props.selectedFeature,
 				plan: props.selectedPlan,
 			};

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -123,7 +123,6 @@ export interface PlansFeaturesMainProps {
 		Extract< UrlFriendlyTermType, 'monthly' | 'yearly' | '2yearly' | '3yearly' >
 	>;
 	planTypeSelector?: 'interval';
-	withDiscount?: string;
 	discountEndDate?: Date;
 	hidePlansFeatureComparison?: boolean;
 	coupon?: string;
@@ -192,7 +191,6 @@ const PlansFeaturesMain = ( {
 	basePlansPath,
 	selectedFeature,
 	plansWithScroll,
-	withDiscount,
 	discountEndDate,
 	hideFreePlan,
 	hidePersonalPlan,
@@ -366,7 +364,7 @@ const PlansFeaturesMain = ( {
 		isInSignup,
 		isLaunchPage,
 		showModalAndExit,
-		withDiscount,
+		coupon,
 	} );
 
 	const isDomainOnlySite = useSelector( ( state: IAppState ) =>
@@ -485,7 +483,6 @@ const PlansFeaturesMain = ( {
 			recordTracksEvent,
 			coupon,
 			selectedSiteId: siteId,
-			withDiscount,
 			intent,
 		};
 
@@ -541,7 +538,6 @@ const PlansFeaturesMain = ( {
 		sitePlanSlug,
 		coupon,
 		siteId,
-		withDiscount,
 		getPlanTypeDestination,
 		onPlanIntervalUpdate,
 		intent,
@@ -771,10 +767,10 @@ const PlansFeaturesMain = ( {
 						siteId={ siteId }
 						isInSignup={ isInSignup }
 						showLegacyStorageFeature={ showLegacyStorageFeature }
-						{ ...( withDiscount &&
+						{ ...( coupon &&
 							discountEndDate && {
 								discountInformation: {
-									withDiscount,
+									coupon,
 									discountEndDate,
 								},
 							} ) }

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -36,9 +36,9 @@ export function plans( context, next ) {
 	// from the Calypso admin plans page. The `/start` onboarding flow
 	// plans page, however, relies on the `coupon` query param for the
 	// same purpose. We handle both coupon and discount here for the time
-	// being to avoid confusion. We'll probably consolidate to just `coupon`
-	// in the future.
-	const withDiscount = context.query.coupon || context.query.discount;
+	// being to avoid confusion and to continue support for legacy
+	// coupons. We'll consolidate to just `coupon` in the future.
+	const coupon = context.query.coupon || context.query.discount;
 
 	context.primary = (
 		<Plans
@@ -47,7 +47,7 @@ export function plans( context, next ) {
 			customerType={ context.query.customerType }
 			selectedFeature={ context.query.feature }
 			selectedPlan={ context.query.plan }
-			withDiscount={ withDiscount }
+			coupon={ coupon }
 			discountEndDate={ context.query.ts }
 			redirectTo={ context.query.redirect_to }
 			redirectToAddDomainFlow={

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -151,6 +151,7 @@ function DescriptionMessage( { isDomainUpsell, isFreePlan, yourDomainName, siteS
 class PlansComponent extends Component {
 	static propTypes = {
 		context: PropTypes.object.isRequired,
+		coupon: PropTypes.string,
 		redirectToAddDomainFlow: PropTypes.bool,
 		domainAndPlanPackage: PropTypes.bool,
 		intervalType: PropTypes.string,
@@ -246,10 +247,12 @@ class PlansComponent extends Component {
 		if ( isEnabled( 'p2/p2-plus' ) && isWPForTeamsSite ) {
 			return (
 				<P2PlansMain
+					// None of these props appear to be used by the P2PlansMain component.
+					// We should consider removing them.
 					selectedPlan={ this.props.selectedPlan }
 					redirectTo={ this.props.redirectTo }
 					site={ selectedSite }
-					withDiscount={ this.props.withDiscount }
+					coupon={ this.props.coupon }
 					discountEndDate={ this.props.discountEndDate }
 				/>
 			);
@@ -273,7 +276,7 @@ class PlansComponent extends Component {
 				selectedFeature={ this.props.selectedFeature }
 				selectedPlan={ this.props.selectedPlan }
 				redirectTo={ this.props.redirectTo }
-				withDiscount={ this.props.withDiscount }
+				coupon={ this.props.coupon }
 				discountEndDate={ this.props.discountEndDate }
 				siteId={ selectedSite?.ID }
 				plansWithScroll={ false }

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -264,7 +264,6 @@ export type PlanTypeSelectorProps = {
 	basePlansPath?: string | null;
 	intervalType: UrlFriendlyTermType;
 	customerType: string;
-	withDiscount?: string;
 	enableStickyBehavior?: boolean;
 	stickyPlanTypeSelectorOffset?: number;
 	onPlanIntervalUpdate: ( interval: SupportedUrlFriendlyTermType ) => void;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95702 and https://github.com/Automattic/wp-calypso/pull/95703 and pau2Xa-6sB-p2#comment-16318

## Proposed Changes

Emails rely on the `discount` query param to auto-apply coupons when redirecting to the logged in plans page. The `/start` onboarding flow plans page, however, relies on the `coupon` query param for the same purpose. Although behind the scenes we'll continue to support both `coupon` and `discount` for the time being on the logged in plans page ( to accommodate legacy outbound marketing emails ), we'll be consolidating to only `coupon` in the future.

Because of this, we replace instances of the term `withDiscount` with the term `coupon`. 

These changes also simplify the feature we're implementing [here](https://github.com/Automattic/wp-calypso/pull/95703). Refactoring this code allows us to pass a `coupon` query param prop into `PlansFeaturesMain` under the name `coupon` which is already being used throughout the component ( instead of needing to use `withDiscount` ).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're moving away from usage of the `discount` query param. We're only supporting it behind the scenes because of existing email marketing that is using the term. We'll be using the term `coupon` instead, which is already widely implemented throughout `/start` onboarding
* Reduce cognitive overhead

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is a refactoring PR. There should be no functional changes.

* Smoke test applying coupons in `/start` onboarding and purchasing a plan with said coupon ( Ex. /start/plans?coupon=federate25 )
* Verify that plans grid pricing is updated to reflect the coupon
* Verify that a plan can be purchased with the coupon auto applied at checkout
* Smoke test applying coupons in the logged in plans page with the `?discount` and `?coupon` query params
* Note that you won't see updated pricing in the plans grid in this case because we're currently implementing that functionality in https://github.com/Automattic/wp-calypso/pull/96600
* Verify that a plan can be purchased with the discount / coupon auto applied at checkout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?