### PR TITLE
Photos picker: Add logic to persist session in cookie

### DIFF
--- a/client/data/media/use-google-photos-picker-session-query.ts
+++ b/client/data/media/use-google-photos-picker-session-query.ts
@@ -17,6 +17,9 @@ export default function useGooglePhotosPickerSessionQuery(
 					sessionId as string
 				) }`,
 			} ),
+		meta: {
+			persist: false,
+		},
 		enabled,
 		...options,
 	} );

--- a/client/data/media/with-google-photos-picker-session.js
+++ b/client/data/media/with-google-photos-picker-session.js
@@ -1,21 +1,32 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useSelector } from 'react-redux';
+import { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { retrieveGooglePhotosPickerSessionCookie } from 'calypso/jetpack-connect/persistence-utils';
+import { setPhotoPickerSession } from 'calypso/state/media/actions';
 import getGooglePhotosPickerFeatureStatus from 'calypso/state/selectors/get-google-photos-picker-feature-status';
 import getGooglePhotosPickerSession from 'calypso/state/selectors/get-google-photos-picker-session';
 import {
 	useCreateGooglePhotosPickerSessionMutation,
 	useDeleteGooglePhotosPickerSessionMutation,
 } from './use-google-photos-picker-session-mutation';
+import useGooglePhotosPickerSessionQuery from './use-google-photos-picker-session-query';
 
 export const withGooglePhotosPickerSession = createHigherOrderComponent( ( Wrapped ) => {
 	return ( props ) => {
+		const dispatch = useDispatch();
+		const [ cachedSessionId ] = useState( retrieveGooglePhotosPickerSessionCookie() );
 		const photosPickerApiEnabled = useSelector( ( state ) =>
 			getGooglePhotosPickerFeatureStatus( state )
 		);
 		const photosPickerSession = useSelector( ( state ) => getGooglePhotosPickerSession( state ) );
 
+		const { data: cachedSession } = useGooglePhotosPickerSessionQuery( cachedSessionId );
 		const { mutate: createPickerSession } = useCreateGooglePhotosPickerSessionMutation();
 		const { mutate: deletePickerSession } = useDeleteGooglePhotosPickerSessionMutation();
+
+		useEffect( () => {
+			cachedSession && dispatch( setPhotoPickerSession( cachedSession ) );
+		}, [ cachedSession, dispatch ] );
 
 		return (
 			<Wrapped

--- a/client/jetpack-connect/persistence-utils.js
+++ b/client/jetpack-connect/persistence-utils.js
@@ -72,25 +72,14 @@ export const retrieveSource = () => {
 	return window.sessionStorage.getItem( SESSION_STORAGE_SOURCE );
 };
 
-export const persistGooglePhotosPickerSessionCookie = ( session ) => {
+export const persistGooglePhotosPickerSessionCookie = ( sessionId ) => {
 	const options = { path: '/' };
 
-	if ( typeof session === 'object' ) {
-		session = JSON.stringify( session );
-	}
-
-	document.cookie = cookie.serialize( GOOGLE_PHOTOS_PICKER_SESSION, session, options );
+	document.cookie = cookie.serialize( GOOGLE_PHOTOS_PICKER_SESSION, sessionId, options );
 };
 
 export const retrieveGooglePhotosPickerSessionCookie = () => {
 	const cookies = cookie.parse( document.cookie );
-	const session = cookies[ GOOGLE_PHOTOS_PICKER_SESSION ];
 
-	let parsedSession;
-	try {
-		parsedSession = JSON.parse( session );
-	} catch ( error ) {
-		parsedSession = null;
-	}
-	return parsedSession;
+	return cookies[ GOOGLE_PHOTOS_PICKER_SESSION ];
 };

--- a/client/jetpack-connect/persistence-utils.js
+++ b/client/jetpack-connect/persistence-utils.js
@@ -4,6 +4,7 @@ import { JETPACK_CONNECT_TTL_SECONDS } from 'calypso/state/jetpack-connect/const
 
 export const SESSION_STORAGE_SELECTED_PLAN = 'jetpack_connect_selected_plan';
 export const SESSION_STORAGE_SOURCE = 'jetpack_connect_source';
+export const GOOGLE_PHOTOS_PICKER_SESSION = 'google_photos_picker_session';
 
 /**
  * Utilities for storing jetpack connect state that needs to persist across
@@ -69,4 +70,27 @@ export const clearSource = () => {
 
 export const retrieveSource = () => {
 	return window.sessionStorage.getItem( SESSION_STORAGE_SOURCE );
+};
+
+export const persistGooglePhotosPickerSessionCookie = ( session ) => {
+	const options = { path: '/' };
+
+	if ( typeof session === 'object' ) {
+		session = JSON.stringify( session );
+	}
+
+	document.cookie = cookie.serialize( GOOGLE_PHOTOS_PICKER_SESSION, session, options );
+};
+
+export const retrieveGooglePhotosPickerSessionCookie = () => {
+	const cookies = cookie.parse( document.cookie );
+	const session = cookies[ GOOGLE_PHOTOS_PICKER_SESSION ];
+
+	let parsedSession;
+	try {
+		parsedSession = JSON.parse( session );
+	} catch ( error ) {
+		parsedSession = null;
+	}
+	return parsedSession;
 };

--- a/client/my-sites/media-library/google-photos-picker-button.tsx
+++ b/client/my-sites/media-library/google-photos-picker-button.tsx
@@ -37,7 +37,7 @@ const GooglePhotosPickerButton = () => {
 			session && refetch();
 		}, 3000 );
 		return () => clearInterval( interval );
-	}, [ refetch ] );
+	}, [ session, refetch ] );
 
 	useEffect( () => {
 		sessionData && dispatch( setPhotoPickerSession( sessionData ) );

--- a/client/my-sites/media-library/google-photos-picker-button.tsx
+++ b/client/my-sites/media-library/google-photos-picker-button.tsx
@@ -33,7 +33,9 @@ const GooglePhotosPickerButton = () => {
 	}, [ session, createSession, moment ] );
 
 	useEffect( () => {
-		const interval = setInterval( refetch, 3000 );
+		const interval = setInterval( () => {
+			session && refetch();
+		}, 3000 );
 		return () => clearInterval( interval );
 	}, [ refetch ] );
 

--- a/client/my-sites/media-library/google-photos-picker-button.tsx
+++ b/client/my-sites/media-library/google-photos-picker-button.tsx
@@ -4,6 +4,7 @@ import './google-photos-picker-button.scss';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import mediaImage from 'calypso/assets/images/illustrations/media.svg';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useCreateGooglePhotosPickerSessionMutation } from 'calypso/data/media/use-google-photos-picker-session-mutation';
 import useGooglePhotosPickerSessionQuery from 'calypso/data/media/use-google-photos-picker-session-query';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -11,6 +12,7 @@ import { setPhotoPickerSession } from 'calypso/state/media/actions';
 import getGooglePhotosPickerSession from 'calypso/state/selectors/get-google-photos-picker-session';
 
 const GooglePhotosPickerButton = () => {
+	const moment = useLocalizedMoment();
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const session = useSelector( getGooglePhotosPickerSession );
@@ -22,8 +24,13 @@ const GooglePhotosPickerButton = () => {
 	};
 
 	useEffect( () => {
-		! session && createSession();
-	}, [ session, createSession ] );
+		const isSessionExpired =
+			session?.expireTime && moment( session.expireTime ).isBefore( new Date() );
+
+		if ( ! session || isSessionExpired ) {
+			createSession();
+		}
+	}, [ session, createSession, moment ] );
 
 	useEffect( () => {
 		const interval = setInterval( refetch, 3000 );

--- a/client/my-sites/media-library/google-photos-picker-button.tsx
+++ b/client/my-sites/media-library/google-photos-picker-button.tsx
@@ -2,46 +2,16 @@ import { Button } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 import './google-photos-picker-button.scss';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import mediaImage from 'calypso/assets/images/illustrations/media.svg';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useCreateGooglePhotosPickerSessionMutation } from 'calypso/data/media/use-google-photos-picker-session-mutation';
-import useGooglePhotosPickerSessionQuery from 'calypso/data/media/use-google-photos-picker-session-query';
-import { useDispatch, useSelector } from 'calypso/state';
-import { setPhotoPickerSession } from 'calypso/state/media/actions';
-import getGooglePhotosPickerSession from 'calypso/state/selectors/get-google-photos-picker-session';
+import useGooglePhotosPickerSession from 'calypso/my-sites/media-library/hook/use-google-photos-picker-session';
 
 const GooglePhotosPickerButton = () => {
-	const moment = useLocalizedMoment();
-	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const session = useSelector( getGooglePhotosPickerSession );
-	const { mutate: createSession, isPending } = useCreateGooglePhotosPickerSessionMutation();
-	const { data: sessionData, refetch } = useGooglePhotosPickerSessionQuery( session?.id );
+	const { session, isPending } = useGooglePhotosPickerSession();
 
 	const openPickerTab = () => {
 		session?.pickerUri && window.open( session.pickerUri, '_blank' );
 	};
-
-	useEffect( () => {
-		const isSessionExpired =
-			session?.expireTime && moment( session.expireTime ).isBefore( new Date() );
-
-		if ( ! session || isSessionExpired ) {
-			createSession();
-		}
-	}, [ session, createSession, moment ] );
-
-	useEffect( () => {
-		const interval = setInterval( () => {
-			session && refetch();
-		}, 3000 );
-		return () => clearInterval( interval );
-	}, [ session, refetch ] );
-
-	useEffect( () => {
-		sessionData && dispatch( setPhotoPickerSession( sessionData ) );
-	}, [ sessionData ] );
 
 	return (
 		<div className="google-photos-picker--container media-library__connect-message">

--- a/client/my-sites/media-library/hook/use-google-photos-picker-session.ts
+++ b/client/my-sites/media-library/hook/use-google-photos-picker-session.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useCreateGooglePhotosPickerSessionMutation } from 'calypso/data/media/use-google-photos-picker-session-mutation';
+import useGooglePhotosPickerSessionQuery from 'calypso/data/media/use-google-photos-picker-session-query';
+import { useDispatch, useSelector } from 'calypso/state';
+import { setPhotoPickerSession } from 'calypso/state/media/actions';
+import getGooglePhotosPickerSession from 'calypso/state/selectors/get-google-photos-picker-session';
+
+/**
+ * Hook to manage the Google Photos picker session.
+ * Creates a new session:
+ * - if there is no session
+ * - or the current session is expired
+ */
+export default function useGooglePhotosPickerSession() {
+	const moment = useLocalizedMoment();
+	const dispatch = useDispatch();
+
+	const session = useSelector( getGooglePhotosPickerSession );
+	const isSessionExpired =
+		session?.expireTime && moment( session.expireTime ).isBefore( new Date() );
+
+	const { mutate: createSession, isPending } = useCreateGooglePhotosPickerSessionMutation();
+	const { data: sessionData, refetch } = useGooglePhotosPickerSessionQuery( session?.id );
+
+	// Create a new session if there is no session or the current session is expired
+	useEffect( () => {
+		if ( ! session || isSessionExpired ) {
+			createSession();
+		}
+	}, [ session, isSessionExpired, createSession ] );
+
+	// Poll for session data every 3 seconds
+	useEffect( () => {
+		const interval = setInterval( () => {
+			session && refetch();
+		}, 3000 );
+		return () => clearInterval( interval );
+	}, [ session, refetch ] );
+
+	// Set the session data in the store
+	useEffect( () => {
+		sessionData && dispatch( setPhotoPickerSession( sessionData ) );
+	}, [ sessionData, dispatch ] );
+
+	return { session, isPending };
+}

--- a/client/state/media/actions.js
+++ b/client/state/media/actions.js
@@ -306,7 +306,7 @@ export function clearSite( siteId ) {
  * @param session
  */
 export function setPhotoPickerSession( session ) {
-	persistGooglePhotosPickerSessionCookie( session );
+	persistGooglePhotosPickerSessionCookie( session.id );
 
 	return {
 		type: MEDIA_PHOTOS_PICKER_SESSION_SET,

--- a/client/state/media/actions.js
+++ b/client/state/media/actions.js
@@ -1,3 +1,4 @@
+import { persistGooglePhotosPickerSessionCookie } from 'calypso/jetpack-connect/persistence-utils';
 import wp from 'calypso/lib/wp';
 import {
 	MEDIA_DELETE,
@@ -305,6 +306,8 @@ export function clearSite( siteId ) {
  * @param session
  */
 export function setPhotoPickerSession( session ) {
+	persistGooglePhotosPickerSessionCookie( session );
+
 	return {
 		type: MEDIA_PHOTOS_PICKER_SESSION_SET,
 		session,

--- a/client/state/selectors/get-google-photos-picker-session.ts
+++ b/client/state/selectors/get-google-photos-picker-session.ts
@@ -1,13 +1,10 @@
 import { get } from 'lodash';
 import { PickerSession } from 'calypso/data/media/use-google-photos-picker-session-mutation';
-import { retrieveGooglePhotosPickerSessionCookie } from 'calypso/jetpack-connect/persistence-utils';
 import { AppState } from 'calypso/types';
 
 /**
  * Get the Google Photos Picker session ID
  */
 export default function getGooglePhotosPickerSession( state: AppState ): PickerSession | undefined {
-	const session = retrieveGooglePhotosPickerSessionCookie();
-
-	return session || get( state, [ 'media', 'googlePhotosPicker', 'session' ], undefined );
+	return get( state, [ 'media', 'googlePhotosPicker', 'session' ], undefined );
 }

--- a/client/state/selectors/get-google-photos-picker-session.ts
+++ b/client/state/selectors/get-google-photos-picker-session.ts
@@ -1,10 +1,13 @@
 import { get } from 'lodash';
 import { PickerSession } from 'calypso/data/media/use-google-photos-picker-session-mutation';
+import { retrieveGooglePhotosPickerSessionCookie } from 'calypso/jetpack-connect/persistence-utils';
 import { AppState } from 'calypso/types';
 
 /**
  * Get the Google Photos Picker session ID
  */
 export default function getGooglePhotosPickerSession( state: AppState ): PickerSession | undefined {
-	return get( state, [ 'media', 'googlePhotosPicker', 'session' ], undefined );
+	const session = retrieveGooglePhotosPickerSessionCookie();
+
+	return session || get( state, [ 'media', 'googlePhotosPicker', 'session' ], undefined );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-36s-p2#comment-5914

## Proposed Changes

* Add functions to `persist` and `retrieve` session object stored in the cookie
* Extend `createSession` condition, checking if the session has expired

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support persisting sessions:
  * if a user clicks on the browser's refresh button (Calypso and Jetpack)
  * persist session between Calypso and Jetpack

## Testing Instructions

* Make sure you have the Photos Picker feature turned ON
* Go to `/media/{SITE_SLUG}`
* Select "Google Photos" source
* Make some selection in the picker tab
* Click on the browser refresh button
* Go to Google Photos
* Verify if the previous selection is available

https://github.com/user-attachments/assets/a0121231-8098-409e-aadb-74d55d0a7a25

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?