### PR TITLE
Untangling: add subtab upsell to Settings -> Caching

### DIFF
--- a/client/components/hosting-hero/style.scss
+++ b/client/components/hosting-hero/style.scss
@@ -20,7 +20,6 @@
 }
 
 .hosting-hero-button {
-	margin: 0 5px;
 	padding: 10px 14px;
 	font-size: rem(14px);
 	height: 40px;

--- a/client/sites/components/panel/style.scss
+++ b/client/sites/components/panel/style.scss
@@ -12,6 +12,10 @@
 	.header-cake__back {
 		padding: 0;
 	}
+
+	.upsell-nudge {
+		width: 100%;
+	}
 }
 
 .panel-section {

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import React, { useMemo, useEffect } from 'react';
 import ItemPreviewPane from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import HostingFeaturesIcon from 'calypso/hosting/hosting-features/components/hosting-features-icon';
-import { areHostingFeaturesSupported } from 'calypso/sites/features';
+import { areHostingFeaturesSupported } from 'calypso/sites/hosting-features/features';
 import { useStagingSite } from 'calypso/sites/tools/staging-site/hooks/use-staging-site';
 import { getMigrationStatus } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -2,13 +2,14 @@ import page from '@automattic/calypso-router';
 import { siteLaunchStatusGroupValues } from '@automattic/sites';
 import { Global, css } from '@emotion/react';
 import { removeQueryArgs } from '@wordpress/url';
+import i18n from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { removeNotice } from 'calypso/state/notices/actions';
+import { removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import SitesDashboard from './components/sites-dashboard';
-import { areHostingFeaturesSupported } from './features';
+import { areHostingFeaturesSupported } from './hosting-features/features';
 import type { Context, Context as PageJSContext } from '@automattic/calypso-router';
 
 const getStatusFilterValue = ( status?: string ) => {
@@ -156,6 +157,25 @@ export function redirectToHostingFeaturesIfNotAtomic( context: PageJSContext, ne
 
 	if ( ! areHostingFeaturesSupported( site ) ) {
 		return page.redirect( `/hosting-features/${ site?.slug }` );
+	}
+
+	next();
+}
+
+export function showHostingFeaturesNoticeIfPresent( context: PageJSContext, next: () => void ) {
+	// Update the url and show the notice after a redirect
+	if ( context.query && context.query.hosting_features === 'activated' ) {
+		context.store.dispatch(
+			successNotice( i18n.translate( 'Hosting features activated successfully!' ), {
+				displayOnNextPage: true,
+			} )
+		);
+		// Remove query param without triggering a re-render
+		window.history.replaceState(
+			null,
+			'',
+			removeQueryArgs( window.location.href, 'hosting_features' )
+		);
 	}
 
 	next();

--- a/client/sites/hosting-features/components/hosting-activation-button.tsx
+++ b/client/sites/hosting-features/components/hosting-activation-button.tsx
@@ -1,0 +1,68 @@
+import { FEATURE_SFTP } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
+import { Dialog } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
+import { translate } from 'i18n-calypso';
+import { useState } from 'react';
+import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
+import { HostingHeroButton } from 'calypso/components/hosting-hero';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+interface HostingActivationButtonProps {
+	redirectUrl?: string;
+}
+
+export default function HostingActivationButton( { redirectUrl }: HostingActivationButtonProps ) {
+	const dispatch = useDispatch();
+	const { searchParams } = new URL( document.location.toString() );
+	const showActivationModal = searchParams.get( 'activate' ) !== null;
+	const [ showEligibility, setShowEligibility ] = useState( showActivationModal );
+
+	const siteId = useSelector( getSelectedSiteId );
+
+	const handleTransfer = ( options: { geo_affinity?: string } ) => {
+		dispatch( recordTracksEvent( 'calypso_hosting_features_activate_confirm' ) );
+		const params = new URLSearchParams( {
+			siteId: String( siteId ),
+			redirect_to: addQueryArgs( redirectUrl, {
+				hosting_features: 'activated',
+			} ),
+			feature: FEATURE_SFTP,
+			initiate_transfer_context: 'hosting',
+			initiate_transfer_geo_affinity: options.geo_affinity || '',
+		} );
+		page( `/setup/transferring-hosted-site?${ params }` );
+	};
+
+	return (
+		<>
+			<HostingHeroButton
+				onClick={ () => {
+					dispatch( recordTracksEvent( 'calypso_hosting_features_activate_click' ) );
+					return setShowEligibility( true );
+				} }
+			>
+				{ translate( 'Activate now' ) }
+			</HostingHeroButton>
+
+			<Dialog
+				additionalClassNames="plugin-details-cta__dialog-content"
+				additionalOverlayClassNames="plugin-details-cta__modal-overlay"
+				isVisible={ showEligibility }
+				onClose={ () => setShowEligibility( false ) }
+				showCloseIcon
+			>
+				<EligibilityWarnings
+					className="hosting__activating-warnings"
+					onProceed={ handleTransfer }
+					backUrl={ redirectUrl }
+					showDataCenterPicker
+					standaloneProceed
+					currentContext="hosting-features"
+				/>
+			</Dialog>
+		</>
+	);
+}

--- a/client/sites/hosting-features/components/hosting-activation.tsx
+++ b/client/sites/hosting-features/components/hosting-activation.tsx
@@ -1,0 +1,17 @@
+import { useTranslate } from 'i18n-calypso';
+import { PanelDescription, PanelHeading, PanelSection } from 'calypso/sites/components/panel';
+import HostingActivationButton from './hosting-activation-button';
+
+export default function HostingActivation( { redirectUrl }: { redirectUrl: string } ) {
+	const translate = useTranslate();
+
+	return (
+		<PanelSection>
+			<PanelHeading>{ translate( 'Activate hosting features' ) }</PanelHeading>
+			<PanelDescription>
+				{ translate( 'Activate now to start using this hosting feature.' ) }
+			</PanelDescription>
+			<HostingActivationButton redirectUrl={ redirectUrl } />
+		</PanelSection>
+	);
+}

--- a/client/sites/hosting-features/features.ts
+++ b/client/sites/hosting-features/features.ts
@@ -1,4 +1,4 @@
-import { FEATURE_SFTP } from '@automattic/calypso-products';
+import { FEATURE_SFTP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { SiteExcerptData } from '@automattic/sites';
 import { useSelector } from 'calypso/state';
 import getSiteFeatures from 'calypso/state/selectors/get-site-features';
@@ -16,6 +16,17 @@ export function areHostingFeaturesSupported( site?: SiteExcerptData | null ) {
 export function useAreHostingFeaturesSupported() {
 	const site = useSelector( getSelectedSite );
 	return areHostingFeaturesSupported( site );
+}
+
+export function useAreHostingFeaturesSupportedAfterActivation() {
+	const features = useSelectedSiteSelector( getSiteFeatures );
+	const hasAtomicFeature = useSelectedSiteSelector( siteHasFeature, WPCOM_FEATURES_ATOMIC );
+
+	if ( ! features ) {
+		return null;
+	}
+
+	return hasAtomicFeature;
 }
 
 export function useAreAdvancedHostingFeaturesSupported() {

--- a/client/sites/settings/caching/style.scss
+++ b/client/sites/settings/caching/style.scss
@@ -1,5 +1,0 @@
-.tools-caching {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
-}

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -2,10 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SidebarItem, Sidebar, PanelWithSidebar } from '../components/panel-sidebar';
-import {
-	useAreAdvancedHostingFeaturesSupported,
-	useAreHostingFeaturesSupported,
-} from '../features';
+import { useAreAdvancedHostingFeaturesSupported } from '../hosting-features/features';
 import AdministrationSettings from './administration';
 import useIsAdministrationSettingSupported from './administration/hooks/use-is-administration-setting-supported';
 import DeleteSite from './administration/tools/delete-site';
@@ -22,7 +19,6 @@ export function SettingsSidebar() {
 
 	const shouldShowAdministration = useIsAdministrationSettingSupported();
 
-	const shouldShowHostingFeatures = useAreHostingFeaturesSupported();
 	const shouldShowAdvancedHostingFeatures = useAreAdvancedHostingFeaturesSupported();
 
 	return (
@@ -34,12 +30,7 @@ export function SettingsSidebar() {
 			>
 				{ __( 'Administration' ) }
 			</SidebarItem>
-			<SidebarItem
-				enabled={ shouldShowHostingFeatures }
-				href={ `/sites/settings/caching/${ slug }` }
-			>
-				{ __( 'Caching' ) }
-			</SidebarItem>
+			<SidebarItem href={ `/sites/settings/caching/${ slug }` }>{ __( 'Caching' ) }</SidebarItem>
 			<SidebarItem
 				enabled={ !! shouldShowAdvancedHostingFeatures }
 				href={ `/sites/settings/web-server/${ slug }` }

--- a/client/sites/settings/index.tsx
+++ b/client/sites/settings/index.tsx
@@ -11,7 +11,7 @@ import {
 	SETTINGS_CACHING,
 	SETTINGS_WEB_SERVER,
 } from 'calypso/sites/components/site-preview-pane/constants';
-import { siteDashboard } from 'calypso/sites/controller';
+import { showHostingFeaturesNoticeIfPresent, siteDashboard } from 'calypso/sites/controller';
 import {
 	redirectIfCantDeleteSite,
 	redirectIfCantStartSiteOwnerTransfer,
@@ -94,6 +94,7 @@ export default function () {
 		'/sites/settings/caching/:site',
 		siteSelection,
 		navigation,
+		showHostingFeaturesNoticeIfPresent,
 		cachingSettings,
 		siteDashboard( SETTINGS_CACHING ),
 		makeLayout,

--- a/client/sites/settings/web-server/index.tsx
+++ b/client/sites/settings/web-server/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
-import { useAreAdvancedHostingFeaturesSupported } from 'calypso/sites/features';
+import { useAreAdvancedHostingFeaturesSupported } from '../../hosting-features/features';
 import DefensiveModeForm from './defensive-mode-form';
 import ServerConfigurationForm from './server-configuration-form';
 

--- a/client/sites/tools/controller.tsx
+++ b/client/sites/tools/controller.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SidebarItem, Sidebar, PanelWithSidebar } from '../components/panel-sidebar';
-import { useAreAdvancedHostingFeaturesSupported } from '../features';
+import { useAreAdvancedHostingFeaturesSupported } from '../hosting-features/features';
 import Database from './database/page';
 import {
 	DeploymentCreation,

--- a/client/sites/tools/database/page.tsx
+++ b/client/sites/tools/database/page.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
-import { useAreAdvancedHostingFeaturesSupported } from 'calypso/sites/features';
+import { useAreAdvancedHostingFeaturesSupported } from '../../hosting-features/features';
 import PhpMyAdminForm from './form';
 
 import './style.scss';

--- a/client/sites/tools/sftp-ssh/page.tsx
+++ b/client/sites/tools/sftp-ssh/page.tsx
@@ -1,10 +1,10 @@
 import { useTranslate } from 'i18n-calypso';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
-import { useAreAdvancedHostingFeaturesSupported } from 'calypso/sites/features';
-import { SftpForm } from 'calypso/sites/tools/sftp-ssh/sftp-form';
+import { useAreAdvancedHostingFeaturesSupported } from '../../hosting-features/features';
 import useSftpSshSettingTitle from './hooks/use-sftp-ssh-setting-title';
 import { SftpCardLoadingPlaceholder } from './sftp-card-loading-placeholder';
+import { SftpForm } from './sftp-form';
 
 import './style.scss';
 


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/9867

## Proposed Changes

This PR adds an upsell to Settings -> Caching subtab based on p9Jlb4-eWT-p2#comment-14261.

## Why are these changes being made?

pbxlJb-6ye-p2

## Testing Instructions

> [!NOTE]  
> Please don't review the copy; we can iterate on it later!

1. Go to /sites.
2. Click a Free site.
3. Go to Settings -> Caching, verify you see:

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/89fa8cd5-c447-4baa-a7c1-f9ba8778e122">

4. Click `Upgrade`.
5. Verify you go through the checkout flow and can complete the flow.
6. Verify you are redirected back to the Caching subtab, and see:

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/c20586f8-6ff1-434f-8c9c-095fe641200b">

7. Click `Activate now`.
8. Verify you go through the hosting activation flow and can complete the flow.
9. Verify you are redirected back to the Caching subtab, and see:

<img width="1161" alt="image" src="https://github.com/user-attachments/assets/5229a9c0-f18f-4c50-8392-c8d0815a9536">

10. REGRESSION: Open another Free site, go to the Hosting Features subtab, and verify you can still upgrade and activate from this subtab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x]Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?