### PR TITLE
Domains: Hide "Remove domain" option for 100-year domains that have auto-renew turned off

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -73,7 +73,7 @@ import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import reinstallPlugins from 'calypso/data/marketplace/reinstall-plugins-api';
 import HundredYearPlanLogo from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/hundred-year-plan-logo';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { resolveDomainStatus } from 'calypso/lib/domains';
+import { getSelectedDomain, resolveDomainStatus } from 'calypso/lib/domains';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	getDomainRegistrationAgreementUrl,
@@ -133,7 +133,11 @@ import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain
 import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { useGetWebsiteContentQuery } from 'calypso/state/signup/steps/website-content/hooks/use-get-website-content-query';
-import { hasLoadedSiteDomains, getAllDomains } from 'calypso/state/sites/domains/selectors';
+import {
+	hasLoadedSiteDomains,
+	getAllDomains,
+	getDomainsBySiteId,
+} from 'calypso/state/sites/domains/selectors';
 import { getSite, getSiteSlug, isRequestingSites } from 'calypso/state/sites/selectors';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { CalypsoDispatch, IAppState } from 'calypso/state/types';
@@ -692,6 +696,10 @@ class ManagePurchase extends Component<
 		if ( isPlanPurchase ) {
 			text = translate( 'Remove plan' );
 		} else if ( isDomainRegistration( purchase ) ) {
+			// 100-year domains cannot be removed by the user
+			if ( this.isHundredYearDomain( purchase ) ) {
+				return null;
+			}
 			text = translate( 'Remove domain' );
 		}
 
@@ -1664,6 +1672,9 @@ export default connect( ( state: IAppState, props: ManagePurchaseProps ) => {
 	const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug ?? '' );
 	const primaryDomain = getPrimaryDomainBySiteId( state, siteId );
 	const currentRoute = getCurrentRoute( state );
+	const domains = purchase && getDomainsBySiteId( state, purchase.siteId );
+	const selectedDomainName = purchase && getName( purchase );
+	const selectedDomain = selectedDomainName && getSelectedDomain( { domains, selectedDomainName } );
 
 	return {
 		currentRoute,
@@ -1696,6 +1707,7 @@ export default connect( ( state: IAppState, props: ManagePurchaseProps ) => {
 		purchases,
 		relatedMonthlyPlanSlug,
 		renewableSitePurchases,
+		selectedDomain,
 		selectedSiteId,
 		site,
 		siteId,

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1674,7 +1674,8 @@ export default connect( ( state: IAppState, props: ManagePurchaseProps ) => {
 	const currentRoute = getCurrentRoute( state );
 	const domains = purchase && getDomainsBySiteId( state, purchase.siteId );
 	const selectedDomainName = purchase && getName( purchase );
-	const selectedDomain = selectedDomainName && getSelectedDomain( { domains, selectedDomainName } );
+	const selectedDomain =
+		domains && selectedDomainName && getSelectedDomain( { domains, selectedDomainName } );
 
 	return {
 		currentRoute,

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -168,6 +168,9 @@ function renderRenewsOrExpiresOnLabel( {
 } ): string | null {
 	if ( isExpiring( purchase ) ) {
 		if ( isDomainRegistration( purchase ) ) {
+			if ( domainDetails?.isHundredYearDomain ) {
+				return translate( 'Paid until' );
+			}
 			return translate( 'Domain expires on' );
 		}
 


### PR DESCRIPTION
## Proposed Changes

This PR hides the "Remove domain" option in the purchase settings page for 100-year domains that have auto-renew turned off.

100-year domains should never have auto-renew turned off, and D165092-code added checks on the backend to prevent that. Turning it off would enable the "Remove domain" option in the purchase settings page. Even if that situation should never occur, this PR guards against it.

This PR also replaces the "Domain expires on" label by "Paid until" for 100-year domains that are going to expire in 3 months or less.

This is a follow-up to #95907.

### Screenshots

| Before | After |
| --- | --- |
| ![Markup on 2024-11-29 at 17:31:33](https://github.com/user-attachments/assets/02ee2e0b-0de3-4f53-9349-3d67e2979fed) | ![Markup on 2024-11-29 at 17:30:55](https://github.com/user-attachments/assets/88ce9baa-1616-43ea-b37c-ac1cf1de2a26) |

## Why are these changes being made?

This protects against users canceling 100-year domains by mistake.

## Testing Instructions

- Build this branch locally or open the live Calypso link
- In the backend, apply the 100-year domain flag to a domain that has auto-renew turned off
- Open the purchase settings page for that domain
- Ensure it looks like the screenshot above, without the "Remove domain" option
- If the domain is going to expire in less than 3 months, it should also show "Paid until" instead of "Domain expires on"

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?