### PR TITLE
Sites Dashboard: Remove "scroll to a selected item" overrides

### DIFF
--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -1,8 +1,7 @@
 import { SiteExcerptData } from '@automattic/sites';
-import { usePrevious } from '@wordpress/compose';
 import { DataViews, Field } from '@wordpress/dataviews';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useMemo, useRef, useLayoutEffect } from 'react';
+import { useCallback, useMemo } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
 import { SitePlan } from 'calypso/sites-dashboard/components/sites-site-plan';
@@ -57,34 +56,6 @@ const DotcomSitesDataViews = ( {
 }: Props ) => {
 	const { __ } = useI18n();
 	const userId = useSelector( getCurrentUserId );
-
-	// Scroll to selected site in the list when in list view.
-	const scrollContainerRef = useRef< HTMLElement >();
-	const previousDataViewsState = usePrevious( dataViewsState );
-	const previousSelectedItem = usePrevious( selectedItem );
-	useLayoutEffect( () => {
-		if ( ! scrollContainerRef.current || previousDataViewsState?.type !== dataViewsState.type ) {
-			scrollContainerRef.current = document.querySelector( '.dataviews-view-list' ) as HTMLElement;
-		}
-
-		if ( ! previousSelectedItem && selectedItem && dataViewsState.type === 'list' ) {
-			window.setTimeout(
-				() => scrollContainerRef.current?.querySelector( 'li.is-selected' )?.scrollIntoView(),
-				300
-			);
-			return;
-		}
-
-		if ( previousDataViewsState?.page !== dataViewsState.page ) {
-			scrollContainerRef.current?.scrollTo( 0, 0 );
-		}
-	}, [
-		dataViewsState.type,
-		dataViewsState.page,
-		selectedItem,
-		previousDataViewsState,
-		previousSelectedItem,
-	] );
 
 	// By default, DataViews is in an "uncontrolled" mode, meaning the current selection is handled internally.
 	// However, each time a site is selected, the URL changes, so, the component is remounted and the current selection is lost.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR removes "scroll to a selected item" overrides since Core already supports that. 

Please note that this change ensures the selected site remains visible within the scrollable container but removes the behavior where the selected site is positioned at the top of the container.

before
![f99c2792c18bcb5f3acf230e10a6b1bc](https://github.com/user-attachments/assets/a3bdf4c0-2a58-45c0-b29f-abcf56e50381)

after
![7c2418c5437169f180c3ca4216e9ff6e](https://github.com/user-attachments/assets/5be5e4b6-42da-438d-b52b-a721ff84576b)

CC: @lucasmendes-design @matt-west @davemart-in 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Please refer to pbxlJb-6A9-p2#comment-4083

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Scroll down by one screen
* Select any site to open the panel

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?