### PR TITLE
Makes add DNS record button primary

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-add-new-record-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new-record-button.tsx
@@ -17,8 +17,9 @@ function DnsAddNewRecordButton( { site, domain, isMobile }: DndAddNewRecordButto
 			borderless={ isMobile }
 			href={ domainManagementDnsAddRecord( site, domain, currentRoute ) }
 			className={ className }
+			primary
 		>
-			<Icon icon={ plus } viewBox="4 4 16 16" size={ 16 } />
+			<Icon className="add-record__icon" icon={ plus } viewBox="4 4 16 16" size={ 16 } />
 			{ ! isMobile && __( 'Add a record' ) }
 		</Button>
 	);

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -135,13 +135,13 @@ class DnsRecords extends Component {
 		);
 
 		const buttons = [
-			<DnsAddNewRecordButton
-				key="add-new-record-button"
+			<DnsImportBindFileButton
+				key="import-bind-file-button"
 				site={ selectedSite?.slug }
 				domain={ selectedDomainName }
 			/>,
-			<DnsImportBindFileButton
-				key="import-bind-file-button"
+			<DnsAddNewRecordButton
+				key="add-new-record-button"
 				site={ selectedSite?.slug }
 				domain={ selectedDomainName }
 			/>,

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -244,6 +244,14 @@ button.dns__breadcrumb-button {
 		display: flex;
 		justify-content: center;
 	}
+	.add-record__icon{
+		fill: var(--studio-gray-80);
+
+		@include break-large {
+			fill: var(--studio-white);
+			
+		}
+	}
 }
 
 .dns__breadcrumb-button {

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -249,7 +249,6 @@ button.dns__breadcrumb-button {
 
 		@include break-large {
 			fill: var(--studio-white);
-			
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9793

## Proposed Changes

Updates the Add DNS Record button to primary on the DNS records page.

**Before**
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/02f66efe-bb09-4a02-a26a-8de90714a621">


**After**
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d8c95695-d33d-4147-b18f-5de9a7405466">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit `/domains/manage/:site/dns/:url`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
