### PR TITLE
Performance Profiler: Add duration and test completed event to both versions

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -226,6 +226,7 @@ export const SitePerformance = () => {
 
 	useEffect( () => {
 		if ( performanceReport.isBasicMetricsFetched && performanceReport.url ) {
+			performance.mark( 'test-started' );
 			recordTracksEvent( 'calypso_performance_profiler_test_started', {
 				url: performanceReport.url,
 				version: profilerVersion(),
@@ -239,6 +240,7 @@ export const SitePerformance = () => {
 
 	const retestPage = () => {
 		recordTracksEvent( 'calypso_performance_profiler_test_again_click' );
+		performance.mark( 'test-started' );
 
 		performanceReport.testAgain().then( ( { data } ) => {
 			if ( data?.token && data.token !== currentPage?.wpcom_performance_report_url?.hash ) {

--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -11,6 +11,7 @@ import { NewsletterBanner } from 'calypso/performance-profiler/components/newsle
 import { PerformanceScore } from 'calypso/performance-profiler/components/performance-score';
 import { ScreenshotThumbnail } from 'calypso/performance-profiler/components/screenshot-thumbnail';
 import { ScreenshotTimeline } from 'calypso/performance-profiler/components/screenshot-timeline';
+import { useReportCompletedEffect } from 'calypso/performance-profiler/hooks/use-report-track-events-effect';
 import './style.scss';
 
 type PerformanceProfilerDashboardContentProps = {
@@ -53,6 +54,8 @@ export const PerformanceProfilerDashboardContent = ( {
 		fullPageScreenshot,
 	} = performanceReport;
 	const insightsRef = useRef< HTMLDivElement >( null );
+
+	useReportCompletedEffect( url, hash );
 
 	return (
 		<div className="performance-profiler-content">

--- a/client/performance-profiler/hooks/use-report-track-events-effect.ts
+++ b/client/performance-profiler/hooks/use-report-track-events-effect.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
+
+export const useReportCompletedEffect = ( url: string, hash: string ) => {
+	useEffect( () => {
+		if ( performance.getEntriesByName( 'test-started' ).length > 0 ) {
+			performance.mark( 'test-completed' );
+			const testMeasure = performance.measure( 'test-duration', 'test-started', 'test-completed' );
+			recordTracksEvent( 'calypso_performance_profiler_test_completed', {
+				url,
+				hash,
+				duration: testMeasure?.duration ?? undefined,
+				version: profilerVersion(),
+			} );
+		}
+	}, [ url, hash ] );
+};

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -28,7 +28,6 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 	const translate = useTranslate();
 	const { url, tab, hash, filter } = props;
 	const isSavedReport = useRef( !! hash );
-	const testStartTime = useRef( 0 );
 	const [ activeTab, setActiveTab ] = React.useState< TabType >( tab );
 	const {
 		data: basicMetrics,
@@ -49,11 +48,11 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 	const siteUrl = new URL( url );
 
 	if ( isFetched && finalUrl ) {
+		performance.mark( 'test-started' );
 		recordTracksEvent( 'calypso_performance_profiler_test_started', {
 			url: finalUrl,
 			version: profilerVersion(),
 		} );
-		testStartTime.current = Date.now();
 	}
 
 	// Append hash to the URL if it's not there to avoid losing it on page reload
@@ -80,16 +79,6 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 		activeTab === TabType.mobile
 			? ( mobileReport as PerformanceReport )
 			: ( desktopReport as PerformanceReport );
-
-	if ( testStartTime.current && desktopLoaded && mobileLoaded ) {
-		recordTracksEvent( 'calypso_performance_profiler_test_completed', {
-			url: siteUrl.href,
-			duration: Date.now() - testStartTime.current,
-			mobile_score: mobileReport?.overall_score,
-			desktop_score: desktopReport?.overall_score,
-			version: profilerVersion(),
-		} );
-	}
 
 	return (
 		<div className="peformance-profiler-dashboard-container">


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9321

## Proposed Changes

* Add a track event for test completion that also stores the duration
* Uses `performance.mark` and `performance.measure` to measure the duration of the tests

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To track the test duration

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch and navigate to the logged-out version of the Speed Test tool, `/speed-test`
* Run a test
* Check that the track event `calypso_performance_profiler_test_completed` contains a `duration` property
* Navigate to the logged-in version of the tool, `/sites/performance/:siteId` (with a correct site)
* Run a test or click on `Test again`
* Check that the track event `calypso_performance_profiler_test_completed` contains a `duration` property

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
