### PR TITLE
Update sites-per-plugin view button

### DIFF
--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -40,11 +40,8 @@ body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management,
 
     .plugin-name-button {
         padding: 0;
-        cursor: pointer;
-
-        &:focus {
-            box-shadow: none;
-        }
+		text-align: start;
+		height: auto;
     }
 }
 

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -66,15 +66,14 @@ export function useFields(
 
 					return (
 						<>
-							<button
+							<Button
 								onClick={ () => toggleDialogForPlugin( item ) }
-								onKeyDown={ ( e ) => e.key === 'Enter' && toggleDialogForPlugin( item ) }
-								className="components-button plugin-name-button"
+								className="plugin-name-button"
 							>
 								{ item.icon && <img className="plugin-icon" alt={ item.name } src={ item.icon } /> }
 								{ ! item.icon && <Icon size={ 32 } icon={ plugins } className="plugin-icon" /> }
 								{ item.name }
-							</button>
+							</Button>
 							{ pluginActionStatus }
 						</>
 					);


### PR DESCRIPTION
Follow up for https://github.com/Automattic/wp-calypso/pull/96729
Fixes https://github.com/Automattic/dotcom-forge/issues/9955

## Proposed Changes

* Updated styles for sites-per-plugin view button

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/user-attachments/assets/44dbcd8b-fe8d-46ae-ad9e-4fbca5113519">  | <img src="https://github.com/user-attachments/assets/a3de3347-5f84-44ae-8351-66561c24cbe4">|
| <img src="https://github.com/user-attachments/assets/54f7a14d-afe5-4d8f-a261-90622e52d766">  | <img src="https://github.com/user-attachments/assets/d8ea2708-2e0b-42f4-94ed-4130b2356699">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/Automattic/wp-calypso/pull/96729#issuecomment-2499710936

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /plugins/manage
* Check that the layout looks "okay" on mobile and desktop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
