### PR TITLE
Site setup flow: fix navigation in importer list

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -464,7 +464,7 @@ const siteSetupFlow: Flow = {
 						return exitFlow( providedDependencies?.url as string );
 					}
 
-					return navigate( providedDependencies?.url as string );
+					return navigate( addQueryArgs( { origin }, providedDependencies?.url as string ) );
 				}
 				case 'importReadyPreview': {
 					return navigate( providedDependencies?.url as string );
@@ -579,9 +579,9 @@ const siteSetupFlow: Flow = {
 						if ( urlQueryParams.get( 'ref' ) === MIGRATION_FLOW ) {
 							return goToFlow( backToFlow );
 						}
-						return navigate( `importList?siteSlug=${ siteSlug }&backToFlow=${ backToFlow }` );
+						return navigate( addQueryArgs( { origin, siteSlug, backToFlow }, 'importList' ) );
 					}
-					return navigate( `importList?siteSlug=${ siteSlug }` );
+					return navigate( addQueryArgs( { origin, siteSlug }, 'importList' ) );
 
 				case 'importerWordpress':
 					if ( backToFlow ) {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -464,7 +464,11 @@ const siteSetupFlow: Flow = {
 						return exitFlow( providedDependencies?.url as string );
 					}
 
-					return navigate( addQueryArgs( { origin }, providedDependencies?.url as string ) );
+					const url = providedDependencies?.url;
+					if ( typeof url === 'string' ) {
+						return navigate( addQueryArgs( { origin }, url ) );
+					}
+					return navigate( url as string );
 				}
 				case 'importReadyPreview': {
 					return navigate( providedDependencies?.url as string );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

[Related to #](https://github.com/Automattic/wp-calypso/issues/96919)

## Proposed Changes

Mantains the `origin` query arg when navigating through the Import List. This way, we always redirect to the correct place when clicking the WordPress importer.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See https://github.com/Automattic/wp-calypso/issues/96919


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start, create a free site
* Select the import intent
 * Click on pick your current platform from a list
* Select Blogger
* Press < Back
* Select WordPress
* Verify you see the migrate vs import step
<img width="729" alt="image" src="https://github.com/user-attachments/assets/22a1ea90-60d5-4665-a5f3-17b76026d48f">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
