### PR TITLE
Fix punctuation on site logs

### DIFF
--- a/client/sites/tools/logs/components/site-logs-header/index.tsx
+++ b/client/sites/tools/logs/components/site-logs-header/index.tsx
@@ -27,7 +27,7 @@ export function SiteLogsHeader( { logType }: { logType: string } ) {
 			<NavigationHeader
 				title={ translate( 'Logs' ) }
 				subtitle={ translate(
-					'View and download various server logs. {{link}}Learn more.{{/link}}',
+					'View and download various server logs. {{link}}Learn more{{/link}}',
 					{
 						components: {
 							link: <InlineSupportLink supportContext="site-monitoring-logs" showIcon={ false } />,

--- a/client/sites/tools/monitoring/components/site-monitoring.tsx
+++ b/client/sites/tools/monitoring/components/site-monitoring.tsx
@@ -569,7 +569,7 @@ export const SiteMonitoring = ( { className }: { className?: string } ) => {
 							{ dateRange }
 						</>
 					}
-					subtitle={ translate( 'Monitor your site’s performance. {{link}}Learn more.{{/link}}', {
+					subtitle={ translate( 'Monitor your site’s performance. {{link}}Learn more{{/link}}', {
 						components: {
 							link: <InlineSupportLink supportContext="site-monitoring" showIcon={ false } />,
 						},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/orgs/Automattic/projects/391/views/12?pane=issue&itemId=88705139&issue=Automattic%7Cdotcom-forge%7C9962

## Proposed Changes

Removes a period from the Learn more link on the site logs and monitoring screens:

**Before**
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/cf2abe43-ed1f-418e-b2d3-3aef945b499e">

<img width="1196" alt="image" src="https://github.com/user-attachments/assets/005a48c8-11f5-4439-9a7d-29dfbd908cb0">


**After**

<img width="1183" alt="image" src="https://github.com/user-attachments/assets/67141c10-b456-4812-ae35-01b0f389953f">

<img width="1179" alt="image" src="https://github.com/user-attachments/assets/85ec1d38-9d9e-43dc-a821-39cc8c5f7249">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Visit the Site Logs ([https://wordpress.com/site-logs/{yourAtomicSite}`](https://wordpress.com/site-logs/%7ByourAtomicSite%7D%60)) and Site Monitoring (https://wordpress.com/site-monitoring/{yourAtomicSite}) pages on an Atomic site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
