### PR TITLE
Domains: Hide domain suggestion error notice if TLD is supported in Gravatar flow

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1059,6 +1059,13 @@ class RegisterDomainStep extends Component {
 			// Since only a limited number of tlds is enabled for now, we show the message for all other TLDs.
 			if ( ! this.state.availableTlds.includes( getTld( domain ) ) ) {
 				this.showSuggestionErrorMessage( domain, 'gravatar_tld_restriction', {} );
+			} else {
+				this.setState( {
+					showSuggestionNotice: false,
+					suggestionError: null,
+					suggestionErrorData: null,
+					suggestionErrorDomain: null,
+				} );
 			}
 			return;
 		}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1065,11 +1065,15 @@ class RegisterDomainStep extends Component {
 					suggestionError: null,
 					suggestionErrorData: null,
 					suggestionErrorDomain: null,
-					showAvailabilityNotice: false,
-					availabilityError: null,
-					availabilityErrorData: null,
 				} );
 			}
+
+			// We won't do availability checks in the Gravatar flow, so we can hide availability error notices
+			this.setState( {
+				showAvailabilityNotice: false,
+				availabilityError: null,
+				availabilityErrorData: null,
+			} );
 			return;
 		}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1065,6 +1065,9 @@ class RegisterDomainStep extends Component {
 					suggestionError: null,
 					suggestionErrorData: null,
 					suggestionErrorDomain: null,
+					showAvailabilityNotice: false,
+					availabilityError: null,
+					availabilityErrorData: null,
 				} );
 			}
 			return;


### PR DESCRIPTION
## Proposed Changes

This PR cleans the suggestion error message in the Gravatar domain flow if the TLD of the domain being searched is supported.

## Why are these changes being made?

If you visit the Gravatar flow with a domain with an unsupported TLD (e.g. `/start/domain-for-gravatar/domain-only?search=yes&new=test202411212.net`), an error notice should be shown. If you visit the Gravatar flow again with a domain with a supported TLD (e.g. `/start/domain-for-gravatar/domain-only?search=yes&new=test202411212.link`), the error message will still be showing. This PR fixes that problem.

## Testing Instructions

- Build this branch locally or open the live Calypso link
- Go to `/start/domain-for-gravatar/domain-only?search=yes&new=test202411212.net` and ensure the error notice is shown
- Go to `/start/domain-for-gravatar/domain-only?search=yes&new=test202411212.link` and ensure the error notice is not shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?