### PR TITLE
Sites Dashboard: Hide Overview action in the list view

### DIFF
--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -33,15 +33,13 @@ import type { Action } from '@wordpress/dataviews';
 
 export function useActions( {
 	openSitePreviewPane,
-	selectedItem,
 	viewType,
 }: {
 	openSitePreviewPane?: (
 		site: SiteExcerptData,
 		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher'
 	) => void;
-	selectedItem?: SiteExcerptData | null;
-	viewType: 'list' | 'table';
+	viewType: 'list' | 'table' | 'grid';
 } ): Action< SiteExcerptData >[] {
 	const { __ } = useI18n();
 	const dispatch = useReduxDispatch();
@@ -416,6 +414,6 @@ export function useActions( {
 				isEligible: ( site ) => !! site?.is_deleted,
 			},
 		],
-		[ __, capabilities, dispatch, openSitePreviewPane, restoreSite, selectedItem?.ID ]
+		[ __, capabilities, dispatch, openSitePreviewPane, restoreSite, viewType ]
 	);
 }

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -34,12 +34,14 @@ import type { Action } from '@wordpress/dataviews';
 export function useActions( {
 	openSitePreviewPane,
 	selectedItem,
+	viewType,
 }: {
 	openSitePreviewPane?: (
 		site: SiteExcerptData,
 		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher'
 	) => void;
 	selectedItem?: SiteExcerptData | null;
+	viewType: 'list' | 'table';
 } ): Action< SiteExcerptData >[] {
 	const { __ } = useI18n();
 	const dispatch = useReduxDispatch();
@@ -98,36 +100,37 @@ export function useActions( {
 
 	return useMemo(
 		() => [
-			{
-				id: 'site-overview',
-				isPrimary: true,
-				label: __( 'Overview' ),
-				icon: drawerLeft,
-				callback: ( sites ) => {
-					const site = sites[ 0 ];
-					const adminUrl = site.options?.admin_url ?? '';
-					const isAdmin = capabilities[ site.ID ]?.manage_options;
-					if (
-						isAdmin &&
-						! isP2Site( site ) &&
-						! isNotAtomicJetpack( site ) &&
-						! isDisconnectedJetpackAndNotAtomic( site )
-					) {
-						openSitePreviewPane && openSitePreviewPane( site, 'action' );
-					} else {
-						navigate( adminUrl );
-					}
-				},
-				isEligible: ( site ) => {
-					if ( site.ID === selectedItem?.ID ) {
-						return false;
-					}
-					if ( site.is_deleted ) {
-						return false;
-					}
-					return true;
-				},
-			},
+			...( viewType !== 'list'
+				? [
+						{
+							id: 'site-overview',
+							isPrimary: true,
+							label: __( 'Overview' ),
+							icon: drawerLeft,
+							callback: ( sites: SiteExcerptData[] ) => {
+								const site = sites[ 0 ];
+								const adminUrl = site.options?.admin_url ?? '';
+								const isAdmin = capabilities[ site.ID ]?.manage_options;
+								if (
+									isAdmin &&
+									! isP2Site( site ) &&
+									! isNotAtomicJetpack( site ) &&
+									! isDisconnectedJetpackAndNotAtomic( site )
+								) {
+									openSitePreviewPane && openSitePreviewPane( site, 'action' );
+								} else {
+									navigate( adminUrl );
+								}
+							},
+							isEligible: ( site: SiteExcerptData ) => {
+								if ( site.is_deleted ) {
+									return false;
+								}
+								return true;
+							},
+						},
+				  ]
+				: [] ),
 			{
 				id: 'open-site',
 				isPrimary: true,

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -184,7 +184,11 @@ const DotcomSitesDataViews = ( {
 		[ __, openSitePreviewPane, userId, siteStatusGroups ]
 	);
 
-	const actions = useActions( { openSitePreviewPane, selectedItem } );
+	const actions = useActions( {
+		openSitePreviewPane,
+		selectedItem,
+		viewType: dataViewsState.type,
+	} );
 
 	return (
 		<div className="sites-dataviews">

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -186,7 +186,6 @@ const DotcomSitesDataViews = ( {
 
 	const actions = useActions( {
 		openSitePreviewPane,
-		selectedItem,
 		viewType: dataViewsState.type,
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR changes always to hide the Overview action in the list view. 

When the site panel is open:

|| before | after |
|--------|--------|--------|
|selected (no change) | <img width="399" alt="Screenshot 2024-11-25 at 13 49 26" src="https://github.com/user-attachments/assets/9830fef9-8323-430b-8020-95b5ebf366a5"> | <img width="397" alt="Screenshot 2024-11-25 at 13 49 12" src="https://github.com/user-attachments/assets/d5561415-4018-421c-b50f-1534c17d3433"> | 
|hover| <img width="397" alt="Screenshot 2024-11-25 at 13 49 33" src="https://github.com/user-attachments/assets/5dbff291-af91-4e7e-9767-ad34fe129d9f"> | <img width="398" alt="Screenshot 2024-11-25 at 13 49 07" src="https://github.com/user-attachments/assets/79db579f-1ce1-44d5-b9a3-4bd6ce60d4a4"> | 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- To prevent the logic from running for every selection. 
- To ensure consistency. 
- Since the row-click interaction is already provided for the list view.
- Since It would not work well if the sites view adds support for bulk actions.

More context: https://github.com/Automattic/wp-calypso/pull/96388#discussion_r1853431572

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
