### PR TITLE
Stats: redirect hourly to daily for summary pages

### DIFF
--- a/apps/odyssey-stats/src/routes.ts
+++ b/apps/odyssey-stats/src/routes.ts
@@ -15,6 +15,7 @@ import {
 	purchase,
 	emailStats,
 	emailSummary,
+	redirectToDaySummary,
 } from 'calypso/my-sites/stats/controller';
 import {
 	SITE_REQUEST,
@@ -125,6 +126,8 @@ export default function ( pageBase = '/' ) {
 
 	// Stat Summary Pages
 	statsPage( `/stats/:period(${ validPeriods })/:module(${ validModules })/:site`, summary );
+	// No hourly stats for modules
+	statsPage( `/stats/hour/:module(${ validModules })/:site`, redirectToDaySummary );
 
 	// Stat Single Post Page
 	statsPage( '/stats/post/:post_id/:site', post );

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -225,6 +225,12 @@ export function site( context, next ) {
 	next();
 }
 
+export function redirectToDaySummary( context ) {
+	page.redirect(
+		`/stats/day/${ context.params.module }/${ context.params.site }${ window.location.search }`
+	);
+}
+
 export function summary( context, next ) {
 	let siteId = context.params.site;
 	const siteFragment = getSiteFragment( context.path );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -17,6 +17,7 @@ import {
 	emailSummary,
 	subscribers,
 	purchase,
+	redirectToDaySummary,
 } from './controller';
 
 import './style.scss';
@@ -73,6 +74,8 @@ export default function () {
 
 	// Stat Summary Pages
 	statsPage( `/stats/:period(${ validPeriods })/:module(${ validModules })/:site`, summary );
+	// No hourly stats for modules
+	statsPage( `/stats/hour/:module(${ validModules })/:site`, redirectToDaySummary );
 
 	// Stat Single Post Page
 	statsPage( '/stats/post/:post_id/:site', post );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/96656#pullrequestreview-2457011114

## Proposed Changes

* Redirect hourly to daily for summary pages, as it's not supported

cc @a8ck3n 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bugfix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live `/stats/hour/jetpack.com?chartStart=2024-11-25&chartEnd=2024-11-25&flags=stats%2Fnew-date-filtering`
* Click view more for a module
* Ensure it takes you to daily view of summary page

<img width="609" alt="image" src="https://github.com/user-attachments/assets/dd1b78c0-7ae8-42ba-acca-89d817f692e5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
