### PR TITLE
Stats: Make chart bars navigable to a detailed chart

### DIFF
--- a/client/components/stats-interval-dropdown/index.jsx
+++ b/client/components/stats-interval-dropdown/index.jsx
@@ -84,6 +84,12 @@ const IntervalDropdown = ( { slug, period, queryParams, intervals, onGatedHandle
 	}
 
 	function onSelectionHandler( interval ) {
+		// Temporary fix to prevent selecting intervals when the applied interval is not in the list. E.g., Hour.
+		// TODO: Remove the selection if the current applied interval is not in the list.
+		if ( ! intervals[ period ] ) {
+			return;
+		}
+
 		page( generateNewLink( interval ) );
 	}
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -201,6 +201,11 @@ class StatsSite extends Component {
 		}
 
 		const { period: barPeriod } = this.props.period;
+		// Stop navigation if the bar period is hour.
+		if ( barPeriod === 'hour' ) {
+			return;
+		}
+
 		// Navigate from the chart bar with period and period start date.
 		page( this.navigationFromChartBar( bar.data.period, barPeriod ) );
 	};

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -167,9 +167,42 @@ class StatsSite extends Component {
 		return activeTab.legendOptions || [];
 	}
 
+	navigationFromChartBar = ( periodStartDate, period ) => {
+		let chartStart = periodStartDate;
+		let chartEnd = moment( chartStart )
+			.endOf( period === 'week' ? 'isoWeek' : period )
+			.format( 'YYYY-MM-DD' );
+
+		// Limit navigation within the currently selected range.
+		const currentChartStart = this.props.context.query?.chartStart;
+		const currentChartEnd = this.props.context.query?.chartEnd;
+		if ( currentChartStart && moment( chartStart ).isBefore( currentChartStart ) ) {
+			chartStart = currentChartStart;
+		}
+		if ( currentChartEnd && moment( chartEnd ).isAfter( currentChartEnd ) ) {
+			chartEnd = currentChartEnd;
+		}
+
+		// Determine the target period for the navigation.
+		const targetPeriod = period === 'day' ? 'hour' : 'day';
+
+		const path = `/stats/${ targetPeriod }/${ this.props.slug }`;
+		const url = getPathWithUpdatedQueryString( { chartStart, chartEnd }, path );
+
+		return url;
+	};
+
 	barClick = ( bar ) => {
 		this.props.recordGoogleEvent( 'Stats', 'Clicked Chart Bar' );
-		page.redirect( getPathWithUpdatedQueryString( { startDate: bar.data.period } ) );
+
+		if ( ! config.isEnabled( 'stats/new-date-filtering' ) ) {
+			page.redirect( getPathWithUpdatedQueryString( { startDate: bar.data.period } ) );
+			return;
+		}
+
+		const { period: barPeriod } = this.props.period;
+		// Navigate from the chart bar with period and period start date.
+		page( this.navigationFromChartBar( bar.data.period, barPeriod ) );
 	};
 
 	onChangeLegend = ( activeLegend ) => this.setState( { activeLegend } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/273

## Proposed Changes

* Determine the chart bar target period and date range to navigate to a detailed chart from the bar clicking.
* Prevent interaction when the selected period is `Hour`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The navigation from clicking on the chart bars makes it easy to discover more detailed stats.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> Note: The date period header still needs to be tweaked.

* Spin this change up with the Calypso Live branch.
* Ensure the chart bar clicking works as previously.
* Append the feature flag to the URL: `?flags=stats/new-date-filtering`.
* Ensure clicking a single-day bar navigates to the hourly views.

https://github.com/user-attachments/assets/1b9e5d2a-0455-45ac-bf8d-63fe5ab773bf

* Ensure clicking a weekly, monthly, or yearly bar navigates to the daily views.

https://github.com/user-attachments/assets/e479b953-d998-47b9-9148-cecb51ed6988

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
