### PR TITLE
Separate logic for ssh and sftp loading check

### DIFF
--- a/client/sites/tools/sftp-ssh/sftp-form.tsx
+++ b/client/sites/tools/sftp-ssh/sftp-form.tsx
@@ -29,7 +29,8 @@ import {
 	enableAtomicSshAccess,
 	disableAtomicSshAccess,
 } from 'calypso/state/hosting/actions';
-import { getAtomicHostingIsLoadingSftpData } from 'calypso/state/selectors/get-atomic-hosting-is-loading-sftp-data';
+import { getAtomicHostingIsLoadingSftpUsers } from 'calypso/state/selectors/get-atomic-hosting-is-loading-sftp-users';
+import { getAtomicHostingIsLoadingSshAccess } from 'calypso/state/selectors/get-atomic-hosting-is-loading-ssh-access';
 import { getAtomicHostingSftpUsers } from 'calypso/state/selectors/get-atomic-hosting-sftp-users';
 import { getAtomicHostingSshAccess } from 'calypso/state/selectors/get-atomic-hosting-ssh-access';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -110,8 +111,11 @@ export const SftpForm = ( {
 	);
 	const isSshAccessEnabled =
 		'ssh' === useSelector( ( state ) => getAtomicHostingSshAccess( state, siteId ) );
-	const isLoadingSftpData = useSelector( ( state ) =>
-		getAtomicHostingIsLoadingSftpData( state, siteId )
+	const isLoadingSshAccess = useSelector( ( state ) =>
+		getAtomicHostingIsLoadingSshAccess( state, siteId )
+	);
+	const isLoadingSftpUsers = useSelector( ( state ) =>
+		getAtomicHostingIsLoadingSftpUsers( state, siteId )
 	);
 	const { username, password } = useSelector( ( state ) => {
 		let username;
@@ -138,7 +142,8 @@ export const SftpForm = ( {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ isPasswordLoading, setPasswordLoading ] = useState( false );
 	const [ isSshAccessLoading, setSshAccessLoading ] = useState( false );
-	const hasSftpFeatureAndIsLoading = siteHasSftpFeature && isLoadingSftpData;
+	const hasSftpFeatureAndIsLoading = siteHasSftpFeature && isLoadingSftpUsers;
+	const hasSshFeatureAndIsLoading = siteHasSshFeature && isLoadingSshAccess;
 	const siteIntent = useSiteOption( 'site_intent' );
 
 	const sshConnectString = `ssh ${ username }@sftp.wp.com`;
@@ -268,7 +273,8 @@ export const SftpForm = ( {
 			</div>
 		);
 	};
-	const displayQuestionsAndButton = ! hasSftpFeatureAndIsLoading && ! ( username || isLoading );
+	const displayQuestionsAndButton =
+		! hasSftpFeatureAndIsLoading && ! hasSshFeatureAndIsLoading && ! ( username || isLoading );
 	const showSshPanel = ! siteHasSftpFeature || siteHasSshFeature;
 
 	const featureExplanation = siteHasSshFeature
@@ -375,7 +381,9 @@ export const SftpForm = ( {
 				</FormFieldset>
 			) }
 			{ isLoading && <Spinner /> }
-			{ hasSftpFeatureAndIsLoading && <SftpCardLoadingPlaceholder /> }
+			{ ( hasSftpFeatureAndIsLoading || hasSshFeatureAndIsLoading ) && (
+				<SftpCardLoadingPlaceholder />
+			) }
 		</div>
 	);
 
@@ -386,9 +394,9 @@ export const SftpForm = ( {
 			title={
 				siteHasSshFeature ? translate( 'SFTP/SSH credentials' ) : translate( 'SFTP credentials' )
 			}
-			isLoading={ hasSftpFeatureAndIsLoading }
+			isLoading={ hasSftpFeatureAndIsLoading || hasSshFeatureAndIsLoading }
 		>
-			{ ! hasSftpFeatureAndIsLoading && (
+			{ ! ( hasSftpFeatureAndIsLoading || hasSshFeatureAndIsLoading ) && (
 				<DescriptionComponent>
 					{ username
 						? translate(

--- a/client/state/selectors/get-atomic-hosting-is-loading-sftp-users.js
+++ b/client/state/selectors/get-atomic-hosting-is-loading-sftp-users.js
@@ -3,7 +3,7 @@ import 'calypso/state/hosting/init';
 /**
  * Returns if the SFTP users data loaded for given site.
  * @param  {Object}  state   Global state tree
- * @param  {number}  siteId The ID of the site we're querying
+ * @param  {number|null}  siteId The ID of the site we're querying
  * @returns {boolean} If the SFTP users data has finished the first request
  */
 export function getAtomicHostingIsLoadingSftpUsers( state, siteId ) {

--- a/client/state/selectors/get-atomic-hosting-is-loading-ssh-access.js
+++ b/client/state/selectors/get-atomic-hosting-is-loading-ssh-access.js
@@ -3,7 +3,7 @@ import 'calypso/state/hosting/init';
 /**
  * Returns if the SSH access data loaded for given site.
  * @param  {Object}  state   Global state tree
- * @param  {number}  siteId The ID of the site we're querying
+ * @param  {number|null}  siteId The ID of the site we're querying
  * @returns {boolean} If the SSH access data has finished the first request
  */
 export function getAtomicHostingIsLoadingSshAccess( state, siteId ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9973

## Proposed Changes

* Separate the logic for ssh and sftp loading so that they don't affect each other

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The ssh/sftp block for Pro plan is broken because Pro plan only has sftp access and the current logic needs both to load in order to show the block

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /hosting-config/:site (if you're seeing a different interface, add `?flags=-untangling/hosting-menu`)
* Check for Pro plan atomic sites (Pro plan has sftp access but not ssh)
* Test with Business plan and E-commerce plan atomic sites should have same behavior on production

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?