### PR TITLE
A4A: Implement Agency ownership transfer

### DIFF
--- a/client/a8c-for-agencies/data/team/use-transfer-ownership.ts
+++ b/client/a8c-for-agencies/data/team/use-transfer-ownership.ts
@@ -1,0 +1,44 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+interface APIError {
+	status: number;
+	code: string | null;
+	message: string;
+}
+
+export interface Params {
+	id: number;
+}
+
+interface APIResponse {
+	success: boolean;
+}
+
+function transferOwnershipMutation( params: Params, agencyId?: number ): Promise< APIResponse > {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to transfer ownership' );
+	}
+
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/transfer-ownership`,
+		method: 'PUT',
+		body: {
+			new_owner_id: params.id,
+		},
+	} );
+}
+
+export default function useTransferOwnershipMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, Params, TContext >
+): UseMutationResult< APIResponse, APIError, Params, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< APIResponse, APIError, Params, TContext >( {
+		...options,
+		mutationFn: ( args ) => transferOwnershipMutation( args, agencyId ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
+++ b/client/a8c-for-agencies/sections/team/hooks/use-handle-member-action.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import useCancelMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-cancel-member-invite';
 import useRemoveMemberMutation from 'calypso/a8c-for-agencies/data/team/use-remove-member';
 import useResendMemberInviteMutation from 'calypso/a8c-for-agencies/data/team/use-resend-member-invite';
+import useTransferOwnershipMutation from 'calypso/a8c-for-agencies/data/team/use-transfer-ownership';
 import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { TeamMember } from '../types';
@@ -21,6 +22,8 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 	const { mutate: cancelMemberInvite } = useCancelMemberInviteMutation();
 
 	const { mutate: removeMember } = useRemoveMemberMutation();
+
+	const { mutate: transferOwnership } = useTransferOwnershipMutation();
 
 	const currentUser = useSelector( getCurrentUser );
 
@@ -114,6 +117,34 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 					}
 				);
 			}
+
+			if ( action === 'transfer-ownership' ) {
+				transferOwnership(
+					{ id: item.id },
+					{
+						onSuccess: () => {
+							dispatch(
+								successNotice( translate( 'Ownership has been successfully transferred.' ), {
+									id: 'transfer-ownership-success',
+									duration: 5000,
+								} )
+							);
+							onRefetchList?.();
+							callback?.();
+						},
+
+						onError: ( error ) => {
+							dispatch(
+								errorNotice( error.message, {
+									id: 'transfer-ownership-error',
+									duration: 5000,
+								} )
+							);
+							callback?.();
+						},
+					}
+				);
+			}
 		},
 		[
 			cancelMemberInvite,
@@ -123,6 +154,7 @@ export default function useHandleMemberAction( { onRefetchList }: Props ) {
 			removeMember,
 			resendMemberInvite,
 			translate,
+			transferOwnership,
 		]
 	);
 }

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -184,6 +184,29 @@ export const ActionColumn = ( {
 						isEnabled: false, // FIXME: Implement this action
 					},
 					{
+						name: 'transfer-ownership',
+						label: translate( 'Transfer ownership' ),
+						isEnabled: member.status === 'active' && currentUser.email !== member.email,
+						confirmationDialog: {
+							title: translate( 'Transfer agency ownership' ),
+							children: translate(
+								'Are you sure you want to transfer ownership of %(agencyName)s to {{b}}%(memberName)s{{/b}}? {{br/}}This action cannot be undone and you will become a regular team member.',
+								{
+									args: {
+										agencyName: agency?.name ?? '',
+										memberName: member.displayName ?? member.email,
+									},
+									components: {
+										b: <b />,
+										br: <br />,
+									},
+									comment: '%(agencyName)s is the agency name, %(memberName)s is the member name',
+								}
+							),
+							ctaLabel: translate( 'Transfer ownership' ),
+						},
+					},
+					{
 						name: 'delete-user',
 						label: isSelfAction ? translate( 'Leave agency' ) : translate( 'Remove team member' ),
 						className: 'is-danger',
@@ -226,6 +249,7 @@ export const ActionColumn = ( {
 		canRemove,
 		isSelfAction,
 		agency?.name,
+		currentUser.email,
 	] );
 
 	const activeActions = actions.filter( ( { isEnabled } ) => isEnabled );


### PR DESCRIPTION
Adds the possibility to transfer the Agency Owner role to a different team member on the agency account.

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1128.

## Proposed Changes

<img width="237" alt="Screenshot 2024-11-21 at 10 38 49" src="https://github.com/user-attachments/assets/29de35f7-597c-421c-bbbf-96196309e7f6">
<img width="736" alt="Screenshot 2024-11-21 at 10 38 39" src="https://github.com/user-attachments/assets/4127163e-f111-4492-8864-0ff46b455e99">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com`.
* Apply D166876-code.
* In your test agency, invite a user to the agency.
* Log in as the agency owner, navigate to Team, click on Actions for the user you invited, and select Transfer ownership.
* A confirmation modal should appear.
* Click the **Transfer ownership** button in the confirmation modal.
* Confirm that the table reloads and you are no longer listed as the agency owner.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?