### PR TITLE
Stats: Navigation arrows with date range

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -243,6 +243,8 @@ class StatsSite extends Component {
 	// Used in case no starting date is present in the URL.
 	getDefaultDaysForPeriod( period, defaultSevenDaysForPeriodDay = false ) {
 		switch ( period ) {
+			case 'hour':
+				return 1;
 			case 'day':
 				// TODO: Temporary fix for the new date filtering feature.
 				if ( defaultSevenDaysForPeriodDay ) {

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -28,6 +28,7 @@ import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/anal
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getMomentSiteZone } from '../hooks/use-moment-site-zone';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import { withStatsPurchases } from '../hooks/use-stats-purchases';
 import NavigationArrows from '../navigation-arrows';
@@ -232,12 +233,13 @@ class StatsPeriodNavigation extends PureComponent {
 			gateDateControl,
 			intervals,
 			siteId,
+			momentSiteZone,
 		} = this.props;
 
-		const isToday = moment( date ).isSame( moment(), period );
+		const isToday = moment( date ).isSame( momentSiteZone, period );
 
 		// TODO: Refactor the isWithNewDateFiltering dedicated variables.
-		const isChartRangeEndToday = moment( dateRange.chartEnd ).isSame( moment(), period );
+		const isChartRangeEndToday = moment( dateRange.chartEnd ).isSame( momentSiteZone, period );
 		const showArrowsForDateRange = showArrows && dateRange.daysInRange <= 30;
 
 		return (
@@ -445,6 +447,7 @@ const connectComponent = connect(
 			intervals,
 			siteId,
 			isSiteJetpackNotAtomic,
+			momentSiteZone: getMomentSiteZone( state, siteId ),
 		};
 	},
 	{ recordGoogleEvent: recordGoogleEventAction, toggleUpsellModal }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -32,6 +32,7 @@ import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import { withStatsPurchases } from '../hooks/use-stats-purchases';
 import NavigationArrows from '../navigation-arrows';
 import StatsCardUpsell from '../stats-card-upsell';
+import { getPathWithUpdatedQueryString } from '../utils';
 
 import './style.scss';
 
@@ -104,6 +105,19 @@ class StatsPeriodNavigation extends PureComponent {
 		return newParams;
 	};
 
+	handleArrowPrevious = () => {
+		const { date, moment, period, url, queryParams, isEmailStats, maxBars } = this.props;
+		const numberOfDAys = this.getNumberOfDays( isEmailStats, period, maxBars );
+		const usedPeriod = this.calculatePeriod( period );
+		const previousDay = moment( date ).subtract( numberOfDAys, usedPeriod ).format( 'YYYY-MM-DD' );
+		const newQueryParams = this.queryParamsForPreviousDate( previousDay );
+		const previousDayQuery = qs.stringify( Object.assign( {}, queryParams, newQueryParams ), {
+			addQueryPrefix: true,
+		} );
+		const href = `${ url }${ previousDayQuery }`;
+		this.handleArrowEvent( 'previous', href );
+	};
+
 	handleArrowNext = () => {
 		const { date, moment, period, url, queryParams, isEmailStats, maxBars } = this.props;
 		const numberOfDAys = this.getNumberOfDays( isEmailStats, period, maxBars );
@@ -115,6 +129,39 @@ class StatsPeriodNavigation extends PureComponent {
 		} );
 		const href = `${ url }${ nextDayQuery }`;
 		this.handleArrowEvent( 'next', href );
+	};
+
+	handlePreviousDateRangeNavigation = () => {
+		this.handleArrowNavigation( true );
+	};
+
+	handleNextRangeDateNavigation = () => {
+		this.handleArrowNavigation( false );
+	};
+
+	handleArrowNavigation = ( previousOrNext = false ) => {
+		const { moment, period, slug, dateRange } = this.props;
+
+		const navigationStart = moment( dateRange.chartStart );
+		const navigationEnd = moment( dateRange.chartEnd );
+
+		if ( previousOrNext ) {
+			// Navigate to the previous date range.
+			navigationStart.subtract( dateRange.daysInRange, 'days' );
+			navigationEnd.subtract( dateRange.daysInRange, 'days' );
+		} else {
+			// Navigate to the next date range.
+			navigationStart.add( dateRange.daysInRange, 'days' );
+			navigationEnd.add( dateRange.daysInRange, 'days' );
+		}
+
+		const chartStart = navigationStart.format( 'YYYY-MM-DD' );
+		const chartEnd = navigationEnd.format( 'YYYY-MM-DD' );
+
+		const path = `/stats/${ period }/${ slug }`;
+		const url = getPathWithUpdatedQueryString( { chartStart, chartEnd }, path );
+
+		page( url );
 	};
 
 	queryParamsForPreviousDate = ( previousDay ) => {
@@ -136,19 +183,6 @@ class StatsPeriodNavigation extends PureComponent {
 				.format( 'YYYY-MM-DD' );
 		}
 		return newParams;
-	};
-
-	handleArrowPrevious = () => {
-		const { date, moment, period, url, queryParams, isEmailStats, maxBars } = this.props;
-		const numberOfDAys = this.getNumberOfDays( isEmailStats, period, maxBars );
-		const usedPeriod = this.calculatePeriod( period );
-		const previousDay = moment( date ).subtract( numberOfDAys, usedPeriod ).format( 'YYYY-MM-DD' );
-		const newQueryParams = this.queryParamsForPreviousDate( previousDay );
-		const previousDayQuery = qs.stringify( Object.assign( {}, queryParams, newQueryParams ), {
-			addQueryPrefix: true,
-		} );
-		const href = `${ url }${ previousDayQuery }`;
-		this.handleArrowEvent( 'previous', href );
 	};
 
 	// Copied from`client/my-sites/stats/stats-chart-tabs/index.jsx`
@@ -202,6 +236,10 @@ class StatsPeriodNavigation extends PureComponent {
 
 		const isToday = moment( date ).isSame( moment(), period );
 
+		// TODO: Refactor the isWithNewDateFiltering dedicated variables.
+		const isChartRangeEndToday = moment( dateRange.chartEnd ).isSame( moment(), period );
+		const showArrowsForDateRange = showArrows && dateRange.daysInRange <= 30;
+
 		return (
 			<div
 				className={ clsx( 'stats-period-navigation', {
@@ -224,12 +262,12 @@ class StatsPeriodNavigation extends PureComponent {
 				{ /* New filtering view: Shows date control in a simplified layout */ }
 				{ isWithNewDateControl && isWithNewDateFiltering && (
 					<div className="stats-period-navigation__date-range-control">
-						{ showArrows && (
+						{ showArrowsForDateRange && (
 							<NavigationArrows
-								disableNextArrow={ disableNextArrow || isToday }
+								disableNextArrow={ disableNextArrow || isChartRangeEndToday }
 								disablePreviousArrow={ disablePreviousArrow }
-								onClickNext={ this.handleArrowNext }
-								onClickPrevious={ this.handleArrowPrevious }
+								onClickNext={ this.handleNextRangeDateNavigation }
+								onClickPrevious={ this.handlePreviousDateRangeNavigation }
 							/>
 						) }
 						<div className="stats-period-navigation__date-control">

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -240,7 +240,7 @@ class StatsPeriodNavigation extends PureComponent {
 
 		// TODO: Refactor the isWithNewDateFiltering dedicated variables.
 		const isChartRangeEndToday = moment( dateRange.chartEnd ).isSame( momentSiteZone, period );
-		const showArrowsForDateRange = showArrows && dateRange.daysInRange <= 30;
+		const showArrowsForDateRange = showArrows && dateRange.daysInRange <= 31;
 
 		return (
 			<div


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/270

## Proposed Changes

* Fix the default `daysInRange` of the hourly views.
* Navigate to the previous/next date range by the arrows for the range less than `30 days`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The previous arrow actions changed selected chart bars. We are making the arrows navigate to the previous/next date range based on the selected date range. To prevent the performance issue, we only enable the navigation for a selected range of less than `30 days`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Ensure the `StatsPeriodNavigation` arrows change the selected bar on the chart as previously.
* Append the feature flag to the URL: `?flags=stats/new-date-filtering`.
* Select the date range to be less than `30 days`.

|30 days|90 days|
|-|-|
|<img width="1273" alt="截圖 2024-11-22 晚上8 18 07" src="https://github.com/user-attachments/assets/d445afe2-0b0d-47e4-a52a-09aab92e9767">|<img width="1284" alt="截圖 2024-11-22 晚上8 17 27" src="https://github.com/user-attachments/assets/c994ff3a-f261-4687-8e74-865c56aeafa2">|

* Click on the previous/next arrow of the `StatsPeriodNavigation`.
* Ensure the date range moves based on the currently selected range days.

https://github.com/user-attachments/assets/0433efc4-499f-4148-aa72-a98cc01c2a8c

* Navigate to the default hourly Traffic page: `/stats/hour/{site-slug}?flags=stats/new-date-filtering`.
* Ensure the selected date range is `Today` rather than the `Last 30 Days`.

|Before|After|
|-|-|
|<img width="1272" alt="截圖 2024-11-22 晚上8 25 47" src="https://github.com/user-attachments/assets/220d82b7-2ac2-4b79-903d-de13969a93ec">|<img width="1267" alt="截圖 2024-11-22 晚上8 25 51" src="https://github.com/user-attachments/assets/d95f89f8-8151-497d-a389-b64fa35b97cc">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
