### PR TITLE
Stats: Support Visitors / Likes / Comments for hourly view (only sum - no graph)

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -96,7 +96,12 @@ class StatModuleChartTabs extends Component {
 		this.intervalId = setInterval( this.makeQuery, DEFAULT_HEARTBEAT );
 	}
 
-	makeQuery = () => this.props.requestChartCounts( this.props.query );
+	makeQuery = () => {
+		this.props.requestChartCounts( this.props.query );
+		if ( this.props.query.chartStart === this.props.query.date ) {
+			this.props.requestChartCounts( this.props.queryDay );
+		}
+	};
 
 	render() {
 		const {
@@ -145,6 +150,7 @@ class StatModuleChartTabs extends Component {
 					activeIndex={ this.props.queryDate }
 					activeKey="period"
 					aggregate={ isNewDateFilteringEnabled }
+					tabCountsAlt={ this.props.tabCountsAlt }
 				/>
 			</div>
 		);
@@ -192,9 +198,22 @@ const connectComponent = connect(
 
 		const queryKey = `${ date }-${ period }-${ quantity }-${ siteId }`;
 		const query = memoizedQuery( chartTab, date, period, quantity, siteId, chartStart );
+		const queryDay = {
+			...query,
+			period: 'day',
+			quantity: 1,
+			statFields: [ 'visitors', 'likes', 'comments' ],
+		};
 
 		const counts = getCountRecords( state, siteId, query.date, query.period, query.quantity );
 		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
+		const tabCountsAlt = getCountRecords(
+			state,
+			siteId,
+			queryDay.date,
+			queryDay.period,
+			queryDay.quantity
+		);
 		const loadingTabs = getLoadingTabs( state, siteId, query.date, query.period, query.quantity );
 		const isActiveTabLoading = loadingTabs.includes( chartTab ) || chartData.length < quantity;
 
@@ -206,6 +225,8 @@ const connectComponent = connect(
 			queryKey,
 			siteId,
 			selectedPeriod: period,
+			queryDay,
+			tabCountsAlt: tabCountsAlt?.[ 0 ],
 		};
 	},
 	{ recordGoogleEvent, requestChartCounts }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -98,7 +98,12 @@ class StatModuleChartTabs extends Component {
 
 	makeQuery = () => {
 		this.props.requestChartCounts( this.props.query );
-		if ( this.props.query.chartStart === this.props.query.date ) {
+
+		// query format needs to align with `memoizedQuery`.
+		if (
+			this.props.query.chartStart === this.props.query.date &&
+			this.props.query.period === 'hour'
+		) {
 			this.props.requestChartCounts( this.props.queryDay );
 		}
 	};

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -31,6 +31,7 @@ class StatsTabs extends Component {
 			selectedTab,
 			borderless,
 			aggregate,
+			tabCountsAlt,
 		} = this.props;
 
 		let statsTabs;
@@ -54,8 +55,10 @@ class StatsTabs extends Component {
 			}
 
 			statsTabs = tabs.map( ( tab ) => {
+				const hasTrend = activeData?.[ tab.attr ] >= 0 && activeData[ tab.attr ] !== null;
 				const hasData =
-					activeData && activeData[ tab.attr ] >= 0 && activeData[ tab.attr ] !== null;
+					( activeData?.[ tab.attr ] >= 0 && activeData[ tab.attr ] !== null ) ||
+					( tabCountsAlt?.[ tab.attr ] >= 0 && tabCountsAlt[ tab.attr ] !== null );
 
 				const tabOptions = {
 					attr: tab.attr,
@@ -64,8 +67,8 @@ class StatsTabs extends Component {
 					label: tab.label,
 					loading: ! hasData,
 					selected: selectedTab === tab.attr,
-					tabClick: switchTab,
-					value: hasData ? activeData[ tab.attr ] : null,
+					tabClick: hasTrend ? switchTab : undefined,
+					value: hasData ? activeData?.[ tab.attr ] ?? tabCountsAlt?.[ tab.attr ] : null,
 					format: tab.format,
 				};
 


### PR DESCRIPTION


## Proposed Changes

* Query single day data to fill in the tabs for hourly view

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Show visitors / likes / comments for a single day

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live for `/stats/hour/jetpack.com?chartStart=2024-11-21&chartEnd=2024-11-21&flags=stats%2Fnew-date-filtering`
* Ensure Visitors, Likes and Comments tabs are correct
* Switch to other date ranges and periods
* Ensure it still works

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/4c4f168e-4ef4-4d2f-a1e2-6a581ef030cc">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
