### PR TITLE
Help Center: Feedback in article sends paying users to support

### DIFF
--- a/packages/help-center/src/components/help-center-feedback-form.tsx
+++ b/packages/help-center/src/components/help-center-feedback-form.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
+import { useSupportStatus } from '../data/use-support-status';
 import { useResetSupportInteraction } from '../hooks/use-reset-support-interaction';
 import { ThumbsDownIcon, ThumbsUpIcon } from '../icons/thumbs';
 import HelpCenterContactSupportOption from './help-center-contact-support-option';
@@ -32,6 +33,9 @@ const HelpCenterFeedbackForm = ( {
 	const { __ } = useI18n();
 	const [ startedFeedback, setStartedFeedback ] = useState< boolean | null >( null );
 	const [ answerValue, setAnswerValue ] = useState< number | null >( null );
+
+	const { data } = useSupportStatus();
+	const isUserEligibleForPaidSupport = data?.eligibility.is_user_eligible ?? false;
 
 	const { sectionName, site } = useHelpCenterContext();
 	const shouldUseHelpCenterExperience = config.isEnabled( 'help-center-experience' );
@@ -132,7 +136,10 @@ const HelpCenterFeedbackForm = ( {
 								) }
 							</p>
 						</div>
-						<GetSupport onClickAdditionalEvent={ handleContactSupportClick } />
+						<GetSupport
+							onClickAdditionalEvent={ handleContactSupportClick }
+							isUserEligibleForPaidSupport={ isUserEligibleForPaidSupport }
+						/>
 					</>
 				) : (
 					<HelpCenterContactSupportOption

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -6,6 +6,7 @@ import './get-support.scss';
 
 interface GetSupportProps {
 	onClickAdditionalEvent?: () => void;
+	isUserEligibleForPaidSupport?: boolean;
 }
 
 interface ButtonConfig {
@@ -13,10 +14,13 @@ interface ButtonConfig {
 	action: () => Promise< void >;
 }
 
-export const GetSupport: React.FC< GetSupportProps > = ( { onClickAdditionalEvent } ) => {
+export const GetSupport: React.FC< GetSupportProps > = ( {
+	onClickAdditionalEvent,
+	isUserEligibleForPaidSupport,
+} ) => {
 	const navigate = useNavigate();
 	const newConversation = useCreateZendeskConversation();
-	const { shouldUseHelpCenterExperience, chat, isUserEligibleForPaidSupport } =
+	const { chat, isUserEligibleForPaidSupport: contextIsUserEligibleForPaidSupport } =
 		useOdieAssistantContext();
 
 	// Early return if user is already talking to a human
@@ -25,11 +29,9 @@ export const GetSupport: React.FC< GetSupportProps > = ( { onClickAdditionalEven
 	}
 
 	const getButtonConfig = (): ButtonConfig => {
-		if ( isUserEligibleForPaidSupport ) {
+		if ( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport ) {
 			return {
-				text: shouldUseHelpCenterExperience
-					? __( 'Get instant support', __i18n_text_domain__ )
-					: __( 'Get support', __i18n_text_domain__ ),
+				text: __( 'Get instant support', __i18n_text_domain__ ),
 				action: async () => {
 					onClickAdditionalEvent?.();
 					await newConversation();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9954
Fixes https://github.com/Automattic/dotcom-forge/issues/9959

## Proposed Changes

GetSupport in components now receives isUserEligibleForPaidSupport info even if in Help Center and outside the Odie context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the appropriate flag
* Paid user
* Go to Help Center and to the bottom of an article
* Give negative feedback
* It should show "Get Instant support"
* Try it with a free user and it should send you to forums instead
