### PR TITLE
Payment Methods: enable PPCP method in all environments except test and production

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -31,7 +31,7 @@ function PayPalLabel() {
 	return (
 		<>
 			<div>
-				<span>PayPal</span>
+				<span>PayPal (PPCP)</span>
 			</div>
 			<PaymentMethodLogos className="paypal__logo payment-logos">
 				<PayPalLogo />

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -26,7 +26,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": false,
+		"checkout/paypal-ppcp": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"cloudflare": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -34,7 +34,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": false,
+		"checkout/paypal-ppcp": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -31,7 +31,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": false,
+		"checkout/paypal-ppcp": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -33,7 +33,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": false,
+		"checkout/paypal-ppcp": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": false,


### PR DESCRIPTION
After D165065-code was merged, we started gating the availability of the new PayPal PPCP payment method through the backend (via the shopping cart's `allowed_payment_methods` and the `/me/allowed-payment-methods` endpoint). This means that we no longer need to gate the PayPal JS availability via Calypso environment configs.

To enable easier testing of the new payment method, this PR sets the config flag to `true` in all but the test and production environments. Thus based on the result of the backend's `is_paypal_ppcp_enabled()`, we'll be able to control which PayPal payment method is available. I left the flags in production and test environments just as a safety precaution.

I've also added a temporary `(PPCP)` to the new payment method selector to help testers know which method they're using.

<img width="594" alt="Screenshot 2024-11-23 at 7 42 47 AM" src="https://github.com/user-attachments/assets/ec84b4af-ed1d-4227-b103-de017925b979">

**To test:**
A visual check should suffice, but you can also verify that `WPCOM_Billing_PayPal_PPCP` or `WPCOM_Billing_PayPal_Express` is available/unavailable via the shopping cart endpoint based on the configs in D167015-code.