### PR TITLE
Fix data missed if selected date is out of selected date range

### DIFF
--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -88,10 +88,32 @@ const StatsDateControl = ( {
 	const moment = useLocalizedMoment();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
+	/**
+	 * Remove start date from query params if it's out of range.
+	 * @param queryParamsObject
+	 * @param startDate
+	 * @param endDate
+	 */
+	const removeOutOfRangeStartDate = (
+		queryParamsObject: Record< string, any >,
+		startDate: string,
+		endDate: string
+	): void => {
+		const selectedStartDate = queryParamsObject.startDate as string | undefined;
+
+		if ( selectedStartDate && ( selectedStartDate < startDate || selectedStartDate > endDate ) ) {
+			// When there is no selected date, it takes today by default.
+			delete queryParamsObject.startDate;
+		}
+	};
+
 	// Shared link generation helper.
 	const generateNewLink = ( period: string, startDate: string, endDate: string ) => {
+		const queryParamsObject = qs.parse( queryParams );
+		removeOutOfRangeStartDate( queryParamsObject, startDate, endDate );
+
 		const newRangeQuery = qs.stringify(
-			Object.assign( {}, queryParams, { chartStart: startDate, chartEnd: endDate } ),
+			Object.assign( {}, queryParamsObject, { chartStart: startDate, chartEnd: endDate } ),
 			{
 				addQueryPrefix: true,
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/85

## Proposed Changes

* When the date range is changed, and there is a date selected in the chart, that date selected will be discarded if it is out of the new date range.
* By default, if no date is selected in the chart, today is selected. 

https://github.com/user-attachments/assets/ab22f4d5-ee35-47cb-9812-ad4c7c43cf8c


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These changes are done because currently we are showing empty data if we change the range and the selected date is out of that range.

## Testing Instructions

You can test it in Calypso Live or in /wp-admin using a local widget in your sandbox

1. Selected date is out of the new range.
* Go to wp-admin to Stats
* By default, the range is showing 30 days. In the chart, select the oldest date available (It needs to be oldest than 7 days)
* Change the Date Range from 30 days to 7 days
* Verify the date selected is changed from your previous selection to Today

2. Selected date is in the new rage
* Go to wp-admin to Stats
* By default, the range is showing 30 days. In the chart, select a date not older than 7 days
* Change the Date Range from 30 days to 7 days
* Verify the date selected has not change

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?