### PR TITLE
Update visual for plugin Updating status

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/plugin-action-status/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-action-status/style.scss
@@ -26,7 +26,30 @@
 	}
 }
 
-.plugin-action-status-inProgress,
+.plugin-action-status-inProgress {
+	background: #b8e6bf;
+	color: #00450c;
+	/* reference busy state from https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/button/style.scss */
+	animation: plugin-action-status-inProgress__busy-animation 2500ms infinite linear;
+	@media (prefers-reduced-motion: reduce) {
+		animation-duration: 0s;
+	}
+	background-size: 100px 100%;
+	background-image: linear-gradient(
+	-45deg,
+		darken( #b8e6bf, 2%) 33%,
+		darken( #b8e6bf, 12%) 33%,
+		darken( #b8e6bf, 12%) 70%,
+		darken( #b8e6bf, 2%) 70%
+	);
+}
+
+@keyframes plugin-action-status-inProgress__busy-animation {
+	0% {
+		background-position: 200px 0;
+	}
+}
+
 .plugin-action-status-up-to-date {
 	background: #f6f7f7;
 	color: #50575e;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9853

## Proposed Changes

* Add a busy state
* Update the colors so that it's more prominent

### Jetpack Cloud `?flags=bulk-plugin-management`

https://github.com/user-attachments/assets/9117b4ea-a5bc-472f-bc34-ad3c5656ea78

### Jetpack Cloud


https://github.com/user-attachments/assets/11dc264a-5d54-407b-adc5-62ce12f90ff4



### Calypso

https://github.com/user-attachments/assets/048c440d-9650-45a2-855c-bf8edc1d3324


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install an older version of a plugin I was running this in wp-cli `wp plugin install insert-headers-and-footers --version=2.2.2 --force`
* Go to jetpack.cloud.localhost:3000/plugins/manage, calypso.localhost:3000/plugins/manage, jetpack.cloud.localhost:3000/plugins/manage?flags=bulk-plugin-management
* Update the plugin and check the badge styles

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
