### PR TITLE
Create initial layout to unblock development of the domain management screens & add feature flag

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
@@ -1,0 +1,27 @@
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
+import DomainManagement from 'calypso/my-sites/domains/domain-management';
+import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
+
+type DomainDashboardLayoutProps = {
+	innerContent: React.ReactNode;
+};
+
+function DomainDashboardLayout( props: DomainDashboardLayoutProps ) {
+	return (
+		<Layout title="Domain Management" wide className="domains-overview">
+			<LayoutColumn className="domains-overview__list">
+				<DomainManagement.BulkAllDomains
+					analyticsPath={ domainManagementRoot() }
+					analyticsTitle="Domain Management > All Domains"
+					sidebarMode
+				/>
+			</LayoutColumn>
+			<LayoutColumn className="domains-overview__details" wide>
+				{ props.innerContent }
+			</LayoutColumn>
+		</Layout>
+	);
+}
+
+export default DomainDashboardLayout;

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -322,4 +322,45 @@ export default {
 		);
 		next();
 	},
+
+	// The main layout that wraps all the domain management pages.
+	domainDashboardLayout( pageContext, next ) {
+		pageContext.primary = (
+			<DomainManagement.DomainDashboardLayout innerContent={ pageContext.primary } />
+		);
+
+		next();
+	},
+
+	domainManagementV2( pageContext, next ) {
+		const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
+
+		pageContext.primary = (
+			<DomainManagementData
+				analyticsPath={ domainManagementRoot( ':domain' ) }
+				analyticsTitle="Domain Management"
+				component={ DomainManagement.Settings }
+				context={ pageContext }
+				selectedDomainName={ selectedDomainName }
+				needsDomains
+			/>
+		);
+		next();
+	},
+
+	domainManagementPaneView( feature ) {
+		return ( pageContext, next ) => {
+			const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
+
+			pageContext.primary = (
+				<DomainManagement.DomainOverviewPane
+					selectedDomainPreview={ pageContext.primary }
+					selectedDomain={ selectedDomainName }
+					selectedFeature={ feature }
+				/>
+			);
+
+			next();
+		};
+	},
 };

--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -1,0 +1,114 @@
+import page from '@automattic/calypso-router';
+import { Button } from '@wordpress/components';
+import { useMergeRefs } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { useMemo, useRef, useState } from 'react';
+import ItemPreviewPane from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
+import * as paths from 'calypso/my-sites/domains/paths';
+import type {
+	ItemData,
+	FeaturePreviewInterface,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
+
+interface Props {
+	selectedDomainPreview: React.ReactNode;
+	selectedDomain: string;
+	selectedFeature: string;
+}
+
+// This is the tabbed preview pane that is used for the domain management pages.
+// Anything passed as selectedDomainPreview will be rendered in the preview pane.
+// The selectedFeature prop is used to determine which tab is selected by default.
+const DomainOverviewPane = ( {
+	selectedDomainPreview,
+	selectedDomain,
+	selectedFeature,
+}: Props ) => {
+	const itemData: ItemData = {
+		title: selectedDomain,
+		subtitle: selectedDomain,
+		blogId: 12435645646456468,
+		isDotcomSite: true,
+		adminUrl: `testdomain.com/wp-admin`,
+		withIcon: false,
+		hideEnvDataInHeader: true,
+	};
+
+	type BtnProps = {
+		focusRef: React.RefObject< HTMLButtonElement >;
+		itemData: ItemData;
+		closeSitePreviewPane?: () => void;
+	};
+
+	const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane }: BtnProps ) => {
+		const adminButtonRef = useRef< HTMLButtonElement | null >( null );
+
+		return (
+			<>
+				<Button onClick={ closeSitePreviewPane } className="item-preview__close-preview-button">
+					{ __( 'Close' ) }
+				</Button>
+				<Button
+					variant="primary"
+					className="item-preview__admin-button"
+					ref={ useMergeRefs( [ adminButtonRef, focusRef ] ) }
+				>
+					{ __( 'Manage Site' ) }
+				</Button>
+			</>
+		);
+	};
+
+	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( selectedFeature );
+
+	const features: FeaturePreviewInterface[] = useMemo( () => {
+		const siteFeatures = [
+			{
+				label: __( 'Overview' ),
+				enabled: true,
+				featureIds: [ 'domain-overview' ],
+			},
+			{
+				label: __( 'Email' ),
+				enabled: true,
+				featureIds: [ 'email' ],
+			},
+		];
+
+		return siteFeatures.map( ( { label, enabled, featureIds } ) => {
+			const selected = enabled && featureIds.includes( selectedSiteFeature );
+			const defaultFeatureId = featureIds[ 0 ];
+			return {
+				id: defaultFeatureId,
+				tab: {
+					label,
+					visible: enabled,
+					selected,
+					onTabClick: () => {
+						if ( enabled && ! selected ) {
+							setSelectedSiteFeature( defaultFeatureId );
+						}
+					},
+				},
+				enabled,
+				preview: enabled ? selectedDomainPreview : null,
+			};
+		} );
+	}, [ __, selectedDomain, selectedSiteFeature ] );
+
+	return (
+		<ItemPreviewPane
+			itemData={ itemData }
+			closeItemPreviewPane={ () => {
+				page.show( paths.domainManagementRoot() );
+			} }
+			features={ features }
+			enforceTabsView
+			itemPreviewPaneHeaderExtraProps={ {
+				headerButtons: PreviewPaneHeaderButtons,
+			} }
+		/>
+	);
+};
+
+export default DomainOverviewPane;

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -1,8 +1,10 @@
 import BulkAllDomains from 'calypso/my-sites/domains/domain-management/list/bulk-all-domains';
 import BulkSiteDomains from 'calypso/my-sites/domains/domain-management/list/bulk-site-domains';
+import DomainDashboardLayout from './components/domain-dashboard-layout';
 import AddDnsRecord from './dns/add-dns-record';
 import DnsRecords from './dns/dns-records';
 import DomainConnectMapping from './domain-connect-mapping';
+import DomainOverviewPane from './domain-overview-pane';
 import EditContactInfoPage from './edit-contact-info-page';
 import BulkEditContactInfoPage from './edit-contact-info-page/bulk-edit-contact-info-page';
 import ManageConsent from './manage-consent';
@@ -32,4 +34,6 @@ export default {
 	TransferDomainToAnyUser,
 	BulkAllDomains,
 	BulkSiteDomains,
+	DomainDashboardLayout,
+	DomainOverviewPane,
 };

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -27,6 +27,7 @@ import './style.scss';
 interface BulkAllDomainsProps {
 	analyticsPath: string;
 	analyticsTitle: string;
+	sidebarMode?: boolean;
 }
 
 export default function BulkAllDomains( props: BulkAllDomainsProps ) {
@@ -265,6 +266,15 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						}
 					}
 				}
+				.domains-overview__list .domains-table {
+					table {
+						grid-template-columns: 4fr auto;
+
+						.domains-table__domain-name {
+							overflow-wrap: anywhere;
+						}
+					}
+				}
 				.is-global-sidebar-visible header.navigation-header {
 					padding-inline: 26px;
 				}
@@ -378,6 +388,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						createBulkAction={ createBulkAction }
 						fetchBulkActionStatus={ fetchBulkActionStatus }
 						deleteBulkActionStatus={ deleteBulkActionStatus }
+						sidebarMode={ props.sidebarMode }
 					/>
 				) : (
 					<div className="bulk-domains-empty-state">

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -326,3 +326,7 @@
 		margin: auto;
 	}
 }
+
+.domains-overview .main.domains-overview__list {
+	max-width: 400px;
+}

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -371,4 +371,15 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	page(
+		paths.allDomainManagementRoot() + '/:domain/:site',
+		siteSelection,
+		navigation,
+		domainManagementController.domainManagementV2,
+		domainManagementController.domainManagementPaneView( 'domain-overview' ),
+		domainManagementController.domainDashboardLayout,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -82,6 +82,10 @@ export function domainManagementAllRoot() {
 	return '/domains/manage/all';
 }
 
+export function allDomainManagementRoot() {
+	return '/domains/all/manage';
+}
+
 export function domainManagementRoot() {
 	return '/domains/manage';
 }

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -52,3 +52,16 @@ body.is-section-domains.is-domain-plan-package-flow {
 		max-width: $break-medium;
 	}
 }
+
+.domains-overview .a4a-layout-with-columns__container {
+    background: var(--color-sidebar-background);
+}
+
+.domains-overview .item-preview__pane {
+    flex-grow: 1;
+    width: auto;
+    transition: flex-grow 0.2s;
+    background: var(--color-light-backdrop);
+    max-height: calc(100vh - 32px - var(--masterbar-height));
+    border-radius: 8px; /* stylelint-disable-line scales/radii */
+}

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -65,3 +65,14 @@ body.is-section-domains.is-domain-plan-package-flow {
     max-height: calc(100vh - 32px - var(--masterbar-height));
     border-radius: 8px; /* stylelint-disable-line scales/radii */
 }
+
+.domains-overview {
+	.domain-settings-page {
+		max-width: 1200px;
+		margin-left: 0;
+	}
+	
+	.item-preview__content div {
+		flex-grow: 1;
+	}
+}

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -23,6 +23,10 @@ const SITE_DASHBOARD_ROUTES = {
 	'site-marketing': '/sites/marketing',
 	'site-tools': '/sites/tools',
 	'site-settings': '/sites/settings',
+
+	// Domain Management
+	'all-domain-management': '/domains/all/manage',
+	'all-email-management': '/domains/all/email',
 };
 
 function isInSection( sectionName: string, sectionNames: string[] ) {

--- a/config/development.json
+++ b/config/development.json
@@ -40,6 +40,7 @@
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-assembler": true,
+		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -18,6 +18,7 @@
 		"automated-migration/pending-status": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": true,
+		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,

--- a/config/production.json
+++ b/config/production.json
@@ -30,6 +30,7 @@
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": false,
+		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
 		"bilmur-script": true,
 		"calypso/help-center": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -29,6 +29,7 @@
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": true,
+		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,

--- a/config/test.json
+++ b/config/test.json
@@ -28,6 +28,7 @@
 		"automated-migration/application-password": false,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
+		"calypso/all-domain-management": false,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -28,6 +28,7 @@
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-assembler": true,
+		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,4 +1,6 @@
+import config from '@automattic/calypso-config';
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
 import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
@@ -89,6 +91,13 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	};
 
 	const handleSelect = () => {
+		const isAllDomainManagementEnabled = config.isEnabled( 'calypso/all-domain-management' );
+
+		if ( isAllDomainManagementEnabled && isAllSitesView ) {
+			page.show( domainManagementLink );
+			return;
+		}
+
 		window.location.href = domainManagementLink;
 	};
 

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -68,6 +68,7 @@ interface BaseDomainsTableProps {
 	fetchBulkActionStatus?: () => Promise< BulkDomainUpdateStatusQueryFnData >;
 	deleteBulkActionStatus?: () => Promise< void >;
 	currentUserCanBulkUpdateContactInfo?: boolean;
+	sidebarMode?: boolean;
 }
 
 export type DomainsTableProps =
@@ -144,6 +145,7 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		userCanSetPrimaryDomains,
 		isLoadingDomains,
 		currentUserCanBulkUpdateContactInfo = false,
+		sidebarMode = false,
 	} = props;
 
 	const [ { sortKey, sortDirection }, setSort ] = useState< {
@@ -240,6 +242,19 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		domainsTableColumns = removeColumns( domainsTableColumns, 'owner' );
 	}
 
+	if ( sidebarMode ) {
+		// Remove all columns except for domain and action.
+		domainsTableColumns = removeColumns(
+			domainsTableColumns,
+			'site',
+			'owner',
+			'ssl',
+			'expire_renew',
+			'status',
+			'status_action'
+		);
+	}
+
 	const sortedDomains = useMemo( () => {
 		if ( ! domains ) {
 			return;
@@ -305,7 +320,7 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 
 	const hasSelectedDomains = selectedDomains.size > 0;
 	const selectableDomains = ( domains ?? [] ).filter( canBulkUpdate );
-	const canSelectAnyDomains = selectableDomains.length > 1;
+	const canSelectAnyDomains = selectableDomains.length > 1 && ! sidebarMode;
 	const areAllDomainsSelected = selectableDomains.length === selectedDomains.size;
 
 	const getBulkSelectionStatus = () => {

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { addQueryArgs } from '@wordpress/url';
 import { stringify } from 'qs';
 import { ResponseDomain } from './types';
@@ -16,6 +17,12 @@ export function domainManagementLink(
 		// Encodes domain names so addresses with slashes in the path (e.g. used in site redirects) don't break routing.
 		// Note they are encoded twice since page.js decodes the path by default.
 		domain = encodeURIComponent( encodeURIComponent( domain ) );
+	}
+
+	const isAllDomainManagementEnabled = config.isEnabled( 'calypso/all-domain-management' );
+
+	if ( isAllDomainManagementEnabled && isAllSitesView ) {
+		return `${ allDomainManagementRoot() }/${ domain }/${ siteSlug }`;
 	}
 
 	if ( isAllSitesView ) {
@@ -93,6 +100,10 @@ export function isUnderDomainManagementAll( path: string ) {
 
 export function domainManagementAllRoot() {
 	return '/domains/manage/all';
+}
+
+export function allDomainManagementRoot() {
+	return '/domains/all/manage';
 }
 
 export function domainManagementEditContactInfo(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96673

## Proposed Changes

This is a barebone layout for the domain and email management pages we'll be working on. The actual layout will be worked on under https://github.com/Automattic/wp-calypso/issues/96554. 

Once the actual layout is developed, we'll discard this one and use the actual one instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To unblock development of dependant screens.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to wordpress.com/domains/manage
* Make sure you see no issues in how the table looks and works
* Also click on a few domains to make sure everything is working as before.
* Now enable the feature flag by entering `window.sessionStorage.setItem('flags', 'calypso/all-domain-management')` in the browser console. Reload the page
* Now click on different domains. They should open in the new layout now.

Note that clicking on the tabs is not yet implemented.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
