### PR TITLE
Reader Recent: update dataview search pagination

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -116,14 +116,14 @@ const Recent = () => {
 		);
 	}, [ dispatch, view, streamKey ] );
 
-	const paginationInfo = useMemo( () => {
+	const defaultPaginationInfo = useMemo( () => {
 		return {
 			totalItems: data?.pagination?.totalItems ?? 0,
 			totalPages: data?.pagination?.totalPages ?? 0,
 		};
 	}, [ data?.pagination ] );
 
-	const { data: shownData } = useMemo( () => {
+	const { data: shownData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( data?.items ?? [], view, fields );
 	}, [ data?.items, view, fields ] );
 
@@ -198,7 +198,7 @@ const Recent = () => {
 									search: newView.search,
 								} )
 							}
-							paginationInfo={ paginationInfo }
+							paginationInfo={ view.search === '' ? defaultPaginationInfo : paginationInfo }
 							defaultLayouts={ { list: {} } }
 							isLoading={ isLoading }
 							selection={ selectedItem ? [ selectedItem.postId?.toString() ] : [] }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Here’s a cleaned-up and more concise version of your PR explanation:

---

Fixes https://github.com/Automattic/loop/issues/219

## Issue Overview
The pagination does not update correctly when using the data view’s search functionality. 

https://github.com/user-attachments/assets/ca891518-ba54-4676-827a-e1844f1d40eb

- **What happens**: Clicking on pagination links after performing a search loads empty pages.  
- **Underlying cause**: The data view does not preload all data required for proper pagination and filtering. Instead, data is requested dynamically based on the page number. This approach does not account for changes in the dataset caused by filtering or searching.  

When the data view is preloaded with all relevant data (e.g., all posts within a timeframe), `filterSortAndPaginate` can handle pagination and filtering effectively. However, due to performance constraints, we currently pass only the total number of available posts from the backend, which determines pagination (e.g., `totalItems` and `totalPages`). This works for unfiltered views but fails for searches because the backend does not filter posts by title text.

Adding backend support for text-based filtering would be impractical, as it would require fetching all posts, filtering by title, and recalculating pagination—a costly operation. 

## Proposed Changes
1. For search scenarios, use `filterSortAndPaginate`’s pagination info to manage the data view.  
   - This effectively hides pagination by limiting the number of pages to 1.  
2. For unfiltered views, continue relying on the default pagination determined by the initial API call.  

## After

https://github.com/user-attachments/assets/78a1d23a-a108-4c16-b093-ef54bcff2eea


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix UI issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso live `/read?flags=reader/recent-feed-overhaul`
* Test search functionality works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
