### PR TITLE
A4A: hide bank info migration step when already active

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/index.tsx
@@ -22,19 +22,17 @@ const SelfMigrationTool = ( { type }: { type: 'pressable' | 'wpcom' } ) => {
 
 	const { pageTitle, heading, pageHeading, pageSubheading, steps, sessionStorageKey } = stepInfo;
 
-	const stepsWithCompletion = steps
-		.map( ( step ) => {
-			return {
-				...step,
-				isCompleted: false,
-			};
-		} )
-		.filter( ( step ) => {
-			if ( tipaltiData?.Status === 'Active' && step.stepId === 'add-bank-info' ) {
-				return false;
-			}
-			return true;
-		} );
+	const stepsWithCompletion = steps.reduce( ( acc, step ) => {
+		// Remove the step to add the bank info if already added
+		if ( tipaltiData.IsPayable && step.stepId === 'add-bank-info' ) {
+			return acc;
+		}
+		acc.push( {
+			...step,
+			isCompleted: false,
+		} as never );
+		return acc;
+	}, [] );
 
 	return (
 		<Layout className="self-migration-tool" title={ pageTitle } wide>

--- a/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/self-migration-tool/index.tsx
@@ -9,6 +9,7 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MIGRATIONS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { TaskSteps } from 'calypso/a8c-for-agencies/components/task-steps';
+import useGetTipaltiPayee from 'calypso/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee';
 import { getMigrationInfo } from './migration-info';
 
 import './style.scss';
@@ -17,15 +18,23 @@ const SelfMigrationTool = ( { type }: { type: 'pressable' | 'wpcom' } ) => {
 	const translate = useTranslate();
 
 	const stepInfo = getMigrationInfo( type, translate );
+	const { data: tipaltiData } = useGetTipaltiPayee();
 
 	const { pageTitle, heading, pageHeading, pageSubheading, steps, sessionStorageKey } = stepInfo;
 
-	const stepsWithCompletion = steps.map( ( step ) => {
-		return {
-			...step,
-			isCompleted: false,
-		};
-	} );
+	const stepsWithCompletion = steps
+		.map( ( step ) => {
+			return {
+				...step,
+				isCompleted: false,
+			};
+		} )
+		.filter( ( step ) => {
+			if ( tipaltiData?.Status === 'Active' && step.stepId === 'add-bank-info' ) {
+				return false;
+			}
+			return true;
+		} );
 
 	return (
 		<Layout className="self-migration-tool" title={ pageTitle } wide>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context p1732531724302539/1732322781.136379-slack-C06EV8FF09J

## Proposed Changes

On the self-migrate page: `/migrations/overview/migrate-to-wpcom` we want to hide the step of adding Tipalti credentials, if user have already them in place (for example from referrals)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use live link below
- If you already have Tipalti credentials, create a new agency account
- Navigate to any self migration page(`/migrations/overview/migrate-to-wpcom` or `/migrations/overview/migrate-to-pressable`).
- Check that you have step `Fill in your payment information to receive commissions`
- Now use the account with Tipalti account or add one on payment settings page: `/migrations/payment-settings`
- Check that step no longer appears.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?