### PR TITLE
Untangling: fix back button layout in Settings -> Administration

### DIFF
--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -48,6 +48,7 @@
 
 	&.is-action {
 		.gridicon {
+			margin-left: -4px;
 			margin-right: 4px;
 		}
 	}

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -254,6 +254,7 @@ class DeleteSite extends Component {
 
 		return (
 			<Panel className="settings-administration__delete-site">
+				<HeaderCakeBack icon="chevron-left" onClick={ this._goBack } />
 				<NavigationHeader
 					compactBreadcrumb={ false }
 					navigationItems={ [] }
@@ -271,7 +272,6 @@ class DeleteSite extends Component {
 					) }
 				></NavigationHeader>
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-				<HeaderCakeBack onClick={ this._goBack } />
 				{ canDeleteSite ? (
 					<PanelSection>
 						<>

--- a/client/sites/settings/administration/tools/manage-connection/index.jsx
+++ b/client/sites/settings/administration/tools/manage-connection/index.jsx
@@ -20,13 +20,13 @@ class ManageConnection extends Component {
 			<Panel className="settings-administration__manage-connection">
 				<DocumentHead title={ translate( 'Site Settings' ) } />
 
+				<HeaderCakeBack icon="chevron-left" onClick={ redirect } />
 				<NavigationHeader
 					title={ translate( 'Manage connection' ) }
 					subtitle={ translate(
 						'Sync your site content for a faster experience, change site owner, repair or terminate your connection.'
 					) }
 				/>
-				<HeaderCakeBack onClick={ redirect } />
 
 				<SiteOwnership />
 				<DataSynchronization />

--- a/client/sites/settings/administration/tools/reset-site/index.jsx
+++ b/client/sites/settings/administration/tools/reset-site/index.jsx
@@ -298,6 +298,7 @@ function SiteResetCard( {
 	return (
 		<Panel className="settings-administration__reset-site">
 			{ ! isLoading && <Interval onTick={ checkStatus } period={ EVERY_FIVE_SECONDS } /> }
+			<HeaderCakeBack icon="chevron-left" href={ `${ source }/${ selectedSiteSlug }` } />
 			<NavigationHeader
 				title={ title }
 				subtitle={ translate(
@@ -310,7 +311,6 @@ function SiteResetCard( {
 				) }
 			/>
 			<PageViewTracker path="/settings/start-reset/:site" title="Settings > Site Reset" />
-			<HeaderCakeBack icon="chevron-left" href={ `${ source }/${ selectedSiteSlug }` } />
 			{ renderBody() }
 			<DIFMUpsell
 				site={ site }

--- a/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
@@ -19,6 +19,7 @@ export function SiteTransferCard( {
 		: translate( 'Site Transfer' );
 	return (
 		<Panel className="settings-administration__transfer-site">
+			<HeaderCakeBack icon="chevron-left" onClick={ onClick } />
 			<NavigationHeader
 				title={ title }
 				subtitle={ translate(
@@ -35,7 +36,6 @@ export function SiteTransferCard( {
 				path="/settings/start-site-transfer/:site"
 				title="Settings > Start Site Transfer"
 			/>
-			<HeaderCakeBack icon="chevron-left" onClick={ onClick } />
 			<PanelSection>{ children }</PanelSection>
 		</Panel>
 	);


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/dotcom-forge/issues/9989

## Proposed Changes

This PR updates the back button position in Settings -> Administration subtabs as follows:

|Before|After|
|-|-|
|<img width="739" alt="image" src="https://github.com/user-attachments/assets/1dd25570-a5a3-47b4-926f-e5e055afe599">|<img width="738" alt="image" src="https://github.com/user-attachments/assets/fe21608c-2e1f-4eef-8a4f-bcca8776c5f1">|

## Why are these changes being made?

pbxlJb-6ye-p2

## Testing Instructions

1. Prepare a site.
2. Go to:
    - `/sites/settings/administration/:slug/reset-site`
    - `/sites/settings/administration/:slug/transfer-site`
    - `/sites/settings/administration/:slug/delete-site`
    - For each of the route above, verify that the back button is above the heading.
3. Prepare a Jurassic Ninja site, and connect it to WordPress.com
    - Go to `/sites/settings/administration/:slug/manage-connection`
    - Verify that the back button is above the heading.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?