### PR TITLE
A4A > Migration:s Add modal for schedule a Pressable demo

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/index.tsx
@@ -1,5 +1,5 @@
-import { Button, Card } from '@wordpress/components';
-import { Icon, external } from '@wordpress/icons';
+import { Button, Card, Modal } from '@wordpress/components';
+import { Icon, close } from '@wordpress/icons';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
@@ -14,8 +14,6 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
-
-const PRESSABLE_CONTACT_LINK = 'https://pressable.com/request-demo';
 
 function HostingOptionCard( {
 	banner,
@@ -56,15 +54,22 @@ export default function MigrationsHostingOptions() {
 	const [ showWPCOMDevSiteConfigurationsModal, setShowWPCOMDevSiteConfigurationsModal ] =
 		useState( false );
 
+	const [ showSchedulePressableDemoModal, setShowSchedulePressableDemoModal ] = useState( false );
+
 	const { randomSiteName, isRandomSiteNameLoading, refetchRandomSiteName } = useRandomSiteName();
 
 	const onCreateSiteSuccess = useSiteCreatedCallback( refetchRandomSiteName );
 
 	const onSchedulePressableDemoClick = useCallback( () => {
+		setShowSchedulePressableDemoModal( true );
 		dispatch(
-			recordTracksEvent( 'calypso_a4a_migrations_hosting_options_schedule_pressable_demo_click' )
+			recordTracksEvent( 'calypso_a4a_migrations_hosting_options_pressable_schedule_demo_click' )
 		);
-	}, [ dispatch ] );
+	}, [ dispatch, setShowSchedulePressableDemoModal ] );
+
+	const onHideSchedulePressableDemoModal = useCallback( () => {
+		setShowSchedulePressableDemoModal( false );
+	}, [ setShowSchedulePressableDemoModal ] );
 
 	const onClickCreateWPCOMDevSite = useCallback( () => {
 		dispatch(
@@ -118,7 +123,6 @@ export default function MigrationsHostingOptions() {
 						</Button>,
 					] }
 				/>
-
 				<HostingOptionCard
 					banner={ PressableBanner }
 					title={ translate( 'Managing over 50 sites? Schedule a demo' ) }
@@ -141,15 +145,40 @@ export default function MigrationsHostingOptions() {
 						<Button
 							variant="secondary"
 							key="schedule-pressable-demo-button"
-							href={ PRESSABLE_CONTACT_LINK }
 							target="_blank"
 							rel="noopener noreferrer"
 							onClick={ onSchedulePressableDemoClick }
 						>
-							{ translate( 'Schedule a demo' ) } <Icon icon={ external } size={ 16 } />
+							{ translate( 'Schedule a demo' ) }
 						</Button>,
 					] }
 				/>
+				{ showSchedulePressableDemoModal && (
+					<Modal
+						className="migrations-pressable-schedule-demo-modal"
+						onRequestClose={ onHideSchedulePressableDemoModal }
+						__experimentalHideHeader
+					>
+						<div>
+							<Button
+								className="migrations-pressable-schedule-demo-modal__close-button"
+								onClick={ () => {
+									setShowSchedulePressableDemoModal( false );
+								} }
+								aria-label={ translate( 'Close' ) }
+							>
+								<Icon size={ 24 } icon={ close } />
+							</Button>
+						</div>
+						<iframe
+							className="migrations-pressable-schedule-demo-modal__iframe"
+							title={ translate( 'Schedule a demo' ) }
+							src="https://meetings.hubspot.com/pressable/schedule-a-demo?embed=true&amp;parentHubspotUtk=63e0ee624a481b4949ebe0a77e186bf9&amp;parentPageUrl=https://pressable.com/request-demo/"
+							width="100%"
+							data-hs-ignore="true"
+						/>
+					</Modal>
+				) }
 			</div>
 
 			<div className="migrations-hosting-options__footnote">

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/style.scss
@@ -77,3 +77,39 @@
 		text-decoration: underline;
 	}
 }
+
+.migrations-pressable-schedule-demo-modal {
+	width: 900px;
+	max-height: 100%;
+}
+
+.components-modal__frame {
+	max-height: 100%;
+}
+
+.migrations-pressable-schedule-demo-modal__iframe {
+	margin: 10px;
+	min-width: 312px;
+	min-height: 690px;
+	border: none;
+}
+
+.migrations-pressable-schedule-demo-modal__close-button {
+	position: absolute;
+	inset-inline-end: 1rem;
+	inset-block-start: 1rem;
+	cursor: pointer;
+	transition: scale 0.2s ease-in;
+	max-height: 24px;
+
+	&:hover {
+		scale: 1.2;
+	}
+
+	&:focus-visible {
+		border-color: var(--color-primary);
+		outline: none;
+		box-shadow: 0 0 0 2px var(--color-primary-10);
+		border-radius: 4px;
+	}
+}


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/1266

## Proposed Changes

This PR adds a modal to schedule a Pressable demo. Currently, we send the user to [this Pressable page](https://pressable.com/request-demo/) with a embed iframe to schedule the demo.

**Card with the Pressable demo information**
<img width="679" alt="image" src="https://github.com/user-attachments/assets/cc41e525-bfeb-4f80-9c00-3faf6b92dd42">

**Modal to schedule the Pressable demo**
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/5456b4ae-b806-4b40-82c4-c1a09807686a">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Launch a live site in Horizon with the link bellow
- Go to the Migrations section: `/migrations/overview`
- Click on `Schedule a demo`
- The modal will be opened with the Pressable schedule content (it's an iframe)
   - In trunk, it goes to [this Pressable page where the iframe is](https://pressable.com/request-demo/).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
