### PR TITLE
Stats: Add a tooltip for the visit count comparison on StatTab

### DIFF
--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -106,6 +106,7 @@ $custom-stats-tab-mobile-break: $break-medium;
 				&:hover {
 					color: var(--studio-black);
 					background-color: var(--color-neutral-0);
+					border: 1.5px solid var(--color-neutral-10);
 
 					.label,
 					.value {
@@ -151,8 +152,8 @@ $custom-stats-tab-mobile-break: $break-medium;
 			}
 
 			&.tab-disabled a {
-				pointer-events: none;
 				cursor: default;
+				border: none;
 			}
 
 			&.is-low {

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -1,5 +1,3 @@
-import { TrendComparison } from '@automattic/components/src/highlight-cards/count-comparison-card';
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
@@ -82,19 +80,12 @@ class StatsTabs extends Component {
 					selected: selectedTab === tab.attr,
 					tabClick: hasTrend ? switchTab : undefined,
 					value,
+					previousValue,
 					format: tab.format,
+					hasPreviousData: !! previousData,
 				};
 
-				return (
-					<StatTab key={ tabOptions.attr } { ...tabOptions }>
-						{ previousData && (
-							<div className="stats-tabs__highlight">
-								<span className="stats-tabs__highlight-value">{ formatNumber( value ) }</span>
-								<TrendComparison count={ value } previousCount={ previousValue } />
-							</div>
-						) }
-					</StatTab>
-				);
+				return <StatTab key={ tabOptions.attr } { ...tabOptions } />;
 			} );
 		}
 

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -1,7 +1,13 @@
+import {
+	TooltipContent,
+	TrendComparison,
+} from '@automattic/components/src/highlight-cards/count-comparison-card';
+import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
+import Popover from '@automattic/components/src/popover';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { Component, createRef } from 'react';
 
 class StatsTabsTab extends Component {
 	static displayName = 'StatsTabsTab';
@@ -15,9 +21,16 @@ class StatsTabsTab extends Component {
 		selected: PropTypes.bool,
 		tabClick: PropTypes.func,
 		compact: PropTypes.bool,
+		previousValue: PropTypes.number,
 		value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
 		format: PropTypes.func,
 	};
+
+	state = {
+		isTooltipVisible: false,
+	};
+
+	tooltipRef = createRef();
 
 	clickHandler = ( event ) => {
 		if ( this.props.tabClick ) {
@@ -36,9 +49,27 @@ class StatsTabsTab extends Component {
 		return String.fromCharCode( 8211 );
 	};
 
+	toggleTooltip = ( isShown ) => {
+		this.setState( {
+			isTooltipVisible: isShown,
+		} );
+	};
+
 	render() {
-		const { className, compact, children, icon, href, label, loading, selected, tabClick, value } =
-			this.props;
+		const {
+			className,
+			compact,
+			children,
+			icon,
+			href,
+			label,
+			loading,
+			selected,
+			tabClick,
+			previousValue,
+			value,
+			hasPreviousData,
+		} = this.props;
 
 		const tabClass = clsx( 'stats-tab', className, {
 			'is-selected': selected,
@@ -59,11 +90,31 @@ class StatsTabsTab extends Component {
 				className={ clsx( tabClass, { 'tab-disabled': ! hasClickAction } ) }
 				onClick={ this.clickHandler }
 			>
-				<a href={ href }>
+				<a
+					href={ href }
+					onMouseEnter={ () => this.toggleTooltip( true ) }
+					onMouseLeave={ () => this.toggleTooltip( false ) }
+				>
 					{ tabIcon }
 					{ tabLabel }
 					{ tabValue }
 					{ children }
+					{ hasPreviousData && (
+						<div className="stats-tabs__highlight">
+							<span className="stats-tabs__highlight-value" ref={ this.tooltipRef }>
+								{ formatNumber( value ) }
+							</span>
+							<TrendComparison count={ value } previousCount={ previousValue } />
+							<Popover
+								className="tooltip tooltip--darker highlight-card-tooltip"
+								isVisible={ this.state.isTooltipVisible }
+								position="bottom right"
+								context={ this.tooltipRef.current }
+							>
+								<TooltipContent count={ value } previousCount={ previousValue } />
+							</Popover>
+						</div>
+					) }
 				</a>
 			</li>
 		);

--- a/packages/components/src/highlight-cards/count-comparison-card.tsx
+++ b/packages/components/src/highlight-cards/count-comparison-card.tsx
@@ -52,7 +52,7 @@ export function TrendComparison( { count, previousCount }: TrendComparisonProps 
 	);
 }
 
-function TooltipContent( { count, previousCount }: CountComparisonCardProps ) {
+export function TooltipContent( { count, previousCount }: CountComparisonCardProps ) {
 	const difference = subtract( count, previousCount ) as number;
 	return (
 		<div className="highlight-card-tooltip-content">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/284

## Proposed Changes

* Move the visit count comparison from `StatsTabs` to `StatTab`.
* Add a tooltip to the `StatTab` for visit count details.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The change is an enhancement from the design feedback: pejTkB-1LV-p2#comment-1752.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Append the feature flag `stats/new-date-filtering` to the URL.
* Ensure that hovering on the chart tabs shows the tooltip with the present and previous values.

<img width="1275" alt="截圖 2024-11-27 晚上11 17 43" src="https://github.com/user-attachments/assets/2c5efea5-39eb-4ffc-86bf-79dd13f97dcf">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?