### PR TITLE
Sites Dashboard: Remove all style overrides except those in `dataview-style.scss`

### DIFF
--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -386,12 +386,6 @@
 }
 
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout.preview-hidden {
-	.dataviews-wrapper {
-		margin: 0 auto;
-		max-width: 1400px;
-		box-sizing: border-box;
-	}
-
 	div.a4a-layout__viewport {
 		margin: 0 auto;
 		max-width: 1400px;

--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -107,16 +107,6 @@
 	}
 }
 
-// Style the sortable table headers.
-.wpcom-site .dataviews-view-table .components-button.is-tertiary {
-	&:active:not(:disabled),
-	&:hover:not(:disabled) {
-		box-shadow: none;
-		background-color: inherit;
-		color: var(--color-accent) !important;
-	}
-}
-
 .wpcom-site {
 	.layout__content {
 		min-height: 100vh;

--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -114,10 +114,6 @@
 			}
 		}
 
-		.components-button.is-compact.has-icon:not(.has-text).dataviews-filters-button {
-			min-width: 40px;
-		}
-
 		.item-preview__content {
 			padding: 10px 10px 88px; /* 88px matches the padding from PR #39201. */
 

--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -198,13 +198,6 @@
 		}
 	}
 
-	thead .dataviews-view-table__row th span {
-		font-size: rem(11px);
-		font-weight: 500;
-		line-height: 14px;
-		color: var(--color-accent-80);
-	}
-
 	.sites-overview__content-wrapper {
 		max-width: none;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9915

## Proposed Changes

This PR removes all style overrides from the Dotcom Sites Dashboard except those in `dataview-style.scss`. (i.e., all the style overrides in Dotcom are now consolidated in `dataview-style.scss`!)

Removing hover (and focus) state overrides on thread:
| before | after |
|--------|--------|
| <img width="110" alt="Screenshot 2024-11-22 at 16 41 25" src="https://github.com/user-attachments/assets/36538c62-3e95-42cb-91e6-2915838f9e36"> | <img width="89" alt="Screenshot 2024-11-22 at 16 41 17" src="https://github.com/user-attachments/assets/bb3cfb34-6b70-469c-a2f0-690718a3dee3"> | 

Removing max-width in wider devices: pbxlJb-6A9-p2#comment-4019:

| before | after |
|--------|--------|
| <img width="2554" alt="Screenshot 2024-11-22 at 16 38 05" src="https://github.com/user-attachments/assets/777145c1-23e4-42a8-836c-bc92237047ce"> | <img width="2558" alt="Screenshot 2024-11-22 at 16 38 47" src="https://github.com/user-attachments/assets/26adecfb-c39a-43ca-a014-841358c32b30"> | 

Removing an override that does not make sense in Dotcom (originally copied from https://github.com/Automattic/wp-calypso/pull/87893)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pbxlJb-6DF-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Observe changes above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?