### PR TITLE
Stats: full width chart tabs + header adjustments for mobile view

### DIFF
--- a/client/components/date-control/index.tsx
+++ b/client/components/date-control/index.tsx
@@ -51,16 +51,25 @@ const DateControl = ( {
 		if ( shortcut ) {
 			return shortcut.label;
 		}
-		// Generate a full date range for the label.
-		const startDate = moment( dateRange.chartStart ).format( 'LL' );
-		const endDate = moment( dateRange.chartEnd ).format( 'LL' );
 
-		// If start and end are the same, then just show one date.
-		if ( startDate === endDate ) {
-			return startDate;
+		// Generate a full date range for the label.
+		const localizedStartDate = moment( dateRange.chartStart );
+		const localizedEndDate = moment( dateRange.chartEnd );
+
+		// If it's the same day, show single date.
+		if ( localizedStartDate.isSame( localizedEndDate, 'day' ) ) {
+			return localizedStartDate.isSame( moment(), 'year' )
+				? localizedStartDate.format( 'MMM D' )
+				: localizedStartDate.format( 'll' );
 		}
 
-		return `${ startDate } - ${ endDate }`;
+		if ( localizedStartDate.year() === localizedEndDate.year() ) {
+			return `${ localizedStartDate.format( 'MMM D' ) } - ${ localizedEndDate.format( `MMM D` ) }${
+				localizedStartDate.isSame( moment(), 'year' ) ? '' : localizedEndDate.format( ', YYYY' ) // Only append year if it's not the current year.
+			}`;
+		}
+
+		return `${ localizedStartDate.format( 'll' ) } - ${ localizedEndDate.format( 'll' ) }`;
 	};
 
 	return (

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -42,6 +42,10 @@ $custom-stats-tab-mobile-break: $break-medium;
 			padding: 24px 0 16px;
 		}
 
+		@media (min-width: $custom-stats-tab-mobile-break) {
+			padding: 24px;
+		}
+
 		&.is-enabled {
 			background-color: inherit;
 		}
@@ -83,7 +87,7 @@ $custom-stats-tab-mobile-break: $break-medium;
 			.gridicon {
 				@media (max-width: $custom-stats-tab-mobile-break) {
 					float: left;
-					margin: 3px 8px 0 20px;
+					margin: 0;
 				}
 			}
 
@@ -94,7 +98,7 @@ $custom-stats-tab-mobile-break: $break-medium;
 				border-radius: 4px;
 				overflow: hidden;
 				color: var(--studio-black);
-				padding: 10px 6px;
+				padding: 10px 24px;
 
 				@media (max-width: $custom-stats-tab-mobile-break) {
 					display: grid;

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -7,6 +7,9 @@ $custom-stats-tab-mobile-break: $break-medium;
 
 .stats > .stats-content {
 	padding-top: $vertical-margin;
+	@media (max-width: $custom-mobile-breakpoint) {
+		padding-top: 0;
+	}
 }
 
 // For modernized main charts with tabs inside the Traffic, Store, and Ads pages

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -245,14 +245,13 @@ ul.module-tabs {
 		background-color: var(--studio-white);
 		border: 1px solid var(--studio-gray-5);
 		border-radius: 4px;
-		padding: 24px;
 
 		/* styling for chart header with new date filtering design */
 		.stats-chart-tabs__header {
 			display: flex;
 			flex-direction: row;
 			align-items: center;
-			margin-bottom: 24px;
+			padding: 24px;
 		}
 
 		.chart__legend{
@@ -261,6 +260,10 @@ ul.module-tabs {
 
 		.chart__y-axis-marker {
 			border-top-color: #DCDCDE;
+		}
+
+		.chart__y-axis {
+			padding-left: 8px;
 		}
 
 		.stats-interval-dropdown, .stats-interval-display {

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 // Module Tabs
 // (currently only used for the bar chart module at the top)
 
@@ -252,6 +254,10 @@ ul.module-tabs {
 			flex-direction: row;
 			align-items: center;
 			padding: 24px;
+
+			@media (max-width: $break-medium) {
+				padding: 8px 24px;
+			}
 		}
 
 		.chart__legend{

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -139,24 +139,24 @@ class StatsDatePicker extends Component {
 		return formattedDate;
 	}
 
+	// TODO: need the align today with site timezone.
 	renderQueryDate() {
 		const { query, queryDate, moment, translate } = this.props;
-		let content;
 
 		if ( ! queryDate || ! isAutoRefreshAllowedForQuery( query ) ) {
-			content = null;
-		} else {
-			const today = moment();
-			const date = moment( queryDate );
-			const isToday = today.isSame( date, 'day' );
-
-			content = translate( '{{b}}Last update: %(time)s{{/b}} (Updates every 30 minutes)', {
-				args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
-				components: {
-					b: <span className="stats-date-picker__last-update" />,
-				},
-			} );
+			return null;
 		}
+
+		const today = moment();
+		const date = moment( queryDate );
+		const isToday = today.isSame( date, 'day' );
+
+		const content = translate( '{{b}}Last update: %(time)s{{/b}} (Updates every 30 minutes)', {
+			args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
+			components: {
+				b: <span className="stats-date-picker__last-update" />,
+			},
+		} );
 
 		return (
 			<div className="stats-date-picker__refresh-status">

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -57,7 +57,7 @@ class StatsDatePicker extends Component {
 	}
 
 	dateForCustomRange( startDate, endDate ) {
-		const { moment, translate } = this.props;
+		const { moment } = this.props;
 
 		const localizedStartDate = moment( startDate );
 		const localizedEndDate = moment( endDate );
@@ -85,17 +85,17 @@ class StatsDatePicker extends Component {
 			return localizedStartDate.format( 'YYYY' );
 		}
 
-		// Default to date range
-		const firstFormatString =
-			localizedStartDate.year() === localizedEndDate.year() ? 'MMM D' : 'll';
+		// Only show year for the second date.
+		if (
+			localizedStartDate.year() === localizedEndDate.year() &&
+			localizedStartDate.isSame( moment(), 'year' )
+		) {
+			return `${ localizedStartDate.format( 'MMM D' ) } - ${ localizedEndDate.format(
+				`MMM D, YYYY`
+			) }`;
+		}
 
-		return translate( '%(startDate)s ~ %(endDate)s', {
-			context: 'Date range for which stats are being displayed',
-			args: {
-				startDate: localizedStartDate.format( firstFormatString ),
-				endDate: localizedEndDate.format( `${ firstFormatString }, YYYY` ),
-			},
-		} );
+		return `${ localizedStartDate.format( 'll' ) } - ${ localizedEndDate.format( 'll' ) }`;
 	}
 
 	dateForDisplay() {

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -34,6 +34,7 @@
 
 			@media (max-width: $break-medium) {
 				padding: 0;
+				justify-content: flex-end;
 			}
 		}
 	}

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -33,7 +33,7 @@
 			align-items: center;
 
 			@media (max-width: $break-medium) {
-				padding: 0 16px;
+				padding: 0;
 			}
 		}
 	}

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -32,9 +32,21 @@
 			padding: 0;
 			align-items: center;
 
+			@media (max-width: $break-large) {
+				margin: 0;
+			}
+
 			@media (max-width: $break-medium) {
 				padding: 0;
 				justify-content: flex-end;
+			}
+
+			@media (max-width: 660px) {
+				margin-bottom: 24px;
+			}
+
+			@media (max-width: $break-mobile) {
+				margin: 24px 0;
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Make date range picker label shorter by omitting year sometimes
* Adjusted too much gap for header
* `renderQueryDate` returns null when not necessary for the sake of layout

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Mobile view improvements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live for the Traffic page
* Ensure the header and chart response well
* Ensure mobile view looks okay
  * Chart is now full width
  * Tabs is now full width



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
