### PR TITLE
Subscriber stats: don't show 'Data available since' for new subscribers

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -82,7 +82,12 @@ const SubscriberDetails = ( {
 				/>
 			</div>
 			{ config.isEnabled( 'individual-subscriber-stats' ) && (
-				<SubscriberStats siteId={ siteId } subscriptionId={ subscriptionId } userId={ userId } />
+				<SubscriberStats
+					siteId={ siteId }
+					subscriptionId={ subscriptionId }
+					userId={ userId }
+					dateSubscribed={ new Date( date_subscribed ) }
+				/>
 			) }
 			<div className="subscriber-details__content">
 				<h3 className="subscriber-details__content-title">

--- a/client/my-sites/subscribers/components/subscriber-stats/subscriber-stats.tsx
+++ b/client/my-sites/subscribers/components/subscriber-stats/subscriber-stats.tsx
@@ -10,9 +10,15 @@ type SubscriberStatsProps = {
 	siteId: number;
 	subscriptionId?: number;
 	userId?: number;
+	dateSubscribed?: Date;
 };
 
-const SubscriberStats = ( { siteId, subscriptionId, userId }: SubscriberStatsProps ) => {
+const SubscriberStats = ( {
+	siteId,
+	subscriptionId,
+	userId,
+	dateSubscribed,
+}: SubscriberStatsProps ) => {
 	const translate = useTranslate();
 
 	const { data: subscriberStats, isLoading } = useSubscriberStatsQuery(
@@ -46,8 +52,7 @@ const SubscriberStats = ( { siteId, subscriptionId, userId }: SubscriberStatsPro
 					value={ `${ clickRate }%` }
 				/>
 			</div>
-			{ subscriberStats?.blog_registration_date &&
-			subscriberStats.blog_registration_date < new Date( '2023-08-17' ) ? (
+			{ dateSubscribed && dateSubscribed < new Date( '2023-08-17' ) ? (
 				<div className="subscriber-stats__tip">
 					<Icon icon={ tip } size={ 16 } />
 					{ translate( 'Data available since August 17th, 2023' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Came via customer feedback p1732790944676319-slack-C052XEUUBL4

## Proposed Changes

- Show the note only if subscriber subscribed longer ago than the date.

### Before

We show _"Data available since August 17th, 2023"_ note for sites that are older than the date.

<img width="1084" alt="Screenshot 2024-11-28 at 13 05 59" src="https://github.com/user-attachments/assets/1e3550f5-f9a9-431a-9478-432d795b8319">

### After

Instead, let's switch showing the note only if the subscriber actually subscribed before that date; otherwise the note doesn't matter even if the site is older. They can still trust the data.

<img width="1077" alt="Screenshot 2024-11-28 at 13 12 58" src="https://github.com/user-attachments/assets/e87a4682-53fa-4104-a35c-11852c4c29e4">
<img width="1052" alt="Screenshot 2024-11-28 at 13 13 20" src="https://github.com/user-attachments/assets/a6c0c766-f8af-42de-a55d-df3d9494f1d4">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?