### PR TITLE
Fix how the TLD list is loaded and checked in the gravatar flow

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1055,9 +1055,27 @@ class RegisterDomainStep extends Component {
 		// Skips availability check for the Gravatar flow - so TLDs that are
 		// available but not eligible for Gravatar won't be displayed
 		if ( this.props.flowName === 'domain-for-gravatar' ) {
+			this.clearSuggestionErrorMessage();
+			const gravatarTlds = [
+				'link',
+				'bio',
+				'contact',
+				'cool',
+				'fyi',
+				'guru',
+				'info',
+				'life',
+				'live',
+				'ninja',
+				'place',
+				'pro',
+				'rocks',
+				'social',
+				'world',
+			];
 			// Also, we want to error messages for unavailable TLDs in Gravatar.
 			// Since only a limited number of tlds is enabled for now, we show the message for all other TLDs.
-			if ( ! this.state.availableTlds.includes( getTld( domain ) ) ) {
+			if ( ! gravatarTlds.includes( getTld( domain ) ) ) {
 				this.showSuggestionErrorMessage( domain, 'gravatar_tld_restriction', {} );
 			}
 			return;
@@ -1787,6 +1805,19 @@ class RegisterDomainStep extends Component {
 			availabilityError: error,
 			availabilityErrorData: errorData,
 			availabilityErrorDomain: domain,
+		} );
+	}
+
+	clearSuggestionErrorMessage() {
+		this.setState( {
+			showSuggestionNotice: false,
+			suggestionError: null,
+			suggestionErrorData: null,
+			suggestionErrorDomain: null,
+			showAvailabilityNotice: false,
+			availabilityError: null,
+			availabilityErrorData: null,
+			availabilityErrorDomain: null,
 		} );
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -344,9 +344,8 @@ class RegisterDomainStep extends Component {
 			// Delete the stored query once it is consumed.
 			globalThis?.sessionStorage?.removeItem( SESSION_STORAGE_QUERY_KEY );
 		} else {
-			this.getAvailableTlds( undefined, undefined, () => {
-				this.save();
-			} );
+			this.getAvailableTlds();
+			this.save();
 		}
 		this._isMounted = true;
 		this.props.recordSearchFormView( this.props.analyticsSection );
@@ -978,7 +977,7 @@ class RegisterDomainStep extends Component {
 		);
 	};
 
-	getAvailableTlds = ( domain = undefined, vendor = undefined, callback = noop ) => {
+	getAvailableTlds = ( domain = undefined, vendor = undefined ) => {
 		const { promoTlds } = this.props;
 		return getAvailableTlds( { vendor, search: domain } )
 			.then( ( availableTlds ) => {
@@ -986,12 +985,9 @@ class RegisterDomainStep extends Component {
 				if ( promoTlds ) {
 					filteredAvailableTlds = availableTlds.filter( ( tld ) => promoTlds.includes( tld ) );
 				}
-				this.setState(
-					{
-						availableTlds: filteredAvailableTlds,
-					},
-					callback
-				);
+				this.setState( {
+					availableTlds: filteredAvailableTlds,
+				} );
 			} )
 			.catch( noop );
 	};
@@ -1059,13 +1055,9 @@ class RegisterDomainStep extends Component {
 		// Skips availability check for the Gravatar flow - so TLDs that are
 		// available but not eligible for Gravatar won't be displayed
 		if ( this.props.flowName === 'domain-for-gravatar' ) {
-			this.clearSuggestionErrorMessage();
 			// Also, we want to error messages for unavailable TLDs in Gravatar.
 			// Since only a limited number of tlds is enabled for now, we show the message for all other TLDs.
-			if (
-				this.state.availableTlds.length > 0 &&
-				! this.state.availableTlds.includes( getTld( domain ) )
-			) {
+			if ( ! this.state.availableTlds.includes( getTld( domain ) ) ) {
 				this.showSuggestionErrorMessage( domain, 'gravatar_tld_restriction', {} );
 			}
 			return;
@@ -1446,20 +1438,19 @@ class RegisterDomainStep extends Component {
 			() => {
 				const timestamp = Date.now();
 
-				this.getAvailableTlds( domain, this.props.vendor, () => {
-					const domainSuggestions = Promise.all( [
-						this.checkDomainAvailability( domain, timestamp ),
-						this.getDomainsSuggestions( domain, timestamp ),
-					] );
+				this.getAvailableTlds( domain, this.props.vendor );
+				const domainSuggestions = Promise.all( [
+					this.checkDomainAvailability( domain, timestamp ),
+					this.getDomainsSuggestions( domain, timestamp ),
+				] );
 
-					domainSuggestions
-						.catch( () => [] ) // handle the error and return an empty list
-						.then( this.handleDomainSuggestions( domain ) );
+				domainSuggestions
+					.catch( () => [] ) // handle the error and return an empty list
+					.then( this.handleDomainSuggestions( domain ) );
 
-					if ( this.isSubdomainResultsVisible() ) {
-						this.getSubdomainSuggestions( domain, timestamp );
-					}
-				} );
+				if ( this.isSubdomainResultsVisible() ) {
+					this.getSubdomainSuggestions( domain, timestamp );
+				}
 			}
 		);
 	};
@@ -1796,15 +1787,6 @@ class RegisterDomainStep extends Component {
 			availabilityError: error,
 			availabilityErrorData: errorData,
 			availabilityErrorDomain: domain,
-		} );
-	}
-
-	clearSuggestionErrorMessage() {
-		this.setState( {
-			showSuggestionNotice: false,
-			suggestionError: null,
-			suggestionErrorData: null,
-			suggestionErrorDomain: null,
 		} );
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -344,8 +344,9 @@ class RegisterDomainStep extends Component {
 			// Delete the stored query once it is consumed.
 			globalThis?.sessionStorage?.removeItem( SESSION_STORAGE_QUERY_KEY );
 		} else {
-			this.getAvailableTlds();
-			this.save();
+			this.getAvailableTlds( undefined, undefined, () => {
+				this.save();
+			} );
 		}
 		this._isMounted = true;
 		this.props.recordSearchFormView( this.props.analyticsSection );
@@ -977,7 +978,7 @@ class RegisterDomainStep extends Component {
 		);
 	};
 
-	getAvailableTlds = ( domain = undefined, vendor = undefined ) => {
+	getAvailableTlds = ( domain = undefined, vendor = undefined, callback = noop ) => {
 		const { promoTlds } = this.props;
 		return getAvailableTlds( { vendor, search: domain } )
 			.then( ( availableTlds ) => {
@@ -985,9 +986,12 @@ class RegisterDomainStep extends Component {
 				if ( promoTlds ) {
 					filteredAvailableTlds = availableTlds.filter( ( tld ) => promoTlds.includes( tld ) );
 				}
-				this.setState( {
-					availableTlds: filteredAvailableTlds,
-				} );
+				this.setState(
+					{
+						availableTlds: filteredAvailableTlds,
+					},
+					callback
+				);
 			} )
 			.catch( noop );
 	};
@@ -1055,9 +1059,13 @@ class RegisterDomainStep extends Component {
 		// Skips availability check for the Gravatar flow - so TLDs that are
 		// available but not eligible for Gravatar won't be displayed
 		if ( this.props.flowName === 'domain-for-gravatar' ) {
+			this.clearSuggestionErrorMessage();
 			// Also, we want to error messages for unavailable TLDs in Gravatar.
 			// Since only a limited number of tlds is enabled for now, we show the message for all other TLDs.
-			if ( ! this.state.availableTlds.includes( getTld( domain ) ) ) {
+			if (
+				this.state.availableTlds.length > 0 &&
+				! this.state.availableTlds.includes( getTld( domain ) )
+			) {
 				this.showSuggestionErrorMessage( domain, 'gravatar_tld_restriction', {} );
 			}
 			return;
@@ -1438,19 +1446,20 @@ class RegisterDomainStep extends Component {
 			() => {
 				const timestamp = Date.now();
 
-				this.getAvailableTlds( domain, this.props.vendor );
-				const domainSuggestions = Promise.all( [
-					this.checkDomainAvailability( domain, timestamp ),
-					this.getDomainsSuggestions( domain, timestamp ),
-				] );
+				this.getAvailableTlds( domain, this.props.vendor, () => {
+					const domainSuggestions = Promise.all( [
+						this.checkDomainAvailability( domain, timestamp ),
+						this.getDomainsSuggestions( domain, timestamp ),
+					] );
 
-				domainSuggestions
-					.catch( () => [] ) // handle the error and return an empty list
-					.then( this.handleDomainSuggestions( domain ) );
+					domainSuggestions
+						.catch( () => [] ) // handle the error and return an empty list
+						.then( this.handleDomainSuggestions( domain ) );
 
-				if ( this.isSubdomainResultsVisible() ) {
-					this.getSubdomainSuggestions( domain, timestamp );
-				}
+					if ( this.isSubdomainResultsVisible() ) {
+						this.getSubdomainSuggestions( domain, timestamp );
+					}
+				} );
 			}
 		);
 	};
@@ -1787,6 +1796,15 @@ class RegisterDomainStep extends Component {
 			availabilityError: error,
 			availabilityErrorData: errorData,
 			availabilityErrorDomain: domain,
+		} );
+	}
+
+	clearSuggestionErrorMessage() {
+		this.setState( {
+			showSuggestionNotice: false,
+			suggestionError: null,
+			suggestionErrorData: null,
+			suggestionErrorDomain: null,
 		} );
 	}
 


### PR DESCRIPTION
The way we check the TLDs in the registration flow for Gravatar domains was assuming that the available TLDs list is already loaded. However the coded didn't work like that and if you go to the flow with a `new` query param that contains an FQDN it would show you "The domain extension you are looking for is currently not supported. Additional domain extensions may become available for a fee in the future." error message even though the TLD is a supported one.

<img width="1313" alt="Screenshot 2024-11-21 at 19 44 23" src="https://github.com/user-attachments/assets/8d782b12-3b8b-4e2f-90f7-74d5c066531b">
Here's how it looks

## Proposed Changes

* add `callback` parameter to the `getAvailableTlds` method so that we can call the `checkDomainAvailability` after the TLDs were loaded and set in the state
* in `checkDomainAvailability` method always clear the error message if in the gravatar flow

## Why are these changes being made?

* Otherwise a bug shows up where you go to the gravatar flow with a valid domain but you get an error

## Testing Instructions

* go to `/start/domain-for-gravatar/domain-only?search=yes&new=test20241121.link` and verify that you won't get the error
* the go to `/start/domain-for-gravatar/domain-only?search=yes&new=test20241121.net` and verify that you see the error
* then go again to `/start/domain-for-gravatar/domain-only?search=yes&new=test20241121.link` and verify that you won't get the error

Unfortunately because of how the signup works the message is shown quckly if the previous search had it. This is how the signup works. Fixing that would require a bigger refactoring and I'm not even sure where to start.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
