### PR TITLE
Add onClick event with e.preventDefault to prevent unwanted re-render

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -941,6 +941,13 @@ export class LoginForm extends Component {
 		const shouldRenderForgotPasswordLink =
 			! isPasswordHidden && isWoo && ! isPartnerSignup && ! isWooPasswordless;
 
+		const signUpUrlWithEmail = addQueryArgs(
+			{
+				user_email: this.state.usernameOrEmail,
+			},
+			signupUrl
+		);
+
 		return (
 			<form
 				className={ clsx( {
@@ -1026,19 +1033,17 @@ export class LoginForm extends Component {
 								{ requestError && requestError.field === 'usernameOrEmail' && (
 									<FormInputValidation isError text={ requestError.message }>
 										{ 'unknown_user' === requestError.code &&
-											! this.props.isWooPasswordlessJPC &&
 											this.props.translate(
 												' Would you like to {{newAccountLink}}create a new account{{/newAccountLink}}?',
 												{
 													components: {
 														newAccountLink: (
 															<a
-																href={ addQueryArgs(
-																	{
-																		user_email: this.state.usernameOrEmail,
-																	},
-																	signupUrl
-																) }
+																onClick={ ( e ) => {
+																	e.preventDefault();
+																	window.location.href = signUpUrlWithEmail;
+																} }
+																href={ signUpUrlWithEmail }
 															/>
 														),
 													},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This is a follow-up PR for https://github.com/Automattic/wp-calypso/pull/96666

In the previous PR, we disabled the 'Create a new account' link due to a re-rendering issue.

Before:

https://github.com/user-attachments/assets/e1e538ac-88e6-41a0-9004-f4d63e1c36a6



## Proposed Changes

* Added onClick event with e.preventDefault to prevent unwanted re-renders.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch locally and run `yarn start`
2. Open this [link](http://calypso.localhost:3000/log-in/jetpack?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D239172539%26redirect_uri%3Dhttps%253A%252F%252Fpink-piccolo.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253Df3099546f0%2526redirect%253Dhttps%25253A%25252F%25252Fpink-piccolo.jurassic.ninja%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-admin%26state%3D1%26scope%3Dadministrator%253A1a2e2b51282f8ac685ca15e67964f8f4%26user_email%3Dmoon.kyong%2540automattic.com%26user_login%3Dmoon0326%26jp_version%3D14.1-a.3%26secret%3DQYBTIYTgqLIIMcpg68zLcFnH8pyT9Jmf%26blogname%3DPink%2520Piccolo%26site_url%3Dhttps%253A%252F%252Fpink-piccolo.jurassic.ninja%26home_url%3Dhttps%253A%252F%252Fpink-piccolo.jurassic.ninja%26site_icon%3D%26site_lang%3Den_US%26site_created%3D2024-11-19%252018%253A10%253A55%26allow_site_connection%3D1%26calypso_env%3Dproduction%26source%3D%26_as%3Dwp-cli%26locale%3Den%26from%3Dwoocommerce-core-profiler%26plugin_name%3Dwoocommerce-payments%26color_scheme%default%26_ui%3D189042142%26_ut%3Dwpcom%253Auser_id%26purchase_nonce%3D3UiGhvFH%26_wp_nonce%3Dd1d5864992%26redirect_after_auth%3Dhttps%253A%252F%252Fpink-piccolo.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin%26site%3Dhttps%253A%252F%252Fpink-piccolo.jurassic.ninja&from=woocommerce-core-profiler) in an incognito session.
3. Enter an unknown username.
4. You should see an error message with "Create a new account" link.
5. Click on "Create a new account"
6. You should be redirected to the login page without any visual glitches. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
