### PR TITLE
Fix UTM card learn more link

### DIFF
--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-jetpack.tsx
@@ -6,7 +6,6 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import { SUPPORT_URL, INSIGHTS_SUPPORT_URL } from 'calypso/my-sites/stats/const';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
@@ -54,29 +53,27 @@ const insightsSupportLinkWithAnchor = ( anchor: string ) => {
 	);
 };
 
-const utmLearnMoreLink = ( isOdysseyStats: boolean ) => {
-	return isOdysseyStats ? (
+const utmLearnMoreLink = () => {
+	return (
 		<a
-			href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
+			href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-utm-url-builder"
 			target="_blank"
 			rel="noopenner noreferrer"
 		/>
-	) : (
-		<InlineSupportLink supportContext="utm-upsell-overlay" showIcon={ false } />
 	);
 };
 
-const useUpsellCopy = ( statType: string, isOdysseyStats: boolean ) => {
+const useUpsellCopy = ( statType: string ) => {
 	const translate = useTranslate();
 	switch ( statType ) {
 		case STATS_FEATURE_DATE_CONTROL:
 			return translate( 'Compare different time periods to analyze your site’s growth.' );
 		case STATS_FEATURE_UTM_STATS:
 			return translate(
-				'Generate UTM parameters and track your campaign performance data. {{link}}Learn more{{/link}}.',
+				'Generate UTM parameters and track your campaign performance data. {{link}}Learn more{{/link}}',
 				{
 					components: {
-						link: utmLearnMoreLink( isOdysseyStats ),
+						link: utmLearnMoreLink(),
 					},
 				}
 			);
@@ -164,7 +161,7 @@ const useUpsellCopy = ( statType: string, isOdysseyStats: boolean ) => {
 const StatsCardUpsellJetpack: React.FC< Props > = ( { className, siteId, statType } ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	const copyText = useUpsellCopy( statType, isOdysseyStats );
+	const copyText = useUpsellCopy( statType );
 
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );


### PR DESCRIPTION
Fallback to external link as InlineSupportLink component refuses to render properly.

Related to #87925
Related to #96596

## Proposed Changes
This PR changes the link on UTM card upsell overlay to external support link

## Why are these changes being made?

Because InlineSupportLink can't render under specific conditions

## Testing Instructions
The UTM card shows an overlay when no upgrade/plan is purchased. The overlay should now show a "Learn more" link.

Odyssey stats was already showing this link, yet Calypso failed to render it. Test on calypso.localhost:3000/stats/day/some-site-of-yours

Before:
<img width="401" alt="image" src="https://github.com/user-attachments/assets/a0224e6c-20e7-46da-b9f0-009222671a38">

After:
<img width="392" alt="image" src="https://github.com/user-attachments/assets/c13326fa-6e13-4ad1-845f-6567ca9ad29b">

- [ ] Verify the link is shown and it points to https://jetpack.com/support/jetpack-stats/traffic-dashboard/utm-url-builder/
- [ ] Verify that the link shown on Odyssey Stats continues to work visiting some.site.of.yours/wp-admin/admin.php?page=stats#!/stats/day/some.site.of.yours

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
