### PR TITLE
Stepper Tracking: Remove checks that prevent step start tracking

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -15,6 +15,10 @@ import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
 import useSnakeCasedKeys from 'calypso/landing/stepper/utils/use-snake-cased-keys';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
+import {
+	getSignupCompleteFlowNameAndClear,
+	getSignupCompleteStepNameAndClear,
+} from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
 import { isRequestingSite } from 'calypso/state/sites/selectors';
 import type { Flow } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -74,12 +78,26 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 			return;
 		}
 
+		const signupCompleteFlowName = getSignupCompleteFlowNameAndClear();
+		const signupCompleteStepName = getSignupCompleteStepNameAndClear();
+		const isReEnteringStepAfterSignupComplete =
+			signupCompleteFlowName === flowName && signupCompleteStepName === stepSlug;
+
+		const reenteringStepAfterSignupCompleteProps = {
+			...( isReEnteringStepAfterSignupComplete && {
+				is_reentering_step_after_signup_complete: true,
+			} ),
+			...( signupCompleteFlowName && { signup_complete_flow_name: signupCompleteFlowName } ),
+			...( signupCompleteStepName && { signup_complete_step_name: signupCompleteStepName } ),
+		};
+
 		recordStepStart( flowName, kebabCase( stepSlug ), {
 			intent,
 			is_in_hosting_flow: isAnyHostingFlow( flowName ),
 			...( design && { assembler_source: getAssemblerSource( design ) } ),
 			...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
 			...( skipStepRender && { skip_step_render: skipStepRender } ),
+			...reenteringStepAfterSignupCompleteProps,
 			...signupStepStartProps,
 		} );
 
@@ -87,7 +105,11 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 		stepCompleteEventPropsRef.current = {
 			flow: flowName,
 			step: stepSlug,
-			optionalProps: { intent, ...( skipStepRender && { skip_step_render: skipStepRender } ) },
+			optionalProps: {
+				intent,
+				...( skipStepRender && { skip_step_render: skipStepRender } ),
+				...reenteringStepAfterSignupCompleteProps,
+			},
 		};
 
 		const stepOldSlug = getStepOldSlug( stepSlug );
@@ -98,6 +120,7 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 				...( design && { assembler_source: getAssemblerSource( design ) } ),
 				...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
 				...( skipStepRender && { skip_step_render: skipStepRender } ),
+				...reenteringStepAfterSignupCompleteProps,
 				...signupStepStartProps,
 			} );
 		}
@@ -107,6 +130,7 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 		const params = {
 			flow: flowName,
 			...( skipStepRender && { skip_step_render: skipStepRender } ),
+			...reenteringStepAfterSignupCompleteProps,
 		};
 		recordPageView( pathname, pageTitle, params );
 

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -15,10 +15,6 @@ import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
 import useSnakeCasedKeys from 'calypso/landing/stepper/utils/use-snake-cased-keys';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
-import {
-	getSignupCompleteFlowNameAndClear,
-	getSignupCompleteStepNameAndClear,
-} from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
 import { isRequestingSite } from 'calypso/state/sites/selectors';
 import type { Flow } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -78,14 +74,25 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 			return;
 		}
 
-		const signupCompleteFlowName = getSignupCompleteFlowNameAndClear();
-		const signupCompleteStepName = getSignupCompleteStepNameAndClear();
+		recordStepStart( flowName, kebabCase( stepSlug ), {
+			intent,
+			is_in_hosting_flow: isAnyHostingFlow( flowName ),
+			...( design && { assembler_source: getAssemblerSource( design ) } ),
+			...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
+			...( skipStepRender && { skip_step_render: skipStepRender } ),
+			...signupStepStartProps,
+		} );
 
-		const isReEnteringStep =
-			signupCompleteFlowName === flowName && signupCompleteStepName === stepSlug;
+		// Apply the props to record in the exit/step-complete event. We only record this if start event gets recorded.
+		stepCompleteEventPropsRef.current = {
+			flow: flowName,
+			step: stepSlug,
+			optionalProps: { intent, ...( skipStepRender && { skip_step_render: skipStepRender } ) },
+		};
 
-		if ( ! isReEnteringStep ) {
-			recordStepStart( flowName, kebabCase( stepSlug ), {
+		const stepOldSlug = getStepOldSlug( stepSlug );
+		if ( stepOldSlug ) {
+			recordStepStart( flowName, kebabCase( stepOldSlug ), {
 				intent,
 				is_in_hosting_flow: isAnyHostingFlow( flowName ),
 				...( design && { assembler_source: getAssemblerSource( design ) } ),
@@ -93,25 +100,6 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 				...( skipStepRender && { skip_step_render: skipStepRender } ),
 				...signupStepStartProps,
 			} );
-
-			// Apply the props to record in the exit/step-complete event. We only record this if start event gets recorded.
-			stepCompleteEventPropsRef.current = {
-				flow: flowName,
-				step: stepSlug,
-				optionalProps: { intent, ...( skipStepRender && { skip_step_render: skipStepRender } ) },
-			};
-
-			const stepOldSlug = getStepOldSlug( stepSlug );
-			if ( stepOldSlug ) {
-				recordStepStart( flowName, kebabCase( stepOldSlug ), {
-					intent,
-					is_in_hosting_flow: isAnyHostingFlow( flowName ),
-					...( design && { assembler_source: getAssemblerSource( design ) } ),
-					...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
-					...( skipStepRender && { skip_step_render: skipStepRender } ),
-					...signupStepStartProps,
-				} );
-			}
 		}
 
 		// Also record page view for data and analytics

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
@@ -170,13 +170,20 @@ describe( 'StepRoute', () => {
 			} );
 		} );
 
-		it( 'skips tracking when the step is re-entered', () => {
+		it( 'records recordStepStart with additional props when the step is re-entered', () => {
 			( getSignupCompleteFlowNameAndClear as jest.Mock ).mockReturnValue( 'some-flow' );
 			( getSignupCompleteStepNameAndClear as jest.Mock ).mockReturnValue( 'some-step-slug' );
 
 			render( { step: regularStep } );
 
-			expect( recordStepStart ).not.toHaveBeenCalled();
+			expect( recordStepStart ).toHaveBeenCalledWith( 'some-flow', 'some-step-slug', {
+				is_reentering_step_after_signup_complete: true,
+				signup_complete_flow_name: 'some-flow',
+				signup_complete_step_name: 'some-step-slug',
+				intent: 'build',
+				assembler_source: 'premium',
+				is_in_hosting_flow: false,
+			} );
 		} );
 
 		it( 'records step-complete when the step is unmounted and step-start was previously recorded', () => {
@@ -191,18 +198,10 @@ describe( 'StepRoute', () => {
 				flow: 'some-flow',
 				optionalProps: {
 					intent: 'build',
+					signup_complete_flow_name: 'some-other-flow',
+					signup_complete_step_name: 'some-other-step-slug',
 				},
 			} );
-		} );
-
-		it( 'skips recording step-complete when the step is unmounted and step-start was not recorded', () => {
-			( getSignupCompleteFlowNameAndClear as jest.Mock ).mockReturnValue( 'some-flow' );
-			( getSignupCompleteStepNameAndClear as jest.Mock ).mockReturnValue( 'some-step-slug' );
-			const { unmount } = render( { step: regularStep } );
-
-			expect( recordStepStart ).not.toHaveBeenCalled();
-			unmount();
-			expect( recordStepComplete ).not.toHaveBeenCalled();
 		} );
 
 		it( 'records skip_step_render on start, complete and page view when the login is required and the user is not logged in', async () => {
@@ -217,10 +216,14 @@ describe( 'StepRoute', () => {
 				assembler_source: 'premium',
 				is_in_hosting_flow: false,
 				skip_step_render: true,
+				signup_complete_flow_name: 'some-other-flow',
+				signup_complete_step_name: 'some-other-step-slug',
 			} );
 			expect( recordPageView ).toHaveBeenCalledWith( '/', 'Setup > some-flow > some-step-slug', {
 				flow: 'some-flow',
 				skip_step_render: true,
+				signup_complete_flow_name: 'some-other-flow',
+				signup_complete_step_name: 'some-other-step-slug',
 			} );
 
 			unmount();
@@ -231,6 +234,8 @@ describe( 'StepRoute', () => {
 				optionalProps: {
 					intent: 'build',
 					skip_step_render: true,
+					signup_complete_flow_name: 'some-other-flow',
+					signup_complete_step_name: 'some-other-step-slug',
 				},
 			} );
 		} );
@@ -245,10 +250,14 @@ describe( 'StepRoute', () => {
 				assembler_source: 'premium',
 				is_in_hosting_flow: false,
 				skip_step_render: true,
+				signup_complete_flow_name: 'some-other-flow',
+				signup_complete_step_name: 'some-other-step-slug',
 			} );
 			expect( recordPageView ).toHaveBeenCalledWith( '/', 'Setup > some-flow > some-step-slug', {
 				flow: 'some-flow',
 				skip_step_render: true,
+				signup_complete_flow_name: 'some-other-flow',
+				signup_complete_step_name: 'some-other-step-slug',
 			} );
 
 			unmount();
@@ -259,6 +268,8 @@ describe( 'StepRoute', () => {
 				optionalProps: {
 					intent: 'build',
 					skip_step_render: true,
+					signup_complete_flow_name: 'some-other-flow',
+					signup_complete_step_name: 'some-other-step-slug',
 				},
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96681

## Proposed Changes

We relax the conditions further for recording the `signup_step_start` event:
- When a user is "reentering the step" after a completed signup flow, we previously did not record the step start event in the `useStepRouteTracking` hook. We now record it and pass additional props to distinguish the event:
  - `is_reentering_step_after_signup_complete`
  - `signup_complete_flow_name` 
  - `signup_complete_step_name`

This PR follows from previous work (https://github.com/Automattic/wp-calypso/pull/94817) to relax the conditions further for recording the step start event. We want to record this event, along with "page view", unconditionally on accessing the step routes (as the only tracking mechanism we have for these routes). See discussions in https://github.com/Automattic/wp-calypso/pull/94817 and associated issue for additional reasoning.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Fix inconsistencies in Tracking. This may have led to inconsistencies observed from comprising Start &b Stepper onboarding flows. 
- We ensure routes are being tracked when accessed, and contextualize the event instead (instead of not recording). See discussions in https://github.com/Automattic/wp-calypso/pull/94817 and associated issue for additional reasoning.

## TODO

- [ ] Investigate the case of `hasRequestedSelectedSite`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

