### PR TITLE
Fix marketplace plugin installation for new atomic sites

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -195,15 +195,14 @@ const MarketplaceProductInstall = ( {
 			( marketplaceInstallationInProgress || directInstallationAllowed ) &&
 			! isPluginUploadFlow &&
 			! initializeInstallFlow &&
-			( wporgPlugin || wpOrgTheme ) &&
-			selectedSite
+			( wporgPlugin || wpOrgTheme )
 		) {
 			const triggerInstallFlow = () => {
 				setInitializeInstallFlow( true );
 				waitFor( 1 ).then( () => setCurrentStep( 1 ) );
 			};
 
-			if ( selectedSite.jetpack ) {
+			if ( isJetpack || isAtomic ) {
 				if ( wpOrgTheme ) {
 					// initilize theme activating
 					dispatch( installAndActivateTheme( wpOrgTheme.id, siteId ) );
@@ -230,7 +229,6 @@ const MarketplaceProductInstall = ( {
 		directInstallationAllowed,
 		isPluginUploadFlow,
 		initializeInstallFlow,
-		selectedSite,
 		siteId,
 		wporgPlugin,
 		wpOrgTheme,
@@ -238,6 +236,8 @@ const MarketplaceProductInstall = ( {
 		themeSlug,
 		dispatch,
 		hasAtomicFeature,
+		isAtomic,
+		isJetpack,
 	] );
 
 	// Validate completion of atomic transfer flow


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/96797

## Proposed Changes

This PR updates a condition responsible for initiating either the plugin installation or the Automated Transfer required for the plugin installation.

Currently, this condition uses the `selectedSite.jetpack` property to check if the plugin can be installed and the `hasAtomicFeature` property to start the Automated Transfer if needed. For freshly transferred sites, the `jetpack` property is false, and that makes this condition to mistakenly start the Automated Transfer, which eventually fails because the site is already atomic.

This PR updates the Jetpack connection check to include the [site options object](https://github.com/Automattic/wp-calypso/blob/5924a5782b60139f88013521d8ea3b75deae66b6/client/state/sites/selectors/is-jetpack-site-pred.ts#L59) by using the `isJetpackSite` selector. It also adds a fallback atomic check.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We received a bug report about atomic sites not being able to install plugins using the Calypso admin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test original issue**
* Create a new Atomic Site
* Go to Hosting Features and make it Atomic
* Set the default dashboard as dotcom (claypso not wp-admin)
* Go to Plugin > Add New plugin
* Install any free plugin
* Check that the plugin installation succeeds

Test for regressions
* With a free or premium site
* Go to Plugin > Add New plugin
* Install any free plugin (requires a plan update)
* Complete checkout with the plan upgrade
* Check that both the Automated Transfer and the plugin installation succeeds