### PR TITLE
Sites Dashboard: Remove the hover & selected color overrides

### DIFF
--- a/client/sites/components/sites-dataviews/dataview-style.scss
+++ b/client/sites/components/sites-dataviews/dataview-style.scss
@@ -23,45 +23,6 @@
 			vertical-align: middle;
 		}
 	}
-
-	ul.dataviews-view-list {
-		// TODO: Remove when theming APIs are implemented. pbxlJb-6A9-p2#comment-4011
-		li:hover {
-			background: var(--color-neutral-0);
-		}
-		// TODO: Remove when theming APIs are implemented. pbxlJb-6A9-p2#comment-4011
-		.is-selected {
-			background-color: var(--color-neutral-0);
-		}
-	}
-}
-
-// Selected and hover states on the site list.
-// TODO: Remove when theming APIs are implemented. pbxlJb-6A9-p2#comment-4011
-.wpcom-site .is-global-sidebar-visible.is-group-sites-dashboard,
-.wpcom-site .is-global-sidebar-visible.is-group-sites {
-	.sites-dashboard:not(.preview-hidden) {
-		ul.dataviews-view-list {
-			li.is-selected,
-			li.is-selected:hover {
-				// Override this element to ensure it doesn’t blend with the Core's alpha-based color.
-				.dataviews-view-list__item-wrapper {
-					background-color: #ebf2fc;
-				}
-				.dataviews-view-list__item-actions {
-					background-color: #ebf2fc;
-					box-shadow: -12px 0 8px 0 #ebf2fc;
-				}
-			}
-			li:hover {
-				--color-neutral-0: #f7faff;
-				.dataviews-view-list__item-actions {
-					background-color: #f7faff;
-					box-shadow: -12px 0 8px 0 #f7faff;
-				}
-			}
-		}
-	}
 }
 
 .wpcom-site .main.a4a-layout.sites-dashboard {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This is the PR to demo removing the hover & selected color overrides.

|| before | after |
|--------|--------|--------|
|table view, hover (**no change**)| <img width="1134" alt="Screenshot 2024-11-27 at 14 52 04" src="https://github.com/user-attachments/assets/d0e49af2-71e5-4a13-9fd2-e4180411e0db"> | <img width="1139" alt="Screenshot 2024-11-27 at 14 52 29" src="https://github.com/user-attachments/assets/5f4d3259-fd40-48a7-817e-1d047a7e607e"> | 
|list view, hover|<img width="407" alt="Screenshot 2024-11-27 at 14 52 19" src="https://github.com/user-attachments/assets/eb62c6c9-4ad9-4981-9f1e-82a56c877bda">|<img width="411" alt="Screenshot 2024-11-27 at 14 52 46" src="https://github.com/user-attachments/assets/e89667e6-7faf-48a8-bfa2-405fdb3d5477">|
list view, selected|<img width="405" alt="Screenshot 2024-11-27 at 14 52 12" src="https://github.com/user-attachments/assets/6a261477-5981-426a-91e6-de624ec2695f">|<img width="409" alt="Screenshot 2024-11-27 at 14 52 40" src="https://github.com/user-attachments/assets/37e1961e-c3ed-4afc-927d-decb48d10045">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
