### PR TITLE
Fix back link in user security page

### DIFF
--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -163,6 +163,18 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 	const hasKeys = data && data.length > 0;
 	const redirectToHosting =
 		queryParams.source && queryParams.source === 'hosting-config' && queryParams.siteSlug;
+	const redirectToTools =
+		queryParams.source && queryParams.source === 'sites/tools/sftp-ssh' && queryParams.siteSlug;
+
+	let backText = __( 'Back' );
+	let backHref = '/me/security';
+	if ( redirectToHosting ) {
+		backText = __( 'Back to Hosting Configuration' );
+		backHref = `/${ queryParams.source }/${ queryParams.siteSlug }`;
+	} else if ( redirectToTools ) {
+		backText = __( 'Back to Advanced Tools' );
+		backHref = `/${ queryParams.source }/${ queryParams.siteSlug }`;
+	}
 
 	const closeDialog = () => setShowDialog( false );
 
@@ -173,12 +185,7 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 
 			<NavigationHeader navigationItems={ [] } title={ __( 'Security' ) } />
 
-			<HeaderCake
-				backText={ redirectToHosting ? __( 'Back to Hosting Configuration' ) : __( 'Back' ) }
-				backHref={
-					redirectToHosting ? `/${ queryParams.source }/${ queryParams.siteSlug }` : '/me/security'
-				}
-			>
+			<HeaderCake backText={ backText } backHref={ backHref }>
 				{ __( 'SSH Key' ) }
 			</HeaderCake>
 

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -166,16 +166,6 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 	const redirectToTools =
 		queryParams.source && queryParams.source === 'sites/tools/sftp-ssh' && queryParams.siteSlug;
 
-	let backText = __( 'Back' );
-	let backHref = '/me/security';
-	if ( redirectToHosting ) {
-		backText = __( 'Back to Hosting Configuration' );
-		backHref = `/${ queryParams.source }/${ queryParams.siteSlug }`;
-	} else if ( redirectToTools ) {
-		backText = __( 'Back to Advanced Tools' );
-		backHref = `/${ queryParams.source }/${ queryParams.siteSlug }`;
-	}
-
 	const closeDialog = () => setShowDialog( false );
 
 	return (
@@ -185,7 +175,14 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 
 			<NavigationHeader navigationItems={ [] } title={ __( 'Security' ) } />
 
-			<HeaderCake backText={ backText } backHref={ backHref }>
+			<HeaderCake
+				backText={ __( 'Back' ) }
+				backHref={
+					redirectToHosting || redirectToTools
+						? `/${ queryParams.source }/${ queryParams.siteSlug }`
+						: '/me/security'
+				}
+			>
 				{ __( 'SSH Key' ) }
 			</HeaderCake>
 

--- a/client/sites/tools/sftp-ssh/ssh-keys.tsx
+++ b/client/sites/tools/sftp-ssh/ssh-keys.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Spinner } from '@automattic/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -85,7 +86,7 @@ function SshKeys( { siteId, siteSlug, username, disabled }: SshKeysProps ) {
 	const showKeysSelect = ! isLoading && ! userKeyIsAttached && userKeys && userKeys.length > 0;
 	const showLinkToAddUserKey = ! isLoading && ! userKeyIsAttached && userKeys?.length === 0;
 	const SSH_ADD_URL = addQueryArgs( '/me/security/ssh-key', {
-		source: 'hosting-config',
+		source: isEnabled( 'untangling/hosting-menu' ) ? 'sites/tools/sftp-ssh' : 'hosting-config',
 		siteSlug,
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/10004

## Proposed Changes

* Fixes back link in user security page when visited from Advanced Tools (UHM enabled)
* Updates the source param of security page
* Updates back link text based on the source url

<img width="678" alt="image" src="https://github.com/user-attachments/assets/58779795-2265-4efb-a4c3-726ba8e6d4b2">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/sites/tools/sftp-ssh/:site`
* Click on `Add an SSH Key`
* It should take you to user security page.
* Back link and text should be updated pointing to Advanced Tools page, and clicking on which should land user in the previous page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
