### PR TITLE
Fix price in tiered pricing lightbox when sale coupon is active

### DIFF
--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -31,6 +31,7 @@ interface ItemPrices {
 	discountedPriceTotal?: number | null;
 	discountedPriceDuration?: number;
 	priceTierList: PriceTierEntry[];
+	saleCouponDiscount?: number | null;
 }
 
 interface ItemRawPrices {
@@ -220,6 +221,7 @@ const useItemPrice = (
 		discountedPriceDuration,
 		discountedPriceTotal,
 		priceTierList,
+		saleCouponDiscount,
 	};
 };
 


### PR DESCRIPTION
## Proposed Changes

* Display correctly discounted price when sale coupon is active in lightbox with a tiered product

## Why are these changes being made?

The discount is not being shown correctly currently on tiered products in the lightbox

## Testing Instructions

1. Checkout this branch locally or use the Calypso Green live link
2. Go to `/pricing#jetpack_stats_yearly`
3. Ensure you see the correct discount no matter which tier is selected
![image](https://github.com/user-attachments/assets/907381ae-867b-4973-88a1-e010de35ab42)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
