### PR TITLE
A4A > Migrations: Update commissions list column text on mobile view

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/commissions-list/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/mobile-view.tsx
@@ -26,11 +26,15 @@ export default function MigrationsCommissionsListMobileView( {
 								<SiteColumn site={ commission.url } />
 							</div>
 						</ListItemCardContent>
-						<ListItemCardContent title={ translate( 'Migrated on' ) }>
-							<div className="migrations-commissions-list-mobile-view__column">
-								<MigratedOnColumn migratedOn={ commission.created_at } />
-							</div>
-						</ListItemCardContent>
+						{
+							// FIXME: This should be "Migrated on" instead of "Date Added"
+							// We will change this when the MC tool is implemented and we have the migration date
+							<ListItemCardContent title={ translate( 'Date Added' ) }>
+								<div className="migrations-commissions-list-mobile-view__column">
+									<MigratedOnColumn migratedOn={ commission.created_at } />
+								</div>
+							</ListItemCardContent>
+						}
 						<ListItemCardContent title={ translate( 'Review status' ) }>
 							<ReviewStatusColumn reviewStatus={ commission.state } />
 						</ListItemCardContent>


### PR DESCRIPTION
## Proposed Changes

This PR updates the column on the commission list from 'Migrated on' to 'Date Added'.

## Why are these changes being made?

* To match the label text on the mobile view to match the large screen view.

## Testing Instructions

* Open the A4A live link
* Go to Migrations: Commissions > Tag a site for commission 
* Once the tag is added, switch to mobile view using the dev tool and verify the text now shows "Date Added" as shown below:

<img width="409" alt="Screenshot 2024-12-02 at 2 38 43 PM" src="https://github.com/user-attachments/assets/72468742-fc68-4087-af31-a0f29edfeb6b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
