### PR TITLE
Sites Dashboard: Remove Action column-related overrides 

### DIFF
--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -76,9 +76,14 @@ const DEFAULT_SITE_TYPE = 'non-p2';
 // Limit fields on breakpoints smaller than 960px wide.
 const desktopFields = [ 'site', 'plan', 'status', 'last-publish', 'stats' ];
 const mobileFields = [ 'site' ];
+const listViewFields = [ 'site' ];
 
-const getFieldsByBreakpoint = ( isDesktop: boolean ) =>
-	isDesktop ? desktopFields : mobileFields;
+const getFieldsByBreakpoint = ( selectedSite: boolean, isDesktop: boolean ) => {
+	if ( selectedSite ) {
+		return listViewFields;
+	}
+	return isDesktop ? desktopFields : mobileFields;
+};
 
 export function showSitesPage( route: string ) {
 	const currentParams = new URL( window.location.href ).searchParams;
@@ -171,7 +176,7 @@ const SitesDashboard = ( {
 		page,
 		perPage,
 		search: search ?? '',
-		fields: getFieldsByBreakpoint( isDesktop ),
+		fields: getFieldsByBreakpoint( !! selectedSite, isDesktop ),
 		...( status
 			? {
 					filters: [
@@ -211,7 +216,7 @@ const SitesDashboard = ( {
 	const [ dataViewsState, setDataViewsState ] = useState< View >( defaultDataViewsState );
 
 	useEffect( () => {
-		const fields = getFieldsByBreakpoint( isDesktop );
+		const fields = getFieldsByBreakpoint( !! selectedSite, isDesktop );
 		const fieldsForBreakpoint = [ ...fields ].sort().toString();
 		const existingFields = [ ...( dataViewsState?.fields ?? [] ) ].sort().toString();
 		// Compare the content of the arrays, not its referrences that will always be different.
@@ -238,7 +243,7 @@ const SitesDashboard = ( {
 				},
 			} );
 		}
-	}, [ isDesktop, isWide, dataViewsState ] );
+	}, [ isDesktop, isWide, dataViewsState, selectedSite ] );
 
 	// Ensure site sort preference is applied when it loads in. This isn't always available on
 	// initial mount.

--- a/client/sites/components/sites-dataviews/dataview-style.scss
+++ b/client/sites/components/sites-dataviews/dataview-style.scss
@@ -133,39 +133,6 @@
 		}
 	}
 
-	.sites-dataviews__actions {
-		display: flex;
-		flex-direction: row;
-		align-items: center;
-		justify-content: end;
-		flex-wrap: nowrap;
-
-		@media (min-width: 1080px) {
-			.site-actions__actions-large-screen {
-				float: none;
-				margin-inline-end: 20px;
-			}
-		}
-
-		> *:not(:last-child) {
-			margin-inline-end: 10px;
-		}
-
-		.components-dropdown-menu__toggle,
-		.site-preview__open {
-			.gridicon {
-				width: 18px;
-				height: 18px;
-			}
-		}
-
-		&.sites-dataviews__actions-error {
-			svg {
-				color: var(--color-accent-5);
-			}
-		}
-	}
-
 	.dataviews-pagination {
 		flex-shrink: 0;
 		background: #fff;
@@ -190,38 +157,6 @@
 
 		@include breakpoint-deprecated( ">1400px" ) {
 			bottom: 0;
-		}
-	}
-
-	// DataView overrides:
-	// Using the List view for the fly-out panel requires hiding certain elements
-	// to properly fit the site list when the panel is open.
-	@media (min-width: $break-large) {
-		ul.dataviews-view-list {
-			// This override could potentially be removed if we’re able to pass the Actions column via data.actions
-			.components-h-stack,
-			.dataviews-view-list__item {
-				width: 100%;
-			}
-
-			// This styling is a bit of a hack: To make the site name clickable area larger, will need
-			// to hide the other fields when in preview mode.
-			.dataviews-view-list__field {
-				// Hide the field except first (Site name) and last (actions menu)
-				&:not(:first-child) {
-					display: none;
-				}
-
-				// Force the site name to take up the full width
-				&:first-child {
-					flex-grow: 1;
-
-					.sites-dataviews__site {
-						width: 100%;
-						justify-content: flex-start;
-					}
-				}
-			}
 		}
 	}
 }

--- a/client/sites/components/sites-dataviews/style.scss
+++ b/client/sites/components/sites-dataviews/style.scss
@@ -7,16 +7,6 @@
 	overflow: hidden;
 	padding-bottom: 0;
 
-
-	.dataviews-view-table__row td:last-of-type {
-		pointer-events: none;
-
-		button,
-		a {
-			pointer-events: auto;
-		}
-	}
-
 	.sites-dataviews__site {
 		display: flex;
 		flex-direction: row;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9734, https://github.com/Automattic/wp-calypso/pull/96326/

## Proposed Changes

This PR removes Action column-related overrides since we now merged https://github.com/Automattic/wp-calypso/pull/94238.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pbxlJb-6DF-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site
* Observe no visual changes

table view
<img width="1301" alt="Screenshot 2024-11-21 at 16 31 17" src="https://github.com/user-attachments/assets/747e2c02-d992-4881-bfd7-55775213cb98">

list view (when the site is selected)
<img width="402" alt="Screenshot 2024-11-21 at 16 31 07" src="https://github.com/user-attachments/assets/333b0fc7-8f5b-4810-adba-37905f3d7adf">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?