### PR TITLE
Stats: Tweak the static display for the hour period on the period dropdown

### DIFF
--- a/client/components/stats-interval-dropdown/index.jsx
+++ b/client/components/stats-interval-dropdown/index.jsx
@@ -80,7 +80,7 @@ const IntervalDropdown = ( { slug, period, queryParams, intervals, onGatedHandle
 	function getDisplayLabel() {
 		// If the period is not in the intervals list, capitalize it and show in the label - however user wouldn't be able to select it.
 		// TODO: this is a temporary solution, we should remove this once we have all the intervals in the list.
-		return intervals[ period ]?.label ?? capitalize( period );
+		return intervals[ period ]?.label ?? `${ capitalize( period ) }s`;
 	}
 
 	function onSelectionHandler( interval ) {
@@ -93,7 +93,10 @@ const IntervalDropdown = ( { slug, period, queryParams, intervals, onGatedHandle
 		page( generateNewLink( interval ) );
 	}
 
-	return (
+	// Check if the selected period is in the intervals list.
+	const selectedPeriod = intervals[ period ];
+
+	return selectedPeriod ? (
 		<Dropdown
 			className="stats-interval-dropdown"
 			renderToggle={ ( { isOpen, onToggle } ) => (
@@ -114,6 +117,11 @@ const IntervalDropdown = ( { slug, period, queryParams, intervals, onGatedHandle
 			) }
 			focusOnMount={ false }
 		/>
+	) : (
+		// TODO: Tweak the styles or move this to another place for better UX.
+		<div className="stats-interval-display">
+			<label>{ getDisplayLabel() }</label>
+		</div>
 	);
 };
 

--- a/client/components/stats-interval-dropdown/style.scss
+++ b/client/components/stats-interval-dropdown/style.scss
@@ -64,3 +64,11 @@
 		background-color: var(--color-accent-5);
 	}
 }
+
+// Mimic the style of Button component.
+.stats-interval-display {
+	font-family: $font-sf-pro-text;
+	font-size: 13px; // stylelint-disable-line declaration-property-unit-allowed-list
+	font-weight: 400;
+	line-height: 36px;
+}

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -263,7 +263,7 @@ ul.module-tabs {
 			border-top-color: #DCDCDE;
 		}
 
-		.stats-interval-dropdown {
+		.stats-interval-dropdown, .stats-interval-display {
 			margin-left: 48px;
 
 			& > .components-button {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This change is a follow-up of https://github.com/Automattic/wp-calypso/pull/96607.

## Proposed Changes

* Make the `Hours` period option unclickable when navigating from clicking on the bar of a day.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are making the `Hours` period option unselectable to avoid confusing users for navigating from hourly views back to other periods.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page with the feature flag: `?flags=stats/new-date-filtering`.
* Click on a single-day bar to navigate to the hourly views.
* Ensure the `Hours` option is displayed static rather than a dropdown option.

|Before|After|
|-|-|
|<img width="1278" alt="截圖 2024-11-22 晚上8 36 58" src="https://github.com/user-attachments/assets/55f32479-95e9-4ad0-bf14-177059c70a78">|<img width="1268" alt="截圖 2024-11-22 晚上8 36 29" src="https://github.com/user-attachments/assets/9e46114e-bcf2-4056-bbd0-48fb1b6e0e91">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
