### PR TITLE
Open sites-per-plugin view on name click

### DIFF
--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -37,6 +37,15 @@ body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management,
     .dataviews-pagination {
         padding: 12px 16px 12px 16px;
     }
+
+    .plugin-name-button {
+        padding: 0;
+        cursor: pointer;
+
+        &:focus {
+            box-shadow: none;
+        }
+    }
 }
 
 .is-section-jetpack-cloud-plugin-management {

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -66,18 +66,15 @@ export function useFields(
 
 					return (
 						<>
-							{ item.icon && <img className="plugin-icon" alt={ item.name } src={ item.icon } /> }
-							{ ! item.icon && <Icon size={ 32 } icon={ plugins } className="plugin-icon" /> }
-							{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-							<a
-								href="#"
+							<button
 								onClick={ () => toggleDialogForPlugin( item ) }
 								onKeyDown={ ( e ) => e.key === 'Enter' && toggleDialogForPlugin( item ) }
-								role="button"
-								tabIndex={ 0 }
+								className="components-button plugin-name-button"
 							>
+								{ item.icon && <img className="plugin-icon" alt={ item.name } src={ item.icon } /> }
+								{ ! item.icon && <Icon size={ 32 } icon={ plugins } className="plugin-icon" /> }
 								{ item.name }
-							</a>
+							</button>
 							{ pluginActionStatus }
 						</>
 					);

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -68,7 +68,16 @@ export function useFields(
 						<>
 							{ item.icon && <img className="plugin-icon" alt={ item.name } src={ item.icon } /> }
 							{ ! item.icon && <Icon size={ 32 } icon={ plugins } className="plugin-icon" /> }
-							<a href={ '/plugins/' + item.slug }>{ item.name }</a>
+							{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+							<a
+								href="#"
+								onClick={ () => toggleDialogForPlugin( item ) }
+								onKeyDown={ ( e ) => e.key === 'Enter' && toggleDialogForPlugin( item ) }
+								role="button"
+								tabIndex={ 0 }
+							>
+								{ item.name }
+							</a>
 							{ pluginActionStatus }
 						</>
 					);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9937

## Proposed Changes

* Instead of open plugin manage page, open the sites-per-plugin view

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Align with current UX in Jetpack Manage Plugin management

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /plugins/manage
* Click on the plugin; should now show the sites-per-plugin view

![sites-per-plugin@2x](https://github.com/user-attachments/assets/cbf2bb92-04a5-45af-9bb3-a678786fa50b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
