### PR TITLE
Sites Dashboard: Remove vertical-align overrides

### DIFF
--- a/client/sites-dashboard/components/sites-site-name.ts
+++ b/client/sites-dashboard/components/sites-site-name.ts
@@ -9,6 +9,7 @@ export const SiteName = styled.a< { fontSize?: number } >`
 	font-size: ${ ( props ) => `${ props.fontSize }px` };
 	letter-spacing: -0.4px;
 	color: var( --studio-gray-100 );
+	line-height: 18px;
 
 	&:is( a ):hover {
 		text-decoration: underline;

--- a/client/sites/components/sites-dataviews/dataview-style.scss
+++ b/client/sites/components/sites-dataviews/dataview-style.scss
@@ -15,15 +15,6 @@
 		}
 	}
 
-	tr.dataviews-view-table__row {
-		th {
-			vertical-align: middle;
-		}
-		td {
-			vertical-align: middle;
-		}
-	}
-
 	ul.dataviews-view-list {
 		// TODO: Remove when theming APIs are implemented. pbxlJb-6A9-p2#comment-4011
 		li:hover {

--- a/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -37,6 +37,8 @@ const SiteListTile = styled( ListTile )`
 	gap: 0;
 	margin-inline-end: 0;
 	width: 280px;
+	// Position the item at the top to align with Core.
+	align-items: revert;
 
 	.preview-hidden & {
 		gap: 12px;

--- a/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -37,7 +37,7 @@ const SiteListTile = styled( ListTile )`
 	gap: 0;
 	margin-inline-end: 0;
 	width: 280px;
-	// Position the item at the top to align with Core.
+	// Position the item at the top to align with Core, reverting ListTile's default centering.
 	align-items: revert;
 
 	.preview-hidden & {

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -93,7 +93,13 @@ const DotcomSitesDataViews = ( {
 			{
 				id: 'icon',
 				render: ( { item }: { item: SiteExcerptData } ) => {
-					return <SiteIcon site={ item } openSitePreviewPane={ openSitePreviewPane } />;
+					return (
+						<SiteIcon
+							site={ item }
+							openSitePreviewPane={ openSitePreviewPane }
+							viewType={ dataViewsState.type }
+						/>
+					);
 				},
 				enableHiding: false,
 				enableSorting: false,
@@ -159,7 +165,7 @@ const DotcomSitesDataViews = ( {
 				getValue: () => null,
 			},
 		],
-		[ __, openSitePreviewPane, userId, siteStatusGroups ]
+		[ __, siteStatusGroups, openSitePreviewPane, dataViewsState.type, userId ]
 	);
 
 	const actions = useActions( {

--- a/client/sites/components/sites-dataviews/site-icon.tsx
+++ b/client/sites/components/sites-dataviews/site-icon.tsx
@@ -17,12 +17,14 @@ import type { SiteExcerptData } from '@automattic/sites';
 export default function SiteIcon( {
 	site,
 	openSitePreviewPane,
+	viewType,
 }: {
 	site: SiteExcerptData;
 	openSitePreviewPane: (
 		site: SiteExcerptData,
 		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher'
 	) => void;
+	viewType: 'list' | 'table' | 'grid';
 } ) {
 	const { adminUrl } = useSiteAdminInterfaceData( site.ID );
 	const isP2Site = site.options?.theme_slug && isP2Theme( site.options?.theme_slug );
@@ -56,7 +58,7 @@ export default function SiteIcon( {
 				className="sites-site-favicon"
 				blogId={ site.ID }
 				fallback={ isMigrationPending ? 'migration' : 'first-grapheme' }
-				size={ 52 }
+				size={ viewType === 'list' ? 52 : 32 }
 			/>
 		</ThumbnailLink>
 	);

--- a/client/sites/components/sites-dataviews/style.scss
+++ b/client/sites/components/sites-dataviews/style.scss
@@ -10,8 +10,7 @@
 	.sites-dataviews__site {
 		display: flex;
 		flex-direction: row;
-		// not to cut off the focus outline
-		padding-left: 2px;
+		padding: 0;
 		overflow: hidden;
 		cursor: pointer;
 
@@ -129,20 +128,5 @@
 		[role="menuitemradio"] {
 			border-radius: 4px;
 		}
-	}
-}
-
-.sites-dashboard__layout:not(.preview-hidden) {
-	.sites-dataviews__preview-trigger {
-		flex-shrink: 0;
-	}
-
-	.sites-dataviews__site {
-		padding: 2px 0 2px 2px;
-	}
-
-	.sites-dataviews__site-name {
-		padding: 0;
-		align-self: flex-start;
 	}
 }

--- a/client/sites/components/sites-dataviews/style.scss
+++ b/client/sites/components/sites-dataviews/style.scss
@@ -61,6 +61,7 @@
 		text-overflow: ellipsis;
 		overflow: hidden;
 		white-space: nowrap;
+		line-height: 18px;
 	}
 
 	.sites-dataviews__site-url {

--- a/client/sites/components/sites-dataviews/style.scss
+++ b/client/sites/components/sites-dataviews/style.scss
@@ -10,8 +10,6 @@
 	.sites-dataviews__site {
 		display: flex;
 		flex-direction: row;
-		padding-bottom: 8px;
-		padding-top: 8px;
 		// not to cut off the focus outline
 		padding-left: 2px;
 		overflow: hidden;
@@ -50,7 +48,6 @@
 	}
 
 	.sites-dataviews__site-name {
-		align-self: center;
 		display: inline-block;
 		text-align: left;
 		text-overflow: ellipsis;
@@ -110,6 +107,9 @@
 		color: var(--color-warning-80);
 	}
 
+	.stats-sparkline {
+		padding-top: 0;
+	}
 }
 
 .is-section-a8c-for-agencies-sites {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9915

## Proposed Changes

This PR removes vertical-align overrides from the Sites Dashboard. 
Also, it aligns icon size with that of A4A: https://github.com/Automattic/dotcom-forge/issues/9949.

before
<img width="1126" alt="Screenshot 2024-11-25 at 17 07 54" src="https://github.com/user-attachments/assets/0d3148d4-4258-4f76-ad05-007b6a203f4a">

after
<img width="876" alt="Screenshot 2024-11-26 at 16 04 33" src="https://github.com/user-attachments/assets/002dea31-a952-46a6-b859-fe0263b3e297">

<details><summary>ver. 1</summary>
<p>

<img width="1370" alt="Screenshot 2024-11-26 at 14 22 29" src="https://github.com/user-attachments/assets/449c602d-6e71-4a49-89a6-bf838dd9a3ff">

</p>
</details> 

In Core, `td` elements have a `min-height = 32px`. As a result, any content taller than 36px (such as SiteField or Status in the screenshot) will appear with reduced spacing at the top. CC: @matt-west @lucasmendes-design 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pbxlJb-6DF-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Ensure that no unexpected visual changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?