### PR TITLE
A4A: add support for new pressable enterprise plans in marketplace

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/constants.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/constants.ts
@@ -1,2 +1,4 @@
 export const FILTER_TYPE_INSTALL = 'install';
 export const FILTER_TYPE_VISITS = 'visits';
+export const PLAN_CATEGORY_STANDARD = 'standard';
+export const PLAN_CATEGORY_ENTERPRISE = 'enterprise';

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -158,14 +158,14 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 };
 
 export default function getPressablePlan( slug: string ) {
-	return addCategoryToPlan( PLAN_DATA[ slug ] );
+	return addPlanCategory( PLAN_DATA[ slug ] );
 }
 
 export function getAllPressablePlans() {
 	return Object.keys( PLAN_DATA );
 }
 
-function addCategoryToPlan( plan: PressablePlan ) {
+function addPlanCategory( plan: PressablePlan ) {
 	if ( plan.slug.startsWith( 'pressable-enterprise' ) ) {
 		plan.category = 'enterprise';
 	} else {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -1,9 +1,11 @@
+import { PLAN_CATEGORY_STANDARD, PLAN_CATEGORY_ENTERPRISE } from '../constants';
+
 export type PressablePlan = {
 	slug: string;
 	install: number;
 	visits: number;
 	storage: number;
-	category?: string;
+	category: string;
 };
 
 const PLAN_DATA: Record< string, PressablePlan > = {
@@ -12,42 +14,49 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 50000,
 		storage: 20,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-2': {
 		slug: 'pressable-wp-2',
 		install: 5,
 		visits: 100000,
 		storage: 50,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-3': {
 		slug: 'pressable-wp-3',
 		install: 10,
 		visits: 250000,
 		storage: 80,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-4': {
 		slug: 'pressable-wp-4',
 		install: 25,
 		visits: 500000,
 		storage: 175,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-5': {
 		slug: 'pressable-wp-5',
 		install: 50,
 		visits: 1000000,
 		storage: 250,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-6': {
 		slug: 'pressable-wp-6',
 		install: 75,
 		visits: 1500000,
 		storage: 350,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-7': {
 		slug: 'pressable-wp-7',
 		install: 100,
 		visits: 2000000,
 		storage: 500,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 
 	// New pressable plans
@@ -56,60 +65,70 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 30000,
 		storage: 20,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-growth': {
 		slug: 'pressable-growth',
 		install: 3,
 		visits: 50000,
 		storage: 30,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-advanced': {
 		slug: 'pressable-advanced',
 		install: 5,
 		visits: 75000,
 		storage: 35,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-pro': {
 		slug: 'pressable-pro',
 		install: 10,
 		visits: 150000,
 		storage: 50,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-premium': {
 		slug: 'pressable-premium',
 		install: 20,
 		visits: 400000,
 		storage: 80,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-business': {
 		slug: 'pressable-business',
 		install: 50,
 		visits: 1000000,
 		storage: 200,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-business-80': {
 		slug: 'pressable-business-80',
 		install: 80,
 		visits: 1600000,
 		storage: 275,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-business-100': {
 		slug: 'pressable-business-100',
 		install: 100,
 		visits: 2000000,
 		storage: 325,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-business-120': {
 		slug: 'pressable-business-120',
 		install: 120,
 		visits: 2400000,
 		storage: 375,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-business-150': {
 		slug: 'pressable-business-150',
 		install: 150,
 		visits: 3000000,
 		storage: 450,
+		category: PLAN_CATEGORY_STANDARD,
 	},
 
 	// Pressable Enterprise plans
@@ -118,58 +137,56 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 200,
 		visits: 4000000,
 		storage: 500,
+		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-5': {
 		slug: 'pressable-enterprise-5',
 		install: 250,
 		visits: 5000000,
 		storage: 550,
+		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-6': {
 		slug: 'pressable-enterprise-6',
 		install: 300,
 		visits: 6000000,
 		storage: 600,
+		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-7': {
 		slug: 'pressable-enterprise-7',
 		install: 350,
 		visits: 7000000,
 		storage: 700,
+		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-8': {
 		slug: 'pressable-enterprise-8',
 		install: 400,
 		visits: 8000000,
 		storage: 800,
+		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-9': {
 		slug: 'pressable-enterprise-9',
 		install: 450,
 		visits: 9000000,
 		storage: 900,
+		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-10': {
 		slug: 'pressable-enterprise-10',
 		install: 500,
 		visits: 10000000,
 		storage: 1000,
+		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 };
 
 export default function getPressablePlan( slug: string ) {
-	return addPlanCategory( PLAN_DATA[ slug ] );
+	return PLAN_DATA[ slug ];
 }
 
 export function getAllPressablePlans() {
 	return Object.keys( PLAN_DATA );
-}
-
-function addPlanCategory( plan: PressablePlan ) {
-	if ( plan.slug.startsWith( 'pressable-enterprise' ) ) {
-		plan.category = 'enterprise';
-	} else {
-		plan.category = 'standard';
-	}
-	return plan;
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -3,6 +3,7 @@ export type PressablePlan = {
 	install: number;
 	visits: number;
 	storage: number;
+	category?: string;
 };
 
 const PLAN_DATA: Record< string, PressablePlan > = {
@@ -110,12 +111,65 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		visits: 3000000,
 		storage: 450,
 	},
+
+	// Pressable Enterprise plans
+	'pressable-enterprise-4': {
+		slug: 'pressable-enterprise-4',
+		install: 200,
+		visits: 4000000,
+		storage: 500,
+	},
+	'pressable-enterprise-5': {
+		slug: 'pressable-enterprise-5',
+		install: 250,
+		visits: 5000000,
+		storage: 550,
+	},
+	'pressable-enterprise-6': {
+		slug: 'pressable-enterprise-6',
+		install: 300,
+		visits: 6000000,
+		storage: 600,
+	},
+	'pressable-enterprise-7': {
+		slug: 'pressable-enterprise-7',
+		install: 350,
+		visits: 7000000,
+		storage: 700,
+	},
+	'pressable-enterprise-8': {
+		slug: 'pressable-enterprise-8',
+		install: 400,
+		visits: 8000000,
+		storage: 800,
+	},
+	'pressable-enterprise-9': {
+		slug: 'pressable-enterprise-9',
+		install: 450,
+		visits: 9000000,
+		storage: 900,
+	},
+	'pressable-enterprise-10': {
+		slug: 'pressable-enterprise-10',
+		install: 500,
+		visits: 10000000,
+		storage: 1000,
+	},
 };
 
 export default function getPressablePlan( slug: string ) {
-	return PLAN_DATA[ slug ];
+	return addCategoryToPlan( PLAN_DATA[ slug ] );
 }
 
 export function getAllPressablePlans() {
 	return Object.keys( PLAN_DATA );
+}
+
+function addCategoryToPlan( plan: PressablePlan ) {
+	if ( plan.slug.startsWith( 'pressable-enterprise' ) ) {
+		plan.category = 'enterprise';
+	} else {
+		plan.category = 'standard';
+	}
+	return plan;
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
@@ -11,6 +11,7 @@ export default function getSliderOptions( type: FilterType, plans: PressablePlan
 			return {
 				label: `${ type === FILTER_TYPE_INSTALL ? plan.install : formatNumber( plan.visits ) }`,
 				value: plan.slug,
+				category: plan.category,
 			};
 		} );
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
@@ -3,9 +3,14 @@ import { FILTER_TYPE_INSTALL } from '../constants';
 import { FilterType } from '../types';
 import { PressablePlan } from './get-pressable-plan';
 
-export default function getSliderOptions( type: FilterType, plans: PressablePlan[] ) {
+export default function getSliderOptions(
+	type: FilterType,
+	plans: PressablePlan[],
+	category?: string
+) {
 	return plans
 		.filter( ( plan ) => plan !== undefined )
+		.filter( ( plan ) => category === undefined || plan.category === category ) // Maybe only return plans of a specific category
 		.sort( ( planA, planB ) => planA.install - planB.install ) // Ensure our options are sorted by install count
 		.map( ( plan ) => {
 			return {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -41,6 +41,7 @@ export default function PlanSelectionFilter( {
 
 	const [ filterType, setFilterType ] = useState< FilterType >( FILTER_TYPE_INSTALL );
 	const [ selectedTab, setSelectedTab ] = useState( PLAN_CATEGORY_STANDARD );
+	const [ disableStandardTab, setDisableStandardTab ] = useState( false );
 
 	const standardOptions = useMemo(
 		() =>
@@ -136,8 +137,20 @@ export default function PlanSelectionFilter( {
 	);
 
 	useEffect( () => {
-		setSelectedTab( pressablePlan?.category ?? PLAN_CATEGORY_STANDARD );
-	}, [ pressablePlan ] );
+		if ( ! pressablePlan ) {
+			return;
+		}
+
+		setSelectedTab( pressablePlan.category ?? PLAN_CATEGORY_STANDARD );
+
+		// Disable the standard tab if the existing plan is the highest standard plan or higher
+		if (
+			pressablePlan.category !== PLAN_CATEGORY_STANDARD ||
+			pressablePlan.slug === standardOptions[ standardOptions.length - 1 ]?.value
+		) {
+			setDisableStandardTab( true );
+		}
+	}, [ pressablePlan, standardOptions ] );
 
 	if ( isLoading ) {
 		return (
@@ -187,6 +200,7 @@ export default function PlanSelectionFilter( {
 					{
 						name: PLAN_CATEGORY_STANDARD,
 						title: translate( 'Shared Resource Plans' ),
+						disabled: disableStandardTab,
 					},
 					{
 						name: PLAN_CATEGORY_ENTERPRISE,

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -42,11 +42,22 @@ export default function PlanSelectionFilter( {
 	const [ filterType, setFilterType ] = useState< FilterType >( FILTER_TYPE_INSTALL );
 	const [ selectedTab, setSelectedTab ] = useState( PLAN_CATEGORY_STANDARD );
 
-	const options = useMemo(
+	const standardOptions = useMemo(
+		() =>
+			getSliderOptions(
+				filterType,
+				plans.map( ( plan ) => getPressablePlan( plan.slug ) ),
+				PLAN_CATEGORY_STANDARD
+			),
+		[ filterType, plans ]
+	);
+
+	const enterpriseOptions = useMemo(
 		() => [
 			...getSliderOptions(
 				filterType,
-				plans.map( ( plan ) => getPressablePlan( plan.slug ) )
+				plans.map( ( plan ) => getPressablePlan( plan.slug ) ),
+				PLAN_CATEGORY_ENTERPRISE
 			),
 			{
 				label: translate( 'More' ),
@@ -56,15 +67,6 @@ export default function PlanSelectionFilter( {
 		],
 		[ filterType, plans, translate ]
 	);
-
-	// Split options based on category then remove the category property
-	const standardOptions = options
-		.filter( ( option ) => option.category === PLAN_CATEGORY_STANDARD )
-		.map( ( { category, ...rest } ) => rest );
-
-	const enterpriseOptions = options
-		.filter( ( option ) => option.category === PLAN_CATEGORY_ENTERPRISE )
-		.map( ( { category, ...rest } ) => rest );
 
 	const onSelectOption = useCallback(
 		( option: Option ) => {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, TabPanel } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
@@ -12,10 +12,15 @@ import getSliderOptions from '../lib/get-slider-options';
 import { FilterType } from '../types';
 
 type Props = {
+	// Plan details for the plan that's currently selected in the UI
 	selectedPlan: APIProductFamilyProduct | null;
+	// All available Pressable plans
 	plans: APIProductFamilyProduct[];
+	// The users existing Pressable plan
 	pressablePlan?: PressablePlan | null;
+	// Plan selection handler
 	onSelectPlan: ( plan: APIProductFamilyProduct | null ) => void;
+	// Whether the existing plan is still being loaded
 	isLoading?: boolean;
 };
 
@@ -30,6 +35,7 @@ export default function PlanSelectionFilter( {
 	const dispatch = useDispatch();
 
 	const [ filterType, setFilterType ] = useState< FilterType >( FILTER_TYPE_INSTALL );
+	const [ selectedTab, setSelectedTab ] = useState( 'standard' );
 
 	const options = useMemo(
 		() => [
@@ -40,10 +46,19 @@ export default function PlanSelectionFilter( {
 			{
 				label: translate( 'More' ),
 				value: null,
+				category: null,
 			},
 		],
 		[ filterType, plans, translate ]
 	);
+
+	// Split options based on category then remove the category property
+	const standardOptions = options
+		.filter( ( option ) => option.category === 'standard' )
+		.map( ( { category, ...rest } ) => rest );
+	const enterpriseOptions = options
+		.filter( ( option ) => option.category === 'enterprise' )
+		.map( ( { category, ...rest } ) => rest );
 
 	const onSelectOption = useCallback(
 		( option: Option ) => {
@@ -58,9 +73,13 @@ export default function PlanSelectionFilter( {
 		[ dispatch, onSelectPlan, plans ]
 	);
 
-	const selectedOption = options.findIndex(
-		( { value } ) => value === ( selectedPlan ? selectedPlan.slug : null )
-	);
+	const selectedCategory =
+		options.find( ( { value } ) => value === ( selectedPlan ? selectedPlan.slug : null ) )
+			?.category || null;
+
+	const selectedOptionIndex = (
+		'standard' === selectedCategory ? standardOptions : enterpriseOptions
+	).findIndex( ( { value } ) => value === ( selectedPlan ? selectedPlan.slug : null ) );
 
 	const onSelectInstallFilterType = useCallback( () => {
 		setFilterType( FILTER_TYPE_INSTALL );
@@ -109,39 +128,84 @@ export default function PlanSelectionFilter( {
 		);
 	}
 
+	const FilterByPicker = () => (
+		<div className="pressable-overview-plan-selection__filter-type">
+			<p className="pressable-overview-plan-selection__filter-label">
+				{ translate( 'Filter by:' ) }
+			</p>
+			<div className="pressable-overview-plan-selection__filter-buttons">
+				<Button
+					className={ clsx( 'pressable-overview-plan-selection__filter-button', {
+						'is-dark': filterType === FILTER_TYPE_INSTALL,
+					} ) }
+					onClick={ onSelectInstallFilterType }
+				>
+					{ translate( 'WordPress installs' ) }
+				</Button>
+
+				<Button
+					className={ clsx( 'pressable-overview-plan-selection__filter-button', {
+						'is-dark': filterType === FILTER_TYPE_VISITS,
+					} ) }
+					onClick={ onSelectVisitFilterType }
+				>
+					{ translate( 'Number of visits' ) }
+				</Button>
+			</div>
+		</div>
+	);
+
 	return (
 		<section className={ wrapperClass }>
-			<div className="pressable-overview-plan-selection__filter-type">
-				<p className="pressable-overview-plan-selection__filter-label">
-					{ translate( 'Filter by:' ) }
-				</p>
-				<div className="pressable-overview-plan-selection__filter-buttons">
-					<Button
-						className={ clsx( 'pressable-overview-plan-selection__filter-button', {
-							'is-dark': filterType === FILTER_TYPE_INSTALL,
-						} ) }
-						onClick={ onSelectInstallFilterType }
-					>
-						{ translate( 'WordPress installs' ) }
-					</Button>
-
-					<Button
-						className={ clsx( 'pressable-overview-plan-selection__filter-button', {
-							'is-dark': filterType === FILTER_TYPE_VISITS,
-						} ) }
-						onClick={ onSelectVisitFilterType }
-					>
-						{ translate( 'Number of visits' ) }
-					</Button>
-				</div>
-			</div>
-
-			<A4ASlider
-				value={ selectedOption }
-				onChange={ onSelectOption }
-				options={ options }
-				minimum={ minimum }
-			/>
+			<TabPanel
+				className="pressable-overview-plan-selection__plan-category-panel"
+				activeClass="active-tab"
+				tabs={ [
+					{
+						name: 'standard',
+						title: translate( 'Shared Resource Plans' ),
+					},
+					{
+						name: 'enterprise',
+						title: translate( 'Signature Shared Resource Plans' ),
+					},
+				] }
+				onSelect={ setSelectedTab }
+				initialTabName={ selectedTab }
+			>
+				{ ( tab ) => {
+					switch ( tab.name ) {
+						case 'standard':
+							return (
+								<>
+									<FilterByPicker />
+									<A4ASlider
+										value={ 'standard' === selectedCategory ? selectedOptionIndex : 0 }
+										onChange={ onSelectOption }
+										options={ standardOptions }
+										minimum={
+											'standard' === pressablePlan?.category ? minimum : standardOptions.length - 1
+										}
+									/>
+								</>
+							);
+						case 'enterprise':
+							return (
+								<>
+									<FilterByPicker />
+									<A4ASlider
+										value={ 'enterprise' === selectedCategory ? selectedOptionIndex : 0 }
+										onChange={ onSelectOption }
+										options={ enterpriseOptions }
+										minimum={ 'enterprise' === pressablePlan?.category ? minimum : 0 }
+									/>
+								</>
+							);
+						default:
+							return null;
+					}
+				} }
+			</TabPanel>
 		</section>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -1,7 +1,7 @@
 import { Button, TabPanel } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -120,6 +120,10 @@ export default function PlanSelectionFilter( {
 		return allAvailablePlans.length;
 	}, [ plans, pressablePlan ] );
 
+	useEffect( () => {
+		setSelectedTab( pressablePlan?.category ?? 'standard' );
+	}, [ pressablePlan ] );
+
 	if ( isLoading ) {
 		return (
 			<div className="pressable-overview-plan-selection__filter is-placeholder">
@@ -159,8 +163,11 @@ export default function PlanSelectionFilter( {
 	return (
 		<section className={ wrapperClass }>
 			<TabPanel
-				className="pressable-overview-plan-selection__plan-category-panel"
-				activeClass="active-tab"
+				key={ selectedTab } // Force re-render when selectedTab changes
+				className="pressable-overview-plan-selection__plan-category-tabpanel"
+				activeClass="pressable-overview-plan-selection__plan-category-tab-is-active"
+				onSelect={ setSelectedTab }
+				initialTabName={ selectedTab }
 				tabs={ [
 					{
 						name: 'standard',
@@ -171,8 +178,6 @@ export default function PlanSelectionFilter( {
 						title: translate( 'Signature Shared Resource Plans' ),
 					},
 				] }
-				onSelect={ setSelectedTab }
-				initialTabName={ selectedTab }
 			>
 				{ ( tab ) => {
 					switch ( tab.name ) {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -16,7 +16,7 @@ type Props = {
 	selectedPlan: APIProductFamilyProduct | null;
 	// All available Pressable plans
 	plans: APIProductFamilyProduct[];
-	// The users existing Pressable plan
+	// The users existing Pressable plan if any
 	pressablePlan?: PressablePlan | null;
 	// Plan selection handler
 	onSelectPlan: ( plan: APIProductFamilyProduct | null ) => void;
@@ -102,23 +102,29 @@ export default function PlanSelectionFilter( {
 			: 'a4a-pressable-filter-wrapper-visits';
 	const wrapperClass = clsx( additionalWrapperClass, 'pressable-overview-plan-selection__filter' );
 
-	const minimum = useMemo( () => {
-		if ( ! pressablePlan ) {
-			return 0;
-		}
-
-		const allAvailablePlans = plans
-			.map( ( plan ) => getPressablePlan( plan.slug ) )
-			.filter( ( plan ) => plan !== undefined )
-			.sort( ( a, b ) => a?.install - b?.install );
-
-		for ( let i = 0; i < allAvailablePlans.length; i++ ) {
-			if ( pressablePlan?.install < allAvailablePlans[ i ]?.install ) {
-				return i;
+	const getSliderMinimum = useCallback(
+		( category: string, categoryOptions: Option[] ) => {
+			if ( ! pressablePlan ) {
+				return 0;
 			}
-		}
-		return allAvailablePlans.length;
-	}, [ plans, pressablePlan ] );
+
+			// Depending on the category of the existing plan, we might want to show other category slider at the most min or max
+			if ( 'standard' === category && 'standard' !== pressablePlan?.category ) {
+				return categoryOptions.length - 1;
+			} else if ( 'enterprise' === category && 'enterprise' !== pressablePlan?.category ) {
+				return 0;
+			}
+
+			for ( let i = 0; i < categoryOptions.length; i++ ) {
+				const plan = getPressablePlan( categoryOptions[ i ].value as string );
+				if ( pressablePlan?.install < plan?.install ) {
+					return i;
+				}
+			}
+			return categoryOptions.length;
+		},
+		[ pressablePlan ]
+	);
 
 	useEffect( () => {
 		setSelectedTab( pressablePlan?.category ?? 'standard' );
@@ -189,9 +195,7 @@ export default function PlanSelectionFilter( {
 										value={ 'standard' === selectedCategory ? selectedOptionIndex : 0 }
 										onChange={ onSelectOption }
 										options={ standardOptions }
-										minimum={
-											'standard' === pressablePlan?.category ? minimum : standardOptions.length - 1
-										}
+										minimum={ getSliderMinimum( 'standard', standardOptions ) }
 									/>
 								</>
 							);
@@ -203,7 +207,7 @@ export default function PlanSelectionFilter( {
 										value={ 'enterprise' === selectedCategory ? selectedOptionIndex : 0 }
 										onChange={ onSelectOption }
 										options={ enterpriseOptions }
-										minimum={ 'enterprise' === pressablePlan?.category ? minimum : 0 }
+										minimum={ getSliderMinimum( 'enterprise', enterpriseOptions ) }
 									/>
 								</>
 							);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -56,6 +56,7 @@ export default function PlanSelectionFilter( {
 	const standardOptions = options
 		.filter( ( option ) => option.category === 'standard' )
 		.map( ( { category, ...rest } ) => rest );
+
 	const enterpriseOptions = options
 		.filter( ( option ) => option.category === 'enterprise' )
 		.map( ( { category, ...rest } ) => rest );
@@ -155,21 +156,26 @@ export default function PlanSelectionFilter( {
 		</div>
 	);
 
+	// Until the plans have been added on the backend we need to make sure we have enterprise plans
+	const planCategoryTabs = [
+		{
+			name: 'standard',
+			title: translate( 'Standard Plans' ),
+		},
+	];
+	if ( enterpriseOptions.length > 0 ) {
+		planCategoryTabs.push( {
+			name: 'enterprise',
+			title: translate( 'Signature Shared Resource Plans' ),
+		} );
+	}
+
 	return (
 		<section className={ wrapperClass }>
 			<TabPanel
 				className="pressable-overview-plan-selection__plan-category-panel"
 				activeClass="active-tab"
-				tabs={ [
-					{
-						name: 'standard',
-						title: translate( 'Shared Resource Plans' ),
-					},
-					{
-						name: 'enterprise',
-						title: translate( 'Signature Shared Resource Plans' ),
-					},
-				] }
+				tabs={ planCategoryTabs }
 				onSelect={ setSelectedTab }
 				initialTabName={ selectedTab }
 			>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -6,7 +6,12 @@ import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
-import { FILTER_TYPE_INSTALL, FILTER_TYPE_VISITS } from '../constants';
+import {
+	FILTER_TYPE_INSTALL,
+	FILTER_TYPE_VISITS,
+	PLAN_CATEGORY_STANDARD,
+	PLAN_CATEGORY_ENTERPRISE,
+} from '../constants';
 import getPressablePlan, { PressablePlan } from '../lib/get-pressable-plan';
 import getSliderOptions from '../lib/get-slider-options';
 import { FilterType } from '../types';
@@ -35,7 +40,7 @@ export default function PlanSelectionFilter( {
 	const dispatch = useDispatch();
 
 	const [ filterType, setFilterType ] = useState< FilterType >( FILTER_TYPE_INSTALL );
-	const [ selectedTab, setSelectedTab ] = useState( 'standard' );
+	const [ selectedTab, setSelectedTab ] = useState( PLAN_CATEGORY_STANDARD );
 
 	const options = useMemo(
 		() => [
@@ -54,11 +59,11 @@ export default function PlanSelectionFilter( {
 
 	// Split options based on category then remove the category property
 	const standardOptions = options
-		.filter( ( option ) => option.category === 'standard' )
+		.filter( ( option ) => option.category === PLAN_CATEGORY_STANDARD )
 		.map( ( { category, ...rest } ) => rest );
 
 	const enterpriseOptions = options
-		.filter( ( option ) => option.category === 'enterprise' )
+		.filter( ( option ) => option.category === PLAN_CATEGORY_ENTERPRISE )
 		.map( ( { category, ...rest } ) => rest );
 
 	const onSelectOption = useCallback(
@@ -75,7 +80,7 @@ export default function PlanSelectionFilter( {
 	);
 
 	const selectedOptionIndex = (
-		'standard' === selectedTab ? standardOptions : enterpriseOptions
+		PLAN_CATEGORY_STANDARD === selectedTab ? standardOptions : enterpriseOptions
 	).findIndex( ( { value } ) => value === ( selectedPlan ? selectedPlan.slug : null ) );
 
 	const onSelectInstallFilterType = useCallback( () => {
@@ -105,9 +110,15 @@ export default function PlanSelectionFilter( {
 			}
 
 			// Depending on the category of the existing plan, we might want to show other category slider at the most min or max
-			if ( 'standard' === category && 'standard' !== pressablePlan?.category ) {
+			if (
+				PLAN_CATEGORY_STANDARD === category &&
+				PLAN_CATEGORY_STANDARD !== pressablePlan?.category
+			) {
 				return categoryOptions.length - 1;
-			} else if ( 'enterprise' === category && 'enterprise' !== pressablePlan?.category ) {
+			} else if (
+				PLAN_CATEGORY_ENTERPRISE === category &&
+				PLAN_CATEGORY_ENTERPRISE !== pressablePlan?.category
+			) {
 				return 0;
 			}
 
@@ -123,7 +134,7 @@ export default function PlanSelectionFilter( {
 	);
 
 	useEffect( () => {
-		setSelectedTab( pressablePlan?.category ?? 'standard' );
+		setSelectedTab( pressablePlan?.category ?? PLAN_CATEGORY_STANDARD );
 	}, [ pressablePlan ] );
 
 	if ( isLoading ) {
@@ -172,38 +183,38 @@ export default function PlanSelectionFilter( {
 				initialTabName={ selectedTab }
 				tabs={ [
 					{
-						name: 'standard',
+						name: PLAN_CATEGORY_STANDARD,
 						title: translate( 'Shared Resource Plans' ),
 					},
 					{
-						name: 'enterprise',
+						name: PLAN_CATEGORY_ENTERPRISE,
 						title: translate( 'Signature Shared Resource Plans' ),
 					},
 				] }
 			>
 				{ ( tab ) => {
 					switch ( tab.name ) {
-						case 'standard':
+						case PLAN_CATEGORY_STANDARD:
 							return (
 								<>
 									<FilterByPicker />
 									<A4ASlider
-										value={ 'standard' === selectedTab ? selectedOptionIndex : 0 }
+										value={ PLAN_CATEGORY_STANDARD === selectedTab ? selectedOptionIndex : 0 }
 										onChange={ onSelectOption }
 										options={ standardOptions }
-										minimum={ getSliderMinimum( 'standard', standardOptions ) }
+										minimum={ getSliderMinimum( PLAN_CATEGORY_STANDARD, standardOptions ) }
 									/>
 								</>
 							);
-						case 'enterprise':
+						case PLAN_CATEGORY_ENTERPRISE:
 							return (
 								<>
 									<FilterByPicker />
 									<A4ASlider
-										value={ 'enterprise' === selectedTab ? selectedOptionIndex : 0 }
+										value={ PLAN_CATEGORY_ENTERPRISE === selectedTab ? selectedOptionIndex : 0 }
 										onChange={ onSelectOption }
 										options={ enterpriseOptions }
-										minimum={ getSliderMinimum( 'enterprise', enterpriseOptions ) }
+										minimum={ getSliderMinimum( PLAN_CATEGORY_ENTERPRISE, enterpriseOptions ) }
 									/>
 								</>
 							);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -74,12 +74,8 @@ export default function PlanSelectionFilter( {
 		[ dispatch, onSelectPlan, plans ]
 	);
 
-	const selectedCategory =
-		options.find( ( { value } ) => value === ( selectedPlan ? selectedPlan.slug : null ) )
-			?.category || null;
-
 	const selectedOptionIndex = (
-		'standard' === selectedCategory ? standardOptions : enterpriseOptions
+		'standard' === selectedTab ? standardOptions : enterpriseOptions
 	).findIndex( ( { value } ) => value === ( selectedPlan ? selectedPlan.slug : null ) );
 
 	const onSelectInstallFilterType = useCallback( () => {
@@ -192,7 +188,7 @@ export default function PlanSelectionFilter( {
 								<>
 									<FilterByPicker />
 									<A4ASlider
-										value={ 'standard' === selectedCategory ? selectedOptionIndex : 0 }
+										value={ 'standard' === selectedTab ? selectedOptionIndex : 0 }
 										onChange={ onSelectOption }
 										options={ standardOptions }
 										minimum={ getSliderMinimum( 'standard', standardOptions ) }
@@ -204,7 +200,7 @@ export default function PlanSelectionFilter( {
 								<>
 									<FilterByPicker />
 									<A4ASlider
-										value={ 'enterprise' === selectedCategory ? selectedOptionIndex : 0 }
+										value={ 'enterprise' === selectedTab ? selectedOptionIndex : 0 }
 										onChange={ onSelectOption }
 										options={ enterpriseOptions }
 										minimum={ getSliderMinimum( 'enterprise', enterpriseOptions ) }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -156,26 +156,21 @@ export default function PlanSelectionFilter( {
 		</div>
 	);
 
-	// Until the plans have been added on the backend we need to make sure we have enterprise plans
-	const planCategoryTabs = [
-		{
-			name: 'standard',
-			title: translate( 'Standard Plans' ),
-		},
-	];
-	if ( enterpriseOptions.length > 0 ) {
-		planCategoryTabs.push( {
-			name: 'enterprise',
-			title: translate( 'Signature Shared Resource Plans' ),
-		} );
-	}
-
 	return (
 		<section className={ wrapperClass }>
 			<TabPanel
 				className="pressable-overview-plan-selection__plan-category-panel"
 				activeClass="active-tab"
-				tabs={ planCategoryTabs }
+				tabs={ [
+					{
+						name: 'standard',
+						title: translate( 'Shared Resource Plans' ),
+					},
+					{
+						name: 'enterprise',
+						title: translate( 'Signature Shared Resource Plans' ),
+					},
+				] }
 				onSelect={ setSelectedTab }
 				initialTabName={ selectedTab }
 			>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -304,7 +304,7 @@
 	max-width: 400px;
 }
 
-.pressable-overview-plan-selection__plan-category-panel {
+.pressable-overview-plan-selection__plan-category-tabpanel {
 	.components-tab-panel__tabs {
 		justify-content: center;
 		border: 1px solid var(--color-neutral-5);
@@ -320,7 +320,7 @@
 				color: inherit;
 			}
 
-			&.active-tab {
+			&.pressable-overview-plan-selection__plan-category-tab-is-active {
 				background-color: var(--color-primary-50);
 				border-color: var(--color-primary-50);
 				fill: var(--color-text-inverted);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -303,3 +303,29 @@
 .pressable-overview-plan-selection__tooltip {
 	max-width: 400px;
 }
+
+.pressable-overview-plan-selection__plan-category-panel {
+	.components-tab-panel__tabs {
+		justify-content: center;
+		border: 1px solid var(--color-neutral-5);
+		border-radius: 4px;
+		padding: 7px 0;
+		margin-bottom: 32px;
+
+		button {
+			flex: 1;
+			margin: 0 7px;
+			&:hover {
+				background-color: initial;
+				color: inherit;
+			}
+
+			&.active-tab {
+				background-color: var(--color-primary-50);
+				border-color: var(--color-primary-50);
+				fill: var(--color-text-inverted);
+				color: var(--color-text-inverted);
+			}
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -311,7 +311,8 @@
 		border: 1px solid var(--color-neutral-5);
 		border-radius: 4px;
 		padding: 7px 0;
-		margin-bottom: 32px;
+		margin: 0 auto 32px;
+		max-width: 600px;
 
 		button {
 			flex: 1;

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -316,9 +316,14 @@
 		button {
 			flex: 1;
 			margin: 0 7px;
+
 			&:hover {
 				background-color: initial;
 				color: inherit;
+			}
+
+			&:disabled, &[aria-disabled="true"] {
+				color: var(--color-neutral-20);
 			}
 
 			&.pressable-overview-plan-selection__plan-category-tab-is-active {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -307,6 +307,7 @@
 .pressable-overview-plan-selection__plan-category-tabpanel {
 	.components-tab-panel__tabs {
 		justify-content: center;
+		flex-wrap: wrap;
 		border: 1px solid var(--color-neutral-5);
 		border-radius: 4px;
 		padding: 7px 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/automattic-for-agencies-dev/issues/1466
P2: pfSQfS-tF-p2

## Proposed Changes

* Add support for new pressable enterprise plans
* Split existing plans and enterprise up into separate tabs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To allow agencies to self-serve purchasing Pressable plans with higher limits

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com`.
* Visit the Pressable marketplace page (`/marketplace/hosting/pressable`).
* You should see two new tabs - "Shared Resource Plans" and "Signature Shared Resource Plans"
* Under "Shared Resource Plans" you should see the existing Pressable plans
* Under "Signature Shared Resource Plans" you should see the new Enterprise Pressable plans ("Signature")
* Make sure the sliders work as expected.
  * If you have an existing plan the slider should start at the next available plan.
  * The slider under "Signature Shared Resource Plans" should default to the far left.
  * In refer mode the sliders should allow choosing any plan (no minimum).
  * The "More" item should appear as the last option under "Signature Shared Resource Plans".
  * Selecting "More" should show the "Contact Us" details just as before.
  * Filtering by installs or visits should continue to work the same.
  * Add one of the new plans to the cart (don't purchase yet). It should show the appropriate "Signature" plan name.
  * Make sure all the displayed plan limits (installs, visits, storage) match what's shown in the spreadsheet in this post (pfSQfS-tF-p2).
* ~~Once D166722-code has shipped, also test purchasing the plans~~
~~:warning: Purchasing plans before that could cause issues since it writes to production tables before the code is live on production. Likely a minor concern but no need to generate errors.~~
  * Make sure purchasing existing plans works the same.
  * Purchase one of the new plans.
  * Once your existing plan is one of the new ones the slider under "Shared Resource Plans" should be all grey so you can't select a lower plan.
  * Under "Signature Shared Resource Plans", the slider should start at the next available plan and not let you select a lower plan, just like before.
  * Make sure when you have any Signature plan or the Business 150 plan that the "Shared Resource Plans" tab is disabled so users can't select a lower or the same plan.
  * Make sure revoking a plan still works ok.

<img width="1671" alt="Screenshot 2024-11-22 at 9 27 52 AM" src="https://github.com/user-attachments/assets/9200fade-9b83-4d01-9dab-f69213b4bb56">
<img width="1671" alt="Screenshot 2024-11-22 at 9 29 34 AM" src="https://github.com/user-attachments/assets/7f05a26d-cb7b-4a83-b2d4-8cd82ecec127">
<img width="1672" alt="Screenshot 2024-11-22 at 9 31 35 AM" src="https://github.com/user-attachments/assets/7fb261ef-96ea-4075-b306-c22ff99634d6">
<img width="1671" alt="Screenshot 2024-11-22 at 9 35 43 AM" src="https://github.com/user-attachments/assets/9055473a-fca0-4ecb-b11c-b0d8c25cd1cb">
<img width="1664" alt="Screenshot 2024-11-22 at 9 36 04 AM" src="https://github.com/user-attachments/assets/8c6ecab7-caed-4a92-8d63-a6fbf4d43ff6">
<img width="1666" alt="Screenshot 2024-11-22 at 9 41 36 AM" src="https://github.com/user-attachments/assets/dc37408e-e1ab-4908-a21c-5618cc9c1326">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?