### PR TITLE
Photos picker: Update UX opening picker right after pressing "change selection" CTA

### DIFF
--- a/client/data/media/use-google-photos-picker-session-mutation.ts
+++ b/client/data/media/use-google-photos-picker-session-mutation.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import wp from 'calypso/lib/wp';
 import { setPhotoPickerSession } from 'calypso/state/media/actions';
@@ -17,7 +18,7 @@ export type PickerSession = {
 export function useCreateGooglePhotosPickerSessionMutation( queryOptions = {} ) {
 	const dispatch = useDispatch();
 
-	return useMutation( {
+	const mutation = useMutation( {
 		...queryOptions,
 		mutationFn: () =>
 			wp.req.post( {
@@ -28,6 +29,17 @@ export function useCreateGooglePhotosPickerSessionMutation( queryOptions = {} ) 
 			dispatch( setPhotoPickerSession( data ) );
 		},
 	} );
+
+	const { mutate } = mutation;
+
+	const createSession = useCallback(
+		( options = {} ) => {
+			mutate( undefined, options );
+		},
+		[ mutate ]
+	);
+
+	return { createSession, ...mutation };
 }
 
 export function useDeleteGooglePhotosPickerSessionMutation( queryOptions = {} ) {

--- a/client/data/media/with-google-photos-picker-session.js
+++ b/client/data/media/with-google-photos-picker-session.js
@@ -21,7 +21,7 @@ export const withGooglePhotosPickerSession = createHigherOrderComponent( ( Wrapp
 		const photosPickerSession = useSelector( ( state ) => getGooglePhotosPickerSession( state ) );
 
 		const { data: cachedSession } = useGooglePhotosPickerSessionQuery( cachedSessionId );
-		const { mutate: createPickerSession } = useCreateGooglePhotosPickerSessionMutation();
+		const { createSession, isPending } = useCreateGooglePhotosPickerSessionMutation();
 		const { mutate: deletePickerSession } = useDeleteGooglePhotosPickerSessionMutation();
 
 		useEffect( () => {
@@ -34,7 +34,8 @@ export const withGooglePhotosPickerSession = createHigherOrderComponent( ( Wrapp
 				photosPickerApiEnabled={ photosPickerApiEnabled }
 				photosPickerSession={ photosPickerSession }
 				deletePhotosPickerSession={ deletePickerSession }
-				createPhotosPickerSession={ createPickerSession }
+				createPhotosPickerSession={ createSession }
+				isCreatingPhotosPickerSession={ isPending }
 			/>
 		);
 	};

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -492,6 +492,7 @@ export class MediaLibraryContent extends Component {
 					photosPickerSession={ this.props.photosPickerSession }
 					createPhotosPickerSession={ this.props.createPhotosPickerSession }
 					deletePhotosPickerSession={ this.props.deletePhotosPickerSession }
+					isCreatingPhotosPickerSession={ this.props.isCreatingPhotosPickerSession }
 				/>
 			);
 		}

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -31,6 +31,7 @@ class MediaLibraryExternalHeader extends Component {
 		photosPickerApiEnabled: PropTypes.bool,
 		photosPickerSession: PropTypes.object,
 		createPhotosPickerSession: PropTypes.func,
+		isCreatingPhotosPickerSession: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -99,15 +100,21 @@ class MediaLibraryExternalHeader extends Component {
 			this.props;
 
 		deletePhotosPickerSession && deletePhotosPickerSession( photosPickerSession?.id );
-		createPhotosPickerSession && createPhotosPickerSession();
+		createPhotosPickerSession &&
+			createPhotosPickerSession( {
+				onSuccess: ( session ) => {
+					session?.pickerUri && window.open( session.pickerUri, '_blank' );
+				},
+			} );
 	};
 
 	renderChangeSelectionButton() {
-		const { photosPickerSession, translate } = this.props;
+		const { photosPickerSession, isCreatingPhotosPickerSession, translate } = this.props;
 
 		return (
 			<Button
 				compact
+				busy={ isCreatingPhotosPickerSession }
 				onClick={ this.onChangeSelection }
 				disable={ ! photosPickerSession?.mediaItemsSet }
 			>

--- a/client/my-sites/media-library/hook/use-google-photos-picker-session.ts
+++ b/client/my-sites/media-library/hook/use-google-photos-picker-session.ts
@@ -20,7 +20,7 @@ export default function useGooglePhotosPickerSession() {
 	const isSessionExpired =
 		session?.expireTime && moment( session.expireTime ).isBefore( new Date() );
 
-	const { mutate: createSession, isPending } = useCreateGooglePhotosPickerSessionMutation();
+	const { createSession, isPending } = useCreateGooglePhotosPickerSessionMutation();
 	const { data: sessionData, refetch } = useGooglePhotosPickerSessionQuery( session?.id );
 
 	// Create a new session if there is no session or the current session is expired


### PR DESCRIPTION
Related to pdtkmj-36s-p2#comment-5914

## Proposed Changes

* Update `createSession` mutation hook supporting custom callbacks
* Update UX: open picker right after pressing "change selection" CTA

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Optimize UX reducing the number of clicks

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you have the Google Photos Picker feature flag
* Go to the Media page
* Select "Google Photos" as the source
* Make photos selection
* Press the "Change selection" button
* Check if the button has a busy state
* Check if the picker is opened automatically in the new tab without need to press "Open Google Photos Picker" manually

<img width="821" alt="Screenshot 2024-12-02 at 00 24 04" src="https://github.com/user-attachments/assets/155f17f1-9d07-46de-8c23-38f792c800bd">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?