### PR TITLE
Add notice in settings that they moved to hosting dashboard

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button, FormLabel, Gridicon } from '@automattic/components';
 import { guessTimezone, localizeUrl } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
@@ -416,7 +417,7 @@ export class SiteSettingsFormGeneral extends Component {
 						</Card>
 					</>
 				) }
-				<SiteSettingsForm { ...this.props } />
+				{ ! isEnabled( 'untangling/hosting-menu' ) && <SiteSettingsForm { ...this.props } /> }
 				{ ! isDevelopmentSite && this.renderAdminInterface() }
 			</div>
 		);

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -1,5 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import GeneralForm from 'calypso/my-sites/site-settings/form-general';
 import SiteTools from 'calypso/sites/settings/administration/tools';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -13,8 +16,21 @@ const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2Hub, isWpcomStagingS
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
 		{ isWPForTeamsSite && isP2Hub && <P2PreapprovedDomainsForm siteId={ site?.ID } /> }
-		{ ! isWpcomStagingSite && (
+		{ ! isWpcomStagingSite && ! isEnabled( 'untangling/hosting-menu' ) && (
 			<SiteTools headerTitle={ translate( 'Site tools' ) } source={ SOURCE_SETTINGS_GENERAL } />
+		) }
+		{ isEnabled( 'untangling/hosting-menu' ) && (
+			<Notice
+				showDismiss={ false }
+				status="is-info"
+				text={ translate(
+					'Privacy, site tools, and other settings have moved to the hosting dashboard.'
+				) }
+			>
+				<NoticeAction href={ `/sites/settings/site/${ site.domain }` } external>
+					{ translate( 'View settings' ) }
+				</NoticeAction>
+			</Notice>
 		) }
 	</div>
 );

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -24,6 +24,7 @@ export * from './revisions-page';
 export * from './shared-types';
 export * from './signup/user-signup-page';
 export * from './site-import-page';
+export * from './site-settings-page';
 export * from './stats-page';
 export * from './themes-detail-page';
 export * from './themes-page';

--- a/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
@@ -1,0 +1,45 @@
+import { Page } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
+
+const selectors = {
+	// Launch site
+	launchSiteButton: 'a:text("Launch site")',
+};
+
+/**
+ * Represents the Sites > Site > Settings page.
+ */
+export class SiteSettingsPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Visits the `/sites/settings/site` endpoint.
+	 *
+	 * @param {string} siteSlug Site URL.
+	 */
+	async visit( siteSlug: string ): Promise< void > {
+		await this.page.goto( getCalypsoURL( `sites/settings/site/${ siteSlug }` ), {
+			waitUntil: 'networkidle',
+			timeout: 20 * 1000,
+		} );
+	}
+
+	/**
+	 * Start the site launch process.
+	 */
+	async launchSite(): Promise< void > {
+		await Promise.all( [
+			this.page.waitForNavigation(),
+			this.page.click( selectors.launchSiteButton ),
+		] );
+	}
+}

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -9,7 +9,7 @@ import {
 	LoginPage,
 	UserSignupPage,
 	SignupPickPlanPage,
-	GeneralSettingsPage,
+	SiteSettingsPage,
 	CartCheckoutPage,
 	StartSiteFlow,
 	SecretsManager,
@@ -188,9 +188,9 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		} );
 
 		it( 'Start site launch', async function () {
-			const generalSettingsPage = new GeneralSettingsPage( page );
-			await generalSettingsPage.visit( newSiteDetails.blog_details.site_slug );
-			await generalSettingsPage.launchSite();
+			const siteSettingsPage = new SiteSettingsPage( page );
+			await siteSettingsPage.visit( newSiteDetails.blog_details.site_slug );
+			await siteSettingsPage.launchSite();
 		} );
 
 		it( 'Skip domain purchase', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/9869

## Proposed Changes

* Hide privacy, site-tools and other settings behind `untangling/hosting-menu` flag.
* Add a notice `Privacy, site tools, and other settings have moved to the hosting dashboard.` when the flag is enabled.
* Also add a link in the notice to point to new settings location `/sites/settings/site/:site`

Settings > General
<img width="759" alt="image" src="https://github.com/user-attachments/assets/50560a42-3883-4f31-99e3-41506cea52f3">

Hosting > Site settings
<img width="743" alt="image" src="https://github.com/user-attachments/assets/e655f516-32b4-4ae1-8aaf-b8ee137b6538">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Settings > General (for default interface style)
* It should show the notice when the flag `untangling/hosting-menu` is enabled.
* It should show privacy and other settings when the flag is disabled.
* Verify the same in Hosting > Site settings (for classic interface style)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
