### PR TITLE
Photos picker: Hide refresh button

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -469,6 +469,11 @@ export class MediaLibraryContent extends Component {
 				return null;
 			}
 
+			const hasRefreshButton =
+				'pexels' !== this.props.source &&
+				'openverse' !== this.props.source &&
+				! this.props.photosPickerApiEnabled;
+
 			return (
 				<MediaLibraryExternalHeader
 					onMediaScaleChange={ this.props.onMediaScaleChange }
@@ -481,7 +486,7 @@ export class MediaLibraryContent extends Component {
 					selectedItems={ this.props.selectedItems }
 					sticky={ ! this.props.scrollable }
 					hasAttribution={ 'pexels' === this.props.source }
-					hasRefreshButton={ 'pexels' !== this.props.source && 'openverse' !== this.props.source }
+					hasRefreshButton={ hasRefreshButton }
 					mediaScale={ this.props.mediaScale }
 					photosPickerApiEnabled={ this.props.photosPickerApiEnabled }
 					photosPickerSession={ this.props.photosPickerSession }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-36s-p2#comment-5914

## Proposed Changes

* Hide the refresh button if the Google Photos Picker is enabled

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's not a relevant feature for the picker context anymore

## Testing Instructions

* Make sure you have Google Photos Picker feature flag
* Go to the `Media` page
* Select "Google Photos" as source
* Make photos selection
* Check the header controls; refresh button should not be there anymore

| Before | After |
|--------|--------|
| <img width="846" alt="Screenshot 2024-11-29 at 17 26 57" src="https://github.com/user-attachments/assets/28a20602-94aa-412f-a898-8d4e80ef6543"> | <img width="851" alt="Screenshot 2024-11-29 at 17 27 07" src="https://github.com/user-attachments/assets/b2038c1c-bed9-4b0f-b08c-7289483b7541"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?