### PR TITLE
Performance Profiler: Fix track event that sends llm survey results

### DIFF
--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -34,7 +34,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 		recordTracksEvent( 'calypso_performance_profiler_llm_survey_click', {
 			hash,
 			url,
-			chatId,
+			chat_id: chatId,
 			rating,
 			description,
 			...( userFeedback && { user_feedback: userFeedback } ),

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -36,7 +36,6 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 			url,
 			chat_id: chatId,
 			rating,
-			description,
 			...( userFeedback && { user_feedback: userFeedback } ),
 			version: profilerVersion(),
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related https://github.com/Automattic/wp-calypso/pull/96501

## Proposed Changes

* Fixes the `eventprop` that is sent when clicking on a survey in the Speed Test tool insights

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix an issue that was preventing the track event to be processed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch, and navigate to a Speed Test tool report, e.g. `/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6Nzc3Mn0.048zsfIxmJ0M_YpPGRg0QSsTmtMglyBAlPMJhrGB1vg`
* Go to the insights section and expand one
* Wait for the AI generated response to be displayed, and click on a survey result, either `good` or `bad`
* After some minutes, go to track events, and make sure you can see the `calypso_performance_profiler_llm_survey_click` track event there with the expected values (including a valid `chat_id`). You can find the URL to the track event here 36502-pb

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?