### PR TITLE
Revert "Add notice indicating settings moved to hosting dashboard"

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button, FormLabel, Gridicon } from '@automattic/components';
 import { guessTimezone, localizeUrl } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
@@ -417,7 +416,7 @@ export class SiteSettingsFormGeneral extends Component {
 						</Card>
 					</>
 				) }
-				{ ! isEnabled( 'untangling/hosting-menu' ) && <SiteSettingsForm { ...this.props } /> }
+				<SiteSettingsForm { ...this.props } />
 				{ ! isDevelopmentSite && this.renderAdminInterface() }
 			</div>
 		);

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -1,8 +1,5 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
 import GeneralForm from 'calypso/my-sites/site-settings/form-general';
 import SiteTools from 'calypso/sites/settings/administration/tools';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -16,21 +13,8 @@ const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2Hub, isWpcomStagingS
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
 		{ isWPForTeamsSite && isP2Hub && <P2PreapprovedDomainsForm siteId={ site?.ID } /> }
-		{ ! isWpcomStagingSite && ! isEnabled( 'untangling/hosting-menu' ) && (
+		{ ! isWpcomStagingSite && (
 			<SiteTools headerTitle={ translate( 'Site tools' ) } source={ SOURCE_SETTINGS_GENERAL } />
-		) }
-		{ isEnabled( 'untangling/hosting-menu' ) && (
-			<Notice
-				showDismiss={ false }
-				status="is-info"
-				text={ translate(
-					'Privacy, site tools, and other settings have moved to the hosting dashboard.'
-				) }
-			>
-				<NoticeAction href={ `/sites/settings/site/${ site.domain }` } external>
-					{ translate( 'View settings' ) }
-				</NoticeAction>
-			</Notice>
 		) }
 	</div>
 );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#96769

Because the pre-release tests are failing.