### PR TITLE
Stats: Swap date display date range and title

### DIFF
--- a/client/components/date-control/index.tsx
+++ b/client/components/date-control/index.tsx
@@ -16,7 +16,6 @@ const DateControl = ( {
 	onDateControlClick,
 	tooltip,
 	dateRange,
-	shortcutList,
 	overlay,
 	// Temporary prop to enable new date filtering UI.
 	isNewDateFilteringEnabled = false,
@@ -24,49 +23,23 @@ const DateControl = ( {
 	const moment = useLocalizedMoment();
 	const siteToday = useMomentSiteZone();
 
-	const getShortcutForRange = () => {
-		// Search the shortcut array for something matching the current date range.
-		// Returns shortcut or null;
-		const today = siteToday.format( 'YYYY-MM-DD' );
-		const yesterday = siteToday.clone().subtract( 1, 'days' ).format( 'YYYY-MM-DD' );
-		const shortcut = shortcutList.find( ( element ) => {
-			if (
-				yesterday === dateRange.chartEnd &&
-				dateRange.daysInRange === element.range + 1 &&
-				element.id === 'yesterday'
-			) {
-				return element;
-			}
-			if ( today === dateRange.chartEnd && dateRange.daysInRange === element.range + 1 ) {
-				return element;
-			}
-			return null;
-		} );
-		return shortcut;
-	};
-
 	const getButtonLabel = () => {
-		// Test for a shortcut match.
-		const shortcut = getShortcutForRange();
-		if ( shortcut ) {
-			return shortcut.label;
-		}
-
-		// Generate a full date range for the label.
 		const localizedStartDate = moment( dateRange.chartStart );
 		const localizedEndDate = moment( dateRange.chartEnd );
 
 		// If it's the same day, show single date.
 		if ( localizedStartDate.isSame( localizedEndDate, 'day' ) ) {
-			return localizedStartDate.isSame( moment(), 'year' )
-				? localizedStartDate.format( 'MMM D' )
-				: localizedStartDate.format( 'll' );
+			return localizedStartDate.format( 'LL' );
 		}
 
-		if ( localizedStartDate.year() === localizedEndDate.year() ) {
-			return `${ localizedStartDate.format( 'MMM D' ) } - ${ localizedEndDate.format( `MMM D` ) }${
-				localizedStartDate.isSame( moment(), 'year' ) ? '' : localizedEndDate.format( ', YYYY' ) // Only append year if it's not the current year.
-			}`;
+		// Only show year for the second date.
+		if (
+			localizedStartDate.year() === localizedEndDate.year() &&
+			localizedStartDate.isSame( moment(), 'year' )
+		) {
+			return `${ localizedStartDate.format( 'MMM D' ) } - ${ localizedEndDate.format(
+				`MMM D, YYYY`
+			) }`;
 		}
 
 		return `${ localizedStartDate.format( 'll' ) } - ${ localizedEndDate.format( 'll' ) }`;

--- a/client/components/date-control/types.d.ts
+++ b/client/components/date-control/types.d.ts
@@ -41,8 +41,9 @@ interface DateControlPickerShortcut {
 	offset: number;
 	range: number;
 	period: string;
-	statType: string;
-	isGated: boolean;
+	statType?: string;
+	isGated?: boolean;
+	shortcutId?: string;
 }
 
 interface DateControlPickerDateProps {

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -1,16 +1,10 @@
 import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
 import moment, { Moment } from 'moment';
 import PropTypes from 'prop-types';
 import useMomentSiteZone from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
-
-const DATERANGE_PERIOD = {
-	DAY: 'day',
-	WEEK: 'week',
-	MONTH: 'month',
-};
+import { useShortcuts } from './use-shortcuts';
 
 type MomentOrNull = Moment | null;
 
@@ -32,7 +26,6 @@ const DateRangePickerShortcuts = ( {
 	endDate?: MomentOrNull;
 	isNewDateFilteringEnabled?: boolean;
 } ) => {
-	const translate = useTranslate();
 	const siteToday = useMomentSiteZone();
 
 	const normalizeDate = ( date: MomentOrNull ) => {
@@ -43,90 +36,15 @@ const DateRangePickerShortcuts = ( {
 	const normalizedStartDate = startDate ? normalizeDate( startDate ) : null;
 	const normalizedEndDate = endDate ? normalizeDate( endDate ) : null;
 
-	// TODO: Receive this list from the parent component.
-	const shortcutList = [
+	const { supportedShortcutList: shortcutList, selectedShortcut } = useShortcuts(
 		{
-			id: 'last_7_days',
-			label: translate( 'Last 7 Days' ),
-			offset: 0,
-			range: 6,
-			period: DATERANGE_PERIOD.DAY,
-			shortcutId: 'last_7_days',
+			chartStart: normalizedStartDate?.format( 'YYYY-MM-DD' ) ?? '',
+			chartEnd: normalizedEndDate?.format( 'YYYY-MM-DD' ) ?? '',
+			daysInRange: normalizedEndDate?.diff( normalizedStartDate, 'days' ) ?? 0,
 		},
-		{
-			id: 'last_30_days',
-			label: translate( 'Last 30 Days' ),
-			offset: 0,
-			range: 29,
-			period: DATERANGE_PERIOD.DAY,
-			shortcutId: 'last_30_days',
-		},
-		{
-			id: 'last_3_months',
-			label: translate( 'Last 90 Days' ),
-			offset: 0,
-			range: 89,
-			period: DATERANGE_PERIOD.WEEK,
-			shortcutId: 'last_3_months',
-		},
-		{
-			id: 'last_year',
-			label: translate( 'Last Year' ),
-			offset: 0,
-			range: 364, // ranges are zero based!
-			period: DATERANGE_PERIOD.MONTH,
-			shortcutId: 'last_year',
-		},
-		{
-			id: 'custom_date_range',
-			label: translate( 'Custom Range' ),
-			offset: 0,
-			range: 0,
-			period: DATERANGE_PERIOD.DAY,
-			shortcutId: 'custom_date_range',
-		},
-	];
-
-	if ( isNewDateFilteringEnabled ) {
-		shortcutList.unshift(
-			{
-				id: 'today',
-				label: translate( 'Today' ),
-				offset: 0,
-				range: 0,
-				period: DATERANGE_PERIOD.DAY,
-				shortcutId: 'today',
-			},
-			{
-				id: 'yesterday',
-				label: translate( 'Yesterday' ),
-				offset: 1,
-				range: 0,
-				period: DATERANGE_PERIOD.DAY,
-				shortcutId: 'yesterday',
-			}
-		);
-	}
-
-	const getShortcutForRange = ( startDate: MomentOrNull, endDate: MomentOrNull ) => {
-		if ( ! startDate || ! endDate ) {
-			return null;
-		}
-		// Search the shortcut array for something matching the current date range.
-		// Returns shortcut or null;
-		const today = siteToday.clone().startOf( 'day' );
-		const daysInRange = Math.abs( endDate.diff( startDate, 'days' ) );
-		const shortcut = shortcutList.find( ( element ) => {
-			if (
-				( endDate.isSame( today, 'day' ) || element.offset === 1 ) &&
-				daysInRange === element.range
-			) {
-				return element;
-			}
-			return null;
-		} );
-		return shortcut;
-	};
+		undefined,
+		isNewDateFilteringEnabled
+	);
 
 	const handleClick = ( { id, offset, range }: { id?: string; offset: number; range: number } ) => {
 		const newToDate = siteToday.clone().startOf( 'day' ).subtract( offset, 'days' );
@@ -142,10 +60,7 @@ const DateRangePickerShortcuts = ( {
 		}
 	};
 
-	currentShortcut =
-		currentShortcut ||
-		getShortcutForRange( normalizedStartDate, normalizedEndDate )?.id ||
-		'custom_date_range';
+	currentShortcut = currentShortcut || selectedShortcut?.id || 'custom_date_range';
 
 	return (
 		<div className="date-range-picker-shortcuts__inner">

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -40,7 +40,7 @@ const DateRangePickerShortcuts = ( {
 		{
 			chartStart: normalizedStartDate?.format( 'YYYY-MM-DD' ) ?? '',
 			chartEnd: normalizedEndDate?.format( 'YYYY-MM-DD' ) ?? '',
-			daysInRange: normalizedEndDate?.diff( normalizedStartDate, 'days' ) ?? 0,
+			daysInRange: ( normalizedEndDate?.diff( normalizedStartDate, 'days' ) ?? 0 ) + 1,
 		},
 		undefined,
 		isNewDateFilteringEnabled

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -110,6 +110,7 @@ export function getShortcuts(
 			}
 			return null;
 		} );
+
 		return shortcut;
 	};
 

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -1,0 +1,133 @@
+import config from '@automattic/calypso-config';
+import { translate, useTranslate } from 'i18n-calypso';
+import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { DateControlPickerShortcut } from '../date-control/types';
+
+export const DATERANGE_PERIOD = {
+	DAY: 'day',
+	WEEK: 'week',
+	MONTH: 'month',
+};
+
+export function getShortcuts(
+	state: object,
+	dateRange: {
+		chartStart: string;
+		chartEnd: string;
+		daysInRange: number;
+	},
+	shortcutList?: string[],
+	translateFunction = translate,
+	isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' )
+) {
+	const siteId = getSelectedSiteId( state );
+	const siteToday = getMomentSiteZone( state, siteId );
+
+	const supportedShortcutList: DateControlPickerShortcut[] = [
+		{
+			id: 'last_7_days',
+			label: translateFunction( 'Last 7 Days' ),
+			offset: 0,
+			range: 6,
+			period: DATERANGE_PERIOD.DAY,
+			shortcutId: 'last_7_days',
+		},
+		{
+			id: 'last_30_days',
+			label: translateFunction( 'Last 30 Days' ),
+			offset: 0,
+			range: 29,
+			period: DATERANGE_PERIOD.DAY,
+			shortcutId: 'last_30_days',
+		},
+		{
+			id: 'last_3_months',
+			label: translateFunction( 'Last 90 Days' ),
+			offset: 0,
+			range: 89,
+			period: DATERANGE_PERIOD.WEEK,
+			shortcutId: 'last_3_months',
+		},
+		{
+			id: 'last_year',
+			label: translateFunction( 'Last Year' ),
+			offset: 0,
+			range: 364, // ranges are zero based!
+			period: DATERANGE_PERIOD.MONTH,
+			shortcutId: 'last_year',
+		},
+		{
+			id: 'custom_date_range',
+			label: translateFunction( 'Custom Range' ),
+			offset: 0,
+			range: 0,
+			period: DATERANGE_PERIOD.DAY,
+			shortcutId: 'custom_date_range',
+		},
+	];
+
+	if ( isNewDateFilteringEnabled ) {
+		supportedShortcutList.unshift(
+			{
+				id: 'today',
+				label: translateFunction( 'Today' ),
+				offset: 0,
+				range: 0,
+				period: DATERANGE_PERIOD.DAY,
+				shortcutId: 'today',
+			},
+			{
+				id: 'yesterday',
+				label: translateFunction( 'Yesterday' ),
+				offset: 1,
+				range: 0,
+				period: DATERANGE_PERIOD.DAY,
+				shortcutId: 'yesterday',
+			}
+		);
+	}
+
+	const getShortcutForRange = () => {
+		if ( ! dateRange?.chartEnd || ! dateRange?.chartStart ) {
+			return null;
+		}
+		// Search the shortcut array for something matching the current date range.
+		// Returns shortcut or null;
+		const today = siteToday.format( 'YYYY-MM-DD' );
+		const yesterday = siteToday.clone().subtract( 1, 'days' ).format( 'YYYY-MM-DD' );
+		const shortcut = supportedShortcutList.find( ( element ) => {
+			if (
+				yesterday === dateRange.chartEnd &&
+				dateRange.daysInRange === element.range + 1 &&
+				element.id === 'yesterday'
+			) {
+				return element;
+			}
+			if ( today === dateRange.chartEnd && dateRange.daysInRange === element.range + 1 ) {
+				return element;
+			}
+			return null;
+		} );
+		return shortcut;
+	};
+
+	return {
+		selectedShortcut: getShortcutForRange(),
+		supportedShortcutList,
+	};
+}
+
+export function useShortcuts(
+	dateRange: { chartStart: string; chartEnd: string; daysInRange: number },
+	shortcutList?: string[],
+	isNewDateFilteringEnabled = false
+) {
+	const translate = useTranslate();
+	const shortcuts = useSelector( ( state ) =>
+		getShortcuts( state, dateRange, shortcutList, translate, isNewDateFilteringEnabled )
+	);
+
+	return shortcuts;
+}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -497,6 +497,7 @@ class StatsSite extends Component {
 									showQueryDate
 									isShort
 									dateRange={ customChartRange }
+									isNewDateFilteringEnabled // @TODO:remove this prop once we release new date filtering
 								/>
 							</StatsPeriodNavigation>
 						</StatsPeriodHeader>
@@ -530,6 +531,7 @@ class StatsSite extends Component {
 										statsType="statsTopPosts"
 										showQueryDate
 										isShort
+										isNewDateFilteringEnabled={ false }
 									/>
 								</StatsPeriodNavigation>
 							</StatsPeriodHeader>

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -173,9 +173,10 @@ class StatsDatePicker extends Component {
 
 	render() {
 		/* eslint-disable wpcalypso/jsx-classname-namespace*/
-		const { summary, translate, query, showQueryDate, isActivity, isShort, dateRange } = this.props;
+		const { summary, translate, query, showQueryDate, isActivity, isShort, dateRange, reduxState } =
+			this.props;
 		const isSummarizeQuery = get( query, 'summarize' );
-		const { selectedShortcut } = getShortcuts( this.props.state, dateRange, undefined, translate );
+		const { selectedShortcut } = getShortcuts( reduxState, dateRange, undefined, translate );
 
 		let sectionTitle = isActivity
 			? translate( '{{prefix}}Activity for {{/prefix}}{{period/}}', {
@@ -241,7 +242,7 @@ const connectComponent = connect( ( state, { query, statsType, showQueryDate } )
 		requesting: showQueryDate
 			? isRequestingSiteStatsForQuery( state, siteId, statsType, query )
 			: false,
-		state,
+		reduxState: state,
 	};
 } );
 

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -3,6 +3,7 @@ import { flowRight, get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { getShortcuts } from 'calypso/components/date-range/use-shortcuts';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	getSiteStatsQueryDate,
@@ -59,12 +60,15 @@ class StatsDatePicker extends Component {
 	dateForCustomRange( startDate, endDate ) {
 		const { moment } = this.props;
 
+		// Generate a full date range for the label.
 		const localizedStartDate = moment( startDate );
 		const localizedEndDate = moment( endDate );
 
 		// If it's the same day, show single date.
 		if ( localizedStartDate.isSame( localizedEndDate, 'day' ) ) {
-			return localizedStartDate.format( 'LL' );
+			return localizedStartDate.isSame( moment(), 'year' )
+				? localizedStartDate.format( 'MMM D' )
+				: localizedStartDate.format( 'll' );
 		}
 
 		// If it's a full month.
@@ -85,20 +89,20 @@ class StatsDatePicker extends Component {
 			return localizedStartDate.format( 'YYYY' );
 		}
 
-		// Only show year for the second date.
-		if (
-			localizedStartDate.year() === localizedEndDate.year() &&
-			localizedStartDate.isSame( moment(), 'year' )
-		) {
-			return `${ localizedStartDate.format( 'MMM D' ) } - ${ localizedEndDate.format(
-				`MMM D, YYYY`
-			) }`;
+		if ( localizedStartDate.year() === localizedEndDate.year() ) {
+			return `${ localizedStartDate.format( 'MMM D' ) } - ${ localizedEndDate.format( `MMM D` ) }${
+				localizedStartDate.isSame( moment(), 'year' ) ? '' : localizedEndDate.format( ', YYYY' ) // Only append year if it's not the current year.
+			}`;
 		}
 
 		return `${ localizedStartDate.format( 'll' ) } - ${ localizedEndDate.format( 'll' ) }`;
 	}
 
-	dateForDisplay() {
+	dateForDisplay( selectedShortcut = null ) {
+		if ( selectedShortcut?.label && selectedShortcut?.id !== 'custom_date_range' ) {
+			return selectedShortcut.label;
+		}
+
 		const { date, moment, period, translate, isShort, dateRange } = this.props;
 		const weekPeriodFormat = isShort ? 'll' : 'LL';
 
@@ -139,24 +143,22 @@ class StatsDatePicker extends Component {
 		return formattedDate;
 	}
 
-	// TODO: need the align today with site timezone.
 	renderQueryDate() {
 		const { query, queryDate, moment, translate } = this.props;
 
-		if ( ! queryDate || ! isAutoRefreshAllowedForQuery( query ) ) {
-			return null;
+		let content = '';
+		if ( queryDate && isAutoRefreshAllowedForQuery( query ) ) {
+			const today = moment();
+			const date = moment( queryDate );
+			const isToday = today.isSame( date, 'day' );
+
+			content = translate( '{{b}}Last update: %(time)s{{/b}} (Updates every 30 minutes)', {
+				args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
+				components: {
+					b: <span className="stats-date-picker__last-update" />,
+				},
+			} );
 		}
-
-		const today = moment();
-		const date = moment( queryDate );
-		const isToday = today.isSame( date, 'day' );
-
-		const content = translate( '{{b}}Last update: %(time)s{{/b}} (Updates every 30 minutes)', {
-			args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
-			components: {
-				b: <span className="stats-date-picker__last-update" />,
-			},
-		} );
 
 		return (
 			<div className="stats-date-picker__refresh-status">
@@ -171,8 +173,9 @@ class StatsDatePicker extends Component {
 
 	render() {
 		/* eslint-disable wpcalypso/jsx-classname-namespace*/
-		const { summary, translate, query, showQueryDate, isActivity, isShort } = this.props;
+		const { summary, translate, query, showQueryDate, isActivity, isShort, dateRange } = this.props;
 		const isSummarizeQuery = get( query, 'summarize' );
+		const { selectedShortcut } = getShortcuts( this.props.state, dateRange, undefined, translate );
 
 		let sectionTitle = isActivity
 			? translate( '{{prefix}}Activity for {{/prefix}}{{period/}}', {
@@ -181,7 +184,9 @@ class StatsDatePicker extends Component {
 						period: (
 							<span className="period">
 								<span className="date">
-									{ isSummarizeQuery ? this.dateForSummarize() : this.dateForDisplay() }
+									{ isSummarizeQuery
+										? this.dateForSummarize()
+										: this.dateForDisplay( selectedShortcut ) }
 								</span>
 							</span>
 						),
@@ -194,7 +199,9 @@ class StatsDatePicker extends Component {
 						period: (
 							<span className="period">
 								<span className="date">
-									{ isSummarizeQuery ? this.dateForSummarize() : this.dateForDisplay() }
+									{ isSummarizeQuery
+										? this.dateForSummarize()
+										: this.dateForDisplay( selectedShortcut ) }
 								</span>
 							</span>
 						),
@@ -207,7 +214,7 @@ class StatsDatePicker extends Component {
 		if ( isShort ) {
 			sectionTitle = (
 				<span className="period">
-					<span className="date">{ this.dateForDisplay() }</span>
+					<span className="date">{ this.dateForDisplay( selectedShortcut ) }</span>
 				</span>
 			);
 		}
@@ -234,6 +241,7 @@ const connectComponent = connect( ( state, { query, statsType, showQueryDate } )
 		requesting: showQueryDate
 			? isRequestingSiteStatsForQuery( state, siteId, statsType, query )
 			: false,
+		state,
 	};
 } );
 

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -173,10 +173,25 @@ class StatsDatePicker extends Component {
 
 	render() {
 		/* eslint-disable wpcalypso/jsx-classname-namespace*/
-		const { summary, translate, query, showQueryDate, isActivity, isShort, dateRange, reduxState } =
-			this.props;
+		const {
+			summary,
+			translate,
+			query,
+			showQueryDate,
+			isActivity,
+			isShort,
+			dateRange,
+			reduxState,
+			isNewDateFilteringEnabled,
+		} = this.props;
 		const isSummarizeQuery = get( query, 'summarize' );
-		const { selectedShortcut } = getShortcuts( reduxState, dateRange, undefined, translate );
+		const { selectedShortcut } = getShortcuts(
+			reduxState,
+			dateRange,
+			undefined,
+			translate,
+			isNewDateFilteringEnabled
+		);
 
 		let sectionTitle = isActivity
 			? translate( '{{prefix}}Activity for {{/prefix}}{{period/}}', {


### PR DESCRIPTION
Addresses feedback from p1HpG7-v6l-p2

## Proposed Changes

* Swap the logic to get display date for title and date range picker
* Show container even when no content to avoid jumpy content when switching dates



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Address feedback

## Testing Instructions

-  Open Calypso Live on the Traffic page for a p2 or internal site `/stats/day/:siteSlug`
- Choose a shortcut from date range picker
- Ensure the title show the shortcut label while the date range shows the exact dates
- Ensure the content isn't jumpy when switching dates/ranges


 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?