### PR TITLE
Photos picker: Update cookie expiration and supporting subdomains

### DIFF
--- a/client/jetpack-connect/persistence-utils.js
+++ b/client/jetpack-connect/persistence-utils.js
@@ -5,6 +5,7 @@ import { JETPACK_CONNECT_TTL_SECONDS } from 'calypso/state/jetpack-connect/const
 export const SESSION_STORAGE_SELECTED_PLAN = 'jetpack_connect_selected_plan';
 export const SESSION_STORAGE_SOURCE = 'jetpack_connect_source';
 export const GOOGLE_PHOTOS_PICKER_SESSION = 'google_photos_picker_session';
+export const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * Utilities for storing jetpack connect state that needs to persist across
@@ -73,7 +74,11 @@ export const retrieveSource = () => {
 };
 
 export const persistGooglePhotosPickerSessionCookie = ( sessionId ) => {
-	const options = { path: '/' };
+	const options = {
+		path: '/',
+		expires: new Date( Date.now() + SEVEN_DAYS_MS ),
+		domain: '.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' ),
+	};
 
 	document.cookie = cookie.serialize( GOOGLE_PHOTOS_PICKER_SESSION, sessionId, options );
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack/pull/40382

## Proposed Changes

* Update cookie `expiration` and `domain` options

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* `domain`: support subdomains
* `expire`: match picker session expiration time (7 days)

## Testing Instructions

- Make sure you have Google Photos Picker feature flag
- Go to the Media page
- Select "Google Photos" as source
- Make photos selection
- Check the cookie details

<img width="1728" alt="Screenshot 2024-12-01 at 22 55 44" src="https://github.com/user-attachments/assets/f0ef5a88-2ef4-4816-b135-712f0b561f26">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
