### PR TITLE
Help Center: try to limit auth requests

### DIFF
--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -39,8 +39,8 @@ const initSmooch = ( {
 	} );
 };
 
-const HelpCenterSmooch: React.FC = () => {
-	const { data: authData } = useAuthenticateZendeskMessaging( true, 'messenger' );
+const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } ) => {
+	const { data: authData } = useAuthenticateZendeskMessaging( enableAuth, 'messenger' );
 	const smoochRef = useRef< HTMLDivElement >( null );
 	const { isHelpCenterShown, isChatLoaded } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
@@ -54,7 +54,7 @@ const HelpCenterSmooch: React.FC = () => {
 	const { isMessagingScriptLoaded } = useLoadZendeskMessaging(
 		'zendesk_support_chat_key',
 		isHelpCenterShown && isEligibleForChat,
-		isEligibleForChat,
+		isEligibleForChat && enableAuth,
 		true
 	);
 	const { setIsChatLoaded, setUnreadCount, setZendeskClientId } =

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -4,6 +4,7 @@
  */
 import { initializeAnalytics } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
+import { useGetSupportInteractions } from '@automattic/odie-client/src/data/use-get-support-interactions';
 import { useSelect } from '@wordpress/data';
 import { createPortal, useEffect, useRef } from '@wordpress/element';
 /**
@@ -39,6 +40,12 @@ const HelpCenter: React.FC< Container > = ( {
 		};
 	}, [] );
 	const { currentUser, canConnectToZendesk } = useHelpCenterContext();
+	const { data: supportInteractionsOpen, isLoading: isLoadingOpenInteractions } =
+		useGetSupportInteractions( 'zendesk', 10, 'open' );
+	const hasOpenZendeskConversations =
+		! isLoadingOpenInteractions && supportInteractionsOpen
+			? supportInteractionsOpen?.length > 0
+			: false;
 
 	useEffect( () => {
 		if ( currentUser ) {
@@ -73,7 +80,9 @@ const HelpCenter: React.FC< Container > = ( {
 				currentRoute={ currentRoute }
 				openingCoordinates={ openingCoordinates }
 			/>
-			{ shouldUseHelpCenterExperience && canConnectToZendesk && <HelpCenterSmooch /> }
+			{ shouldUseHelpCenterExperience && canConnectToZendesk && (
+				<HelpCenterSmooch enableAuth={ isHelpCenterShown || hasOpenZendeskConversations } />
+			) }
 		</>,
 		portalParent
 	);


### PR DESCRIPTION
## Proposed Changes

* Only enable the zendesk authentication query if the user has open conversations or the Help Center is open.

## Why are these changes being made?

In the current configuration we are running this request on every page load. It is cached by useQuery, but this could be limited. This will change to only run the fetch if it is needed.

## Testing Instructions

1. Clear the `calypso_store` data Dev Console ⇢ Application ⇢ IndexedDb ⇢ Calypso.
2. Open your Network requests in the dev console
3. Load this branch/live link
4. Check if there have been any requests to `/help/authenticate/chat` - there should be none if you have no open zendesk interactions. (if you don't have a user like this, just hard code `hasOpenZendeskConversations` to false)
5. Open Help Center and make sure everything is working properly.