### PR TITLE
Untangling: add upsell to Advanced Tools and Settings subtabs

### DIFF
--- a/client/components/panel/style.scss
+++ b/client/components/panel/style.scss
@@ -18,6 +18,10 @@
 		padding: 0;
 	}
 
+	.upsell-nudge {
+		width: 100%;
+	}
+
 	// TODO: remove after the untangling/hosting-menu flag is enabled
 	#primary > & {
 		margin-left: auto;

--- a/client/sites/hosting-features/features.ts
+++ b/client/sites/hosting-features/features.ts
@@ -39,3 +39,13 @@ export function useAreAdvancedHostingFeaturesSupported() {
 	}
 	return areHostingFeaturesSupported( site ) && hasSftpFeature;
 }
+
+export function useAreAdvancedHostingFeaturesSupportedAfterActivation() {
+	const features = useSelectedSiteSelector( getSiteFeatures );
+	const hasSftpFeature = useSelectedSiteSelector( siteHasFeature, FEATURE_SFTP );
+
+	if ( ! features ) {
+		return null;
+	}
+	return hasSftpFeature;
+}

--- a/client/sites/settings/caching/index.tsx
+++ b/client/sites/settings/caching/index.tsx
@@ -44,7 +44,7 @@ export default function CachingSettings() {
 		return (
 			<UpsellNudge
 				title={ translate(
-					'Upgrade to the %(businessPlanName)s plan to manage your site’s server-side caching and get access to all {{a}}advanced tools{{/a}}.',
+					'Upgrade to the %(businessPlanName)s plan to get access to this feature and all {{a}}advanced tools{{/a}}.',
 					{
 						components: { a: <a href={ `/sites/tools/${ siteSlug }` } /> },
 						args: { businessPlanName: getPlanBusinessTitle() },

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -2,7 +2,6 @@ import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SidebarItem, Sidebar, PanelWithSidebar } from '../components/panel-sidebar';
-import { useAreAdvancedHostingFeaturesSupported } from '../hosting-features/features';
 import AdministrationSettings from './administration';
 import useIsAdministrationSettingSupported from './administration/hooks/use-is-administration-setting-supported';
 import DeleteSite from './administration/tools/delete-site';
@@ -19,8 +18,6 @@ export function SettingsSidebar() {
 
 	const shouldShowAdministration = useIsAdministrationSettingSupported();
 
-	const shouldShowAdvancedHostingFeatures = useAreAdvancedHostingFeaturesSupported();
-
 	return (
 		<Sidebar>
 			<SidebarItem href={ `/sites/settings/site/${ slug }` }>{ __( 'Site' ) }</SidebarItem>
@@ -31,10 +28,7 @@ export function SettingsSidebar() {
 				{ __( 'Administration' ) }
 			</SidebarItem>
 			<SidebarItem href={ `/sites/settings/caching/${ slug }` }>{ __( 'Caching' ) }</SidebarItem>
-			<SidebarItem
-				enabled={ !! shouldShowAdvancedHostingFeatures }
-				href={ `/sites/settings/web-server/${ slug }` }
-			>
+			<SidebarItem href={ `/sites/settings/web-server/${ slug }` }>
 				{ __( 'Web server' ) }
 			</SidebarItem>
 		</Sidebar>

--- a/client/sites/settings/index.tsx
+++ b/client/sites/settings/index.tsx
@@ -106,6 +106,7 @@ export default function () {
 		'/sites/settings/web-server/:site',
 		siteSelection,
 		navigation,
+		showHostingFeaturesNoticeIfPresent,
 		webServerSettings,
 		siteDashboard( SETTINGS_WEB_SERVER ),
 		makeLayout,

--- a/client/sites/settings/web-server/index.tsx
+++ b/client/sites/settings/web-server/index.tsx
@@ -6,6 +6,8 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { Panel } from 'calypso/components/panel';
 import HostingActivation from 'calypso/sites/hosting-features/components/hosting-activation';
 import { useSelector } from 'calypso/state';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
 	useAreAdvancedHostingFeaturesSupported,
@@ -24,6 +26,7 @@ export default function WebServerSettings() {
 
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const isSiteAtomic = useSelectedSiteSelector( isAtomicSite );
 
 	const renderSetting = () => {
 		if ( isSupported ) {
@@ -51,13 +54,22 @@ export default function WebServerSettings() {
 
 		return (
 			<UpsellNudge
-				title={ translate(
-					'Upgrade to the %(businessPlanName)s plan to get access to this feature and all {{a}}advanced tools{{/a}}.',
-					{
-						components: { a: <a href={ `/sites/tools/${ siteSlug }` } /> },
-						args: { businessPlanName: getPlanBusinessTitle() },
-					}
-				) }
+				title={
+					isSiteAtomic
+						? translate(
+								'Upgrade to the %(businessPlanName)s plan to get access to this feature.',
+								{
+									args: { businessPlanName: getPlanBusinessTitle() },
+								}
+						  )
+						: translate(
+								'Upgrade to the %(businessPlanName)s plan to get access to this feature and all {{a}}advanced tools{{/a}}.',
+								{
+									components: { a: <a href={ `/sites/tools/${ siteSlug }` } /> },
+									args: { businessPlanName: getPlanBusinessTitle() },
+								}
+						  )
+				}
 				tracksImpressionName="calypso_settings_web_server_upgrade_impression"
 				event="calypso_settings_web_server_upgrade_upsell"
 				tracksClickName="calypso_settings_web_server_upgrade_click"

--- a/client/sites/settings/web-server/index.tsx
+++ b/client/sites/settings/web-server/index.tsx
@@ -1,8 +1,16 @@
+import { FEATURE_SFTP, getPlanBusinessTitle } from '@automattic/calypso-products';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import NavigationHeader from 'calypso/components/navigation-header';
-import Notice from 'calypso/components/notice';
 import { Panel } from 'calypso/components/panel';
-import { useAreAdvancedHostingFeaturesSupported } from '../../hosting-features/features';
+import HostingActivation from 'calypso/sites/hosting-features/components/hosting-activation';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	useAreAdvancedHostingFeaturesSupported,
+	useAreAdvancedHostingFeaturesSupportedAfterActivation,
+} from '../../hosting-features/features';
 import DefensiveModeForm from './defensive-mode-form';
 import ServerConfigurationForm from './server-configuration-form';
 
@@ -12,26 +20,52 @@ export default function WebServerSettings() {
 	const translate = useTranslate();
 
 	const isSupported = useAreAdvancedHostingFeaturesSupported();
-	if ( isSupported === null ) {
-		return null;
-	}
+	const isSupportedAfterActivation = useAreAdvancedHostingFeaturesSupportedAfterActivation();
 
-	const renderNotSupportedNotice = () => {
-		return (
-			<>
-				<Notice showDismiss={ false } status="is-warning">
-					{ translate( 'This setting is not supported for this site.' ) }
-				</Notice>
-			</>
-		);
-	};
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const renderSetting = () => {
+		if ( isSupported ) {
+			return (
+				<>
+					<ServerConfigurationForm />
+					<DefensiveModeForm />
+				</>
+			);
+		}
+
+		if ( isSupported === null ) {
+			return null;
+		}
+
+		const redirectUrl = `/sites/settings/web-server/${ siteId }`;
+
+		if ( isSupportedAfterActivation ) {
+			return <HostingActivation redirectUrl={ redirectUrl } />;
+		}
+
+		const href = addQueryArgs( `/checkout/${ siteId }/business`, {
+			redirect_to: redirectUrl,
+		} );
+
 		return (
-			<>
-				<ServerConfigurationForm />
-				<DefensiveModeForm />
-			</>
+			<UpsellNudge
+				title={ translate(
+					'Upgrade to the %(businessPlanName)s plan to get access to this feature and all {{a}}advanced tools{{/a}}.',
+					{
+						components: { a: <a href={ `/sites/tools/${ siteSlug }` } /> },
+						args: { businessPlanName: getPlanBusinessTitle() },
+					}
+				) }
+				tracksImpressionName="calypso_settings_web_server_upgrade_impression"
+				event="calypso_settings_web_server_upgrade_upsell"
+				tracksClickName="calypso_settings_web_server_upgrade_click"
+				href={ href }
+				callToAction={ translate( 'Upgrade' ) }
+				feature={ FEATURE_SFTP }
+				showIcon
+			/>
 		);
 	};
 
@@ -43,7 +77,7 @@ export default function WebServerSettings() {
 					'For sites with specialized needs, fine-tune how the web server runs your website.'
 				) }
 			/>
-			{ isSupported ? renderSetting() : renderNotSupportedNotice() }
+			{ renderSetting() }
 		</Panel>
 	);
 }

--- a/client/sites/tools/controller.tsx
+++ b/client/sites/tools/controller.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import HostingFeatures from 'calypso/sites/hosting-features/components/hosting-features';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SidebarItem, Sidebar, PanelWithSidebar } from '../components/panel-sidebar';
-import { useAreAdvancedHostingFeaturesSupported } from '../hosting-features/features';
 import Database from './database/page';
 import {
 	DeploymentCreation,
@@ -21,7 +20,6 @@ import type { Context as PageJSContext } from '@automattic/calypso-router';
 
 export function ToolsSidebar() {
 	const slug = useSelector( getSelectedSiteSlug );
-	const shouldShowAdvancedHostingFeatures = useAreAdvancedHostingFeaturesSupported();
 
 	const sftpSshTitle = useSftpSshSettingTitle();
 
@@ -35,18 +33,8 @@ export function ToolsSidebar() {
 			</SidebarItem>
 			<SidebarItem href={ `/sites/tools/monitoring/${ slug }` }>{ __( 'Monitoring' ) }</SidebarItem>
 			<SidebarItem href={ `/sites/tools/logs/${ slug }` }>{ __( 'Logs' ) }</SidebarItem>
-			<SidebarItem
-				enabled={ !! shouldShowAdvancedHostingFeatures }
-				href={ `/sites/tools/sftp-ssh/${ slug }` }
-			>
-				{ sftpSshTitle }
-			</SidebarItem>
-			<SidebarItem
-				enabled={ !! shouldShowAdvancedHostingFeatures }
-				href={ `/sites/tools/database/${ slug }` }
-			>
-				{ __( 'Database' ) }
-			</SidebarItem>
+			<SidebarItem href={ `/sites/tools/sftp-ssh/${ slug }` }>{ sftpSshTitle }</SidebarItem>
+			<SidebarItem href={ `/sites/tools/database/${ slug }` }>{ __( 'Database' ) }</SidebarItem>
 		</Sidebar>
 	);
 }

--- a/client/sites/tools/database/form.tsx
+++ b/client/sites/tools/database/form.tsx
@@ -32,7 +32,7 @@ export function useOpenPhpMyAdmin() {
 	const dispatch = useDispatch();
 
 	const openPhpMyAdmin = useCallback(
-		async function openPhpMyAdmin( siteId ) {
+		async function openPhpMyAdmin( siteId: number | null ) {
 			setLoading( true );
 			try {
 				const { token } = await wpcom.req.post( {
@@ -58,7 +58,19 @@ export function useOpenPhpMyAdmin() {
 	};
 }
 
-export default function PhpMyAdminForm( { disabled, ContainerComponent, DescriptionComponent } ) {
+interface PhpMyAdminFormProps {
+	ContainerComponent: React.ComponentType< any >; // eslint-disable-line @typescript-eslint/no-explicit-any
+	DescriptionComponent: React.ComponentType< any >; // eslint-disable-line @typescript-eslint/no-explicit-any
+	upsell?: React.ReactNode;
+	disabled?: boolean;
+}
+
+export default function PhpMyAdminForm( {
+	disabled,
+	ContainerComponent,
+	DescriptionComponent,
+	upsell,
+}: PhpMyAdminFormProps ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const [ isRestorePasswordDialogVisible, setIsRestorePasswordDialogVisible ] = useState( false );
 	const { openPhpMyAdmin, loading } = useOpenPhpMyAdmin();
@@ -126,7 +138,7 @@ export default function PhpMyAdminForm( { disabled, ContainerComponent, Descript
 					'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL.'
 				) }
 			</DescriptionComponent>
-			{ form }
+			{ upsell ?? form }
 		</ContainerComponent>
 	);
 }

--- a/client/sites/tools/database/page.tsx
+++ b/client/sites/tools/database/page.tsx
@@ -6,7 +6,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { Panel } from 'calypso/components/panel';
 import HostingActivation from 'calypso/sites/hosting-features/components/hosting-activation';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
 	useAreAdvancedHostingFeaturesSupported,
 	useAreAdvancedHostingFeaturesSupportedAfterActivation,
@@ -29,7 +29,6 @@ export default function Database() {
 	const isSupportedAfterActivation = useAreAdvancedHostingFeaturesSupportedAfterActivation();
 
 	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const renderSetting = () => {
 		if ( isSupported ) {
@@ -59,9 +58,8 @@ export default function Database() {
 		const upsell = (
 			<UpsellNudge
 				title={ translate(
-					'Upgrade to the %(businessPlanName)s plan to get access to this feature and all {{a}}advanced tools{{/a}}.',
+					'Upgrade to the %(businessPlanName)s plan to get access to this feature.',
 					{
-						components: { a: <a href={ `/sites/tools/${ siteSlug }` } /> },
 						args: { businessPlanName: getPlanBusinessTitle() },
 					}
 				) }

--- a/client/sites/tools/database/page.tsx
+++ b/client/sites/tools/database/page.tsx
@@ -1,8 +1,16 @@
+import { FEATURE_SFTP, getPlanBusinessTitle } from '@automattic/calypso-products';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import NavigationHeader from 'calypso/components/navigation-header';
-import Notice from 'calypso/components/notice';
 import { Panel } from 'calypso/components/panel';
-import { useAreAdvancedHostingFeaturesSupported } from '../../hosting-features/features';
+import HostingActivation from 'calypso/sites/hosting-features/components/hosting-activation';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	useAreAdvancedHostingFeaturesSupported,
+	useAreAdvancedHostingFeaturesSupportedAfterActivation,
+} from '../../hosting-features/features';
 import PhpMyAdminForm from './form';
 
 function Container( { children }: { children: React.ReactNode } ) {
@@ -18,34 +26,64 @@ export default function Database() {
 	const translate = useTranslate();
 
 	const isSupported = useAreAdvancedHostingFeaturesSupported();
-	if ( isSupported === null ) {
-		return null;
-	}
+	const isSupportedAfterActivation = useAreAdvancedHostingFeaturesSupportedAfterActivation();
 
-	const renderNotSupportedNotice = () => {
-		return (
-			<>
-				<Description />
-				<Notice showDismiss={ false } status="is-warning">
-					{ translate( 'This setting is not supported for this site.' ) }
-				</Notice>
-			</>
-		);
-	};
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const renderSetting = () => {
+		if ( isSupported ) {
+			return (
+				<PhpMyAdminForm
+					disabled={ false }
+					ContainerComponent={ Container }
+					DescriptionComponent={ Description }
+				/>
+			);
+		}
+
+		if ( isSupported === null ) {
+			return null;
+		}
+
+		const redirectUrl = `/sites/tools/database/${ siteId }`;
+
+		if ( isSupportedAfterActivation ) {
+			return <HostingActivation redirectUrl={ redirectUrl } />;
+		}
+
+		const href = addQueryArgs( `/checkout/${ siteId }/business`, {
+			redirect_to: redirectUrl,
+		} );
+
+		const upsell = (
+			<UpsellNudge
+				title={ translate(
+					'Upgrade to the %(businessPlanName)s plan to get access to this feature and all {{a}}advanced tools{{/a}}.',
+					{
+						components: { a: <a href={ `/sites/tools/${ siteSlug }` } /> },
+						args: { businessPlanName: getPlanBusinessTitle() },
+					}
+				) }
+				tracksImpressionName="calypso_tools_database_upgrade_impression"
+				event="calypso_tools_database_upgrade_upsell"
+				tracksClickName="calypso_tools_database_upgrade_click"
+				href={ href }
+				callToAction={ translate( 'Upgrade' ) }
+				feature={ FEATURE_SFTP }
+				showIcon
+			/>
+		);
+
 		return (
 			<PhpMyAdminForm
 				disabled={ false }
 				ContainerComponent={ Container }
 				DescriptionComponent={ Description }
+				upsell={ upsell }
 			/>
 		);
 	};
 
-	return (
-		<Panel className="tools-database phpmyadmin-card">
-			{ isSupported ? renderSetting() : renderNotSupportedNotice() }
-		</Panel>
-	);
+	return <Panel className="tools-database phpmyadmin-card">{ renderSetting() }</Panel>;
 }

--- a/client/sites/tools/sftp-ssh/page.tsx
+++ b/client/sites/tools/sftp-ssh/page.tsx
@@ -6,7 +6,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { Panel } from 'calypso/components/panel';
 import HostingActivation from 'calypso/sites/hosting-features/components/hosting-activation';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
 	useAreAdvancedHostingFeaturesSupported,
 	useAreAdvancedHostingFeaturesSupportedAfterActivation,
@@ -31,7 +31,6 @@ export default function SftpSsh() {
 	const isSupportedAfterActivation = useAreAdvancedHostingFeaturesSupportedAfterActivation();
 
 	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const renderSetting = () => {
 		if ( isSupported ) {
@@ -55,9 +54,8 @@ export default function SftpSsh() {
 		const upsell = (
 			<UpsellNudge
 				title={ translate(
-					'Upgrade to the %(businessPlanName)s plan to get access to this feature and all {{a}}advanced tools{{/a}}.',
+					'Upgrade to the %(businessPlanName)s plan to get access to this feature.',
 					{
-						components: { a: <a href={ `/sites/tools/${ siteSlug }` } /> },
 						args: { businessPlanName: getPlanBusinessTitle() },
 					}
 				) }

--- a/client/sites/tools/sftp-ssh/page.tsx
+++ b/client/sites/tools/sftp-ssh/page.tsx
@@ -1,8 +1,16 @@
+import { FEATURE_SFTP, getPlanBusinessTitle } from '@automattic/calypso-products';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import NavigationHeader from 'calypso/components/navigation-header';
-import Notice from 'calypso/components/notice';
 import { Panel } from 'calypso/components/panel';
-import { useAreAdvancedHostingFeaturesSupported } from '../../hosting-features/features';
+import HostingActivation from 'calypso/sites/hosting-features/components/hosting-activation';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	useAreAdvancedHostingFeaturesSupported,
+	useAreAdvancedHostingFeaturesSupportedAfterActivation,
+} from '../../hosting-features/features';
 import useSftpSshSettingTitle from './hooks/use-sftp-ssh-setting-title';
 import { SftpCardLoadingPlaceholder } from './sftp-card-loading-placeholder';
 import { SftpForm } from './sftp-form';
@@ -20,28 +28,57 @@ export default function SftpSsh() {
 	const translate = useTranslate();
 
 	const isSupported = useAreAdvancedHostingFeaturesSupported();
-	if ( isSupported === null ) {
-		return null;
-	}
+	const isSupportedAfterActivation = useAreAdvancedHostingFeaturesSupportedAfterActivation();
 
-	const renderNotSupportedNotice = () => {
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const renderSetting = () => {
+		if ( isSupported ) {
+			return <SftpForm ContainerComponent={ Container } DescriptionComponent={ Description } />;
+		}
+
+		if ( isSupported === null ) {
+			return null;
+		}
+
+		const redirectUrl = `/sites/tools/sftp-ssh/${ siteId }`;
+
+		if ( isSupportedAfterActivation ) {
+			return <HostingActivation redirectUrl={ redirectUrl } />;
+		}
+
+		const href = addQueryArgs( `/checkout/${ siteId }/business`, {
+			redirect_to: redirectUrl,
+		} );
+
+		const upsell = (
+			<UpsellNudge
+				title={ translate(
+					'Upgrade to the %(businessPlanName)s plan to get access to this feature and all {{a}}advanced tools{{/a}}.',
+					{
+						components: { a: <a href={ `/sites/tools/${ siteSlug }` } /> },
+						args: { businessPlanName: getPlanBusinessTitle() },
+					}
+				) }
+				tracksImpressionName="calypso_tools_sftp_ssh_upgrade_impression"
+				event="calypso_tools_sftp_ssh_upgrade_upsell"
+				tracksClickName="calypso_tools_sftp_ssh_upgrade_click"
+				href={ href }
+				callToAction={ translate( 'Upgrade' ) }
+				feature={ FEATURE_SFTP }
+				showIcon
+			/>
+		);
+
 		return (
-			<>
-				<Description />
-				<Notice showDismiss={ false } status="is-warning">
-					{ translate( 'This setting is not supported for this site.' ) }
-				</Notice>
-			</>
+			<SftpForm
+				ContainerComponent={ Container }
+				DescriptionComponent={ Description }
+				upsell={ upsell }
+			/>
 		);
 	};
 
-	const renderSetting = () => {
-		return <SftpForm ContainerComponent={ Container } DescriptionComponent={ Description } />;
-	};
-
-	return (
-		<Panel className="tools-sftp-ssh">
-			{ isSupported ? renderSetting() : renderNotSupportedNotice() }
-		</Panel>
-	);
+	return <Panel className="tools-sftp-ssh">{ renderSetting() }</Panel>;
 }

--- a/client/sites/tools/sftp-ssh/sftp-form.tsx
+++ b/client/sites/tools/sftp-ssh/sftp-form.tsx
@@ -88,12 +88,14 @@ const disableSshAccess = ( siteId: number | null ) =>
 type SftpFormProps = {
 	ContainerComponent: React.ComponentType< any >; // eslint-disable-line @typescript-eslint/no-explicit-any
 	DescriptionComponent: React.ComponentType< any >; // eslint-disable-line @typescript-eslint/no-explicit-any
+	upsell?: React.ReactNode;
 	disabled?: boolean;
 };
 
 export const SftpForm = ( {
 	ContainerComponent,
 	DescriptionComponent,
+	upsell,
 	disabled,
 }: SftpFormProps ) => {
 	const translate = useTranslate();
@@ -402,7 +404,7 @@ export const SftpForm = ( {
 						: featureExplanation }
 				</DescriptionComponent>
 			) }
-			{ form }
+			{ upsell ?? form }
 		</ContainerComponent>
 	);
 };

--- a/client/sites/tools/staging-site/components/staging-site-upsell-nudge/index.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-upsell-nudge/index.tsx
@@ -8,14 +8,13 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { CardContentWrapper } from '../staging-site-card/card-content/card-content-wrapper';
 
 const StagingSiteUpsellNudge = () => {
 	const translate = useTranslate();
 
 	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const isUntangled = isEnabled( 'untangling/hosting-menu' );
 
@@ -32,9 +31,8 @@ const StagingSiteUpsellNudge = () => {
 				title={
 					isUntangled
 						? translate(
-								'Upgrade to the %(businessPlanName)s plan to get access to this feature and all {{a}}advanced tools{{/a}}.',
+								'Upgrade to the %(businessPlanName)s plan to get access to this feature.',
 								{
-									components: { a: <a href={ `/sites/tools/${ siteSlug }` } /> },
 									args: { businessPlanName: getPlanBusinessTitle() },
 								}
 						  )

--- a/client/sites/tools/staging-site/components/staging-site-upsell-nudge/index.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-upsell-nudge/index.tsx
@@ -1,25 +1,47 @@
-import { PLAN_BUSINESS, getPlan, FEATURE_SITE_STAGING_SITES } from '@automattic/calypso-products';
+import { isEnabled } from '@automattic/calypso-config';
+import {
+	PLAN_BUSINESS,
+	FEATURE_SITE_STAGING_SITES,
+	getPlanBusinessTitle,
+} from '@automattic/calypso-products';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { CardContentWrapper } from '../staging-site-card/card-content/card-content-wrapper';
 
 const StagingSiteUpsellNudge = () => {
 	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) ?? 0;
+
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const isUntangled = isEnabled( 'untangling/hosting-menu' );
+
 	const href = addQueryArgs( `/checkout/${ siteId }/business`, {
-		redirect_to: `/staging-site/${ siteId }`,
+		redirect_to: isUntangled
+			? `/sites/tools/staging-site/${ siteId }`
+			: `/staging-site/${ siteId }`,
 	} );
 
 	return (
 		<CardContentWrapper>
 			<UpsellNudge
 				className="staging-site-upsell-nudge"
-				title={ translate( 'Upgrade to the %(businessPlanName)s plan to add a staging site.', {
-					args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-				} ) }
+				title={
+					isUntangled
+						? translate(
+								'Upgrade to the %(businessPlanName)s plan to get access to this feature and all {{a}}advanced tools{{/a}}.',
+								{
+									components: { a: <a href={ `/sites/tools/${ siteSlug }` } /> },
+									args: { businessPlanName: getPlanBusinessTitle() },
+								}
+						  )
+						: translate( 'Upgrade to the %(businessPlanName)s plan to add a staging site.', {
+								args: { businessPlanName: getPlanBusinessTitle() },
+						  } )
+				}
 				tracksImpressionName="calypso_staging_site_upgrade_impression"
 				event="calypso_staging_site_upgrade_upsell"
 				tracksClickName="calypso_staging_site_upgrade_click"

--- a/client/sites/tools/staging-site/components/staging-site/index.tsx
+++ b/client/sites/tools/staging-site/components/staging-site/index.tsx
@@ -1,5 +1,6 @@
 import { FEATURE_SITE_STAGING_SITES } from '@automattic/calypso-products';
 import { useSelector } from 'calypso/state';
+import getSiteFeatures from 'calypso/state/selectors/get-site-features';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -10,10 +11,15 @@ import './style.scss';
 
 const StagingSite = () => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) ?? 0;
+	const features = useSelector( ( state ) => getSiteFeatures( state, siteId ) );
 	const hasStagingSitesFeature = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, FEATURE_SITE_STAGING_SITES )
 	);
 	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
+
+	if ( ! features ) {
+		return null;
+	}
 
 	if ( ! hasStagingSitesFeature ) {
 		return <StagingSiteUpsellNudge />;

--- a/client/sites/tools/staging-site/index.tsx
+++ b/client/sites/tools/staging-site/index.tsx
@@ -5,7 +5,7 @@ import './style.scss';
 
 export default function StagingSite() {
 	return (
-		<Panel wide className="tools-staging-site">
+		<Panel className="tools-staging-site">
 			<StagingSiteWrapper />
 		</Panel>
 	);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9928

## Proposed Changes

This PR adds subtab upsells to:

- Advanced Tools -> {Staging Site, SFTP, Database}
- Settings -> Web server

## Why are these changes being made?

pbxlJb-6ye-p2

## Testing Instructions

### FREE SITE

1. Open /sites
2. Click a Free site
3. Go to Settings -> Web server, verify you see the upsell:

<img width="935" alt="image" src="https://github.com/user-attachments/assets/ef068b39-efd1-413a-9c30-9a6766ec4155">

4. Verify you can go through the upsell flow.

### ECOMMERCE TRIAL SITE

1. Sign up for an ecommerce trial site at https://wordpress.com/ecommerce/.
1. Open /sites
2. Click the new site
3. For each {Advanced Tools -> Staging site, Advanced Tools -> SFTP, Advanced Tools -> Database, Settings -> Web Server}:
    - Verify you can see the upsell.
    - Verify the Upgrade button link is correct (compare with the Web server above) (so that you don't have to go through the whole flow)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?