### PR TITLE
Overview: Add visits fetching states

### DIFF
--- a/client/sites/overview/components/plan-site-visits.tsx
+++ b/client/sites/overview/components/plan-site-visits.tsx
@@ -96,16 +96,20 @@ export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
 			} );
 		}
 
-		const visits = visitsResponse === 'disabled' ? 0 : visitsResponse;
+		if ( visitsResponse === 'disabled' ) {
+			return translate( 'Stats are disabled', {
+				comment: 'A message that the stats are disabled',
+			} );
+		}
 
-		if ( visits === 0 ) {
+		if ( visitsResponse === 0 ) {
 			return translate( 'No visits so far this month', {
 				comment: 'A notice that the site has not yet received any visits during the current month',
 			} );
 		}
 
 		return translate( '%(visitCount)s this month', {
-			args: { visitCount: visits },
+			args: { visitCount: visitsResponse },
 			comment: 'A description of the number of visits the site has received in the current month',
 		} );
 	};

--- a/client/sites/overview/components/plan-site-visits.tsx
+++ b/client/sites/overview/components/plan-site-visits.tsx
@@ -1,31 +1,41 @@
 import { LoadingPlaceholder } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
-import { useEffect, useState } from 'react'; // eslint-disable-line no-unused-vars -- used in the jsdoc types
+import { useCallback, useLayoutEffect, useState } from 'react'; // eslint-disable-line no-unused-vars -- used in the jsdoc types
 import wpcom from 'calypso/lib/wp';
 import './style.scss';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
+import { requestSite } from 'calypso/state/sites/actions';
+import { getSiteSlug, isJetpackModuleActive } from 'calypso/state/sites/selectors';
 
 interface PlanSiteVisitsProps {
 	siteId: number;
 }
 
-interface VisitResponse {
+interface VisitAPIResponse {
 	data: [ string, number ][];
 }
 
+type VisitResponse = number | 'loading' | 'disabled' | 'error';
+
 export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
 	const dispatch = useDispatch();
-	const [ visitsNumber, setVisitsNumber ] = useState< number | null >( null );
+	const [ visitsResponse, setVisitsResponse ] = useState< VisitResponse >( 'loading' );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const canViewStat = useSelector( ( state ) => canCurrentUser( state, siteId, 'publish_posts' ) );
 
 	const translate = useTranslate();
 
-	useEffect( () => {
+	const isEnablingStats = useSelector( ( state ) =>
+		isActivatingJetpackModule( state, siteId, 'stats' )
+	);
+
+	const fetchVisits = useCallback( () => {
 		// It's possible to go with `unit: month` and `quantity: 1` to get the last month's data
 		// but I tested thoroughly - it doesn't work for this case, since looks like it doesn't include the current (today) day,
 		// and additionally it provides extra info about previous month, if, for example, `date` is the first day of the month (e.g. "2024-07-01")
@@ -36,6 +46,9 @@ export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
 		// 2) It counts not calendar month, but 30 days from the "yesterday"
 		const todayDate = moment().format( 'YYYY-MM-DD' );
 		const numberOfDays = todayDate.split( '-' ).pop();
+
+		setVisitsResponse( 'loading' );
+
 		wpcom.req
 			.get( `/sites/${ siteId }/stats/visits`, {
 				unit: 'day',
@@ -44,35 +57,130 @@ export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
 				date: todayDate,
 				stat_fields: 'views',
 			} )
-			.then( ( result: VisitResponse ) => {
+			.then( ( result: VisitAPIResponse ) => {
 				const views = result.data.reduce(
 					( acc: number, [ , curr ]: [ string, number ] ) => acc + curr,
 					0
 				);
 
-				setVisitsNumber( views );
+				setVisitsResponse( views );
+			} )
+			.catch( ( e: Error ) => {
+				if ( e.name === 'InvalidBlogError' ) {
+					setVisitsResponse( 'disabled' );
+				} else {
+					setVisitsResponse( 'error' );
+				}
 			} );
 	}, [ siteId ] );
 
+	const hasModuleActive =
+		useSelector( ( state ) => isJetpackModuleActive( state, siteId, 'stats' ) ) ?? false;
+
+	useLayoutEffect( () => {
+		fetchVisits();
+	}, [ fetchVisits, hasModuleActive ] );
+
 	if ( ! canViewStat ) {
-		return;
+		return null;
 	}
 
 	const getSiteVisitsContent = () => {
-		if ( visitsNumber === 0 ) {
+		if ( visitsResponse === 'loading' ) {
+			return <LoadingPlaceholder className="hosting-overview__plan-site-visits-placeholder" />;
+		}
+
+		if ( visitsResponse === 'error' ) {
+			return translate( 'Error loading visits', {
+				comment: 'A message that the visits are not loaded',
+			} );
+		}
+
+		const visits = visitsResponse === 'disabled' ? 0 : visitsResponse;
+
+		if ( visits === 0 ) {
 			return translate( 'No visits so far this month', {
 				comment: 'A notice that the site has not yet received any visits during the current month',
 			} );
 		}
 
-		if ( ! visitsNumber ) {
-			return <LoadingPlaceholder className="hosting-overview__plan-site-visits-placeholder" />;
-		}
-
 		return translate( '%(visitCount)s this month', {
-			args: { visitCount: visitsNumber },
+			args: { visitCount: visits },
 			comment: 'A description of the number of visits the site has received in the current month',
 		} );
+	};
+
+	const getSiteVisitsCTA = () => {
+		if ( visitsResponse === 'disabled' ) {
+			return (
+				<Button
+					variant="link"
+					disabled={ !! isEnablingStats }
+					css={ { textDecoration: 'none !important', fontSize: 'inherit' } }
+					onClick={ async () => {
+						dispatch( recordTracksEvent( 'calypso_hosting_overview_visit_stats_enable_click' ) );
+
+						try {
+							await dispatch( activateModule( siteId, 'stats' ) );
+
+							dispatch(
+								recordTracksEvent( 'calypso_hosting_overview_visit_stats_enable_success' )
+							);
+
+							setVisitsResponse( 'loading' );
+						} catch ( e: unknown ) {
+							if ( e instanceof Error ) {
+								dispatch(
+									recordTracksEvent( 'calypso_hosting_overview_visit_stats_enable_error', {
+										error: e.message,
+									} )
+								);
+							}
+						}
+
+						dispatch( requestSite( siteId ) );
+					} }
+				>
+					{ isEnablingStats
+						? translate( 'Enabling stats…', {
+								comment: 'A message that stats are being enabled',
+						  } )
+						: translate( 'Enable stats', {
+								comment: 'A button that enables stats for the site',
+						  } ) }
+				</Button>
+			);
+		}
+
+		if ( visitsResponse === 'error' ) {
+			return (
+				<Button
+					variant="link"
+					css={ { textDecoration: 'none !important', fontSize: 'inherit' } }
+					onClick={ () => {
+						fetchVisits();
+						dispatch( recordTracksEvent( 'calypso_hosting_overview_visit_stats_try_again_click' ) );
+					} }
+				>
+					{ translate( 'Try again' ) }
+				</Button>
+			);
+		}
+
+		return (
+			<Button
+				variant="link"
+				css={ { textDecoration: 'none !important', fontSize: 'inherit' } }
+				href={ `/stats/month/${ siteSlug }` }
+				onClick={ () => {
+					dispatch( recordTracksEvent( 'calypso_hosting_overview_visit_stats_click' ) );
+				} }
+			>
+				{ translate( 'Visit stats', {
+					comment: 'A link taking the user to more detailed site statistics',
+				} ) }
+			</Button>
+		);
 	};
 
 	return (
@@ -88,16 +196,7 @@ export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
 				</div>
 			</div>
 			<div className="hosting-overview__plan-site-visits-content">{ getSiteVisitsContent() }</div>
-			<a
-				href={ `/stats/month/${ siteSlug }` }
-				onClick={ () => {
-					dispatch( recordTracksEvent( 'calypso_hosting_overview_visit_stats_click' ) );
-				} }
-			>
-				{ translate( 'Visit stats', {
-					comment: 'A link taking the user to more detailed site statistics',
-				} ) }
-			</a>
+			{ getSiteVisitsCTA() }
 		</div>
 	);
 }


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/9525.

## Proposed Changes

Takes into consideration the status of the Jetpack Stats module before showing the "View stats" link.


https://github.com/user-attachments/assets/5fbc218e-6e93-4f67-8831-87838c47c102



Lets the user enable the Stats module directly from the Overview page without needing to enter the Jetpack page directly.


## Testing Instructions

Visit the Blog Report Card and disable the "Site Stats" module. Go back to Calypso and click the "Enable stats" button. You should see the stats again.

To test a failure in enabling the stats, you can block the request within dev tools:

![image](https://github.com/user-attachments/assets/36f8633c-1a87-4920-8396-f2427a1ded8b)