### PR TITLE
Reader Recent Feed Overhaul: Fix header padding when there are no subscriptions.

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -219,7 +219,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 					) }
 				</div>
 			</div>
-			{ hasSubscriptions && (
+			{ hasSubscriptions ? (
 				<div className={ `recent-feed__post-column ${ selectedItem ? 'overlay' : '' }` }>
 					{ ! ( selectedItem && getPostFromItem( selectedItem ) ) && isLoading && (
 						<RecentPostSkeleton />
@@ -245,7 +245,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 						</>
 					) }
 				</div>
-			) }
+			) : null }
 		</div>
 	);
 };

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -155,10 +155,10 @@
 			.recent-feed__list-column-header {
 				max-width: none;
 				margin: 0;
-				padding: 16px 0;
+				padding: 16px 24px;
 				border-bottom: 1px solid var( --studio-gray-0 );
 
-				header {
+				header.navigation-header {
 					max-width: $break-medium;
 					margin: 0 auto;
 					padding: 0;

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -161,7 +161,7 @@
 				header {
 					max-width: $break-medium;
 					margin: 0 auto;
-					padding: 0 24px;
+					padding: 0;
 				}
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/232

## Proposed Changes

* Clean up no subscriptions header and remove rogue 0.

Before | After
---- | ---
![Screen Shot 2024-11-27 at 4 39 12 PM](https://github.com/user-attachments/assets/ff01ce79-fd37-48c0-ae05-a19936c83ccd) | ![Screen Shot 2024-11-27 at 4 38 53 PM](https://github.com/user-attachments/assets/de6bda9f-d10e-4737-9631-14918e57bfde)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2iv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new account.
* Remove all of your subscriptions.
* Go to /read?flags=reader/recent-feed-overhaul
* Check that the header is aligned with the content at all screen sizes.
* Check that the rogue 0 doesn't appear.
* Regression test the view with subscriptions.
* Regression test the current /read stream view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?