### PR TITLE
jamesgill23/skip-campaign-stats-new-campaigns

### DIFF
--- a/client/data/promote-post/use-campaign-chart-stats-query.ts
+++ b/client/data/promote-post/use-campaign-chart-stats-query.ts
@@ -39,7 +39,8 @@ export type CampaignChartStatsResponse = {
 export const useCampaignChartStatsQuery = (
 	siteId: number,
 	campaignId: number,
-	startDate: string
+	startDate: string,
+	hasStats: boolean
 ) => {
 	return useQuery( {
 		queryKey: [ 'promote-post-campaign-stats', siteId, campaignId, startDate ],
@@ -55,7 +56,7 @@ export const useCampaignChartStatsQuery = (
 				'1.1'
 			);
 		},
-		enabled: !! siteId && !! campaignId && !! startDate,
+		enabled: !! siteId && !! campaignId && !! startDate && hasStats,
 		retryDelay: 3000,
 		meta: {
 			persist: false,

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -57,7 +57,6 @@ interface Props {
 	isLoading?: boolean;
 	siteId: number;
 	campaign: CampaignResponse;
-	campaignChartStats?: CampaignChartStatsResponse;
 }
 
 const FlexibleSkeleton = () => {
@@ -129,10 +128,6 @@ export default function CampaignItemDetails( props: Props ) {
 	const { data, isLoading: isLoadingBillingSummary } = useBillingSummaryQuery();
 	const paymentBlocked = data?.paymentsBlocked ?? false;
 
-	const campaignStatsQuery = useCampaignChartStatsQuery( siteId, campaignId, campaign.start_date );
-	const { isLoading: campaignsStatsIsLoading } = campaignStatsQuery;
-	const { data: campaignStats } = campaignStatsQuery;
-
 	const {
 		audience_list,
 		content_config,
@@ -168,6 +163,15 @@ export default function CampaignItemDetails( props: Props ) {
 		conversion_rate,
 		conversion_last_currency_found,
 	} = campaign_stats || {};
+
+	const campaignStatsQuery = useCampaignChartStatsQuery(
+		siteId,
+		campaignId,
+		campaign.start_date,
+		!! impressions_total
+	);
+	const { isLoading: campaignsStatsIsLoading } = campaignStatsQuery;
+	const { data: campaignStats } = campaignStatsQuery;
 
 	const { card_name, payment_method, credits, total, orders, payment_links } = billing_data || {};
 	const { title, clickUrl } = content_config || {};

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -16,7 +16,6 @@ import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import {
 	CampaignChartSeriesData,
-	CampaignChartStatsResponse,
 	useCampaignChartStatsQuery,
 } from 'calypso/data/promote-post/use-campaign-chart-stats-query';
 import useBillingSummaryQuery from 'calypso/data/promote-post/use-promote-post-billing-summary-query';

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -339,6 +339,10 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 		.campaign-item-details__impressions .campaign-item-details__main-stats-row {
 			border-bottom: 1px solid #ddd;
+
+			&:only-child {
+				border-bottom: none;
+			}
 		}
 
 		.campaign-item-details__main-stats-row-bottom {


### PR DESCRIPTION
## Proposed Changes

* Skip the campaign stats call if there are no stats, otherwise it errors

## Why are these changes being made?

* Stop uneccessary requests and noise in the error logs
![Screenshot 2024-11-22 at 12 58 37](https://github.com/user-attachments/assets/ef20b0ea-2580-449b-a783-1051104a8473)



## Testing Instructions

- Create a new campaign
- Open the network tab,
- Check that the stats endpoint is not called (your new campaign won't have stats (`https://public-api.wordpress.com/wpcom/v2/sites/{siteId}/wordads/dsp/api/v1.1/stats/{campaignId}?params=xx`)



**Demo**

This shows existing behaviour in trunk, then this branch

https://www.loom.com/share/0bf97f34467845779c4f86f45af90d83?sid=70a64dd0-db4e-4378-86d0-aab169224441


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
