### PR TITLE
Sites Dashboard: Remove selected site color overrides

### DIFF
--- a/client/sites/components/sites-dataviews/dataview-style.scss
+++ b/client/sites/components/sites-dataviews/dataview-style.scss
@@ -16,27 +16,6 @@
 	}
 }
 
-// Selected and hover states on the site list.
-// TODO: Remove when theming APIs are implemented. pbxlJb-6A9-p2#comment-4011
-.wpcom-site .is-global-sidebar-visible.is-group-sites-dashboard,
-.wpcom-site .is-global-sidebar-visible.is-group-sites {
-	.sites-dashboard:not(.preview-hidden) {
-		ul.dataviews-view-list {
-			li.is-selected,
-			li.is-selected:hover {
-				// Override this element to ensure it doesn’t blend with the Core's alpha-based color.
-				.dataviews-view-list__item-wrapper {
-					background-color: #ebf2fc;
-				}
-				.dataviews-view-list__item-actions {
-					background-color: #ebf2fc;
-					box-shadow: -12px 0 8px 0 #ebf2fc;
-				}
-			}
-		}
-	}
-}
-
 .wpcom-site .main.a4a-layout.sites-dashboard {
 	.a4a-layout__top-wrapper,
 	.a4a-layout__body {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 
- https://github.com/Automattic/wp-calypso/pull/96901
- https://github.com/Automattic/wp-calypso/pull/96811
- https://github.com/Automattic/wp-calypso/pull/96896

## Proposed Changes

This PR proposes to remove the selected color override along with https://github.com/Automattic/wp-calypso/pull/96896, given that other pages using DataViews do not override it. Having this override only in the Sites Dashboard seems suboptimal. We can iterate on this with p9Jlb4-fba-p2 initiative ideally with theming API. 

|| before | after |
|--------|--------|--------|
|selected| <img width="411" alt="Screenshot 2024-11-29 at 14 23 00" src="https://github.com/user-attachments/assets/db5a2fe5-c47f-457b-b89e-ce54dcba9336"> | <img width="413" alt="Screenshot 2024-11-29 at 14 26 50" src="https://github.com/user-attachments/assets/24ef7194-051f-4a95-bab1-d14a0f839044"> | 
|hover (no change)|<img width="413" alt="Screenshot 2024-11-29 at 14 25 09" src="https://github.com/user-attachments/assets/52ba6cba-ef02-4461-8574-efed4b3950e1">|<img width="417" alt="Screenshot 2024-11-29 at 14 24 36" src="https://github.com/user-attachments/assets/4cecf6ad-358c-4bf9-9f32-0c7d6d056cbc">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pbxlJb-6DF-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?