### PR TITLE
Site Management / Advanced Tools - fix ui issues in staging site page

### DIFF
--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -1,5 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
+import { Button as WPButton } from '@wordpress/components';
+import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import SiteIcon from 'calypso/blocks/site-icon';
 import { navigate } from 'calypso/lib/navigate';
@@ -13,9 +15,13 @@ import { SiteSyncCard } from './staging-sync-card';
 
 const SiteRow = styled.div( {
 	display: 'flex',
-	alignItems: 'center',
+	alignItems: 'flex-start',
 	marginBottom: 24,
-	'.site-icon': { flexShrink: 0 },
+	'.site-icon': {
+		flexShrink: 0,
+		alignSelf: 'flex-start',
+		marginTop: '2px',
+	},
 } );
 
 const BorderedContainer = styled.div( {
@@ -60,10 +66,6 @@ const SiteName = styled.a( {
 	'&, &:hover, &:visited': {
 		color: 'var( --studio-gray-100 )',
 	},
-} );
-
-const StagingSiteLink = styled.div( {
-	wordBreak: 'break-word',
 } );
 
 const ActionButtons = styled.div( {
@@ -157,9 +159,17 @@ export const ManageStagingSiteCardContent = ( {
 								</SiteName>
 								<SitesStagingBadge>{ translate( 'Staging' ) }</SitesStagingBadge>
 							</SiteNameContainer>
-							<StagingSiteLink>
-								<a href={ stagingSite.url }>{ stagingSite.url }</a>
-							</StagingSiteLink>
+							<WPButton
+								variant="link"
+								href={ stagingSite.url }
+								target="_blank"
+								className="tools-staging-site__site-url"
+							>
+								<span>
+									{ stagingSite.url }
+									<Icon icon={ external } size={ 16 } />
+								</span>
+							</WPButton>
 						</SiteInfo>
 					</SiteRow>
 					<ActionButtons>

--- a/client/sites/tools/staging-site/style.scss
+++ b/client/sites/tools/staging-site/style.scss
@@ -4,3 +4,11 @@
 	align-items: flex-start;
     gap: 16px;
 }
+
+.tools-staging-site__site-url {
+    word-wrap: break-word;
+
+    svg {
+        vertical-align: middle;
+    }
+}

--- a/client/sites/tools/staging-site/style.scss
+++ b/client/sites/tools/staging-site/style.scss
@@ -8,6 +8,10 @@
 .tools-staging-site__site-url {
     word-wrap: break-word;
 
+    &.is-link {
+        text-decoration: none;
+    }
+
     svg {
         vertical-align: middle;
     }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/10001

## Proposed Changes

* Add external link icon to match the same setting as in the site header

<img width="381" alt="image" src="https://github.com/user-attachments/assets/4dfd9655-de02-4703-bcd6-c1c4da6f9d7a">


* Site icon and title are now `top aligned`

<img width="390" alt="image" src="https://github.com/user-attachments/assets/5acdc9fe-1167-4d44-8dd4-08cc0e7e6099">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit: `/sites/tools/staging-site/:site`
* Verify the staging site UI in small and large screens

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
