### PR TITLE
Design Picker: Fix the upgrade badge for selected plan on design picker

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -86,6 +86,11 @@ const getFlowFromURL = () => {
 	return fromPath || fromQuery;
 };
 
+const getSiteIdFromURL = () => {
+	const siteId = new URLSearchParams( window.location.search ).get( 'siteId' );
+	return siteId ? Number( siteId ) : null;
+};
+
 const HOTJAR_ENABLED_FLOWS = [
 	MIGRATION_FLOW,
 	SITE_MIGRATION_FLOW,
@@ -108,6 +113,7 @@ window.AppBoot = async () => {
 	}
 
 	const flowName = getFlowFromURL();
+	const siteId = getSiteIdFromURL();
 
 	if ( ! flowName ) {
 		// Stop the boot process if we can't determine the flow, reducing the number of edge cases
@@ -150,8 +156,7 @@ window.AppBoot = async () => {
 
 	// When re-using steps from /start, we need to set the current flow name in the redux store, since some depend on it.
 	reduxStore.dispatch( setCurrentFlowName( flow.name ) );
-	// Reset the selected site ID when the stepper is loaded.
-	reduxStore.dispatch( setSelectedSiteId( null ) as unknown as AnyAction );
+	reduxStore.dispatch( setSelectedSiteId( siteId ) as unknown as AnyAction );
 
 	await geolocateCurrencySymbol();
 


### PR DESCRIPTION
Related to:
- https://github.com/Automattic/dotcom-forge/issues/9676

## Proposed Changes
- Added a function to extract the site ID from URL parameters
- The site ID is properly set in the Redux store during initialization, which prevents incorrect theme tier badge displays.

## Why are these changes being made?
- During site onboarding, theme upgrade badges were incorrectly shown. Users would see an Upgrade button on Personal themes despite having a Personal plan. The same issue persisted for other plan tiers.

## Testing Instructions

- Open the Calypso live link.
- Create a new site with Personal plan
- Navigate to theme selection step
- Personal and free themes show no upgrade badge
- Test that premium and higher-tier themes show upgrade badges correctly

| Before (Personal plan selected) | After (Personal plan selected) |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/17025926-2c6f-4b97-bc5a-afa647c40940) | ![image](https://github.com/user-attachments/assets/e5ff3fb8-fb9a-4baf-8f6b-db7f78500915) |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
