### PR TITLE
Help Center: Fix content overflow

### DIFF
--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -68,6 +68,7 @@
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
+		width: 80%;
 
 		.help-center-support-chat__conversation-information-message {
 			display: -webkit-box;

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -182,6 +182,10 @@
 					}
 				}
 			}
+			img {
+				max-width: 100%;
+    			height: auto;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9952
Fixes https://github.com/Automattic/dotcom-forge/issues/9952

## Proposed Changes

* Fixes two issues related to content overflow
1 — When sending Zendesk image attachments, it was not being loaded properly on site-editor
2 — Gigantic messages were overflowing in History  

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes overflow content

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and add this flag `?flags=help-center-experience`

Issue 1

Send an image attachment on Zendesk
* Navigate to {YOUR_SITE/wp-admin/site-editor.php?flags=help-center-experience} and open the Help Center, open the chat and make sure the image is fitting the content nicely.

More [details](https://github.com/Automattic/dotcom-forge/issues/9952)

Issue 2
* Send a gigantic URL message and check on history if there's a horizontal scroll, **it should not**.

**Should not have scroll**
<img width="481" alt="image" src="https://github.com/user-attachments/assets/e6f80103-5815-430e-bd0f-6d8e58d619dd">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
