### PR TITLE
Chart filtering

### DIFF
--- a/client/data/promote-post/use-campaign-chart-stats-query.ts
+++ b/client/data/promote-post/use-campaign-chart-stats-query.ts
@@ -36,14 +36,20 @@ export type CampaignChartStatsResponse = {
 		};
 	};
 };
+
+export enum ChartResolution {
+	Hour = 'hour',
+	Day = 'day',
+}
+
 export const useCampaignChartStatsQuery = (
 	siteId: number,
 	campaignId: number,
-	startDate: string,
+	chartParams: { startDate: string; resolution: ChartResolution },
 	hasStats: boolean
 ) => {
 	return useQuery( {
-		queryKey: [ 'promote-post-campaign-stats', siteId, campaignId, startDate ],
+		queryKey: [ 'promote-post-campaign-stats', siteId, campaignId, chartParams ],
 		queryFn: async () => {
 			return await requestDSPHandleErrors< CampaignChartStatsResponse >(
 				siteId,
@@ -51,13 +57,13 @@ export const useCampaignChartStatsQuery = (
 				'GET',
 				{
 					tz: 'UTC',
-					start_date: startDate,
-					resolution: 'hour',
+					start_date: chartParams.startDate,
+					resolution: chartParams.resolution,
 				},
 				'1.1'
 			);
 		},
-		enabled: !! siteId && !! campaignId && !! startDate && hasStats,
+		enabled: !! siteId && !! campaignId && !! chartParams.startDate && hasStats,
 		retryDelay: 3000,
 		meta: {
 			persist: false,

--- a/client/data/promote-post/use-campaign-chart-stats-query.ts
+++ b/client/data/promote-post/use-campaign-chart-stats-query.ts
@@ -45,7 +45,7 @@ export enum ChartResolution {
 export const useCampaignChartStatsQuery = (
 	siteId: number,
 	campaignId: number,
-	chartParams: { startDate: string; resolution: ChartResolution },
+	chartParams: { startDate: string; endDate: string; resolution: ChartResolution },
 	hasStats: boolean
 ) => {
 	return useQuery( {
@@ -56,8 +56,9 @@ export const useCampaignChartStatsQuery = (
 				`/stats/${ campaignId }`,
 				'GET',
 				{
-					tz: 'UTC',
+					tz: Intl?.DateTimeFormat()?.resolvedOptions()?.timeZone ?? 'UTC',
 					start_date: chartParams.startDate,
+					end_date: chartParams.endDate,
 					resolution: chartParams.resolution,
 				},
 				'1.1'

--- a/client/data/promote-post/use-campaign-chart-stats-query.ts
+++ b/client/data/promote-post/use-campaign-chart-stats-query.ts
@@ -52,6 +52,7 @@ export const useCampaignChartStatsQuery = (
 				{
 					tz: 'UTC',
 					start_date: startDate,
+					resolution: 'hour',
 				},
 				'1.1'
 			);

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -136,7 +136,7 @@ export default function CampaignItemDetails( props: Props ) {
 		ChartSourceOptions.Clicks
 	);
 	const [ selectedDateRange, setSelectedDateRange ] = useState< ChartSourceDateRanges >(
-		ChartSourceDateRanges.WHOLE_CAMPAIGN
+		ChartSourceDateRanges.LAST_7_DAYS
 	);
 	const { cancelCampaign } = useCancelCampaignMutation( () => setShowErrorDialog( true ) );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
@@ -147,6 +147,15 @@ export default function CampaignItemDetails( props: Props ) {
 	const paymentBlocked = data?.paymentsBlocked ?? false;
 
 	const [ showReportErrorDialog, setShowReportErrorDialog ] = useState( false );
+
+	const getEffectiveEndDate = () => {
+		const endDate = campaign?.end_date ? new Date( campaign.end_date ) : null;
+		const today = new Date();
+
+		// If the campaign has already finished, fetch data relative to the end date (we can't fetch data after that point)
+		const effectiveEndDate = endDate && endDate < today ? endDate : today;
+		return effectiveEndDate;
+	};
 
 	const {
 		audience_list,
@@ -185,11 +194,7 @@ export default function CampaignItemDetails( props: Props ) {
 	} = campaign_stats || {};
 
 	const getChartStartDate = ( dateRange: ChartSourceDateRanges ) => {
-		const endDate = campaign?.end_date ? new Date( campaign.end_date ) : null;
-		const today = new Date();
-
-		// If the campaign has already finished, fetch data relative to the end date (we can't fetch data after that point)
-		const effectiveEndDate = endDate && endDate < today ? endDate : today;
+		const effectiveEndDate = getEffectiveEndDate();
 		let startDate = new Date( effectiveEndDate );
 
 		switch ( dateRange ) {
@@ -216,7 +221,8 @@ export default function CampaignItemDetails( props: Props ) {
 	};
 
 	const [ chartParams, setChartParams ] = useState( {
-		startDate: getChartStartDate( ChartSourceDateRanges.WHOLE_CAMPAIGN ),
+		startDate: getChartStartDate( ChartSourceDateRanges.LAST_7_DAYS ),
+		endDate: getEffectiveEndDate().toISOString().split( 'T' )[ 0 ],
 		resolution: ChartResolution.Day,
 	} );
 
@@ -233,6 +239,7 @@ export default function CampaignItemDetails( props: Props ) {
 		// Update the params for the chart here, which will trigger the refetch
 		setChartParams( {
 			startDate: newStartDate,
+			endDate: getEffectiveEndDate().toISOString().split( 'T' )[ 0 ],
 			resolution: newResolution,
 		} );
 		setSelectedDateRange( newDateRange );

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import './style.scss';
 import { Badge, Dialog } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Button, DropdownMenu } from '@wordpress/components';
+import { Button, DropdownMenu, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronLeft, chevronDown } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -100,18 +100,31 @@ const getExternalTabletIcon = ( fillColor = '#A7AAAD' ) => (
 	</span>
 );
 
-const getCampaignStatsChart = (
-	campaignChartStats: CampaignChartSeriesData[],
-	source: ChartSourceOptions
-) => {
-	return <CampaignStatsLineChart data={ campaignChartStats } source={ source } />;
-};
-
 export enum ChartSourceOptions {
 	Impressions = 'impressions',
 	Clicks = 'clicks',
 	Spend = 'spend',
 }
+
+// Define the available date range options
+enum ChartSourceDateRanges {
+	TODAY = 'today',
+	YESTERDAY = 'yesterday',
+	LAST_7_DAYS = 'last_7_days',
+	LAST_14_DAYS = 'last_14_days',
+	LAST_30_DAYS = 'last_30_days',
+	WHOLE_CAMPAIGN = 'whole_campaign',
+}
+
+// User facing strings for date ranges
+const ChartSourceDateRangeLabels = {
+	[ ChartSourceDateRanges.TODAY ]: __( 'Today' ),
+	[ ChartSourceDateRanges.YESTERDAY ]: __( 'Yesterday' ),
+	[ ChartSourceDateRanges.LAST_7_DAYS ]: __( 'Last 7 days' ),
+	[ ChartSourceDateRanges.LAST_14_DAYS ]: __( 'Last 14 days' ),
+	[ ChartSourceDateRanges.LAST_30_DAYS ]: __( 'Last 30 days' ),
+	[ ChartSourceDateRanges.WHOLE_CAMPAIGN ]: __( 'Whole Campaign' ),
+};
 
 export default function CampaignItemDetails( props: Props ) {
 	const isRunningInWpAdmin = useIsRunningInWpAdmin();
@@ -120,6 +133,9 @@ export default function CampaignItemDetails( props: Props ) {
 	const [ showErrorDialog, setShowErrorDialog ] = useState( false );
 	const [ chartSource, setChartSource ] = useState< ChartSourceOptions >(
 		ChartSourceOptions.Clicks
+	);
+	const [ selectedDateRange, setSelectedDateRange ] = useState< ChartSourceDateRanges >(
+		ChartSourceDateRanges.WHOLE_CAMPAIGN
 	);
 	const { cancelCampaign } = useCancelCampaignMutation( () => setShowErrorDialog( true ) );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
@@ -167,10 +183,38 @@ export default function CampaignItemDetails( props: Props ) {
 		conversion_last_currency_found,
 	} = campaign_stats || {};
 
+	const getChartStartDate = ( range: ChartSourceDateRanges ): string => {
+		const today = new Date();
+		const endDate = new Date( campaign.end_date );
+		const effectiveEndDate = endDate < today ? endDate : today;
+
+		const startDate = new Date( campaign.start_date );
+
+		switch ( range ) {
+			case ChartSourceDateRanges.YESTERDAY:
+				startDate.setDate( effectiveEndDate.getDate() - 1 );
+				break;
+			case ChartSourceDateRanges.LAST_7_DAYS:
+				startDate.setDate( effectiveEndDate.getDate() - 7 );
+				break;
+			case ChartSourceDateRanges.LAST_14_DAYS:
+				startDate.setDate( effectiveEndDate.getDate() - 14 );
+				break;
+			case ChartSourceDateRanges.LAST_30_DAYS:
+				startDate.setDate( effectiveEndDate.getDate() - 30 );
+				break;
+		}
+
+		return startDate.toISOString().split( 'T' )[ 0 ];
+	};
+
+	// Use the date from the selected range to fetch data
+	const startDate = getChartStartDate( selectedDateRange );
+
 	const campaignStatsQuery = useCampaignChartStatsQuery(
 		siteId,
 		campaignId,
-		campaign.start_date,
+		startDate,
 		!! impressions_total
 	);
 	const { isLoading: campaignsStatsIsLoading } = campaignStatsQuery;
@@ -180,6 +224,60 @@ export default function CampaignItemDetails( props: Props ) {
 	const { title, clickUrl } = content_config || {};
 	const canDisplayPaymentSection =
 		orders && orders.length > 0 && ( payment_method || ! isNaN( total || 0 ) );
+
+	// If the chart range is more than X, group hourly data into days
+	const chartStatsFormatted = ( data: CampaignChartSeriesData[], showChartAsHourly: boolean ) => {
+		if ( showChartAsHourly ) {
+			return data;
+		}
+
+		const dailyTotals: Record< string, number > = {};
+
+		data.forEach( ( record ) => {
+			const dateOnly = new Date( record.date_utc ).toISOString().split( 'T' )[ 0 ];
+			if ( ! dailyTotals[ dateOnly ] ) {
+				dailyTotals[ dateOnly ] = 0;
+			}
+			dailyTotals[ dateOnly ] += record.total;
+		} );
+
+		return Object.entries( dailyTotals ).map( ( [ date_utc, total ] ) => ( { date_utc, total } ) );
+	};
+
+	const getCampaignStatsChart = (
+		campaignChartStats: CampaignChartSeriesData[],
+		source: ChartSourceOptions,
+		isLoading = false
+	) => {
+		const endDate = new Date( end_date );
+		const today = new Date();
+
+		// druid doesn't store hourly data for more than 30 days
+		const thirtyDaysAgo = new Date();
+		thirtyDaysAgo.setDate( today.getDate() - 30 );
+
+		// If the time range of the chart is short, we can show the suer an hourly breakdown
+		const showChartAsHourly =
+			[ ChartSourceDateRanges.TODAY, ChartSourceDateRanges.YESTERDAY ].includes(
+				selectedDateRange
+			) && endDate >= thirtyDaysAgo;
+
+		const chartDataFormatted = chartStatsFormatted( campaignChartStats, showChartAsHourly );
+		if ( isLoading || ! campaignChartStats ) {
+			return (
+				<div className="campaign-item-details__graph-stats-row">
+					<Spinner />
+				</div>
+			);
+		}
+		return (
+			<CampaignStatsLineChart
+				data={ chartDataFormatted }
+				source={ source }
+				hourly={ showChartAsHourly }
+			/>
+		);
+	};
 
 	const onClickPromote = useOpenPromoteWidget( {
 		keyValue: `post-${ getPostIdFromURN( target_urn || '' ) }_campaign-${ campaign_id }`,
@@ -340,6 +438,42 @@ export default function CampaignItemDetails( props: Props ) {
 		[ campaignStatus.CANCELED, campaignStatus.FINISHED, campaignStatus.SUSPENDED ].includes(
 			ui_status
 		);
+
+	const chartControls = [];
+
+	// Skip "today" or "yesterday" if the campaign is finished, we could make this condition more complex
+	// but they can see the data clearly using last 7 days.
+	if ( ! campaignIsFinished ) {
+		chartControls.push( {
+			onClick: () => setSelectedDateRange( ChartSourceDateRanges.TODAY ),
+			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.TODAY ],
+		} );
+
+		chartControls.push( {
+			onClick: () => setSelectedDateRange( ChartSourceDateRanges.YESTERDAY ),
+			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.YESTERDAY ],
+		} );
+	}
+
+	// The rest of the controls are safe to show permanently
+	chartControls.push(
+		{
+			onClick: () => setSelectedDateRange( ChartSourceDateRanges.LAST_7_DAYS ),
+			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.LAST_7_DAYS ],
+		},
+		{
+			onClick: () => setSelectedDateRange( ChartSourceDateRanges.LAST_14_DAYS ),
+			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.LAST_14_DAYS ],
+		},
+		{
+			onClick: () => setSelectedDateRange( ChartSourceDateRanges.LAST_30_DAYS ),
+			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.LAST_30_DAYS ],
+		},
+		{
+			onClick: () => setSelectedDateRange( ChartSourceDateRanges.WHOLE_CAMPAIGN ),
+			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.WHOLE_CAMPAIGN ],
+		}
+	);
 
 	const buttons = [
 		{
@@ -670,41 +804,49 @@ export default function CampaignItemDetails( props: Props ) {
 										) }
 									</div>
 
-									{ ! campaignsStatsIsLoading && campaignStats && (
-										<>
-											<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
-												<div>
-													<div className="campaign-item-page__graph">
-														<DropdownMenu
-															class="campaign-item-page__graph-selector"
-															controls={ [
-																{
-																	onClick: () => setChartSource( ChartSourceOptions.Clicks ),
-																	title: __( 'Clicks' ),
-																	isDisabled: chartSource === ChartSourceOptions.Clicks,
-																},
-																{
-																	onClick: () => setChartSource( ChartSourceOptions.Impressions ),
-																	title: __( 'Impressions' ),
-																	isDisabled: chartSource === ChartSourceOptions.Impressions,
-																},
-															] }
-															icon={ chevronDown }
-															text={
-																chartSource === ChartSourceOptions.Clicks
-																	? __( 'Clicks' )
-																	: __( 'Impressions' )
-															}
-															label={ chartSource }
-														/>
-														{ getCampaignStatsChart(
-															campaignStats?.series[ chartSource ],
-															chartSource
-														) }
-													</div>
+									<>
+										<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
+											<div>
+												<div className="campaign-item-page__graph">
+													<DropdownMenu
+														class="campaign-item-page__graph-selector"
+														controls={ chartControls }
+														icon={ chevronDown }
+														text={ ChartSourceDateRangeLabels[ selectedDateRange ] }
+														label={ ChartSourceDateRangeLabels[ selectedDateRange ] }
+													/>
+													<DropdownMenu
+														class="campaign-item-page__graph-selector"
+														controls={ [
+															{
+																onClick: () => setChartSource( ChartSourceOptions.Clicks ),
+																title: __( 'Clicks' ),
+																isDisabled: chartSource === ChartSourceOptions.Clicks,
+															},
+															{
+																onClick: () => setChartSource( ChartSourceOptions.Impressions ),
+																title: __( 'Impressions' ),
+																isDisabled: chartSource === ChartSourceOptions.Impressions,
+															},
+														] }
+														icon={ chevronDown }
+														text={
+															chartSource === ChartSourceOptions.Clicks
+																? __( 'Clicks' )
+																: __( 'Impressions' )
+														}
+														label={ chartSource }
+													/>
+													{ getCampaignStatsChart(
+														campaignStats?.series[ chartSource ] ?? [],
+														chartSource,
+														campaignsStatsIsLoading
+													) }
 												</div>
 											</div>
+										</div>
 
+										{ campaignStats && (
 											<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
 												<div>
 													<div className="campaign-item-page__locaton-charts">
@@ -723,8 +865,8 @@ export default function CampaignItemDetails( props: Props ) {
 													</div>
 												</div>
 											</div>
-										</>
-									) }
+										) }
+									</>
 								</div>
 							</div>
 						) }
@@ -816,12 +958,11 @@ export default function CampaignItemDetails( props: Props ) {
 								<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
 									<div>
 										<div className="campaign-item-page__graph">
-											{ ! campaignsStatsIsLoading &&
-												campaignStats &&
-												getCampaignStatsChart(
-													campaignStats?.series.spend,
-													ChartSourceOptions.Spend
-												) }
+											{ getCampaignStatsChart(
+												campaignStats?.series.spend ?? [],
+												ChartSourceOptions.Spend,
+												campaignsStatsIsLoading
+											) }
 										</div>
 									</div>
 								</div>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -16,6 +16,7 @@ import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import {
 	CampaignChartSeriesData,
+	ChartResolution,
 	useCampaignChartStatsQuery,
 } from 'calypso/data/promote-post/use-campaign-chart-stats-query';
 import useBillingSummaryQuery from 'calypso/data/promote-post/use-promote-post-billing-summary-query';
@@ -183,14 +184,15 @@ export default function CampaignItemDetails( props: Props ) {
 		conversion_last_currency_found,
 	} = campaign_stats || {};
 
-	const getChartStartDate = ( range: ChartSourceDateRanges ): string => {
+	const getChartStartDate = ( dateRange: ChartSourceDateRanges ) => {
+		const endDate = campaign?.end_date ? new Date( campaign.end_date ) : null;
 		const today = new Date();
-		const endDate = new Date( campaign.end_date );
-		const effectiveEndDate = endDate < today ? endDate : today;
 
-		const startDate = new Date( campaign.start_date );
+		// If the campaign has already finished, fetch data relative to the end date (we can't fetch data after that point)
+		const effectiveEndDate = endDate && endDate < today ? endDate : today;
+		let startDate = new Date( effectiveEndDate );
 
-		switch ( range ) {
+		switch ( dateRange ) {
 			case ChartSourceDateRanges.YESTERDAY:
 				startDate.setDate( effectiveEndDate.getDate() - 1 );
 				break;
@@ -203,18 +205,43 @@ export default function CampaignItemDetails( props: Props ) {
 			case ChartSourceDateRanges.LAST_30_DAYS:
 				startDate.setDate( effectiveEndDate.getDate() - 30 );
 				break;
+			case ChartSourceDateRanges.WHOLE_CAMPAIGN:
+				if ( campaign?.start_date ) {
+					startDate = new Date( campaign.start_date );
+				}
+				break;
 		}
 
 		return startDate.toISOString().split( 'T' )[ 0 ];
 	};
 
-	// Use the date from the selected range to fetch data
-	const startDate = getChartStartDate( selectedDateRange );
+	const [ chartParams, setChartParams ] = useState( {
+		startDate: getChartStartDate( ChartSourceDateRanges.WHOLE_CAMPAIGN ),
+		resolution: ChartResolution.Day,
+	} );
+
+	const updateChartParams = ( newDateRange: ChartSourceDateRanges ) => {
+		// These shorter time frames can show hourly data, we can show up to 30 days of hourly data (max days stored in Druid)
+		const newResolution = [ ChartSourceDateRanges.TODAY, ChartSourceDateRanges.YESTERDAY ].includes(
+			newDateRange
+		)
+			? ChartResolution.Hour
+			: ChartResolution.Day;
+
+		const newStartDate = getChartStartDate( newDateRange );
+
+		// Update the params for the chart here, which will trigger the refetch
+		setChartParams( {
+			startDate: newStartDate,
+			resolution: newResolution,
+		} );
+		setSelectedDateRange( newDateRange );
+	};
 
 	const campaignStatsQuery = useCampaignChartStatsQuery(
 		siteId,
 		campaignId,
-		startDate,
+		chartParams,
 		!! impressions_total
 	);
 	const { isLoading: campaignsStatsIsLoading } = campaignStatsQuery;
@@ -225,56 +252,30 @@ export default function CampaignItemDetails( props: Props ) {
 	const canDisplayPaymentSection =
 		orders && orders.length > 0 && ( payment_method || ! isNaN( total || 0 ) );
 
-	// If the chart range is more than X, group hourly data into days
-	const chartStatsFormatted = ( data: CampaignChartSeriesData[], showChartAsHourly: boolean ) => {
-		if ( showChartAsHourly ) {
-			return data;
-		}
-
-		const dailyTotals: Record< string, number > = {};
-
-		data.forEach( ( record ) => {
-			const dateOnly = new Date( record.date_utc ).toISOString().split( 'T' )[ 0 ];
-			if ( ! dailyTotals[ dateOnly ] ) {
-				dailyTotals[ dateOnly ] = 0;
-			}
-			dailyTotals[ dateOnly ] += record.total;
-		} );
-
-		return Object.entries( dailyTotals ).map( ( [ date_utc, total ] ) => ( { date_utc, total } ) );
-	};
-
 	const getCampaignStatsChart = (
-		campaignChartStats: CampaignChartSeriesData[],
+		data: CampaignChartSeriesData[],
 		source: ChartSourceOptions,
 		isLoading = false
 	) => {
-		const endDate = new Date( end_date );
-		const today = new Date();
-
-		// druid doesn't store hourly data for more than 30 days
-		const thirtyDaysAgo = new Date();
-		thirtyDaysAgo.setDate( today.getDate() - 30 );
-
-		// If the time range of the chart is short, we can show the suer an hourly breakdown
-		const showChartAsHourly =
-			[ ChartSourceDateRanges.TODAY, ChartSourceDateRanges.YESTERDAY ].includes(
-				selectedDateRange
-			) && endDate >= thirtyDaysAgo;
-
-		const chartDataFormatted = chartStatsFormatted( campaignChartStats, showChartAsHourly );
-		if ( isLoading || ! campaignChartStats ) {
+		if ( isLoading ) {
 			return (
-				<div className="campaign-item-details__graph-stats-row">
-					<Spinner />
+				<div className="campaign-item-details__graph-stats-loader">
+					<div>
+						<Spinner />
+					</div>
 				</div>
 			);
 		}
+
+		if ( ! data ) {
+			return null;
+		}
+
 		return (
 			<CampaignStatsLineChart
-				data={ chartDataFormatted }
+				data={ data }
 				source={ source }
-				hourly={ showChartAsHourly }
+				resolution={ chartParams.resolution }
 			/>
 		);
 	};
@@ -441,39 +442,69 @@ export default function CampaignItemDetails( props: Props ) {
 
 	const chartControls = [];
 
-	// Skip "today" or "yesterday" if the campaign is finished, we could make this condition more complex
-	// but they can see the data clearly using last 7 days.
-	if ( ! campaignIsFinished ) {
-		chartControls.push( {
-			onClick: () => setSelectedDateRange( ChartSourceDateRanges.TODAY ),
-			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.TODAY ],
-		} );
+	// Some controls are conditional, depending on how long the campaign has been active, or if the campaign is in the past
+	// It would be pointless showing "today" to a finished campaign, or 30 days to a 7-day campaign
+	const conditionalControls = [
+		{
+			condition: ! campaignIsFinished,
+			controls: [
+				{
+					onClick: () => updateChartParams( ChartSourceDateRanges.TODAY ),
+					title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.TODAY ],
+					isDisabled: selectedDateRange === ChartSourceDateRanges.TODAY,
+				},
+				{
+					onClick: () => updateChartParams( ChartSourceDateRanges.YESTERDAY ),
+					title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.YESTERDAY ],
+					isDisabled: selectedDateRange === ChartSourceDateRanges.YESTERDAY,
+				},
+			],
+		},
+		{
+			condition: activeDays >= 7,
+			controls: [
+				{
+					onClick: () => updateChartParams( ChartSourceDateRanges.LAST_7_DAYS ),
+					title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.LAST_7_DAYS ],
+					isDisabled: selectedDateRange === ChartSourceDateRanges.LAST_7_DAYS,
+				},
+			],
+		},
+		{
+			condition: activeDays >= 14,
+			controls: [
+				{
+					onClick: () => updateChartParams( ChartSourceDateRanges.LAST_14_DAYS ),
+					title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.LAST_14_DAYS ],
+					isDisabled: selectedDateRange === ChartSourceDateRanges.LAST_14_DAYS,
+				},
+			],
+		},
+		{
+			condition: activeDays >= 30,
+			controls: [
+				{
+					onClick: () => updateChartParams( ChartSourceDateRanges.LAST_30_DAYS ),
+					title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.LAST_30_DAYS ],
+					isDisabled: selectedDateRange === ChartSourceDateRanges.LAST_30_DAYS,
+				},
+			],
+		},
+	];
 
-		chartControls.push( {
-			onClick: () => setSelectedDateRange( ChartSourceDateRanges.YESTERDAY ),
-			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.YESTERDAY ],
-		} );
-	}
-
-	// The rest of the controls are safe to show permanently
-	chartControls.push(
-		{
-			onClick: () => setSelectedDateRange( ChartSourceDateRanges.LAST_7_DAYS ),
-			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.LAST_7_DAYS ],
-		},
-		{
-			onClick: () => setSelectedDateRange( ChartSourceDateRanges.LAST_14_DAYS ),
-			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.LAST_14_DAYS ],
-		},
-		{
-			onClick: () => setSelectedDateRange( ChartSourceDateRanges.LAST_30_DAYS ),
-			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.LAST_30_DAYS ],
-		},
-		{
-			onClick: () => setSelectedDateRange( ChartSourceDateRanges.WHOLE_CAMPAIGN ),
-			title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.WHOLE_CAMPAIGN ],
+	// Add the available controls
+	conditionalControls.forEach( ( { condition, controls } ) => {
+		if ( condition ) {
+			chartControls.push( ...controls );
 		}
-	);
+	} );
+
+	// The controls that are always shown
+	chartControls.push( {
+		onClick: () => setSelectedDateRange( ChartSourceDateRanges.WHOLE_CAMPAIGN ),
+		title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.WHOLE_CAMPAIGN ],
+		isDisabled: selectedDateRange === ChartSourceDateRanges.WHOLE_CAMPAIGN,
+	} );
 
 	const buttons = [
 		{

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -334,6 +334,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				color: var(--color-primary);
 				font-weight: 500;
 				font-size: 0.875rem;
+				border-radius: 4px;
 			}
 		}
 
@@ -1272,5 +1273,19 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 				margin-right: 5px;
 			}
 		}
+	}
+}
+
+.components-dropdown-menu__menu-item, .components-button {
+	padding: 8px;
+	border-radius: 4px;
+
+	&:focus:not(:disabled) {
+		box-shadow: none;
+	}
+
+	&:hover:not(:disabled) {
+		background: var( --studio-gray-0 );
+		color: var( --theme-base-color );
 	}
 }

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -228,10 +228,6 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		.campaign-item-details__payment {
 			display: flex;
 			flex-direction: column;
-
-			@media (max-width: $break-medium) {
-				flex-direction: row;
-			}
 		}
 
 		.campaign-item-details__payment {
@@ -324,6 +320,12 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		}
 		.campaign-item-details__graph-stats-row {
 			grid-template-columns: 1fr;
+		}
+
+		.campaign-item-details__graph-stats-loader {
+			display: block;
+			text-align: center;
+			height: 100%;
 		}
 
 		.campaign-item-page__graph {
@@ -981,7 +983,6 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		display: inline-block;
 		overflow: hidden;
 		position: relative;
-		max-width: 250px;
 		height: 16px;
 		width: 100%;
 

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -4,7 +4,10 @@ import _ from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
-import { CampaignChartSeriesData } from 'calypso/data/promote-post/use-campaign-chart-stats-query';
+import {
+	CampaignChartSeriesData,
+	ChartResolution,
+} from 'calypso/data/promote-post/use-campaign-chart-stats-query';
 import { ChartSourceOptions } from 'calypso/my-sites/promote-post-i2/components/campaign-item-details';
 import 'uplot/dist/uPlot.min.css';
 import { formatCents } from 'calypso/my-sites/promote-post-i2/utils';
@@ -17,11 +20,12 @@ const DEFAULT_DIMENSIONS = {
 type GraphProps = {
 	data: CampaignChartSeriesData[];
 	source: ChartSourceOptions;
-	hourly: boolean;
+	resolution: ChartResolution;
 };
 
-const CampaignStatsLineChart = ( { data, source, hourly }: GraphProps ) => {
+const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 	const [ width, setWidth ] = useState( DEFAULT_DIMENSIONS.width );
+	const hourly = resolution === ChartResolution.Hour;
 
 	const primaryColor = getComputedStyle( document.body )
 		.getPropertyValue( '--color-primary' )

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -1,3 +1,4 @@
+import { useLocale } from '@automattic/i18n-utils';
 import { hexToRgb } from '@automattic/onboarding';
 import _ from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -16,9 +17,10 @@ const DEFAULT_DIMENSIONS = {
 type GraphProps = {
 	data: CampaignChartSeriesData[];
 	source: ChartSourceOptions;
+	hourly: boolean;
 };
 
-const CampaignStatsLineChart = ( { data, source }: GraphProps ) => {
+const CampaignStatsLineChart = ( { data, source, hourly }: GraphProps ) => {
 	const [ width, setWidth ] = useState( DEFAULT_DIMENSIONS.width );
 
 	const primaryColor = getComputedStyle( document.body )
@@ -37,12 +39,12 @@ const CampaignStatsLineChart = ( { data, source }: GraphProps ) => {
 	};
 
 	useEffect( () => {
-		// set initial width
+		// Set initial width
 		updateWidth();
 		window.addEventListener( 'resize', updateWidth );
 
 		return () => {
-			// remove on unmount
+			// Remove on unmount
 			window.removeEventListener( 'resize', updateWidth );
 		};
 	}, [] );
@@ -53,6 +55,14 @@ const CampaignStatsLineChart = ( { data, source }: GraphProps ) => {
 
 	// Convert to uPlot's AlignedData format
 	const uplotData: uPlot.AlignedData = [ new Float64Array( labels ), new Float64Array( values ) ];
+	const locale = useLocale();
+
+	const formatDate = ( date: Date, hourly: boolean ) => {
+		const options: Intl.DateTimeFormatOptions = hourly
+			? { hour: 'numeric', minute: 'numeric' }
+			: { month: 'short', day: 'numeric' };
+		return new Intl.DateTimeFormat( locale, options ).format( date );
+	};
 
 	const options = useMemo( () => {
 		return {
@@ -73,12 +83,7 @@ const CampaignStatsLineChart = ( { data, source }: GraphProps ) => {
 					values: ( u: uPlot, splits: number[] ) => {
 						// Filter the splits to show only non-overlapping labels
 						return splits.map( ( s, i ) =>
-							i % 4 === 0
-								? new Intl.DateTimeFormat( 'en', {
-										month: 'short',
-										day: 'numeric',
-								  } ).format( new Date( s * 1000 ) )
-								: ''
+							i % 4 === 0 ? formatDate( new Date( s * 1000 ), hourly ) : ''
 						);
 					},
 				},
@@ -110,12 +115,7 @@ const CampaignStatsLineChart = ( { data, source }: GraphProps ) => {
 						if ( rawValue == null ) {
 							return '-';
 						}
-
-						const date = new Date( rawValue * 1000 );
-						return new Intl.DateTimeFormat( 'en', {
-							month: 'short',
-							day: 'numeric',
-						} ).format( date );
+						return formatDate( new Date( rawValue * 1000 ), hourly );
 					},
 				},
 				{
@@ -158,7 +158,7 @@ const CampaignStatsLineChart = ( { data, source }: GraphProps ) => {
 				},
 			],
 		};
-	}, [ source, primaryColor, primaryRGB ] );
+	}, [ width, source, primaryColor, formatDate, hourly, primaryRGB ] );
 
 	return (
 		<div style={ { position: 'relative' } }>


### PR DESCRIPTION
## Proposed Changes

* Adds date filtering to the Blaze stats charts
* Adds loading spinner
* Adds hourly/daily resolutions

![Screenshot 2024-11-28 at 19 09 14](https://github.com/user-attachments/assets/ff096505-c2be-47f0-8855-2392c27b43c5)

## Testing Instructions

Here are some scenarios that can be tested, some of them require specific data that could be hard to replicate so you can check the code for these too,  I have also provided a demo video to show them in use.

- [ ] Check the different range options work
- [ ] Yesterday / Today disappear if campaign has finished
- [ ] Last X days will be relative to today in an active campaign
- [ ] Last X days will be relative to the end date of a finished campaign
- [ ] Last X days won't show on a campaign that is less than X
- [ ] Today and Yesterday will fetch hourly data


Her is a demo of the above scenarios

https://github.com/user-attachments/assets/e8593dbe-b768-40cf-95df-2cae249bf178


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
