### PR TITLE
Marketplace: match category name in titles

### DIFF
--- a/client/data/marketplace/search-api.ts
+++ b/client/data/marketplace/search-api.ts
@@ -181,6 +181,8 @@ function getFilterByCategory( category: string ): {
 	return {
 		bool: {
 			should: [
+				// matching category name from titles
+				{ match: { 'plugin.title.en': category } },
 				// matching wp.org categories and tags
 				{ term: { 'taxonomy.plugin_category.slug': category } },
 				{ terms: { 'taxonomy.plugin_tags.slug': categoryTags || [ category ] } },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9829

## Proposed Changes

This PR updates the ES query to also match plugins whose titles contain the category name. Even if a plugin is not tagged or categorized with a specific category, it will be included on the category page if the title contains the exact category name. This can add a lot of results to extension categories of services, eg. WooCommerce, Paypal, etc.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/dotcom-forge/issues/9829

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch D167088-code and sandbox `public-api`
* On this PR env, go to `/plugins/browse/braintree`
* Check that the [Braintree for WooCommerce Payment Gateway](https://wordpress.com/plugins/woocommerce-gateway-paypal-powered-by-braintree) plugin is shown on the list
* Check other categories for possible regressions

| Header | Header |
|--------|--------|
| ![CleanShot 2024-11-25 at 16 15 27@2x](https://github.com/user-attachments/assets/cb8fe107-62b5-44ed-a5bc-2114bb765e4b) | ![CleanShot 2024-11-25 at 16 16 12@2x](https://github.com/user-attachments/assets/bf1ef598-5234-400f-be0f-708f04a87931) |