### PR TITLE
Remove "Checklist" from sites pending migration in Sites dashboard

### DIFF
--- a/client/sites/components/sites-dataviews/sites-site-status.tsx
+++ b/client/sites/components/sites-dataviews/sites-site-status.tsx
@@ -1,6 +1,7 @@
 import { useSiteLaunchStatusLabel } from '@automattic/sites';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
+import { SiteLaunchNag } from 'calypso/sites-dashboard/components/sites-site-launch-nag';
 import TransferNoticeWrapper from 'calypso/sites-dashboard/components/sites-transfer-notice-wrapper';
 import { WithAtomicTransfer } from 'calypso/sites-dashboard/components/with-atomic-transfer';
 import { getMigrationStatus, MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
@@ -38,6 +39,7 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 	const { __ } = useI18n();
 
 	const translatedStatus = useSiteLaunchStatusLabel( site );
+	const isPending = getMigrationStatus( site ) === 'pending';
 	const isDIFMInProgress = useSelector( ( state ) => isDIFMLiteInProgress( state, site.ID ) );
 
 	if ( site.is_deleted ) {
@@ -48,12 +50,11 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 		);
 	}
 
-	const statusElement =
-		getMigrationStatus( site ) === 'pending' ? (
-			<span className="sites-dataviews__migration-pending-status">{ translatedStatus }</span>
-		) : (
-			translatedStatus
-		);
+	const statusElement = isPending ? (
+		<span className="sites-dataviews__migration-pending-status">{ translatedStatus }</span>
+	) : (
+		translatedStatus
+	);
 
 	return (
 		<WithAtomicTransfer site={ site }>
@@ -66,7 +67,10 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 						{ isDIFMInProgress ? (
 							<BadgeDIFM className="site__badge">{ __( 'Express Service' ) }</BadgeDIFM>
 						) : (
-							statusElement
+							<div>
+								{ statusElement }
+								{ ! isPending && <SiteLaunchNag site={ site } /> }
+							</div>
 						) }
 					</>
 				)

--- a/client/sites/components/sites-dataviews/sites-site-status.tsx
+++ b/client/sites/components/sites-dataviews/sites-site-status.tsx
@@ -1,7 +1,6 @@
 import { useSiteLaunchStatusLabel } from '@automattic/sites';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { SiteLaunchNag } from 'calypso/sites-dashboard/components/sites-site-launch-nag';
 import TransferNoticeWrapper from 'calypso/sites-dashboard/components/sites-transfer-notice-wrapper';
 import { WithAtomicTransfer } from 'calypso/sites-dashboard/components/with-atomic-transfer';
 import { getMigrationStatus, MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
@@ -67,10 +66,7 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 						{ isDIFMInProgress ? (
 							<BadgeDIFM className="site__badge">{ __( 'Express Service' ) }</BadgeDIFM>
 						) : (
-							<div>
-								{ statusElement }
-								<SiteLaunchNag site={ site } />
-							</div>
+							statusElement
 						) }
 					</>
 				)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #96417.

## Proposed Changes

* Removes the _Checklist_ link for sites that are pending migration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the migration flow.
* Follow the steps, choosing the DIY option until you reach the instructions page.
* Make note of the domain for the new site (e.g. the `siteSlug` query parameter value).
* Head to the `/sites` dashboard.
* Find the domain of the new site.
* Ensure there is no "Checklist" link in the row.
* Click on the row.
* In the header, ensure there is no "Checklist" link.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
