### PR TITLE
Untangling: refactor: rename Panel* -> PanelCard*

### DIFF
--- a/client/components/panel/index.tsx
+++ b/client/components/panel/index.tsx
@@ -24,7 +24,7 @@ export function Panel( {
 	);
 }
 
-export function PanelSection( {
+export function PanelCard( {
 	isBorderless,
 	className,
 	children,
@@ -35,8 +35,8 @@ export function PanelSection( {
 } ) {
 	return (
 		<div
-			className={ clsx( 'panel-section', className, {
-				'panel-section--borderless': isBorderless,
+			className={ clsx( 'panel-card', className, {
+				'panel-card--borderless': isBorderless,
 			} ) }
 		>
 			{ children }
@@ -44,7 +44,7 @@ export function PanelSection( {
 	);
 }
 
-export function PanelHeading( {
+export function PanelCardHeading( {
 	asFormLabel,
 	id,
 	children,
@@ -59,6 +59,6 @@ export function PanelHeading( {
 	return <h2 id={ id }>{ children }</h2>;
 }
 
-export function PanelDescription( { children }: { children: React.ReactNode } ) {
-	return <p className="panel-description">{ children }</p>;
+export function PanelCardDescription( { children }: { children: React.ReactNode } ) {
+	return <p className="panel-card__description">{ children }</p>;
 }

--- a/client/components/panel/style.scss
+++ b/client/components/panel/style.scss
@@ -29,16 +29,16 @@
 	}
 }
 
-.panel-section {
+.panel-card {
 	box-sizing: border-box;
 	background-color: #fff;
 	width: 100%;
 
-	&.panel-section--borderless{
+	&.panel-card--borderless{
 		margin-top: 24px;
 	}
 
-	&:not(.panel-section--borderless) {
+	&:not(.panel-card--borderless) {
 		padding: 22px;
 		border: 1px solid var(--studio-gray-5);
 		border-radius: 3px;
@@ -52,7 +52,7 @@
 		margin-bottom: 12px;
 	}
 
-	p.panel-description {
+	p.panel-card__description {
 		margin-bottom: 12px;
 	}
 

--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -19,7 +19,7 @@ import cloudflareIllustration from 'calypso/assets/images/illustrations/cloudfla
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -145,7 +145,7 @@ export function CloudflareAnalyticsSettings( {
 		return (
 			<form id="analytics" onSubmit={ handleSubmitForm }>
 				<>
-					<PanelHeading>{ translate( 'Cloudflare Web Analytics' ) }</PanelHeading>
+					<PanelCardHeading>{ translate( 'Cloudflare Web Analytics' ) }</PanelCardHeading>
 					<div className="analytics site-settings__analytics">
 						<div className="analytics site-settings__analytics-illustration">
 							<img src={ cloudflareIllustration } alt="" />
@@ -227,7 +227,7 @@ export function CloudflareAnalyticsSettings( {
 	if ( ! site ) {
 		return null;
 	}
-	return <PanelSection>{ renderForm() }</PanelSection>;
+	return <PanelCard>{ renderForm() }</PanelCard>;
 }
 
 const mapStateToProps = ( state ) => {

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -19,7 +19,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SupportInfo from 'calypso/components/support-info';
 import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
@@ -134,7 +134,7 @@ const GoogleAnalyticsJetpackForm = ( {
 				<QueryJetpackModules siteId={ siteId } />
 
 				<>
-					<PanelHeading>{ translate( 'Google Analytics' ) }</PanelHeading>
+					<PanelCardHeading>{ translate( 'Google Analytics' ) }</PanelCardHeading>
 					<div className="analytics site-settings__analytics">
 						<div className="analytics site-settings__analytics-illustration">
 							<img src={ googleIllustration } alt="" />
@@ -292,6 +292,6 @@ const GoogleAnalyticsJetpackForm = ( {
 	if ( ! site ) {
 		return null;
 	}
-	return <PanelSection>{ renderForm() }</PanelSection>;
+	return <PanelCard>{ renderForm() }</PanelCard>;
 };
 export default GoogleAnalyticsJetpackForm;

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -18,7 +18,7 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 
 import './style.scss';
 
@@ -90,7 +90,7 @@ const GoogleAnalyticsSimpleForm = ( {
 				onSubmit={ handleSubmitForm }
 			>
 				<>
-					<PanelHeading>{ translate( 'Google Analytics' ) }</PanelHeading>
+					<PanelCardHeading>{ translate( 'Google Analytics' ) }</PanelCardHeading>
 					<div className="analytics site-settings__analytics">
 						<div className="analytics site-settings__analytics-illustration">
 							<img src={ googleIllustration } alt="" />
@@ -197,7 +197,7 @@ const GoogleAnalyticsSimpleForm = ( {
 	if ( ! site ) {
 		return null;
 	}
-	return <PanelSection>{ renderForm() }</PanelSection>;
+	return <PanelCard>{ renderForm() }</PanelCard>;
 };
 
 export default GoogleAnalyticsSimpleForm;

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -9,7 +9,7 @@ import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connec
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SupportInfo from 'calypso/components/support-info';
 import withSiteRoles from 'calypso/data/site-roles/with-site-roles';
 import { getStatsPathForTab } from 'calypso/lib/route';
@@ -121,10 +121,10 @@ class JetpackSiteStats extends Component {
 		);
 
 		return (
-			<PanelSection className="site-settings__traffic-settings">
+			<PanelCard className="site-settings__traffic-settings">
 				<QueryJetpackConnection siteId={ siteId } />
 
-				<PanelHeading>{ translate( 'Jetpack Stats' ) }</PanelHeading>
+				<PanelCardHeading>{ translate( 'Jetpack Stats' ) }</PanelCardHeading>
 
 				<FoldableCard
 					className="site-settings__foldable-card is-top-level"
@@ -179,7 +179,7 @@ class JetpackSiteStats extends Component {
 				<Button href={ getStatsPathForTab( 'day', siteSlug ) }>
 					{ translate( 'View your site stats' ) }
 				</Button>
-			</PanelSection>
+			</PanelCard>
 		);
 	}
 }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -21,7 +21,7 @@ import CountedTextarea from 'calypso/components/forms/counted-textarea';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import MetaTitleEditor from 'calypso/components/seo/meta-title-editor';
 import { toApi as seoTitleToApi } from 'calypso/components/seo/meta-title-editor/mappings';
 import SupportInfo from 'calypso/components/support-info';
@@ -335,8 +335,8 @@ export class SiteSettingsFormSEO extends Component {
 					aria-label="SEO Site Settings"
 				>
 					{ showAdvancedSeo && ! conflictedSeoPlugin && (
-						<PanelSection>
-							<PanelHeading>
+						<PanelCard>
+							<PanelCardHeading>
 								{ translate( 'Page Title Structure' ) }
 								{ siteIsJetpack && (
 									<SupportInfo
@@ -348,7 +348,7 @@ export class SiteSettingsFormSEO extends Component {
 										link=" https://wordpress.com/support/seo-tools/#page-title-structure"
 									/>
 								) }
-							</PanelHeading>
+							</PanelCardHeading>
 							<div compact className="seo-settings__page-title-header">
 								<img
 									className="seo-settings__page-title-header-image"
@@ -378,13 +378,13 @@ export class SiteSettingsFormSEO extends Component {
 							>
 								{ translate( 'Save' ) }
 							</Button>
-						</PanelSection>
+						</PanelCard>
 					) }
 
 					{ ! conflictedSeoPlugin &&
 						( showAdvancedSeo || ( ! siteIsJetpack && showWebsiteMeta ) ) && (
-							<PanelSection>
-								<PanelHeading>{ translate( 'Website Meta' ) }</PanelHeading>
+							<PanelCard>
+								<PanelCardHeading>{ translate( 'Website Meta' ) }</PanelCardHeading>
 								<div>
 									<p>
 										{ translate(
@@ -430,7 +430,7 @@ export class SiteSettingsFormSEO extends Component {
 								>
 									{ translate( 'Save' ) }
 								</Button>
-							</PanelSection>
+							</PanelCard>
 						) }
 				</form>
 				<WebPreview

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -3,7 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import getJetpackModules from 'calypso/state/selectors/get-jetpack-modules';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -22,8 +22,8 @@ export const SeoSettingsHelpCard = ( {
 		: 'https://wpbizseo.wordpress.com/';
 
 	return (
-		<PanelSection>
-			<PanelHeading>{ translate( 'Search engine optimization' ) }</PanelHeading>
+		<PanelCard>
+			<PanelCardHeading>{ translate( 'Search engine optimization' ) }</PanelCardHeading>
 			{ hasAdvancedSEOFeature && (
 				<>
 					<p>
@@ -51,7 +51,7 @@ export const SeoSettingsHelpCard = ( {
 					) }
 				</>
 			) }
-		</PanelSection>
+		</PanelCard>
 	);
 };
 

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -9,7 +9,7 @@ import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInput from 'calypso/components/forms/form-text-input-with-affixes';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SupportInfo from 'calypso/components/support-info';
 import { protectForm } from 'calypso/lib/protect-form';
 import versionCompare from 'calypso/lib/version-compare';
@@ -271,11 +271,11 @@ class SiteVerification extends Component {
 		} );
 
 		return (
-			<PanelSection className="seo-settings__site-verification">
+			<PanelCard className="seo-settings__site-verification">
 				<QuerySiteSettings siteId={ siteId } />
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
-				<PanelHeading>
+				<PanelCardHeading>
 					{ translate( 'Site verification services' ) }
 					{ siteIsJetpack && (
 						<>
@@ -287,7 +287,7 @@ class SiteVerification extends Component {
 							/>
 						</>
 					) }
-				</PanelHeading>
+				</PanelCardHeading>
 				<>
 					{ siteIsJetpack && (
 						<FormFieldset>
@@ -356,7 +356,7 @@ class SiteVerification extends Component {
 						</Button>
 					</form>
 				</>
-			</PanelSection>
+			</PanelCard>
 		);
 	}
 }

--- a/client/my-sites/site-settings/seo-settings/style.scss
+++ b/client/my-sites/site-settings/seo-settings/style.scss
@@ -10,7 +10,7 @@
 		float: unset !important;
 	}
 
-	.panel-section {
+	.panel-card {
 		margin-bottom: 16px;
 	}
 }

--- a/client/my-sites/site-settings/shortlinks.jsx
+++ b/client/my-sites/site-settings/shortlinks.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -35,9 +35,9 @@ class Shortlinks extends Component {
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<PanelSection>
+			<PanelCard>
 				<>
-					<PanelHeading>
+					<PanelCardHeading>
 						{ translate( 'WP.me Shortlinks' ) }
 						<SupportInfo
 							text={ translate(
@@ -45,7 +45,7 @@ class Shortlinks extends Component {
 							) }
 							link="https://jetpack.com/support/wp-me-shortlinks/"
 						/>
-					</PanelHeading>
+					</PanelCardHeading>
 					<FormFieldset>
 						<JetpackModuleToggle
 							siteId={ selectedSiteId }
@@ -55,7 +55,7 @@ class Shortlinks extends Component {
 						/>
 					</FormFieldset>
 				</>
-			</PanelSection>
+			</PanelCard>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -8,7 +8,7 @@ import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connec
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import getJetpackModule from 'calypso/state/selectors/get-jetpack-module';
@@ -188,10 +188,10 @@ class Sitemaps extends Component {
 		const { siteId, siteIsJetpack, translate } = this.props;
 
 		return (
-			<PanelSection>
+			<PanelCard>
 				{ siteId && <QueryJetpackConnection siteId={ siteId } /> }
 
-				<PanelHeading>
+				<PanelCardHeading>
 					{ translate( 'Sitemaps' ) }
 					{ siteIsJetpack
 						? this.renderInfoLink( 'https://jetpack.com/support/sitemaps/' )
@@ -199,10 +199,10 @@ class Sitemaps extends Component {
 								localizeUrl( 'https://wordpress.com/support/sitemaps/' ),
 								false
 						  ) }
-				</PanelHeading>
+				</PanelCardHeading>
 
 				{ siteIsJetpack ? this.renderJetpackSettings() : this.renderWpcomSettings() }
-			</PanelSection>
+			</PanelCard>
 		);
 	}
 }

--- a/client/sites/hosting-features/components/hosting-activation.tsx
+++ b/client/sites/hosting-features/components/hosting-activation.tsx
@@ -1,17 +1,17 @@
 import { useTranslate } from 'i18n-calypso';
-import { PanelDescription, PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardDescription, PanelCardHeading } from 'calypso/components/panel';
 import HostingActivationButton from './hosting-activation-button';
 
 export default function HostingActivation( { redirectUrl }: { redirectUrl: string } ) {
 	const translate = useTranslate();
 
 	return (
-		<PanelSection>
-			<PanelHeading>{ translate( 'Activate hosting features' ) }</PanelHeading>
-			<PanelDescription>
+		<PanelCard>
+			<PanelCardHeading>{ translate( 'Activate hosting features' ) }</PanelCardHeading>
+			<PanelCardDescription>
 				{ translate( 'Activate now to start using this hosting feature.' ) }
-			</PanelDescription>
+			</PanelCardDescription>
 			<HostingActivationButton redirectUrl={ redirectUrl } />
-		</PanelSection>
+		</PanelCard>
 	);
 }

--- a/client/sites/marketing/connections/services-group.jsx
+++ b/client/sites/marketing/connections/services-group.jsx
@@ -5,7 +5,7 @@ import { Fragment, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import isFetchingJetpackModules from 'calypso/state/selectors/is-fetching-jetpack-modules';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
@@ -91,8 +91,8 @@ const SharingServicesGroup = ( {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<PanelSection className="sharing-services-group">
-			<PanelHeading>{ title }</PanelHeading>
+		<PanelCard className="sharing-services-group">
+			<PanelCardHeading>{ title }</PanelCardHeading>
 			<ul className="sharing-services-group__services">
 				{ showPlaceholder &&
 					times( numberOfPlaceholders, ( index ) => (
@@ -144,7 +144,7 @@ const SharingServicesGroup = ( {
 						return <Component key={ service.ID } service={ service } />;
 					} ) }
 			</ul>
-		</PanelSection>
+		</PanelCard>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };

--- a/client/sites/marketing/sharing/appearance.jsx
+++ b/client/sites/marketing/sharing/appearance.jsx
@@ -6,7 +6,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import { PanelSection } from 'calypso/components/panel';
+import { PanelCard } from 'calypso/components/panel';
 import SupportInfo from 'calypso/components/support-info';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
@@ -158,7 +158,7 @@ class SharingButtonsAppearance extends Component {
 		// Disable classname namespace because `sharing-buttons` makes the most sense here
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<PanelSection className="sharing-buttons-appearance">
+			<PanelCard className="sharing-buttons-appearance">
 				<p className="sharing-buttons-appearance__description">
 					{ this.props.translate(
 						'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.'
@@ -185,7 +185,7 @@ class SharingButtonsAppearance extends Component {
 						? this.props.translate( 'Saving…' )
 						: this.props.translate( 'Save changes' ) }
 				</button>
-			</PanelSection>
+			</PanelCard>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}

--- a/client/sites/marketing/sharing/components/buttons-block-appearance.jsx
+++ b/client/sites/marketing/sharing/components/buttons-block-appearance.jsx
@@ -1,7 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import ExternalLink from 'calypso/components/external-link';
-import { PanelSection } from 'calypso/components/panel';
+import { PanelCard } from 'calypso/components/panel';
 import { useSelector } from 'calypso/state';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import SharingButtonsPreviewButtons from '../preview-buttons';
@@ -25,7 +25,7 @@ const ButtonsBlockAppearance = ( { isJetpack, translate, siteId } ) => {
 	);
 
 	return (
-		<PanelSection>
+		<PanelCard>
 			<p className="sharing-buttons-appearance__description">
 				{ translate(
 					'Allow readers to easily share your posts with others by adding a sharing buttons block anywhere in one of your site’s templates.'
@@ -42,7 +42,7 @@ const ButtonsBlockAppearance = ( { isJetpack, translate, siteId } ) => {
 			</div>
 			<p className="sharing-buttons__example-text">{ translate( 'Sharing Buttons example:' ) }</p>
 			<SharingButtonsPreviewButtons buttons={ buttons } style="icon-text" />
-		</PanelSection>
+		</PanelCard>
 	);
 };
 

--- a/client/sites/marketing/sharing/options.jsx
+++ b/client/sites/marketing/sharing/options.jsx
@@ -10,7 +10,7 @@ import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import MultiCheckbox from 'calypso/components/forms/multi-checkbox';
-import { PanelSection } from 'calypso/components/panel';
+import { PanelCard } from 'calypso/components/panel';
 import SupportInfo from 'calypso/components/support-info';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPostTypes } from 'calypso/state/post-types/selectors';
@@ -260,7 +260,7 @@ class SharingButtonsOptions extends Component {
 
 		return (
 			<Fragment>
-				<PanelSection className="sharing-buttons__panel">
+				<PanelCard className="sharing-buttons__panel">
 					{ siteId && <QueryPostTypes siteId={ siteId } /> }
 					<div className="sharing-buttons__fieldset-group">
 						{ this.getSharingShowOptionsElement() }
@@ -275,7 +275,7 @@ class SharingButtonsOptions extends Component {
 					>
 						{ saving ? translate( 'Saving…' ) : translate( 'Save changes' ) }
 					</button>
-				</PanelSection>
+				</PanelCard>
 			</Fragment>
 		);
 	}

--- a/client/sites/marketing/style.scss
+++ b/client/sites/marketing/style.scss
@@ -117,7 +117,7 @@
 	}
 }
 
-.panel-section.sharing-services-group {
+.panel-card.sharing-services-group {
 	padding-bottom: 0;
 }
 

--- a/client/sites/marketing/traffic/style.scss
+++ b/client/sites/marketing/traffic/style.scss
@@ -297,7 +297,7 @@
 		max-width: 170px;
 	}
 
-	.panel-section {
+	.panel-card {
 		margin-bottom: 16px;
 	}
 

--- a/client/sites/settings/administration/tools/card.jsx
+++ b/client/sites/settings/administration/tools/card.jsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import clsx from 'clsx';
-import { PanelDescription, PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardDescription, PanelCardHeading } from 'calypso/components/panel';
 import SiteToolsLink from 'calypso/my-sites/site-settings/site-tools/link';
 import { isHostingMenuUntangled } from '../../utils';
 
@@ -12,12 +12,12 @@ export default function AdministrationToolCard( props ) {
 	}
 
 	return (
-		<PanelSection>
-			<PanelHeading>{ title }</PanelHeading>
-			<PanelDescription>{ description }</PanelDescription>
+		<PanelCard>
+			<PanelCardHeading>{ title }</PanelCardHeading>
+			<PanelCardDescription>{ description }</PanelCardDescription>
 			<Button href={ href } onClick={ onClick } className={ clsx( { 'is-scary': isWarning } ) }>
 				{ title }
 			</Button>
-		</PanelSection>
+		</PanelCard>
 	);
 }

--- a/client/sites/settings/administration/tools/delete-site/delete-site-warnings.jsx
+++ b/client/sites/settings/administration/tools/delete-site/delete-site-warnings.jsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 import { isHostingMenuUntangled } from '../../../utils';
 
@@ -67,13 +67,15 @@ function DeleteSiteWarnings( { p2HubP2Count, isAtomicRemovalInProgress, isTrialS
 	};
 
 	return (
-		<PanelSection>
+		<PanelCard>
 			<>
-				{ isUntangled && <PanelHeading>{ translate( 'Unable to delete site' ) }</PanelHeading> }
+				{ isUntangled && (
+					<PanelCardHeading>{ translate( 'Unable to delete site' ) }</PanelCardHeading>
+				) }
 				<p>{ renderWarningContent() }</p>
 				{ getButtons() }
 			</>
-		</PanelSection>
+		</PanelCard>
 	);
 }
 

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -12,7 +12,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import { Panel, PanelHeading, PanelSection } from 'calypso/components/panel';
+import { Panel, PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import withP2HubP2Count from 'calypso/data/p2/with-p2-hub-p2-count';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSettingsSource } from 'calypso/my-sites/site-settings/site-tools/utils';
@@ -273,16 +273,16 @@ class DeleteSite extends Component {
 				></NavigationHeader>
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 				{ canDeleteSite ? (
-					<PanelSection>
+					<PanelCard>
 						<>
 							{ isUntangled && (
-								<PanelHeading>{ translate( 'Confirm site deletion' ) }</PanelHeading>
+								<PanelCardHeading>{ translate( 'Confirm site deletion' ) }</PanelCardHeading>
 							) }
 							{ this.renderNotice() }
 							{ this.renderBody() }
 						</>
 						{ this.renderDeleteSiteCTA() }
-					</PanelSection>
+					</PanelCard>
 				) : (
 					<DeleteSiteWarnings
 						isAtomicRemovalInProgress={ isAtomicRemovalInProgress }

--- a/client/sites/settings/administration/tools/reset-site/index.jsx
+++ b/client/sites/settings/administration/tools/reset-site/index.jsx
@@ -15,7 +15,7 @@ import HeaderCakeBack from 'calypso/components/header-cake/back';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { Panel, PanelHeading, PanelSection } from 'calypso/components/panel';
+import { Panel, PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import { getSettingsSource } from 'calypso/my-sites/site-settings/site-tools/utils';
@@ -214,28 +214,34 @@ function SiteResetCard( {
 				}
 			);
 			return (
-				<PanelSection>
-					{ isUntangled && <PanelHeading>{ translate( 'Site reset successful' ) }</PanelHeading> }
+				<PanelCard>
+					{ isUntangled && (
+						<PanelCardHeading>{ translate( 'Site reset successful' ) }</PanelCardHeading>
+					) }
 					<p>{ message }</p>
-				</PanelSection>
+				</PanelCard>
 			);
 		} else if ( isResetInProgress ) {
 			return (
-				<PanelSection>
+				<PanelCard>
 					<>
-						{ isUntangled && <PanelHeading>{ translate( 'Resetting site' ) }</PanelHeading> }
+						{ isUntangled && (
+							<PanelCardHeading>{ translate( 'Resetting site' ) }</PanelCardHeading>
+						) }
 						<LoadingBar progress={ status?.progress } />
 						<p className="reset-site__in-progress-message">
 							{ translate( "We're resetting your site. We'll email you once it's ready." ) }
 						</p>
 					</>
-				</PanelSection>
+				</PanelCard>
 			);
 		}
 		return (
 			<>
-				<PanelSection>
-					{ isUntangled && <PanelHeading>{ translate( 'Confirm site reset' ) }</PanelHeading> }
+				<PanelCard>
+					{ isUntangled && (
+						<PanelCardHeading>{ translate( 'Confirm site reset' ) }</PanelCardHeading>
+					) }
 					<p>{ instructions }</p>
 					{ content.length > 0 && (
 						<>
@@ -290,7 +296,7 @@ function SiteResetCard( {
 						</Button>
 					</div>
 					{ backupHint && <FormSettingExplanation>{ backupHint }</FormSettingExplanation> }
-				</PanelSection>
+				</PanelCard>
 			</>
 		);
 	};

--- a/client/sites/settings/administration/tools/reset-site/style.scss
+++ b/client/sites/settings/administration/tools/reset-site/style.scss
@@ -1,6 +1,6 @@
 .settings-administration__reset-site {
 	.panel-with-sidebar & {
-		.panel-section {
+		.panel-card {
 			button {
 				margin-top: 12px;
 			}

--- a/client/sites/settings/administration/tools/transfer-site/confirmation-transfer.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/confirmation-transfer.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import Notice from 'calypso/components/notice';
-import { PanelHeading } from 'calypso/components/panel';
+import { PanelCardHeading } from 'calypso/components/panel';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isHostingMenuUntangled } from '../../../utils';
 import { useConfirmTransfer } from './use-confirm-transfer';
@@ -65,7 +65,9 @@ export function ConfirmationTransfer( {
 		);
 		return (
 			<>
-				{ isUntangled && <PanelHeading>{ translate( 'Invitation email sent' ) }</PanelHeading> }
+				{ isUntangled && (
+					<PanelCardHeading>{ translate( 'Invitation email sent' ) }</PanelCardHeading>
+				) }
 				{ notice }
 			</>
 		);
@@ -92,7 +94,7 @@ export function ConfirmationTransfer( {
 
 	return (
 		<>
-			{ isUntangled && <PanelHeading>{ translate( 'Transferring site' ) }</PanelHeading> }
+			{ isUntangled && <PanelCardHeading>{ translate( 'Transferring site' ) }</PanelCardHeading> }
 			<p>
 				<LoadingBar key="transfer-site-loading-bar" progress={ progress } />
 			</p>

--- a/client/sites/settings/administration/tools/transfer-site/index.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useQueryUserPurchases } from 'calypso/components/data/query-user-purchases';
-import { PanelHeading } from 'calypso/components/panel';
+import { PanelCardHeading } from 'calypso/components/panel';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { getSettingsSource } from 'calypso/my-sites/site-settings/site-tools/utils';
 import { isHostingMenuUntangled } from 'calypso/sites/settings/utils';
@@ -46,7 +46,9 @@ const SiteTransferComplete = () => {
 	);
 	return (
 		<>
-			{ isUntangled && <PanelHeading>{ translate( 'Confirmation email sent' ) }</PanelHeading> }
+			{ isUntangled && (
+				<PanelCardHeading>{ translate( 'Confirmation email sent' ) }</PanelCardHeading>
+			) }
 			{ message }
 		</>
 	);

--- a/client/sites/settings/administration/tools/transfer-site/pending-domain-transfer.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/pending-domain-transfer.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
-import { PanelHeading } from 'calypso/components/panel';
+import { PanelCardHeading } from 'calypso/components/panel';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { isHostingMenuUntangled } from '../../../utils';
 
@@ -17,7 +17,9 @@ const PendingDomainTransfer = ( { domain }: { domain: ResponseDomain } ) => {
 	return (
 		<>
 			<>
-				{ isUntangled && <PanelHeading>{ translate( 'Pending domain transfers' ) }</PanelHeading> }
+				{ isUntangled && (
+					<PanelCardHeading>{ translate( 'Pending domain transfers' ) }</PanelCardHeading>
+				) }
 				<p>
 					{ createInterpolateElement(
 						sprintf(

--- a/client/sites/settings/administration/tools/transfer-site/site-owner-user-search.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/site-owner-user-search.tsx
@@ -5,7 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, FormEvent, ChangeEvent } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { PanelHeading } from 'calypso/components/panel';
+import { PanelCardHeading } from 'calypso/components/panel';
 import useUsersQuery from 'calypso/data/users/use-users-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TeamMembersSiteTransfer from 'calypso/my-sites/people/team-members-site-transfer';
@@ -163,7 +163,7 @@ const SiteOwnerTransferEligibility = ( {
 
 	return (
 		<>
-			{ isUntangled && <PanelHeading>{ translate( 'Confirm new owner' ) }</PanelHeading> }
+			{ isUntangled && <PanelCardHeading>{ translate( 'Confirm new owner' ) }</PanelCardHeading> }
 			{ form }
 		</>
 	);

--- a/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
@@ -2,7 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import HeaderCakeBack from 'calypso/components/header-cake/back';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { Panel, PanelSection } from 'calypso/components/panel';
+import { Panel, PanelCard } from 'calypso/components/panel';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { isHostingMenuUntangled } from 'calypso/sites/settings/utils';
 
@@ -36,7 +36,7 @@ export function SiteTransferCard( {
 				path="/settings/start-site-transfer/:site"
 				title="Settings > Start Site Transfer"
 			/>
-			<PanelSection>{ children }</PanelSection>
+			<PanelCard>{ children }</PanelCard>
 		</Panel>
 	);
 }

--- a/client/sites/settings/administration/tools/transfer-site/start-site-owner-transfer.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/start-site-owner-transfer.tsx
@@ -7,7 +7,7 @@ import { localize, useTranslate } from 'i18n-calypso';
 import { useState, FormEvent } from 'react';
 import { connect, useSelector } from 'react-redux';
 import Notice from 'calypso/components/notice';
-import { PanelHeading } from 'calypso/components/panel';
+import { PanelCardHeading } from 'calypso/components/panel';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
@@ -347,7 +347,9 @@ const StartSiteOwnerTransfer = ( {
 	return (
 		<>
 			<>
-				{ isUntangled && <PanelHeading>{ translate( 'Confirm site transfer' ) }</PanelHeading> }
+				{ isUntangled && (
+					<PanelCardHeading>{ translate( 'Confirm site transfer' ) }</PanelCardHeading>
+				) }
 				<Notice status="is-info" showDismiss={ false }>
 					{ translate(
 						'Please read the following actions that will take place when you transfer this site'

--- a/client/sites/settings/caching/form.tsx
+++ b/client/sites/settings/caching/form.tsx
@@ -6,7 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useState } from 'react';
 import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { PanelDescription, PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardDescription, PanelCardHeading } from 'calypso/components/panel';
 import {
 	useEdgeCacheQuery,
 	useSetEdgeCacheMutation,
@@ -145,11 +145,13 @@ export default function CachingForm( { disabled }: CachingFormProps ) {
 					} ) }
 				</HostingCardDescription>
 			</>
-			<PanelSection isBorderless={ ! isUntangled }>
-				<PanelHeading asFormLabel={ ! isUntangled }>{ translate( 'All caches' ) }</PanelHeading>
-				<PanelDescription>
+			<PanelCard isBorderless={ ! isUntangled }>
+				<PanelCardHeading asFormLabel={ ! isUntangled }>
+					{ translate( 'All caches' ) }
+				</PanelCardHeading>
+				<PanelCardDescription>
 					{ translate( 'Clearing the cache may temporarily make your site less responsive.' ) }
-				</PanelDescription>
+				</PanelCardDescription>
 				<Tooltip
 					placement="top"
 					text={
@@ -175,20 +177,20 @@ export default function CachingForm( { disabled }: CachingFormProps ) {
 						</Button>
 					</div>
 				</Tooltip>
-			</PanelSection>
+			</PanelCard>
 
 			{ ! isUntangled && <div className="cache-card__hr" /> }
 
-			<PanelSection isBorderless={ ! isUntangled }>
+			<PanelCard isBorderless={ ! isUntangled }>
 				{ isEdgeCacheInitialLoading ? (
 					<EdgeCacheLoadingPlaceholder />
 				) : (
 					<>
-						<PanelHeading asFormLabel={ ! isUntangled }>
+						<PanelCardHeading asFormLabel={ ! isUntangled }>
 							{ translate( 'Global edge cache', {
 								comment: 'Edge cache is a type of CDN that stores generated HTML pages',
 							} ) }
-						</PanelHeading>
+						</PanelCardHeading>
 						<ToggleControl
 							__nextHasNoMarginBottom
 							className="cache-card__edge-cache-toggle"
@@ -245,16 +247,16 @@ export default function CachingForm( { disabled }: CachingFormProps ) {
 							) }
 					</>
 				) }
-			</PanelSection>
+			</PanelCard>
 
 			{ config.isEnabled( 'hosting-server-settings-enhancements' ) && (
-				<PanelSection isBorderless={ ! isUntangled }>
-					<PanelHeading asFormLabel={ ! isUntangled }>
+				<PanelCard isBorderless={ ! isUntangled }>
+					<PanelCardHeading asFormLabel={ ! isUntangled }>
 						{ translate( 'Object cache', {
 							comment: 'Object cache stores database lookups and some network requests',
 						} ) }
-					</PanelHeading>
-					<PanelDescription>
+					</PanelCardHeading>
+					<PanelCardDescription>
 						{ translate(
 							'Data is cached using Memcached to reduce database lookups. {{a}}Learn more{{/a}}',
 							{
@@ -264,7 +266,7 @@ export default function CachingForm( { disabled }: CachingFormProps ) {
 								},
 							}
 						) }
-					</PanelDescription>
+					</PanelCardDescription>
 
 					<Tooltip
 						placement="top"
@@ -288,7 +290,7 @@ export default function CachingForm( { disabled }: CachingFormProps ) {
 							</Button>
 						</div>
 					</Tooltip>
-				</PanelSection>
+				</PanelCard>
 			) }
 		</HostingCard>
 	);

--- a/client/sites/settings/site/agency.tsx
+++ b/client/sites/settings/site/agency.tsx
@@ -3,7 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import useFetchAgencyFromBlog from 'calypso/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { isHostingMenuUntangled } from '../utils';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -119,16 +119,16 @@ export function A4AFullyManagedSiteForm( {
 	}
 
 	return (
-		<PanelSection>
-			<PanelHeading id="site-settings__a4a-fully-managed-header">
+		<PanelCard>
+			<PanelCardHeading id="site-settings__a4a-fully-managed-header">
 				{ translate( 'Agency settings' ) }
-			</PanelHeading>
+			</PanelCardHeading>
 			{ renderContent() }
 			{ ! isDevSite && (
 				<Button onClick={ onSaveSetting } busy={ isSaving } disabled={ disabled }>
 					{ translate( 'Save' ) }
 				</Button>
 			) }
-		</PanelSection>
+		</PanelCard>
 	);
 }

--- a/client/sites/settings/site/enhanced-ownership.jsx
+++ b/client/sites/settings/site/enhanced-ownership.jsx
@@ -8,7 +8,7 @@ import { useTranslate } from 'i18n-calypso';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
@@ -111,12 +111,12 @@ export default function EnhancedOwnershipForm( {
 	}
 
 	return (
-		<PanelSection>
-			<PanelHeading>{ translate( 'Control your legacy' ) }</PanelHeading>
+		<PanelCard>
+			<PanelCardHeading>{ translate( 'Control your legacy' ) }</PanelCardHeading>
 			{ renderForm() }
 			<Button busy={ isSaving } disabled={ disabled } onClick={ onSave }>
 				{ translate( 'Save' ) }
 			</Button>
-		</PanelSection>
+		</PanelCard>
 	);
 }

--- a/client/sites/settings/site/footer-credit/index.jsx
+++ b/client/sites/settings/site/footer-credit/index.jsx
@@ -6,7 +6,7 @@ import {
 import { CompactCard, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { preventWidows } from 'calypso/lib/formatting';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
@@ -93,11 +93,11 @@ export default function FooterCredit( { site, siteIsJetpack } ) {
 					{ renderUpsellNudge() }
 				</div>
 			) : (
-				<PanelSection className="settings-site__footer-credit">
-					<PanelHeading>{ translate( 'Footer credit' ) }</PanelHeading>
+				<PanelCard className="settings-site__footer-credit">
+					<PanelCardHeading>{ translate( 'Footer credit' ) }</PanelCardHeading>
 					{ renderContent() }
 					{ renderUpsellNudge() }
-				</PanelSection>
+				</PanelCard>
 			) }
 		</>
 	);

--- a/client/sites/settings/site/privacy/index.tsx
+++ b/client/sites/settings/site/privacy/index.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { PanelDescription, PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardDescription, PanelCardHeading } from 'calypso/components/panel';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
@@ -109,15 +109,15 @@ const PrivacyForm = ( {
 		);
 	}
 	return (
-		<PanelSection className="settings-site__privacy">
-			<PanelHeading>{ translate( 'Privacy' ) }</PanelHeading>
-			<PanelDescription>
+		<PanelCard className="settings-site__privacy">
+			<PanelCardHeading>{ translate( 'Privacy' ) }</PanelCardHeading>
+			<PanelCardDescription>
 				{ translate( 'Control who can view your site. {{a}}Learn more{{/a}}', {
 					components: {
 						a: <InlineSupportLink showIcon={ false } supportContext="privacy" />,
 					},
 				} ) }
-			</PanelDescription>
+			</PanelCardDescription>
 			{ renderForm() }
 			<Button
 				busy={ isSavingSettings }
@@ -126,7 +126,7 @@ const PrivacyForm = ( {
 			>
 				{ translate( 'Save' ) }
 			</Button>
-		</PanelSection>
+		</PanelCard>
 	);
 };
 

--- a/client/sites/settings/site/privacy/style.scss
+++ b/client/sites/settings/site/privacy/style.scss
@@ -56,7 +56,7 @@
 }
 
 .settings-site__privacy {
-	p.panel-description {
+	p.panel-card__description {
 		margin-bottom: 24px;
 	}
 }

--- a/client/sites/settings/site/subscription-gifting.jsx
+++ b/client/sites/settings/site/subscription-gifting.jsx
@@ -5,7 +5,7 @@ import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { PanelDescription, PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardDescription, PanelCardHeading } from 'calypso/components/panel';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -75,9 +75,9 @@ export default function SubscriptionGiftingForm( {
 	}
 
 	return (
-		<PanelSection>
-			<PanelHeading>{ translate( 'Accept a gift subscription' ) }</PanelHeading>
-			<PanelDescription>
+		<PanelCard>
+			<PanelCardHeading>{ translate( 'Accept a gift subscription' ) }</PanelCardHeading>
+			<PanelCardDescription>
 				{ translate(
 					"Allow a site visitor to cover the full cost of your site's WordPress.com plan. {{a}}Learn more{{/a}}",
 					{
@@ -86,11 +86,11 @@ export default function SubscriptionGiftingForm( {
 						},
 					}
 				) }
-			</PanelDescription>
+			</PanelCardDescription>
 			{ renderForm() }
 			<Button busy={ isSaving } disabled={ disabled } onClick={ onSave }>
 				{ translate( 'Save' ) }
 			</Button>
-		</PanelSection>
+		</PanelCard>
 	);
 }

--- a/client/sites/settings/site/toolbar.jsx
+++ b/client/sites/settings/site/toolbar.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connection';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
@@ -73,11 +73,11 @@ const Masterbar = ( {
 	}
 
 	return (
-		<PanelSection>
+		<PanelCard>
 			<QueryJetpackConnection siteId={ selectedSiteId } />
-			<PanelHeading>{ translate( 'WordPress.com toolbar' ) }</PanelHeading>
+			<PanelCardHeading>{ translate( 'WordPress.com toolbar' ) }</PanelCardHeading>
 			{ renderForm() }
-		</PanelSection>
+		</PanelCard>
 	);
 };
 

--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -7,7 +7,7 @@ import { translate } from 'i18n-calypso';
 import { useState } from 'react';
 import useFetchAgencyFromBlog from 'calypso/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SitePreviewLinks from 'calypso/components/site-preview-links';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -220,19 +220,19 @@ const LaunchSite = () => {
 					<LaunchCard>{ renderContent() }</LaunchCard>
 				</>
 			) : (
-				<PanelSection>
-					<PanelHeading>{ translate( 'Launch site' ) }</PanelHeading>
+				<PanelCard>
+					<PanelCardHeading>{ translate( 'Launch site' ) }</PanelCardHeading>
 					{ renderContent() }
-				</PanelSection>
+				</PanelCard>
 			) }
 			{ showPreviewLink &&
 				( ! isUntangled ? (
 					<Card>{ renderPreviewLinks() }</Card>
 				) : (
-					<PanelSection>
-						<PanelHeading>{ translate( 'Coming soon' ) }</PanelHeading>
+					<PanelCard>
+						<PanelCardHeading>{ translate( 'Coming soon' ) }</PanelCardHeading>
 						{ renderPreviewLinks() }
-					</PanelSection>
+					</PanelCard>
 				) ) }
 			{ querySiteDomainsComponent }
 		</>

--- a/client/sites/settings/web-server/defensive-mode-form.tsx
+++ b/client/sites/settings/web-server/defensive-mode-form.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import FormSelect from 'calypso/components/forms/form-select';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { PanelDescription, PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardDescription, PanelCardHeading } from 'calypso/components/panel';
 import {
 	useEdgeCacheDefensiveModeMutation,
 	useEdgeCacheDefensiveModeQuery,
@@ -61,14 +61,14 @@ export default function DefensiveModeForm( { disabled }: DefensiveModeFormProps 
 	const enabledUntil = moment.unix( defensiveModeData?.enabled_until ?? 0 ).local();
 
 	return (
-		<PanelSection>
-			<PanelHeading>
+		<PanelCard>
+			<PanelCardHeading>
 				{ translate( 'Defensive mode', {
 					comment: 'Defensive mode is a feature to protect against DDoS attacks.',
 					textOnly: true,
 				} ) }
-			</PanelHeading>
-			<PanelDescription>
+			</PanelCardHeading>
+			<PanelCardDescription>
 				{ translate(
 					'Extra protection against spam bots and attacks. Visitors will see a quick loading page while we run additional security checks. {{a}}Learn more{{/a}}',
 					{
@@ -79,7 +79,7 @@ export default function DefensiveModeForm( { disabled }: DefensiveModeFormProps 
 						},
 					}
 				) }
-			</PanelDescription>
+			</PanelCardDescription>
 
 			{ isLoadingDefensiveMode && <EdgeCacheLoadingPlaceholder /> }
 
@@ -191,6 +191,6 @@ export default function DefensiveModeForm( { disabled }: DefensiveModeFormProps 
 					</Button>
 				</>
 			) }
-		</PanelSection>
+		</PanelCard>
 	);
 }

--- a/client/sites/settings/web-server/server-configuration-form.tsx
+++ b/client/sites/settings/web-server/server-configuration-form.tsx
@@ -13,7 +13,7 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { HostingCardDescription } from 'calypso/components/hosting-card';
-import { PanelHeading, PanelSection } from 'calypso/components/panel';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import { useDataCenterOptions } from 'calypso/data/data-center/use-data-center-options';
 import { usePhpVersions } from 'calypso/data/php-versions/use-php-versions';
 import { useSelector } from 'calypso/state';
@@ -420,15 +420,15 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 	};
 
 	return (
-		<PanelSection>
+		<PanelCard>
 			<QuerySiteGeoAffinity siteId={ siteId } />
 			<QuerySitePhpVersion siteId={ siteId } />
 			<QuerySiteWpVersion siteId={ siteId } />
 			<QuerySiteStaticFile404 siteId={ siteId } />
 
-			<PanelHeading id="web-server-settings">
+			<PanelCardHeading id="web-server-settings">
 				{ isUntangled ? translate( 'Server configuration' ) : translate( 'Web server settings' ) }
-			</PanelHeading>
+			</PanelCardHeading>
 			<HostingCardDescription hide={ isUntangled }>
 				{ translate(
 					'For sites with specialized needs, fine-tune how the web server runs your website.'
@@ -439,6 +439,6 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 			{ ! isLoading && getGeoAffinityContent() }
 			{ ! isLoading && getStaticFile404Content() }
 			{ isLoading && getPlaceholderContent() }
-		</PanelSection>
+		</PanelCard>
 	);
 }


### PR DESCRIPTION
## Proposed Changes

This PR is just a rename of existing components:

- `PanelSection` -> `PanelCard`
- `PanelHeading` -> `PanelCardHeading`
- `PanelDescription` -> `PanelCardDescription`

## Why are these changes being made?

We want to make these components reusable. They are being renamed because they are "card" and are to replace the existing `<Card/>` component.

## Testing Instructions

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
