### PR TITLE
Stats: Fix for date range picker not updating on open

### DIFF
--- a/client/components/date-control/index.tsx
+++ b/client/components/date-control/index.tsx
@@ -100,6 +100,7 @@ const DateControl = ( {
 				customTitle="Date Range"
 				focusedMonth={ moment( dateRange.chartEnd ).toDate() }
 				onShortcutClick={ onShortcutClick }
+				trackExternalDateChanges
 			/>
 		</div>
 	);

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -54,6 +54,7 @@ export class DateRange extends Component {
 		overlay: PropTypes.node,
 		customTitle: PropTypes.string,
 		onShortcutClick: PropTypes.func,
+		trackExternalDateChanges: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -145,15 +146,18 @@ export class DateRange extends Component {
 	 * Note this does not commit the current date state
 	 */
 	openPopover = () => {
-		this.setState( {
+		const newState = {
 			popoverVisible: true,
-			startDate: this.props.selectedStartDate,
-			endDate: this.props.selectedEndDate,
-			textInputStartDate: this.toDateString( this.props.selectedStartDate ),
-			textInputEndDate: this.toDateString( this.props.selectedEndDate ),
-			staleStartDate: this.props.selectedStartDate,
-			staleEndDate: this.props.selectedEndDate,
-		} );
+		};
+		if ( this.props.trackExternalDateChanges ) {
+			newState.startDate = this.props.selectedStartDate;
+			newState.endDate = this.props.selectedEndDate;
+			newState.textInputStartDate = this.toDateString( this.props.selectedStartDate );
+			newState.textInputEndDate = this.toDateString( this.props.selectedEndDate );
+			newState.staleStartDate = this.props.selectedStartDate;
+			newState.staleEndDate = this.props.selectedEndDate;
+		}
+		this.setState( newState );
 	};
 
 	/**

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -72,6 +72,7 @@ export class DateRange extends Component {
 		useArrowNavigation: false,
 		overlay: null,
 		customTitle: '',
+		trackExternalDateChanges: false,
 	};
 
 	constructor( props ) {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -462,7 +462,7 @@ export class DateRange extends Component {
 				isVisible={ this.state.popoverVisible }
 				context={ this.triggerButtonRef.current }
 				position="bottom"
-				onClose={ this.closePopoverAndCommit }
+				onClose={ this.closePopover }
 			>
 				<div className="date-range__popover-content">
 					<div

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -147,6 +147,12 @@ export class DateRange extends Component {
 	openPopover = () => {
 		this.setState( {
 			popoverVisible: true,
+			startDate: this.props.selectedStartDate,
+			endDate: this.props.selectedEndDate,
+			textInputStartDate: this.toDateString( this.props.selectedStartDate ),
+			textInputEndDate: this.toDateString( this.props.selectedEndDate ),
+			staleStartDate: this.props.selectedStartDate,
+			staleEndDate: this.props.selectedEndDate,
 		} );
 	};
 

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -7,11 +7,17 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import DateControl from '../date-control';
 import { DateControlPickerShortcut } from '../date-control/types';
+
+type DateRange = {
+	chartStart: string;
+	chartEnd: string;
+	daysInRange: number;
+};
 interface StatsDateControlProps {
 	slug: string;
 	queryParams: string;
 	period: 'day' | 'week' | 'month' | 'year';
-	dateRange: any;
+	dateRange: DateRange;
 	shortcutList: DateControlPickerShortcut[];
 	overlay?: JSX.Element;
 	onGatedHandler: (

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -110,8 +110,6 @@ const StatsDateControl = ( {
 	};
 
 	// Handler for Apply button.
-	// This is being called even when canceling the date selection.
-	// TODO: Fix this so it's only called when the Apply button is clicked.
 	const onApplyButtonHandler = ( startDate: string, endDate: string ) => {
 		// Determine period based on date range.
 		const rangeInDays = Math.abs( moment( endDate ).diff( moment( startDate ), 'days' ) );

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -110,6 +110,8 @@ const StatsDateControl = ( {
 	};
 
 	// Handler for Apply button.
+	// This is being called even when canceling the date selection.
+	// TODO: Fix this so it's only called when the Apply button is clicked.
 	const onApplyButtonHandler = ( startDate: string, endDate: string ) => {
 		// Determine period based on date range.
 		const rangeInDays = Math.abs( moment( endDate ).diff( moment( startDate ), 'days' ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/wp-calypso/issues/96714

## Proposed Changes

- Updates the internal state when opening the popover so that any updated URL params are captured.
- Only commits changes if the Apply button is clicked.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Without the state updates, the internal state overrides any changes that are triggered outside the control. For example, updating the date range via the navigation arrows updates the page correctly but the date picker doesn't see those changes and resets the page based on its internal state the next time it is shown.

Now only commits changes if the Apply button was clicked. This means clicking away from the date picker no longer updates the page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the flag: `&flags=stats/new-date-filtering`
* Confirm the page defaults to "Last 7 Days".
* Click the left-facing navigation arrow and confirm the page properly updates.
* Open the date picker and confirm the updated range is properly reflected everywhere. — state bug fixed
* Close the date picker and confirm the page is not updated. — apply bug fixed
* Confirm that changing the date range and then clicking away or canceling both work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
