### PR TITLE
Update copy to 10K instead of 100K for Growth stats

### DIFF
--- a/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
@@ -98,7 +98,7 @@ function getFeatureStrings(
 		case 'growth':
 			// JetPack Creator features
 			return [
-				translate( 'Stats (Up to 100K site views, upgradeable)' ),
+				translate( 'Stats (10K site views, upgradeable)' ),
 				translate( 'Social' ),
 				translate( 'Display ads with WordAds' ),
 				translate( 'Pay with PayPal' ),


### PR DESCRIPTION
## Proposed Changes

* Growth Stats should have a limit of 10K rather than 100K

## Why are these changes being made?

There were some miscommunications about which tier of stats should exist in Growth. It is confirmed it should be 10K

## Testing Instructions

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
