### PR TITLE
Sites Dashboard: Remove max-width constraints for full-width title alignment

### DIFF
--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -18,10 +18,9 @@
 	.a4a-layout__body {
 		> * {
 			padding-inline: 48px;
-			max-width: none;
-			max-width: 1400px !important;
-			margin-inline: auto !important;
-
+			// Override the max-width set in a8c-for-agencies/components/layout/style.scss
+			// as the title aligns with DataViews (full width).
+			max-width: revert;
 			@media (max-width: 402px) {
 				padding-inline: 24px;
 			}
@@ -387,9 +386,9 @@
 
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout.preview-hidden {
 	div.a4a-layout__viewport {
-		margin: 0 auto;
-		max-width: 1400px;
-		box-sizing: border-box;
+		// margin: 0 auto;
+		// max-width: 1400px;
+		// box-sizing: border-box;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR removes max-width constraints for full-width title alignment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p1732272905062089-slack-CRWCHQGUB

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Ensure the title is aligned with DataViews in the large view

<img width="2560" alt="Screenshot 2024-11-25 at 12 13 05" src="https://github.com/user-attachments/assets/4648aa60-c902-418b-ab52-37edd5942393">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?