### PR TITLE
Reader Recent Feed Overhaul: Add screen reader navigation

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -492,7 +492,10 @@ export class FullPostView extends Component {
 					) }
 					{ referral && ! referralPost && <QueryReaderPost postKey={ referral } /> }
 					{ ! post || ( isLoading && <QueryReaderPost postKey={ postKey } /> ) }
-					<BackButton onClick={ this.handleBack } />
+					<BackButton
+						onClick={ this.handleBack }
+						aria-label={ translate( 'Return to the list of posts.' ) }
+					/>
 					<div className="reader-full-post__visit-site-container">
 						<ExternalLink
 							icon

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -31,6 +31,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const postColumnRef = useRef< HTMLDivElement | null >( null );
+	const itemRefs = useRef< { [ key: string ]: HTMLDivElement | null } >( {} );
 
 	const [ view, setView ] = useState< View >( {
 		type: 'list',
@@ -98,7 +99,14 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				getValue: ( { item }: { item: ReaderPost } ) =>
 					`${ getPostFromItem( item )?.title ?? '' } - ${ item?.site_name ?? '' }`,
 				render: ( { item }: { item: ReaderPost } ) => {
-					return <RecentPostField post={ getPostFromItem( item ) } />;
+					return (
+						<RecentPostField
+							ref={ ( el ) => {
+								itemRefs.current[ item.postId?.toString() ?? '' ] = el;
+							} }
+							post={ getPostFromItem( item ) }
+						/>
+					);
 				},
 				enableHiding: false,
 				enableSorting: false,

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -2,13 +2,14 @@ import { WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { translate } from 'i18n-calypso';
-import { useState, useEffect, useCallback, useMemo, useLayoutEffect } from 'react';
+import { useState, useEffect, useCallback, useMemo, useLayoutEffect, useRef } from 'react';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { UnknownAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import AsyncLoad from 'calypso/components/async-load';
 import EmptyContent from 'calypso/components/empty-content';
+import Focusable from 'calypso/components/focusable';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPaginatedStream } from 'calypso/state/reader/streams/actions';
@@ -30,6 +31,11 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 	const [ selectedItem, setSelectedItem ] = useState< ReaderPost | null >( null );
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const selectedPostId = selectedItem?.postId?.toString();
+	const postContentId = 'reader-post-content';
+	const postColumnRef = useRef< HTMLDivElement | null >( null );
+	useKeyboardNavigation( selectedItem, postContentId );
+	usePostContentAnnouncements( postContentId );
 
 	const [ view, setView ] = useState< View >( {
 		type: 'list',
@@ -97,14 +103,23 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				getValue: ( { item }: { item: ReaderPost } ) =>
 					`${ getPostFromItem( item )?.title ?? '' } - ${ item?.site_name ?? '' }`,
 				render: ( { item }: { item: ReaderPost } ) => {
-					return <RecentPostField post={ getPostFromItem( item ) } />;
+					const isItemSelected = item.postId?.toString() === selectedPostId;
+					return (
+						<Focusable
+							id={ `post-${ item.postId }` }
+							aria-expanded={ isItemSelected }
+							aria-controls={ isItemSelected ? postContentId : undefined }
+						>
+							<RecentPostField post={ getPostFromItem( item ) } />
+						</Focusable>
+					);
 				},
 				enableHiding: false,
 				enableSorting: false,
 				enableGlobalSearch: true,
 			},
 		],
-		[ getPostFromItem ]
+		[ getPostFromItem, selectedPostId ]
 	);
 
 	const fetchData = useCallback( () => {
@@ -190,6 +205,10 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 								( item: ReaderPost ) => item.postId?.toString() === newSelection[ 0 ]
 							);
 							setSelectedItem( selectedPost || null );
+							// Focus the post column after a short delay to ensure DOM updates.
+							setTimeout( () => {
+								postColumnRef.current?.focus();
+							}, 0 );
 						} }
 					/>
 				</div>

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -9,7 +9,6 @@ import { ThunkDispatch } from 'redux-thunk';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import AsyncLoad from 'calypso/components/async-load';
 import EmptyContent from 'calypso/components/empty-content';
-import Focusable from 'calypso/components/focusable';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPaginatedStream } from 'calypso/state/reader/streams/actions';
@@ -31,8 +30,6 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 	const [ selectedItem, setSelectedItem ] = useState< ReaderPost | null >( null );
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
 	const [ isLoading, setIsLoading ] = useState( false );
-	const selectedPostId = selectedItem?.postId?.toString();
-	const postContentId = 'reader-post-content';
 	const postColumnRef = useRef< HTMLDivElement | null >( null );
 
 	const [ view, setView ] = useState< View >( {
@@ -101,23 +98,14 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				getValue: ( { item }: { item: ReaderPost } ) =>
 					`${ getPostFromItem( item )?.title ?? '' } - ${ item?.site_name ?? '' }`,
 				render: ( { item }: { item: ReaderPost } ) => {
-					const isItemSelected = item.postId?.toString() === selectedPostId;
-					return (
-						<Focusable
-							id={ `post-${ item.postId }` }
-							aria-expanded={ isItemSelected }
-							aria-controls={ isItemSelected ? postContentId : undefined }
-						>
-							<RecentPostField post={ getPostFromItem( item ) } />
-						</Focusable>
-					);
+					return <RecentPostField post={ getPostFromItem( item ) } />;
 				},
 				enableHiding: false,
 				enableSorting: false,
 				enableGlobalSearch: true,
 			},
 		],
-		[ getPostFromItem, selectedPostId ]
+		[ getPostFromItem ]
 	);
 
 	const fetchData = useCallback( () => {

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -207,7 +207,12 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 					/>
 				</div>
 			</div>
-			<div className={ `recent-feed__post-column ${ selectedItem ? 'overlay' : '' }` }>
+			<section
+				aria-labelledby={ selectedItem ? `post-${ selectedItem.postId }` : undefined }
+				ref={ postColumnRef }
+				className={ `recent-feed__post-column ${ selectedItem ? 'overlay' : '' }` }
+				tabIndex={ -1 }
+			>
 				{ ! ( selectedItem && getPostFromItem( selectedItem ) ) && isLoading && (
 					<RecentPostSkeleton />
 				) }
@@ -225,13 +230,21 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 							require="calypso/blocks/reader-full-post"
 							feedId={ selectedItem.feedId }
 							postId={ selectedItem.postId }
-							onClose={ () => setSelectedItem( null ) }
+							onClose={ () => {
+								const focusItem = itemRefs.current[ selectedItem?.postId?.toString() ?? '' ];
+								if ( ! isWide ) {
+									setSelectedItem( null );
+								}
+								requestAnimationFrame( () => {
+									focusItem?.focus();
+								} );
+							} }
 							layout="recent"
 						/>
 						<EngagementBar feedId={ selectedItem?.feedId } postId={ selectedItem?.postId } />
 					</>
 				) }
-			</div>
+			</section>
 		</div>
 	);
 };

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -172,7 +172,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				<div className="recent-feed__list-column-header">
 					<NavigationHeader title={ translate( 'Recent' ) }>{ viewToggle }</NavigationHeader>
 				</div>
-				<div className="recent-feed__list-column-content">
+				<aside className="recent-feed__list-column-content">
 					<DataViews
 						getItemId={ ( item: ReaderPost, index = 0 ) =>
 							item.postId?.toString() ?? `item-${ index }`
@@ -205,7 +205,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 							}, 0 );
 						} }
 					/>
-				</div>
+				</aside>
 			</div>
 			<section
 				aria-labelledby={ selectedItem ? `post-${ selectedItem.postId }` : undefined }

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -34,8 +34,6 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 	const selectedPostId = selectedItem?.postId?.toString();
 	const postContentId = 'reader-post-content';
 	const postColumnRef = useRef< HTMLDivElement | null >( null );
-	useKeyboardNavigation( selectedItem, postContentId );
-	usePostContentAnnouncements( postContentId );
 
 	const [ view, setView ] = useState< View >( {
 		type: 'list',

--- a/client/reader/recent/recent-post-field.tsx
+++ b/client/reader/recent/recent-post-field.tsx
@@ -1,16 +1,18 @@
+import { forwardRef } from 'react';
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 import type { PostItem } from './types';
+
 interface RecentPostFieldProps {
 	post: PostItem;
 }
 
-const RecentPostField: React.FC< RecentPostFieldProps > = ( { post } ) => {
+const RecentPostField = forwardRef< HTMLDivElement, RecentPostFieldProps >( ( { post }, ref ) => {
 	if ( ! post ) {
 		return null;
 	}
 
 	return (
-		<div className="recent-post-field">
+		<div className="recent-post-field" ref={ ref } role="button" tabIndex={ 0 }>
 			<div className="recent-post-field__title">
 				<div className="recent-post-field__title-text">{ post?.title }</div>
 				<div className="recent-post-field__site-name">{ post?.site_name }</div>
@@ -25,6 +27,6 @@ const RecentPostField: React.FC< RecentPostFieldProps > = ( { post } ) => {
 			</div>
 		</div>
 	);
-};
+} );
 
 export default RecentPostField;

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -2,6 +2,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/dataviews/build-style/style.css";
+@import "calypso/assets/stylesheets/shared/mixins/hide-content-accessibly";
 
 body.is-reader-full-post {
 	overflow: hidden;
@@ -232,7 +233,7 @@ body.is-reader-full-post {
 
 		.back-button {
 			@media ( min-width: $break-wide ) {
-				display: none;
+				@include hide-content-accessibly();
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/229

## Proposed Changes

* Focus the post column when a post is selected.
* Change the back button to be visible to screen readers on wide screen resolutions.
* Focus the item in the posts list when the back button is clicked.

https://github.com/user-attachments/assets/cd59fd77-d0d3-454b-a919-d4e624adda82

<img width="1806" alt="Screen Shot 2024-12-04 at 4 35 27 PM" src="https://github.com/user-attachments/assets/b444da8a-5442-4944-ae8c-f39a43711ccf">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2iv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Turn on a screen reader. On a Mac: press Cmd + F5, then open Safari.
* Go to /read?flags=reader/recent-feed-overhaul
* Navigate through the middle column of posts and check that you can select a post by pressing enter or following the screen reader's directions.
* When you select a post, it should be focused in the right column.
* When you start tabbing or navigating in the right column, the first element should be a button with label "Return to the list of posts."
* Press enter or follow the screen reader's directions to click the button.
* The item in the posts list should be focused again.
* Regression test that the Back button is still visible on mobile and takes you back to the posts list. 
* Regression test that the Back button is still visible and takes you back to the posts list in the current stream view (/read without the feature flag).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?