### PR TITLE
Purchases: General Enhancements to Remove Domain Dialog

### DIFF
--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -16,6 +16,7 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 
+
 class RemoveDomainDialog extends Component {
 	static propTypes = {
 		isRemoving: PropTypes.bool.isRequired,

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -10,8 +10,8 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import { getName } from 'calypso/lib/purchases';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
-import wpcom from 'calypso/lib/wp';
 import { domainManagementEdit, domainManagementTransferOut } from 'calypso/my-sites/domains/paths';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -62,6 +62,7 @@ class RemoveDomainDialog extends Component {
 						}
 					) }
 				</p>
+				<p>{ translate( 'Do you still want to continue with deleting your domain?' ) }</p>
 			</Fragment>
 		);
 	}
@@ -152,28 +153,13 @@ class RemoveDomainDialog extends Component {
 		);
 	}
 
-	async isWpComEmailBasedOnDomain() {
-		this.setState( {
-			isCheckingEmail: true,
-		} );
-
-		const { purchase } = this.props;
-		const productName = getName( purchase );
-		const { email } = await wpcom.me().get();
-
-		this.setState( {
-			isCheckingEmail: false,
-		} );
-
-		return email.endsWith( productName );
-	}
-
-	nextStep = async ( closeDialog ) => {
+	nextStep = ( closeDialog ) => {
 		if ( this.props.isRemoving ) {
 			return;
 		}
 
-		const isEmailBasedOnDomain = await this.isWpComEmailBasedOnDomain();
+		const productName = getName( this.props.purchase );
+		const isEmailBasedOnDomain = this.props.userEmail.endsWith( productName );
 
 		switch ( this.state.step ) {
 			case 1:
@@ -201,9 +187,9 @@ class RemoveDomainDialog extends Component {
 		const productName = getName( purchase );
 
 		// To be removed once "Never mind" is translated; the typo has been fixed in existing translations.
-		const closeDialogString = hasTranslation( 'Nevermind' )
-			? translate( 'Nevermind' )
-			: translate( 'Never mind' );
+		const oldString = translate( 'Nevermind' );
+		const newString = translate( 'Never mind ' );
+		const closeDialogString = hasTranslation( 'Never mind' ) ? newString : oldString;
 
 		const buttons = [
 			{
@@ -262,6 +248,7 @@ export default connect( ( state, ownProps ) => {
 		isGravatarDomain: selectedDomain?.isGravatarDomain,
 		hasTitanWithUs: hasTitanMailWithUs( selectedDomain ),
 		currentRoute: getCurrentRoute( state ),
+		userEmail: getCurrentUserEmail( state ),
 		slug: getSiteSlug( state, ownProps.purchase.siteId ),
 	};
 } )( localize( RemoveDomainDialog ) );

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -188,7 +188,7 @@ class RemoveDomainDialog extends Component {
 
 		// To be removed once "Never mind" is translated; the typo has been fixed in existing translations.
 		const oldString = translate( 'Nevermind' );
-		const newString = translate( 'Never mind ' );
+		const newString = translate( 'Never mind' );
 		const closeDialogString = hasTranslation( 'Never mind' ) ? newString : oldString;
 
 		const buttons = [

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -202,7 +202,7 @@ class RemoveDomainDialog extends Component {
 						{
 							action: 'remove',
 							additionalClassNames: [
-								this.props.isRemoving || this.state.isCheckingEmail ? 'is-busy' : '',
+								this.props.isRemoving ? 'is-busy' : '',
 								this.state.step === 3 ? 'is-scary' : '',
 								'dialog__button--domains-remove',
 							],

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -1,5 +1,4 @@
 import { Dialog, FormLabel } from '@automattic/components';
-import { hasTranslation } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -186,16 +185,11 @@ class RemoveDomainDialog extends Component {
 		const { purchase, translate, chatButton } = this.props;
 		const productName = getName( purchase );
 
-		// To be removed once "Never mind" is translated; the typo has been fixed in existing translations.
-		const oldString = translate( 'Nevermind' );
-		const newString = translate( 'Never mind' );
-		const closeDialogString = hasTranslation( 'Never mind' ) ? newString : oldString;
-
 		const buttons = [
 			{
 				action: 'cancel',
 				disabled: this.props.isRemoving,
-				label: this.state.step === 3 ? closeDialogString : translate( 'Cancel' ),
+				label: this.state.step === 3 ? translate( 'Never mind' ) : translate( 'Cancel' ),
 			},
 			...( this.state.step !== 2
 				? [

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -35,9 +35,11 @@
 	}
 }
 
-.dialog__action-buttons {
-	.remove-domain-dialog__chat-button.precancellation-chat-button__main-button.button,
-	.cancel-auto-renewal-form__chat-button.precancellation-chat-button__main-button.button {
+.remove-domain-dialog.dialog {
+    max-width: 800px;
+
+	.remove-domain-dialog__chat-button,
+	.cancel-auto-renewal-form__chat-button {
 		display: block;
 		float: left;
 		font-size: 0.875rem;


### PR DESCRIPTION
Follow-up to #96213

## Proposed Changes

These introduce various changes to the Remove Domain Dialog to make it more user-friendly:

- Sets a `max-width` so that it is more readable; currently it takes up the full width, which is difficult to read and means that the dialog jumps around when switching steps.
- When on the second step (ie. the one that appears if a user's WP.com email matches their domain), removes the "Continue" button. At present, the button still shows but doesn't do anything when clicked.
- For the form validation where a user needs to confirm their domain address, uses the `disabled` state instead of having this button always active. This matches what is done in the Site Reset, Delete Site, and Close Account dialogs that require similar confirmatory input. Also sets the button to `scary` for the same reason - it is a permanent change! 
- Fixes a typo for the cancellation string: "Nevermind" -> "Never mind" (translators have fixed this typo, so it's okay to default to the old string for translations) 
- Moves the information on Step 3 to above the input; it probably makes sense for the user to read it first before entering their domain.
- When the dialog is closed, ensure that it's set back to the first step. 

## Why are these changes being made?

General enhancements to make the dialog more user-friendly and consistent with similar dialogs in Calypso. 

## Testing Instructions

1. Go to Me > Purchases
2. Select a domain for a domain-only site 
3. Press "Remove domain" 
4. Confirm that the dialog works as expected with these changes

| Step 1 | Step 2 | Step 3 |
|--------|--------|--------|
| <img width="1084" alt="Screenshot 2024-11-23 at 18 12 49" src="https://github.com/user-attachments/assets/6d1a240b-b5df-4746-9819-037390408913"> | <img width="1113" alt="Screenshot 2024-11-23 at 18 12 58" src="https://github.com/user-attachments/assets/27d7af4d-3732-466f-b759-6286218036a5"> | <img width="1119" alt="Screenshot 2024-11-23 at 18 12 52" src="https://github.com/user-attachments/assets/d530335a-f075-4bbc-86d0-d40d5558af83"> | 

One thing to note, Step 2 only appears when your WordPress.com account email is based on your domain. It may just be easier to force this as `true` to test it.

https://github.com/Automattic/wp-calypso/blob/7e5f54c29580df8e97c1443c7f95b2011a8cdf80/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx#L176

cc @sirbrillig, @DavidRothstein, @michaeldcain 

