### PR TITLE
Stats: Enable date ranges on Summary pages

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -283,6 +283,14 @@ export function summary( context, next ) {
 		: momentSiteZone.endOf( activeFilter.period ).locale( 'en' );
 	const period = rangeOfPeriod( activeFilter.period, date );
 
+	// Support for custom date ranges.
+	// Evaluate the endDate param if provided and create a date range object if valid.
+	// Valid means endDate is a valid date and is not before the startDate.
+	const isValidEndDate = queryOptions.endDate && moment( queryOptions.endDate ).isValid();
+	const endDate = isValidEndDate ? moment( queryOptions.endDate ).locale( 'en' ) : null;
+	const isValidRange = isValidEndDate && ! endDate.isBefore( date );
+	const dateRange = isValidRange ? { startDate: date, endDate: endDate } : null;
+
 	const extraProps =
 		context.params.module === 'videodetails' ? { postId: parseInt( queryOptions.post, 10 ) } : {};
 
@@ -302,6 +310,7 @@ export function summary( context, next ) {
 				path={ context.pathname }
 				statsQueryOptions={ statsQueryOptions }
 				date={ date }
+				dateRange={ dateRange }
 				context={ context }
 				period={ period }
 				{ ...extraProps }

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -113,6 +113,9 @@ const StatsModuleUTM = ( {
 	const showLoader = isLoading || isFetchingUTM;
 
 	const getHref = () => {
+		if ( ! hideSummaryLink && summaryUrl ) {
+			return summaryUrl;
+		}
 		// Some modules do not have view all abilities
 		if ( ! summary && period && path && siteSlug ) {
 			return `/stats/${ period.period }/${ path }/${ siteSlug }?startDate=${ period.startOf.format(

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -261,17 +261,24 @@ class StatsSite extends Component {
 		}
 	}
 
-	getStatHref( period, path, siteSlug ) {
-		return period && path && siteSlug
-			? '/stats/' +
-					period?.period +
-					'/' +
-					path +
-					'/' +
-					siteSlug +
-					'?startDate=' +
-					period?.startOf?.format( 'YYYY-MM-DD' )
-			: undefined;
+	// Note: This is only used in the empty version of the module.
+	// There's a similar function inside stats-module/index.jsx that is used when we have content.
+	getStatHref( path, query ) {
+		const { period, slug } = this.props;
+		const paramsValid = period && path && slug;
+		if ( ! paramsValid ) {
+			return undefined;
+		}
+
+		let url = `/stats/${ period.period }/${ path }/${ slug }`;
+
+		if ( query?.start_date ) {
+			url += `?startDate=${ query.start_date }&endDate=${ query.date }`;
+		} else {
+			url += `?startDate=${ period.endOf.format( 'YYYY-MM-DD' ) }`;
+		}
+
+		return url;
 	}
 
 	renderStats( isInternal ) {
@@ -568,14 +575,14 @@ class StatsSite extends Component {
 							moduleStrings={ moduleStrings.posts }
 							period={ this.props.period }
 							query={ query }
-							summaryUrl={ this.getStatHref( this.props.period, 'posts', slug ) }
+							summaryUrl={ this.getStatHref( 'posts', query ) }
 							className={ halfWidthModuleClasses }
 						/>
 						<StatsModuleReferrers
 							moduleStrings={ moduleStrings.referrers }
 							period={ this.props.period }
 							query={ query }
-							summaryUrl={ this.getStatHref( this.props.period, 'referrers', slug ) }
+							summaryUrl={ this.getStatHref( 'referrers', query ) }
 							className={ halfWidthModuleClasses }
 						/>
 
@@ -583,7 +590,7 @@ class StatsSite extends Component {
 							moduleStrings={ moduleStrings.countries }
 							period={ this.props.period }
 							query={ query }
-							summaryUrl={ this.getStatHref( this.props.period, 'countryviews', slug ) }
+							summaryUrl={ this.getStatHref( 'countryviews', query ) }
 							className={ clsx( 'stats__flexible-grid-item--full' ) }
 						/>
 
@@ -593,7 +600,7 @@ class StatsSite extends Component {
 								siteId={ siteId }
 								period={ this.props.period }
 								query={ query }
-								summaryUrl={ this.getStatHref( this.props.period, 'utm', slug ) }
+								summaryUrl={ this.getStatHref( 'utm', query ) }
 								summary={ false }
 								className={ halfWidthModuleClasses }
 							/>
@@ -617,7 +624,7 @@ class StatsSite extends Component {
 							moduleStrings={ moduleStrings.clicks }
 							period={ this.props.period }
 							query={ query }
-							summaryUrl={ this.getStatHref( this.props.period, 'clicks', slug ) }
+							summaryUrl={ this.getStatHref( 'clicks', query ) }
 							className={ halfWidthModuleClasses }
 						/>
 
@@ -626,7 +633,7 @@ class StatsSite extends Component {
 								moduleStrings={ moduleStrings.authors }
 								period={ this.props.period }
 								query={ query }
-								summaryUrl={ this.getStatHref( this.props.period, 'authors', slug ) }
+								summaryUrl={ this.getStatHref( 'authors', query ) }
 								className={ halfWidthModuleClasses }
 							/>
 						) }
@@ -637,7 +644,7 @@ class StatsSite extends Component {
 								period={ this.props.period }
 								moduleStrings={ moduleStrings.emails }
 								query={ query }
-								summaryUrl={ this.getStatHref( this.props.period, 'emails', slug ) }
+								summaryUrl={ this.getStatHref( 'emails', query ) }
 								className={ halfWidthModuleClasses }
 							/>
 						) }
@@ -646,7 +653,7 @@ class StatsSite extends Component {
 							moduleStrings={ moduleStrings.search }
 							period={ this.props.period }
 							query={ query }
-							summaryUrl={ this.getStatHref( this.props.period, 'searchterms', slug ) }
+							summaryUrl={ this.getStatHref( 'searchterms', query ) }
 							className={ halfWidthModuleClasses }
 						/>
 
@@ -655,7 +662,7 @@ class StatsSite extends Component {
 								moduleStrings={ moduleStrings.videoplays }
 								period={ this.props.period }
 								query={ query }
-								summaryUrl={ this.getStatHref( this.props.period, 'videoplays', slug ) }
+								summaryUrl={ this.getStatHref( 'videoplays', query ) }
 								className={ halfWidthModuleClasses }
 							/>
 						) }
@@ -667,7 +674,7 @@ class StatsSite extends Component {
 									moduleStrings={ moduleStrings.filedownloads }
 									period={ this.props.period }
 									query={ query }
-									summaryUrl={ this.getStatHref( this.props.period, 'filedownloads', slug ) }
+									summaryUrl={ this.getStatHref( 'filedownloads', query ) }
 									className={ halfWidthModuleClasses }
 								/>
 							)

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -33,6 +33,11 @@ class StatsDatePicker extends Component {
 
 	dateForSummarize() {
 		const { query, moment, translate } = this.props;
+
+		if ( query.start_date ) {
+			return this.dateForCustomRange();
+		}
+
 		const localizedDate = moment();
 
 		switch ( query.num ) {
@@ -49,6 +54,21 @@ class StatsDatePicker extends Component {
 					},
 				} );
 		}
+	}
+
+	dateForCustomRange() {
+		const { query, moment, translate } = this.props;
+
+		const localizedStartDate = moment( query.start_date );
+		const localizedEndDate = moment( query.date );
+
+		return translate( '%(startDate)s ~ %(endDate)s', {
+			context: 'Date range for which stats are being displayed',
+			args: {
+				startDate: localizedStartDate.format( 'll' ),
+				endDate: localizedEndDate.format( 'll' ),
+			},
+		} );
 	}
 
 	dateForDisplay() {

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -38,6 +38,9 @@ export const StatsModuleSummaryLinks = ( props ) => {
 	const dispatch = useDispatch();
 
 	const getSummaryPeriodLabel = () => {
+		if ( query.start_date ) {
+			return translate( 'Custom Range Summary' );
+		}
 		switch ( period.period ) {
 			case 'day':
 				return translate( 'Day Summary' );
@@ -62,12 +65,21 @@ export const StatsModuleSummaryLinks = ( props ) => {
 		recordStats( item );
 	};
 
+	// Template for standard range options (7, 30, Quarter, Year, All Time).
 	const summaryPath = `/stats/day/${ path }/${ siteSlug }?startDate=${ moment().format(
 		'YYYY-MM-DD'
 	) }&summarize=1&num=`;
-	const summaryPeriodPath = `/stats/${
+
+	// Path for summary or custom range option. ie: The first button in the row.
+	// Defaults to one day/week/month/year.
+	let summaryPeriodPath = `/stats/${
 		period.period
 	}/${ path }/${ siteSlug }?startDate=${ period.endOf.format( 'YYYY-MM-DD' ) }`;
+	// Override if custom range was used in query.
+	if ( query.start_date ) {
+		summaryPeriodPath = `/stats/${ period.period }/${ path }/${ siteSlug }?startDate=${ query.start_date }&endDate=${ query.date }`;
+	}
+
 	const options = [
 		{
 			value: '0',

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -79,22 +79,26 @@ class StatsModule extends Component {
 		return <DatePicker period={ period } date={ startOf } path={ path } query={ query } summary />;
 	}
 
-	getHref() {
-		const { summary, period, path, siteSlug } = this.props;
-
-		// Some modules do not have view all abilities
-		if ( ! summary && period && path && siteSlug ) {
-			return (
-				'/stats/' +
-				period.period +
-				'/' +
-				path +
-				'/' +
-				siteSlug +
-				'?startDate=' +
-				period.startOf.format( 'YYYY-MM-DD' )
-			);
+	getSummaryLink() {
+		const { summary, period, path, siteSlug, query } = this.props;
+		if ( summary ) {
+			return;
 		}
+
+		const paramsValid = period && path && siteSlug;
+		if ( ! paramsValid ) {
+			return undefined;
+		}
+
+		let url = `/stats/${ period.period }/${ path }/${ siteSlug }`;
+
+		if ( query?.start_date ) {
+			url += `?startDate=${ query.start_date }&endDate=${ query.date }`;
+		} else {
+			url += `?startDate=${ period.endOf.format( 'YYYY-MM-DD' ) }`;
+		}
+
+		return url;
 	}
 
 	isAllTimeList() {
@@ -166,7 +170,7 @@ class StatsModule extends Component {
 					showMore={
 						displaySummaryLink && ! summary
 							? {
-									url: this.getHref(),
+									url: this.getSummaryLink(),
 									label:
 										data.length >= 10
 											? translate( 'View all', {

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -88,6 +88,15 @@ class StatsSummary extends Component {
 			date: endOf.format( 'YYYY-MM-DD' ),
 			max: 0,
 		};
+
+		// Update query with date range if it provided.
+		const dateRange = this.props.dateRange;
+		if ( dateRange ) {
+			query.start_date = dateRange.startDate.format( 'YYYY-MM-DD' );
+			query.date = dateRange.endDate.format( 'YYYY-MM-DD' );
+			query.summarize = 1;
+		}
+
 		const moduleQuery = merge( {}, statsQueryOptions, query );
 		const urlParams = new URLSearchParams( this.props.context.querystring );
 		const listItemClassName = 'stats__summary--narrow-mobile';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/red-team/issues/252

## Proposed Changes

Updates the Traffic page to push the full date range to the Summary pages.

Updates the Summary pages to accept the `endDate` parameter. If provided, validates the date and creates a dateRange object that is passed into the summary page. This is then used to update the segmented control (the row of connected buttons), the summary header, and in the API request.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of the date filtering project.

pejTkB-1zs-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link.
* Test a few of the "View all" links on the Traffic page to confirm the resulting summary pages still work as expected. They should show a summary based on the current period from the Traffic page: day, week, month, etc.
* Enable the new date filtering: `&flags=stats/new-date-filtering`
* Hover over a "View all" link and confirm that both `startDate` and `endDate` values are present in the link.
* Click through to the summary page and confirm the custom range us applied to the page. (see screenshot)
* Click around to see if anything seems broken!

### New endDate param added to summary links
<img width="669" alt="SCR-20241123-bzlm" src="https://github.com/user-attachments/assets/ecf900d2-09bc-4e97-9c7a-b7be01e4dae1">

### Updated summary page respecting custom range
<img width="744" alt="SCR-20241123-cafz" src="https://github.com/user-attachments/assets/fbdc9b3f-0427-41b2-bcce-3c3d5cfdd1ca">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?