### PR TITLE
Stats: previousData should be aggregated or not just like current data

### DIFF
--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -64,7 +64,10 @@ class StatsTabs extends Component {
 		if ( data && ! children ) {
 			const trendData = this.formatData( data, aggregate );
 			const activeData = { ...tabCountsAlt, ...trendData };
-			const activePreviousData = { ...tabCountsAltComp, ...this.formatData( previousData ) };
+			const activePreviousData = {
+				...tabCountsAltComp,
+				...this.formatData( previousData, aggregate ),
+			};
 
 			statsTabs = tabs.map( ( tab ) => {
 				const hasTrend = trendData?.[ tab.attr ] >= 0 && trendData[ tab.attr ] !== null;


### PR DESCRIPTION
Follow up for https://github.com/Automattic/wp-calypso/pull/96839

## Proposed Changes

* Pass aggregate to function after the default value is changed

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* bugfix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live `/stats/day/jetpack.com`
* Ensure comparison is showing

<img width="968" alt="image" src="https://github.com/user-attachments/assets/5586a66c-c5c7-4ed4-9b84-00fc68261eaf">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
