### PR TITLE
Update 100-year domain copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -167,7 +167,7 @@ const StyledFoldableCard = styled( FoldableCard )`
 			.foldable-card__action {
 				width: 32px;
 			}
-			.gridicons-chevron-down {
+			.gridicon {
 				fill: var( --studio-gray-0 );
 				height: 16px;
 				width: 16px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/info-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/info-modal.tsx
@@ -159,6 +159,54 @@ export default function InfoModal( {
 		flowName === HUNDRED_YEAR_DOMAIN_FLOW
 			? translate( '100-Year Domain' )
 			: getPlan( PLAN_100_YEARS )?.getTitle();
+	const featureOneTitle =
+		flowName === HUNDRED_YEAR_DOMAIN_FLOW
+			? translate( 'Century-Long Domain Security' )
+			: translate( 'Century-Long Domain Registration' );
+	const featureOneDescription =
+		flowName === HUNDRED_YEAR_DOMAIN_FLOW
+			? translate(
+					'Say goodbye to the hassle of renewals. With our 100-Year Domain, your digital presence is safeguarded for the next century through a one-time setup, ensuring your domain remains yours—forever.'
+			  )
+			: translate(
+					'A domain is your most valuable digital asset. While standard domain registrations last a decade, our 100-Year Plan gives you an opportunity to secure your domain for a full century.'
+			  );
+	const featureTwoTitle =
+		flowName === HUNDRED_YEAR_DOMAIN_FLOW
+			? translate( 'Preservation for Future Generations' )
+			: translate( 'Peace Of Mind' );
+	const featureTwoDescription =
+		flowName === HUNDRED_YEAR_DOMAIN_FLOW
+			? translate(
+					'Preserve your business, passion project, or life’s work with century-long domain ownership. Your digital assets will remain a lasting part of your legacy, accessible for generations to come.'
+			  )
+			: translate(
+					'As guardians of your life’s work, we take our duty seriously. At the platform level, we maintain multiple backups of your content across geographically distributed data centers, automatically submit your site to the Internet Archive if it’s public, and will provide an optional locked mode.'
+			  );
+	const featureThreeTitle =
+		flowName === HUNDRED_YEAR_DOMAIN_FLOW
+			? translate( 'Trust & Stability Guaranteed' )
+			: translate( 'Enhanced Ownership Protocols' );
+	const featureThreeDescription =
+		flowName === HUNDRED_YEAR_DOMAIN_FLOW
+			? translate(
+					'We’ve developed a specialized trust account system to secure your domain’s longevity, ensuring stability regardless of future industry changes. Your investment today guarantees continuity tomorrow.'
+			  )
+			: translate(
+					'Navigate life’s milestones with ease. Whether you’re gifting a site to a newborn or facilitating a smooth transfer of ownership, we’re here to assist every step of the way.'
+			  );
+	const featureFourTitle =
+		flowName === HUNDRED_YEAR_DOMAIN_FLOW
+			? translate( 'Innovative Long-term Solutions' )
+			: translate( 'Top-Tier Managed WordPress Hosting' );
+	const featureFourDescription =
+		flowName === HUNDRED_YEAR_DOMAIN_FLOW
+			? translate(
+					'In collaboration with WordPress and The Internet Archive, we go beyond traditional domain management. Your site is backed by cutting-edge safeguards, distributed backups, and future-proof investment strategies.'
+			  )
+			: translate(
+					'The very best managed WordPress experience with unmetered bandwidth, best-in-class speed, and unstoppable security bundled in one convenient package.'
+			  );
 
 	return (
 		<StyledModal title="" onRequestClose={ onClose } isFullScreen>
@@ -188,36 +236,20 @@ export default function InfoModal( {
 				</Header>
 				<Row>
 					<RowItem>
-						<RowTitle>{ translate( 'Century-Long Domain Registration' ) }</RowTitle>
-						<RowContent>
-							{ translate(
-								'A domain is your most valuable digital asset. While standard domain registrations last a decade, our 100-Year Plan gives you an opportunity to secure your domain for a full century.'
-							) }
-						</RowContent>
+						<RowTitle>{ featureOneTitle }</RowTitle>
+						<RowContent>{ featureOneDescription }</RowContent>
 					</RowItem>
 					<RowItem>
-						<RowTitle>{ translate( 'Peace Of Mind' ) }</RowTitle>
-						<RowContent>
-							{ translate(
-								'As guardians of your life’s work, we take our duty seriously. At the platform level, we maintain multiple backups of your content across geographically distributed data centers, automatically submit your site to the Internet Archive if it’s public, and will provide an optional locked mode.'
-							) }
-						</RowContent>
+						<RowTitle>{ featureTwoTitle }</RowTitle>
+						<RowContent>{ featureTwoDescription }</RowContent>
 					</RowItem>
 					<RowItem>
-						<RowTitle>{ translate( 'Enhanced Ownership Protocols' ) }</RowTitle>
-						<RowContent>
-							{ translate(
-								'Navigate life’s milestones with ease. Whether you’re gifting a site to a newborn or facilitating a smooth transfer of ownership, we’re here to assist every step of the way.'
-							) }
-						</RowContent>
+						<RowTitle>{ featureThreeTitle }</RowTitle>
+						<RowContent>{ featureThreeDescription }</RowContent>
 					</RowItem>
 					<RowItem>
-						<RowTitle>{ translate( 'Top-Tier Managed WordPress Hosting' ) }</RowTitle>
-						<RowContent>
-							{ translate(
-								'The very best managed WordPress experience with unmetered bandwidth, best-in-class speed, and unstoppable security bundled in one convenient package.'
-							) }
-						</RowContent>
+						<RowTitle>{ featureFourTitle }</RowTitle>
+						<RowContent>{ featureFourDescription }</RowContent>
 					</RowItem>
 				</Row>
 			</Wrapper>


### PR DESCRIPTION
## Proposed Changes

This PR adds custom copy for the 100-year domain purchase flow and it fixes a bug on mobile where the foldable card icon is not visible.

**Before**
<img width="1345" alt="image" src="https://github.com/user-attachments/assets/3f16f867-5313-4c0d-a834-8cc697ff6b45">

<img width="1345" alt="image" src="https://github.com/user-attachments/assets/79962f68-7ff1-4996-b9c3-438f425cbea8">


**After**
<img width="1345" alt="image" src="https://github.com/user-attachments/assets/efd3bd70-a887-4998-b6dd-82894dc662b7">

<img width="1345" alt="image" src="https://github.com/user-attachments/assets/5ef77c50-2ab5-45a4-9e1b-f18e9c0b2c1f">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We currently have stale copy for the 100-year domains. This PR updates it with new copy.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `/setup/hundred-year-domain/domains` and compare against production (`wordpress.com/setup/hundred-year-domain/domains`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
