### PR TITLE
Stats: fix some issues on other tabs caused hourly stats + new date range

### DIFF
--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -10,7 +10,7 @@ const week = { value: 'week', label: translate( 'Weeks' ) };
 const month = { value: 'month', label: translate( 'Months' ) };
 const year = { value: 'year', label: translate( 'Years' ) };
 
-export const intervals = [ hour, day, week, month, year ];
+export const intervals = [ day, week, month, year ];
 export const emailIntervals = [ hour, day ];
 
 export const AVAILABLE_PAGE_MODULES = {

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -239,8 +239,8 @@ class StatsPeriodNavigation extends PureComponent {
 		const isToday = moment( date ).isSame( momentSiteZone, period );
 
 		// TODO: Refactor the isWithNewDateFiltering dedicated variables.
-		const isChartRangeEndToday = moment( dateRange.chartEnd ).isSame( momentSiteZone, period );
-		const showArrowsForDateRange = showArrows && dateRange.daysInRange <= 31;
+		const isChartRangeEndToday = moment( dateRange?.chartEnd ).isSame( momentSiteZone, period );
+		const showArrowsForDateRange = showArrows && dateRange?.daysInRange <= 31;
 
 		return (
 			<div


### PR DESCRIPTION


## Proposed Changes

* Add conditional chaining for dateRange access, which causes issue when called from the WordAds tab
* Remove hour as an interval

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* fixes

## Testing Instructions

* Open WordAds tab
* Ensure it shows correctly
* Ensure the stats period selection header doesn't show hour

<img width="662" alt="Screenshot 2024-11-25 at 12 04 49 PM" src="https://github.com/user-attachments/assets/bd5646ba-7dcc-4fa1-96f2-e4ff0fa09aaf">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
