### PR TITLE
Stats: Tweaked support for date ranges in StatsDatePicker headers

### DIFF
--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -35,7 +35,7 @@ class StatsDatePicker extends Component {
 		const { query, moment, translate } = this.props;
 
 		if ( query.start_date ) {
-			return this.dateForCustomRange();
+			return this.dateForCustomRange( query.start_date, query.date );
 		}
 
 		const localizedDate = moment();
@@ -56,11 +56,11 @@ class StatsDatePicker extends Component {
 		}
 	}
 
-	dateForCustomRange() {
-		const { query, moment, translate } = this.props;
+	dateForCustomRange( startDate, endDate ) {
+		const { moment, translate } = this.props;
 
-		const localizedStartDate = moment( query.start_date );
-		const localizedEndDate = moment( query.date );
+		const localizedStartDate = moment( startDate );
+		const localizedEndDate = moment( endDate );
 
 		const firstFormatString =
 			localizedStartDate.year() === localizedEndDate.year() ? 'MMM D' : 'll';

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -181,8 +181,9 @@ class StatsDatePicker extends Component {
 		const isSummarizeQuery = get( query, 'summarize' );
 
 		let sectionTitle = isActivity
-			? translate( 'Activity for {{period/}}', {
+			? translate( '{{prefix}}Activity for {{/prefix}}{{period/}}', {
 					components: {
+						prefix: <span className="prefix" />,
 						period: (
 							<span className="period">
 								<span className="date">
@@ -193,8 +194,9 @@ class StatsDatePicker extends Component {
 					},
 					comment: 'Example: "Activity for December 2017"',
 			  } )
-			: translate( 'Stats for {{period/}}', {
+			: translate( '{{prefix}}Stats for {{/prefix}}{{period/}}', {
 					components: {
+						prefix: <span className="prefix" />,
 						period: (
 							<span className="period">
 								<span className="date">

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -62,10 +62,13 @@ class StatsDatePicker extends Component {
 		const localizedStartDate = moment( query.start_date );
 		const localizedEndDate = moment( query.date );
 
+		const firstFormatString =
+			localizedStartDate.year() === localizedEndDate.year() ? 'MMM D' : 'll';
+
 		return translate( '%(startDate)s ~ %(endDate)s', {
 			context: 'Date range for which stats are being displayed',
 			args: {
-				startDate: localizedStartDate.format( 'll' ),
+				startDate: localizedStartDate.format( firstFormatString ),
 				endDate: localizedEndDate.format( 'll' ),
 			},
 		} );

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -93,7 +93,7 @@ class StatsDatePicker extends Component {
 			context: 'Date range for which stats are being displayed',
 			args: {
 				startDate: localizedStartDate.format( firstFormatString ),
-				endDate: localizedEndDate.format( 'll' ),
+				endDate: localizedEndDate.format( `${ firstFormatString }, YYYY` ),
 			},
 		} );
 	}

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -62,6 +62,30 @@ class StatsDatePicker extends Component {
 		const localizedStartDate = moment( startDate );
 		const localizedEndDate = moment( endDate );
 
+		// If it's the same day, show single date.
+		if ( localizedStartDate.isSame( localizedEndDate, 'day' ) ) {
+			return localizedStartDate.format( 'LL' );
+		}
+
+		// If it's a full month.
+		if (
+			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'month' ), 'day' ) &&
+			localizedEndDate.isSame( localizedEndDate.clone().endOf( 'month' ), 'day' ) &&
+			localizedStartDate.isSame( localizedEndDate, 'month' )
+		) {
+			return localizedStartDate.format( 'MMMM YYYY' );
+		}
+
+		// If it's a full year.
+		if (
+			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'year' ), 'day' ) &&
+			localizedEndDate.isSame( localizedEndDate.clone().endOf( 'year' ), 'day' ) &&
+			localizedStartDate.isSame( localizedEndDate, 'year' )
+		) {
+			return localizedStartDate.format( 'YYYY' );
+		}
+
+		// Default to date range
 		const firstFormatString =
 			localizedStartDate.year() === localizedEndDate.year() ? 'MMM D' : 'll';
 
@@ -78,42 +102,9 @@ class StatsDatePicker extends Component {
 		const { date, moment, period, translate, isShort, dateRange } = this.props;
 		const weekPeriodFormat = isShort ? 'll' : 'LL';
 
-		// If we have chartStart/chartEnd in dateRange, use those for the date range
+		// Respect the dateRange if provided.
 		if ( dateRange?.chartStart && dateRange?.chartEnd ) {
-			const startDate = moment( dateRange.chartStart );
-			const endDate = moment( dateRange.chartEnd );
-
-			// If it's the same day, show single date
-			if ( startDate.isSame( endDate, 'day' ) ) {
-				return startDate.format( 'LL' );
-			}
-
-			// If it's a full month
-			if (
-				startDate.isSame( startDate.clone().startOf( 'month' ), 'day' ) &&
-				endDate.isSame( endDate.clone().endOf( 'month' ), 'day' ) &&
-				startDate.isSame( endDate, 'month' )
-			) {
-				return startDate.format( 'MMMM YYYY' );
-			}
-
-			// If it's a full year
-			if (
-				startDate.isSame( startDate.clone().startOf( 'year' ), 'day' ) &&
-				endDate.isSame( endDate.clone().endOf( 'year' ), 'day' ) &&
-				startDate.isSame( endDate, 'year' )
-			) {
-				return startDate.format( 'YYYY' );
-			}
-
-			// Default to date range
-			return translate( '%(startDate)s - %(endDate)s', {
-				context: 'Date range for which stats are being displayed',
-				args: {
-					startDate: startDate.format( weekPeriodFormat ),
-					endDate: endDate.format( weekPeriodFormat ),
-				},
-			} );
+			return this.dateForCustomRange( dateRange.chartStart, dateRange.chartEnd );
 		}
 
 		// Ensure we have a moment instance here to work with.

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@automattic/typography/styles/variables";
+
 .stats-period-navigation {
 	display: flex;
 	flex-flow: row wrap;
@@ -16,6 +19,10 @@
 		line-height: 40px;
 		color: var(--studio-gray-100);
 		text-align: left;
+
+		@media (max-width: $break-mobile) {
+			font-size: $font-title-medium;
+		}
 	}
 
 	.stats-date-picker__refresh-status {

--- a/packages/components/src/styles/mixins.scss
+++ b/packages/components/src/styles/mixins.scss
@@ -12,5 +12,9 @@
 
 	@media (max-width: $break-mobile) {
 		font-size: $font-title-medium;
+
+		.prefix {
+			display: none;
+		}
 	}
 }

--- a/packages/components/src/styles/mixins.scss
+++ b/packages/components/src/styles/mixins.scss
@@ -1,4 +1,6 @@
 @use "sass:math";
+
+@import "@wordpress/base-styles/breakpoints";
 @import "@automattic/typography/styles/variables";
 
 @mixin stats-section-header {
@@ -7,4 +9,8 @@
 	font-size: $font-title-large;
 	font-weight: 400;
 	line-height: 40px;
+
+	@media (max-width: $break-mobile) {
+		font-size: $font-title-medium;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

pejTkB-1LV-p2#comment-1768

## Proposed Changes

* Updates the header font size on mobile on Traffic & Summary pages.
* Removes prefix text on mobile. ie: No "Stats for" or "Activity for" on mobile screens.
* Don't repeat the year if it's the same across the date range. ie: "Nov 1, 2024 - Nov 7, 2024" becomes "Nov 1 ~ Nov 7, 2024"
* Refactor date formatting so it's shared across Traffic & Summary pages.

#### Desktop display before
<img width="736" alt="SCR-20241127-ubsw" src="https://github.com/user-attachments/assets/92e9052e-4551-4c1d-b713-8eddb6ce7d6d">

#### Desktop display after
<img width="734" alt="SCR-20241127-ubuw" src="https://github.com/user-attachments/assets/058862b9-f547-4bfa-9c98-0852d50ffa79">

#### Mobile display before
<img width="414" alt="SCR-20241127-uchv" src="https://github.com/user-attachments/assets/f5c2664a-9e3d-4610-ae4f-a708ab9a1dd1">

#### Mobile display after
<img width="416" alt="SCR-20241127-ucmt" src="https://github.com/user-attachments/assets/b8ec5552-9234-4929-9e01-bddd918aa2b9">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Minor clean up to presentation on mobile screen sizes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Traffic page and check the date formatting.
* Visit any Summary page via the "View all" links and confirm the formatting matches.
* Test on mobile screens and confirm the font size is correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?