### PR TITLE
Jetpack AI Logo Generator: Preserve user language when getting the first prompt

### DIFF
--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -67,6 +67,8 @@
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
+		"@automattic/i18n-utils": "workspace:^",
+		"@automattic/languages": "workspace:^",
 		"clsx": "^2.1.1",
 		"debug": "^4.3.4"
 	}

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import { useLocale } from '@automattic/i18n-utils';
+import languages from '@automattic/languages';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
@@ -74,6 +76,8 @@ const useLogoGenerator = () => {
 		setLogoUpdateError,
 	} = useRequestErrors();
 
+	const locale = useLocale();
+
 	const { ID = null, name = null, description = null } = siteDetails || {};
 	const siteId = ID ? String( ID ) : null;
 
@@ -90,7 +94,10 @@ const useLogoGenerator = () => {
 
 			debug( 'Generating first prompt for site', siteId );
 
-			const firstPromptGenerationPrompt = `Generate a simple and short prompt asking for a logo based on the site's name and description, keeping the same language.
+			const langName =
+				languages.find( ( language ) => language.langSlug === locale )?.name ?? 'English';
+
+			const firstPromptGenerationPrompt = `Generate a simple and short prompt asking for a logo based on the site's name and description. The prompt should be in ${ langName } (${ locale }).
 Example for a site named "The minimalist fashion blog", described as "Daily inspiration for all things fashion": A logo for a minimalist fashion site focused on daily sartorial inspiration with a clean and modern aesthetic that is sleek and sophisticated.
 Another example, now for a site called "El observatorio de aves", described as "Un sitio dedicado a nuestros compañeros y compañeras entusiastas de la observación de aves.": Un logo para un sitio web dedicado a la observación de aves,  capturando la esencia de la naturaleza y la pasión por la avifauna en un diseño elegante y representativo, reflejando una estética natural y apasionada por la vida silvestre.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1227,6 +1227,8 @@ __metadata:
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/data-stores": "workspace:^"
+    "@automattic/i18n-utils": "workspace:^"
+    "@automattic/languages": "workspace:^"
     "@testing-library/jest-dom": "npm:^6.4.5"
     "@testing-library/react": "npm:^15.0.7"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/96665.

## Proposed Changes

The prompt should be in the users' locale. Here's an example:

![image](https://github.com/user-attachments/assets/30a18f74-4e73-437d-999f-90dcaefcc3a3)

## Why are these changes being made?

To maintain consistency with the users' language. Our previous prompt said to preserve the language but didn't say what the language was. Because we had examples in English and Spanish, it was preserving Spanish instead as it was the most comprehensive example.

## Testing Instructions

[Change your accounts' language](https://wordpress.com/me/account) to English and open the Logo Generator on any site. You should get the first prompt in English. Change the language to something other than English (Afrikaans, for example) and verify that the prompt is in Afrikaans. In my screenshot, it's in Italian.
