### PR TITLE
Site list: match hover styling from core usage

### DIFF
--- a/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -103,6 +103,7 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 			<SiteListTile
 				contentClassName={ clsx(
 					'sites-dataviews__site-name',
+					site.is_deleted && 'sites-dataviews__site-name--deleted',
 					css`
 						min-width: 0;
 						text-align: start;

--- a/client/sites/components/sites-dataviews/site-icon.tsx
+++ b/client/sites/components/sites-dataviews/site-icon.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import * as React from 'react';
 import SiteFavicon from 'calypso/a8c-for-agencies/components/items-dashboard/site-favicon';
@@ -33,6 +34,10 @@ export default function SiteIcon( {
 	const onClick = ( event: React.MouseEvent ) => {
 		event.preventDefault();
 
+		if ( site.is_deleted ) {
+			return;
+		}
+
 		if (
 			isAdmin &&
 			! isP2Site &&
@@ -48,19 +53,15 @@ export default function SiteIcon( {
 	const isMigrationPending = getMigrationStatus( site ) === 'pending';
 	const siteTitle = isMigrationPending ? translate( 'Incoming Migration' ) : site.title;
 
-	if ( site.is_deleted ) {
-		return (
-			<SiteFavicon
-				className="sites-site-favicon"
-				blogId={ site.ID }
-				fallback={ isMigrationPending ? 'migration' : 'first-grapheme' }
-				size={ viewType === 'list' ? 52 : 32 }
-			/>
-		);
-	}
-
 	return (
-		<ThumbnailLink title={ siteTitle } onClick={ onClick } className="sites-dataviews__site-icon">
+		<ThumbnailLink
+			title={ siteTitle }
+			onClick={ onClick }
+			className={ clsx(
+				'sites-dataviews__site-icon',
+				site.is_deleted && 'sites-dataviews__site-icon--deleted'
+			) }
+		>
 			<SiteFavicon
 				className="sites-site-favicon"
 				blogId={ site.ID }

--- a/client/sites/components/sites-dataviews/site-icon.tsx
+++ b/client/sites/components/sites-dataviews/site-icon.tsx
@@ -33,10 +33,6 @@ export default function SiteIcon( {
 	const onClick = ( event: React.MouseEvent ) => {
 		event.preventDefault();
 
-		if ( site.is_deleted ) {
-			return;
-		}
-
 		if (
 			isAdmin &&
 			! isP2Site &&
@@ -51,6 +47,17 @@ export default function SiteIcon( {
 
 	const isMigrationPending = getMigrationStatus( site ) === 'pending';
 	const siteTitle = isMigrationPending ? translate( 'Incoming Migration' ) : site.title;
+
+	if ( site.is_deleted ) {
+		return (
+			<SiteFavicon
+				className="sites-site-favicon"
+				blogId={ site.ID }
+				fallback={ isMigrationPending ? 'migration' : 'first-grapheme' }
+				size={ viewType === 'list' ? 52 : 32 }
+			/>
+		);
+	}
 
 	return (
 		<ThumbnailLink title={ siteTitle } onClick={ onClick } className="sites-dataviews__site-icon">

--- a/client/sites/components/sites-dataviews/style.scss
+++ b/client/sites/components/sites-dataviews/style.scss
@@ -7,6 +7,11 @@
 	overflow: hidden;
 	padding-bottom: 0;
 
+	// TODO: DataViews adds is-hovered to row/li's when hovering over them, we're targeting that
+	// to style the site name with a blue color to match core page list view. We need to target
+	// the row hover as the .sites-dataviews__site button doesn't cover the whole cell.
+	// At some point, this may be able to be cleaned up via a new onClick handler for primary fields,
+	// see https://github.com/WordPress/gutenberg/issues/67391#issuecomment-2506037360
 	.is-hovered {
 		.sites-dataviews__site {
 			.sites-dataviews__site-name:not(.sites-dataviews__site-name--deleted) {

--- a/client/sites/components/sites-dataviews/style.scss
+++ b/client/sites/components/sites-dataviews/style.scss
@@ -7,16 +7,9 @@
 	overflow: hidden;
 	padding-bottom: 0;
 
-	.sites-dataviews__site {
-		display: flex;
-		flex-direction: row;
-		padding: 0;
-		overflow: hidden;
-		cursor: pointer;
-
-		&:not(:disabled) {
-			&:hover,
-			&:focus {
+	.is-hovered {
+		.sites-dataviews__site {
+			.sites-dataviews__site-name:not(.sites-dataviews__site-name--deleted) {
 				.sites-dataviews__site-title {
 					color: var(--color-accent);
 				}
@@ -25,8 +18,16 @@
 				}
 			}
 		}
+	}
 
-		&:disabled {
+	.sites-dataviews__site {
+		display: flex;
+		flex-direction: row;
+		padding: 0;
+		overflow: hidden;
+		cursor: pointer;
+
+		.sites-dataviews__site-name--deleted {
 			.sites-dataviews__site-title {
 				color: var(--color-neutral-30);
 			}
@@ -72,6 +73,11 @@
 	.sites-dataviews__site-icon {
 		cursor: pointer;
 		padding: 0;
+
+		&.sites-dataviews__site-icon--deleted {
+			cursor: default;
+			filter: grayscale(100%);
+		}
 	}
 
 	.site-sort__clickable {

--- a/client/sites/components/sites-dataviews/style.scss
+++ b/client/sites/components/sites-dataviews/style.scss
@@ -7,7 +7,7 @@
 	overflow: hidden;
 	padding-bottom: 0;
 
-	// TODO: DataViews adds is-hovered to row/li's when hovering over them, we're targeting that
+	// TODO: DataViews adds .is-hovered to row/li's when hovering over them, we're targeting that
 	// to style the site name with a blue color to match core page list view. We need to target
 	// the row hover as the .sites-dataviews__site button doesn't cover the whole cell.
 	// At some point, this may be able to be cleaned up via a new onClick handler for primary fields,

--- a/client/sites/components/sites-dataviews/style.scss
+++ b/client/sites/components/sites-dataviews/style.scss
@@ -27,7 +27,6 @@
 		}
 
 		&:disabled {
-			cursor: default;
 			.sites-dataviews__site-title {
 				color: var(--color-neutral-30);
 			}


### PR DESCRIPTION
Follow up on https://github.com/Automattic/wp-calypso/pull/96896

## Proposed Changes

- Reworks hover state so the list view highlights the text at the same time it highlights the `<li />`
- Reworks deleted site styling to work in with the above change

Before 

https://github.com/user-attachments/assets/7661a993-58c7-420e-a7e1-5ba909dc3b5c

After

https://github.com/user-attachments/assets/60a1228e-78c3-4b0b-bac9-cce84d48a1a3

### Testing

Requires /sites with deleted sites and site icons.