### PR TITLE
Enable paypal-js in staging and the calypso live links

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -36,7 +36,7 @@
 		"catch-js-errors": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
-		"checkout/paypal-ppcp": false,
+		"checkout/paypal-ppcp": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": true,
 		"checkout/razorpay": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -36,7 +36,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": false,
+		"checkout/paypal-ppcp": true,
 		"checkout/checkout-version": true,
 		"checkout/razorpay": false,
 		"cloudflare": true,


### PR DESCRIPTION
Now that #94790 is merged we need to enable the PayPal JS library in staging and calypso live links to make testing easier.

## Proposed Changes

* Update the config for staging and wpcalypso to allow the PayPal JS payment method to be displayed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the calypso.live links:
* Confirm that with no backend changes the PayPal method still displays in checkout and is the normal NVP method.
* Using a sandbox and using the store test tables and adding a constant `define( 'PAYPAL_PPCP_ENABLED', true);` to enable the backend payment method, the PayPal payment method should be the new PayPal JS version. 
