### PR TITLE
Sites Dashboard: Hide actions on a deleted site

### DIFF
--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -30,6 +30,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
 import type { Action } from '@wordpress/dataviews';
+
 export function useActions( {
 	openSitePreviewPane,
 	selectedItem,
@@ -45,7 +46,7 @@ export function useActions( {
 
 	const queryClient = useQueryClient();
 	const reduxDispatch = useReduxDispatch();
-	const { mutate: restoreSite, isPending: isRestoring } = useRestoreSiteMutation( {
+	const { mutate: restoreSite } = useRestoreSiteMutation( {
 		onSuccess() {
 			queryClient.invalidateQueries( {
 				queryKey: [
@@ -397,7 +398,6 @@ export function useActions( {
 				id: 'restore',
 				label: __( 'Restore' ),
 				isPrimary: true,
-				disabled: isRestoring,
 				callback: ( sites ) => {
 					const site = sites[ 0 ];
 					restoreSite( site.ID );
@@ -405,6 +405,6 @@ export function useActions( {
 				isEligible: ( site ) => !! site?.is_deleted,
 			},
 		],
-		[ __, capabilities, dispatch, openSitePreviewPane, selectedItem?.ID ]
+		[ __, capabilities, dispatch, openSitePreviewPane, restoreSite, selectedItem?.ID ]
 	);
 }

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -1,8 +1,16 @@
 import { FEATURE_SFTP, WPCOM_FEATURES_COPY_SITE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import {
+	SiteExcerptData,
+	SITE_EXCERPT_REQUEST_FIELDS,
+	SITE_EXCERPT_REQUEST_OPTIONS,
+} from '@automattic/sites';
+import { useQueryClient } from '@tanstack/react-query';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useMemo } from 'react';
+import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
+import useRestoreSiteMutation from 'calypso/sites/hooks/use-restore-site-mutation';
 import {
 	getAdminInterface,
 	getPluginsUrl,
@@ -16,18 +24,56 @@ import {
 } from 'calypso/sites-dashboard/utils';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
-import type { SiteExcerptData } from '@automattic/sites';
 import type { Action } from '@wordpress/dataviews';
-import type { mutateFunction } from 'calypso/sites/hooks/use-restore-site-mutation';
 
-export function useActions( {
-	restoreSite,
-}: {
-	restoreSite: mutateFunction;
-} ): Action< SiteExcerptData >[] {
+export function useActions(): Action< SiteExcerptData >[] {
 	const { __ } = useI18n();
 	const dispatch = useReduxDispatch();
+
+	const queryClient = useQueryClient();
+	const reduxDispatch = useReduxDispatch();
+	const { mutate: restoreSite, isPending: isRestoring } = useRestoreSiteMutation( {
+		onSuccess() {
+			queryClient.invalidateQueries( {
+				queryKey: [
+					USE_SITE_EXCERPTS_QUERY_KEY,
+					SITE_EXCERPT_REQUEST_FIELDS,
+					SITE_EXCERPT_REQUEST_OPTIONS,
+					[],
+					'all',
+				],
+			} );
+			queryClient.invalidateQueries( {
+				queryKey: [
+					USE_SITE_EXCERPTS_QUERY_KEY,
+					SITE_EXCERPT_REQUEST_FIELDS,
+					SITE_EXCERPT_REQUEST_OPTIONS,
+					[],
+					'deleted',
+				],
+			} );
+			reduxDispatch(
+				successNotice( __( 'The site has been restored.' ), {
+					duration: 3000,
+				} )
+			);
+		},
+		onError: ( error ) => {
+			if ( error.status === 403 ) {
+				reduxDispatch(
+					errorNotice( __( 'Only an administrator can restore a deleted site.' ), {
+						duration: 5000,
+					} )
+				);
+			} else {
+				reduxDispatch(
+					errorNotice( __( 'We were unable to restore the site.' ), { duration: 5000 } )
+				);
+			}
+		},
+	} );
 
 	return useMemo(
 		() => [
@@ -287,6 +333,8 @@ export function useActions( {
 			{
 				id: 'restore',
 				label: __( 'Restore' ),
+				isPrimary: true,
+				disabled: isRestoring,
 				callback: ( sites ) => {
 					const site = sites[ 0 ];
 					restoreSite( site.ID );
@@ -294,6 +342,6 @@ export function useActions( {
 				isEligible: ( site ) => !! site?.is_deleted,
 			},
 		],
-		[ __, dispatch, restoreSite ]
+		[ __, dispatch, isRestoring, restoreSite ]
 	);
 }

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -122,6 +122,9 @@ export function useActions( {
 					if ( site.ID === selectedItem?.ID ) {
 						return false;
 					}
+					if ( site.is_deleted ) {
+						return false;
+					}
 					return true;
 				},
 			},
@@ -137,6 +140,12 @@ export function useActions( {
 						siteUrl.opener = null;
 						siteUrl.focus();
 					}
+				},
+				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+					return true;
 				},
 			},
 			{

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -19,8 +19,13 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
 import type { SiteExcerptData } from '@automattic/sites';
 import type { Action } from '@wordpress/dataviews';
+import type { mutateFunction } from 'calypso/sites/hooks/use-restore-site-mutation';
 
-export function useActions( { restoreSite }: { restoreSite: any } ): Action< SiteExcerptData >[] {
+export function useActions( {
+	restoreSite,
+}: {
+	restoreSite: mutateFunction;
+} ): Action< SiteExcerptData >[] {
 	const { __ } = useI18n();
 	const dispatch = useReduxDispatch();
 
@@ -286,7 +291,7 @@ export function useActions( { restoreSite }: { restoreSite: any } ): Action< Sit
 					const site = sites[ 0 ];
 					restoreSite( site.ID );
 				},
-				isEligible: ( site ) => site?.is_deleted,
+				isEligible: ( site ) => !! site?.is_deleted,
 			},
 		],
 		[ __, dispatch, restoreSite ]

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -397,7 +397,6 @@ export function useActions( {
 			{
 				id: 'restore',
 				label: __( 'Restore' ),
-				isPrimary: true,
 				callback: ( sites ) => {
 					const site = sites[ 0 ];
 					restoreSite( site.ID );

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -20,7 +20,7 @@ import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/laun
 import type { SiteExcerptData } from '@automattic/sites';
 import type { Action } from '@wordpress/dataviews';
 
-export function useActions(): Action< SiteExcerptData >[] {
+export function useActions( { restoreSite }: { restoreSite: any } ): Action< SiteExcerptData >[] {
 	const { __ } = useI18n();
 	const dispatch = useReduxDispatch();
 
@@ -34,6 +34,10 @@ export function useActions(): Action< SiteExcerptData >[] {
 					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_launch_click' ) );
 				},
 				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+
 					const isLaunched = site.launch_status !== 'unlaunched';
 					const isA4ADevSite = site.is_a4a_dev_site;
 					const isWpcomStagingSite = site.is_wpcom_staging_site;
@@ -52,6 +56,10 @@ export function useActions(): Action< SiteExcerptData >[] {
 					);
 				},
 				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+
 					const isLaunched = site.launch_status !== 'unlaunched';
 					const isA4ADevSite = site.is_a4a_dev_site;
 					const isWpcomStagingSite = site.is_wpcom_staging_site;
@@ -67,12 +75,22 @@ export function useActions(): Action< SiteExcerptData >[] {
 					page( getSettingsUrl( sites[ 0 ].slug ) );
 					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_settings_click' ) );
 				},
+				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+					return true;
+				},
 			},
 
 			{
 				id: 'general-settings',
 				label: __( 'General settings' ),
 				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+
 					const adminInterface = getAdminInterface( site );
 					const isWpAdminInterface = adminInterface === 'wp-admin';
 					return isWpAdminInterface;
@@ -100,6 +118,10 @@ export function useActions(): Action< SiteExcerptData >[] {
 					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_hosting_click' ) );
 				},
 				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+
 					const isSiteJetpackNotAtomic = isNotAtomicJetpack( site );
 					return ! isSiteJetpackNotAtomic && ! isP2Site( site );
 				},
@@ -115,6 +137,10 @@ export function useActions(): Action< SiteExcerptData >[] {
 					);
 				},
 				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+
 					return !! site.is_wpcom_atomic;
 				},
 			},
@@ -135,6 +161,10 @@ export function useActions(): Action< SiteExcerptData >[] {
 					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_plugins_click' ) );
 				},
 				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+
 					return ! isP2Site( site );
 				},
 			},
@@ -152,6 +182,10 @@ export function useActions(): Action< SiteExcerptData >[] {
 					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_copy_site_click' ) );
 				},
 				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+
 					const isWpcomStagingSite = site.is_wpcom_staging_site;
 					const shouldShowSiteCopyItem =
 						!! site.plan?.features.active.includes( WPCOM_FEATURES_COPY_SITE );
@@ -177,6 +211,10 @@ export function useActions(): Action< SiteExcerptData >[] {
 					);
 				},
 				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+
 					const adminInterface = getAdminInterface( site );
 					const isWpAdminInterface = adminInterface === 'wp-admin';
 					const isClassicSimple = isWpAdminInterface && isSimpleSite( site );
@@ -195,6 +233,10 @@ export function useActions(): Action< SiteExcerptData >[] {
 					);
 				},
 				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+
 					const isLaunched = site.launch_status !== 'unlaunched';
 					return isLaunched;
 				},
@@ -211,6 +253,10 @@ export function useActions(): Action< SiteExcerptData >[] {
 					);
 				},
 				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+
 					const hasCustomDomain = isCustomDomain( site.slug );
 					const isSiteJetpackNotAtomic = isNotAtomicJetpack( site );
 					return hasCustomDomain && ! isSiteJetpackNotAtomic;
@@ -225,8 +271,24 @@ export function useActions(): Action< SiteExcerptData >[] {
 					window.location.href = site.options?.admin_url ?? '';
 					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_wpadmin_click' ) );
 				},
+				isEligible: ( site ) => {
+					if ( site.is_deleted ) {
+						return false;
+					}
+					return true;
+				},
+			},
+
+			{
+				id: 'restore',
+				label: __( 'Restore' ),
+				callback: ( sites ) => {
+					const site = sites[ 0 ];
+					restoreSite( site.ID );
+				},
+				isEligible: ( site ) => site?.is_deleted,
 			},
 		],
-		[ __, dispatch ]
+		[ __, dispatch, restoreSite ]
 	);
 }

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -1,22 +1,13 @@
-import {
-	SiteExcerptData,
-	SITE_EXCERPT_REQUEST_FIELDS,
-	SITE_EXCERPT_REQUEST_OPTIONS,
-} from '@automattic/sites';
-import { useQueryClient } from '@tanstack/react-query';
+import { SiteExcerptData } from '@automattic/sites';
 import { usePrevious } from '@wordpress/compose';
 import { DataViews, Field } from '@wordpress/dataviews';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo, useRef, useLayoutEffect } from 'react';
-import { useDispatch as useReduxDispatch } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
-import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
-import useRestoreSiteMutation from 'calypso/sites/hooks/use-restore-site-mutation';
 import { SitePlan } from 'calypso/sites-dashboard/components/sites-site-plan';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { useActions } from './actions';
 import SiteField from './dataviews-fields/site-field';
 import { SiteStats } from './sites-site-stats';
@@ -137,49 +128,6 @@ const DotcomSitesDataViews = ( {
 		};
 	}, [] );
 
-	const queryClient = useQueryClient();
-	const reduxDispatch = useReduxDispatch();
-	const { mutate: restoreSite, isPending: isRestoring } = useRestoreSiteMutation( {
-		onSuccess() {
-			queryClient.invalidateQueries( {
-				queryKey: [
-					USE_SITE_EXCERPTS_QUERY_KEY,
-					SITE_EXCERPT_REQUEST_FIELDS,
-					SITE_EXCERPT_REQUEST_OPTIONS,
-					[],
-					'all',
-				],
-			} );
-			queryClient.invalidateQueries( {
-				queryKey: [
-					USE_SITE_EXCERPTS_QUERY_KEY,
-					SITE_EXCERPT_REQUEST_FIELDS,
-					SITE_EXCERPT_REQUEST_OPTIONS,
-					[],
-					'deleted',
-				],
-			} );
-			reduxDispatch(
-				successNotice( __( 'The site has been restored.' ), {
-					duration: 3000,
-				} )
-			);
-		},
-		onError: ( error ) => {
-			if ( error.status === 403 ) {
-				reduxDispatch(
-					errorNotice( __( 'Only an administrator can restore a deleted site.' ), {
-						duration: 5000,
-					} )
-				);
-			} else {
-				reduxDispatch(
-					errorNotice( __( 'We were unable to restore the site.' ), { duration: 5000 } )
-				);
-			}
-		},
-	} );
-
 	const siteStatusGroups = useSiteStatusGroups();
 
 	// Generate DataViews table field-columns
@@ -209,9 +157,7 @@ const DotcomSitesDataViews = ( {
 			{
 				id: 'status',
 				label: __( 'Status' ),
-				render: ( { item }: { item: SiteExcerptData } ) => (
-					<SiteStatus site={ item } isRestoring={ isRestoring } />
-				),
+				render: ( { item }: { item: SiteExcerptData } ) => <SiteStatus site={ item } />,
 				enableHiding: false,
 				enableSorting: true,
 				elements: siteStatusGroups,
@@ -250,10 +196,10 @@ const DotcomSitesDataViews = ( {
 				getValue: () => null,
 			},
 		],
-		[ __, openSitePreviewPane, userId, siteStatusGroups, isRestoring ]
+		[ __, openSitePreviewPane, userId, siteStatusGroups ]
 	);
 
-	const actions = useActions( { restoreSite } );
+	const actions = useActions();
 
 	return (
 		<div className="sites-dataviews">

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -1,17 +1,26 @@
+import {
+	SiteExcerptData,
+	SITE_EXCERPT_REQUEST_FIELDS,
+	SITE_EXCERPT_REQUEST_OPTIONS,
+} from '@automattic/sites';
+import { useQueryClient } from '@tanstack/react-query';
 import { usePrevious } from '@wordpress/compose';
 import { DataViews, Field } from '@wordpress/dataviews';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo, useRef, useLayoutEffect } from 'react';
+import { useDispatch as useReduxDispatch } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
+import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
+import useRestoreSiteMutation from 'calypso/sites/hooks/use-restore-site-mutation';
 import { SitePlan } from 'calypso/sites-dashboard/components/sites-site-plan';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { useActions } from './actions';
 import SiteField from './dataviews-fields/site-field';
 import { SiteStats } from './sites-site-stats';
 import { SiteStatus } from './sites-site-status';
-import type { SiteExcerptData } from '@automattic/sites';
 import type { View } from '@wordpress/dataviews';
 
 import './style.scss';
@@ -128,6 +137,49 @@ const DotcomSitesDataViews = ( {
 		};
 	}, [] );
 
+	const queryClient = useQueryClient();
+	const reduxDispatch = useReduxDispatch();
+	const { mutate: restoreSite, isPending: isRestoring } = useRestoreSiteMutation( {
+		onSuccess() {
+			queryClient.invalidateQueries( {
+				queryKey: [
+					USE_SITE_EXCERPTS_QUERY_KEY,
+					SITE_EXCERPT_REQUEST_FIELDS,
+					SITE_EXCERPT_REQUEST_OPTIONS,
+					[],
+					'all',
+				],
+			} );
+			queryClient.invalidateQueries( {
+				queryKey: [
+					USE_SITE_EXCERPTS_QUERY_KEY,
+					SITE_EXCERPT_REQUEST_FIELDS,
+					SITE_EXCERPT_REQUEST_OPTIONS,
+					[],
+					'deleted',
+				],
+			} );
+			reduxDispatch(
+				successNotice( __( 'The site has been restored.' ), {
+					duration: 3000,
+				} )
+			);
+		},
+		onError: ( error ) => {
+			if ( error.status === 403 ) {
+				reduxDispatch(
+					errorNotice( __( 'Only an administrator can restore a deleted site.' ), {
+						duration: 5000,
+					} )
+				);
+			} else {
+				reduxDispatch(
+					errorNotice( __( 'We were unable to restore the site.' ), { duration: 5000 } )
+				);
+			}
+		},
+	} );
+
 	const siteStatusGroups = useSiteStatusGroups();
 
 	// Generate DataViews table field-columns
@@ -157,7 +209,9 @@ const DotcomSitesDataViews = ( {
 			{
 				id: 'status',
 				label: __( 'Status' ),
-				render: ( { item }: { item: SiteExcerptData } ) => <SiteStatus site={ item } />,
+				render: ( { item }: { item: SiteExcerptData } ) => (
+					<SiteStatus site={ item } isRestoring={ isRestoring } />
+				),
 				enableHiding: false,
 				enableSorting: true,
 				elements: siteStatusGroups,
@@ -196,10 +250,10 @@ const DotcomSitesDataViews = ( {
 				getValue: () => null,
 			},
 		],
-		[ __, openSitePreviewPane, userId, siteStatusGroups ]
+		[ __, openSitePreviewPane, userId, siteStatusGroups, isRestoring ]
 	);
 
-	const actions = useActions();
+	const actions = useActions( { restoreSite } );
 
 	return (
 		<div className="sites-dataviews">

--- a/client/sites/components/sites-dataviews/sites-site-status.tsx
+++ b/client/sites/components/sites-dataviews/sites-site-status.tsx
@@ -34,7 +34,7 @@ const DeletedStatus = styled.div`
 
 interface SiteStatusProps {
 	site: SiteExcerptData;
-	isRestoring: boolean;
+	isRestoring?: boolean;
 }
 
 export const SiteStatus = ( { site, isRestoring }: SiteStatusProps ) => {

--- a/client/sites/components/sites-dataviews/sites-site-status.tsx
+++ b/client/sites/components/sites-dataviews/sites-site-status.tsx
@@ -1,23 +1,13 @@
-import { Button } from '@automattic/components';
-import {
-	SITE_EXCERPT_REQUEST_FIELDS,
-	SITE_EXCERPT_REQUEST_OPTIONS,
-	useSiteLaunchStatusLabel,
-} from '@automattic/sites';
+import { useSiteLaunchStatusLabel } from '@automattic/sites';
 import styled from '@emotion/styled';
-import { useQueryClient } from '@tanstack/react-query';
 import { Spinner } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useDispatch as useReduxDispatch } from 'react-redux';
-import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { SiteLaunchNag } from 'calypso/sites-dashboard/components/sites-site-launch-nag';
 import TransferNoticeWrapper from 'calypso/sites-dashboard/components/sites-transfer-notice-wrapper';
 import { WithAtomicTransfer } from 'calypso/sites-dashboard/components/with-atomic-transfer';
 import { getMigrationStatus, MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
-import useRestoreSiteMutation from '../../hooks/use-restore-site-mutation';
 import type { SiteExcerptData } from '@automattic/sites';
 
 const BadgeDIFM = styled.span`
@@ -42,80 +32,22 @@ const DeletedStatus = styled.div`
 	}
 `;
 
-const RestoreButton = styled( Button )`
-	color: var( --color-link ) !important;
-	font-size: 12px;
-	text-decoration: underline;
-`;
-
 interface SiteStatusProps {
 	site: SiteExcerptData;
+	isRestoring: boolean;
 }
 
-export const SiteStatus = ( { site }: SiteStatusProps ) => {
+export const SiteStatus = ( { site, isRestoring }: SiteStatusProps ) => {
 	const { __ } = useI18n();
-	const queryClient = useQueryClient();
-	const reduxDispatch = useReduxDispatch();
 
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const isDIFMInProgress = useSelector( ( state ) => isDIFMLiteInProgress( state, site.ID ) );
-
-	const { mutate: restoreSite, isPending: isRestoring } = useRestoreSiteMutation( {
-		onSuccess() {
-			queryClient.invalidateQueries( {
-				queryKey: [
-					USE_SITE_EXCERPTS_QUERY_KEY,
-					SITE_EXCERPT_REQUEST_FIELDS,
-					SITE_EXCERPT_REQUEST_OPTIONS,
-					[],
-					'all',
-				],
-			} );
-			queryClient.invalidateQueries( {
-				queryKey: [
-					USE_SITE_EXCERPTS_QUERY_KEY,
-					SITE_EXCERPT_REQUEST_FIELDS,
-					SITE_EXCERPT_REQUEST_OPTIONS,
-					[],
-					'deleted',
-				],
-			} );
-			reduxDispatch(
-				successNotice( __( 'The site has been restored.' ), {
-					duration: 3000,
-				} )
-			);
-		},
-		onError: ( error ) => {
-			if ( error.status === 403 ) {
-				reduxDispatch(
-					errorNotice( __( 'Only an administrator can restore a deleted site.' ), {
-						duration: 5000,
-					} )
-				);
-			} else {
-				reduxDispatch(
-					errorNotice( __( 'We were unable to restore the site.' ), { duration: 5000 } )
-				);
-			}
-		},
-	} );
-
-	const handleRestoreSite = () => {
-		restoreSite( site.ID );
-	};
 
 	if ( site.is_deleted ) {
 		return (
 			<DeletedStatus>
 				<span>{ __( 'Deleted' ) }</span>
-				{ isRestoring ? (
-					<Spinner />
-				) : (
-					<RestoreButton borderless onClick={ handleRestoreSite }>
-						{ __( 'Restore' ) }
-					</RestoreButton>
-				) }
+				{ isRestoring && <Spinner /> }
 			</DeletedStatus>
 		);
 	}

--- a/client/sites/components/sites-dataviews/sites-site-status.tsx
+++ b/client/sites/components/sites-dataviews/sites-site-status.tsx
@@ -1,6 +1,5 @@
 import { useSiteLaunchStatusLabel } from '@automattic/sites';
 import styled from '@emotion/styled';
-import { Spinner } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { SiteLaunchNag } from 'calypso/sites-dashboard/components/sites-site-launch-nag';
 import TransferNoticeWrapper from 'calypso/sites-dashboard/components/sites-transfer-notice-wrapper';
@@ -34,10 +33,9 @@ const DeletedStatus = styled.div`
 
 interface SiteStatusProps {
 	site: SiteExcerptData;
-	isRestoring?: boolean;
 }
 
-export const SiteStatus = ( { site, isRestoring }: SiteStatusProps ) => {
+export const SiteStatus = ( { site }: SiteStatusProps ) => {
 	const { __ } = useI18n();
 
 	const translatedStatus = useSiteLaunchStatusLabel( site );
@@ -47,7 +45,6 @@ export const SiteStatus = ( { site, isRestoring }: SiteStatusProps ) => {
 		return (
 			<DeletedStatus>
 				<span>{ __( 'Deleted' ) }</span>
-				{ isRestoring && <Spinner /> }
 			</DeletedStatus>
 		);
 	}

--- a/client/sites/hooks/use-restore-site-mutation.ts
+++ b/client/sites/hooks/use-restore-site-mutation.ts
@@ -1,9 +1,4 @@
-import {
-	UseMutateFunction,
-	useMutation,
-	UseMutationOptions,
-	UseMutationResult,
-} from '@tanstack/react-query';
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
 import { addQueryArgs } from '@wordpress/url';
 import wpcom from 'calypso/lib/wp';
 
@@ -17,9 +12,6 @@ interface APIError {
 interface APIResponse {
 	success: true;
 }
-
-export type mutateFunction = UseMutateFunction< APIResponse, APIError, number, unknown >;
-
 function restoreSite( siteId: number ) {
 	return wpcom.req.post( {
 		method: 'put',

--- a/client/sites/hooks/use-restore-site-mutation.ts
+++ b/client/sites/hooks/use-restore-site-mutation.ts
@@ -1,4 +1,9 @@
-import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import {
+	UseMutateFunction,
+	useMutation,
+	UseMutationOptions,
+	UseMutationResult,
+} from '@tanstack/react-query';
 import { addQueryArgs } from '@wordpress/url';
 import wpcom from 'calypso/lib/wp';
 
@@ -12,6 +17,8 @@ interface APIError {
 interface APIResponse {
 	success: true;
 }
+
+export type mutateFunction = UseMutateFunction< APIResponse, APIError, number, unknown >;
 
 function restoreSite( siteId: number ) {
 	return wpcom.req.post( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9903, https://github.com/WordPress/gutenberg/pull/67218

## Proposed Changes

This PR hides actions except "Restore" on a deleted site. 

before

https://github.com/user-attachments/assets/3f7686d0-b6ea-4e9f-8bd5-f593779a5b59

after

https://github.com/user-attachments/assets/01e9e78e-1713-4b30-bf4a-c259abcffc09

I removed the loading state, as the loading status in action items doesn’t seem to be natively supported. I don't think it will be a big issue, because after a success or failure, a notification will be displayed. We can follow up with [ActionWithModal](https://github.com/WordPress/gutenberg/blob/ed66cc50e3c0b6785a48c15230c090790c0b0e6c/packages/dataviews/src/components/dataviews-item-actions/index.tsx#L166) to handle actions' states, but I consider displaying a state for restoration to be a low priority at this time. CCing: @oandregal @youknowriad in case you have insight.

<details><summary>ver. 1</summary>
<p>

after

https://github.com/user-attachments/assets/35f8bf5a-ba7d-467f-b9fb-27456b7ae2e8

I retained the loading spinner in the status column, as loading status in actions doesn’t seem to be natively supported. This might be worth revisiting in a follow-up. 

</p>
</details> 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/dotcom-forge/issues/9903

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Test the Restore action for a deleted site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
