### PR TITLE
Reader Recent: set selected item when paging

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -134,10 +134,13 @@ const Recent = () => {
 
 	// Set the first item as selected if no item is selected and screen is wide.
 	useEffect( () => {
-		if ( isWide && data?.items?.length > 0 && ! selectedItem ) {
-			setSelectedItem( data.items[ 0 ] );
+		if ( isWide && data?.items?.length > 0 ) {
+			if ( view.page && view.perPage ) {
+				const selectedPost = data?.items?.[ ( view.page - 1 ) * view.perPage ];
+				setSelectedItem( selectedPost || null );
+			}
 		}
-	}, [ isWide, data?.items, selectedItem ] );
+	}, [ isWide, data?.items, view ] );
 
 	// When the selected feed changes, clear the selected item and reset the page to 1.
 	useEffect( () => {

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -132,7 +132,7 @@ const Recent = () => {
 		fetchData();
 	}, [ fetchData ] );
 
-	// Set the first item as selected if no item is selected and screen is wide.
+	// Set the first item as selected on the current page.
 	useEffect( () => {
 		if ( isWide && data?.items?.length > 0 ) {
 			if ( view.page && view.perPage ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/231

## Proposed Changes

* Sets the selected post to the first post in the page when the pagination changes to a new page

## Before
https://github.com/user-attachments/assets/46f48623-3808-46bb-914c-f46f1b335959

## After
https://github.com/user-attachments/assets/36455d22-42cc-401c-becd-64972371750b 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso live `/read?flags=reader/recent-feed-overhaul`
* Confirm the selected post changes with each page change as per example above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
