### PR TITLE
Add E2E smoke test for Social on Simple sites

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -95,9 +95,10 @@ export class EditorToolbarComponent {
 	 * @returns {Promise<boolean>} True if target is in an expanded state. False otherwise.
 	 */
 	private async targetIsOpen( target: Locator ): Promise< boolean > {
+		const checked = await target.getAttribute( 'aria-checked' );
 		const pressed = await target.getAttribute( 'aria-pressed' );
 		const expanded = await target.getAttribute( 'aria-expanded' );
-		return pressed === 'true' || expanded === 'true';
+		return checked === 'true' || pressed === 'true' || expanded === 'true';
 	}
 
 	/* Block Inserter */
@@ -322,11 +323,21 @@ export class EditorToolbarComponent {
 
 		// To support i18n tests.
 		const translatedTargetName = await this.translateFromPage( target );
-		const button = editorParent
+
+		let button = editorParent
 			.locator( '.editor-header__settings, .edit-post-header__settings' )
 			.getByLabel( translatedTargetName );
 
+		// For other pinned settings, we need to open the options menu
+		// because those are hidden on mobile/small screens
+		if ( target !== 'Settings' ) {
+			await this.openMoreOptionsMenu();
+
+			button = editorParent.getByRole( 'menuitemcheckbox', { name: translatedTargetName } );
+		}
+
 		if ( await this.targetIsOpen( button ) ) {
+			await this.closeMoreOptionsMenu();
 			return;
 		}
 
@@ -451,9 +462,30 @@ export class EditorToolbarComponent {
 	 * Opens the more options menu (three dots).
 	 */
 	async openMoreOptionsMenu(): Promise< void > {
-		// const label = await this.translateFromPage( moreOptionsLabel );
-		// const selector = selectors.moreOptionsButton( label );
+		const button = await this.getMoreOptionsButton();
 
+		if ( await this.targetIsOpen( button ) ) {
+			return;
+		}
+
+		await button.click();
+	}
+
+	/**
+	 * Closes the more options menu.
+	 */
+	async closeMoreOptionsMenu(): Promise< void > {
+		const button = await this.getMoreOptionsButton();
+
+		if ( await this.targetIsOpen( button ) ) {
+			await button.click();
+		}
+	}
+
+	/**
+	 * Returns the more options button instance.
+	 */
+	async getMoreOptionsButton() {
 		const editorParent = await this.editor.parent();
 
 		// To support i18n tests.
@@ -461,16 +493,10 @@ export class EditorToolbarComponent {
 		// Narrowing down to the "Editor top bar" is needed because it might conflict with
 		// the options button for the block toolbar, causing a strict-mode violation error
 		// due to duplicate elements on the page.
-		const button = editorParent.getByLabel( 'Editor top bar' ).getByRole( 'button', {
+		return editorParent.getByLabel( 'Editor top bar' ).getByRole( 'button', {
 			name: translatedTargetName,
 			exact: true,
 		} );
-
-		if ( await this.targetIsOpen( button ) ) {
-			return;
-		}
-
-		await button.click();
 	}
 
 	/** FSE unique buttons */

--- a/test/e2e/specs/jetpack/social__editor-smoke.ts
+++ b/test/e2e/specs/jetpack/social__editor-smoke.ts
@@ -1,0 +1,49 @@
+/**
+ * @group jetpack-wpcom-integration
+ */
+
+import { DataHelper, EditorPage, SecretsManager, TestAccount } from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+/**
+ * Tests features offered by Jetpack Social.
+ *
+ * Keywords: Social, Jetpack, Publicize
+ */
+describe( DataHelper.createSuiteTitle( 'Social: Editor Smoke test' ), function () {
+	let page: Page;
+	let editorPage: EditorPage;
+
+	const siteSlug =
+		SecretsManager.secrets.testAccounts.simpleSiteFreePlanUser.testSites?.primary.url;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		editorPage = new EditorPage( page );
+
+		const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Verify that Social UI is visible', async function () {
+		await editorPage.visit( 'post', { siteSlug } );
+
+		// Open the Jetpack sidebar.
+		await editorPage.openSettings( 'Jetpack' );
+
+		// Expand the Publicize panel.
+		await editorPage.expandSection( 'Share this post' );
+
+		const editorParent = await editorPage.getEditorParent();
+
+		const toggle = editorParent.getByLabel( 'Share when publishing' );
+
+		expect( await toggle.isChecked() ).toBe( false );
+
+		const link = editorParent.getByRole( 'link', { name: 'Connect an account' } );
+
+		expect( await link.isVisible() ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
Last week, on Simple sites, Publicize in the editor was broken by a Jetpack PR (p1732317266569039-slack-CDLH4C1UZ) and we have no guard against it.

## Proposed Changes

* Add a smoke E2E test for Social on simple sites

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid breaking publicize UI in future

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just verify that CI is happy.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?