### PR TITLE
Remove custom flow for the "write" intent

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -312,7 +312,7 @@ const siteSetupFlow: Flow = {
 					}
 
 					// If the user skips starting point, redirect them to the post editor
-					if ( intent === 'write' && startingPoint !== 'skip-to-my-home' ) {
+					if ( isGoalsHoldout && intent === 'write' && startingPoint !== 'skip-to-my-home' ) {
 						if ( startingPoint !== 'write' ) {
 							window.sessionStorage.setItem( 'wpcom_signup_complete_show_draft_post_modal', '1' );
 						}
@@ -384,8 +384,8 @@ const siteSetupFlow: Flow = {
 
 						case SiteIntent.DIFM:
 							return navigate( 'difmStartingPoint' );
+
 						case SiteIntent.Write:
-							return navigate( 'options' );
 						case SiteIntent.Sell:
 							// If we're not in the holdout, intentionally fall through to the default case
 							if ( isGoalsHoldout ) {
@@ -536,7 +536,6 @@ const siteSetupFlow: Flow = {
 						case SiteIntent.DIFM:
 							return navigate( 'difmStartingPoint' );
 						case SiteIntent.Write:
-							return navigate( 'bloggerStartingPoint' );
 						case SiteIntent.Sell:
 							// If we're not in the holdout, intentionally fall through to the default case
 							if ( isGoalsHoldout ) {

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -21,7 +21,6 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () {
 	const blogName = DataHelper.getBlogName();
-	const blogTagLine = `${ blogName } tagline`;
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'signupfree',
 	} );
@@ -65,6 +64,7 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 	} );
 
 	describe( 'Onboarding', function () {
+		const themeName = 'Poema';
 		let startSiteFlow: StartSiteFlow;
 
 		beforeAll( async function () {
@@ -84,12 +84,8 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 			await startSiteFlow.clickButton( 'Continue' );
 		} );
 
-		it( 'Enter blog name', async function () {
-			await startSiteFlow.enterBlogName( blogName );
-		} );
-
-		it( 'Enter blog tagline', async function () {
-			await startSiteFlow.enterTagline( blogTagLine );
+		it( 'Select theme', async function () {
+			await startSiteFlow.selectTheme( themeName );
 			await startSiteFlow.clickButton( 'Continue' );
 		} );
 	} );
@@ -97,15 +93,14 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 	describe( 'Write', function () {
 		const postTitle = DataHelper.getRandomPhrase();
 
-		let startSiteFlow: StartSiteFlow;
 		let editorPage: EditorPage;
 
-		beforeAll( async function () {
-			startSiteFlow = new StartSiteFlow( page );
+		it( 'Launchpad is shown', async function () {
+			await page.waitForURL( /launchpad/, { timeout: 30000 } );
 		} );
 
 		it( 'Write first post', async function () {
-			await startSiteFlow.clickWriteAction( 'Start writing' );
+			await page.getByRole( 'link', { name: 'Write your first post' } ).click();
 		} );
 
 		it( 'Editor loads', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #96567

## Proposed Changes

* Removes the `options` step from the write flow
* Removes the "land directly in editor" behaviour from the write flow (but it's still linked to in the launchpad)
* Keeps a 10% holdout (via the `calypso_onboarding_goals_holdout_20241126` experiment) on the old experience.

**The Regular Experience**

https://github.com/user-attachments/assets/9796ad0f-f482-46d4-a271-adff0a5deb8a

**The Holdout Experience**


https://github.com/user-attachments/assets/9b0dcfcb-492e-430a-919d-5bc0ac6f1e81



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We are moving onboarding customisation our of the flow and into the launchpad. See p58i-irT-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to `control` or `holdout` group in explat 22115-explat-experiment
* Create a new site starting at `/start` or `/setup/onboarding`
* Confirm back/forward navigation works throughout the flow
* Confirm that the "Select a design" and "Write your first post" tasks in the launchpad are correctly ticked
   * If you use the default experience "Select a design" is ticked, "Write your first post" isn't
   * If you are in the holdout, by the time you get to the launchpad, it will depend on whether you published your post or selected a design or not

If you test with a premium plan then BigSky might have appeared as an option after submitting the goals step. It depends whether you choose [eligible goals](https://github.com/Automattic/wp-calypso/blob/4d865e5bb668b6919e8b62078d368e036038dd31/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts#L20-L21).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?