### PR TITLE
Stats: fix dashboard header/tab alignment

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -78,6 +78,11 @@
 	& .inner-notice-container.has-odyssey-stats-bg-color {
 		background-color: var(--jetpack-white-off);
 	}
+	& .stats .navigation-header__main .jetpack-header {
+		@media (max-width: 600px) {
+			padding-left: 0;
+		}
+	}
 
 	// Offset margin of menu items set in Calypso.
 	ul.wp-submenu,

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -114,7 +114,7 @@
 
 		.section-nav-tab {
 			&:not(:first-child) {
-				margin-left: 16px;
+				margin-left: 40px;
 
 				@media (max-width: $break-mobile) {
 					margin-left: 0;
@@ -122,7 +122,7 @@
 			}
 
 			.section-nav-tab__link {
-				padding: 8px 12px;
+				padding: 8px 0;
 				font-size: $font-body-small;
 				line-height: 20px;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/red-team#256.

## Proposed Changes

Fix the alignment of the header and navigation tabs in the Stats dashboard on Calypso Blue.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These changes are being implemented to align the header and navigation tabs with the similar design found in the WP Admin dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- In a local or Calypso live environment, navigate to the `Stats` section in the sidebar of a given site.
  - This can also be tested using a Jurassic Ninja site, such as `/stats/day/artistic-ukulele-worm.jurassic.ninja`.
- Check the alignment of the `Traffic / Insights / Subscribers` navigation bar compared to the `Jetpack Stats` header.

| Before | After |
| --- | --- |
| <img width="367" alt="image" src="https://github.com/user-attachments/assets/39cb5a69-7440-48ef-a972-ecbcd315f962"> | <img width="363" alt="image" src="https://github.com/user-attachments/assets/9e5c3ad4-61c3-4261-9e63-2bd763298553"> |

---

> [!NOTE]
> The length of the underline highlighting the active tab has been shortened slightly. This adjustment reflects the fact that the first item is no longer centered in its column. However, this behavior is consistent with what is observed in WP Admin:

| WP Admin |
| --- |
| <img width="357" alt="image" src="https://github.com/user-attachments/assets/93168236-d369-4461-9345-0338dfb9c485"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
