### PR TITLE
Bulk Plugin Management: Record clicks

### DIFF
--- a/client/my-sites/plugins/plugins-list/use-actions.tsx
+++ b/client/my-sites/plugins/plugins-list/use-actions.tsx
@@ -28,8 +28,8 @@ export function useActions(
 		{
 			id: 'manage-plugin',
 			href: `some-url`,
-			callback( plugins: Array< Plugin > ) {
-				recordIntentionEvent( plugins, this.id );
+			callback: ( plugins: Array< Plugin > ) => {
+				recordIntentionEvent( plugins, 'manage-plugin' );
 				plugins.length && navigate( '/plugins/' + plugins[ 0 ].slug );
 			},
 			label: translate( 'Manage Plugin' ),
@@ -40,8 +40,8 @@ export function useActions(
 		{
 			id: 'activate-plugin',
 			href: `some-url`,
-			callback( plugins: Array< Plugin > ) {
-				recordIntentionEvent( plugins, this.id );
+			callback: ( plugins: Array< Plugin > ) => {
+				recordIntentionEvent( plugins, 'activate-plugin' );
 				bulkActionDialog( PluginActions.ACTIVATE, plugins );
 			},
 			label: translate( 'Activate' ),
@@ -55,8 +55,8 @@ export function useActions(
 		{
 			id: 'deactivate-plugin',
 			href: `some-url`,
-			callback( plugins: Array< Plugin > ) {
-				recordIntentionEvent( plugins, this.id );
+			callback: ( plugins: Array< Plugin > ) => {
+				recordIntentionEvent( plugins, 'deactivate-plugin' );
 				bulkActionDialog( PluginActions.DEACTIVATE, plugins );
 			},
 			label: translate( 'Deactivate' ),
@@ -70,8 +70,8 @@ export function useActions(
 		{
 			id: 'enable-autoupdate',
 			href: `some-url`,
-			callback( plugins: Array< Plugin > ) {
-				recordIntentionEvent( plugins, this.id );
+			callback: ( plugins: Array< Plugin > ) => {
+				recordIntentionEvent( plugins, 'enable-autoupdate' );
 				bulkActionDialog( PluginActions.ENABLE_AUTOUPDATES, plugins );
 			},
 			label: translate( 'Enable auto-updates' ),
@@ -84,8 +84,8 @@ export function useActions(
 		{
 			id: 'disable-autoupdate',
 			href: `some-url`,
-			callback( plugins: Array< Plugin > ) {
-				recordIntentionEvent( plugins, this.id );
+			callback: ( plugins: Array< Plugin > ) => {
+				recordIntentionEvent( plugins, 'disable-autoupdate' );
 				bulkActionDialog( PluginActions.DISABLE_AUTOUPDATES, plugins );
 			},
 			label: translate( 'Disable auto-updates' ),
@@ -98,8 +98,8 @@ export function useActions(
 		{
 			id: 'remove-plugin',
 			href: `some-url`,
-			callback( plugins: Array< Plugin > ) {
-				recordIntentionEvent( plugins, this.id );
+			callback: ( plugins: Array< Plugin > ) => {
+				recordIntentionEvent( plugins, 'remove-plugin' );
 				bulkActionDialog( PluginActions.REMOVE, plugins );
 			},
 			label: translate( 'Remove' ),

--- a/client/my-sites/plugins/plugins-list/use-actions.tsx
+++ b/client/my-sites/plugins/plugins-list/use-actions.tsx
@@ -1,6 +1,8 @@
 import { Icon, link, linkOff, trash } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import { navigate } from 'calypso/lib/navigate';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
 import { Plugin } from 'calypso/state/plugins/installed/types';
 import { PluginActions } from '../hooks/types';
@@ -8,11 +10,26 @@ import { PluginActions } from '../hooks/types';
 export function useActions(
 	bulkActionDialog: ( action: string, plugins: Array< Plugin > ) => void
 ) {
+	const dispatch = useDispatch();
+
+	const recordIntentionEvent = ( plugins: Array< Plugin >, action: string ) => {
+		/**
+		 * There's currently no better way to differentiate between bulk and single action clicks.
+		 */
+		const eventName =
+			plugins.length > 1
+				? 'calypso_plugins_manage_list_bulk_action_click'
+				: 'calypso_plugins_manage_list_action_click';
+
+		dispatch( recordTracksEvent( eventName, { action } ) );
+	};
+
 	const actions = [
 		{
 			id: 'manage-plugin',
 			href: `some-url`,
-			callback: ( plugins: Array< Plugin > ) => {
+			callback( plugins: Array< Plugin > ) {
+				recordIntentionEvent( plugins, this.id );
 				plugins.length && navigate( '/plugins/' + plugins[ 0 ].slug );
 			},
 			label: translate( 'Manage Plugin' ),
@@ -23,7 +40,8 @@ export function useActions(
 		{
 			id: 'activate-plugin',
 			href: `some-url`,
-			callback: ( plugins: Array< Plugin > ) => {
+			callback( plugins: Array< Plugin > ) {
+				recordIntentionEvent( plugins, this.id );
 				bulkActionDialog( PluginActions.ACTIVATE, plugins );
 			},
 			label: translate( 'Activate' ),
@@ -37,7 +55,8 @@ export function useActions(
 		{
 			id: 'deactivate-plugin',
 			href: `some-url`,
-			callback: ( plugins: Array< Plugin > ) => {
+			callback( plugins: Array< Plugin > ) {
+				recordIntentionEvent( plugins, this.id );
 				bulkActionDialog( PluginActions.DEACTIVATE, plugins );
 			},
 			label: translate( 'Deactivate' ),
@@ -51,7 +70,8 @@ export function useActions(
 		{
 			id: 'enable-autoupdate',
 			href: `some-url`,
-			callback: ( plugins: Array< Plugin > ) => {
+			callback( plugins: Array< Plugin > ) {
+				recordIntentionEvent( plugins, this.id );
 				bulkActionDialog( PluginActions.ENABLE_AUTOUPDATES, plugins );
 			},
 			label: translate( 'Enable auto-updates' ),
@@ -64,7 +84,8 @@ export function useActions(
 		{
 			id: 'disable-autoupdate',
 			href: `some-url`,
-			callback: ( plugins: Array< Plugin > ) => {
+			callback( plugins: Array< Plugin > ) {
+				recordIntentionEvent( plugins, this.id );
 				bulkActionDialog( PluginActions.DISABLE_AUTOUPDATES, plugins );
 			},
 			label: translate( 'Disable auto-updates' ),
@@ -77,7 +98,8 @@ export function useActions(
 		{
 			id: 'remove-plugin',
 			href: `some-url`,
-			callback: ( plugins: Array< Plugin > ) => {
+			callback( plugins: Array< Plugin > ) {
+				recordIntentionEvent( plugins, this.id );
 				bulkActionDialog( PluginActions.REMOVE, plugins );
 			},
 			label: translate( 'Remove' ),


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/9743.

## Proposed Changes

Records the action click (i.e., the "intention") when clicking each row's action items, and the bulk actions click at the bottom.

See more in p1732601593029299-slack-C04H4NY6STW.

## Why are these changes being made?

To better understand usage.

## Testing Instructions

### Row buttons

Click on the plugin name. The `calypso_plugins_manage_list_plugin_name_click` event should be dispatched with the `plugin_slug` property. The AC wanted to track the name, but it might be affected by the locale, so it's safer to use the slug.

<img width="861" alt="image" src="https://github.com/user-attachments/assets/ec54d7b2-035a-4395-9013-824558364178">

---

Click on the amount of sites the plugin is installed. The `calypso_plugins_manage_list_plugin_sitecount_click` event should be dispatched with the `plugin_slug` and `site_count` property. 

<img width="860" alt="image" src="https://github.com/user-attachments/assets/624519ba-226f-4e48-8f39-804fd0e57df0">

---

Click on the "Update to version X" button. The `calypso_plugins_manage_list_plugin_updateavailable_click` event should be dispatched with the `plugin_slug` property. 

<img width="951" alt="image" src="https://github.com/user-attachments/assets/47bbadc8-df8f-4970-8faf-c18e881662b0">

### Actions

Click any item on the three-dots menu. The `calypso_plugins_manage_list_action_click` event should be dispatched, with the `action` property matching its action ID.

![image](https://github.com/user-attachments/assets/6c9db5e3-5857-4bcf-8ebd-9b1cd1edc98d)

---

Select two plugins and click any of the bulk actions. The `calypso_plugins_manage_list_bulk_action_click` event should be dispatched, with the `action` property matching its action ID.

![image](https://github.com/user-attachments/assets/0b98e4fc-f1b3-4100-9a92-e890dd2d3fd1)