### PR TITLE
A4A: add non-removable tags

### DIFF
--- a/client/a8c-for-agencies/components/agency-site-tag/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tag/index.tsx
@@ -5,17 +5,20 @@ import './style.scss';
 interface Props {
 	tag: string;
 	onRemoveTag: ( tag: string ) => void;
+	isRemovable?: boolean;
 }
 
-export default function AgencySiteTag( { tag, onRemoveTag }: Props ) {
+export default function AgencySiteTag( { tag, onRemoveTag, isRemovable = true }: Props ) {
 	return (
 		<Badge className="agency-site-tag" type="info">
 			<span className="agency-site-tag__text">{ tag }</span>
-			<Icon
-				className="agency-site-tag__close"
-				onClick={ () => onRemoveTag( tag ) }
-				icon={ closeSmall }
-			/>
+			{ isRemovable && (
+				<Icon
+					className="agency-site-tag__close"
+					onClick={ () => onRemoveTag( tag ) }
+					icon={ closeSmall }
+				/>
+			) }
 		</Badge>
 	);
 }

--- a/client/a8c-for-agencies/components/agency-site-tags/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tags/index.tsx
@@ -63,8 +63,13 @@ export default function AgencySiteTags( { tags, isLoading, onAddTags, onRemoveTa
 			{ tags.length ? (
 				<Card tagName="ul" className="agency-site-tags__list">
 					{ tags.map( ( tag ) => (
-						<li>
-							<AgencySiteTag key={ tag } tag={ tag } onRemoveTag={ onRemoveTag } />
+						<li key={ tag }>
+							<AgencySiteTag
+								key={ tag }
+								tag={ tag }
+								onRemoveTag={ onRemoveTag }
+								isRemovable={ tag !== 'a4a_self_migrated_site' }
+							/>
 						</li>
 					) ) }
 				</Card>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
