### PR TITLE
Passwordless Auth Core Profiler -- Fix bugs related to Woo Payments flow

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -67,10 +67,10 @@ import getMagicLoginRequestedAuthSuccessfully from 'calypso/state/selectors/get-
 import isFetchingMagicLoginAuth from 'calypso/state/selectors/is-fetching-magic-login-auth';
 import isFetchingMagicLoginEmail from 'calypso/state/selectors/is-fetching-magic-login-email';
 import isMagicLoginEmailRequested from 'calypso/state/selectors/is-magic-login-email-requested';
+import isWooPasswordlessJPCFlow from 'calypso/state/selectors/is-woo-passwordless-jpc-flow';
 import { withEnhancers } from 'calypso/state/utils';
 import MainContentWooCoreProfiler from './main-content-woo-core-profiler';
 import RequestLoginEmailForm from './request-login-email-form';
-
 import './style.scss';
 
 const RESEND_EMAIL_COUNTDOWN_TIME = 90; // In seconds
@@ -107,6 +107,7 @@ class MagicLogin extends Component {
 
 		// From `localize`
 		translate: PropTypes.func.isRequired,
+		isWooPasswordlessJPC: PropTypes.bool,
 	};
 
 	state = {
@@ -1213,13 +1214,11 @@ class MagicLogin extends Component {
 			query,
 			translate,
 			showCheckYourEmail: showEmailLinkVerification,
+			isWooPasswordlessJPC,
 		} = this.props;
 		const { showSecondaryEmailOptions, showEmailCodeVerification, usernameOrEmail } = this.state;
 
-		if (
-			query?.from === 'woocommerce-core-profiler' &&
-			config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' )
-		) {
+		if ( isWooPasswordlessJPC ) {
 			return (
 				<Main className="magic-login magic-login__request-link is-white-login">
 					{ this.renderLocaleSuggestions() }
@@ -1337,6 +1336,7 @@ const mapState = ( state ) => ( {
 	isFromAutomatticForAgenciesPlugin:
 		'automattic-for-agencies-client' ===
 		new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
+	isWooPasswordlessJPC: isWooPasswordlessJPCFlow( state ),
 } );
 
 const mapDispatch = {

--- a/client/state/selectors/is-woo-passwordless-jpc-flow.ts
+++ b/client/state/selectors/is-woo-passwordless-jpc-flow.ts
@@ -8,9 +8,28 @@ const isWooCommercePaymentsOnboardingFlow = ( state: AppState ): boolean => {
 	const from =
 		get( getInitialQueryArguments( state ), 'from' ) === 'woocommerce-payments' ||
 		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-payments';
+
+	const redirectTo =
+		get( getInitialQueryArguments( state ), 'redirect_to' ) ||
+		get( getCurrentQueryArguments( state ), 'redirect_to' );
+
+	// Unlike WooCommerce Core Profiler flow, we use both `from` and `plugin_name` to determine if the user is in the Woo Payments onboarding flow.
+	// `plugin_name` might not present in the query arguments, so we need to check the `redirect_to` query argument as well.
+	const redirectToHasWooCommercePayments =
+		typeof redirectTo === 'string' &&
+		( () => {
+			try {
+				return new URLSearchParams( redirectTo ).get( 'plugin_name' ) === 'woocommerce-payments';
+			} catch {
+				return false;
+			}
+		} )();
+
 	const plugin =
 		get( getInitialQueryArguments( state ), 'plugin_name' ) === 'woocommerce-payments' ||
-		get( getCurrentQueryArguments( state ), 'plugin_name' ) === 'woocommerce-payments';
+		get( getCurrentQueryArguments( state ), 'plugin_name' ) === 'woocommerce-payments' ||
+		redirectToHasWooCommercePayments;
+
 	return from && plugin;
 };
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR fixes two bugs that caused some pages to not render correctly in the Woo Payments flow.

## Proposed Changes

* Render the correct magic login page 
* Search `plugin` in `redirect_to`, as well as the initial and current queries.


## Testing Instructions

1. Checkout this branch locally and run `yarn start`.
2. Once the build is ready, visit this [link](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=239399521&redirect_uri=https%3A%2F%2Fgenerously-provincial.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D022af65161%26redirect%3Dhttps%253A%252F%252Fgenerously-provincial.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=administrator%3A2db2c5a31e6f8fc51302ddeb4ce65a3f&user_email=moon.kyong%40automattic.com&user_login=moon0326&jp_version=14.1-a.7&secret=aaa&blogname=Generously%20Provincial&site_url=https%3A%2F%2Fgenerously-provincial.jurassic.ninja&home_url=https%3A%2F%2Fgenerously-provincial.jurassic.ninja&site_icon=&site_lang=en_US&site_created=2024-11-26%2022%3A31%3A45&allow_site_connection=1&calypso_env=production&source=&_as=wp-cli&locale=en&from=woocommerce-payments&plugin_name=woocommerce-payments&_ui=189042142&_ut=wpcom%3Auser_id&purchase_nonce=XKT4d5im&_wp_nonce=929bfc39c6&redirect_after_auth=https%3A%2F%2Fgenerously-provincial.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Fgenerously-provincial.jurassic.ninja) in an incognito window. The link has `from=woocommerce-payments` and `plugin_name=woocommerce-payments` to simulate Woo Payments flow.
3. Confirm the page renders without any visual glitches.
4. Click on `Log in` link
5. Confirm you're still on the passwordless auth flow.
6. Enter a passwordless account and click on `Continue`
7. You should see Woo-themed magic link page.

![Screenshot 2024-11-26 at 3 26 39 PM](https://github.com/user-attachments/assets/bb2c3c68-4542-4a6f-9619-910229b54a0b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
