### PR TITLE
Open Studio sync after hosted site flow

### DIFF
--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -4,6 +4,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useLayoutEffect } from 'react';
 import { recordFreeHostingTrialStarted } from 'calypso/lib/analytics/ad-tracking/ad-track-trial-start';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
@@ -208,6 +209,16 @@ const hosting: Flow = {
 				window.location.assign( urlWithQueryParams );
 			}
 		}, [ userIsLoggedIn, isEligible, currentStepSlug, queryParams, logInUrl ] );
+
+		useEffect( () => {
+			if ( queryParams.studioSiteId ) {
+				recordTracksEvent( 'calypso_studio_sync_step', {
+					flow: NEW_HOSTED_SITE_FLOW,
+					step: currentStepSlug,
+				} );
+			}
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [ currentStepSlug ] );
 
 		useEffect(
 			() => {

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -85,18 +85,6 @@ const hosting: Flow = {
 			}
 		};
 
-		const saveStudioSiteId = ( siteId: number ) => {
-			const studioSiteId = queryParams[ 'studio-site-id' ];
-			if ( ! studioSiteId ) {
-				return;
-			}
-
-			// TODO: Save studio site ID to the backend. In the meantime, we'll save it in local storage.
-			const studioSiteIds = JSON.parse( localStorage.getItem( 'studio-site-ids' ) || '{}' );
-			studioSiteIds[ studioSiteId ] = siteId;
-			localStorage.setItem( 'studio-site-ids', JSON.stringify( studioSiteIds ) );
-		};
-
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			if ( providedDependencies.siteId ) {
 				setSignupCompleteSiteID( providedDependencies.siteId );
@@ -151,7 +139,6 @@ const hosting: Flow = {
 						destinationParams[ 'redirect_to' ] = addQueryArgs( `/home/${ siteId }`, {
 							'studio-site-id': queryParams[ 'studio-site-id' ],
 						} );
-						saveStudioSiteId( siteId );
 					}
 					// Purchasing Business or Commerce plans will trigger an atomic transfer, so go to stepper flow where we wait for it to complete.
 					const destination = addQueryArgs( '/setup/transferring-hosted-site', destinationParams );

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -130,14 +130,14 @@ const hosting: Flow = {
 					return navigate( 'processing' );
 
 				case 'processing': {
-					const hasStudioSyncSiteId = queryParams[ 'studio-site-id' ];
+					const hasStudioSyncSiteId = queryParams.studioSiteId;
 					const siteId = providedDependencies.siteId || getSignupCompleteSiteID();
 					const destinationParams: Record< string, string > = {
 						siteId,
 					};
 					if ( hasStudioSyncSiteId ) {
 						destinationParams[ 'redirect_to' ] = addQueryArgs( `/home/${ siteId }`, {
-							'studio-site-id': queryParams[ 'studio-site-id' ],
+							studioSiteId: queryParams.studioSiteId,
 						} );
 					}
 					// Purchasing Business or Commerce plans will trigger an atomic transfer, so go to stepper flow where we wait for it to complete.

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -85,6 +85,18 @@ const hosting: Flow = {
 			}
 		};
 
+		const saveStudioSiteId = ( siteId: number ) => {
+			const studioSiteId = queryParams[ 'studio-site-id' ];
+			if ( ! studioSiteId ) {
+				return;
+			}
+
+			// TODO: Save studio site ID to the backend. In the meantime, we'll save it in local storage.
+			const studioSiteIds = JSON.parse( localStorage.getItem( 'studio-site-ids' ) || '{}' );
+			studioSiteIds[ studioSiteId ] = siteId;
+			localStorage.setItem( 'studio-site-ids', JSON.stringify( studioSiteIds ) );
+		};
+
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			if ( providedDependencies.siteId ) {
 				setSignupCompleteSiteID( providedDependencies.siteId );
@@ -130,10 +142,19 @@ const hosting: Flow = {
 					return navigate( 'processing' );
 
 				case 'processing': {
+					const hasStudioSyncSiteId = queryParams[ 'studio-site-id' ];
+					const siteId = providedDependencies.siteId || getSignupCompleteSiteID();
+					const destinationParams: Record< string, string > = {
+						siteId,
+					};
+					if ( hasStudioSyncSiteId ) {
+						destinationParams[ 'redirect_to' ] = addQueryArgs( `/home/${ siteId }`, {
+							'studio-site-id': queryParams[ 'studio-site-id' ],
+						} );
+						saveStudioSiteId( siteId );
+					}
 					// Purchasing Business or Commerce plans will trigger an atomic transfer, so go to stepper flow where we wait for it to complete.
-					const destination = addQueryArgs( '/setup/transferring-hosted-site', {
-						siteId: providedDependencies.siteId || getSignupCompleteSiteID(),
-					} );
+					const destination = addQueryArgs( '/setup/transferring-hosted-site', destinationParams );
 
 					// If the product is a free trial, record the trial start event for ad tracking.
 					if ( planCartItem && isFreeHostingTrial( planCartItem?.product_slug ) ) {

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -124,6 +124,12 @@ const Home = ( {
 		}
 	}, [ emailDnsDiagnostics ] );
 
+	useEffect( () => {
+		const studioSiteId = getQueryArgs()[ 'studio-site-id' ];
+		const studioSiteUrl = `wpcom-local-dev://sync-connect-site?studioSiteId=${ studioSiteId }&remoteSiteId=${ siteId }`;
+		window.location.href = studioSiteUrl;
+	}, [ siteId ] );
+
 	const isFirstSecondaryCardInPrimaryLocation =
 		Array.isArray( layout?.primary ) &&
 		layout.primary.length === 0 &&
@@ -253,6 +259,31 @@ const Home = ( {
 		);
 	};
 
+	const renderStudioSyncNotice = () => {
+		const studioSiteId = getQueryArgs()[ 'studio-site-id' ];
+		if ( ! studioSiteId ) {
+			return null;
+		}
+		const studioSiteUrl = `wpcom-local-dev://sync-connect-site?studioSiteId=${ studioSiteId }&remoteSiteId=${ siteId }`;
+
+		return (
+			<Notice
+				text={ translate( 'Connect to your Studio site to start syncing.' ) }
+				icon="sync"
+				showDismiss={ false }
+				status="is-info"
+			>
+				<NoticeAction
+					onClick={ () => {
+						window.location.href = studioSiteUrl;
+					} }
+				>
+					{ translate( 'Connect Studio' ) }
+				</NoticeAction>
+			</Notice>
+		);
+	};
+
 	return (
 		<Main wideLayout className="customer-home__main">
 			<PageViewTracker path="/home/:site" title={ translate( 'My Home' ) } />
@@ -271,6 +302,7 @@ const Home = ( {
 				/>
 			) : null }
 
+			{ renderStudioSyncNotice() }
 			{ renderUnverifiedEmailNotice() }
 			{ renderDnsSettingsDiagnosticNotice() }
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -127,6 +127,10 @@ const Home = ( {
 	useEffect( () => {
 		const studioSiteId = getQueryArgs().studioSiteId;
 		const studioSiteUrl = `wpcom-local-dev://sync-connect-site?studioSiteId=${ studioSiteId }&remoteSiteId=${ siteId }`;
+		recordTracksEvent( 'calypso_studio_sync_connect_site', {
+			remoteSiteId: siteId,
+			click: false,
+		} );
 		window.location.href = studioSiteUrl;
 	}, [ siteId ] );
 
@@ -275,6 +279,10 @@ const Home = ( {
 			>
 				<NoticeAction
 					onClick={ () => {
+						recordTracksEvent( 'calypso_studio_sync_connect_site', {
+							remoteSiteId: siteId,
+							click: true,
+						} );
 						window.location.href = studioSiteUrl;
 					} }
 				>

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -126,6 +126,9 @@ const Home = ( {
 
 	useEffect( () => {
 		const studioSiteId = getQueryArgs().studioSiteId;
+		if ( ! studioSiteId ) {
+			return;
+		}
 		const studioSiteUrl = `wpcom-local-dev://sync-connect-site?studioSiteId=${ studioSiteId }&remoteSiteId=${ siteId }`;
 		recordTracksEvent( 'calypso_studio_sync_connect_site', {
 			remoteSiteId: siteId,

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -125,7 +125,7 @@ const Home = ( {
 	}, [ emailDnsDiagnostics ] );
 
 	useEffect( () => {
-		const studioSiteId = getQueryArgs()[ 'studio-site-id' ];
+		const studioSiteId = getQueryArgs().studioSiteId;
 		const studioSiteUrl = `wpcom-local-dev://sync-connect-site?studioSiteId=${ studioSiteId }&remoteSiteId=${ siteId }`;
 		window.location.href = studioSiteUrl;
 	}, [ siteId ] );
@@ -260,7 +260,7 @@ const Home = ( {
 	};
 
 	const renderStudioSyncNotice = () => {
-		const studioSiteId = getQueryArgs()[ 'studio-site-id' ];
+		const studioSiteId = getQueryArgs().studioSiteId;
 		if ( ! studioSiteId ) {
 			return null;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/9359

## Proposed Changes

* Add logic to pass Studio site id and override redirection URL for new-hosted-site-flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to use new-hosted-site-flow and at the end of the flow redirect to Studio

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Ideally the site id is a real Studio site from your appData.

* Follow this link: http://calypso.localhost:3000/setup/new-hosted-site/domains?studioSiteId=026a8080-362a-4ab9-921d-2c63510ffe5a
* Follow the steps and buy a site
* Observe the site is created and is atomic
* Observe the final URL is /home/siteId with the studioSiteId GET param: i.e. http://calypso.localhost:3000/home/239279206?studioSiteId=026a8080-362a-4ab9-921d-2c63510ffe5a
* Observe there is a notice and a popup triggered automatically


* Remove the studioSiteId param from the URL
* Observe the notice and alert are not visible

Final URL:
<img width="1724" alt="Screenshot 2024-11-22 at 22 19 49" src="https://github.com/user-attachments/assets/7da15b3c-b784-4e44-9c33-0ff169579e2d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
