### PR TITLE
Stats: Fix stats period header spacing and sticky spacing

### DIFF
--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -8,11 +8,16 @@
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: center;
-	// .stats-content has a gap already, so the .stats__period-header from the new design only needs margin-top.
 	margin-top: 16px;
+	padding: 0;
 
 	.stats-content & {
 		margin: 16px 0;
+	}
+
+	.is-sticky & {
+		margin-top: 0;
+		padding: 0 32px;
 	}
 
 	.period {

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -8,7 +8,7 @@
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: center;
-	margin-top: 16px;
+	margin-top: 32px;
 	padding: 0;
 
 	.stats-content & {

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -56,13 +56,6 @@ $stats-card-min-width: 390px;
 	}
 }
 
-.stats__period-header {
-	padding: 0;
-
-	.is-sticky & {
-		padding: 0 32px;
-	}
-}
 
 .stats-card {
 	@media (max-width: $break-medium) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

related to: pejTkB-1LV-p2#comment-1769

## Proposed Changes

Fix header spacing inconsistencies

- Remove 16px margin-top on .stats__period-header when sticky to prevent extra space
- Increase .stats__period-header margin-top from 16px to 32px in non-sticky state to achieve balanced spacing that matches the design

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Feedback from project CfT

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open live branch
* append `flags=stats/new-date-filtering`
* check that the spacing top and bottom is consistent on header both when sticky and without sticky behaviour

![image](https://github.com/user-attachments/assets/7f61b274-f168-4ff0-8ae3-172dfe21d980)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
