### PR TITLE
Strip protocol and trailing slash from DIFM confirmation page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -15,6 +15,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { urlToDomainAndPath } from 'calypso/lib/url';
 import { UserData } from 'calypso/lib/user/user';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -161,7 +162,7 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 									{
 										email: user?.email,
 										// Strip protocol and trailing slash.
-										webSite: fromUrl.replace( /(^\w+:|^)\/\//, '' ).replace( /\/$/, '' ),
+										webSite: urlToDomainAndPath( fromUrl ),
 									}
 								),
 								{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -160,7 +160,8 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 									),
 									{
 										email: user?.email,
-										webSite: fromUrl,
+										// Strip protocol and trailing slash.
+										webSite: fromUrl.replace( /(^\w+:|^)\/\//, '' ).replace( /\/$/, '' ),
 									}
 								),
 								{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #96419.

## Proposed Changes

* Strips the protocol and trailing slash from the source URL on the DIFM confirmation page.

<img width="845" alt="Screenshot 2024-11-23 at 11 49 45 AM" src="https://github.com/user-attachments/assets/fbf6e9ec-a2e7-4b43-85b1-f985c8c65591">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Step through the migration flow.
- Ensure you select the Do It For Me option.
- Submit credentials and click Continue.
- Ensure there is no protocol or trailing slash for the source URL.

## Pre-merge Checklist
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
