### PR TITLE
A4A: Address the Pressable Referrals feedback from the CfT post. Copy tweaks.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -209,7 +209,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 	}
 
 	if ( isClient ) {
-		actionContent = <SubmitPaymentInfo disableButton={ checkoutItems?.length === 0 } isClient />;
+		actionContent = <SubmitPaymentInfo disableButton={ checkoutItems?.length === 0 } />;
 	}
 
 	return (

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -209,7 +209,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 	}
 
 	if ( isClient ) {
-		actionContent = <SubmitPaymentInfo disableButton={ checkoutItems?.length === 0 } />;
+		actionContent = <SubmitPaymentInfo disableButton={ checkoutItems?.length === 0 } isClient />;
 	}
 
 	return (

--- a/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
@@ -67,9 +67,14 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 		if ( status === 'success' ) {
 			dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_submit_payment_info_success' ) );
 			dispatch(
-				successNotice( translate( 'Thank you for your purchase!' ), {
-					displayOnNextPage: true,
-				} )
+				successNotice(
+					paymentMethodRequired
+						? translate( 'Thank you for your purchase!' )
+						: translate( 'Thank you for your purchase! Your agency can now set up your product.' ),
+					{
+						displayOnNextPage: true,
+					}
+				)
 			);
 			page.redirect( A4A_CLIENT_SUBSCRIPTIONS_LINK );
 		}
@@ -94,7 +99,7 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 				errorNotice( translate( 'Failed to submit payment information. Please try again.' ) )
 			);
 		}
-	}, [ dispatch, error?.code, status, translate ] );
+	}, [ dispatch, error?.code, status, translate, paymentMethodRequired ] );
 
 	return (
 		<>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
@@ -16,13 +16,7 @@ import useSubmitPaymentInfoMutation from '../hooks/use-submit-payment-info-mutat
 import { getClientReferralQueryArgs } from '../lib/get-client-referral-query-args';
 import NoticeSummary from './notice-summary';
 
-export default function SubmitPaymentInfo( {
-	disableButton,
-	isClient,
-}: {
-	disableButton?: boolean;
-	isClient?: boolean;
-} ) {
+export default function SubmitPaymentInfo( { disableButton }: { disableButton?: boolean } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -74,9 +68,7 @@ export default function SubmitPaymentInfo( {
 			dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_submit_payment_info_success' ) );
 			dispatch(
 				successNotice(
-					isClient
-						? translate( 'Thank you for your purchase! Your agency can now set up your product.' )
-						: translate( 'Thank you for your purchase!' ),
+					translate( 'Thank you for your purchase! Your agency can now set up your product.' ),
 					{
 						displayOnNextPage: true,
 					}
@@ -105,7 +97,7 @@ export default function SubmitPaymentInfo( {
 				errorNotice( translate( 'Failed to submit payment information. Please try again.' ) )
 			);
 		}
-	}, [ dispatch, error?.code, status, translate, paymentMethodRequired ] );
+	}, [ dispatch, error?.code, status, translate ] );
 
 	return (
 		<>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
@@ -16,7 +16,13 @@ import useSubmitPaymentInfoMutation from '../hooks/use-submit-payment-info-mutat
 import { getClientReferralQueryArgs } from '../lib/get-client-referral-query-args';
 import NoticeSummary from './notice-summary';
 
-export default function SubmitPaymentInfo( { disableButton }: { disableButton?: boolean } ) {
+export default function SubmitPaymentInfo( {
+	disableButton,
+	isClient,
+}: {
+	disableButton?: boolean;
+	isClient?: boolean;
+} ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -68,9 +74,9 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 			dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_submit_payment_info_success' ) );
 			dispatch(
 				successNotice(
-					paymentMethodRequired
-						? translate( 'Thank you for your purchase!' )
-						: translate( 'Thank you for your purchase! Your agency can now set up your product.' ),
+					isClient
+						? translate( 'Thank you for your purchase! Your agency can now set up your product.' )
+						: translate( 'Thank you for your purchase!' ),
 					{
 						displayOnNextPage: true,
 					}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -81,16 +81,7 @@ export default function PlanSelectionDetails( {
 			<div className="pressable-overview-plan-selection__details-card">
 				<div className="pressable-overview-plan-selection__details-card-header">
 					<h3 className="pressable-overview-plan-selection__details-card-header-title plan-name">
-						{ isNewHostingPage
-							? translate( 'Pressable' )
-							: translate( '%(planName)s plan', {
-									args: {
-										planName: selectedPlan
-											? getPressableShortName( selectedPlan.name )
-											: customString,
-									},
-									comment: '%(planName)s is the name of the selected plan.',
-							  } ) }
+						{ selectedPlan ? selectedPlan.name : customString }
 					</h3>
 
 					{ ! isReferMode && selectedPlan && (

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/referral-mode/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/referral-mode/index.tsx
@@ -59,7 +59,7 @@ export default function ReferralPressableOverviewPlanSelection( { onAddToCart }:
 			} ) }
 		>
 			<div className="pressable-overview-plan-selection__upgrade-title narrow">
-				{ translate( 'Choose plan to refer' ) }
+				{ translate( 'Choose a plan to refer' ) }
 			</div>
 			<PlanSelectionFilter
 				selectedPlan={ selectedPlan }


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/1523

## Proposed Changes

This PR addresses the feedback from the Pressable Referral CfT post. It updates some copy.

**Agency View:**

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/f003f572-dc57-4c7b-9ad0-58907063ac07">

**Client View:**

![image](https://github.com/user-attachments/assets/0dcf8bc3-5094-4a5e-8807-b12226e7eb6c)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code and the new copy.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
