### PR TITLE
Domains: Fix domains site picker not showing atomic sites

### DIFF
--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -17,7 +17,9 @@ class SitePicker extends Component {
 	};
 
 	filterSites = ( site ) => {
-		return site.capabilities?.manage_options && ! site.jetpack && ! site.options?.is_domain_only;
+		const isWPCOMSimpleSite = ! site.jetpack && ! site.is_a4a_client;
+		const isWPCOMSite = isWPCOMSimpleSite || site.is_wpcom_atomic;
+		return site.capabilities?.manage_options && isWPCOMSite && ! site.options?.is_domain_only;
 	};
 
 	renderScreen() {

--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -18,7 +18,8 @@ class SitePicker extends Component {
 
 	filterSites = ( site ) => {
 		const isWPCOMSimpleSite = ! site.jetpack && ! site.is_a4a_client;
-		const isWPCOMSite = isWPCOMSimpleSite || site.is_wpcom_atomic;
+		const isWPCOMSite =
+			( isWPCOMSimpleSite || site.is_wpcom_atomic ) && ! site.is_wpcom_staging_site;
 		return site.capabilities?.manage_options && isWPCOMSite && ! site.options?.is_domain_only;
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/96844

## Proposed Changes
The filter was filtering out all jetpack sites which atomic is also a jetpack site

* filter out only jetpack only site by checking if the site is a wpcom simple or atomic site

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allow users to attached new domains to an existing atomic site

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/domains/manage`
* Select `Add new domain`
* Navigate steps and choose `Existing WordPress.com site`
* At the site picker verify you are able to search and select atomic sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
