### PR TITLE
A4A: add ability to remove tags from site

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
@@ -1,6 +1,5 @@
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
@@ -32,6 +31,7 @@ const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 
 	const onRemoveSite = useCallback( () => {
 		closeDropdown();
+		//Remove=ing the A4A_MIGRATED_SITE_TAG tag only
 		const newTags = site.tags.reduce( ( acc, tag ) => {
 			if ( tag.name === A4A_MIGRATED_SITE_TAG ) {
 				return acc;
@@ -51,12 +51,8 @@ const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 
 	return (
 		<div>
-			<Button
-				onClick={ showActions }
-				ref={ buttonActionRef }
-				className={ clsx( 'site-actions__actions-large-screen' ) }
-			>
-				<Gridicon icon="ellipsis" size={ 18 } className="site-actions__all-actions" />
+			<Button onClick={ showActions } ref={ buttonActionRef }>
+				<Gridicon icon="ellipsis" size={ 18 } />
 			</Button>
 			<PopoverMenu
 				context={ buttonActionRef.current }
@@ -65,12 +61,10 @@ const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 				position="bottom left"
 			>
 				<PopoverMenuItem
-					key="untag-site"
 					localizeUrl={ false }
 					onClick={ () => {
 						setShowRemoveSiteDialog( true );
 					} }
-					className={ clsx( 'site-actions__menu-item' ) }
 				>
 					{ translate( 'Untag site' ) }
 				</PopoverMenuItem>
@@ -81,16 +75,16 @@ const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 					onClose={ () => setShowRemoveSiteDialog( false ) }
 					onConfirm={ onRemoveSite }
 					isLoading={ isPending }
+					isDisabled={ isPending }
 					title={ translate( 'Untag site' ) }
-					className="untag-site__dialog"
 					children={ translate(
-						'Are you sure you want to remove the site {{b}}%(siteURL)s{{/b}} from the dashboard?',
+						'Are you sure you want to untag {{b}}%(site)s{{/b}}? This will stop it from being considered for a migration payout.',
 						{
-							args: { siteURL: site.url },
+							args: { site: site.url },
 							components: {
 								b: <b />,
 							},
-							comment: '%(siteName)s is the site name',
+							comment: '%(site)s is the site name',
 						}
 					) }
 				/>

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
@@ -5,6 +5,8 @@ import { useCallback, useRef, useState } from 'react';
 import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import useUpdateSiteTagsMutation from '../../sites/site-preview-pane/hooks/use-update-site-tags-mutation';
 import { A4A_MIGRATED_SITE_TAG } from '../lib/constants';
 import { TaggedSite } from '../types';
@@ -16,6 +18,8 @@ type Props = {
 
 const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ showRemoveSiteDialog, setShowRemoveSiteDialog ] = useState( false );
@@ -31,7 +35,7 @@ const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 
 	const onRemoveSite = useCallback( () => {
 		closeDropdown();
-		//Remove=ing the A4A_MIGRATED_SITE_TAG tag only
+		// Removing the A4A_MIGRATED_SITE_TAG tag only
 		const newTags = site.tags.reduce( ( acc, tag ) => {
 			if ( tag.name === A4A_MIGRATED_SITE_TAG ) {
 				return acc;
@@ -44,10 +48,28 @@ const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 			{
 				onSuccess: () => {
 					fetchMigratedSites();
+					setShowRemoveSiteDialog( false );
+					dispatch(
+						successNotice(
+							translate( 'Successfully untagged {{strong}}%(siteUrl)s{{/strong}}.', {
+								components: { strong: <strong /> },
+								args: { siteUrl: site.url },
+							} ),
+							{ id: 'a4a-commission-list-untag-success', duration: 5000 }
+						)
+					);
 				},
 			}
 		);
-	}, [ fetchMigratedSites, mutate, site, closeDropdown ] );
+	}, [
+		fetchMigratedSites,
+		mutate,
+		site,
+		closeDropdown,
+		setShowRemoveSiteDialog,
+		dispatch,
+		translate,
+	] );
 
 	return (
 		<div>

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
@@ -7,6 +7,7 @@ import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-c
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import useUpdateSiteTagsMutation from '../../sites/site-preview-pane/hooks/use-update-site-tags-mutation';
+import { A4A_MIGRATED_SITE_TAG } from '../lib/constants';
 import { TaggedSite } from '../types';
 
 type Props = {
@@ -31,8 +32,15 @@ const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 
 	const onRemoveSite = useCallback( () => {
 		closeDropdown();
+		const newTags = site.tags.reduce( ( acc, tag ) => {
+			if ( tag.name === A4A_MIGRATED_SITE_TAG ) {
+				return acc;
+			}
+			acc.push( tag.name );
+			return acc;
+		}, [] as string[] );
 		mutate(
-			{ siteId: site.id, tags: [] },
+			{ siteId: site.id, tags: newTags },
 			{
 				onSuccess: () => {
 					fetchMigratedSites();

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
@@ -1,0 +1,94 @@
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useRef, useState } from 'react';
+import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import useUpdateSiteTagsMutation from '../../sites/site-preview-pane/hooks/use-update-site-tags-mutation';
+import { TaggedSite } from '../types';
+
+type Props = {
+	site: TaggedSite;
+	fetchMigratedSites: () => void;
+};
+
+const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
+	const translate = useTranslate();
+	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ showRemoveSiteDialog, setShowRemoveSiteDialog ] = useState( false );
+	const { mutate, isPending } = useUpdateSiteTagsMutation();
+
+	const showActions = useCallback( () => {
+		setIsOpen( true );
+	}, [] );
+
+	const closeDropdown = useCallback( () => {
+		setIsOpen( false );
+	}, [] );
+
+	const onRemoveSite = useCallback( () => {
+		closeDropdown();
+		mutate(
+			{ siteId: site.id, tags: [] },
+			{
+				onSuccess: () => {
+					fetchMigratedSites();
+				},
+			}
+		);
+	}, [ fetchMigratedSites, mutate, site, closeDropdown ] );
+
+	return (
+		<div>
+			<Button
+				onClick={ showActions }
+				ref={ buttonActionRef }
+				className={ clsx( 'site-actions__actions-large-screen' ) }
+			>
+				<Gridicon icon="ellipsis" size={ 18 } className="site-actions__all-actions" />
+			</Button>
+			<PopoverMenu
+				context={ buttonActionRef.current }
+				isVisible={ isOpen }
+				onClose={ closeDropdown }
+				position="bottom left"
+			>
+				<PopoverMenuItem
+					key="untag-site"
+					localizeUrl={ false }
+					onClick={ () => {
+						setShowRemoveSiteDialog( true );
+					} }
+					className={ clsx( 'site-actions__menu-item' ) }
+				>
+					{ translate( 'Untag site' ) }
+				</PopoverMenuItem>
+			</PopoverMenu>
+
+			{ showRemoveSiteDialog && (
+				<A4AConfirmationDialog
+					onClose={ () => setShowRemoveSiteDialog( false ) }
+					onConfirm={ onRemoveSite }
+					isLoading={ isPending }
+					title={ translate( 'Untag site' ) }
+					className="untag-site__dialog"
+					children={ translate(
+						'Are you sure you want to remove the site {{b}}%(siteURL)s{{/b}} from the dashboard?',
+						{
+							args: { siteURL: site.url },
+							components: {
+								b: <b />,
+							},
+							comment: '%(siteName)s is the site name',
+						}
+					) }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default CommissionListActions;

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -1,12 +1,11 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
-import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, ReactNode, useState, useCallback } from 'react';
+import { useMemo, ReactNode, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
-import useUpdateSiteTagsMutation from '../../sites/site-preview-pane/hooks/use-update-site-tags-mutation';
 import { MigratedOnColumn, ReviewStatusColumn, SiteColumn } from './commission-columns';
+import CommissionListActions from './commission-list-actions';
 import MigrationsCommissionsListMobileView from './mobile-view';
 import type { TaggedSite } from '../types';
 import type { Field } from '@wordpress/dataviews';
@@ -21,7 +20,6 @@ export default function MigrationsCommissionsList( {
 	const translate = useTranslate();
 
 	const isDesktop = useDesktopBreakpoint();
-	const { mutate } = useUpdateSiteTagsMutation();
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
@@ -31,13 +29,6 @@ export default function MigrationsCommissionsList( {
 		totalItems: items.length,
 		totalPages: 1,
 	};
-
-	const onRemove = useCallback(
-		async ( siteId: number ) => {
-			await mutate( { siteId, tags: [] }, { onSuccess: fetchMigratedSites } );
-		},
-		[ fetchMigratedSites, mutate ]
-	);
 
 	const fields: Field< any >[] = useMemo(
 		() => [
@@ -69,16 +60,15 @@ export default function MigrationsCommissionsList( {
 			},
 			{
 				id: 'remove',
-				label: translate( 'Remove' ).toUpperCase(),
+				label: translate( 'Actions' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: TaggedSite } ) => (
-					<Button onClick={ () => onRemove( item.id ) }>{ translate( 'Remove' ) }</Button>
+					<CommissionListActions fetchMigratedSites={ fetchMigratedSites } site={ item } />
 				),
-				enableHiding: false,
 				enableSorting: false,
 			},
 		],
-		[ translate, onRemove ]
+		[ translate, fetchMigratedSites ]
 	);
 
 	if ( ! isDesktop ) {

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -1,18 +1,27 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, ReactNode, useState } from 'react';
+import { useMemo, ReactNode, useState, useCallback } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import useUpdateSiteTagsMutation from '../../sites/site-preview-pane/hooks/use-update-site-tags-mutation';
 import { MigratedOnColumn, ReviewStatusColumn, SiteColumn } from './commission-columns';
 import MigrationsCommissionsListMobileView from './mobile-view';
 import type { TaggedSite } from '../types';
 import type { Field } from '@wordpress/dataviews';
 
-export default function MigrationsCommissionsList( { items }: { items: TaggedSite[] } ) {
+export default function MigrationsCommissionsList( {
+	items,
+	fetchMigratedSites,
+}: {
+	items: TaggedSite[];
+	fetchMigratedSites: () => void;
+} ) {
 	const translate = useTranslate();
 
 	const isDesktop = useDesktopBreakpoint();
+	const { mutate } = useUpdateSiteTagsMutation();
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
@@ -22,6 +31,13 @@ export default function MigrationsCommissionsList( { items }: { items: TaggedSit
 		totalItems: items.length,
 		totalPages: 1,
 	};
+
+	const onRemove = useCallback(
+		async ( siteId: number ) => {
+			await mutate( { siteId, tags: [] }, { onSuccess: fetchMigratedSites } );
+		},
+		[ fetchMigratedSites, mutate ]
+	);
 
 	const fields: Field< any >[] = useMemo(
 		() => [
@@ -51,8 +67,18 @@ export default function MigrationsCommissionsList( { items }: { items: TaggedSit
 				enableHiding: false,
 				enableSorting: false,
 			},
+			{
+				id: 'remove',
+				label: translate( 'Remove' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: TaggedSite } ) => (
+					<Button onClick={ () => onRemove( item.id ) }>{ translate( 'Remove' ) }</Button>
+				),
+				enableHiding: false,
+				enableSorting: false,
+			},
 		],
-		[ translate ]
+		[ translate, onRemove ]
 	);
 
 	if ( ! isDesktop ) {

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/style.scss
@@ -5,8 +5,3 @@
 .migrations-commissions-list-mobile-view__column {
 	@include a4a-font-body-md;
 }
-
-.untag-site__dialog {
-	text-wrap: pretty;
-    max-width: 800px;
-}

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/style.scss
@@ -5,3 +5,8 @@
 .migrations-commissions-list-mobile-view__column {
 	@include a4a-font-body-md;
 }
+
+.untag-site__dialog {
+	text-wrap: pretty;
+    max-width: 800px;
+}

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -58,10 +58,13 @@ export default function MigrationsCommissions() {
 		) : (
 			<div className="migrations-commissions__content">
 				<MigrationsConsolidatedCommissions items={ taggedSites } />
-				<MigrationsCommissionsList items={ taggedSites } />
+				<MigrationsCommissionsList
+					items={ taggedSites }
+					fetchMigratedSites={ fetchMigratedSites }
+				/>
 			</div>
 		);
-	}, [ isLoading, showEmptyState, taggedSites, setShowAddSitesModal ] );
+	}, [ isLoading, showEmptyState, taggedSites, setShowAddSitesModal, fetchMigratedSites ] );
 
 	return (
 		<Layout

--- a/client/a8c-for-agencies/sections/migrations/types.ts
+++ b/client/a8c-for-agencies/sections/migrations/types.ts
@@ -1,7 +1,12 @@
+interface Tag {
+	name: string;
+}
+
 export interface TaggedSite {
 	id: number;
 	blog_id: number;
 	created_at: number;
 	url: string;
 	state: string;
+	tags: Tag[];
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1732531724302539/1732322781.136379-slack-C06EV8FF09J

## Proposed Changes

This PR adds ability to remove site from the List of self migrated tasks.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As per request we are adding ability to untag the site, so it won't be listed and shown as a self migrated site.

https://github.com/user-attachments/assets/62aa88bf-3fb9-45ec-b7c0-560ee29ecd29


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `/migrations/commissions` and check that it works properly with adding/removing site tags.

Screenshots:

<img width="615" alt="Screenshot 2024-12-02 at 2 02 52 PM" src="https://github.com/user-attachments/assets/4db937f3-0146-4867-a84a-93a0f234ae88">

<img width="1071" alt="Screenshot 2024-12-02 at 2 07 56 PM" src="https://github.com/user-attachments/assets/65337a29-9b2e-434a-9059-e77d640144b5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?