### PR TITLE
Sites Dashboard: Remove more unnecessary DataViews style overrides

### DIFF
--- a/client/sites/components/sites-dataviews/dataview-style.scss
+++ b/client/sites/components/sites-dataviews/dataview-style.scss
@@ -3,11 +3,6 @@
 @import "@wordpress/dataviews/build-style/style.css";
 
 .sites-dataviews {
-	.dataviews-wrapper {
-		// Maybe move upstream to the gutenberg repository
-		width: 100%;
-	}
-
 	.dataviews-view-list {
 		// DataView overrides: Ideally instead of reusing the site name full field
 		// We should be setting a media field and a primary field.
@@ -20,112 +15,23 @@
 		}
 	}
 
-	table.dataviews-view-table thead .dataviews-view-table__row th {
-		border-bottom-color: var(--color-border-secondary);
-
-		span,
-		.dataviews-view-table-header-button {
-			color: inherit;
-		}
-	}
-
-	table.dataviews-view-table .dataviews-view-table__row td {
-		border-bottom-color: var(--color-border-secondary);
-	}
-
-	thead tr.dataviews-view-table__row:hover {
-		background: var(--studio-white);
-	}
-
 	tr.dataviews-view-table__row {
-		background: var(--studio-white);
-
-		.components-checkbox-control__input {
-			opacity: 0;
-		}
-		.components-checkbox-control__input:checked,
-		.components-checkbox-control__input:indeterminate {
-			opacity: 1;
-		}
-
-		.dataviews-view-table-selection-checkbox {
-			padding-left: 12px;
-			&.is-selected {
-				.components-checkbox-control__input {
-					opacity: 1;
-				}
-			}
-		}
-
-		&:hover {
-			background-color: #f7faff;
-			.site-set-favorite__favorite-icon,
-			.components-checkbox-control__input {
-				opacity: 1;
-			}
-		}
-
 		th {
-			border-bottom: 1px solid var(--color-neutral-5);
-			font-size: rem(13px);
-			font-weight: 400;
 			vertical-align: middle;
 		}
-
 		td {
-			border-bottom: 1px solid var(--color-neutral-5);
 			vertical-align: middle;
-
-			&:has(.sites-dataviews__site) {
-				width: 20%;
-			}
-		}
-
-		.dataviews-view-table__cell-content-wrapper {
-			font-size: rem(13px);
-		}
-
-		.dataviews-view-table__checkbox-column,
-		.components-checkbox-control__input {
-			label.components-checkbox-control__label {
-				display: none;
-			}
-			&[type="checkbox"] {
-				border-color: var(--color-neutral-5);
-			}
-		}
-
-		.site-sort__clickable {
-			cursor: pointer;
 		}
 	}
 
 	ul.dataviews-view-list {
+		// TODO: Remove when theming APIs are implemented. pbxlJb-6A9-p2#comment-4011
 		li:hover {
 			background: var(--color-neutral-0);
 		}
+		// TODO: Remove when theming APIs are implemented. pbxlJb-6A9-p2#comment-4011
 		.is-selected {
 			background-color: var(--color-neutral-0);
-		}
-
-		// Needs to be moved upstream to the gutenberg repository.
-		.dataviews-view-list__item {
-			box-sizing: border-box;
-		}
-	}
-
-	thead .dataviews-view-table__row th {
-		span,
-		button {
-			font-size: rem(11px);
-			font-weight: 500;
-			line-height: 20px;
-			color: var(--color-accent-80);
-			text-transform: uppercase;
-		}
-
-		.dataviews-view-table-header-button {
-			color: inherit;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9915

## Proposed Changes

This PR removes more DataViews style overrides.

- Most of the overrides removed in this PR were no longer necessary. 
- Some overrides do not apply to Sites Dashboard.

| production | this PR (no changes) |
|--------|--------|
| <img width="1436" alt="Screenshot 2024-11-25 at 16 31 16" src="https://github.com/user-attachments/assets/c0bdd46b-e4cd-4dcb-aeae-581b0f07fd2f"> | <img width="1436" alt="Screenshot 2024-11-25 at 16 31 28" src="https://github.com/user-attachments/assets/39fe0506-815e-4b92-b38e-86ae18bc6738"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pbxlJb-6DF-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites.
* Ensure that no significant visual or functional regressions are introduced.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?