### PR TITLE
Standardize margin for content panels and headers

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -44,7 +44,6 @@ $brand-display: "SF Pro Display", sans-serif;
 	.plugins-update-manager-multisite-filters,
 	.plugins-update-manager-multisite-table-container {
 		@media screen and (min-width: $break-xhuge) {
-			max-width: 1400px;
 			margin: 0 auto;
 		}
 		@media screen and (min-width: $break-large) {
@@ -167,17 +166,6 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		.validation-msg {
 			width: 100%;
-		}
-	}
-}
-
-main.scheduled-updates-list {
-	.plugins-update-manager-multisite {
-		&__header-main {
-			@media screen and (min-width: $break-xhuge) {
-				max-width: 1400px;
-				padding-inline: 64px;
-			}
 		}
 	}
 }

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -3,8 +3,14 @@
 $brand-display: "SF Pro Display", sans-serif;
 
 .plugins-update-manager-multisite {
-	@media screen and (max-width: $break-medium) {
-		margin: 1rem;
+	padding-inline: 48px;
+
+	@media (max-width: $break-medium) {
+		padding-inline: 2rem;
+	}
+
+	@media (max-width: $break-small) {
+		padding-inline: 16px;	
 	}
 
 	&__header {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -610,10 +610,6 @@ body.is-mobile-app-view {
 		flex: 0 1 auto;
 		padding: 0;
 
-		&:not(.masterbar__item--always-show-content) {
-			width: 46px;
-		}
-
 		.masterbar__item-content {
 			display: none;
 		}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -544,7 +544,7 @@ body.is-mobile-app-view {
 		padding: 0;
 
 		&:not(.masterbar__item--always-show-content) {
-			width: 52px;
+			width: 46px;
 		}
 		// Show gravatar content
 		&:not(.masterbar__item-howdy) .masterbar__item-content {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -149,7 +149,7 @@
 			padding-inline: 0;
 
 			.navigation-header__main {
-				padding-inline: 16px;
+				padding-inline: 21px;
 
 				@include break-mobile {
 					padding-inline: 48px;
@@ -160,7 +160,6 @@
 				max-width: 100%;
 
 				.navigation-header__main {
-					max-width: 1400px;
 					margin: 0 auto;
 					padding-inline: 48px;
 				}
@@ -241,7 +240,6 @@
 		}
 	}
 	.domains-table {
-		max-width: 1400px;
 		margin-left: auto;
 		margin-right: auto;
 
@@ -252,7 +250,7 @@
 
 
 		.domains-table-toolbar {
-			margin-inline: 0;
+			margin-inline: 5px;
 
 			@include break-mobile {
 				margin-inline: 32px;

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -3,6 +3,7 @@
 
 .plugins-browser-list {
 	padding-top: 40px;
+	padding-inline: 0;
 
 	.feature-example & {
 		margin: 0;
@@ -19,11 +20,6 @@
 			font-weight: 500;
 			color: var(--studio-gray-80);
 		}
-	}
-
-	@media ( max-width: $break-small ) {
-		padding-left: 16px;
-		padding-right: 16px;
 	}
 
 	.spotlight {

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -21,7 +21,7 @@
 		}
 	}
 
-	@include breakpoint-deprecated("<660px") {
+	@media ( max-width: $break-small ) {
 		padding-left: 16px;
 		padding-right: 16px;
 	}

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management {
     display: flex;
     flex-direction: column;
@@ -6,6 +9,10 @@ body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management {
 	.navigation-header {
 		border-block-end: 1px solid var(--color-border-secondary);
 		padding-inline: 48px;
+    
+        @media (max-width: 430px) {
+            padding-inline: 24px;
+        }
 
         .navigation-header__main {
             margin: auto;

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -8,7 +8,6 @@ body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management {
 		padding-inline: 48px;
 
         .navigation-header__main {
-            max-width: 1400px;
             margin: auto;
         }
 	}
@@ -17,7 +16,6 @@ body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management {
 body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management,
 .is-section-jetpack-cloud-plugin-management .plugin-management-wrapper.is-bulk-plugin-management {
     .dataviews-wrapper {
-        max-width: 1500px;
         margin: auto;
 
         .dataviews-view-table {

--- a/client/my-sites/plugins/plugins-navigation-header/style.scss
+++ b/client/my-sites/plugins/plugins-navigation-header/style.scss
@@ -12,8 +12,12 @@
 		border-block-end: 1px solid var(--color-border-secondary);
 	}
 
+	@media (max-width: $break-medium) {
+		padding-inline: 2rem;
+	}
+
 	@media (max-width: $break-small) {
-		padding-inline: 16px;
+		padding-inline: 16px;	
 	}
 
 	@include break-xhuge {

--- a/client/my-sites/plugins/plugins-navigation-header/style.scss
+++ b/client/my-sites/plugins/plugins-navigation-header/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .plugins-navigation-header.navigation-header {
-	padding-inline: 16px;
+	padding-inline: 48px;
 
 	.navigation-header__main {
 		align-items: center;
@@ -12,17 +12,13 @@
 		border-block-end: 1px solid var(--color-border-secondary);
 	}
 
-	@include break-huge {
-		padding-inline: 64px;
+	@media (max-width: $break-small) {
+		padding-inline: 16px;
 	}
 
 	@include break-xhuge {
-		max-width: 100%;
-
 		.navigation-header__main {
-			max-width: 1400px;
 			margin: 0 auto;
-			padding-inline: 64px;
 		}
 	}
 

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -9,7 +9,7 @@ $search-categories-padding-top: 40px;
 	gap: 12px;
 	padding-top: $search-categories-padding-top;
 
-	@media (max-width: 660px) {
+	@media (max-width: $break-small) {
 		padding: 0 16px;
 	}
 

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -7,11 +7,8 @@ $search-categories-padding-top: 40px;
 	display: flex;
 	align-items: center;
 	gap: 12px;
+	padding-inline: 0;
 	padding-top: $search-categories-padding-top;
-
-	@media (max-width: $break-small) {
-		padding: 0 16px;
-	}
 
 	.search-categories__searchbox {
 		max-width: 265px;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -70,8 +70,14 @@ body.is-section-plugins {
 	.is-logged-in main:not(.a4a-layout):not(.a4a-layout-column) {
 		&:not(.plugins-browser),
 		&.plugins-browser .plugins-browser__content-wrapper {
-			@include break-small {
-				padding-inline: 48px;
+			padding-inline: 48px;
+
+			@media (max-width: $break-medium) {
+				padding-inline: 2rem;
+			}
+		
+			@media (max-width: $break-small) {
+				padding-inline: 16px;	
 			}
 		}
 
@@ -133,16 +139,7 @@ body.is-section-plugins {
 		.plugins-update-manager-multisite__header,
 		.plugins-update-manager-multisite-filter {
 			margin: 0;
-			padding: 24px;
-			padding-inline: 48px;
-
-			@include breakpoint-deprecated( "<960px" ) {
-				padding: 1rem;
-			}
-
-			@include breakpoint-deprecated( "<660px" ) {
-				padding: 1rem 0;
-			}
+			padding: 24px 0;
 		}
 
 		.plugins-update-manager-multisite__header {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -71,8 +71,7 @@ body.is-section-plugins {
 		&:not(.plugins-browser),
 		&.plugins-browser .plugins-browser__content-wrapper {
 			@include break-small {
-				padding-left: 2rem;
-				padding-right: 2rem;
+				padding-inline: 48px;
 			}
 		}
 
@@ -134,7 +133,8 @@ body.is-section-plugins {
 		.plugins-update-manager-multisite__header,
 		.plugins-update-manager-multisite-filter {
 			margin: 0;
-			padding: 1.5rem 4rem;
+			padding: 24px;
+			padding-inline: 48px;
 
 			@include breakpoint-deprecated( "<960px" ) {
 				padding: 1rem;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -284,6 +284,7 @@
 .domains-table-mobile-cards {
 	overflow-y: auto;
 	max-height: calc(100vh - 326px);
+	padding-inline: 5px;
 
 	.domains-table-mobile-cards-select-all {
 		display: flex;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9946
Slack thread: p1732197974469459-slack-C04H4NY6STW

Video explaining the changes here: p1732818331404739/1732197974.469459-slack-C04H4NY6STW

## Proposed Changes

* Standardize Global navigation margin for content panels, headers and mobile navigation
* Header and content panels have inner-padding of 48px
* Mobile spacing works well on all screens

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want our users to have an unified experience through Dotcom

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to all these pages and ensure they follow the same spacing patterns:

* /sites
* /p2s
* /domains/manage
* /themes
* /plugins
* /plugins/manage
* /plugins/scheduled-updates


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?