### PR TITLE
Plans: Hide term savings price display in the logged in plans page

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -843,8 +843,9 @@ const PlansFeaturesMain = ( {
 										enableLogosOnlyForEnterprisePlan={ showSimplifiedFeatures }
 										hideFeatureGroupTitles={ showSimplifiedFeatures }
 										enableTermSavingsPriceDisplay={
-											isEnabled( 'plans/term-savings-price-display' ) ||
-											longerPlanTermDefaultExperiment.isEligibleForTermSavings
+											( isEnabled( 'plans/term-savings-price-display' ) ||
+												longerPlanTermDefaultExperiment.isEligibleForTermSavings ) &&
+											isInSignup
 										}
 									/>
 								) }
@@ -906,8 +907,9 @@ const PlansFeaturesMain = ( {
 													enableFeatureTooltips
 													featureGroupMap={ featureGroupMapForComparisonGrid }
 													enableTermSavingsPriceDisplay={
-														isEnabled( 'plans/term-savings-price-display' ) ||
-														longerPlanTermDefaultExperiment.isEligibleForTermSavings
+														( isEnabled( 'plans/term-savings-price-display' ) ||
+															longerPlanTermDefaultExperiment.isEligibleForTermSavings ) &&
+														isInSignup
 													}
 												/>
 											) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1732646141389969-slack-CV2TX2PAN and p1732648406144139-slack-CV2TX2PAN

## Proposed Changes

* Modified the `enableTermSavingsPriceDisplay` condition to include the `isInSignup` check, ensuring that the term savings price display is only enabled when the user is in onboarding.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  Defaulting to longer term plans leads to a subpar UX experience in the logged in plans page. See this comment specifically p1732652464476219/1732648406.144139-slack-CV2TX2PAN. 
* It would also interfere with the Hide Lower Tiers Experiment pbxNRc-4gN-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/start/plans?flags=plans%2Fterm-savings-price-display. 
* Verify that term savings are still displayed for 1y, 2y, and 3y plans.

<img width="1485" alt="Screenshot 2024-11-27 at 00 49 58" src="https://github.com/user-attachments/assets/a6798a40-91b9-47be-b516-12059acef284">

* Visit http://calypso.localhost:3000/plans/{SITE_SLUG}?flags=plans%2Fterm-savings-price-display. Verify that term savings are no longer displayed for 1y, 2y, and 3y plans

<img width="1288" alt="Screenshot 2024-11-27 at 00 50 40" src="https://github.com/user-attachments/assets/f1b6b48b-8bd6-4a5e-95cc-fcbaf8ac8cc2">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?