### PR TITLE
A4A: Make sure we aren't trying to use an undefined plan

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
@@ -5,6 +5,7 @@ import { PressablePlan } from './get-pressable-plan';
 
 export default function getSliderOptions( type: FilterType, plans: PressablePlan[] ) {
 	return plans
+		.filter( ( plan ) => plan !== undefined )
 		.sort( ( planA, planB ) => planA.install - planB.install ) // Ensure our options are sorted by install count
 		.map( ( plan ) => {
 			return {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -89,10 +89,11 @@ export default function PlanSelectionFilter( {
 
 		const allAvailablePlans = plans
 			.map( ( plan ) => getPressablePlan( plan.slug ) )
-			.sort( ( a, b ) => a.install - b.install );
+			.filter( ( plan ) => plan !== undefined )
+			.sort( ( a, b ) => a?.install - b?.install );
 
 		for ( let i = 0; i < allAvailablePlans.length; i++ ) {
-			if ( pressablePlan.install < allAvailablePlans[ i ].install ) {
+			if ( pressablePlan?.install < allAvailablePlans[ i ]?.install ) {
 				return i;
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Check for undefined before trying to use a plan.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This keeps the frontend from breaking when we ship new Pressable plans on the backend that haven't been added to the frontend yet.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the Pressable marketplace page (`/marketplace/hosting/pressable`) works exactly the same as before. There aren't any functional changes.
* Sandbox `public-api.wordpress.com`
* Apply D166722-code on the backend.
* Test again and make sure everything still works as expected.
* To be extra sure, make sure the wpcom hosting page works fine as well.

<img width="1523" alt="Screenshot 2024-11-21 at 1 56 49 PM" src="https://github.com/user-attachments/assets/01de167c-d94f-4fee-a873-8093019cab52">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?