### PR TITLE
Stats: Make UTM module respect time period filter on post details page

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -21,8 +21,6 @@ import { getSiteSlug, isJetpackSite, isSitePreviewable } from 'calypso/state/sit
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import StatsModuleUTM from '../features/modules/stats-utm';
-import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
 import PostDetailHighlightsSection from '../post-detail-highlights-section';
 import PostDetailTableSection from '../post-detail-table-section';
 import StatsPlaceholder from '../stats-module/placeholder';
@@ -211,24 +209,14 @@ class StatsPostDetail extends Component {
 
 					{ ! isLoading && countViews > 0 && (
 						<>
-							<PostSummary siteId={ siteId } postId={ postId } />
+							<PostSummary
+								siteId={ siteId }
+								postId={ postId }
+								supportsUTMStats={ supportsUTMStats }
+							/>
 							<PostDetailTableSection siteId={ siteId } postId={ postId } />
 						</>
 					) }
-
-					<StatsGlobalValuesContext.Consumer>
-						{ ( isInternal ) =>
-							( supportsUTMStats || isInternal ) && (
-								<div className="stats-module-utm__post-detail">
-									<StatsModuleUTM
-										siteId={ siteId }
-										postId={ postId }
-										query={ { num: -1, max: 0 } }
-									/>
-								</div>
-							)
-						}
-					</StatsGlobalValuesContext.Consumer>
 
 					<JetpackColophon />
 				</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88911

## Proposed Changes

* Moves the UTM module on the post details page above the all-time insights
* Makes the UTM module respond to the date picker and chart, showing results for the specified date range

| Before | After |
| - | - |
| ![Screenshot from 2024-11-22 17-47-54](https://github.com/user-attachments/assets/cdc9c58a-413a-42bc-b429-82a1841cef3e) | ![Screenshot from 2024-11-22 17-46-50](https://github.com/user-attachments/assets/5f74a7d6-1b8b-4021-bae9-c9373923f547) | ![Screenshot from 2024-11-22 17-47-54](https://github.com/user-attachments/assets/cdc9c58a-413a-42bc-b429-82a1841cef3e)
| ![Screenshot from 2024-11-22 17-48-03](https://github.com/user-attachments/assets/78947435-ee2f-4d94-86d4-50ffa65dce31) | ![Screenshot from 2024-11-22 17-47-03](https://github.com/user-attachments/assets/5739b439-f1e7-4f25-a3d5-1c3e5161db73) |
| ![Screenshot from 2024-11-22 17-50-18](https://github.com/user-attachments/assets/2998e167-982a-476f-a44b-19c9993eb39a) | ![Screenshot from 2024-11-22 17-50-30](https://github.com/user-attachments/assets/5b103876-27a0-4064-b77d-63be7c384b1d) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* UX enhancements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a post's details page on Stats
* Make sure this post has some visits with UTM parameters
* Change the period and date range on the picker
* Check that the UTM module loads the data according to the filter (you can check the query in the network request by filtering by "utm" and looking for the request's URL params)

The number of entries in the UTM module normally should *NOT* match match the number of views in the chart, because the chart counts every visit, whereas the UTM module only counts visits with the UTM parameters, so it is expected to have previous visits in the chart but 0 results in the UTM module.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
