### PR TITLE
Enable stats/paid-wpcom-v3 in staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -188,6 +188,7 @@
 		"stats/empty-module-v2": true,
 		"stats/new-date-filtering": false,
 		"stats/paid-wpcom-v2": true,
+		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION
Follow up on https://github.com/Automattic/wp-calypso/pull/96939, enables the new flag in staging.

## Proposed Changes

* Enables the feature flag `stats/paid-wpcom-v3` in staging

## Testing Instructions

Traffic page on stats should show the new upsell in staging, wpcalypso, and development but not production.

e.g.
- http://wordpress.com/stats/day/testingcalypso13.wordpress.com
- http://wpcalypso.wordpress.com/stats/day/testingcalypso13.wordpress.com
- http://calypso.localhost:3000/stats/day/testingcalypso13.wordpress.com


![Screenshot(149)](https://github.com/user-attachments/assets/0e022fd8-4edc-4566-9d41-111855772132)
