### PR TITLE
CheckoutModal: Ensure cancel_to and redirect_to are relative urls

### DIFF
--- a/client/my-sites/checkout/modal/index.tsx
+++ b/client/my-sites/checkout/modal/index.tsx
@@ -75,11 +75,11 @@ const CheckoutModal: FunctionComponent< Props > = ( {
 		checkoutOnSuccessCallback?.();
 		onClose?.();
 
-		// Reload the page to get latest data
 		if ( isRelativeUrl( redirectTo ) ) {
-			navigate( redirectTo );
+			// Using full page reload here to refresh the latest plan data for the new site
+			window.location.href = redirectTo;
 		} else {
-			navigate( previousRouteWithArgs );
+			window.location.href = previousRouteWithArgs;
 		}
 	};
 

--- a/client/my-sites/checkout/modal/index.tsx
+++ b/client/my-sites/checkout/modal/index.tsx
@@ -9,6 +9,7 @@ import { navigate } from 'calypso/lib/navigate';
 import { getRazorpayConfiguration, getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
+import { isRelativeUrl } from 'calypso/my-sites/checkout/src/lib/leave-checkout';
 import { useSelector, useDispatch } from 'calypso/state';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route.js';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -60,7 +61,11 @@ const CheckoutModal: FunctionComponent< Props > = ( {
 
 	const handleRequestClose = () => {
 		onClose?.();
-		navigate( cancelTo );
+		if ( isRelativeUrl( cancelTo ) ) {
+			navigate( cancelTo );
+		} else {
+			navigate( previousRouteWithArgs );
+		}
 	};
 
 	// IMPORTANT NOTE: This will not be called for redirect payment methods like
@@ -71,7 +76,11 @@ const CheckoutModal: FunctionComponent< Props > = ( {
 		onClose?.();
 
 		// Reload the page to get latest data
-		window.location.href = redirectTo;
+		if ( isRelativeUrl( redirectTo ) ) {
+			navigate( redirectTo );
+		} else {
+			navigate( previousRouteWithArgs );
+		}
 	};
 
 	useEffect( () => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9902
Follows up on https://github.com/Automattic/wp-calypso/pull/96514

## Proposed Changes

* Wraps redirects for cancel_to and redirect_to in isRelativeUrl checks within the checkout modal.

## Testing Instructions

- http://calypso.localhost:3000/setup/assembler-first/new-or-existing-site
- Select new or existing site
- Continue through until there is an option to choose a premium style, choose one
- Continue until prompted to upgrade to a personal plan, click to upgrade
- Modify the redirect_to param in the url to something like example.com
- Make a purchase using store sandbox or credits
- Redirect should load previous route with args instead ... ? (currently not working as expected, it reloads the checkout modal not the previous screen)

Note, to skip assembler setup you can load the url directly (swapping site for a site with free plan): http://calypso.localhost:3000/setup/assembler-first/pattern-assembler?siteSlug=testingcalypso16.wordpress.com&siteId=239255304&screen=upsell&header_pattern_id=15892&footer_pattern_id=15364&color_variation_title=Pearl

![Screenshot(132)](https://github.com/user-attachments/assets/cb9f7429-15fe-4118-8b78-7a544882f377)
![Screenshot(133)](https://github.com/user-attachments/assets/ae495480-e983-4ce1-9b3e-4637ba700bed)
