### PR TITLE
Stats: hourly route for Odyssey and Calypso

### DIFF
--- a/apps/odyssey-stats/src/routes.ts
+++ b/apps/odyssey-stats/src/routes.ts
@@ -85,6 +85,7 @@ const redirectToSiteTrafficPage = () => {
 
 export default function ( pageBase = '/' ) {
 	const validPeriods = [ 'day', 'week', 'month', 'year' ].join( '|' );
+	const validTrafficPagePeriods = [ 'hour', 'day', 'week', 'month', 'year' ].join( '|' );
 	const validEmailPeriods = [ 'hour', 'day' ].join( '|' );
 
 	const validModules = [
@@ -116,7 +117,7 @@ export default function ( pageBase = '/' ) {
 	statsPage( `/stats/subscribers/:period(${ validPeriods })/:site`, subscribers );
 
 	// Stat Site Pages
-	statsPage( `/stats/:period(${ validPeriods })/:site`, site );
+	statsPage( `/stats/:period(${ validTrafficPagePeriods })/:site`, site );
 
 	// Redirect this to default /stats/day/:module/:site view to
 	// keep the paths and page view reporting consistent.

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -27,7 +27,8 @@ const statsPage = ( url, controller ) => {
 };
 
 export default function () {
-	const validPeriods = [ 'hour', 'day', 'week', 'month', 'year' ].join( '|' );
+	const validPeriods = [ 'day', 'week', 'month', 'year' ].join( '|' );
+	const validTrafficPagePeriods = [ 'hour', 'day', 'week', 'month', 'year' ].join( '|' );
 	const validEmailPeriods = [ 'hour', 'day' ].join( '|' );
 
 	const validModules = [
@@ -50,7 +51,7 @@ export default function () {
 	page( '/stats', '/stats/day' );
 
 	// Stat Overview Page
-	statsPage( `/stats/:period(${ validPeriods })`, overview );
+	statsPage( `/stats/:period(${ validTrafficPagePeriods })`, overview );
 
 	// Stat Purchase Page
 	statsPage( '/stats/purchase/:site?', purchase );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -51,7 +51,7 @@ export default function () {
 	page( '/stats', '/stats/day' );
 
 	// Stat Overview Page
-	statsPage( `/stats/:period(${ validTrafficPagePeriods })`, overview );
+	statsPage( `/stats/:period(${ validPeriods })`, overview );
 
 	// Stat Purchase Page
 	statsPage( '/stats/purchase/:site?', purchase );
@@ -65,7 +65,7 @@ export default function () {
 	statsPage( `/stats/subscribers/:period(${ validPeriods })/:site`, subscribers );
 
 	// Stat Site Pages
-	statsPage( `/stats/:period(${ validPeriods })/:site`, site );
+	statsPage( `/stats/:period(${ validTrafficPagePeriods })/:site`, site );
 
 	// Redirect this to default /stats/day/:module/:site view to
 	// keep the paths and page view reporting consistent.

--- a/client/my-sites/stats/test/index.js
+++ b/client/my-sites/stats/test/index.js
@@ -55,7 +55,8 @@ const validModules = [
 	'devices',
 ].join( '|' );
 
-const validPeriods = [ 'hour', 'day', 'week', 'month', 'year' ].join( '|' );
+const validPeriods = [ 'day', 'week', 'month', 'year' ].join( '|' );
+const validTrafficPagePeriods = [ 'hour', 'day', 'week', 'month', 'year' ].join( '|' );
 
 const routes = {
 	[ `/stats/:period(${ validPeriods })` ]: [
@@ -67,7 +68,7 @@ const routes = {
 	],
 	'/stats/insights': [ siteSelection, navigation, sites, makeLayout, clientRender ],
 	'/stats/insights/:site': [ siteSelection, navigation, insights, makeLayout, clientRender ],
-	[ `/stats/:period(${ validPeriods })/:site` ]: [
+	[ `/stats/:period(${ validTrafficPagePeriods })/:site` ]: [
 		siteSelection,
 		navigation,
 		site,
@@ -83,7 +84,6 @@ const routes = {
 		clientRender,
 	],
 	'/stats/post/:post_id/:site': [ siteSelection, navigation, post, makeLayout, clientRender ],
-
 	'/stats/page/:post_id/:site': [ siteSelection, navigation, post, makeLayout, clientRender ],
 	'/stats/follows/comment/:site': [ siteSelection, navigation, follows, makeLayout, clientRender ],
 	'/stats/follows/comment/:page_num/:site': [


### PR DESCRIPTION
Related: https://github.com/Automattic/red-team/issues/283

## Proposed Changes

* Add hourly route for Odyssey Stats and align Calypso, because we don't have hourly for other routes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Support hourly views

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build Odyssey Stats locally following instructions  PCYsg-Pp7-p2
* Open `/wp-admin/admin.php?page=stats#!/stats/hour/:site`
* Ensure you can see hourly Stats in the chart

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/4a159a57-e0ba-44ba-a68b-8fb10051b229">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?