### PR TITLE
Fix E2E tests of sell flow

### DIFF
--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -40,7 +40,6 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'ftmepersonal',
 	} );
-	const blogTagLine = DataHelper.getRandomPhrase();
 
 	let page: Page;
 	let newUserDetails: NewUserResponse;
@@ -146,15 +145,6 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 
 		it( 'Select "Sell" goal', async function () {
 			await startSiteFlow.selectGoal( 'Sell' );
-			await startSiteFlow.clickButton( 'Continue' );
-		} );
-
-		it( 'Enter blog name', async function () {
-			await startSiteFlow.enterBlogName( testUser.siteName );
-		} );
-
-		it( 'Enter blog tagline', async function () {
-			await startSiteFlow.enterTagline( blogTagLine );
 			await startSiteFlow.clickButton( 'Continue' );
 		} );
 	} );


### PR DESCRIPTION
The sell flow was removed by default in #96762, however CI tests didn't catch that this broke existing E2E test.

I've removed the sell flow from the "Sell intent" onboarding test
