### PR TITLE
User: Change login button color

### DIFF
--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -327,10 +327,10 @@ $image-height: 47px;
 
 	.login .button.is-primary {
 		// Note: Matches primary button to `button.signup-form__submit`
-		background-color: #117ac9;
+		background-color: var(--studio-wordpress-blue, #3858e9);
 		color: var(--color-text-inverted);
 		box-shadow: none;
-		border: 0 #0e64a5;
+		border: 0 var(--studio-wordpress-blue-60);
 		font-weight: 500;
 		letter-spacing: 0.32px;
 		line-height: 17px;
@@ -341,8 +341,8 @@ $image-height: 47px;
 
 		&:hover,
 		&:focus {
-			background-color: #0e64a5;
-			border-color: #0e64a5;
+			background-color: var(--studio-wordpress-blue-60);
+			border-color: var(--studio-wordpress-blue-60);
 			color: var(--color-text-inverted);
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96633#issuecomment-2506344603

## Proposed Changes

Change the login button background color

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Reach login page
