### PR TITLE
A4A: Remove 'Plugin requires update' from the Site dashboard error indicator.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/hooks/use-get-site-errors.tsx
@@ -25,23 +25,6 @@ export default function useGetSiteErrors() {
 				} );
 			}
 
-			if ( data?.plugin?.status === 'warning' ) {
-				errors.push( {
-					severity: 'medium',
-					message: translate(
-						'%(count)s plugin requires update',
-						'%(count)s plugins require updates',
-						{
-							count: data.plugin.updates,
-							args: {
-								count: data.plugin.updates,
-							},
-							comment: '%(count) here is the number of plugins that require updates',
-						}
-					),
-				} );
-			}
-
 			if ( data?.site?.value?.is_simple ) {
 				const siteSlug = data?.site?.value?.url?.replace( /(^\w+:|^)\/\//, '' );
 				const wpOverviewUrl = `https://wordpress.com/overview/${ siteSlug }`;


### PR DESCRIPTION
This PR removes the 'Plugin requires update' indicator from the Site dashboard error indicator.

| Before | After |
|--------|--------|
| <img width="1812" alt="Screenshot 2024-11-27 at 3 59 02 PM" src="https://github.com/user-attachments/assets/36ed0e58-cea3-4bff-b34c-8d6b71ee255d"> | <img width="1771" alt="Screenshot 2024-11-27 at 3 59 36 PM" src="https://github.com/user-attachments/assets/0d3226fa-3a96-4c3b-8d10-dba2425c6b13"> | 


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1490

## Proposed Changes

* Do not include 'Plugin requires update' from the Site error indicator since we already have a dedicated column for this.

## Why are these changes being made?

* This prevents our dashboard from appearing broken during any WPCOM Gutenberg updates impacting all Atomic features sites.

## Testing Instructions

* Choose a Site from your Site dashboard and install an out-dated plugin.
* Use the A4A live link and go to the `/sites` page.
* Confirm that you do not see the warning icon.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
