### PR TITLE
Marketplace Theme Install: Fix stuck loading screen

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo } from 'react';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import { useQueryThemes } from 'calypso/components/data/query-theme';
 import { useDispatch, useSelector } from 'calypso/state';
+import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import { isJetpackSite, getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import { clearActivated } from 'calypso/state/themes/actions';
 import {
@@ -50,6 +51,7 @@ export function useThemesThankYouData(
 	);
 
 	useQuerySitePurchases( siteId );
+	const isRequestingSitePurchases = useSelector( isFetchingSitePurchases );
 
 	const dotComThemes = useSelector( ( state ) => getThemes( state, 'wpcom', themeSlugs ) );
 	const dotOrgThemes = useSelector( ( state ) => getThemes( state, 'wporg', themeSlugs ) );
@@ -141,7 +143,9 @@ export function useThemesThankYouData(
 	}, [ hasExternallyManagedThemes, hasExternallyManagedThemesSubscribed, siteSlug ] );
 
 	const isAtomicNeeded =
-		hasDotOrgThemes || ( hasExternallyManagedThemes && hasExternallyManagedThemesSubscribed );
+		hasDotOrgThemes ||
+		( hasExternallyManagedThemes &&
+			( isRequestingSitePurchases || hasExternallyManagedThemesSubscribed ) );
 
 	// Clear completed activated theme request state to avoid displaying the Thanks modal
 	useEffect( () => {
@@ -184,6 +188,7 @@ export function useThemesThankYouData(
 		// Always display the loading screen for the following situations:
 		// - Redirect to the plugin-bundle flow after the theme is activated for Woo themes.
 		// - Redirect to the Theme Details page after the atomic transfer if it's required.
-		! ( continueWithPluginBundle || isAtomicNeeded || allThemesFetched ),
+		// - Redirect to the /home page if the user removed the externally managed theme from checkout.
+		! ( continueWithPluginBundle || isAtomicNeeded || ( ! isAtomicNeeded && allThemesFetched ) ),
 	];
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -6,7 +6,10 @@ import { useQueryThemes } from 'calypso/components/data/query-theme';
 import { useDispatch, useSelector } from 'calypso/state';
 import { isJetpackSite, getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import { clearActivated } from 'calypso/state/themes/actions';
-import { getThemes } from 'calypso/state/themes/selectors';
+import {
+	getThemes,
+	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
+} from 'calypso/state/themes/selectors';
 import { hasExternallyManagedThemes as getHasExternallyManagedThemes } from 'calypso/state/themes/selectors/is-externally-managed-theme';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { Theme } from 'calypso/types';
@@ -117,10 +120,25 @@ export function useThemesThankYouData(
 				( dotComTheme: { id: string } | undefined ) => dotComTheme?.id === theme.id
 			)
 	);
+
+	const themesSubscribed = useSelector( ( state ) =>
+		themeSlugs.filter( ( themeId ) => getIsMarketplaceThemeSubscribed( state, themeId, siteId ) )
+	);
+
+	const hasExternallyManagedThemesSubscribed = themesSubscribed.length > 0;
+
 	const hasExternallyManagedThemes = useSelector( ( state ) =>
 		getHasExternallyManagedThemes( state, themeSlugs )
 	);
-	const isAtomicNeeded = hasDotOrgThemes || hasExternallyManagedThemes;
+
+	useEffect( () => {
+		if ( ! hasExternallyManagedThemesSubscribed && hasExternallyManagedThemes ) {
+			page( `/home/${ siteSlug }` );
+		}
+	}, [ hasExternallyManagedThemes, hasExternallyManagedThemesSubscribed, siteSlug ] );
+
+	const isAtomicNeeded =
+		hasDotOrgThemes || ( hasExternallyManagedThemes && hasExternallyManagedThemesSubscribed );
 
 	// Clear completed activated theme request state to avoid displaying the Thanks modal
 	useEffect( () => {
@@ -163,6 +181,6 @@ export function useThemesThankYouData(
 		// Always display the loading screen for the following situations:
 		// - Redirect to the plugin-bundle flow after the theme is activated for Woo themes.
 		// - Redirect to the Theme Details page after the atomic transfer if it's required.
-		! ( continueWithPluginBundle || isAtomicNeeded ),
+		! ( continueWithPluginBundle || isAtomicNeeded || allThemesFetched ),
 	];
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
+import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import { useQueryThemes } from 'calypso/components/data/query-theme';
 import { useDispatch, useSelector } from 'calypso/state';
 import { isJetpackSite, getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
@@ -47,6 +48,8 @@ export function useThemesThankYouData(
 	const subtitle = translate(
 		"Your new theme is a reflection of your unique style and personality, and we're thrilled to see it come to life."
 	);
+
+	useQuerySitePurchases( siteId );
 
 	const dotComThemes = useSelector( ( state ) => getThemes( state, 'wpcom', themeSlugs ) );
 	const dotOrgThemes = useSelector( ( state ) => getThemes( state, 'wporg', themeSlugs ) );


### PR DESCRIPTION
When a user adds a Partner theme during onboarding (Design Picker) and then removes the Partner theme from the checkout and purchases only the Business plan, the user is redirected to /marketplace/thank-you page.

Since the theme was removed, the page loads indefinitely for the Atomic transfer and the theme installation to finish - thus, blocking the user on this page.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96864

## Proposed Changes

* Check if the user has actually purchased the theme
* If not bail and redirect to /home

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* if the users selected a Partner theme during onboarding and then removed it from checkout, the Marketplace interface will remain blocked in the loading state

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link
* Go to /start and create a new site (free)
* Go to Design Picker and select a Partner theme (SolarOne)
* In checkout, remove the SolarOne product
* Purchase only the Business
* You're redirected to /marketplace/thank-you
* You're redirected to /home/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
