### PR TITLE
Untangling: add 'restore plugins and themes' to Settings -> Administration

### DIFF
--- a/client/sites/settings/administration/tools/index.jsx
+++ b/client/sites/settings/administration/tools/index.jsx
@@ -6,7 +6,7 @@ import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import { withSiteCopy } from 'calypso/landing/stepper/hooks/use-site-copy';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import {
 	hasLoadedSitePurchasesFromServer,
 	getPurchasesError,
@@ -22,6 +22,7 @@ import { isJetpackSite, getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { isHostingMenuUntangled } from '../../utils';
 import AdministrationToolCard from './card';
+import { requestRestore } from './restore-plan-software';
 
 import './style.scss';
 
@@ -48,6 +49,7 @@ class SiteTools extends Component {
 			cloneUrl,
 			showChangeAddress,
 			showClone,
+			showRestorePlanSoftware,
 			showDeleteContent,
 			showDeleteSite,
 			showManageConnection,
@@ -64,6 +66,11 @@ class SiteTools extends Component {
 		const startOverLink = isUntangled
 			? `/sites/settings/administration/${ siteSlug }/reset-site`
 			: `/settings/start-over/${ siteSlug }?source=${ source }`;
+
+		const restorePlanSoftwareTitle = translate( 'Restore plugins and themes' );
+		const restorePlanSoftwareText = translate(
+			'If your website is missing plugins and themes that come with your plan, you may restore them here.'
+		);
 
 		const startSiteTransferLink = isUntangled
 			? `/sites/settings/administration/${ siteSlug }/transfer-site`
@@ -141,6 +148,13 @@ class SiteTools extends Component {
 						description={ startSiteTransferText }
 					/>
 				) }
+				{ isUntangled && showRestorePlanSoftware && (
+					<AdministrationToolCard
+						onClick={ this.restorePlanSoftware }
+						title={ restorePlanSoftwareTitle }
+						description={ restorePlanSoftwareText }
+					/>
+				) }
 				{ showDeleteContent && (
 					<AdministrationToolCard
 						href={ startOverLink }
@@ -176,6 +190,16 @@ class SiteTools extends Component {
 	trackStartOver() {
 		trackDeleteSiteOption( 'start-over' );
 	}
+
+	restorePlanSoftware = () => {
+		const { siteId, translate } = this.props;
+		requestRestore( {
+			siteId,
+			translate,
+			successNotice: this.props.successNotice,
+			errorNotice: this.props.errorNotice,
+		} );
+	};
 }
 
 export default connect(
@@ -211,6 +235,7 @@ export default connect(
 			cloneUrl,
 			showChangeAddress: ! isJetpack && ! isVip && ! isP2,
 			showClone: 'active' === rewindState.state && ! isAtomic,
+			showRestorePlanSoftware: isAtomic,
 			showDeleteContent: isAtomic || ( ! isJetpack && ! isVip && ! isP2Hub ),
 			showDeleteSite: ( ! isJetpack || isAtomic ) && ! isVip && sitePurchasesLoaded,
 			showManageConnection: isJetpack && ! isAtomic,
@@ -221,5 +246,6 @@ export default connect(
 	},
 	{
 		errorNotice,
+		successNotice,
 	}
 )( localize( withSiteCopy( SiteTools ) ) );

--- a/client/sites/settings/administration/tools/restore-plan-software/index.js
+++ b/client/sites/settings/administration/tools/restore-plan-software/index.js
@@ -1,0 +1,21 @@
+import { stripHTML } from 'calypso/lib/formatting/strip-html';
+import wpcom from 'calypso/lib/wp';
+
+export function requestRestore( { siteId, successNotice, errorNotice, translate } ) {
+	wpcom.req
+		.post( {
+			path: `/sites/${ siteId }/hosting/restore-plan-software`,
+			apiNamespace: 'wpcom/v2',
+		} )
+		.then( () => {
+			successNotice(
+				translate( 'Requested restoration of plugins and themes that come with your plan.' )
+			);
+		} )
+		.catch( ( error ) => {
+			const message =
+				stripHTML( error.message ) ||
+				translate( 'Failed to request restoration of plan plugin and themes.' );
+			errorNotice( message );
+		} );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9856

## Proposed Changes

This PR adds the "Restore plugins and themes" card, previously from Server Settings, to Settings -> Administration.

<img width="744" alt="image" src="https://github.com/user-attachments/assets/b8fa7af8-3429-4fb5-a1ec-3a923b0b7ddd">


## Why are these changes being made?

pbxlJb-6ye-p2

## Testing Instructions

1. Go to /sites.
2. Click an Atomic site.
3. Go to Settings -> Administration.
4. Open browser console.
5. Click the `Restore plugins and themes` button.
6. Verify you see that the `POST https://public-api.wordpress.com/wpcom/v2/sites/<siteId>/hosting/restore-plan-software` endpoint is called, and a success notice is shown (this is the existing behavior in production).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?