### PR TITLE
Sites Dashboard: Remove the max-width for the banner

### DIFF
--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -20,10 +20,8 @@
 			padding-inline: 48px;
 			// Override the max-width set in a8c-for-agencies/components/layout/style.scss
 			// as the title aligns with DataViews (full width).
+			// TODO: Remove when we drop A4A Layout or when A4A Layout drops the max-width.
 			max-width: revert;
-			@media (max-width: 402px) {
-				padding-inline: 24px;
-			}
 		}
 	}
 
@@ -79,14 +77,6 @@
 		margin: 0 auto;
 		padding-inline: 48px;
 		width: 100%;
-
-		@media (max-width: 402px) {
-			padding-inline: 24px;
-		}
-
-		@include break-huge {
-			max-width: 1400px;
-		}
 	}
 
 	.sites-banner {
@@ -377,14 +367,6 @@
 		display: flex;
 		flex-direction: column;
 		height: 100%;
-	}
-}
-
-.wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout.preview-hidden {
-	div.a4a-layout__viewport {
-		// margin: 0 auto;
-		// max-width: 1400px;
-		// box-sizing: border-box;
 	}
 }
 

--- a/client/sites/components/sites-dataviews/dataview-style.scss
+++ b/client/sites/components/sites-dataviews/dataview-style.scss
@@ -63,3 +63,28 @@
 		}
 	}
 }
+
+.wpcom-site .main.a4a-layout.sites-dashboard {
+	.a4a-layout__top-wrapper,
+	.a4a-layout__body {
+		> * {
+			// To align with Core's hard-coded device width.
+			// https://github.com/WordPress/gutenberg/blob/ed66cc50e3c0b6785a48c15230c090790c0b0e6c/packages/dataviews/src/components/dataviews/style.scss#L84
+			// TODO: Remove when Core changes to use one of the predefined breakpoints.
+			@media (max-width: 430px) {
+				padding-inline: 24px;
+			}
+		}
+	}
+}
+
+.wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout .sites-overview {
+	.sites-banner-container {
+		// To align with Core's hard-coded device width.
+		// https://github.com/WordPress/gutenberg/blob/ed66cc50e3c0b6785a48c15230c090790c0b0e6c/packages/dataviews/src/components/dataviews/style.scss#L84
+		// TODO: Remove when Core changes to use one of the predefined breakpoints.
+		@media (max-width: 430px) {
+			padding-inline: 24px;
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9915

## Proposed Changes

This PR is a follow-up for https://github.com/Automattic/wp-calypso/pull/96713#issuecomment-2497120519. 

<img width="883" alt="Screenshot 2024-11-26 at 15 36 17" src="https://github.com/user-attachments/assets/8afb426a-a1fa-4cd2-b440-e64efb9dcf98">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pbxlJb-6DF-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Comment out [this line](https://github.com/Automattic/wp-calypso/blob/30d2f7cfb9ffc7b24edfa1d3d858ecc1bd2230d0/client/sites/components/sites-dashboard-banners-manager.tsx#L77) to show the banner on your local Calypso. (I wasn't sure how to show the banner.)
* Go to /sites
* Observe the banner is aligned with the "Sites" and DataView.
	* in the large view > 1440px
	* in the mobile view (especially > 430px)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?