### PR TITLE
Add coupon to Black Friday 2024 promo card 

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/black-friday-2024/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/black-friday-2024/index.jsx
@@ -20,7 +20,7 @@ const BlackFriday2024 = () => {
 			title={ title }
 			description={ description }
 			actionText={ translate( 'Get the Sale' ) }
-			actionUrl={ `/plans/${ siteSlug }?coupon=` }
+			actionUrl={ `/plans/${ siteSlug }?coupon=BF25` }
 			completeOnStart={ false }
 			illustration={ blackFriday2024Illustration }
 			taskId={ TASK_BLACK_FRIDAY_2024 }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -270,7 +270,7 @@ class PlansComponent extends Component {
 				( ! this.props.isDomainUpsell ||
 					( this.props.isDomainUpsell && currentPlanIntervalType === 'monthly' ) ) ) ||
 			// TODO: Remove after 1733443200000.
-			( this.props.coupon === 'REPLACE_ME' && Date.now() < new Date( 1733443200000 ) );
+			( this.props.coupon === 'BF25' && Date.now() < new Date( 1733443200000 ) );
 
 		return (
 			<PlansFeaturesMain


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #96610

## Proposed Changes

* This adds the coupon code to the My Home Black Friday card

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions form #96610 
* Clicking the `Get the sale` should show the plans page with the coupon applied
* The interval toggle on the /plans page should be hidden

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
