### PR TITLE
Odie: fix traintracks

### DIFF
--- a/packages/odie-client/src/components/message/sources.tsx
+++ b/packages/odie-client/src/components/message/sources.tsx
@@ -24,7 +24,6 @@ export const Sources = ( { message }: { message: Message } ) => {
 						fetch_query: source?.railcar?.fetch_query,
 						fetch_lang: source?.railcar?.fetch_lang,
 						ui_position: index,
-						rec_query: source?.railcar?.rec_query,
 						rec_blog_id: source?.railcar?.rec_blog_id,
 						rec_post_id: source?.railcar?.rec_post_id,
 					} );

--- a/packages/odie-client/src/components/message/sources.tsx
+++ b/packages/odie-client/src/components/message/sources.tsx
@@ -14,13 +14,15 @@ export const Sources = ( { message }: { message: Message } ) => {
 		if ( messageLength > 0 ) {
 			// Record TrainTracks render events
 			message.context?.sources?.forEach( ( source: Source, index: number ) => {
-				trackEvent( 'sources_traintracks_render', {
-					fetch_algo: source?.railcar?.fetch_algo,
-					ui_algo: 'default',
-					railcar: source?.railcar?.railcar,
-					fetch_position: source?.railcar?.fetch_position,
-					ui_position: index,
-				} );
+				if ( source.railcar ) {
+					trackEvent( 'sources_traintracks_render', {
+						fetch_algo: source?.railcar?.fetch_algo,
+						ui_algo: 'default',
+						railcar: source?.railcar?.railcar,
+						fetch_position: source?.railcar?.fetch_position,
+						ui_position: index,
+					} );
+				}
 			} );
 			return [
 				...new Map(

--- a/packages/odie-client/src/components/message/sources.tsx
+++ b/packages/odie-client/src/components/message/sources.tsx
@@ -18,9 +18,15 @@ export const Sources = ( { message }: { message: Message } ) => {
 					trackEvent( 'sources_traintracks_render', {
 						fetch_algo: source?.railcar?.fetch_algo,
 						ui_algo: 'default',
+						message_id: message?.message_id,
 						railcar: source?.railcar?.railcar,
 						fetch_position: source?.railcar?.fetch_position,
+						fetch_query: source?.railcar?.fetch_query,
+						fetch_lang: source?.railcar?.fetch_lang,
 						ui_position: index,
+						rec_query: source?.railcar?.rec_query,
+						rec_blog_id: source?.railcar?.rec_blog_id,
+						rec_post_id: source?.railcar?.rec_post_id,
 					} );
 				}
 			} );

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -77,8 +77,13 @@ export type Source = {
 		ui_position: number;
 		ui_algo: string;
 		fetch_algo: string;
+		fetch_lang: string;
 		fetch_position: number;
+		fetch_query: number;
 		railcar: string;
+		rec_blog_id: string;
+		rec_post_id: string;
+		rec_url: string;
 	};
 };
 

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -74,8 +74,6 @@ export type Source = {
 	post_id: number;
 	content: string;
 	railcar?: {
-		ui_position: number;
-		ui_algo: string;
 		fetch_algo: string;
 		fetch_lang: string;
 		fetch_position: number;
@@ -84,6 +82,8 @@ export type Source = {
 		rec_blog_id: string;
 		rec_post_id: string;
 		rec_url: string;
+		ui_position: number;
+		ui_algo: string;
 	};
 };
 


### PR DESCRIPTION
In doing analysis on the Tracks events for odie sources, I noticed several issues
1. When we fetch an existing chat, we are firing tracks events for every message in the chat. We should only fire TrainTracks events when there is a new response. The solution here is to only fire the events when there is a railcar attached to the source as part of the response from the API
2. We were missing some valuable information in the event properties, in particular the query. This adds those in as well.

## Proposed Changes

* Only fire traintracks events when there is a railcar for the source
* add additional properties to the event

## Why are these changes being made?
* In order to be able to measure click-through rate of Odie retrieval, so that we can improve the performance of the AI assistant. 

## Testing Instructions
First, to see the issue:
* navigate to the wordpress.com dashboard for any site. 
* Open the help center (? button in top right)
* Open the Network tab in your browser and filter for `t.gif`
* Click on "need more help" to open the AI assistant
* If you have some chat history, you will see many `t.gif` pixel requests with event name `_en=calypso_odie_sources_traintracks_render`. There should be 0 at this point
* Also note that there is no message_id, rec_url, rec_blog_id, rec_post_id, fetch_lang, or fetch_query properties on the events

Now, to see the fix:
* Apply D166895-code to your wp.com sandbox
* Sandbox the public api
* Reload the page and clear the network tab in the browser dev tools
* Go to the AI assistant again. You should now see no such `t.gif` events (there will be some other events but no `calypso_odie_sources_traintracks_render` events
* Ask the bot a question
* Now you should see some `calypso_odie_sources_traintracks_render` events, probably 10 - one for each source that Odie found. It could be less, depending on the query. Confirm that the missing event properties are now there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?