### PR TITLE
Fix reverted sites flashing eligibility message when uploading a plugin

### DIFF
--- a/client/state/plugins/upload/reducer.js
+++ b/client/state/plugins/upload/reducer.js
@@ -78,7 +78,7 @@ export const inProgress = keyedReducer( 'siteId', ( state = {}, action ) => {
 			return true;
 		case AUTOMATED_TRANSFER_STATUS_SET: {
 			const { status } = action;
-			return status !== 'complete';
+			return status !== 'complete' && status !== 'reverted';
 		}
 	}
 


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/96915

## Proposed Changes
When a site is reverted and we access the marketplace plugin upload, the initial check for when a plugin upload is in progress returns `true` and so triggers the upload plugin page even though no upload is happening. This happens because when the `transfer_status` is set to `reverted` the `inProgress` redux reducer returns true as it currently only return `false` when the status is `complete`.

* set `inProgres` to false if the transfer status is either `complete` or `reverted`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix broken experience where an upload is triggered without the users action.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

_You can use these instructions on prod to verify the issue then apply the changes to verify the fix_

* Revert one of your current atomic sites.
* After revert go to `plugins/upload/siteSlug`
* Verify you see the eligibility message and it remained on screen until the user chooses to continue.

![image](https://github.com/user-attachments/assets/53a19466-53c8-46de-84c0-5dd532a0e2b3)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
