### PR TITLE
Stats: Fix for blank Summary pages

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -273,7 +273,10 @@ class StatsSite extends Component {
 			return undefined;
 		}
 
-		let url = `/stats/${ period.period }/${ path }/${ slug }`;
+		// Summary pages don't support hourly periods so we default to daily.
+		const finalPeriod = period.period === 'hour' ? 'day' : period.period;
+
+		let url = `/stats/${ finalPeriod }/${ path }/${ slug }`;
 
 		if ( query?.start_date ) {
 			url += `?startDate=${ query.start_date }&endDate=${ query.date }`;

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -90,7 +90,10 @@ class StatsModule extends Component {
 			return undefined;
 		}
 
-		let url = `/stats/${ period.period }/${ path }/${ siteSlug }`;
+		// Summary pages don't support hourly periods so we default to daily.
+		const finalPeriod = period.period === 'hour' ? 'day' : period.period;
+
+		let url = `/stats/${ finalPeriod }/${ path }/${ siteSlug }`;
 
 		if ( query?.start_date ) {
 			url += `?startDate=${ query.start_date }&endDate=${ query.date }`;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The addition of `hour` as a period results in blank Summary pages. As a workaround, we detect this and make sure our "View all" links on the Traffic page use `day` instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To prevent blank Summary pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable date filtering: `&flags=stats/new-date-filtering`
* Click into a single day on the chart so that it updates to showing hourly data.
* Hover over the "View all" link for any module and confirm the path contains `/stats/day` instead of `/stats/hour`.
* Click the link and confirm the Summary page loads and shows results.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
