### PR TITLE
Stats: Align period header styles with design

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -456,14 +456,6 @@ class StatsSite extends Component {
 					isOdysseyStats={ isOdysseyStats }
 					statsPurchaseSuccess={ context.query.statsPurchaseSuccess }
 				/>
-				{ isNewDateFilteringEnabled && (
-					<div
-						className="stats-new-date-filtering-callout"
-						style={ { background: 'antiquewhite', maring: '24px', padding: '24px' } }
-					>
-						<p>New date filtering enabled.</p>
-					</div>
-				) }
 				{ ! isNewDateFilteringEnabled && (
 					// @TODO: remove highlight section completely once flag is released
 					<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -8,7 +8,12 @@
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: center;
-	margin: 16px 0;
+	// .stats-content has a gap already, so the .stats__period-header from the new design only needs margin-top.
+	margin-top: 16px;
+
+	.stats-content & {
+		margin: 16px 0;
+	}
 
 	.period {
 		font-family: $brand-serif;
@@ -20,6 +25,7 @@
 	 // this new selector removes padding only for the date filtering design
 		&.stats-period-navigation__is-with-new-date-filtering {
 			padding: 0;
+			align-items: center;
 
 			@media (max-width: $break-medium) {
 				padding: 0 16px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/213

## Proposed Changes

* Adjust Stats period header styles and layout to align with the design.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To finalize the styles and layout for convenient testing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page with the feature flag: `?flags=stats/new-date-filtering`.
* Ensure the period header styling and layout are aligned with the design.

|Before|After|
|-|-|
|<img width="1281" alt="截圖 2024-11-25 下午5 31 18" src="https://github.com/user-attachments/assets/79b42b97-efb3-452c-a959-3926eeba593e">|<img width="1283" alt="截圖 2024-11-25 下午5 25 33" src="https://github.com/user-attachments/assets/449b82b3-cc70-41d5-9f24-0e2615d1b88d">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
