### PR TITLE
Fix missing border

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -629,63 +629,63 @@ export default function CampaignItemDetails( props: Props ) {
 											</>
 										) }
 									</div>
-								</div>
 
-								{ ! campaignsStatsIsLoading && campaignStats && (
-									<>
-										<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
-											<div>
-												<div className="campaign-item-page__graph">
-													<DropdownMenu
-														class="campaign-item-page__graph-selector"
-														controls={ [
-															{
-																onClick: () => setChartSource( ChartSourceOptions.Clicks ),
-																title: __( 'Clicks' ),
-																isDisabled: chartSource === ChartSourceOptions.Clicks,
-															},
-															{
-																onClick: () => setChartSource( ChartSourceOptions.Impressions ),
-																title: __( 'Impressions' ),
-																isDisabled: chartSource === ChartSourceOptions.Impressions,
-															},
-														] }
-														icon={ chevronDown }
-														text={
-															chartSource === ChartSourceOptions.Clicks
-																? __( 'Clicks' )
-																: __( 'Impressions' )
-														}
-														label={ chartSource }
-													/>
-													{ getCampaignStatsChart(
-														campaignStats?.series[ chartSource ],
-														chartSource
-													) }
-												</div>
-											</div>
-										</div>
-
-										<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
-											<div>
-												<div className="campaign-item-page__locaton-charts">
-													<span className="campaign-item-details__label">
-														{ chartSource === ChartSourceOptions.Clicks
-															? __( 'Clicks by location' )
-															: __( 'Impressions by location' ) }
-													</span>
-													<div>
-														<LocationChart
-															stats={ campaignStats?.total_stats.countryStats[ chartSource ] }
-															total={ campaignStats.total_stats.total[ chartSource ] }
-															source={ chartSource }
+									{ ! campaignsStatsIsLoading && campaignStats && (
+										<>
+											<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
+												<div>
+													<div className="campaign-item-page__graph">
+														<DropdownMenu
+															class="campaign-item-page__graph-selector"
+															controls={ [
+																{
+																	onClick: () => setChartSource( ChartSourceOptions.Clicks ),
+																	title: __( 'Clicks' ),
+																	isDisabled: chartSource === ChartSourceOptions.Clicks,
+																},
+																{
+																	onClick: () => setChartSource( ChartSourceOptions.Impressions ),
+																	title: __( 'Impressions' ),
+																	isDisabled: chartSource === ChartSourceOptions.Impressions,
+																},
+															] }
+															icon={ chevronDown }
+															text={
+																chartSource === ChartSourceOptions.Clicks
+																	? __( 'Clicks' )
+																	: __( 'Impressions' )
+															}
+															label={ chartSource }
 														/>
+														{ getCampaignStatsChart(
+															campaignStats?.series[ chartSource ],
+															chartSource
+														) }
 													</div>
 												</div>
 											</div>
-										</div>
-									</>
-								) }
+
+											<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
+												<div>
+													<div className="campaign-item-page__locaton-charts">
+														<span className="campaign-item-details__label">
+															{ chartSource === ChartSourceOptions.Clicks
+																? __( 'Clicks by location' )
+																: __( 'Impressions by location' ) }
+														</span>
+														<div>
+															<LocationChart
+																stats={ campaignStats?.total_stats.countryStats[ chartSource ] }
+																total={ campaignStats.total_stats.total[ chartSource ] }
+																source={ chartSource }
+															/>
+														</div>
+													</div>
+												</div>
+											</div>
+										</>
+									) }
+								</div>
 							</div>
 						) }
 


### PR DESCRIPTION


Related to #

## Proposed Changes

Fixes missing border between graph sections:

![Screenshot 2024-11-22 at 17 50 48](https://github.com/user-attachments/assets/537ca4d2-ec86-4b10-b985-f80010b7f996)


## Why are these changes being made?

Here is the style before, the first container was inherting "only child" styles, so not showing a dividing border below.

![Screenshot 2024-11-22 at 17 49 51](https://github.com/user-attachments/assets/b79d1547-3a0a-4638-9f40-ad63925a1208)

## Testing Instructions

* Load up a campaign that is active or completed, ensure you see a divider line between the clicks/impressions and the charts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
