### PR TITLE
Payment Methods: change the PPCP indicator to 'A8C-only'

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -34,7 +34,7 @@ function PayPalLabel() {
 	return (
 		<>
 			<div>
-				<span>PayPal (PPCP)</span>
+				<span>PayPal (A8C-only)</span>
 			</div>
 			<PaymentMethodLogos className="paypal__logo payment-logos">
 				<PayPalLogo />


### PR DESCRIPTION
In #96692 we added an indicator to the upcoming PayPal PPCP payment method to help distinguish it in testing, but now that we're opening it up for greater internal testing, this updates the indicator to be clear that only A12s are seeing it.

<img width="603" alt="Screenshot 2024-11-28 at 5 28 06 AM" src="https://github.com/user-attachments/assets/c50f0d61-b6f2-4c23-99f0-db018122d85b">

**To test:**
- Visual check should suffice