### PR TITLE
Fix UI issues in site management panel

### DIFF
--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -301,10 +301,9 @@
 				max-height: calc(100vh - var(--masterbar-height));
 			}
 			.preview-pane__navigation {
-				box-shadow: 0 0 0 1px var(--color-border-subtle), 0 1px 2px var(--color-border-subtle);
-				// Fix the weird box-shadow on the top when the action buttons are wrapped into the newline;
+				box-shadow: none;
+				border-bottom: 1px solid var(--color-border-subtle);
 				padding-top: 1px;
-				clip-path: inset(2px 0 -1px 0);
 			}
 		}
 

--- a/client/sites/hosting-features/components/hosting-features.tsx
+++ b/client/sites/hosting-features/components/hosting-features.tsx
@@ -125,7 +125,7 @@ const HostingFeatures = ( { showAsTools }: HostingFeaturesProps ) => {
 		? translate( 'Activate all hosting features' )
 		: translate( 'Activate all developer tools' );
 
-	const activateTitleAsTools = hasEnTranslation( 'Activate all advanced tools' );
+	const activateTitleAsTools = translate( 'Activate all advanced tools' );
 
 	const activationStatusTitle = translate( 'Activating hosting features' );
 	const activationStatusTitleAsTools = translate( 'Activating advanced tools' );

--- a/client/sites/settings/components/difm-upsell-banner/style.scss
+++ b/client/sites/settings/components/difm-upsell-banner/style.scss
@@ -13,5 +13,9 @@
 		.banner__action {
 			margin-inline-end: 0;
 		}
+		.wordpress-logo {
+			fill: var(--color-text);
+			margin: 0;
+		}
 	}
 }

--- a/client/sites/tools/deployments/components/repositories/style.scss
+++ b/client/sites/tools/deployments/components/repositories/style.scss
@@ -1,3 +1,6 @@
+@import 'node_modules/@wordpress/base-styles/breakpoints';
+@import 'node_modules/@wordpress/base-styles/mixins';
+
 .github-deployments-repositories {
 	display: flex;
 	flex-direction: column;
@@ -6,8 +9,22 @@
 
 	&__search-bar {
 		display: flex;
-		gap: 16px;
+		flex-direction: column;
+		gap: 8px;
 		margin-bottom: 16px;
+
+		@include break-small {
+			flex-direction: row;
+			gap: 16px;
+		}
+
+		.select-dropdown__container {
+			width: 100%;
+
+			@include break-small {
+				width: auto;
+			}
+		}
 	}
 
 	.components-spinner {
@@ -20,7 +37,6 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		width: 517px;
 		margin: 64px auto;
 		text-align: center;
 		p:first-child {

--- a/client/sites/tools/deployments/deployment-creation/style.scss
+++ b/client/sites/tools/deployments/deployment-creation/style.scss
@@ -1,5 +1,5 @@
 .repository-selection-dialog {
-	width: 622px;
+	max-width: 622px;
 	height: 515px;
 	display: flex;
 	flex-direction: column;
@@ -10,6 +10,7 @@
 	}
 
 	.formatted-header {
+		margin: 0;
 		margin-bottom: 24px !important;
 	}
 

--- a/client/sites/tools/deployments/deployment-creation/style.scss
+++ b/client/sites/tools/deployments/deployment-creation/style.scss
@@ -1,9 +1,15 @@
+@import 'node_modules/@wordpress/base-styles/breakpoints';
+@import 'node_modules/@wordpress/base-styles/mixins';
+
 .repository-selection-dialog {
-	max-width: 622px;
 	height: 515px;
 	display: flex;
 	flex-direction: column;
 	padding: 32px;
+
+	@include break-small {
+		width: 622px;
+	}
 
 	h1 {
 		margin-bottom: 8px !important;

--- a/client/sites/tools/deployments/deployment-run-logs/style.scss
+++ b/client/sites/tools/deployments/deployment-run-logs/style.scss
@@ -80,6 +80,10 @@ td.github-deployments-logs-content {
 
 .github-deployments-runs {
 	width: 100%;
+	
+	.action-panel {
+		overflow: auto;
+	}
 }
 
 .github-deployments-commit-author {

--- a/client/sites/tools/deployments/deployment-run-logs/style.scss
+++ b/client/sites/tools/deployments/deployment-run-logs/style.scss
@@ -84,6 +84,11 @@ td.github-deployments-logs-content {
 	.action-panel {
 		overflow: auto;
 	}
+
+	.card {
+		margin-left: 1px;
+		margin-right: 1px;
+	}
 }
 
 .github-deployments-commit-author {

--- a/client/sites/tools/deployments/style.scss
+++ b/client/sites/tools/deployments/style.scss
@@ -1,6 +1,7 @@
 .tools-deployments {
 	display: flex;
     flex-direction: column;
+	overflow: auto;
     gap: 16px;
 	margin: 0;
 
@@ -13,5 +14,9 @@
 	.components-button.is-primary.is-busy {
 		background-image: linear-gradient(-45deg, var(--color-accent) 28%, var(--color-accent-60) 28%, var(--color-accent-60) 72%, var(--color-accent) 72%);
 		background-size: 100px 100%;
+	}
+
+	.github-deployments__body {
+		overflow: auto;
 	}
 }

--- a/client/sites/tools/staging-site/style.scss
+++ b/client/sites/tools/staging-site/style.scss
@@ -4,3 +4,7 @@
 	align-items: flex-start;
     gap: 16px;
 }
+
+.staging-site-upsell-nudge {
+    width: 100%;
+}

--- a/client/sites/tools/staging-site/style.scss
+++ b/client/sites/tools/staging-site/style.scss
@@ -4,7 +4,3 @@
 	align-items: flex-start;
     gap: 16px;
 }
-
-.staging-site-upsell-nudge {
-    width: 100%;
-}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/9956

## Proposed Changes

**Issue:** Upsell banner should be full-width.
**Route:** `/sites/tools/staging-site/:site`

| Before | After |
| --- | --- |
| <img width="799" alt="image" src="https://github.com/user-attachments/assets/46288815-a963-4c80-9af8-d89ac18430b9"> | <img width="659" alt="image" src="https://github.com/user-attachments/assets/2b8c3fca-acb0-4e4b-a426-394e6a63b704"> |

**Issue:** Deployment table is truncated on the right side.
**Route:** `/sites/tools/deployments/:site`

| Before | After |
| --- | --- |
| <img width="664" alt="image" src="https://github.com/user-attachments/assets/6804a2af-ef3e-4193-a527-4bdac006dea3"> | <img width="664" alt="image" src="https://github.com/user-attachments/assets/778007dd-ed5c-42fe-8ce5-2e7f749a0237"> |

**Issue:** Back button is not using the same icon as the rest of options in Administration.
**Route:** `/sites/settings/administration/:site/delete-site`

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/2aa6b5e5-5c9b-4c6a-ab49-844d2b16cbdb) | <img width="648" alt="image" src="https://github.com/user-attachments/assets/71d3071d-b87f-420a-861c-303f9bbec255"> |

**Issue:** Lack of a heading makes it seem like a bug.
**Route:** `/sites/tools/:site`

| Before | After |
| --- | --- |
| <img width="720" alt="image" src="https://github.com/user-attachments/assets/d2ebadd3-bcfb-4793-8fdb-8b445ab57b0b"> | <img width="950" alt="image" src="https://github.com/user-attachments/assets/d9dab9d0-76b3-4446-b668-29a8f42ce036"> |

**Issue:** Filter border disappears when scrolling down.
**Route:** `/sites/overview/:site`

| Before | After |
| --- | --- |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/4f46e6a6-fabe-49b9-9df7-be4979f5bcf9"> | <img width="372" alt="image" src="https://github.com/user-attachments/assets/d17d5f11-2cb8-4faa-b616-85a86b3740a9"> |

**Issue:** Width issues with the repository modal.
**Route:** `/sites/tools/deployments/:site/create`

| Before | After |
| --- | --- |
| <img width="409" alt="image" src="https://github.com/user-attachments/assets/d4105355-6dbf-462a-b8ec-10584402a862"> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/04edfd8c-9604-436a-892c-90199125356b"> |
| <img width="357" alt="image" src="https://github.com/user-attachments/assets/5ef97437-fbed-4ffe-9782-e7fcf14435c1"> | <img width="352" alt="image" src="https://github.com/user-attachments/assets/b5f59b57-1251-4f03-a0b0-d3d58bd5fadd"> |

**Issue:** DIFM banner seems to be missing an icon on the left side.
**Route:** `/sites/settings/site/:site`

| Before | After |
| --- | --- |
| <img width="364" alt="image" src="https://github.com/user-attachments/assets/c00c6bf5-ca9d-4a94-b24a-3f4fa2327319"> | <img width="338" alt="image" src="https://github.com/user-attachments/assets/103d0b4f-7dc6-4008-8464-4745773ff59f"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the listed routes above for each screen and verify the before and after UI.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
