### PR TITLE
Global View: Fix Themes and Plugins/manage navigation

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -521,7 +521,11 @@ export function noSite( context, next ) {
 	return next();
 }
 
-const PATHS_EXCLUDED_FROM_SINGLE_SITE_CONTEXT_FOR_SINGLE_SITE_USERS = [ '/plugins' ];
+const PATHS_EXCLUDED_FROM_SINGLE_SITE_CONTEXT_FOR_SINGLE_SITE_USERS = [
+	'/plugins',
+	'/plugins/manage',
+	'/themes',
+];
 
 /*
  * Set up site selection based on last URL param and/or handle no-sites error cases

--- a/client/my-sites/themes/atomic-transfer-dialog.tsx
+++ b/client/my-sites/themes/atomic-transfer-dialog.tsx
@@ -107,11 +107,21 @@ class AtomicTransferDialog extends Component< AtomicTransferDialogProps > {
 
 	componentDidUpdate( prevProps: Readonly< AtomicTransferDialogProps > ): void {
 		const { siteId, siteSlug, uploadError, isJetpack } = this.props;
-		if ( siteId && siteSlug && prevProps.isJetpack !== isJetpack ) {
+		if (
+			siteId &&
+			siteSlug &&
+			prevProps.isJetpack !== undefined &&
+			prevProps.isJetpack !== isJetpack
+		) {
 			this.continueToActivate();
 		}
 
-		if ( siteId && uploadError && prevProps.uploadError !== uploadError ) {
+		if (
+			siteId &&
+			uploadError &&
+			prevProps.uploadError !== undefined &&
+			prevProps.uploadError !== uploadError
+		) {
 			setTimeout( () => {
 				this.initiateTransfer();
 			}, 2000 );

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -10,7 +10,6 @@ import {
 	addNavigationIfLoggedIn,
 	navigation,
 	noSite,
-	selectSiteOrSkipIfLoggedInWithMultipleSites,
 	siteSelection,
 	sites,
 } from 'calypso/my-sites/controller';
@@ -73,7 +72,6 @@ export default function ( router ) {
 		routesWithoutSites,
 		redirectWithoutLocaleParamIfLoggedIn,
 		fetchAndValidateVerticalsAndFilters,
-		selectSiteOrSkipIfLoggedInWithMultipleSites,
 		noSite,
 		renderThemes,
 		addNavigationIfLoggedIn,


### PR DESCRIPTION
For Single site users the Theme Showcase and Plugins > Manage used in the global view were pointing to the in-site context UI.

This PR makes it consistent with the other UIs (Domains, Plugins) and loads the Global View version.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96619

## Proposed Changes

* Point `/themes` to the Global View version for single site users
* Point `/plugins/manage` to the Global View version for single-site users

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistency: Sites, Domains and Plugins are all pointing to the global view.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link and open an incognito window
* Login with a test account that has only one site
* Go to /sites and click on "Themes" and "Plugins > Manage Plugins"
* Make sure the Global View is now loaded instead of the in-site one

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
