### PR TITLE
Enable logged out for /me/account/closed

### DIFF
--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -1,8 +1,21 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender, setSelectedSiteIdByOrigin } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	setSelectedSiteIdByOrigin,
+	redirectLoggedOut,
+} from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
 import { account } from './controller';
 
 export default function () {
-	page( '/me/account', sidebar, setSelectedSiteIdByOrigin, account, makeLayout, clientRender );
+	page(
+		'/me/account',
+		redirectLoggedOut,
+		sidebar,
+		setSelectedSiteIdByOrigin,
+		account,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -1,5 +1,10 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender, setSelectedSiteIdByOrigin } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	setSelectedSiteIdByOrigin,
+	redirectLoggedOut,
+} from 'calypso/controller';
 import * as controller from './controller';
 
 import './style.scss';
@@ -7,6 +12,7 @@ import './style.scss';
 export default function () {
 	page(
 		'/me',
+		redirectLoggedOut,
 		controller.sidebar,
 		setSelectedSiteIdByOrigin,
 		controller.profile,
@@ -22,5 +28,14 @@ export default function () {
 	page( '/me/trophies', controller.profileRedirect, makeLayout, clientRender );
 	page( '/me/find-friends', controller.profileRedirect, makeLayout, clientRender );
 
-	page( '/me/get-apps', controller.sidebar, controller.apps, makeLayout, clientRender );
+	page(
+		'/me/get-apps',
+		redirectLoggedOut,
+		controller.sidebar,
+		controller.apps,
+		makeLayout,
+		clientRender
+	);
+
+	page( '/me/*', redirectLoggedOut );
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -36,10 +36,21 @@ const sections = [
 		paths: [ '/me/account' ],
 		module: 'calypso/me/account',
 		group: 'me',
+		// /me/account/closed is enabled to logged out users for self-serve account restoration
+		// enableLoggedOut is needed as /me/account/closed is nested within /me/account
+		// redirectLoggedOut is now handled in client/me/account/index.js
+		enableLoggedOut: true,
+	},
+	{
+		name: 'account-closed',
+		paths: [ '/me/account/closed' ],
+		module: 'calypso/me/account-close',
+		group: 'me',
+		enableLoggedOut: true,
 	},
 	{
 		name: 'account-close',
-		paths: [ '/me/account/close', '/me/account/closed' ],
+		paths: [ '/me/account/close' ],
 		module: 'calypso/me/account-close',
 		group: 'me',
 	},
@@ -96,6 +107,12 @@ const sections = [
 		module: 'calypso/me/site-blocks',
 		group: 'me',
 	},
+	{
+		name: 'help',
+		paths: [ '/me/chat' ],
+		module: 'calypso/me/help',
+		group: 'me',
+	},
 	// This should be the last section for `/me` paths as it would otherwise have precedence over
 	// the other sub `/me/*` sections when resolving the requested path
 	{
@@ -103,6 +120,10 @@ const sections = [
 		paths: [ '/me' ],
 		module: 'calypso/me',
 		group: 'me',
+		// /me/account/closed is enabled to logged out users for self-serve account restoration
+		// enableLoggedOut is needed as /me/account/closed is nested within /me
+		// redirectLoggedOut is handled in client/me/index.js
+		enableLoggedOut: true,
 	},
 	{
 		name: 'activity',
@@ -492,12 +513,6 @@ const sections = [
 		paths: [ '/help' ],
 		module: 'calypso/me/help',
 		enableLoggedOut: true,
-		group: 'me',
-	},
-	{
-		name: 'help',
-		paths: [ '/me/chat' ],
-		module: 'calypso/me/help',
 		group: 'me',
 	},
 	{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9909

## Proposed Changes

* Enable logged out for /me/account/closed
* This should not change any existing behavior other than `/me/account/closed` page

Note that `/me/account/closed` currently defaults to the "Account is deleting" state but it's not doing anything. This is also the current production behavior if you are logged in and access `/me/account/closed` directly.
To be focused on enabling logged out for `/me/account/closed`, this will not be addressed in this PR.

![expected@2x](https://github.com/user-attachments/assets/7bd3c6eb-8ca3-4692-b883-aeb856279bb1)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allow users to self-restore accounts pet6gk-1Em-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this diff and **rerun** `yarn start` (this is a must for the changes to be reflected)
* You are logged out
* Go to `calypso.localhost:3000/me/account/closed` and it should be accessible
* The other /me routes and will redirect to `/log-in?redirect_to=<where you wanted to go>

I've checked the important `/me` routes I could find in wp-calypso

- [ ] /me
- [ ] /me/account
- [ ] /me/account/close
- [ ] /me/account/closed
- [ ] /me/profile
- [ ] /me/public-profile
- [ ] /me/trophies
- [ ] /me/find-friends
- [ ] /me/get-apps
- [ ] /me/quickstart
- [ ] /me/concierge
- [ ] /me/developer
- [ ] /me/chat
- [ ] /me/notifications
- [ ] /me/privacy
- [ ] /me/purchases
- [ ] /me/purchases/add-credit-card
- [ ] /me/billing
- [ ] /me/purchases/billing
- [ ] /me/purchases-by-owner (this currently is a blank page on production if it's not `/me/purchases-by-owner/:ownershipId`, this PR retains the same behavior)
- [ ] /me/security

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?