### PR TITLE
A4A: Fix the Pressable usage plan data when agency has referrals with Pressable plans

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-get-pressable-plan-by-product-id.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-get-pressable-plan-by-product-id.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
+
+type Props = {
+	product_id: number;
+};
+
+export default function useGetPressablePlanByProductId( { product_id }: Props ) {
+	const { pressablePlans } = useProductAndPlans( {
+		selectedSite: null,
+		productSearchQuery: '',
+	} );
+
+	return useMemo( () => {
+		return pressablePlans.find( ( plan ) => plan.product_id === product_id ) ?? null;
+	}, [ pressablePlans, product_id ] );
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/bundle-details.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/bundle-details.tsx
@@ -27,17 +27,11 @@ export default function BundleDetails( { parentLicenseId }: Props ) {
 				<LicensePreview
 					isChildLicense
 					key={ item.licenseId }
-					licenseKey={ item.licenseKey }
-					product={ item.product }
-					blogId={ item.blogId }
-					siteUrl={ item.siteUrl }
-					hasDownloads={ item.hasDownloads }
-					issuedAt={ item.issuedAt }
-					attachedAt={ item.attachedAt }
-					revokedAt={ item.revokedAt }
+					license={ item }
 					licenseType={
 						item.ownerType === LicenseType.Standard ? LicenseType.Standard : LicenseType.Partner
 					}
+					productName={ item.product }
 				/>
 			) ) }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -3,27 +3,20 @@ import { Card, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PressableUsageDetails from 'calypso/a8c-for-agencies/components/pressable-usage-details';
-import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
 import { isPressableHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
-import useExistingPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-existing-pressable-plan';
+import useGetPressablePlanByProductId from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-get-pressable-plan-by-product-id';
 import FormattedDate from 'calypso/components/formatted-date';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { getLicenseState, noop } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
 import { LicenseState, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import LicenseDetailsActions from './actions';
 import type { ReferralAPIResponse } from 'calypso/a8c-for-agencies/sections/referrals/types';
+import type { License } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
 
 interface Props {
-	licenseKey: string;
-	product: string;
-	siteUrl: string | null;
-	blogId: number | null;
-	hasDownloads: boolean;
-	issuedAt: string;
-	attachedAt: string | null;
-	revokedAt: string | null;
+	license: License;
 	onCopyLicense?: () => void;
 	licenseType: LicenseType;
 	isChildLicense?: boolean;
@@ -34,31 +27,26 @@ const DETAILS_DATE_FORMAT = 'YYYY-MM-DD h:mm:ss A';
 const DETAILS_DATE_FORMAT_SHORT = 'YYYY-MM-DD';
 
 export default function LicenseDetails( {
-	licenseKey,
-	product,
-	siteUrl,
-	blogId,
-	hasDownloads,
-	issuedAt,
-	attachedAt,
-	revokedAt,
+	license,
 	onCopyLicense = noop,
 	licenseType,
 	isChildLicense,
 	referral,
 }: Props ) {
+	const licenseKey = license.licenseKey;
+	const product = license.product;
+	const siteUrl = license.siteUrl;
+	const blogId = license.blogId;
+	const hasDownloads = license.hasDownloads;
+	const issuedAt = license.issuedAt;
+	const attachedAt = license.attachedAt;
+	const revokedAt = license.revokedAt;
+
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
 
-	const { pressablePlans } = useProductAndPlans( {
-		selectedSite: null,
-		productSearchQuery: '',
-	} );
-
-	const { existingPlan: pressablePlan } = useExistingPressablePlan( {
-		plans: pressablePlans,
-	} );
+	const pressablePlan = useGetPressablePlanByProductId( { product_id: license.productId } );
 
 	const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -84,15 +84,8 @@ export default function LicenseList() {
 					licenses.map( ( license ) => (
 						<LicenseTransition key={ license.licenseKey }>
 							<LicensePreview
-								parentLicenseId={ license.licenseId }
-								licenseKey={ license.licenseKey }
-								product={ getProductName( license.product ) }
-								blogId={ license.blogId }
-								siteUrl={ license.siteUrl }
-								hasDownloads={ license.hasDownloads }
-								issuedAt={ license.issuedAt }
-								attachedAt={ license.attachedAt }
-								revokedAt={ license.revokedAt }
+								license={ license }
+								productName={ getProductName( license.product ) }
 								licenseType={
 									license.ownerType === LicenseType.Standard
 										? LicenseType.Standard

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -35,21 +35,15 @@ import LicensesOverviewContext from '../licenses-overview/context';
 import LicenseActions from './license-actions';
 import LicenseBundleDropDown from './license-bundle-dropdown';
 import type { ReferralAPIResponse } from 'calypso/a8c-for-agencies/sections/referrals/types';
-import type { LicenseMeta } from 'calypso/state/partner-portal/types';
+import type { License, LicenseMeta } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
 
 interface Props {
-	licenseKey: string;
-	product: string;
-	blogId: number | null;
-	siteUrl: string | null;
-	hasDownloads: boolean;
-	issuedAt: string;
-	attachedAt: string | null;
-	revokedAt: string | null;
+	license: License;
 	licenseType: LicenseType;
 	parentLicenseId?: number | null;
+	productName: string;
 	quantity?: number | null;
 	isChildLicense?: boolean;
 	meta?: LicenseMeta;
@@ -57,21 +51,22 @@ interface Props {
 }
 
 export default function LicensePreview( {
-	licenseKey,
-	blogId,
-	product,
-	siteUrl,
-	hasDownloads,
-	issuedAt,
-	attachedAt,
-	revokedAt,
+	license,
 	licenseType,
 	parentLicenseId,
+	productName,
 	quantity,
 	isChildLicense,
 	meta,
 	referral,
 }: Props ) {
+	const licenseKey = license.licenseKey;
+	const blogId = license.blogId;
+	const siteUrl = license.siteUrl;
+	const issuedAt = license.issuedAt;
+	const attachedAt = license.attachedAt;
+	const revokedAt = license.revokedAt;
+
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -236,7 +231,7 @@ export default function LicensePreview( {
 	//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
 	const productTitle = licenseKey.startsWith( 'wpcom-hosting-business' )
 		? translate( 'WordPress.com Site' )
-		: product;
+		: productName;
 
 	const isDevelopmentSite = Boolean( meta?.isDevSite );
 
@@ -277,12 +272,12 @@ export default function LicensePreview( {
 					{ quantity ? (
 						<div className="license-preview__bundle">
 							<Gridicon icon="minus" className="license-preview__no-value" />
-							<div className="license-preview__product-small">{ product }</div>
+							<div className="license-preview__product-small">{ productName }</div>
 							<div>{ bundleCountContent }</div>
 						</div>
 					) : (
 						<>
-							<div className="license-preview__product-small">{ product }</div>
+							<div className="license-preview__product-small">{ productName }</div>
 							{ domain }
 							{ isPressableLicense &&
 								! revokedAt &&
@@ -370,7 +365,7 @@ export default function LicensePreview( {
 				<div>
 					{ !! isParentLicense && ! revokedAt && (
 						<LicenseBundleDropDown
-							product={ product }
+							product={ productName }
 							licenseKey={ licenseKey }
 							bundleSize={ quantity }
 						/>
@@ -403,14 +398,7 @@ export default function LicensePreview( {
 					<BundleDetails parentLicenseId={ parentLicenseId } />
 				) : (
 					<LicenseDetails
-						licenseKey={ licenseKey }
-						product={ product }
-						siteUrl={ siteUrl }
-						blogId={ blogId }
-						hasDownloads={ hasDownloads }
-						issuedAt={ issuedAt }
-						attachedAt={ attachedAt }
-						revokedAt={ revokedAt }
+						license={ license }
 						onCopyLicense={ onCopyLicense }
 						licenseType={ licenseType }
 						isChildLicense={ isChildLicense }


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/1494

## Proposed Changes

This PR resolves the issue of displaying the Pressable usage information for the agency when the agency has referrals with Pressable plans. It shows the correct usage data, but the plan name and the plan limits are not correct because it's taking the first Pressable plan, which is a client-referral Pressable plan.

We have to get the Pressable license (without referral) to ensure we are getting the correct plan.

![image](https://github.com/user-attachments/assets/feb8666a-bf0a-4822-9d05-a2a84e3a9f0c)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Use the A4A Demo account. With this account, you can replicate the issue in production and check that it is fixed in this PR.
- Launch a live Horizon site and test it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
