### PR TITLE
Update Core Profiler loader styles for responsiveness and disable animation

### DIFF
--- a/client/jetpack-connect/woo-loader.scss
+++ b/client/jetpack-connect/woo-loader.scss
@@ -6,6 +6,8 @@
 	width: 100%;
 	max-width: 100%;
 	max-height: 100%;
+	margin: 0;
+	animation: none;
 
 	.components-modal__header {
 		display: none;
@@ -22,11 +24,7 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-
-	@include breakpoint-deprecated( "<800px" ) {
-		width: calc(100% - 40px);
-		padding: 0 20px;
-	}
+	padding-inline: 20px;;
 
 	.loader-hearticon {
 		position: relative;
@@ -50,6 +48,7 @@
 		align-items: center;
 		justify-content: center;
 		max-width: 520px;
+		width: 100%;
 	}
 
 	.jetpack-connect-progress-bar {


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/89283 and related to https://github.com/Automattic/wp-calypso/issues/96420

This PR addresses various mobile UI issues in the WooCommerce Core Profiler’s Jetpack connect screens. These fixes ensure proper alignment and prevent content overflow, improving the user experience on smaller screens. Besides, this PR disables the modal animation to prevent jankiness in the transition to the loader.

## Proposed Changes

* Disable the modal animation to prevent jankiness in the transition to the loader
* Update the Jetpack connect screens to ensure proper alignment and prevent content overflow on smaller screens

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the user experience on smaller screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set up a fresh JN site and log in to WordPress.com.
2. On a mobile browser (e.g., Safari on iPhone) or using DevTools to simulate a mobile device, go to the WooCommerce setup wizard.
3. Proceed through the wizard steps until the plugin step.
4. Select Jetpack, click Continue, and observe:
5. The Connect button and text are now centered.
6. No content overflow issues are present.
7. Click Connect your account and observe the loading screen:
- The screen should be displayed without delay/animations.
- The screen should be fullscreen.
- The loading images should be perfectly centered.


https://github.com/user-attachments/assets/564f2b7f-286f-4f0e-9608-74cf729e3ef0


https://github.com/user-attachments/assets/2e1f3fa5-0139-4af9-bc20-3ec1e2225b19



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
