### PR TITLE
Refactor credentials step to fit application password project.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-approval/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-approval/index.tsx
@@ -1,0 +1,38 @@
+import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const SiteMigrationApplicationPasswordApproval: Step = function ( { navigation } ) {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<DocumentHead title={ translate( 'Get ready for blazing fast speeds' ) } />
+			<StepContainer
+				stepName="site-migration-approval"
+				flowName="site-migration"
+				goBack={ navigation?.goBack }
+				goNext={ navigation?.submit }
+				hideSkip
+				isFullLayout
+				formattedHeader={
+					<FormattedHeader
+						id="site-migration-credentials-header"
+						headerText={ translate( 'Get ready for blazing fast speeds' ) }
+						subHeaderText={ translate(
+							'Help us get started by providing some basic details about your current website.'
+						) }
+						align="center"
+					/>
+				}
+				stepContent={ <></> }
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default SiteMigrationApplicationPasswordApproval;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-passwords-approval/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-passwords-approval/index.tsx
@@ -5,7 +5,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
-const SiteMigrationApplicationPasswordApproval: Step = function ( { navigation } ) {
+const SiteMigrationApplicationPasswordsApproval: Step = function ( { navigation } ) {
 	const translate = useTranslate();
 
 	return (
@@ -35,4 +35,4 @@ const SiteMigrationApplicationPasswordApproval: Step = function ( { navigation }
 	);
 };
 
-export default SiteMigrationApplicationPasswordApproval;
+export default SiteMigrationApplicationPasswordsApproval;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { NextButton } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
@@ -5,6 +6,7 @@ import { UrlData } from 'calypso/blocks/import/types';
 import Notice from 'calypso/components/notice';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useCredentialsForm } from '../hooks/use-credentials-form';
+import { ApplicationPasswordInfo } from '../types';
 import { AccessMethodPicker } from './access-method-picker';
 import { BackupFileField } from './backup-file-field';
 import { ErrorMessage } from './error-message';
@@ -14,7 +16,10 @@ import { SpecialInstructions } from './special-instructions';
 import { UsernameField } from './username-field';
 
 interface CredentialsFormProps {
-	onSubmit: ( siteInfo?: UrlData | undefined ) => void;
+	onSubmit: (
+		siteInfo?: UrlData | undefined,
+		applicationPasswordInfo?: ApplicationPasswordInfo
+	) => void;
 	onSkip: () => void;
 }
 
@@ -24,6 +29,8 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 		useCredentialsForm( onSubmit );
 
 	const queryError = useQuery().get( 'error' ) || null;
+
+	const applicationPasswordEnabled = isEnabled( 'automated-migration/application-password' );
 
 	let errorMessage;
 	if ( errors.root && errors.root.type !== 'manual' && errors.root.message ) {
@@ -45,6 +52,8 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 		return translate( 'Continue' );
 	};
 
+	const showSpecialInstructions = ! applicationPasswordEnabled || accessMethod === 'backup';
+
 	return (
 		<form className="site-migration-credentials__form" onSubmit={ submitHandler }>
 			{ errorMessage && (
@@ -64,14 +73,18 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 				{ accessMethod === 'credentials' && (
 					<div className="site-migration-credentials">
 						<SiteAddressField control={ control } errors={ errors } />
-						<UsernameField control={ control } errors={ errors } />
-						<PasswordField control={ control } errors={ errors } />
+						{ ! applicationPasswordEnabled && (
+							<>
+								<UsernameField control={ control } errors={ errors } />
+								<PasswordField control={ control } errors={ errors } />
+							</>
+						) }
 					</div>
 				) }
 
 				{ accessMethod === 'backup' && <BackupFileField control={ control } errors={ errors } /> }
 
-				<SpecialInstructions control={ control } errors={ errors } />
+				{ showSpecialInstructions && <SpecialInstructions control={ control } errors={ errors } /> }
 
 				<ErrorMessage
 					error={ errors.root && errors.root.type === 'manual' ? errors.root : undefined }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -6,7 +6,7 @@ import { UrlData } from 'calypso/blocks/import/types';
 import Notice from 'calypso/components/notice';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useCredentialsForm } from '../hooks/use-credentials-form';
-import { ApplicationPasswordInfo } from '../types';
+import { ApplicationPasswordsInfo } from '../types';
 import { AccessMethodPicker } from './access-method-picker';
 import { BackupFileField } from './backup-file-field';
 import { ErrorMessage } from './error-message';
@@ -18,7 +18,7 @@ import { UsernameField } from './username-field';
 interface CredentialsFormProps {
 	onSubmit: (
 		siteInfo?: UrlData | undefined,
-		applicationPasswordInfo?: ApplicationPasswordInfo
+		applicationPasswordsInfo?: ApplicationPasswordsInfo
 	) => void;
 	onSkip: () => void;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { FormLabel } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
@@ -23,9 +24,13 @@ export const SiteAddressField: React.FC< CredentialsFormFieldProps > = ( { contr
 		? translate( 'Enter your WordPress site address' )
 		: translate( 'Enter your WordPress site address.' );
 
+	const labelText = isEnabled( 'automated-migration/application-password' )
+		? translate( 'Current WordPress site address' )
+		: translate( 'Current site address' );
+
 	return (
 		<div className="site-migration-credentials__form-field">
-			<FormLabel htmlFor="from_url">{ translate( 'Current site address' ) }</FormLabel>
+			<FormLabel htmlFor="from_url">{ labelText }</FormLabel>
 			<Controller
 				control={ control }
 				name="from_url"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -119,9 +119,9 @@ export const useCredentialsForm = (
 		setSiteInfo( siteInfoResult );
 
 		if ( isApplicationPasswordEnabled && accessMethod === 'credentials' ) {
-			submitWithApplicationPassword( siteInfoResult );
+			await submitWithApplicationPassword( siteInfoResult );
 		} else {
-			requestAutomatedMigrationAndSubmit( data, siteInfoResult );
+			await requestAutomatedMigrationAndSubmit( data, siteInfoResult );
 		}
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -97,17 +97,15 @@ export const useCredentialsForm = (
 	);
 
 	const submitWithApplicationPassword = useCallback(
-		( siteInfoResult?: UrlData ) => {
+		( siteInfoResult: UrlData ) => {
 			if ( isWPCOM( siteInfoResult ) || isNotWordPress( siteInfoResult ) ) {
 				onSubmit( siteInfoResult );
-
-				return;
+			} else {
+				const applicationPasswordInfo = {
+					isAvailable: true,
+				};
+				onSubmit( siteInfoResult, applicationPasswordInfo );
 			}
-
-			const applicationPasswordInfo = {
-				isAvailable: true,
-			};
-			onSubmit( siteInfoResult, applicationPasswordInfo );
 		},
 		[ onSubmit ]
 	);
@@ -118,7 +116,7 @@ export const useCredentialsForm = (
 		const siteInfoResult = shouldAnalyzeUrl ? await analyzeUrl( data.from_url ) : siteInfo;
 		setSiteInfo( siteInfoResult );
 
-		if ( isApplicationPasswordEnabled && accessMethod === 'credentials' ) {
+		if ( isApplicationPasswordEnabled && accessMethod === 'credentials' && siteInfoResult ) {
 			await submitWithApplicationPassword( siteInfoResult );
 		} else {
 			await requestAutomatedMigrationAndSubmit( data, siteInfoResult );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -1,11 +1,12 @@
-import { useEffect, useState } from 'react';
+import { isEnabled } from '@automattic/calypso-config';
+import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { UrlData } from 'calypso/blocks/import/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wp from 'calypso/lib/wp';
-import { CredentialsFormData } from '../types';
+import { CredentialsFormData, ApplicationPasswordInfo } from '../types';
 import { useFormErrorMapping } from './use-form-error-mapping';
 import { useRequestAutomatedMigration } from './use-request-automated-migration';
 
@@ -28,7 +29,10 @@ const isWPCOM = ( siteInfo?: UrlData ) => {
 	return !! siteInfo?.platform_data?.is_wpcom;
 };
 
-export const useCredentialsForm = ( onSubmit: ( siteInfo?: UrlData ) => void ) => {
+export const useCredentialsForm = (
+	onSubmit: ( siteInfo?: UrlData, applicationPasswordInfo?: ApplicationPasswordInfo ) => void
+) => {
+	const isApplicationPasswordEnabled = isEnabled( 'automated-migration/application-password' );
 	const siteSlug = useSiteSlugParam();
 	const importSiteQueryParam = useQuery().get( 'from' ) || '';
 	const [ siteInfo, setSiteInfo ] = useState< UrlData | undefined >( undefined );
@@ -75,22 +79,49 @@ export const useCredentialsForm = ( onSubmit: ( siteInfo?: UrlData ) => void ) =
 	const canBypassVerification = isLoginFailed || isWPCOM( siteInfo ) || isNotWordPress( siteInfo );
 	const shouldAnalyzeUrl = ! isLoginFailed && accessMethod === 'credentials';
 
+	const requestAutomatedMigrationAndSubmit = useCallback(
+		async ( data: CredentialsFormData, siteInfoResult?: UrlData ) => {
+			try {
+				const payload = {
+					...data,
+					bypassVerification: canBypassVerification,
+				};
+				await requestAutomatedMigration( payload );
+				recordTracksEvent( 'calypso_site_migration_automated_request_success' );
+				onSubmit( siteInfoResult );
+			} catch ( error ) {
+				recordTracksEvent( 'calypso_site_migration_automated_request_error' );
+			}
+		},
+		[ canBypassVerification, onSubmit, requestAutomatedMigration ]
+	);
+
+	const submitWithApplicationPassword = useCallback(
+		( siteInfoResult?: UrlData ) => {
+			if ( isWPCOM( siteInfoResult ) || isNotWordPress( siteInfoResult ) ) {
+				onSubmit( siteInfoResult );
+
+				return;
+			}
+
+			const applicationPasswordInfo = {
+				isAvailable: true,
+			};
+			onSubmit( siteInfoResult, applicationPasswordInfo );
+		},
+		[ onSubmit ]
+	);
+
 	const submitHandler = handleSubmit( async ( data: CredentialsFormData ) => {
 		clearErrors();
 
 		const siteInfoResult = shouldAnalyzeUrl ? await analyzeUrl( data.from_url ) : siteInfo;
 		setSiteInfo( siteInfoResult );
 
-		try {
-			const payload = {
-				...data,
-				bypassVerification: canBypassVerification,
-			};
-			await requestAutomatedMigration( payload );
-			recordTracksEvent( 'calypso_site_migration_automated_request_success' );
-			onSubmit( siteInfoResult );
-		} catch ( error ) {
-			recordTracksEvent( 'calypso_site_migration_automated_request_error' );
+		if ( isApplicationPasswordEnabled && accessMethod === 'credentials' ) {
+			submitWithApplicationPassword( siteInfoResult );
+		} else {
+			requestAutomatedMigrationAndSubmit( data, siteInfoResult );
 		}
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -6,7 +6,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wp from 'calypso/lib/wp';
-import { CredentialsFormData, ApplicationPasswordInfo } from '../types';
+import { CredentialsFormData, ApplicationPasswordsInfo } from '../types';
 import { useFormErrorMapping } from './use-form-error-mapping';
 import { useRequestAutomatedMigration } from './use-request-automated-migration';
 
@@ -30,7 +30,7 @@ const isWPCOM = ( siteInfo?: UrlData ) => {
 };
 
 export const useCredentialsForm = (
-	onSubmit: ( siteInfo?: UrlData, applicationPasswordInfo?: ApplicationPasswordInfo ) => void
+	onSubmit: ( siteInfo?: UrlData, applicationPasswordsInfo?: ApplicationPasswordsInfo ) => void
 ) => {
 	const isApplicationPasswordEnabled = isEnabled( 'automated-migration/application-password' );
 	const siteSlug = useSiteSlugParam();
@@ -101,10 +101,10 @@ export const useCredentialsForm = (
 			if ( isWPCOM( siteInfoResult ) || isNotWordPress( siteInfoResult ) ) {
 				onSubmit( siteInfoResult );
 			} else {
-				const applicationPasswordInfo = {
+				const applicationPasswordsInfo = {
 					isAvailable: true,
 				};
-				onSubmit( siteInfoResult, applicationPasswordInfo );
+				onSubmit( siteInfoResult, applicationPasswordsInfo );
 			}
 		},
 		[ onSubmit ]

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -10,17 +10,17 @@ import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/us
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { CredentialsForm } from './components/credentials-form';
-import { ApplicationPasswordInfo } from './types';
+import { ApplicationPasswordsInfo } from './types';
 import type { Step } from '../../types';
 import './style.scss';
 
-const getAction = ( siteInfo?: UrlData, applicationPasswordInfo?: ApplicationPasswordInfo ) => {
+const getAction = ( siteInfo?: UrlData, applicationPasswordsInfo?: ApplicationPasswordsInfo ) => {
 	if ( ! siteInfo ) {
 		return 'submit';
 	}
 
-	if ( applicationPasswordInfo?.isAvailable ) {
-		return 'application-password-approval';
+	if ( applicationPasswordsInfo?.isAvailable ) {
+		return 'application-passwords-approval';
 	}
 
 	if ( siteInfo?.platform_data?.is_wpcom ) {
@@ -42,9 +42,9 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 
 	const handleSubmit = (
 		siteInfo?: UrlData | undefined,
-		applicationPasswordInfo?: ApplicationPasswordInfo
+		applicationPasswordsInfo?: ApplicationPasswordsInfo
 	) => {
-		const action = getAction( siteInfo, applicationPasswordInfo );
+		const action = getAction( siteInfo, applicationPasswordsInfo );
 		return navigation.submit?.( { action, from: siteInfo?.url, platform: siteInfo?.platform } );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -9,12 +10,17 @@ import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/us
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { CredentialsForm } from './components/credentials-form';
+import { ApplicationPasswordInfo } from './types';
 import type { Step } from '../../types';
 import './style.scss';
 
-const getAction = ( siteInfo?: UrlData ) => {
+const getAction = ( siteInfo?: UrlData, applicationPasswordInfo?: ApplicationPasswordInfo ) => {
 	if ( ! siteInfo ) {
 		return 'submit';
+	}
+
+	if ( applicationPasswordInfo?.isAvailable ) {
+		return 'application-password-approval';
 	}
 
 	if ( siteInfo?.platform_data?.is_wpcom ) {
@@ -34,8 +40,11 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 
 	const { mutate: updateMigrationStatus } = useUpdateMigrationStatus( siteId );
 
-	const handleSubmit = ( siteInfo?: UrlData | undefined ) => {
-		const action = getAction( siteInfo );
+	const handleSubmit = (
+		siteInfo?: UrlData | undefined,
+		applicationPasswordInfo?: ApplicationPasswordInfo
+	) => {
+		const action = getAction( siteInfo, applicationPasswordInfo );
 		return navigation.submit?.( { action, from: siteInfo?.url, platform: siteInfo?.platform } );
 	};
 
@@ -51,6 +60,12 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 		}
 	}, [ siteId, updateMigrationStatus ] );
 
+	const subHeaderText = isEnabled( 'automated-migration/application-password' )
+		? translate( 'Help us get started by providing some basic details about your current website.' )
+		: translate(
+				'Please share the following details to access your site and start your migration to WordPress.com.'
+		  );
+
 	return (
 		<>
 			<DocumentHead title={ translate( 'Tell us about your WordPress site' ) } />
@@ -65,9 +80,7 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 					<FormattedHeader
 						id="site-migration-credentials-header"
 						headerText={ translate( 'Tell us about your WordPress site' ) }
-						subHeaderText={ translate(
-							'Please share the following details to access your site and start your migration to WordPress.com.'
-						) }
+						subHeaderText={ subHeaderText }
 						align="center"
 					/>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import config, { isEnabled } from '@automattic/calypso-config';
 import { waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
@@ -41,7 +42,12 @@ const messages = {
 const { getByRole, getByLabelText, getByTestId, getByText, findByText } = screen;
 
 const continueButton = ( name = /Continue/ ) => getByRole( 'button', { name } );
-const siteAddressInput = () => getByLabelText( 'Current site address' );
+const siteAddressInput = () =>
+	getByLabelText(
+		isEnabled( 'automated-migration/application-password' )
+			? 'Current WordPress site address'
+			: 'Current site address'
+	);
 const usernameInput = () => getByLabelText( 'WordPress admin username' );
 const passwordInput = () => getByLabelText( 'Password' );
 const backupOption = () => getByRole( 'radio', { name: 'Backup file' } );
@@ -57,6 +63,11 @@ const fillAllFields = async () => {
 	await userEvent.type( siteAddressInput(), 'site-url.com' );
 	await userEvent.type( usernameInput(), 'username' );
 	await userEvent.type( passwordInput(), 'password' );
+};
+
+const fillAddressField = async () => {
+	await userEvent.click( credentialsOption() );
+	await userEvent.type( siteAddressInput(), 'site-url.com' );
 };
 
 const fillNoteField = async () => {
@@ -93,6 +104,11 @@ const siteInfoUsingWordPress = {
 	platform: 'wordpress',
 };
 
+const siteInfoUsingTumblr = {
+	...baseSiteInfo,
+	platform: 'tumblr',
+};
+
 const siteInfoUsingWPCOM = {
 	...baseSiteInfo,
 	url: 'https://site-url.wpcomstating.com',
@@ -101,14 +117,29 @@ const siteInfoUsingWPCOM = {
 	},
 };
 
+const isApplicationPasswordEnabled = isEnabled( 'automated-migration/application-password' );
+const restaureIsApplicationPasswordEnabled = () => {
+	if ( isApplicationPasswordEnabled ) {
+		config.enable( 'automated-migration/application-password' );
+	} else {
+		config.disable( 'automated-migration/application-password' );
+	}
+};
+
 describe( 'SiteMigrationCredentials', () => {
 	beforeAll( () => nock.disableNetConnect() );
 	beforeEach( () => {
 		jest.clearAllMocks();
 		( wp.req.get as jest.Mock ).mockResolvedValue( siteInfoUsingWordPress );
 	} );
+	afterEach( () => {
+		jest.clearAllMocks();
+		restaureIsApplicationPasswordEnabled();
+		( wp.req.get as jest.Mock ).mockResolvedValue( siteInfoUsingWordPress );
+	} );
 
 	it( 'creates an automated migration ticket', async () => {
+		config.disable( 'automated-migration/application-password' );
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 
@@ -147,6 +178,7 @@ describe( 'SiteMigrationCredentials', () => {
 	} );
 
 	it( 'creates a credentials ticket when site info fetching throws error', async () => {
+		config.disable( 'automated-migration/application-password' );
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 
@@ -250,6 +282,16 @@ describe( 'SiteMigrationCredentials', () => {
 		await userEvent.click( credentialsOption() );
 
 		expect( getByText( messages.urlError ) ).toBeVisible();
+	} );
+
+	it( 'shows errors on the required fields when the user does not fill the fields when user select credentials option and application-password is disabled', async () => {
+		config.disable( 'automated-migration/application-password' );
+		render();
+
+		await userEvent.click( continueButton() );
+		await userEvent.click( credentialsOption() );
+
+		expect( getByText( messages.urlError ) ).toBeVisible();
 		expect( getByText( messages.usernameError ) ).toBeVisible();
 		expect( getByText( messages.passwordError ) ).toBeVisible();
 	} );
@@ -272,6 +314,7 @@ describe( 'SiteMigrationCredentials', () => {
 	} );
 
 	it( 'shows error messages by each field when the server returns "invalid param" by each field', async () => {
+		config.disable( 'automated-migration/application-password' );
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 
@@ -321,6 +364,7 @@ describe( 'SiteMigrationCredentials', () => {
 	} );
 
 	it( 'shows an error message when the server returns a generic error', async () => {
+		config.disable( 'automated-migration/application-password' );
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 
@@ -339,6 +383,7 @@ describe( 'SiteMigrationCredentials', () => {
 	} );
 
 	it( 'shows an generic error when server doesn`t return error and shows normal Continue button', async () => {
+		config.disable( 'automated-migration/application-password' );
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 
@@ -372,6 +417,7 @@ describe( 'SiteMigrationCredentials', () => {
 	} );
 
 	it( 'shows "Verifying credentials" on the Continue button during submission', async () => {
+		config.disable( 'automated-migration/application-password' );
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 		const pendingPromise = new Promise( () => {} );
@@ -386,7 +432,23 @@ describe( 'SiteMigrationCredentials', () => {
 		} );
 	} );
 
-	it( 'shows error message when site is not accessible', async () => {
+	it( 'shows "Verifying credentials" on the Continue button during submission with application password', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+		const pendingPromise = new Promise( () => {} );
+
+		( wpcomRequest as jest.Mock ).mockImplementation( () => pendingPromise );
+
+		await fillAddressField();
+		userEvent.click( continueButton() );
+
+		await waitFor( () => {
+			expect( continueButton( /Verifying credentials/ ) ).toBeVisible();
+		} );
+	} );
+
+	it( 'shows error message when inputed credentials fail to log in', async () => {
+		config.disable( 'automated-migration/application-password' );
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 
@@ -421,6 +483,7 @@ describe( 'SiteMigrationCredentials', () => {
 	] )(
 		'shows error message for %p verification error',
 		async ( { response_code, errorMessage } ) => {
+			config.disable( 'automated-migration/application-password' );
 			const submit = jest.fn();
 			render( { navigation: { submit } } );
 
@@ -447,6 +510,7 @@ describe( 'SiteMigrationCredentials', () => {
 	);
 
 	it( 'shows Continue anyways button and an already on WPCOM', async () => {
+		config.disable( 'automated-migration/application-password' );
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 		await fillAllFields();
@@ -486,6 +550,7 @@ describe( 'SiteMigrationCredentials', () => {
 	} );
 
 	it( 'creates a credentials ticket even when the siteinfo request faces an error', async () => {
+		config.disable( 'automated-migration/application-password' );
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 		await fillAllFields();
@@ -517,6 +582,7 @@ describe( 'SiteMigrationCredentials', () => {
 	} );
 
 	it( 'shows "Verifying credentials" on the Continue button during submission when fetching site info', async () => {
+		config.disable( 'automated-migration/application-password' );
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 		const pendingPromise = new Promise( () => {} );
@@ -536,7 +602,28 @@ describe( 'SiteMigrationCredentials', () => {
 		} );
 	} );
 
+	it( 'shows "Verifying credentials" on the Continue button during submission when fetching site info with application password', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+		const pendingPromise = new Promise( () => {} );
+
+		( wpcomRequest as jest.Mock ).mockResolvedValue( {
+			status: 200,
+			body: {},
+		} );
+
+		( wp.req.get as jest.Mock ).mockImplementation( () => pendingPromise );
+
+		await fillAddressField();
+		await userEvent.click( continueButton() );
+
+		await waitFor( () => {
+			expect( continueButton( /Verifying credentials/ ) ).toBeVisible();
+		} );
+	} );
+
 	it( 'shows "Verifying credentials" on the Continue button during site info verification', async () => {
+		config.disable( 'automated-migration/application-password' );
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 		const pendingPromise = new Promise( () => {} );
@@ -549,6 +636,48 @@ describe( 'SiteMigrationCredentials', () => {
 
 		await waitFor( () => {
 			expect( continueButton( /Verifying credentials/ ) ).toBeVisible();
+		} );
+	} );
+
+	it( 'submits application-password-approval action when using password application', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+		await fillAddressField();
+		( wp.req.get as jest.Mock ).mockResolvedValue( baseSiteInfo );
+		await userEvent.click( continueButton() );
+
+		expect( submit ).toHaveBeenCalledWith( {
+			action: 'application-password-approval',
+			from: 'https://site-url.wordpress.com',
+			platform: 'wordpress',
+		} );
+	} );
+
+	it( 'submits already-wpcom action when site is already WPCOM', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+		await fillAddressField();
+		( wp.req.get as jest.Mock ).mockResolvedValue( siteInfoUsingWPCOM );
+		await userEvent.click( continueButton() );
+
+		expect( submit ).toHaveBeenCalledWith( {
+			action: 'already-wpcom',
+			from: 'https://site-url.wpcomstating.com',
+			platform: 'wordpress',
+		} );
+	} );
+
+	it( 'submits site-is-not-using-wordpress action when platform is not wordpress', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+		await fillAddressField();
+		( wp.req.get as jest.Mock ).mockResolvedValue( siteInfoUsingTumblr );
+		await userEvent.click( continueButton() );
+
+		expect( submit ).toHaveBeenCalledWith( {
+			action: 'site-is-not-using-wordpress',
+			from: 'https://site-url.wordpress.com',
+			platform: 'tumblr',
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -639,7 +639,7 @@ describe( 'SiteMigrationCredentials', () => {
 		} );
 	} );
 
-	it( 'submits application-password-approval action when using password application', async () => {
+	it( 'submits application-passwords-approval action when using password application', async () => {
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 		await fillAddressField();
@@ -647,7 +647,7 @@ describe( 'SiteMigrationCredentials', () => {
 		await userEvent.click( continueButton() );
 
 		expect( submit ).toHaveBeenCalledWith( {
-			action: 'application-password-approval',
+			action: 'application-passwords-approval',
 			from: 'https://site-url.wordpress.com',
 			platform: 'wordpress',
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/types.ts
@@ -43,3 +43,7 @@ export interface MigrationError {
 		};
 	};
 }
+
+export interface ApplicationPasswordInfo {
+	isAvailable: boolean;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/types.ts
@@ -44,6 +44,6 @@ export interface MigrationError {
 	};
 }
 
-export interface ApplicationPasswordInfo {
+export interface ApplicationPasswordsInfo {
 	isAvailable: boolean;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -247,6 +247,12 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/site-migration-credentials' ),
 	},
 
+	SITE_MIGRATION_APPLICATION_PASSWORD_APPROVAL: {
+		slug: 'application-password-approval',
+		asyncComponent: () =>
+			import( './steps-repository/site-migration-application-password-approval' ),
+	},
+
 	SITE_MIGRATION_IDENTIFY: {
 		slug: 'site-migration-identify',
 		asyncComponent: () => import( './steps-repository/site-migration-identify' ),

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -247,10 +247,10 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/site-migration-credentials' ),
 	},
 
-	SITE_MIGRATION_APPLICATION_PASSWORD_APPROVAL: {
-		slug: 'application-password-approval',
+	SITE_MIGRATION_APPLICATION_PASSWORDS_APPROVAL: {
+		slug: 'application-passwords-approval',
 		asyncComponent: () =>
-			import( './steps-repository/site-migration-application-password-approval' ),
+			import( './steps-repository/site-migration-application-passwords-approval' ),
 	},
 
 	SITE_MIGRATION_IDENTIFY: {

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -52,6 +52,7 @@ const siteMigration: Flow = {
 			STEPS.ERROR,
 			STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
 			STEPS.SITE_MIGRATION_SOURCE_URL,
+			STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_APPROVAL,
 			STEPS.SITE_MIGRATION_CREDENTIALS,
 			STEPS.SITE_MIGRATION_ALREADY_WPCOM,
 			STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT,
@@ -428,7 +429,12 @@ const siteMigration: Flow = {
 
 				case STEPS.SITE_MIGRATION_CREDENTIALS.slug: {
 					const { action, from } = providedDependencies as {
-						action: 'skip' | 'submit' | 'already-wpcom' | 'site-is-not-using-wordpress';
+						action:
+							| 'skip'
+							| 'submit'
+							| 'application-password-approval'
+							| 'already-wpcom'
+							| 'site-is-not-using-wordpress';
 						from: string;
 					};
 
@@ -460,6 +466,15 @@ const siteMigration: Flow = {
 									platform: providedDependencies.platform as string,
 								},
 								STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT.slug
+							)
+						);
+					}
+
+					if ( action === 'application-password-approval' ) {
+						return navigate(
+							addQueryArgs(
+								{ siteId, from: from || fromQueryParam, siteSlug },
+								STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_APPROVAL.slug
 							)
 						);
 					}

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -52,7 +52,7 @@ const siteMigration: Flow = {
 			STEPS.ERROR,
 			STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
 			STEPS.SITE_MIGRATION_SOURCE_URL,
-			STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_APPROVAL,
+			STEPS.SITE_MIGRATION_APPLICATION_PASSWORDS_APPROVAL,
 			STEPS.SITE_MIGRATION_CREDENTIALS,
 			STEPS.SITE_MIGRATION_ALREADY_WPCOM,
 			STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT,
@@ -432,7 +432,7 @@ const siteMigration: Flow = {
 						action:
 							| 'skip'
 							| 'submit'
-							| 'application-password-approval'
+							| 'application-passwords-approval'
 							| 'already-wpcom'
 							| 'site-is-not-using-wordpress';
 						from: string;
@@ -470,11 +470,11 @@ const siteMigration: Flow = {
 						);
 					}
 
-					if ( action === 'application-password-approval' ) {
+					if ( action === 'application-passwords-approval' ) {
 						return navigate(
 							addQueryArgs(
 								{ siteId, from: from || fromQueryParam, siteSlug },
-								STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_APPROVAL.slug
+								STEPS.SITE_MIGRATION_APPLICATION_PASSWORDS_APPROVAL.slug
 							)
 						);
 					}

--- a/config/test.json
+++ b/config/test.json
@@ -25,7 +25,7 @@
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
-		"automated-migration/application-password": false,
+		"automated-migration/application-password": true,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"calypsoify/plugins": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/96564

## Proposed Changes

![image](https://github.com/user-attachments/assets/f28f533c-1bd6-43bf-bce0-2dff33a68e01)

As part of application passwords integration on migrations, we are refactoring the credentials step. If application passwords is available on the source site, users may not be required to input admin username and password.

Under the `automated-migration/application-password` feature flag we are removing the username and password fields.
We are planning to have an additional step to collect those in case application passwords approval is not available.

Conditionally to the feature flag, we are also preventing the call to `useRequestAutomatedMigration` which should be done in a posterior step. Either the `Get ready for blazing fast speeds` or `Securely share your credentials` which are still to be built.

If the site is not Wordpress platform at all, we should direct the user to the `Looks like there's been a mix-up` step.

If the site is already a WPCOM site we redirect, we should redirect to the `Your site is already on WordPress.com` survey step.

## Testing Instructions

The `automated-migration/application-password` feature flag is already on localhost environment. 
Start a Do it for me migration until you reach the `/site-migration-credentials` step.
Password and usernames should not be present anymore.

Keep using the valid source site address and click on Continue button.
You should be redirected to a `Get ready for blazing fast speeds` step. This step should be empty, it is just a placeholder for future implementation.

Click on back button.
Try a URL that is not a wordpress platform site. For example `https://automattic.tumblr.com/`. You should be directed to `Looks like there's been a mix-up` step.

Click on back button.
Try a URL that is already on WPCOM site. For example `https://matt.blog/`. You should be directed to the `Your site is already on WordPress.com` step.

Make a regression test with feature flag disabled, by adding `flags=-automated-migration/application-password` url query parameter.
Migration flow should keep working as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
