### PR TITLE
Stats: Update to fix header consistency

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -486,6 +486,7 @@ class StatsSite extends Component {
 								statsType="statsTopPosts"
 								showQueryDate
 								isShort
+								dateRange={ customChartRange }
 							/>
 						</StatsPeriodNavigation>
 					</StatsPeriodHeader>

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -52,15 +52,26 @@ class StatsDatePicker extends Component {
 	}
 
 	dateForDisplay() {
-		const { date, moment, period, translate, isShort } = this.props;
+		const { date, moment, period, translate, isShort, dateRange } = this.props;
+
+		// ll is a date localized with abbreviated Month by momentjs
+		const weekPeriodFormat = isShort ? 'll' : 'LL';
+
+		// If we have chartStart/chartEnd in dateRange, use those for the date range
+		if ( dateRange?.chartStart && dateRange?.chartEnd ) {
+			return translate( '%(startDate)s - %(endDate)s', {
+				context: 'Date range for which stats are being displayed',
+				args: {
+					startDate: moment( dateRange.chartStart ).format( weekPeriodFormat ),
+					endDate: moment( dateRange.chartEnd ).format( weekPeriodFormat ),
+				},
+			} );
+		}
 
 		// Ensure we have a moment instance here to work with.
 		const momentDate = moment.isMoment( date ) ? date : moment( date );
 		const localizedDate = moment( momentDate.format( 'YYYY-MM-DD' ) );
 		let formattedDate;
-
-		// ll is a date localized with abbreviated Month by momentjs
-		const weekPeriodFormat = isShort ? 'll' : 'LL';
 
 		switch ( period ) {
 			case 'week':

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -53,17 +53,42 @@ class StatsDatePicker extends Component {
 
 	dateForDisplay() {
 		const { date, moment, period, translate, isShort, dateRange } = this.props;
-
-		// ll is a date localized with abbreviated Month by momentjs
 		const weekPeriodFormat = isShort ? 'll' : 'LL';
 
 		// If we have chartStart/chartEnd in dateRange, use those for the date range
 		if ( dateRange?.chartStart && dateRange?.chartEnd ) {
+			const startDate = moment( dateRange.chartStart );
+			const endDate = moment( dateRange.chartEnd );
+
+			// If it's the same day, show single date
+			if ( startDate.isSame( endDate, 'day' ) ) {
+				return startDate.format( 'LL' );
+			}
+
+			// If it's a full month
+			if (
+				startDate.isSame( startDate.clone().startOf( 'month' ), 'day' ) &&
+				endDate.isSame( endDate.clone().endOf( 'month' ), 'day' ) &&
+				startDate.isSame( endDate, 'month' )
+			) {
+				return startDate.format( 'MMMM YYYY' );
+			}
+
+			// If it's a full year
+			if (
+				startDate.isSame( startDate.clone().startOf( 'year' ), 'day' ) &&
+				endDate.isSame( endDate.clone().endOf( 'year' ), 'day' ) &&
+				startDate.isSame( endDate, 'year' )
+			) {
+				return startDate.format( 'YYYY' );
+			}
+
+			// Default to date range
 			return translate( '%(startDate)s - %(endDate)s', {
 				context: 'Date range for which stats are being displayed',
 				args: {
-					startDate: moment( dateRange.chartStart ).format( weekPeriodFormat ),
-					endDate: moment( dateRange.chartEnd ).format( weekPeriodFormat ),
+					startDate: startDate.format( weekPeriodFormat ),
+					endDate: endDate.format( weekPeriodFormat ),
 				},
 			} );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/271

## Proposed Changes

* Ensure the days consistently show date ranges with exact dates

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To ensure header consistency for the Date Filtering for the Traffic Page project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open up the Calypso live branch
* Apply the `stats/new-date-filtering` flag
* Try different date ranges and selections, ensuring that the title continues to show the exact + correct date ranges
* Check other stats locations and triple check this doesn't affect anything else, anywhere else
* Select a full year date range (eg. 1st jan - 31st dec) and check that just the year is shown (eg. 2023)
* Select a full month date range (eg. 1st jan - 31st jan) and check that just the month + year is shown (eg. October 2024)
* Select a single day, and check just the date is showing (eg. November 22, 2024)

![image](https://github.com/user-attachments/assets/c76e94e2-ef39-4432-9c90-84de84903568)
![image](https://github.com/user-attachments/assets/b13eef59-af8e-4a47-9676-00c5a0636aad)
![image](https://github.com/user-attachments/assets/23253450-389e-4ee4-841e-ac0d3b6f6e1d)
![image](https://github.com/user-attachments/assets/6cfcf421-a2ad-469e-9679-86d6c91e903b)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
