### PR TITLE
I18N-169 i18n: Add AI Translations Banner

### DIFF
--- a/client/blocks/ai-translations-banner/index.jsx
+++ b/client/blocks/ai-translations-banner/index.jsx
@@ -20,7 +20,10 @@ export default function AITranslationsBanner() {
 		return <QueryLocaleSuggestions />;
 	}
 
-	if ( ! isAITranslatedLocale( localeSuggestions?.[ 0 ]?.locale ) ) {
+	if (
+		! isCurrentlyUsingAITranslatedLocale &&
+		! isAITranslatedLocale( localeSuggestions?.[ 0 ]?.locale )
+	) {
 		return;
 	}
 

--- a/client/blocks/ai-translations-banner/index.jsx
+++ b/client/blocks/ai-translations-banner/index.jsx
@@ -1,23 +1,15 @@
 import { getLanguage, isAITranslatedLocale, isDefaultLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
-import { useDispatch } from 'react-redux';
-import { dismissCard } from 'calypso/blocks/dismissible-card/actions';
 import Banner from 'calypso/components/banner';
 import QueryLocaleSuggestions from 'calypso/components/data/query-locale-suggestions';
 import { useSelector } from 'calypso/state';
 import getLocaleSuggestions from 'calypso/state/selectors/get-locale-suggestions';
-import { setUserSetting } from 'calypso/state/user-settings/actions';
-import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 
 const BANNER_NAME = 'ai_translations_banner';
 
 export default function AITranslationsBanner() {
 	const translate = useTranslate();
 	const localeSuggestions = useSelector( getLocaleSuggestions );
-	const dispatch = useDispatch();
-	const [ isBusy, setIsBusy ] = useState( false );
-
 	const isCurrentlyUsingAITranslatedLocale = isAITranslatedLocale( translate.localeSlug );
 
 	if ( ! isDefaultLocale( translate.localeSlug ) && ! isCurrentlyUsingAITranslatedLocale ) {
@@ -33,14 +25,6 @@ export default function AITranslationsBanner() {
 	}
 
 	const language = getLanguage( localeSuggestions?.[ 0 ]?.locale );
-	const handleClick = async () => {
-		setIsBusy( true );
-		dispatch( setUserSetting( 'language', language.langSlug ) );
-		await dispatch( saveUnsavedUserSettings( [ 'language' ] ) );
-		dispatch( dismissCard( BANNER_NAME ) );
-
-		window.location.reload();
-	};
 
 	return (
 		<Banner
@@ -59,10 +43,8 @@ export default function AITranslationsBanner() {
 			}
 			event={ BANNER_NAME }
 			dismissPreferenceName={ BANNER_NAME }
-			onClick={ handleClick }
-			isBusy={ isBusy }
+			href="/me/account"
 			horizontal
-			disableHref
 		/>
 	);
 }

--- a/client/blocks/ai-translations-banner/index.jsx
+++ b/client/blocks/ai-translations-banner/index.jsx
@@ -33,8 +33,13 @@ export default function AITranslationsBanner() {
 				args: [ language.name ],
 			} ) }
 			description={ translate(
-				"We've added translations for %s, combining AI technology and a human touch. Help us improve by sharing feedback.",
-				{ args: [ language.name ] }
+				"We've added translations for %s, combining AI technology and a human touch. Help us improve by {{feedbackLink}}sharing feedback{{/feedbackLink}}.",
+				{
+					args: [ language.name ],
+					components: {
+						feedbackLink: <a href="https://wordpress.com/forums/forum/translations/" />,
+					},
+				}
 			) }
 			callToAction={
 				isCurrentlyUsingAITranslatedLocale

--- a/client/blocks/ai-translations-banner/index.jsx
+++ b/client/blocks/ai-translations-banner/index.jsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import Banner from 'calypso/components/banner';
 import QueryLocaleSuggestions from 'calypso/components/data/query-locale-suggestions';
 import { useSelector } from 'calypso/state';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import getLocaleSuggestions from 'calypso/state/selectors/get-locale-suggestions';
 
 const BANNER_NAME = 'ai_translations_banner';
@@ -10,9 +11,10 @@ const BANNER_NAME = 'ai_translations_banner';
 export default function AITranslationsBanner() {
 	const translate = useTranslate();
 	const localeSuggestions = useSelector( getLocaleSuggestions );
-	const isCurrentlyUsingAITranslatedLocale = isAITranslatedLocale( translate.localeSlug );
+	const userLocaleSlug = useSelector( getCurrentUserLocale );
+	const isCurrentlyUsingAITranslatedLocale = isAITranslatedLocale( userLocaleSlug );
 
-	if ( ! isDefaultLocale( translate.localeSlug ) && ! isCurrentlyUsingAITranslatedLocale ) {
+	if ( ! isDefaultLocale( userLocaleSlug ) && ! isCurrentlyUsingAITranslatedLocale ) {
 		return null;
 	}
 
@@ -28,7 +30,7 @@ export default function AITranslationsBanner() {
 	}
 
 	const localeSlug = isCurrentlyUsingAITranslatedLocale
-		? translate.localeSlug
+		? userLocaleSlug
 		: localeSuggestions?.[ 0 ]?.locale;
 
 	const language = getLanguage( localeSlug );

--- a/client/blocks/ai-translations-banner/index.jsx
+++ b/client/blocks/ai-translations-banner/index.jsx
@@ -24,7 +24,11 @@ export default function AITranslationsBanner() {
 		return;
 	}
 
-	const language = getLanguage( localeSuggestions?.[ 0 ]?.locale );
+	const localeSlug = isCurrentlyUsingAITranslatedLocale
+		? translate.localeSlug
+		: localeSuggestions?.[ 0 ]?.locale;
+
+	const language = getLanguage( localeSlug );
 
 	return (
 		<Banner

--- a/client/blocks/ai-translations-banner/index.jsx
+++ b/client/blocks/ai-translations-banner/index.jsx
@@ -1,0 +1,68 @@
+import { getLanguage, isAITranslatedLocale, isDefaultLocale } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { dismissCard } from 'calypso/blocks/dismissible-card/actions';
+import Banner from 'calypso/components/banner';
+import QueryLocaleSuggestions from 'calypso/components/data/query-locale-suggestions';
+import { useSelector } from 'calypso/state';
+import getLocaleSuggestions from 'calypso/state/selectors/get-locale-suggestions';
+import { setUserSetting } from 'calypso/state/user-settings/actions';
+import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
+
+const BANNER_NAME = 'ai_translations_banner';
+
+export default function AITranslationsBanner() {
+	const translate = useTranslate();
+	const localeSuggestions = useSelector( getLocaleSuggestions );
+	const dispatch = useDispatch();
+	const [ isBusy, setIsBusy ] = useState( false );
+
+	const isCurrentlyUsingAITranslatedLocale = isAITranslatedLocale( translate.localeSlug );
+
+	if ( ! isDefaultLocale( translate.localeSlug ) && ! isCurrentlyUsingAITranslatedLocale ) {
+		return null;
+	}
+
+	if ( ! localeSuggestions ) {
+		return <QueryLocaleSuggestions />;
+	}
+
+	if ( ! isAITranslatedLocale( localeSuggestions?.[ 0 ]?.locale ) ) {
+		return;
+	}
+
+	const language = getLanguage( localeSuggestions?.[ 0 ]?.locale );
+	const handleClick = async () => {
+		setIsBusy( true );
+		dispatch( setUserSetting( 'language', language.langSlug ) );
+		await dispatch( saveUnsavedUserSettings( [ 'language' ] ) );
+		dispatch( dismissCard( BANNER_NAME ) );
+
+		window.location.reload();
+	};
+
+	return (
+		<Banner
+			icon="globe"
+			title={ translate( 'WordPress.com is now available in %s!', {
+				args: [ language.name ],
+			} ) }
+			description={ translate(
+				"We've added translations for %s, combining AI technology and a human touch. Help us improve by sharing feedback.",
+				{ args: [ language.name ] }
+			) }
+			callToAction={
+				isCurrentlyUsingAITranslatedLocale
+					? undefined
+					: translate( 'Switch to %s', { args: [ language.name ] } )
+			}
+			event={ BANNER_NAME }
+			dismissPreferenceName={ BANNER_NAME }
+			onClick={ handleClick }
+			isBusy={ isBusy }
+			horizontal
+			disableHref
+		/>
+	);
+}

--- a/client/blocks/ai-translations-banner/index.jsx
+++ b/client/blocks/ai-translations-banner/index.jsx
@@ -42,13 +42,13 @@ export default function AITranslationsBanner() {
 				}
 			) }
 			callToAction={
-				isCurrentlyUsingAITranslatedLocale
-					? undefined
-					: translate( 'Switch to %s', { args: [ language.name ] } )
+				! isCurrentlyUsingAITranslatedLocale &&
+				translate( 'Switch to %s', { args: [ language.name ] } )
 			}
 			event={ BANNER_NAME }
 			dismissPreferenceName={ BANNER_NAME }
 			href="/me/account"
+			disableHref={ isCurrentlyUsingAITranslatedLocale }
 			horizontal
 		/>
 	);

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -5,6 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
+import AITranslationsBanner from 'calypso/blocks/ai-translations-banner';
 import SiteIcon from 'calypso/blocks/site-icon';
 import AsyncLoad from 'calypso/components/async-load';
 import EmptyContent from 'calypso/components/empty-content';
@@ -292,6 +293,7 @@ const HomeContent = ( {
 			{ siteId && isJetpack && isPossibleJetpackConnectionProblem && (
 				<JetpackConnectionHealthBanner siteId={ siteId } />
 			) }
+			<AITranslationsBanner />
 			{ header }
 			{ ! isLoading && ! layout && homeLayoutError ? (
 				<TrackComponentView
@@ -302,11 +304,13 @@ const HomeContent = ( {
 					} }
 				/>
 			) : null }
+<<<<<<< HEAD
 
 			{ renderStudioSyncNotice() }
+=======
+>>>>>>> 2bf7e03b481 (i18n: Add AI Translations Banner)
 			{ renderUnverifiedEmailNotice() }
 			{ renderDnsSettingsDiagnosticNotice() }
-
 			{ isLoading && <div className="customer-home__loading-placeholder"></div> }
 			{ ! isLoading && layout && ! homeLayoutError ? (
 				<>

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -304,11 +304,7 @@ const HomeContent = ( {
 					} }
 				/>
 			) : null }
-<<<<<<< HEAD
-
 			{ renderStudioSyncNotice() }
-=======
->>>>>>> 2bf7e03b481 (i18n: Add AI Translations Banner)
 			{ renderUnverifiedEmailNotice() }
 			{ renderDnsSettingsDiagnosticNotice() }
 			{ isLoading && <div className="customer-home__loading-placeholder"></div> }

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -297,5 +297,5 @@ export function retrieveLocaleFromPathLocaleInFront( path: string ): string {
  * @returns {boolean}
  */
 export function isAITranslatedLocale( locale: string ) {
-	return [ 'el', 'fi', 'hu', 'nb', 'pl', 'th' ].indexOf( locale ) > -1;
+	return [ 'el', 'nb' ].indexOf( locale ) > -1;
 }

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -289,3 +289,7 @@ export function retrieveLocaleFromPathLocaleInFront( path: string ): string {
 
 	return 'en';
 }
+
+export function isAITranslatedLocale( locale: string ) {
+	return [ 'el', 'fi', 'hu', 'nb', 'pl', 'th' ].indexOf( locale ) > -1;
+}

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -291,7 +291,7 @@ export function retrieveLocaleFromPathLocaleInFront( path: string ): string {
 }
 
 /**
- * Check whether the provided locale is translated wit AI.
+ * Check whether the provided locale is translated with AI.
  *
  * @param {string} locale Locale slug
  * @returns {boolean}

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -290,6 +290,12 @@ export function retrieveLocaleFromPathLocaleInFront( path: string ): string {
 	return 'en';
 }
 
+/**
+ * Check whether the provided locale is translated wit AI.
+ *
+ * @param {string} locale Locale slug
+ * @returns {boolean}
+ */
 export function isAITranslatedLocale( locale: string ) {
 	return [ 'el', 'fi', 'hu', 'nb', 'pl', 'th' ].indexOf( locale ) > -1;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#886

## Proposed Changes

* Display banner about the AI translated locales (Norwegian, Polish, Finish, Thai, Greek, or Hungarian) for users that:
  * Users that have their browser primary language set to one of the AI translated locales, and use English on their WordPress.com account.
  * Users that have their browser primary language set to one of the AI translated locales, and use any of the AI translated locales on their WordPress.com account.

**Preview:**
![AbkHhvVThWuQyNRb](https://github.com/user-attachments/assets/ac0e9e0d-5ebf-46d7-948d-9a68fa21ec68)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We'd like to notify users about the machine translated locales. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply code-D167396.
* Set the primary language of your browser to one of the machine translated locales - Norwegian, Polish, Finish, Thai, Greek, or Hungarian.
* Change your WordPress.com account language to English.
* Visit the home screen - `/home/`.
* Confirm the banner is being displayed.
* Change your WordPress.com account language to one of the machine translated locales - Norwegian, Polish, Finish, Thai, Greek, or Hungarian.
* Visit the home screen again - `/home/`.
* Confirm the banner is displayed again but without the CTA.
* Change your account to any other language and confirm the banner is no longer displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
