### PR TITLE
Remove list view on hover background color overrides

### DIFF
--- a/client/sites/components/sites-dataviews/dataview-style.scss
+++ b/client/sites/components/sites-dataviews/dataview-style.scss
@@ -14,17 +14,6 @@
 			}
 		}
 	}
-
-	ul.dataviews-view-list {
-		// TODO: Remove when theming APIs are implemented. pbxlJb-6A9-p2#comment-4011
-		li:hover {
-			background: var(--color-neutral-0);
-		}
-		// TODO: Remove when theming APIs are implemented. pbxlJb-6A9-p2#comment-4011
-		.is-selected {
-			background-color: var(--color-neutral-0);
-		}
-	}
 }
 
 // Selected and hover states on the site list.
@@ -42,13 +31,6 @@
 				.dataviews-view-list__item-actions {
 					background-color: #ebf2fc;
 					box-shadow: -12px 0 8px 0 #ebf2fc;
-				}
-			}
-			li:hover {
-				--color-neutral-0: #f7faff;
-				.dataviews-view-list__item-actions {
-					background-color: #f7faff;
-					box-shadow: -12px 0 8px 0 #f7faff;
 				}
 			}
 		}


### PR DESCRIPTION
Related to #

## Proposed Changes

* Remove on hover color overrides for list view to match the site list behavior table view

## Testing Instructions

* /sites
* Click into a site overview
* Confirm background color on hover h

Before

https://github.com/user-attachments/assets/21d1137b-9c26-4711-8294-747ae6744c79

After

https://github.com/user-attachments/assets/5c0949dd-c8dd-41d1-9ad4-a62f2ab58bb8



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
