### PR TITLE
Fixing redirect URL for the Growth plan

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/use-get-jetpack-activation-confirmation-info.ts
+++ b/client/my-sites/checkout/checkout-thank-you/use-get-jetpack-activation-confirmation-info.ts
@@ -2,6 +2,7 @@ import {
 	JETPACK_ANTI_SPAM_PRODUCTS,
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_COMPLETE_PLANS,
+	JETPACK_GROWTH_PLANS,
 	JETPACK_SCAN_PRODUCTS,
 	JETPACK_SEARCH_PRODUCTS,
 	JETPACK_SECURITY_PLANS,
@@ -71,6 +72,11 @@ const useGetJetpackActivationConfirmationInfo = (
 				? `${ baseJetpackCloudUrl }/backup/${ siteSlug }`
 				: `${ baseJetpackCloudUrl }/landing`,
 		},
+		jetpack_growth: {
+			image: successImageDefault,
+			text: translate( "You're all set!" ),
+			buttonUrl: jetpackAdminUrl || baseJetpackCloudUrl,
+		},
 		jetpack_scan: {
 			image: successImageScan,
 			text: translate( 'You can see your security scans on {{a}}cloud.jetpack.com{{/a}}.', {
@@ -123,6 +129,7 @@ const useGetJetpackActivationConfirmationInfo = (
 		jetpack_search: JETPACK_SEARCH_PRODUCTS,
 		jetpack_security: JETPACK_SECURITY_PLANS,
 		jetpack_videopress: JETPACK_VIDEOPRESS_PRODUCTS,
+		jetpack_growth: JETPACK_GROWTH_PLANS,
 	};
 
 	const productGroup =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-marketing/issues/1102

## Proposed Changes

* Add config for the new Growth plan to allow reditect from the checkout thank you page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Avoid redirecting to the Boost page for The Growth plan

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* purchase new Growth yearly plan using the checkout URL highlighted in the instructions here p8oabR-1AZ-p2
* open the live branch
* update the URL of the live branch and change to `.../checkout/jetpack/thank-you/licensing-auto-activate-completed/jetpack_growth_yearly?destinationSiteId=[your_site_id]`
* verify that the URL is not redirecting to Boost

<img width="1718" alt="SCR-20241129-lnqw" src="https://github.com/user-attachments/assets/b8fd2f5e-3409-4765-ac92-97aeb106352d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?