### PR TITLE
Add new stats/paid-wpcom-v3 flag and upsell

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -75,6 +75,7 @@ import StatsPeriodHeader from './stats-period-header';
 import StatsPeriodNavigation from './stats-period-navigation';
 import StatsPlanUsage from './stats-plan-usage';
 import statsStrings from './stats-strings';
+import StatsUpsell from './stats-upsell';
 import StatsUpsellModal from './stats-upsell-modal';
 import { getPathWithUpdatedQueryString } from './utils';
 
@@ -567,141 +568,147 @@ class StatsSite extends Component {
 						) }
 					</>
 
-					{ ! isOdysseyStats && <MiniCarousel slug={ slug } isSitePrivate={ isSitePrivate } /> }
+					{ ! config.isEnabled( 'stats/paid-wpcom-v3' ) && (
+						<>
+							{ ! isOdysseyStats && <MiniCarousel slug={ slug } isSitePrivate={ isSitePrivate } /> }
 
-					<div className={ moduleListClasses }>
-						<StatsModuleTopPosts
-							moduleStrings={ moduleStrings.posts }
-							period={ this.props.period }
-							query={ query }
-							summaryUrl={ this.getStatHref( 'posts', query ) }
-							className={ halfWidthModuleClasses }
-						/>
-						<StatsModuleReferrers
-							moduleStrings={ moduleStrings.referrers }
-							period={ this.props.period }
-							query={ query }
-							summaryUrl={ this.getStatHref( 'referrers', query ) }
-							className={ halfWidthModuleClasses }
-						/>
-
-						<StatsModuleCountries
-							moduleStrings={ moduleStrings.countries }
-							period={ this.props.period }
-							query={ query }
-							summaryUrl={ this.getStatHref( 'countryviews', query ) }
-							className={ clsx( 'stats__flexible-grid-item--full' ) }
-						/>
-
-						{ /* If UTM if supported display the module or update Jetpack plugin card */ }
-						{ supportsUTMStats && ! isOldJetpack && (
-							<StatsModuleUTM
-								siteId={ siteId }
-								period={ this.props.period }
-								query={ query }
-								summaryUrl={ this.getStatHref( 'utm', query ) }
-								summary={ false }
-								className={ halfWidthModuleClasses }
-							/>
-						) }
-
-						{ supportsUTMStats && isOldJetpack && (
-							<StatsModuleUTMOverlay
-								siteId={ siteId }
-								className={ halfWidthModuleClasses }
-								overlay={
-									<StatsCardUpdateJetpackVersion
-										className="stats-module__upsell stats-module__upgrade"
-										siteId={ siteId }
-										statType="utm"
-									/>
-								}
-							/>
-						) }
-
-						<StatsModuleClicks
-							moduleStrings={ moduleStrings.clicks }
-							period={ this.props.period }
-							query={ query }
-							summaryUrl={ this.getStatHref( 'clicks', query ) }
-							className={ halfWidthModuleClasses }
-						/>
-
-						{ ! this.isModuleHidden( 'authors' ) && (
-							<StatsModuleAuthors
-								moduleStrings={ moduleStrings.authors }
-								period={ this.props.period }
-								query={ query }
-								summaryUrl={ this.getStatHref( 'authors', query ) }
-								className={ halfWidthModuleClasses }
-							/>
-						) }
-
-						{ /* Either stacks with "Authors" or takes full width, depending on UTM and Authors visibility */ }
-						{ ! isNewDateFilteringEnabled && supportsEmailStats && (
-							<StatsModuleEmails
-								period={ this.props.period }
-								moduleStrings={ moduleStrings.emails }
-								query={ query }
-								summaryUrl={ this.getStatHref( 'emails', query ) }
-								className={ halfWidthModuleClasses }
-							/>
-						) }
-
-						<StatsModuleSearch
-							moduleStrings={ moduleStrings.search }
-							period={ this.props.period }
-							query={ query }
-							summaryUrl={ this.getStatHref( 'searchterms', query ) }
-							className={ halfWidthModuleClasses }
-						/>
-
-						{ ! this.isModuleHidden( 'videos' ) && (
-							<StatsModuleVideos
-								moduleStrings={ moduleStrings.videoplays }
-								period={ this.props.period }
-								query={ query }
-								summaryUrl={ this.getStatHref( 'videoplays', query ) }
-								className={ halfWidthModuleClasses }
-							/>
-						) }
-
-						{
-							// File downloads are not yet supported in Jetpack environment
-							! isJetpack && (
-								<StatsModuleDownloads
-									moduleStrings={ moduleStrings.filedownloads }
+							<div className={ moduleListClasses }>
+								<StatsModuleTopPosts
+									moduleStrings={ moduleStrings.posts }
 									period={ this.props.period }
 									query={ query }
-									summaryUrl={ this.getStatHref( 'filedownloads', query ) }
+									summaryUrl={ this.getStatHref( 'posts', query ) }
 									className={ halfWidthModuleClasses }
 								/>
-							)
-						}
+								<StatsModuleReferrers
+									moduleStrings={ moduleStrings.referrers }
+									period={ this.props.period }
+									query={ query }
+									summaryUrl={ this.getStatHref( 'referrers', query ) }
+									className={ halfWidthModuleClasses }
+								/>
 
-						{ supportsDevicesStats && ! isOldJetpack && (
-							<StatsModuleDevices
-								siteId={ siteId }
-								period={ this.props.period }
-								query={ query }
-								className={ halfWidthModuleClasses }
-							/>
-						) }
+								<StatsModuleCountries
+									moduleStrings={ moduleStrings.countries }
+									period={ this.props.period }
+									query={ query }
+									summaryUrl={ this.getStatHref( 'countryviews', query ) }
+									className={ clsx( 'stats__flexible-grid-item--full' ) }
+								/>
 
-						{ supportsDevicesStats && isOldJetpack && (
-							<StatsModuleUpgradeDevicesOverlay
-								className={ halfWidthModuleClasses }
-								siteId={ siteId }
-								overlay={
-									<StatsCardUpdateJetpackVersion
-										className="stats-module__upsell stats-module__upgrade"
+								{ /* If UTM if supported display the module or update Jetpack plugin card */ }
+								{ supportsUTMStats && ! isOldJetpack && (
+									<StatsModuleUTM
 										siteId={ siteId }
-										statType="devices"
+										period={ this.props.period }
+										query={ query }
+										summaryUrl={ this.getStatHref( 'utm', query ) }
+										summary={ false }
+										className={ halfWidthModuleClasses }
 									/>
+								) }
+
+								{ supportsUTMStats && isOldJetpack && (
+									<StatsModuleUTMOverlay
+										siteId={ siteId }
+										className={ halfWidthModuleClasses }
+										overlay={
+											<StatsCardUpdateJetpackVersion
+												className="stats-module__upsell stats-module__upgrade"
+												siteId={ siteId }
+												statType="utm"
+											/>
+										}
+									/>
+								) }
+
+								<StatsModuleClicks
+									moduleStrings={ moduleStrings.clicks }
+									period={ this.props.period }
+									query={ query }
+									summaryUrl={ this.getStatHref( 'clicks', query ) }
+									className={ halfWidthModuleClasses }
+								/>
+
+								{ ! this.isModuleHidden( 'authors' ) && (
+									<StatsModuleAuthors
+										moduleStrings={ moduleStrings.authors }
+										period={ this.props.period }
+										query={ query }
+										summaryUrl={ this.getStatHref( 'authors', query ) }
+										className={ halfWidthModuleClasses }
+									/>
+								) }
+
+								{ /* Either stacks with "Authors" or takes full width, depending on UTM and Authors visibility */ }
+								{ ! isNewDateFilteringEnabled && supportsEmailStats && (
+									<StatsModuleEmails
+										period={ this.props.period }
+										moduleStrings={ moduleStrings.emails }
+										query={ query }
+										summaryUrl={ this.getStatHref( 'emails', query ) }
+										className={ halfWidthModuleClasses }
+									/>
+								) }
+
+								<StatsModuleSearch
+									moduleStrings={ moduleStrings.search }
+									period={ this.props.period }
+									query={ query }
+									summaryUrl={ this.getStatHref( 'searchterms', query ) }
+									className={ halfWidthModuleClasses }
+								/>
+
+								{ ! this.isModuleHidden( 'videos' ) && (
+									<StatsModuleVideos
+										moduleStrings={ moduleStrings.videoplays }
+										period={ this.props.period }
+										query={ query }
+										summaryUrl={ this.getStatHref( 'videoplays', query ) }
+										className={ halfWidthModuleClasses }
+									/>
+								) }
+
+								{
+									// File downloads are not yet supported in Jetpack environment
+									! isJetpack && (
+										<StatsModuleDownloads
+											moduleStrings={ moduleStrings.filedownloads }
+											period={ this.props.period }
+											query={ query }
+											summaryUrl={ this.getStatHref( 'filedownloads', query ) }
+											className={ halfWidthModuleClasses }
+										/>
+									)
 								}
-							/>
-						) }
-					</div>
+
+								{ supportsDevicesStats && ! isOldJetpack && (
+									<StatsModuleDevices
+										siteId={ siteId }
+										period={ this.props.period }
+										query={ query }
+										className={ halfWidthModuleClasses }
+									/>
+								) }
+
+								{ supportsDevicesStats && isOldJetpack && (
+									<StatsModuleUpgradeDevicesOverlay
+										className={ halfWidthModuleClasses }
+										siteId={ siteId }
+										overlay={
+											<StatsCardUpdateJetpackVersion
+												className="stats-module__upsell stats-module__upgrade"
+												siteId={ siteId }
+												statType="devices"
+											/>
+										}
+									/>
+								) }
+							</div>
+						</>
+					) }
+
+					{ config.isEnabled( 'stats/paid-wpcom-v3' ) && <StatsUpsell siteId={ siteId } /> }
 				</div>
 				{ supportsPlanUsage && (
 					<StatsPlanUsage siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
@@ -709,7 +716,9 @@ class StatsSite extends Component {
 				{ ! shouldShowUpsells ? null : (
 					<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />
 				) }
-				<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
+				{ ! config.isEnabled( 'stats/paid-wpcom-v3' ) && (
+					<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
+				) }
 				{ supportUserFeedback && <StatsFeedbackController siteId={ siteId } /> }
 				<JetpackColophon />
 				<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -27,7 +27,10 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import StickyPanel from 'calypso/components/sticky-panel';
 import memoizeLast from 'calypso/lib/memoize-last';
-import { STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS } from 'calypso/my-sites/stats/constants';
+import {
+	STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS,
+	STAT_TYPE_REFERRERS,
+} from 'calypso/my-sites/stats/constants';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import {
 	recordGoogleEvent,
@@ -304,6 +307,7 @@ class StatsSite extends Component {
 			shouldForceDefaultDateRange,
 			supportUserFeedback,
 			momentSiteZone,
+			wpcomShowUpsell,
 		} = this.props;
 		const isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' ) || isInternal;
 		let defaultPeriod = PAST_SEVEN_DAYS;
@@ -568,7 +572,7 @@ class StatsSite extends Component {
 						) }
 					</>
 
-					{ ! config.isEnabled( 'stats/paid-wpcom-v3' ) && (
+					{ ! wpcomShowUpsell && (
 						<>
 							{ ! isOdysseyStats && <MiniCarousel slug={ slug } isSitePrivate={ isSitePrivate } /> }
 
@@ -708,7 +712,7 @@ class StatsSite extends Component {
 						</>
 					) }
 
-					{ config.isEnabled( 'stats/paid-wpcom-v3' ) && <StatsUpsell siteId={ siteId } /> }
+					{ wpcomShowUpsell && <StatsUpsell siteId={ siteId } /> }
 				</div>
 				{ supportsPlanUsage && (
 					<StatsPlanUsage siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
@@ -869,6 +873,9 @@ export default connect(
 			siteId,
 			STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS
 		);
+		const wpcomShowUpsell =
+			config.isEnabled( 'stats/paid-wpcom-v3' ) &&
+			shouldGateStats( state, siteId, STAT_TYPE_REFERRERS );
 
 		return {
 			canUserViewStats,
@@ -892,6 +899,7 @@ export default connect(
 			isOldJetpack,
 			shouldForceDefaultDateRange,
 			momentSiteZone: getMomentSiteZone( state, siteId ),
+			wpcomShowUpsell,
 		};
 	},
 	{

--- a/client/my-sites/stats/stats-upsell/index.tsx
+++ b/client/my-sites/stats/stats-upsell/index.tsx
@@ -10,7 +10,6 @@ import { useTranslate } from 'i18n-calypso';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { useSelector } from 'calypso/state';
-import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getUpsellModalStatType } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -32,9 +31,6 @@ export default function StatsUpsell( { siteId }: { siteId: number } ) {
 	const isLoading = plans.isLoading || ! pricing;
 	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
 	const eventPrefix = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-	const isSimpleClassic = useSelector( ( state ) =>
-		getSiteOption( state, selectedSiteId, 'is_wpcom_simple' )
-	);
 	const statType = useSelector( ( state ) => getUpsellModalStatType( state, siteId ) );
 
 	const onClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
@@ -42,11 +38,10 @@ export default function StatsUpsell( { siteId }: { siteId: number } ) {
 		recordTracksEvent( `${ eventPrefix }_stats_upsell_submit`, {
 			stat_type: statType,
 		} );
-		if ( isSimpleClassic ) {
+		if ( isOdysseyStats ) {
 			const checkoutProductUrl = new URL(
 				`https://wordpress.com/checkout/${ siteSlug }/${ PLAN_PREMIUM }`
 			);
-			checkoutProductUrl.searchParams.set( 'redirect_to', window.location.href );
 			window.open( checkoutProductUrl, '_self' );
 		} else {
 			page( `/checkout/${ siteSlug }/${ plan?.pathSlug ?? 'premium' }` );

--- a/client/my-sites/stats/stats-upsell/index.tsx
+++ b/client/my-sites/stats/stats-upsell/index.tsx
@@ -1,0 +1,157 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
+import { Gridicon, PlanPrice } from '@automattic/components';
+import { Plans } from '@automattic/data-stores';
+import formatCurrency from '@automattic/format-currency';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
+import { useSelector } from 'calypso/state';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getUpsellModalStatType } from 'calypso/state/stats/paid-stats-upsell/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+export default function StatsUpsell( { siteId }: { siteId: number } ) {
+	const translate = useTranslate();
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const plans = Plans.usePlans( { coupon: undefined } );
+	const plan = plans?.data?.[ PLAN_PREMIUM ];
+	const pricing = Plans.usePricingMetaForGridPlans( {
+		planSlugs: [ PLAN_PREMIUM ],
+		siteId: selectedSiteId,
+		coupon: undefined,
+		useCheckPlanAvailabilityForPurchase,
+		storageAddOns: null,
+	} )?.[ PLAN_PREMIUM ];
+	const isLoading = plans.isLoading || ! pricing;
+	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
+	const eventPrefix = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+	const isSimpleClassic = useSelector( ( state ) =>
+		getSiteOption( state, selectedSiteId, 'is_wpcom_simple' )
+	);
+	const statType = useSelector( ( state ) => getUpsellModalStatType( state, siteId ) );
+
+	const onClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
+		event.preventDefault();
+		recordTracksEvent( `${ eventPrefix }_stats_upsell_submit`, {
+			stat_type: statType,
+		} );
+		if ( isSimpleClassic ) {
+			const checkoutProductUrl = new URL(
+				`https://wordpress.com/checkout/${ siteSlug }/${ PLAN_PREMIUM }`
+			);
+			checkoutProductUrl.searchParams.set( 'redirect_to', window.location.href );
+			window.open( checkoutProductUrl, '_self' );
+		} else {
+			page( `/checkout/${ siteSlug }/${ plan?.pathSlug ?? 'premium' }` );
+		}
+	};
+
+	return (
+		<div className="stats-upsell">
+			<TrackComponentView
+				eventName={ `${ eventPrefix }_stats_upsell_view` }
+				eventProperties={ {
+					stat_type: statType,
+				} }
+			/>
+			<div className="stats-upsell__content">
+				<div className="stats-upsell__left">
+					<h1 className="stats-upsell__title">{ translate( 'Grow faster with Jetpack Stats' ) }</h1>
+					<div className="stats-upsell__text">
+						{ translate( 'Finesse your scaling-up strategy with detailed insights and data.' ) }
+					</div>
+					<Button
+						variant="primary"
+						className="stats-upsell__button"
+						onClick={ onClick }
+						disabled={ isLoading }
+					>
+						{ ! plan?.productNameShort
+							? translate( 'Upgrade plan' )
+							: translate( 'Upgrade to %(planName)s', {
+									args: { planName: plan.productNameShort },
+							  } ) }
+					</Button>
+				</div>
+				<div className="stats-upsell__right">
+					<h2 className="stats-upsell__plan">
+						{ ! plan?.productNameShort
+							? ''
+							: translate( '%(planName)s plan', { args: { planName: plan.productNameShort } } ) }
+					</h2>
+					{ pricing && (
+						<div className="stats-upsell__price-amount">
+							<PlanPrice
+								className="screen-upsell__plan-price"
+								currencyCode={ pricing.currencyCode }
+								rawPrice={ pricing.discountedPrice.monthly ?? pricing.originalPrice.monthly }
+								displayPerMonthNotation={ false }
+								isLargeCurrency
+								isSmallestUnit
+							/>
+						</div>
+					) }
+					<div className="stats-upsell__price-per-month">
+						{ ! pricing
+							? ''
+							: translate( 'per month, %(planPrice)s billed yearly', {
+									args: {
+										planPrice: formatCurrency(
+											pricing.discountedPrice.full ?? pricing.originalPrice.full ?? 0,
+											pricing.currencyCode ?? '',
+											{
+												stripZeros: true,
+												isSmallestUnit: true,
+											}
+										),
+									},
+							  } ) }
+					</div>
+					<div className="stats-upsell__features">
+						<div className="stats-upsell__feature">
+							<Gridicon icon="checkmark" size={ 18 } />
+							<div className="stats-upsell__feature-text">
+								{ translate(
+									'All stats available: traffic trends, sources, optimal time to post…'
+								) }
+							</div>
+						</div>
+						<div className="stats-upsell__feature">
+							<Gridicon icon="checkmark" size={ 18 } />
+							<div className="stats-upsell__feature-text">
+								{ translate( 'Download data as CSV' ) }
+							</div>
+						</div>
+						<div className="stats-upsell__feature">
+							<Gridicon icon="checkmark" size={ 18 } />
+							<div className="stats-upsell__feature-text">
+								{ translate( 'Instant access to upcoming features' ) }
+							</div>
+						</div>
+						<div className="stats-upsell__feature">
+							<Gridicon icon="checkmark" size={ 18 } />
+							<div className="stats-upsell__feature-text">
+								{ translate( '14-day money-back guarantee' ) }
+							</div>
+						</div>
+						<div className="stats-upsell__feature">
+							<Gridicon icon="checkmark" size={ 18 } />
+							<div className="stats-upsell__feature-text">
+								{ translate( 'All %(planName)s plan features', {
+									args: { planName: plan?.productNameShort ?? '' },
+								} ) }
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/stats/stats-upsell/style.scss
+++ b/client/my-sites/stats/stats-upsell/style.scss
@@ -1,0 +1,114 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.stats-upsell {
+	max-width: 375px;
+	margin: auto;
+	background: var(--studio-gray-0);
+	@include break-medium {
+		max-width: 700px;
+	}
+	.components-modal__content {
+		padding: 0;
+	}
+
+	.stats-upsell__close-button {
+		position: absolute;
+		top: 16px;
+		right: 16px;
+	}
+
+	.stats-upsell__content {
+		display: flex;
+		align-items: flex-start;
+
+		flex-direction: column;
+		@include break-medium {
+			flex-direction: row;
+		}
+	}
+	.stats-upsell__left,
+	.stats-upsell__right {
+		display: flex;
+		padding: 40px;
+		flex-direction: column;
+		align-self: stretch;
+		align-items: flex-start;
+
+		min-width: 279px;
+	}
+
+	.stats-upsell__left {
+		background: var(--studio-white);
+		gap: 24px;
+		@include break-medium {
+			flex: 1;
+		}
+	}
+
+	.stats-upsell__right {
+
+		gap: 8px;
+		@include break-medium {
+			flex: 1;
+		}
+	}
+
+	.stats-upsell__title {
+		@extend .wp-brand-font;
+		/* stylelint-disable declaration-property-unit-allowed-list -- typography-exception */
+		font-size: 28px;
+		line-height: 34px; /* 125% */
+		@include break-medium {
+			font-size: $font-title-large;
+			line-height: 40px; /* 125% */
+		}
+	}
+
+	.stats-upsell__text {
+		font-size: $font-body;
+	}
+
+	.stats-upsell__plan {
+		font-size: $font-title-small;
+		font-weight: 600;
+	}
+	.stats-upsell__price-amount {
+		display: flex;
+		align-items: center;
+		font-size: $font-title-large;
+		font-weight: 500;
+
+		abbr {
+			font-size: $font-title-small;
+			line-height: $font-title-large;
+			font-weight: 400;
+		}
+	}
+	.stats-upsell__price-per-month {
+		font-size: $font-body-extra-small;
+		color: var(--color-neutral);
+	}
+
+	.stats-upsell__features {
+		padding-top: 7px;
+		font-size: $font-body-small;
+		display: flex;
+		flex-direction: column;
+		row-gap: 8px;
+
+		svg {
+			color: #0675c4;
+		}
+
+		.stats-upsell__feature {
+			display: flex;
+			column-gap: 8px;
+
+			.stats-upsell__feature-text {
+				flex: 1;
+			}
+		}
+	}
+}

--- a/config/development.json
+++ b/config/development.json
@@ -221,6 +221,7 @@
 		"stats/empty-module-v2": true,
 		"stats/new-date-filtering": false,
 		"stats/paid-wpcom-v2": true,
+		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -185,6 +185,7 @@
 		"stats/empty-module-v2": true,
 		"stats/new-date-filtering": false,
 		"stats/paid-wpcom-v2": true,
+		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION
Related to # p1HpG7-v7f-p2#comment-74882

## Proposed Changes

- Copies the [existing stats modal](https://github.com/Automattic/wp-calypso/blob/82549a6b87257170a8cd389ee0ac9793355b7d74/client/my-sites/stats/stats-upsell-modal/index.tsx#L22) and inlines it. 
- Enabled on dev and wpcalypso (calypso.live) for further iteration.

## Testing Instructions

* Visit stats traffic page: http://calypso.localhost:3000/stats/day/sitetest603.wordpress.com
* Observe the new upsell below the main traffic graph
* Observe the old upsells and promos being hidden
* Observe the old behavior when removing the flag: http://calypso.localhost:3000/stats/day/sitetest603.wordpress.com?flags=-stats/paid-wpcom-v3

![Screenshot(149)](https://github.com/user-attachments/assets/9755251e-cf1f-41b3-bb68-7fabec5610e3)

