### PR TITLE
Prototype: Move goals step to front of onboarding if `onboarding/goals-first` flag

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
@@ -1,0 +1,32 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useEffect, useState } from 'react';
+
+/**
+ * Check whether the user should have the "goals first" onboarding experience.
+ * Returns [ isLoading, isGoalsAtFrontExperiment ]
+ *
+ * The experience is currently gated behind a feature flag which is loaded immediately,
+ * but we want to code as if loading time might be involved. So this hook has a fake
+ * timer.
+ * Note: It's important that there be no timer in the production experience
+ * i.e. when the feature flag is disabled.
+ */
+export function useGoalsFirstExperiment(): [ boolean, boolean ] {
+	const [ isLoading, setIsLoading ] = useState( true );
+	useEffect( () => {
+		if ( ! isEnabled( 'onboarding/goals-first' ) ) {
+			return;
+		}
+
+		const id = setTimeout( () => setIsLoading( false ), 700 );
+		return () => {
+			clearTimeout( id );
+		};
+	}, [] );
+
+	if ( ! isEnabled( 'onboarding/goals-first' ) ) {
+		return [ false, false ];
+	}
+
+	return [ isLoading, true ];
+}

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -73,6 +73,7 @@ button {
 .new-hosted-site,
 .import-hosted-site,
 .site-setup,
+.onboarding.goals,
 .site-migration,
 .migration,
 .migration-signup,

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -13,9 +13,10 @@ import {
 import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../constants';
 import { ONBOARD_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
+import { useGoalsFirstExperiment } from './helpers/use-goals-first-experiment';
 import { recordStepNavigation } from './internals/analytics/record-step-navigation';
 import { STEPS } from './internals/steps';
-import { Flow, ProvidedDependencies } from './internals/types';
+import { AssertConditionState, Flow, ProvidedDependencies } from './internals/types';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -31,19 +32,12 @@ const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => 
 	}
 };
 
-const useGoalsFirstExperiment = (): [ boolean, boolean ] => {
-	// Currently loading isn't required because we're using a feature flag, but in the future
-	// we may need to take account of loading time.
-	const isLoading = false;
-
-	return [ isLoading, isEnabled( 'onboarding/goals-first' ) ];
-};
-
 const onboarding: Flow = {
 	name: ONBOARDING_FLOW,
 	isSignupFlow: true,
 	__experimentalUseBuiltinAuth: true,
 	useSteps() {
+		// We have already checked the value has loaded in useAssertConditions
 		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 		const steps = stepsWithRequiredLogin( [
@@ -70,7 +64,7 @@ const onboarding: Flow = {
 		] );
 
 		if ( isGoalsAtFrontExperiment ) {
-			// Note that this step is not wrapped in `stepsWithRequiredLogin`
+			// This step is not wrapped in `stepsWithRequiredLogin`
 			steps.unshift( STEPS.GOALS );
 		}
 
@@ -268,6 +262,13 @@ const onboarding: Flow = {
 		};
 
 		return { goBack, submit };
+	},
+	useAssertConditions() {
+		const [ isLoading ] = useGoalsFirstExperiment();
+
+		return {
+			state: isLoading ? AssertConditionState.CHECKING : AssertConditionState.SUCCESS,
+		};
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,4 +1,5 @@
-import { OnboardSelect } from '@automattic/data-stores';
+import { isEnabled } from '@automattic/calypso-config';
+import { OnboardSelect, Onboard } from '@automattic/data-stores';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
@@ -13,7 +14,10 @@ import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../constants';
 import { ONBOARD_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { recordStepNavigation } from './internals/analytics/record-step-navigation';
+import { STEPS } from './internals/steps';
 import { Flow, ProvidedDependencies } from './internals/types';
+
+const SiteIntent = Onboard.SiteIntent;
 
 const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => {
 	const isDomainsStep = currentStepSlug === 'domains';
@@ -27,12 +31,22 @@ const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => 
 	}
 };
 
+const useGoalsFirstExperiment = (): [ boolean, boolean ] => {
+	// Currently loading isn't required because we're using a feature flag, but in the future
+	// we may need to take account of loading time.
+	const isLoading = false;
+
+	return [ isLoading, isEnabled( 'onboarding/goals-first' ) ];
+};
+
 const onboarding: Flow = {
 	name: ONBOARDING_FLOW,
 	isSignupFlow: true,
 	__experimentalUseBuiltinAuth: true,
 	useSteps() {
-		return stepsWithRequiredLogin( [
+		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
+
+		const steps = stepsWithRequiredLogin( [
 			{
 				slug: 'domains',
 				asyncComponent: () => import( './internals/steps-repository/unified-domains' ),
@@ -54,6 +68,13 @@ const onboarding: Flow = {
 				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
 			},
 		] );
+
+		if ( isGoalsAtFrontExperiment ) {
+			// Note that this step is not wrapped in `stepsWithRequiredLogin`
+			steps.unshift( STEPS.GOALS );
+		}
+
+		return steps;
 	},
 
 	useStepNavigation( currentStepSlug, navigate ) {
@@ -84,6 +105,29 @@ const onboarding: Flow = {
 
 		const submit = async ( providedDependencies: ProvidedDependencies = {} ) => {
 			switch ( currentStepSlug ) {
+				case 'goals': {
+					const { intent, skip } = providedDependencies;
+
+					if ( skip ) {
+						// TODO Implement skipping to dashboard
+						return;
+					}
+
+					switch ( intent ) {
+						case SiteIntent.Import:
+							// TODO Implement exit to site migration
+							return;
+
+						case SiteIntent.DIFM:
+							// TODO Implement exit to DIFM
+							return;
+
+						default: {
+							return navigate( 'domains' );
+						}
+					}
+				}
+
 				case 'domains':
 					setSiteUrl( providedDependencies.siteUrl );
 					setDomain( providedDependencies.suggestion );
@@ -164,8 +208,9 @@ const onboarding: Flow = {
 				case 'create-site':
 					return navigate( 'processing', undefined, true );
 				case 'processing': {
-					const destination = addQueryArgs( '/setup/site-setup/goals', {
+					const destination = addQueryArgs( '/setup/site-setup', {
 						siteSlug: providedDependencies.siteSlug,
+						...( isEnabled( 'onboarding/goals-first' ) && { flags: 'onboarding/goals-first' } ),
 					} );
 					persistSignupDestination( destination );
 					setSignupCompleteFlowName( flowName );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
 import { MIGRATION_FLOW } from '@automattic/onboarding';
@@ -21,6 +20,7 @@ import { useSiteData } from '../hooks/use-site-data';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE, STEPPER_INTERNAL_STORE } from '../stores';
 import { shouldRedirectToSiteMigration } from './helpers';
+import { useGoalsFirstExperiment } from './helpers/use-goals-first-experiment';
 import { useLaunchpadDecider } from './internals/hooks/use-launchpad-decider';
 import { STEPS } from './internals/steps';
 import { redirect } from './internals/steps-repository/import/util';
@@ -48,14 +48,6 @@ function isLaunchpadIntent( intent: string ) {
 	return intent === SiteIntent.Write || intent === SiteIntent.Build;
 }
 
-const useGoalsFirstExperiment = (): [ boolean, boolean ] => {
-	// Currently loading isn't required because we're using a feature flag, but in the future
-	// we may need to take account of loading time.
-	const isLoading = false;
-
-	return [ isLoading, isEnabled( 'onboarding/goals-first' ) ];
-};
-
 const siteSetupFlow: Flow = {
 	name: 'site-setup',
 	isSignupFlow: false,
@@ -75,6 +67,7 @@ const siteSetupFlow: Flow = {
 	},
 
 	useSteps() {
+		// We have already checked the value has loaded in useAssertConditions
 		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 		const steps = [
@@ -735,6 +728,13 @@ const siteSetupFlow: Flow = {
 				state: AssertConditionState.FAILURE,
 				message:
 					'site-setup the user needs to have the manage_options capability to go through the flow.',
+			};
+		}
+
+		const [ isLoadingGoalsFirstExp ] = useGoalsFirstExperiment();
+		if ( isLoadingGoalsFirstExp ) {
+			result = {
+				state: AssertConditionState.CHECKING,
 			};
 		}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
 import { MIGRATION_FLOW } from '@automattic/onboarding';
@@ -47,6 +48,14 @@ function isLaunchpadIntent( intent: string ) {
 	return intent === SiteIntent.Write || intent === SiteIntent.Build;
 }
 
+const useGoalsFirstExperiment = (): [ boolean, boolean ] => {
+	// Currently loading isn't required because we're using a feature flag, but in the future
+	// we may need to take account of loading time.
+	const isLoading = false;
+
+	return [ isLoading, isEnabled( 'onboarding/goals-first' ) ];
+};
+
 const siteSetupFlow: Flow = {
 	name: 'site-setup',
 	isSignupFlow: false,
@@ -66,7 +75,9 @@ const siteSetupFlow: Flow = {
 	},
 
 	useSteps() {
-		return [
+		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
+
+		const steps = [
 			STEPS.GOALS,
 			STEPS.INTENT,
 			STEPS.OPTIONS,
@@ -94,6 +105,14 @@ const siteSetupFlow: Flow = {
 			STEPS.ERROR,
 			STEPS.DIFM_STARTING_POINT,
 		];
+
+		if ( isGoalsAtFrontExperiment ) {
+			// The user has already seen the goals step in the `onboarding` flow
+			// TODO Ensure that DESIGN_CHOICES is at the front if the user is Big Sky eligible
+			steps.splice( 0, 4 );
+		}
+
+		return steps;
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const isGoalsHoldout = useIsGoalsHoldout( currentStep );

--- a/client/landing/stepper/declarative-flow/test/site-setup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-setup-flow.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { renderHook } from '@testing-library/react';
 import { STEPS } from '../internals/steps';
 import siteSetupFlow from '../site-setup-flow';
 import { getFlowLocation, renderFlow } from './helpers';
@@ -27,9 +28,9 @@ describe( 'Site Setup Flow', () => {
 	 * It's totally fine to change this test if the flow changes. But please make sure to update and test the site-setup-wg accordingly.
 	 */
 	describe( 'First steps should be goals and intent capture', () => {
-		const steps = siteSetupFlow.useSteps();
-		const firstStep = steps[ 0 ];
-		const secondStep = steps[ 1 ];
+		const { result } = renderHook( () => siteSetupFlow.useSteps() );
+		const firstStep = result.current[ 0 ];
+		const secondStep = result.current[ 1 ];
 
 		it( 'should be goals', () => {
 			expect( firstStep.slug ).toBe( STEPS.GOALS.slug );

--- a/config/development.json
+++ b/config/development.json
@@ -170,6 +170,7 @@
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
+		"onboarding/goals-first": false,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"page/export": true,

--- a/config/development.json
+++ b/config/development.json
@@ -170,7 +170,7 @@
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
-		"onboarding/goals-first": false,
+		"onboarding/goals-first": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"page/export": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -138,6 +138,7 @@
 		"onboarding/trail-map-feature-grid-copy": false,
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,
+		"onboarding/goals-first": true,
 		"p2/p2-plus": true,
 		"p2-enabled": true,
 		"page/export": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #96756

## Proposed Changes

Uses an `onboarding/goals-first` feature flag to move the goals step to the very beginning of the onboarding flow. This PR allows you to prototype the change, but it is far from complete.

https://github.com/user-attachments/assets/00e7ce5f-ca4c-4c35-8520-199e28661b63



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to start moving more onboarding tasks in front of the paywall. This creates a skeleton of that change. Once this PR is merged—hidden behind a feature flag—we can add tasks for each of the TODOs I've left in the code and have multiple people working on it.

CC @Automattic/vertex this PR is adding a feature flag to the `onboarding` flow as mentioned here p1732691488986329-slack-C02T4NVL4JJ

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The prototype flow
   * Start at `/setup/onboarding?flags=onboarding/goals-first`
   * Confirm you can create a new site, however most of the branching is broken. To be completed in follow up PRs.
* The `onboarding` flow
   * This PR shouldn't have made any changes to the flow beginning at `/setup/onboarding`
   * It's not currently used by any users, but might be soon
* The production flow
   * **Do not break the flow beginning at `/start`**
   * This PR should not cause any changes to the main flow starting at `/start`
   * The main flow eventually lands in the `site-setup` stepper flow, that's the only place this might make unintentional changes to that flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?