### PR TITLE
PayPal: update key for PayPal Express assignment processor

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -186,7 +186,8 @@ export default function PaymentMethodSelector( {
 			onPageLoadError={ logError }
 			paymentMethods={ paymentMethods }
 			paymentProcessors={ {
-				paypal: ( data: unknown ) => assignPayPalProcessor( purchase, reduxDispatch, data ),
+				'paypal-express': ( data: unknown ) =>
+					assignPayPalProcessor( purchase, reduxDispatch, data ),
 				'existing-card': ( data: unknown ) =>
 					assignExistingCardProcessor( purchase, reduxDispatch, data ),
 				'existing-card-ebanx': ( data: unknown ) =>


### PR DESCRIPTION
In #94790, we updated the PayPal Express payment method ID to `paypal-express` to allow simultaneous testing of PayPal Express and PPCP payment methods. The same key is also used as the `paymentProcessorId` to pair a processor to a payment method, and while we updated the processor list for Checkout, we missed the processor list for the manage purchase screens.

This updates the manage purchase processor list to use the correct `paypal-express` key.

Reported: p1732399559650689-slack-C02BEP610

**To test:**
- visit Me > Upgrades and select an existing purchase
- click "Add/Change payment method"
- select PayPal from the methods and input a country and zipcode
- click the PayPal button
- verify that you're redirected to PayPal