### PR TITLE
Global Theme Showcase: Make layout full width

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -60,6 +60,7 @@ $button-border: 4px;
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			max-width: none;
 			overflow-y: auto;
+			padding-bottom: 0;
 		}
 	}
 
@@ -70,7 +71,6 @@ $button-border: 4px;
 
 		@media screen and (min-width: 960px) {
 			padding: 24px 20px;
-			box-sizing: initial;
 		}
 	}
 }

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -36,16 +36,12 @@
 			height: 100%;
 		}
 		.themes__header-navigation-container {
-			margin-left: -14px;
-			margin-right: -14px;
 			@media (min-width: $break-small) {
 				border-block-end: 1px solid var(--color-border-secondary);
 			}
 		}
 		.navigation-header {
 			padding-top: 24px;
-			max-width: 1400px;
-			margin: 0 auto;
 			padding-inline: 48px;
 			@media (max-width: 402px) {
 				padding-inline: 24px;
@@ -83,8 +79,6 @@
 			}
 			.themes__controls,
 			.themes__showcase {
-				margin-left: -14px;
-				margin-right: -14px;
 				@media (max-width: $break-small) {
 					padding: 0;
 				}
@@ -104,7 +98,6 @@
 					padding-inline: 24px;
 				}
 				box-sizing: border-box;
-				max-width: 1400px;
 			}
 		}
 	}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -24,6 +24,7 @@
 			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			max-width: none;
+			padding-bottom: 0;
 			@media (max-width: $break-mobile), (max-height: $break-mobile) {
 				overflow-y: auto;
 				overflow-x: hidden;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/96721

## Proposed Changes

Adjusts the layout of the `/themes` screen in the global view so it's aligned with the full width layout used on `/sites`.

This also prevents the scrollbar from bleeding into the grey border outside of the white frame (see screenshots for the medium viewport below).

Additionally, the white space that was appearing at the bottom of the page in some viewports (e.g. medium, tablet) has been removed.

Viewport | `/sites` | `/themes` (before) | `/themes` (after)
--- | --- | --- | ---
Large | <img width="2672" alt="Screenshot 2024-11-26 at 11 59 51" src="https://github.com/user-attachments/assets/43e4207a-1ecf-4066-a10a-a087a9a6bc2a"> | <img width="2672" alt="Screenshot 2024-11-26 at 12 01 05" src="https://github.com/user-attachments/assets/39e895aa-a26e-4b8c-9031-acd8e9a72720"> | <img width="2672" alt="Screenshot 2024-11-26 at 12 03 05" src="https://github.com/user-attachments/assets/eb55785c-6b51-4734-8f89-6268a93e0709">
Medium | <img width="1392" alt="Screenshot 2024-11-26 at 12 00 01" src="https://github.com/user-attachments/assets/98be5df4-eca0-4a3c-88d4-86048f60148e"> | <img width="1392" alt="Screenshot 2024-11-26 at 12 01 13" src="https://github.com/user-attachments/assets/e85989d6-d0c3-4f96-95e7-8e4094a42842"> | <img width="1392" alt="Screenshot 2024-11-26 at 12 03 11" src="https://github.com/user-attachments/assets/296ebed4-2413-485a-9222-bcf2332ab01a">
Tablet | <img width="764" alt="Screenshot 2024-11-26 at 12 00 37" src="https://github.com/user-attachments/assets/ab77538b-a5f6-4432-bc23-8ac117e739d2"> | <img width="772" alt="Screenshot 2024-11-26 at 12 02 24" src="https://github.com/user-attachments/assets/5d7c3250-4718-4d98-b326-2d62f687aa2b"> | <img width="786" alt="Screenshot 2024-11-26 at 12 03 26" src="https://github.com/user-attachments/assets/4fb2400d-61c1-4336-92cd-05a2158a62fe">
Mobile | <img width="534" alt="Screenshot 2024-11-26 at 12 00 49" src="https://github.com/user-attachments/assets/5f29b186-ec91-4cf1-8104-3177e11261dc"> | <img width="484" alt="Screenshot 2024-11-26 at 12 02 40" src="https://github.com/user-attachments/assets/f3889b30-cb25-4856-b619-9cf747ef8b9f"> | <img width="490" alt="Screenshot 2024-11-26 at 12 03 36" src="https://github.com/user-attachments/assets/73f24103-f482-4663-9e40-7b02ee903471">


This PR also applies some fixes to the Global Theme Details page so the white bottom space is removed and the horizontal scroll is prevented. Note that no layout changes have been applied to the Global Theme Details page, so the content still has a max width.

Viewport | `/theme/:theme` (before) | `/themes/:theme` (after)
--- | --- | ---
Tablet | <img width="802" alt="Screenshot 2024-11-26 at 12 05 04" src="https://github.com/user-attachments/assets/842ff497-ab93-4741-99c9-de5889c5c2f2"> | <img width="763" alt="Screenshot 2024-11-26 at 12 05 52" src="https://github.com/user-attachments/assets/28d66410-261b-44d3-a432-8fd12a631de6">


## Why are these changes being made?

Because we want both layouts to be aligned.

## Testing Instructions

- Use the Calypso live link below
- While logged in, go to `/themes`
- Make sure the layout (margins, width of the content) matches the one in `/sites`
- Try with different viewports to make sure it looks good with different browser widths
- Select a theme and make sure that there is no white space at the bottom. Also check that there is no horizontal scroll. 
- Make sure there are no regression in the LOTS (`/themes` while logged out) and in the TS for a site (`/themes/:site`).
