### PR TITLE
Untangling: redirect /sites/tools to the first subtab when hosting features are supported

### DIFF
--- a/client/sites/hosting-features/components/hosting-features.tsx
+++ b/client/sites/hosting-features/components/hosting-features.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_SFTP, getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
@@ -53,10 +54,14 @@ const HostingFeatures = ( { showAsTools }: HostingFeaturesProps ) => {
 	// The ref is required to persist the value of redirect_to after renders
 	const redirectToRef = useRef( searchParams.get( 'redirect_to' ) );
 
-	const redirectUrl =
-		redirectToRef.current ?? hasSftpFeature
-			? `/hosting-config/${ siteId }`
-			: `/overview/${ siteId }`;
+	let redirectUrl = redirectToRef.current as string;
+	if ( ! redirectUrl ) {
+		if ( isEnabled( 'untangling/hosting-menu' ) ) {
+			redirectUrl = `/sites/tools/${ siteId }`;
+		} else {
+			redirectUrl = hasSftpFeature ? `/hosting-config/${ siteId }` : `/overview/${ siteId }`;
+		}
+	}
 
 	const hasEnTranslation = useHasEnTranslation();
 

--- a/client/sites/tools/controller.tsx
+++ b/client/sites/tools/controller.tsx
@@ -1,8 +1,10 @@
+import page, { Context as PageJSContext } from '@automattic/calypso-router';
 import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
 import HostingFeatures from 'calypso/sites/hosting-features/components/hosting-features';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SidebarItem, Sidebar, PanelWithSidebar } from '../components/panel-sidebar';
+import { areHostingFeaturesSupported } from '../hosting-features/features';
 import Database from './database/page';
 import {
 	DeploymentCreation,
@@ -16,7 +18,6 @@ import Monitoring from './monitoring';
 import useSftpSshSettingTitle from './sftp-ssh/hooks/use-sftp-ssh-setting-title';
 import SftpSsh from './sftp-ssh/page';
 import StagingSite from './staging-site';
-import type { Context as PageJSContext } from '@automattic/calypso-router';
 
 export function ToolsSidebar() {
 	const slug = useSelector( getSelectedSiteSlug );
@@ -40,6 +41,14 @@ export function ToolsSidebar() {
 }
 
 export function tools( context: PageJSContext, next: () => void ) {
+	const state = context.store.getState();
+	const site = getSelectedSite( state );
+
+	if ( areHostingFeaturesSupported( site ) ) {
+		// Redirect to the first subtab
+		return page.redirect( `/sites/tools/staging-site/${ site?.slug }` );
+	}
+
 	context.primary = <HostingFeatures showAsTools />;
 	next();
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9990
Fixes https://github.com/Automattic/dotcom-forge/issues/9938

## Proposed Changes

This PR redirects the Advanced Tools upsell to the first subtab (Staging Site) when the currently selected site already activated hosting features.

With this change, whenever we're in the Advanced Tools tab, we will be always in this tab when switching sites.

## Why are these changes being made?

pbxlJb-6ye-p2

## Testing Instructions

1. Go to /sites
2. Click a Free site
3. Click the Advanced Tools tab
4. Click another Atomic site
5. Verify that you still in the Advanced Tools tab
6. Click around any other site with various plans and verify that you don't suddenly get redirected to any other tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?