### PR TITLE
Coupons: use grey colour for all badges

### DIFF
--- a/client/my-sites/earn/memberships/coupons-list.tsx
+++ b/client/my-sites/earn/memberships/coupons-list.tsx
@@ -177,7 +177,7 @@ function CouponsList() {
 									) }
 									{ currentCoupon?.discount_type === COUPON_DISCOUNT_TYPE_PERCENTAGE && (
 										<div className="memberships__coupons-coupon-badge">
-											<Badge type="warning-clear">
+											<Badge type="info">
 												{ getDiscountBadge(
 													currentCoupon?.duration || '',
 													currentCoupon?.discount_type,
@@ -188,7 +188,7 @@ function CouponsList() {
 									) }
 									{ currentCoupon?.discount_type === COUPON_DISCOUNT_TYPE_AMOUNT && (
 										<div className="memberships__coupons-coupon-badge">
-											<Badge type="warning-clear">
+											<Badge type="info">
 												{ getDiscountBadge(
 													currentCoupon?.duration || '',
 													currentCoupon?.discount_type,
@@ -200,28 +200,24 @@ function CouponsList() {
 									) }
 									{ currentCoupon?.cannot_be_combined && (
 										<div className="memberships__coupons-coupon-badge">
-											<Badge type="info-blue">
+											<Badge type="info">
 												{ translate( 'Cannot be combined with other coupons' ) }
 											</Badge>
 										</div>
 									) }
 									{ currentCoupon?.first_time_purchase_only && (
 										<div className="memberships__coupons-coupon-badge">
-											<Badge type="info-green">{ translate( 'First-time order only' ) }</Badge>
+											<Badge type="info">{ translate( 'First-time order only' ) }</Badge>
 										</div>
 									) }
 									{ ( currentCoupon?.email_allow_list?.length ?? 0 ) > 0 && (
 										<div className="memberships__coupons-coupon-badge">
-											<Badge type="info-purple">
-												{ translate( 'Limited to specific emails' ) }
-											</Badge>
+											<Badge type="info">{ translate( 'Limited to specific emails' ) }</Badge>
 										</div>
 									) }
 									{ ( currentCoupon?.plan_ids_allow_list?.length ?? 0 ) > 0 && (
 										<div className="memberships__coupons-coupon-badge">
-											<Badge type="info-purple">
-												{ translate( 'Limited to specific products' ) }
-											</Badge>
+											<Badge type="info">{ translate( 'Limited to specific products' ) }</Badge>
 										</div>
 									) }
 								</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

internal reference peKye1-1bu-p2

## Proposed Changes

* Use grey colour for all badges in coupons list

**Before**

<img width="1077" alt="screenshot-2024-11-26-at-11 41 55" src="https://github.com/user-attachments/assets/3e8adf5c-089d-4ebe-a990-1d17cff76e26">


**After**

![image](https://github.com/user-attachments/assets/feee095d-3e37-4d9e-8946-27b29ce0360f)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?