### PR TITLE
Untangling: apply new design to Marketing -> Connections

### DIFF
--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -1,4 +1,4 @@
-import { CompactCard, FoldableCard } from '@automattic/components';
+import { Button, FoldableCard } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { includes } from 'lodash';
@@ -13,7 +13,7 @@ import SupportInfo from 'calypso/components/support-info';
 import withSiteRoles from 'calypso/data/site-roles/with-site-roles';
 import { getStatsPathForTab } from 'calypso/lib/route';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { PanelHeading, PanelSection } from 'calypso/sites/components/panel';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -121,10 +121,10 @@ class JetpackSiteStats extends Component {
 		);
 
 		return (
-			<div className="site-settings__traffic-settings">
+			<PanelSection className="site-settings__traffic-settings">
 				<QueryJetpackConnection siteId={ siteId } />
 
-				<SettingsSectionHeader title={ translate( 'Jetpack Stats' ) } />
+				<PanelHeading>{ translate( 'Jetpack Stats' ) }</PanelHeading>
 
 				<FoldableCard
 					className="site-settings__foldable-card is-top-level"
@@ -176,10 +176,10 @@ class JetpackSiteStats extends Component {
 					</FormFieldset>
 				</FoldableCard>
 
-				<CompactCard href={ getStatsPathForTab( 'day', siteSlug ) }>
+				<Button href={ getStatsPathForTab( 'day', siteSlug ) }>
 					{ translate( 'View your site stats' ) }
-				</CompactCard>
-			</div>
+				</Button>
+			</PanelSection>
 		);
 	}
 }

--- a/client/sites/marketing/connections/connections.jsx
+++ b/client/sites/marketing/connections/connections.jsx
@@ -20,7 +20,7 @@ const SharingConnections = ( { translate, isP2Hub, siteId } ) => {
 	);
 
 	return (
-		<div className="connections__sharing-settings connections__sharing-connections">
+		<>
 			<PageViewTracker path="/marketing/connections/:site" title="Marketing > Connections" />
 
 			{ isP2Hub && <QueryP2Connections siteId={ siteId } /> }
@@ -51,7 +51,7 @@ const SharingConnections = ( { translate, isP2Hub, siteId } ) => {
 			/>
 
 			{ adminInterfaceIsWPAdmin && <GoogleAnalyticsSettings /> }
-		</div>
+		</>
 	);
 };
 

--- a/client/sites/marketing/connections/index.tsx
+++ b/client/sites/marketing/connections/index.tsx
@@ -1,9 +1,11 @@
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { Panel } from 'calypso/sites/components/panel';
 import SharingConnections from './connections';
 
 import '../style.scss';
+import './style.scss';
 
 export default function MarketingConnections( {
 	siteId,
@@ -14,7 +16,7 @@ export default function MarketingConnections( {
 } ) {
 	const translate = useTranslate();
 	return (
-		<div className="marketing-connections">
+		<Panel className="marketing-connections connections__sharing-settings connections__sharing-connections">
 			<NavigationHeader
 				title={ translate( 'Connections' ) }
 				subtitle={ translate(
@@ -29,6 +31,6 @@ export default function MarketingConnections( {
 				) }
 			/>
 			<SharingConnections isP2Hub={ isP2Hub } siteId={ siteId } />
-		</div>
+		</Panel>
 	);
 }

--- a/client/sites/marketing/connections/service-examples.jsx
+++ b/client/sites/marketing/connections/service-examples.jsx
@@ -27,26 +27,7 @@ import './service-examples.scss';
  * a method with the example's content.
  * @type {string[]}
  */
-const SERVICES_WITH_EXAMPLES = [
-	'bandpage',
-	'facebook',
-	'instagram-business',
-	'google_plus',
-	'google_my_business',
-	'instagram-basic-display',
-	'linkedin',
-	'tumblr',
-	'nextdoor',
-	'twitter',
-	'threads',
-	'google_photos',
-	'google-drive',
-	'mailchimp',
-	'p2_slack',
-	'p2_github',
-	'mastodon',
-	'bluesky',
-];
+export const SERVICES_WITH_EXAMPLES = [ 'google_plus', 'mastodon', 'bluesky' ];
 
 class SharingServiceExamples extends Component {
 	static propTypes = {

--- a/client/sites/marketing/connections/service-placeholder.jsx
+++ b/client/sites/marketing/connections/service-placeholder.jsx
@@ -15,7 +15,7 @@ class SharingServicePlaceholder extends Component {
 				<Gridicon icon="share" size={ 48 } className="sharing-service__logo" />
 
 				<div className="sharing-service__name">
-					<h2 />
+					<h3 />
 					<p className="sharing-service__description" />
 				</div>
 			</div>

--- a/client/sites/marketing/connections/service.jsx
+++ b/client/sites/marketing/connections/service.jsx
@@ -49,7 +49,7 @@ import MailchimpSettings, { renderMailchimpLogo } from './mailchimp-settings';
 import ServiceAction from './service-action';
 import ServiceConnectedAccounts from './service-connected-accounts';
 import ServiceDescription from './service-description';
-import ServiceExamples from './service-examples';
+import ServiceExamples, { SERVICES_WITH_EXAMPLES } from './service-examples';
 import ServiceTip from './service-tip';
 
 /**
@@ -490,6 +490,14 @@ export class SharingService extends Component {
 		);
 	}
 
+	shouldBeExpandable( status ) {
+		return (
+			this.shouldBeExpanded( status ) ||
+			SERVICES_WITH_EXAMPLES.includes( this.props.service.ID ) ||
+			this.getConnections().length > 0
+		);
+	}
+
 	shouldBeExpanded( status ) {
 		if ( this.isMailchimpService() && this.state.justConnected ) {
 			return true;
@@ -546,9 +554,9 @@ export class SharingService extends Component {
 				{ this.isMailchimpService( connectionStatus ) && renderMailchimpLogo() }
 
 				<div className="sharing-service__name">
-					<h2>
+					<h3>
 						{ this.props.service.label } { this.renderBadges() }
-					</h2>
+					</h3>
 					<ServiceDescription
 						service={ this.props.service }
 						status={ connectionStatus }
@@ -643,6 +651,7 @@ export class SharingService extends Component {
 					header={ header }
 					clickableHeader
 					//For Mailchimp we want to open settings, because in other services we have the popup.
+					expandable={ this.shouldBeExpandable( connectionStatus ) }
 					expanded={ this.shouldBeExpanded( connectionStatus ) }
 					compact
 					summary={ action }

--- a/client/sites/marketing/connections/services-group.jsx
+++ b/client/sites/marketing/connections/services-group.jsx
@@ -5,7 +5,7 @@ import { Fragment, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import SectionHeader from 'calypso/components/section-header';
+import { PanelHeading, PanelSection } from 'calypso/sites/components/panel';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import isFetchingJetpackModules from 'calypso/state/selectors/is-fetching-jetpack-modules';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -91,8 +91,8 @@ const SharingServicesGroup = ( {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<div className="sharing-services-group">
-			<SectionHeader label={ title } />
+		<PanelSection className="sharing-services-group">
+			<PanelHeading>{ title }</PanelHeading>
 			<ul className="sharing-services-group__services">
 				{ showPlaceholder &&
 					times( numberOfPlaceholders, ( index ) => (
@@ -144,7 +144,7 @@ const SharingServicesGroup = ( {
 						return <Component key={ service.ID } service={ service } />;
 					} ) }
 			</ul>
-		</div>
+		</PanelSection>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };

--- a/client/sites/marketing/connections/services/fediverse.jsx
+++ b/client/sites/marketing/connections/services/fediverse.jsx
@@ -16,10 +16,10 @@ function FediverseHeader() {
 		<div>
 			<SocialLogo icon="fediverse" size={ 48 } className="sharing-service__logo" />
 			<div className="sharing-service__name">
-				<h2>
+				<h3>
 					{ translate( 'Fediverse' ) }
 					<Badge className="service__new-badge">{ translate( 'New' ) }</Badge>
-				</h2>
+				</h3>
 				<p className="sharing-service__description">
 					{ translate( 'Mastodon today, Threads tomorrow. Enter the Fediverse with ActivityPub.' ) }
 				</p>

--- a/client/sites/marketing/connections/style.scss
+++ b/client/sites/marketing/connections/style.scss
@@ -1,0 +1,6 @@
+#analytics {
+	.form-fieldset {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+}

--- a/client/sites/marketing/style.scss
+++ b/client/sites/marketing/style.scss
@@ -119,6 +119,10 @@
 
 .sharing-services-group__services {
 	margin: 24px -22px -23px -22px;
+
+	.notice {
+		margin-bottom: 0;
+	}
 }
 
 .sharing-services-group__services .notice.sharing-service__unsupported {

--- a/client/sites/marketing/style.scss
+++ b/client/sites/marketing/style.scss
@@ -85,6 +85,10 @@
 
 	.sharing-service__name {
 		float: left;
+
+		h3 {
+			font-weight: 500;
+		}
 	}
 
 	@include breakpoint-deprecated( "<480px" ) {
@@ -105,6 +109,16 @@
 			margin-left: 6px;
 		}
 	}
+}
+
+.sharing {
+	.sharing-services-group {
+		margin-bottom: 16px;
+	}
+}
+
+.sharing-services-group__services {
+	margin: 24px -22px -23px -22px;
 }
 
 .sharing-services-group__services .notice.sharing-service__unsupported {
@@ -456,7 +470,7 @@
 .sharing-connection__account-sitewide-connection.form-label {
 	display: block;
 	margin-bottom: 0;
-	font-size: 1rem;
+	font-size: 0.875rem;
 }
 
 .sharing-connection__account-sitewide-connection input[type="checkbox"] {

--- a/packages/components/src/foldable-card/index.jsx
+++ b/packages/components/src/foldable-card/index.jsx
@@ -1,8 +1,10 @@
+import { Icon } from '@wordpress/components';
+import { chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, createElement } from 'react';
-import { Card, CompactCard, ScreenReaderText, Gridicon } from '../';
+import { Card, CompactCard, Gridicon, ScreenReaderText } from '../';
 
 import './style.scss';
 
@@ -18,6 +20,7 @@ class FoldableCard extends Component {
 		clickableHeader: PropTypes.bool,
 		compact: PropTypes.bool,
 		disabled: PropTypes.bool,
+		expandable: PropTypes.bool,
 		expandedSummary: PropTypes.node,
 		expanded: PropTypes.bool,
 		headerTagName: PropTypes.string,
@@ -40,8 +43,8 @@ class FoldableCard extends Component {
 		onClose: noop,
 		cardKey: '',
 		headerTagName: 'span',
-		icon: 'chevron-down',
 		iconSize: 24,
+		expandable: true,
 		expanded: false,
 		screenReaderText: false,
 		smooth: false,
@@ -75,7 +78,7 @@ class FoldableCard extends Component {
 	};
 
 	getClickAction() {
-		if ( this.props.disabled ) {
+		if ( this.props.disabled || ! this.props.expandable ) {
 			return;
 		}
 		return this.onClick;
@@ -101,14 +104,18 @@ class FoldableCard extends Component {
 			const screenReaderText = this.props.screenReaderText || this.props.translate( 'More' );
 			return (
 				<button
-					disabled={ this.props.disabled }
+					disabled={ this.props.disabled || ! this.props.expandable }
 					type="button"
 					className="foldable-card__action foldable-card__expand"
 					aria-expanded={ this.state.expanded }
 					onClick={ clickAction }
 				>
 					<ScreenReaderText>{ screenReaderText }</ScreenReaderText>
-					<Gridicon icon={ this.props.icon } size={ this.props.iconSize } />
+					{ this.props.icon ? (
+						<Gridicon icon={ this.props.icon } size={ this.props.iconSize } />
+					) : (
+						<Icon icon={ chevronDown } size={ this.props.iconSize } className="gridicon" />
+					) }
 				</button>
 			);
 		}
@@ -135,7 +142,7 @@ class FoldableCard extends Component {
 		const headerClickAction = this.props.clickableHeader ? this.getClickAction() : null;
 		const headerClasses = clsx( 'foldable-card__header', {
 			'is-clickable': !! this.props.clickableHeader,
-			'has-border': !! this.props.summary,
+			'is-expandable': this.props.expandable,
 		} );
 		const header = createElement(
 			this.props.headerTagName,

--- a/packages/components/src/foldable-card/style.scss
+++ b/packages/components/src/foldable-card/style.scss
@@ -8,10 +8,6 @@
 	position: relative;
 	transition: margin 0.15s linear;
 	padding: 0;
-
-	&.is-expanded {
-		margin: 8px 0;
-	}
 }
 
 .foldable-card__header {
@@ -24,7 +20,7 @@
 	justify-content: space-between;
 	position: relative;
 
-	&.is-clickable {
+	&.is-clickable.is-expandable {
 		cursor: pointer;
 	}
 
@@ -78,7 +74,7 @@
 	outline: thin dotted;
 }
 
-button.foldable-card__action {
+button:not(:disabled).foldable-card__action {
 	cursor: pointer;
 }
 
@@ -109,7 +105,6 @@ button.foldable-card__action {
 	width: 48px;
 
 	.gridicon {
-		fill: var(--color-neutral-30);
 		display: flex;
 		align-items: center;
 		width: 100%;
@@ -118,12 +113,12 @@ button.foldable-card__action {
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
 	}
 
-	.gridicon:hover {
-		fill: var(--color-neutral-30);
+	&:not(:disabled) .gridicon {
+		fill: var(--studio-gray-100);
 	}
 
-	&:hover .gridicon {
-		fill: var(--color-neutral-50);
+	&:disabled .gridicon {
+		fill: var(--studio-gray-20);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9857

## Proposed Changes

This PR attempts to apply the design from p9Jlb4-f3i-p2 to Marketing -> Connections.

|Before|After|
|-|-|
|<img width="825" alt="image" src="https://github.com/user-attachments/assets/5cf28da2-e86d-4a19-9e1c-9d92ae583272">|<img width="822" alt="image" src="https://github.com/user-attachments/assets/972371ab-7e08-4929-85dc-eb5e7a10bfff">|

@matt-west, for consistency, for this iteration, I didn't update the button colors:

<img width="151" alt="image" src="https://github.com/user-attachments/assets/0e3616fe-994d-4fb3-a964-dd35759f1cff">

This is because the rest of /sites pages are not using that scheme, so it would be weirder. I'm proposing to update the colors together with all other screens. Thoughts?

## Why are these changes being made?

pbxlJb-6ye-p2

## Testing Instructions

1. Go to /sites
2. Select a site (which is not Atomic Classic)
3. Go to Marketing -> Connections
4. Play around with the connections

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?