### PR TITLE
Domains Manage: Align empty state content with navigation header

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -361,12 +361,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			<Main>
 				<DocumentHead title={ translate( 'Domains' ) } />
 				<BodySectionCssClass
-					bodyClass={ [
-						'edit__body-white',
-						'is-bulk-domains-page',
-						'is-bulk-all-domains-page',
-						...( isDomainsEmpty ? [ 'is-bulk-all-domains-page--is-empty' ] : [] ),
-					] }
+					bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page', 'is-bulk-all-domains-page' ] }
 				/>
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
 				{ ! isLoading && ! isDomainsEmpty && <GoogleDomainOwnerBanner /> }
@@ -385,7 +380,11 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						deleteBulkActionStatus={ deleteBulkActionStatus }
 					/>
 				) : (
-					<EmptyState />
+					<div className="bulk-domains-empty-state">
+						<div className="bulk-domains-empty-state__main">
+							<EmptyState />
+						</div>
+					</div>
 				) }
 			</Main>
 		</>

--- a/client/my-sites/domains/domain-management/list/empty-state/style.scss
+++ b/client/my-sites/domains/domain-management/list/empty-state/style.scss
@@ -1,31 +1,5 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
-
-.is-bulk-all-domains-page.is-bulk-all-domains-page--is-empty .layout__content .main .navigation-header {
-	border-block-end: 1px solid var(--studio-gray-0);
-	padding-bottom: 1rem;
-	padding-inline: 1rem;
-	padding-top: 1rem;
-
-	@include break-large {
-		margin: 0;
-		padding-bottom: 1.5rem;
-		padding-inline: 4rem;
-		padding-top: 1.5rem;
-	}
-}
-
 .domains-empty-state {
-	padding-inline: 1rem;
 	text-align: left;
-
-	@include break-large {
-		padding-inline: 4rem;
-	}
-
-	@include break-wide {
-		max-width: 50%;
-	}
 
 	p {
 		color: var(--studio-gray-100);

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -166,6 +166,27 @@
 				}
 			}
 		}
+
+		.bulk-domains-empty-state {
+			.bulk-domains-empty-state__main {
+				padding-inline: 16px;
+
+				@include break-mobile {
+					padding-inline: 48px;
+				}
+			}
+
+			@include break-huge {
+				max-width: 100%;
+
+				.bulk-domains-empty-state__main {
+					box-sizing: border-box;
+					max-width: 1400px;
+					margin: 0 auto;
+					padding-inline: 48px;
+				}
+			}
+		}
 	}
 
 	.empty-domains-list-card {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/96618.

## Proposed Changes

Title. Align it with the stateful domains page.

### Empty domains manage page

https://github.com/user-attachments/assets/bb1bb5c9-219b-4144-a765-63dc02f1933e

### Stateful domains manage page

https://github.com/user-attachments/assets/c75b330d-a2e7-4cc6-a171-0e6eddcde600

## Why are these changes being made?

Visual consistency.

## Testing Instructions

Use two accounts to verify that the domains page with domains and the same page without share the same layout rules.