### PR TITLE
Stats: Remove selected bar in chart when new date filtering is enabled

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -115,6 +115,15 @@ class StatModuleChartTabs extends Component {
 			showChartHeader = false,
 			isNewDateFilteringEnabled = false,
 		} = this.props;
+
+		let chartData = this.props.chartData;
+		if ( isNewDateFilteringEnabled ) {
+			chartData = chartData?.map( ( record ) => {
+				record.className = record.className?.replaceAll( 'is-selected', '' );
+				return record;
+			} );
+		}
+
 		const classes = [
 			'is-chart-tabs',
 			className,
@@ -141,7 +150,7 @@ class StatModuleChartTabs extends Component {
 				) }
 
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
-				<Chart barClick={ this.props.barClick } data={ this.props.chartData } minBarWidth={ 35 }>
+				<Chart barClick={ this.props.barClick } data={ chartData } minBarWidth={ 35 }>
 					<StatsEmptyState />
 				</Chart>
 				<StatTabs


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/282

## Proposed Changes

* Strip `is-selected` when new date filtering is enabled
* 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Enhancements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Claypso Live `/stats/day/jetpack.com`
* Ensure no bars are highlighted

<img width="1181" alt="Screenshot 2024-11-28 at 10 44 48 AM" src="https://github.com/user-attachments/assets/39c7ef46-8870-4b27-8c9c-aac79c7db27d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
