### PR TITLE
Avoid null site access when navigating from site settings to /sites

### DIFF
--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -14,12 +14,12 @@ import { SOURCE_SETTINGS_GENERAL } from './site-tools/utils';
 
 const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2Hub, isWpcomStagingSite } ) => (
 	<div className="site-settings__main general-settings">
-		<GeneralForm site={ site } />
+		{ site && <GeneralForm site={ site } /> }
 		{ isWPForTeamsSite && isP2Hub && <P2PreapprovedDomainsForm siteId={ site?.ID } /> }
 		{ ! isWpcomStagingSite && ! isEnabled( 'untangling/hosting-menu' ) && (
 			<SiteTools headerTitle={ translate( 'Site tools' ) } source={ SOURCE_SETTINGS_GENERAL } />
 		) }
-		{ isEnabled( 'untangling/hosting-menu' ) && (
+		{ isEnabled( 'untangling/hosting-menu' ) && site && (
 			<Notice
 				showDismiss={ false }
 				status="is-info"


### PR DESCRIPTION
Related to #

## Proposed Changes

* Prevents the site settings page from accessing the site object during a re-render after the selected site has been cleared.

![Screenshot 2024-11-29 at 15-33-54 General Settings — WordPress com](https://github.com/user-attachments/assets/7951bc4a-9f4a-49bd-a0b8-3a06d41dcec0)

## Testing Instructions

* Visit site settings: http://calypso.localhost:3000/settings/general/
* Click the "W" to go to /sites
* Observe no calypso crash, or in production, the need to click again / see a ?retry=1 param.
