### PR TITLE
A4A > Site Details: Disable site tags on staging

### DIFF
--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -32,7 +32,6 @@
 		"a8c-for-agencies/import-site-from-wpcom": true,
 		"cookie-banner": false,
 		"oauth": true,
-		"a4a/site-details-pane": true,
 		"a4a/site-migration": false,
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,


### PR DESCRIPTION
## Proposed Changes

This PR disables the site tagging feature on staging as we don't have a plan to ship this feature, and it could cause some confusion. 

## Why are these changes being made?

* To disable the site tagging feature on staging.

## Testing Instructions

* Open the A4A live link
* Append the URL with ?flags=-a4a/site-details-pane
* Go to Sites > Open the details pane > Verify you no longer see the `Details` tab. Also, verify the feature flag is disabled on staging by looking at the code changes.


| Before | After |
|--------|--------|
| <img width="726" alt="Screenshot 2024-11-22 at 11 43 19 AM" src="https://github.com/user-attachments/assets/0f4c4675-e650-4729-88e1-3b229c8fa30b">| <img width="677" alt="Screenshot 2024-11-22 at 11 44 05 AM" src="https://github.com/user-attachments/assets/bd1a8468-f3f0-441c-9219-92d1f3ebe03b"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
