### PR TITLE
Stats: Set "Last xxx Days" shortcuts with a complete date range

### DIFF
--- a/client/components/date-control/types.d.ts
+++ b/client/components/date-control/types.d.ts
@@ -38,8 +38,6 @@ interface DateControlPickerShortcutsProps {
 interface DateControlPickerShortcut {
 	id: string;
 	label: string;
-	offset?: number;
-	range?: number;
 	startDate?: string;
 	endDate?: string;
 	period: string;

--- a/client/components/date-control/types.d.ts
+++ b/client/components/date-control/types.d.ts
@@ -35,17 +35,6 @@ interface DateControlPickerShortcutsProps {
 	onClick: ( shortcut: DateControlPickerShortcut ) => void;
 }
 
-interface DateControlPickerShortcut {
-	id: string;
-	label: string;
-	startDate?: string;
-	endDate?: string;
-	period: string;
-	statType?: string;
-	isGated?: boolean;
-	shortcutId?: string;
-}
-
 interface DateControlPickerDateProps {
 	startDate?: string;
 	endDate?: string;
@@ -59,7 +48,6 @@ interface DateControlPickerDateProps {
 export {
 	DateControlProps,
 	DateControlPickerProps,
-	DateControlPickerShortcut,
 	DateControlPickerShortcutsProps,
 	DateControlPickerDateProps,
 };

--- a/client/components/date-control/types.d.ts
+++ b/client/components/date-control/types.d.ts
@@ -38,8 +38,10 @@ interface DateControlPickerShortcutsProps {
 interface DateControlPickerShortcut {
 	id: string;
 	label: string;
-	offset: number;
-	range: number;
+	offset?: number;
+	range?: number;
+	startDate?: string;
+	endDate?: string;
 	period: string;
 	statType?: string;
 	isGated?: boolean;

--- a/client/components/date-control/types.d.ts
+++ b/client/components/date-control/types.d.ts
@@ -6,7 +6,7 @@ interface DateControlProps {
 		chartEnd: string;
 		daysInRange: number;
 	};
-	shortcutList: DateControlPickerShortcut[];
+	shortcutList: DateRangePickerShortcut[];
 	onShortcutClick: ( shortcutId: string ) => void;
 	tooltip?: string;
 	overlay?: JSX.Element;
@@ -17,9 +17,9 @@ interface DateControlProps {
 interface DateControlPickerProps {
 	buttonLabel: string;
 	dateRange: any;
-	shortcutList: DateControlPickerShortcut[];
+	shortcutList: DateRangePickerShortcut[];
 	selectedShortcut: string | undefined;
-	onShortcut: ( shortcut: DateControlPickerShortcut ) => void;
+	onShortcut: ( shortcut: DateRangePickerShortcut ) => void;
 	onApply: ( startDate: string, endDate: string ) => void;
 	overlay?: JSX.Element;
 	onGatedHandler: (
@@ -30,9 +30,9 @@ interface DateControlPickerProps {
 }
 
 interface DateControlPickerShortcutsProps {
-	shortcutList: DateControlPickerShortcut[];
+	shortcutList: DateRangePickerShortcut[];
 	currentShortcut: string | undefined;
-	onClick: ( shortcut: DateControlPickerShortcut ) => void;
+	onClick: ( shortcut: DateRangePickerShortcut ) => void;
 }
 
 interface DateControlPickerDateProps {

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -8,7 +8,7 @@ import { useShortcuts } from './use-shortcuts';
 
 type MomentOrNull = Moment | null;
 
-export interface DateControlPickerShortcut {
+export interface DateRangePickerShortcut {
 	id: string;
 	label: string;
 	startDate: string;
@@ -54,7 +54,7 @@ const DateRangePickerShortcuts = ( {
 		isNewDateFilteringEnabled
 	);
 
-	const handleClick = ( { id, startDate, endDate }: Partial< DateControlPickerShortcut > ) => {
+	const handleClick = ( { id, startDate, endDate }: Partial< DateRangePickerShortcut > ) => {
 		onClick( moment( startDate ), moment( endDate ), id || '' );
 
 		// Call the onShortcutClick if provided

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -3,7 +3,7 @@ import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import moment, { Moment } from 'moment';
 import PropTypes from 'prop-types';
-import useMomentSiteZone from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
+import { DATE_FORMAT } from 'calypso/my-sites/stats/constants';
 import { useShortcuts } from './use-shortcuts';
 
 type MomentOrNull = Moment | null;
@@ -26,8 +26,6 @@ const DateRangePickerShortcuts = ( {
 	endDate?: MomentOrNull;
 	isNewDateFilteringEnabled?: boolean;
 } ) => {
-	const siteToday = useMomentSiteZone();
-
 	const normalizeDate = ( date: MomentOrNull ) => {
 		return date ? date.startOf( 'day' ) : date;
 	};
@@ -38,21 +36,24 @@ const DateRangePickerShortcuts = ( {
 
 	const { supportedShortcutList: shortcutList, selectedShortcut } = useShortcuts(
 		{
-			chartStart: normalizedStartDate?.format( 'YYYY-MM-DD' ) ?? '',
-			chartEnd: normalizedEndDate?.format( 'YYYY-MM-DD' ) ?? '',
+			chartStart: normalizedStartDate?.format( DATE_FORMAT ) ?? '',
+			chartEnd: normalizedEndDate?.format( DATE_FORMAT ) ?? '',
 			daysInRange: ( normalizedEndDate?.diff( normalizedStartDate, 'days' ) ?? 0 ) + 1,
 		},
 		undefined,
 		isNewDateFilteringEnabled
 	);
 
-	const handleClick = ( { id, offset, range }: { id?: string; offset: number; range: number } ) => {
-		const newToDate = siteToday.clone().startOf( 'day' ).subtract( offset, 'days' );
-		const newFromDate = siteToday
-			.clone()
-			.startOf( 'day' )
-			.subtract( offset + range, 'days' );
-		onClick( newFromDate, newToDate, id || '' );
+	const handleClick = ( {
+		id,
+		startDate,
+		endDate,
+	}: {
+		id?: string;
+		startDate: string;
+		endDate: string;
+	} ) => {
+		onClick( moment( startDate ), moment( endDate ), id || '' );
 
 		// Call the onShortcutClick if provided
 		if ( onShortcutClick && id ) {

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -8,6 +8,17 @@ import { useShortcuts } from './use-shortcuts';
 
 type MomentOrNull = Moment | null;
 
+export interface DateControlPickerShortcut {
+	id: string;
+	label: string;
+	startDate: string;
+	endDate: string;
+	period: string;
+	statType?: string;
+	isGated?: boolean;
+	shortcutId?: string;
+}
+
 const DateRangePickerShortcuts = ( {
 	currentShortcut,
 	onClick,
@@ -43,15 +54,7 @@ const DateRangePickerShortcuts = ( {
 		isNewDateFilteringEnabled
 	);
 
-	const handleClick = ( {
-		id,
-		startDate,
-		endDate,
-	}: {
-		id?: string;
-		startDate: string;
-		endDate: string;
-	} ) => {
+	const handleClick = ( { id, startDate, endDate }: Partial< DateControlPickerShortcut > ) => {
 		onClick( moment( startDate ), moment( endDate ), id || '' );
 
 		// Call the onShortcutClick if provided

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -40,7 +40,6 @@ const DateRangePickerShortcuts = ( {
 			chartEnd: normalizedEndDate?.format( DATE_FORMAT ) ?? '',
 			daysInRange: ( normalizedEndDate?.diff( normalizedStartDate, 'days' ) ?? 0 ) + 1,
 		},
-		undefined,
 		isNewDateFilteringEnabled
 	);
 

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { translate, useTranslate } from 'i18n-calypso';
+import { memoize } from 'lodash';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -21,7 +22,6 @@ export function getShortcuts(
 		chartEnd: string;
 		daysInRange: number;
 	},
-	shortcutList?: string[],
 	translateFunction = translate,
 	isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' )
 ) {
@@ -31,98 +31,106 @@ export function getShortcuts(
 	const siteTodayStr = siteToday.format( DATE_FORMAT );
 	const yesterdayStr = siteYesterday.format( DATE_FORMAT );
 
-	const supportedShortcutList: DateControlPickerShortcut[] = [
-		{
-			id: 'last_7_days',
-			label: translateFunction( 'Last 7 Days' ),
-			startDate: siteYesterday.clone().subtract( 6, 'days' ).format( DATE_FORMAT ),
-			endDate: yesterdayStr,
-			period: DATERANGE_PERIOD.DAY,
-			shortcutId: 'last_7_days',
-		},
-		{
-			id: 'last_30_days',
-			label: translateFunction( 'Last 30 Days' ),
-			startDate: siteYesterday.clone().subtract( 29, 'days' ).format( DATE_FORMAT ),
-			endDate: yesterdayStr,
-			period: DATERANGE_PERIOD.DAY,
-			shortcutId: 'last_30_days',
-		},
-		{
-			id: 'last_3_months',
-			label: translateFunction( 'Last 90 Days' ),
-			startDate: siteYesterday.clone().subtract( 89, 'days' ).format( DATE_FORMAT ),
-			endDate: yesterdayStr,
-			period: DATERANGE_PERIOD.WEEK,
-			shortcutId: 'last_3_months',
-		},
-		{
-			id: 'last_year',
-			label: translateFunction( 'Last Year' ),
-			startDate: siteYesterday.clone().subtract( 364, 'days' ).format( DATE_FORMAT ),
-			endDate: yesterdayStr,
-			period: DATERANGE_PERIOD.MONTH,
-			shortcutId: 'last_year',
-		},
-		{
-			id: 'custom_date_range',
-			label: translateFunction( 'Custom Range' ),
-			period: DATERANGE_PERIOD.DAY,
-			shortcutId: 'custom_date_range',
-		},
-	];
+	return memoize(
+		() => {
+			const supportedShortcutList: DateControlPickerShortcut[] = [
+				{
+					id: 'last_7_days',
+					label: translateFunction( 'Last 7 Days' ),
+					startDate: siteYesterday.clone().subtract( 6, 'days' ).format( DATE_FORMAT ),
+					endDate: yesterdayStr,
+					period: DATERANGE_PERIOD.DAY,
+					shortcutId: 'last_7_days',
+				},
+				{
+					id: 'last_30_days',
+					label: translateFunction( 'Last 30 Days' ),
+					startDate: siteYesterday.clone().subtract( 29, 'days' ).format( DATE_FORMAT ),
+					endDate: yesterdayStr,
+					period: DATERANGE_PERIOD.DAY,
+					shortcutId: 'last_30_days',
+				},
+				{
+					id: 'last_3_months',
+					label: translateFunction( 'Last 90 Days' ),
+					startDate: siteYesterday.clone().subtract( 89, 'days' ).format( DATE_FORMAT ),
+					endDate: yesterdayStr,
+					period: DATERANGE_PERIOD.WEEK,
+					shortcutId: 'last_3_months',
+				},
+				{
+					id: 'last_year',
+					label: translateFunction( 'Last Year' ),
+					startDate: siteYesterday.clone().subtract( 364, 'days' ).format( DATE_FORMAT ),
+					endDate: yesterdayStr,
+					period: DATERANGE_PERIOD.MONTH,
+					shortcutId: 'last_year',
+				},
+				{
+					id: 'custom_date_range',
+					label: translateFunction( 'Custom Range' ),
+					period: DATERANGE_PERIOD.DAY,
+					shortcutId: 'custom_date_range',
+				},
+			];
 
-	if ( isNewDateFilteringEnabled ) {
-		supportedShortcutList.unshift(
-			{
-				id: 'today',
-				label: translateFunction( 'Today' ),
-				startDate: siteTodayStr,
-				endDate: siteTodayStr,
-				period: DATERANGE_PERIOD.DAY,
-				shortcutId: 'today',
-			},
-			{
-				id: 'yesterday',
-				label: translateFunction( 'Yesterday' ),
-				startDate: yesterdayStr,
-				endDate: yesterdayStr,
-				period: DATERANGE_PERIOD.DAY,
-				shortcutId: 'yesterday',
+			if ( isNewDateFilteringEnabled ) {
+				supportedShortcutList.unshift(
+					{
+						id: 'today',
+						label: translateFunction( 'Today' ),
+						startDate: siteTodayStr,
+						endDate: siteTodayStr,
+						period: DATERANGE_PERIOD.DAY,
+						shortcutId: 'today',
+					},
+					{
+						id: 'yesterday',
+						label: translateFunction( 'Yesterday' ),
+						startDate: yesterdayStr,
+						endDate: yesterdayStr,
+						period: DATERANGE_PERIOD.DAY,
+						shortcutId: 'yesterday',
+					}
+				);
 			}
-		);
-	}
 
-	const getShortcutForRange = () => {
-		if ( ! dateRange?.chartEnd || ! dateRange?.chartStart ) {
-			return null;
-		}
-		// Search the shortcut array for something matching the current date range.
-		// Returns shortcut or null;
-		const shortcut = supportedShortcutList.find( ( element ) => {
-			if ( element.endDate === dateRange.chartEnd && element.startDate === dateRange.chartStart ) {
-				return element;
-			}
-			return null;
-		} );
+			const getShortcutForRange = () => {
+				if ( ! dateRange?.chartEnd || ! dateRange?.chartStart ) {
+					return null;
+				}
+				// Search the shortcut array for something matching the current date range.
+				// Returns shortcut or null;
+				const shortcut = supportedShortcutList.find( ( element ) => {
+					if (
+						element.endDate === dateRange.chartEnd &&
+						element.startDate === dateRange.chartStart
+					) {
+						return element;
+					}
+					return null;
+				} );
 
-		return shortcut;
-	};
+				return shortcut;
+			};
 
-	return {
-		selectedShortcut: getShortcutForRange(),
-		supportedShortcutList,
-	};
+			return {
+				selectedShortcut: getShortcutForRange(),
+				supportedShortcutList,
+			};
+		},
+		() =>
+			`${ siteId }-${ siteTodayStr }-${ dateRange?.chartStart }-${ dateRange?.chartEnd }-${ isNewDateFilteringEnabled }`
+	)();
 }
 
 export function useShortcuts(
 	dateRange: { chartStart: string; chartEnd: string; daysInRange: number },
-	shortcutList?: string[],
 	isNewDateFilteringEnabled = false
 ) {
 	const translate = useTranslate();
 	const shortcuts = useSelector( ( state ) =>
-		getShortcuts( state, dateRange, shortcutList, translate, isNewDateFilteringEnabled )
+		getShortcuts( state, dateRange, translate, isNewDateFilteringEnabled )
 	);
 
 	return shortcuts;

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -4,7 +4,7 @@ import { memoize } from 'lodash';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { DateControlPickerShortcut } from './shortcuts';
+import { DateRangePickerShortcut } from './shortcuts';
 
 export const DATERANGE_PERIOD = {
 	HOUR: 'hour',
@@ -33,7 +33,7 @@ export function getShortcuts(
 
 	return memoize(
 		() => {
-			const supportedShortcutList: DateControlPickerShortcut[] = [
+			const supportedShortcutList: DateRangePickerShortcut[] = [
 				{
 					id: 'last_7_days',
 					label: translateFunction( 'Last 7 Days' ),

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -4,7 +4,7 @@ import { memoize } from 'lodash';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { DateControlPickerShortcut } from '../date-control/types';
+import { DateControlPickerShortcut } from './shortcuts';
 
 export const DATERANGE_PERIOD = {
 	HOUR: 'hour',

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -6,10 +6,13 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DateControlPickerShortcut } from '../date-control/types';
 
 export const DATERANGE_PERIOD = {
+	HOUR: 'hour',
 	DAY: 'day',
 	WEEK: 'week',
 	MONTH: 'month',
 };
+
+const DATE_FORMAT = 'YYYY-MM-DD';
 
 export function getShortcuts(
 	state: object,
@@ -24,45 +27,46 @@ export function getShortcuts(
 ) {
 	const siteId = getSelectedSiteId( state );
 	const siteToday = getMomentSiteZone( state, siteId );
+	const siteYesterday = siteToday.clone().subtract( 1, 'days' );
+	const siteTodayStr = siteToday.format( DATE_FORMAT );
+	const yesterdayStr = siteYesterday.format( DATE_FORMAT );
 
 	const supportedShortcutList: DateControlPickerShortcut[] = [
 		{
 			id: 'last_7_days',
 			label: translateFunction( 'Last 7 Days' ),
-			offset: 0,
-			range: 6,
+			startDate: siteYesterday.clone().subtract( 6, 'days' ).format( DATE_FORMAT ),
+			endDate: yesterdayStr,
 			period: DATERANGE_PERIOD.DAY,
 			shortcutId: 'last_7_days',
 		},
 		{
 			id: 'last_30_days',
 			label: translateFunction( 'Last 30 Days' ),
-			offset: 0,
-			range: 29,
+			startDate: siteYesterday.clone().subtract( 29, 'days' ).format( DATE_FORMAT ),
+			endDate: yesterdayStr,
 			period: DATERANGE_PERIOD.DAY,
 			shortcutId: 'last_30_days',
 		},
 		{
 			id: 'last_3_months',
 			label: translateFunction( 'Last 90 Days' ),
-			offset: 0,
-			range: 89,
+			startDate: siteYesterday.clone().subtract( 89, 'days' ).format( DATE_FORMAT ),
+			endDate: yesterdayStr,
 			period: DATERANGE_PERIOD.WEEK,
 			shortcutId: 'last_3_months',
 		},
 		{
 			id: 'last_year',
 			label: translateFunction( 'Last Year' ),
-			offset: 0,
-			range: 364, // ranges are zero based!
+			startDate: siteYesterday.clone().subtract( 364, 'days' ).format( DATE_FORMAT ),
+			endDate: yesterdayStr,
 			period: DATERANGE_PERIOD.MONTH,
 			shortcutId: 'last_year',
 		},
 		{
 			id: 'custom_date_range',
 			label: translateFunction( 'Custom Range' ),
-			offset: 0,
-			range: 0,
 			period: DATERANGE_PERIOD.DAY,
 			shortcutId: 'custom_date_range',
 		},
@@ -73,16 +77,16 @@ export function getShortcuts(
 			{
 				id: 'today',
 				label: translateFunction( 'Today' ),
-				offset: 0,
-				range: 0,
+				startDate: siteTodayStr,
+				endDate: siteTodayStr,
 				period: DATERANGE_PERIOD.DAY,
 				shortcutId: 'today',
 			},
 			{
 				id: 'yesterday',
 				label: translateFunction( 'Yesterday' ),
-				offset: 1,
-				range: 0,
+				startDate: yesterdayStr,
+				endDate: yesterdayStr,
 				period: DATERANGE_PERIOD.DAY,
 				shortcutId: 'yesterday',
 			}
@@ -95,17 +99,8 @@ export function getShortcuts(
 		}
 		// Search the shortcut array for something matching the current date range.
 		// Returns shortcut or null;
-		const today = siteToday.format( 'YYYY-MM-DD' );
-		const yesterday = siteToday.clone().subtract( 1, 'days' ).format( 'YYYY-MM-DD' );
 		const shortcut = supportedShortcutList.find( ( element ) => {
-			if (
-				yesterday === dateRange.chartEnd &&
-				dateRange.daysInRange === element.range + 1 &&
-				element.id === 'yesterday'
-			) {
-				return element;
-			}
-			if ( today === dateRange.chartEnd && dateRange.daysInRange === element.range + 1 ) {
+			if ( element.endDate === dateRange.chartEnd && element.startDate === dateRange.chartStart ) {
 				return element;
 			}
 			return null;

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -69,6 +69,8 @@ export function getShortcuts(
 				{
 					id: 'custom_date_range',
 					label: translateFunction( 'Custom Range' ),
+					startDate: '',
+					endDate: '',
 					period: DATERANGE_PERIOD.DAY,
 					shortcutId: 'custom_date_range',
 				},

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
+import { createSelector } from '@automattic/state-utils';
 import { translate, useTranslate } from 'i18n-calypso';
-import { memoize } from 'lodash';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -15,116 +15,134 @@ export const DATERANGE_PERIOD = {
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
-export function getShortcuts(
-	state: object,
-	dateRange: {
-		chartStart: string;
-		chartEnd: string;
-		daysInRange: number;
-	},
-	translateFunction = translate,
-	isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' )
-) {
-	const siteId = getSelectedSiteId( state );
-	const siteToday = getMomentSiteZone( state, siteId );
-	const siteYesterday = siteToday.clone().subtract( 1, 'days' );
-	const siteTodayStr = siteToday.format( DATE_FORMAT );
-	const yesterdayStr = siteYesterday.format( DATE_FORMAT );
-
-	return memoize(
-		() => {
-			const supportedShortcutList: DateRangePickerShortcut[] = [
-				{
-					id: 'last_7_days',
-					label: translateFunction( 'Last 7 Days' ),
-					startDate: siteYesterday.clone().subtract( 6, 'days' ).format( DATE_FORMAT ),
-					endDate: yesterdayStr,
-					period: DATERANGE_PERIOD.DAY,
-					shortcutId: 'last_7_days',
-				},
-				{
-					id: 'last_30_days',
-					label: translateFunction( 'Last 30 Days' ),
-					startDate: siteYesterday.clone().subtract( 29, 'days' ).format( DATE_FORMAT ),
-					endDate: yesterdayStr,
-					period: DATERANGE_PERIOD.DAY,
-					shortcutId: 'last_30_days',
-				},
-				{
-					id: 'last_3_months',
-					label: translateFunction( 'Last 90 Days' ),
-					startDate: siteYesterday.clone().subtract( 89, 'days' ).format( DATE_FORMAT ),
-					endDate: yesterdayStr,
-					period: DATERANGE_PERIOD.WEEK,
-					shortcutId: 'last_3_months',
-				},
-				{
-					id: 'last_year',
-					label: translateFunction( 'Last Year' ),
-					startDate: siteYesterday.clone().subtract( 364, 'days' ).format( DATE_FORMAT ),
-					endDate: yesterdayStr,
-					period: DATERANGE_PERIOD.MONTH,
-					shortcutId: 'last_year',
-				},
-				{
-					id: 'custom_date_range',
-					label: translateFunction( 'Custom Range' ),
-					startDate: '',
-					endDate: '',
-					period: DATERANGE_PERIOD.DAY,
-					shortcutId: 'custom_date_range',
-				},
-			];
-
-			if ( isNewDateFilteringEnabled ) {
-				supportedShortcutList.unshift(
-					{
-						id: 'today',
-						label: translateFunction( 'Today' ),
-						startDate: siteTodayStr,
-						endDate: siteTodayStr,
-						period: DATERANGE_PERIOD.DAY,
-						shortcutId: 'today',
-					},
-					{
-						id: 'yesterday',
-						label: translateFunction( 'Yesterday' ),
-						startDate: yesterdayStr,
-						endDate: yesterdayStr,
-						period: DATERANGE_PERIOD.DAY,
-						shortcutId: 'yesterday',
-					}
-				);
-			}
-
-			const getShortcutForRange = () => {
-				if ( ! dateRange?.chartEnd || ! dateRange?.chartStart ) {
-					return null;
-				}
-				// Search the shortcut array for something matching the current date range.
-				// Returns shortcut or null;
-				const shortcut = supportedShortcutList.find( ( element ) => {
-					if (
-						element.endDate === dateRange.chartEnd &&
-						element.startDate === dateRange.chartStart
-					) {
-						return element;
-					}
-					return null;
-				} );
-
-				return shortcut;
-			};
-
-			return {
-				selectedShortcut: getShortcutForRange(),
-				supportedShortcutList,
-			};
+export const getShortcuts = createSelector(
+	(
+		state: object,
+		dateRange: {
+			chartStart: string;
+			chartEnd: string;
 		},
-		() =>
-			`${ siteId }-${ siteTodayStr }-${ dateRange?.chartStart }-${ dateRange?.chartEnd }-${ isNewDateFilteringEnabled }`
-	)();
-}
+		translateFunction = translate,
+		isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' )
+	) => {
+		const siteId = getSelectedSiteId( state );
+		const siteToday = getMomentSiteZone( state, siteId );
+		const siteTodayStr = siteToday.format( DATE_FORMAT );
+		const siteYesterday = siteToday.clone().subtract( 1, 'days' );
+		const yesterdayStr = siteYesterday.format( DATE_FORMAT );
+
+		const supportedShortcutList = [
+			{
+				id: 'last_7_days',
+				label: translateFunction( 'Last 7 Days' ),
+				startDate: siteYesterday.clone().subtract( 6, 'days' ).format( DATE_FORMAT ),
+				endDate: yesterdayStr,
+				period: DATERANGE_PERIOD.DAY,
+				shortcutId: 'last_7_days',
+			},
+			{
+				id: 'last_30_days',
+				label: translateFunction( 'Last 30 Days' ),
+				startDate: siteYesterday.clone().subtract( 29, 'days' ).format( DATE_FORMAT ),
+				endDate: yesterdayStr,
+				period: DATERANGE_PERIOD.DAY,
+				shortcutId: 'last_30_days',
+			},
+			{
+				id: 'last_3_months',
+				label: translateFunction( 'Last 90 Days' ),
+				startDate: siteYesterday.clone().subtract( 89, 'days' ).format( DATE_FORMAT ),
+				endDate: yesterdayStr,
+				period: DATERANGE_PERIOD.WEEK,
+				shortcutId: 'last_3_months',
+			},
+			{
+				id: 'last_year',
+				label: translateFunction( 'Last Year' ),
+				startDate: siteYesterday.clone().subtract( 364, 'days' ).format( DATE_FORMAT ),
+				endDate: yesterdayStr,
+				period: DATERANGE_PERIOD.MONTH,
+				shortcutId: 'last_year',
+			},
+			{
+				id: 'custom_date_range',
+				label: translateFunction( 'Custom Range' ),
+				startDate: '',
+				endDate: '',
+				period: DATERANGE_PERIOD.DAY,
+				shortcutId: 'custom_date_range',
+			},
+		];
+
+		if ( isNewDateFilteringEnabled ) {
+			supportedShortcutList.unshift(
+				{
+					id: 'today',
+					label: translateFunction( 'Today' ),
+					startDate: siteTodayStr,
+					endDate: siteTodayStr,
+					period: DATERANGE_PERIOD.DAY,
+					shortcutId: 'today',
+				},
+				{
+					id: 'yesterday',
+					label: translateFunction( 'Yesterday' ),
+					startDate: yesterdayStr,
+					endDate: yesterdayStr,
+					period: DATERANGE_PERIOD.DAY,
+					shortcutId: 'yesterday',
+				}
+			);
+		}
+
+		const findShortcutForRange = (
+			supportedShortcutList: DateRangePickerShortcut[],
+			dateRange: { chartStart: string; chartEnd: string }
+		) => {
+			if ( ! dateRange?.chartEnd || ! dateRange?.chartStart ) {
+				return null;
+			}
+			// Search the shortcut array for something matching the current date range.
+			// Returns shortcut or null;
+			const shortcut = supportedShortcutList.find( ( element ) => {
+				if (
+					element.endDate === dateRange.chartEnd &&
+					element.startDate === dateRange.chartStart
+				) {
+					return element;
+				}
+				return null;
+			} );
+
+			return shortcut;
+		};
+
+		return {
+			selectedShortcut: findShortcutForRange( supportedShortcutList, dateRange ),
+			supportedShortcutList,
+		};
+	},
+	(
+		state: object,
+		dateRange: {
+			chartStart: string;
+			chartEnd: string;
+		},
+		translateFunction,
+		isNewDateFilteringEnabled
+	) => {
+		const siteId = getSelectedSiteId( state );
+		const siteToday = getMomentSiteZone( state, siteId );
+
+		return [
+			siteId,
+			siteToday.format( DATE_FORMAT ),
+			dateRange?.chartStart,
+			dateRange.chartEnd,
+			isNewDateFilteringEnabled,
+		];
+	}
+);
 
 export function useShortcuts(
 	dateRange: { chartStart: string; chartEnd: string; daysInRange: number },

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -138,7 +138,7 @@ export const getShortcuts = createSelector(
 			siteId,
 			siteToday.format( DATE_FORMAT ),
 			dateRange?.chartStart,
-			dateRange.chartEnd,
+			dateRange?.chartEnd,
 			isNewDateFilteringEnabled,
 		];
 	}

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -6,7 +6,7 @@ import qs from 'qs';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import DateControl from '../date-control';
-import { DateControlPickerShortcut } from '../date-control/types';
+import { DateControlPickerShortcut } from '../date-range/shortcuts';
 
 type DateRange = {
 	chartStart: string;

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -6,7 +6,7 @@ import qs from 'qs';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import DateControl from '../date-control';
-import { DateControlPickerShortcut } from '../date-range/shortcuts';
+import { DateRangePickerShortcut } from '../date-range/shortcuts';
 
 type DateRange = {
 	chartStart: string;
@@ -18,7 +18,7 @@ interface StatsDateControlProps {
 	queryParams: string;
 	period: 'day' | 'week' | 'month' | 'year';
 	dateRange: DateRange;
-	shortcutList: DateControlPickerShortcut[];
+	shortcutList: DateRangePickerShortcut[];
 	overlay?: JSX.Element;
 	onGatedHandler: (
 		events: { name: string; params?: object }[],

--- a/client/my-sites/stats/constants.ts
+++ b/client/my-sites/stats/constants.ts
@@ -72,3 +72,5 @@ export const STATS_FEATURE_UTM_STATS = 'stats_utm';
 
 // other
 export const STATS_DO_YOU_LOVE_JETPACK_STATS_NOTICE = 'DoYouLoveJetpackStatsNotice';
+
+export const DATE_FORMAT = 'YYYY-MM-DD';

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -358,7 +358,7 @@ class StatsSite extends Component {
 			// (e.g. months defaulting to 30 days and showing one point)
 			customChartRange.chartStart = momentSiteZone
 				.clone()
-				.subtract( daysInRange - 1, 'days' )
+				.subtract( daysInRange, 'days' )
 				.format( DATE_FORMAT );
 		}
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -28,6 +28,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import StickyPanel from 'calypso/components/sticky-panel';
 import memoizeLast from 'calypso/lib/memoize-last';
 import {
+	DATE_FORMAT,
 	STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS,
 	STAT_TYPE_REFERRERS,
 } from 'calypso/my-sites/stats/constants';
@@ -177,7 +178,7 @@ class StatsSite extends Component {
 		let chartStart = periodStartDate;
 		let chartEnd = moment( chartStart )
 			.endOf( period === 'week' ? 'isoWeek' : period )
-			.format( 'YYYY-MM-DD' );
+			.format( DATE_FORMAT );
 
 		// Limit navigation within the currently selected range.
 		const currentChartStart = this.props.context.query?.chartStart;
@@ -283,7 +284,7 @@ class StatsSite extends Component {
 		if ( query?.start_date ) {
 			url += `?startDate=${ query.start_date }&endDate=${ query.date }`;
 		} else {
-			url += `?startDate=${ period.endOf.format( 'YYYY-MM-DD' ) }`;
+			url += `?startDate=${ period.endOf.format( DATE_FORMAT ) }`;
 		}
 
 		return url;
@@ -324,7 +325,7 @@ class StatsSite extends Component {
 			defaultPeriod = PAST_THIRTY_DAYS;
 		}
 
-		const queryDate = date.format( 'YYYY-MM-DD' );
+		const queryDate = date.format( DATE_FORMAT );
 		const { period, endOf } = this.props.period;
 		const moduleStrings = statsStrings();
 
@@ -338,7 +339,9 @@ class StatsSite extends Component {
 		if ( chartEnd ) {
 			customChartRange = { chartEnd };
 		} else {
-			customChartRange = { chartEnd: momentSiteZone.format( 'YYYY-MM-DD' ) };
+			customChartRange = {
+				chartEnd: momentSiteZone.clone().subtract( 1, 'days' ).format( DATE_FORMAT ),
+			};
 		}
 
 		// Find the quantity of bars for the chart.
@@ -356,7 +359,7 @@ class StatsSite extends Component {
 			customChartRange.chartStart = momentSiteZone
 				.clone()
 				.subtract( daysInRange - 1, 'days' )
-				.format( 'YYYY-MM-DD' );
+				.format( DATE_FORMAT );
 		}
 
 		customChartRange.daysInRange = daysInRange;
@@ -392,16 +395,16 @@ class StatsSite extends Component {
 
 			// For StatsDateControl
 			customChartRange.daysInRange = 7;
-			customChartRange.chartEnd = momentSiteZone.format( 'YYYY-MM-DD' );
+			customChartRange.chartEnd = momentSiteZone.format( DATE_FORMAT );
 			customChartRange.chartStart = momentSiteZone
 				.clone()
 				.subtract( customChartRange.daysInRange - 1, 'days' )
-				.format( 'YYYY-MM-DD' );
+				.format( DATE_FORMAT );
 		}
 
 		const query = isNewDateFilteringEnabled
 			? chartRangeToQuery( customChartRange )
-			: memoizedQuery( period, endOf.format( 'YYYY-MM-DD' ) );
+			: memoizedQuery( period, endOf.format( DATE_FORMAT ) );
 
 		// For period option links
 		const traffic = {

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -188,7 +188,6 @@ class StatsDatePicker extends Component {
 		const { selectedShortcut } = getShortcuts(
 			reduxState,
 			dateRange,
-			undefined,
 			translate,
 			isNewDateFilteringEnabled
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/276

## Proposed Changes

* Set `Last xxx Days` shortcuts to end with yesterday to have a complete date range.
* Extract a shared `findShortcutFromList` function to reduce inconsistency between `DateRange` and `DateControl`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make the default days range complete to be more valued as highlights.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page with the feature flag `stats/new-date-filtering`.
* Ensure the default `Last 7 Days` shortcut ends with yesterday rather than today.

<img width="780" alt="截圖 2024-11-28 下午5 13 03" src="https://github.com/user-attachments/assets/3fcec23b-17ad-4345-9e67-16fc668a1d6e">

* Click on the date range picker.
* Ensure other `Last xxx Days` options also apply with the end of yesterday correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
