### PR TITLE
Wooecommerce Install: Fix form style

### DIFF
--- a/client/signup/steps/woocommerce-install/step-store-address/style.scss
+++ b/client/signup/steps/woocommerce-install/step-store-address/style.scss
@@ -6,6 +6,8 @@ body.is-section-signup .is-woocommerce-install .signup__step.is-store-address {
 	.step-store-address__instructions-container {
 		.components-combobox-control__suggestions-container {
 			position: relative;
+			z-index: 1;
+			background-color: var(--color-surface);
 			// Remove `width: 100%;` https://github.com/WordPress/gutenberg/blob/0135921bcb72ceec629fa8f9e755891afab747b9/packages/components/src/combobox-control/style.scss#L32
 			width: unset;
 
@@ -13,12 +15,13 @@ body.is-section-signup .is-woocommerce-install .signup__step.is-store-address {
 			margin-bottom: unset;
 		}
 
+		.components-base-control {
+			max-height: 80px;
+		}
+
 		.components-form-token-field__suggestions-list {
-			position: absolute;
-			top: 54px;
-			left: 0;
 			background-color: var(--color-surface);
-			z-index: 10;
+			margin: 12px -16px -12px;
 			width: min-content;
 		}
 

--- a/client/signup/steps/woocommerce-install/step-store-address/style.scss
+++ b/client/signup/steps/woocommerce-install/step-store-address/style.scss
@@ -5,6 +5,7 @@ body.is-section-signup .is-woocommerce-install .signup__step.is-store-address {
 
 	.step-store-address__instructions-container {
 		.components-combobox-control__suggestions-container {
+			position: relative;
 			// Remove `width: 100%;` https://github.com/WordPress/gutenberg/blob/0135921bcb72ceec629fa8f9e755891afab747b9/packages/components/src/combobox-control/style.scss#L32
 			width: unset;
 
@@ -13,7 +14,11 @@ body.is-section-signup .is-woocommerce-install .signup__step.is-store-address {
 		}
 
 		.components-form-token-field__suggestions-list {
-			margin: 12px -16px -12px;
+			position: absolute;
+			top: 54px;
+			left: 0;
+			background-color: var(--color-surface);
+			z-index: 10;
 			width: min-content;
 		}
 

--- a/client/signup/steps/woocommerce-install/style.scss
+++ b/client/signup/steps/woocommerce-install/style.scss
@@ -109,6 +109,7 @@
 				.components-combobox-control__suggestions-container,
 				.components-select-control__input,
 				.components-text-control__input {
+					height: auto;
 					line-height: 18px;
 					padding: $grid-unit-15 $grid-unit-20;
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83904

## Proposed Changes

* Set the height of the input to auto so it's not too narrow compare to the country dropdown
* Set country dropdown position to absolute so the page don't bounce when the option is open

Before:

https://github.com/user-attachments/assets/e7c4903e-ecb4-4715-a03a-b2842bd1bbd4

After:

https://github.com/user-attachments/assets/a6baca37-5fc6-43d3-b67a-5ba1d259e4e0


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's a bug and breaking user experiences

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/woocommerce-installation/
* Choose a test site site
* Click "Set up my store"
* Click on the country field and make sure the page not bouncing anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
