### PR TITLE
Design Picker: Support the free-only filer

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -958,7 +958,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
 			siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
 			showActiveThemeBadge={ intent !== 'build' }
-			isTierFilterEnabled={ ! isGoalsHoldout }
+			isTierFilterEnabled={ isEnabled( 'design-picker/goal-centric' ) && ! isGoalsHoldout }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -958,7 +958,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
 			siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
 			showActiveThemeBadge={ intent !== 'build' }
-			isTierFilterEnabled={ isGoalsHoldout }
+			isTierFilterEnabled={ ! isGoalsHoldout }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -68,6 +68,7 @@ import {
 } from 'calypso/state/themes/selectors';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { getPreferredBillingCycleProductSlug } from 'calypso/state/themes/theme-utils';
+import { useIsGoalsHoldout } from '../../../../hooks/use-is-goals-holdout';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSiteData } from '../../../../hooks/use-site-data';
@@ -115,6 +116,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const [ isAddedGoalsExpLoading, addedGoalsExpAssignment ] = useExperiment(
 		'calypso_onboarding_goals_step_added_goals'
 	);
+
+	const isGoalsHoldout = useIsGoalsHoldout( stepName );
 
 	const queryParams = useQuery();
 	const { goBack, submit, exitFlow } = navigation;
@@ -955,6 +958,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
 			siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
 			showActiveThemeBadge={ intent !== 'build' }
+			isTierFilterEnabled={ isGoalsHoldout }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -8,13 +8,13 @@ import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import { useIsSiteAssemblerEnabled } from 'calypso/data/site-assembler';
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { useExperiment } from 'calypso/lib/explat';
 import { ImporterMainPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/route';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { WRITE_INTENT_DEFAULT_DESIGN } from '../constants';
+import { useIsGoalsHoldout } from '../hooks/use-is-goals-holdout';
 import { useIsPluginBundleEligible } from '../hooks/use-is-plugin-bundle-eligible';
 import { useSiteData } from '../hooks/use-site-data';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
@@ -96,11 +96,7 @@ const siteSetupFlow: Flow = {
 		];
 	},
 	useStepNavigation( currentStep, navigate ) {
-		const [ , experimentAssignment ] = useExperiment( 'calypso_onboarding_goals_holdout_20241126', {
-			// Hold off assigning user to group until it's absolutely necessary
-			isEligible: [ 'goals', 'designSetup' ].includes( currentStep ),
-		} );
-		const isGoalsHoldout = experimentAssignment?.variationName === 'holdout';
+		const isGoalsHoldout = useIsGoalsHoldout( currentStep );
 
 		const stepData = useSelect(
 			( select ) => ( select( STEPPER_INTERNAL_STORE ) as StepperInternalSelect ).getStepData(),

--- a/client/landing/stepper/hooks/use-is-goals-holdout.tsx
+++ b/client/landing/stepper/hooks/use-is-goals-holdout.tsx
@@ -1,0 +1,10 @@
+import { useExperiment } from 'calypso/lib/explat';
+
+export const useIsGoalsHoldout = ( step: string ) => {
+	const [ , experimentAssignment ] = useExperiment( 'calypso_onboarding_goals_holdout_20241126', {
+		// Hold off assigning user to group until it's absolutely necessary
+		isEligible: [ 'goals', 'designSetup' ].includes( step ),
+	} );
+
+	return experimentAssignment?.variationName === 'holdout';
+};

--- a/config/development.json
+++ b/config/development.json
@@ -56,6 +56,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
+		"design-picker/goal-centric": true,
 		"design-picker/use-assembler-styles": true,
 		"desktop-promo": true,
 		"dev/auth-helper": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -34,7 +34,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"design-picker/goal-centric": true,
+		"design-picker/goal-centric": false,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"external-media": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -34,6 +34,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
+		"design-picker/goal-centric": true,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"external-media": true,

--- a/config/production.json
+++ b/config/production.json
@@ -47,6 +47,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
+		"design-picker/goal-centric": false,
 		"desktop-promo": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,6 +45,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
+		"design-picker/goal-centric": false,
 		"desktop-promo": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,6 +44,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
+		"design-picker/goal-centric": true,
 		"design-picker/use-assembler-styles": true,
 		"desktop-promo": true,
 		"dev/auth-helper": true,

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -42,6 +42,7 @@
 		"@wordpress/url": "^4.8.0",
 		"clsx": "^2.1.1",
 		"react-intersection-observer": "^9.4.3",
+		"react-router-dom": "^6.23.1",
 		"tslib": "^2.3.0",
 		"utility-types": "^3.10.0"
 	},

--- a/packages/design-picker/src/components/design-picker-tier-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-tier-filter/index.tsx
@@ -1,0 +1,35 @@
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSearchParams } from 'react-router-dom';
+import './style.scss';
+
+const DesignPickerTierFilter = () => {
+	const translate = useTranslate();
+	const [ searchParams, setSearchParams ] = useSearchParams();
+
+	const isFreeOnly = searchParams.get( 'tier' ) === 'free';
+
+	const handleChange = ( value: boolean ) => {
+		setSearchParams( ( currentSearchParams: any ) => {
+			if ( value ) {
+				currentSearchParams.set( 'tier', 'free' );
+			} else {
+				currentSearchParams.delete( 'tier' );
+			}
+
+			return currentSearchParams;
+		} );
+	};
+
+	return (
+		<ToggleControl
+			className="design-picker__tier-filter"
+			__nextHasNoMarginBottom
+			label={ translate( 'Free only' ) }
+			checked={ isFreeOnly }
+			onChange={ handleChange }
+		/>
+	);
+};
+
+export default DesignPickerTierFilter;

--- a/packages/design-picker/src/components/design-picker-tier-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-tier-filter/style.scss
@@ -1,0 +1,5 @@
+.design-picker__tier-filter {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}

--- a/packages/design-picker/src/components/no-results/index.tsx
+++ b/packages/design-picker/src/components/no-results/index.tsx
@@ -1,0 +1,9 @@
+import { useTranslate } from 'i18n-calypso';
+
+const NoResults = () => {
+	const translate = useTranslate();
+
+	return <span>{ translate( 'No designs matched.' ) }</span>;
+};
+
+export default NoResults;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -25,6 +25,9 @@
 	.design-picker__filters {
 		display: flex;
 		justify-content: space-between;
+		flex-direction: column;
+		gap: 10px;
+		margin-bottom: 24px;
 
 		.design-picker__design-your-own-button {
 			flex-shrink: 0;
@@ -41,10 +44,15 @@
 
 		.design-picker__category-filter.responsive-toolbar-group__dropdown {
 			width: 100%;
+			padding-bottom: 0;
 
 			.responsive-toolbar-group__grouped-list {
 				justify-content: flex-start;
 			}
+		}
+
+		@include break-small {
+			flex-direction: row;
 		}
 	}
 
@@ -475,7 +483,7 @@
 .design-picker--has-categories {
 	.responsive-toolbar-group__swipe {
 		.responsive-toolbar-group__swipe-list {
-			padding: 0 0 24px;
+			padding: 0;
 
 			>div:first-of-type {
 				button {

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -17,6 +17,7 @@ import {
 } from '../utils';
 import { isLockedStyleVariation } from '../utils/is-locked-style-variation';
 import { UnifiedDesignPickerCategoryFilter } from './design-picker-category-filter/unified-design-picker-category-filter';
+import DesignPickerTierFilter from './design-picker-tier-filter';
 import PatternAssemblerCta, { usePatternAssemblerCtaData } from './pattern-assembler-cta';
 import ThemeCard from './theme-card';
 import type { Categorization } from '../hooks/use-categorization';
@@ -254,6 +255,7 @@ interface DesignPickerProps {
 	isSiteAssemblerEnabled?: boolean; // Temporary for A/B test
 	siteActiveTheme?: string | null;
 	showActiveThemeBadge?: boolean;
+	isTierFilterEnabled?: boolean;
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -271,6 +273,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isSiteAssemblerEnabled,
 	siteActiveTheme = null,
 	showActiveThemeBadge = false,
+	isTierFilterEnabled = false,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const filteredDesigns = useMemo( () => {
@@ -306,6 +309,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						{ assemblerCtaData.title }
 					</Button>
 				) }
+				{ isTierFilterEnabled && <DesignPickerTierFilter /> }
 			</div>
 
 			<div className="design-picker__grid">
@@ -355,6 +359,7 @@ export interface UnifiedDesignPickerProps {
 	isSiteAssemblerEnabled?: boolean; // Temporary for A/B test
 	siteActiveTheme?: string | null;
 	showActiveThemeBadge?: boolean;
+	isTierFilterEnabled?: boolean;
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -374,6 +379,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	isSiteAssemblerEnabled,
 	siteActiveTheme = null,
 	showActiveThemeBadge = false,
+	isTierFilterEnabled = false,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 
@@ -410,6 +416,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
 					siteActiveTheme={ siteActiveTheme }
 					showActiveThemeBadge={ showActiveThemeBadge }
+					isTierFilterEnabled={ isTierFilterEnabled }
 				/>
 				{ bottomAnchorContent }
 			</div>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -12,12 +12,12 @@ import {
 	getAssemblerDesign,
 	getDesignPreviewUrl,
 	getMShotOptions,
-	isBlankCanvasDesign,
 	isDefaultGlobalStylesVariationSlug,
 } from '../utils';
 import { isLockedStyleVariation } from '../utils/is-locked-style-variation';
 import { UnifiedDesignPickerCategoryFilter } from './design-picker-category-filter/unified-design-picker-category-filter';
 import DesignPickerTierFilter from './design-picker-tier-filter';
+import NoResults from './no-results';
 import PatternAssemblerCta, { usePatternAssemblerCtaData } from './pattern-assembler-cta';
 import ThemeCard from './theme-card';
 import type { Categorization } from '../hooks/use-categorization';
@@ -308,10 +308,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 
 			<div className="design-picker__grid">
 				{ filteredDesigns.map( ( design, index ) => {
-					if ( isBlankCanvasDesign( design ) ) {
-						return null;
-					}
-
 					return (
 						<DesignCard
 							key={ design.recipe?.slug ?? design.slug ?? index }
@@ -328,6 +324,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						/>
 					);
 				} ) }
+				{ filteredDesigns.length === 0 && <NoResults /> }
 				{ isSiteAssemblerEnabled && (
 					<PatternAssemblerCta onButtonClick={ () => onDesignYourOwn( getAssemblerDesign() ) } />
 				) }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -4,16 +4,16 @@ import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import clsx from 'clsx';
 import photon from 'photon';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SHOW_ALL_SLUG } from '../constants';
+import { useFilteredDesigns } from '../hooks/use-filtered-designs';
 import {
 	getAssemblerDesign,
 	getDesignPreviewUrl,
 	getMShotOptions,
 	isBlankCanvasDesign,
 	isDefaultGlobalStylesVariationSlug,
-	filterDesignsByCategory,
 } from '../utils';
 import { isLockedStyleVariation } from '../utils/is-locked-style-variation';
 import { UnifiedDesignPickerCategoryFilter } from './design-picker-category-filter/unified-design-picker-category-filter';
@@ -276,13 +276,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isTierFilterEnabled = false,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
-	const filteredDesigns = useMemo( () => {
-		if ( categorization?.selection ) {
-			return filterDesignsByCategory( designs, categorization.selection );
-		}
-
-		return designs;
-	}, [ designs, categorization?.selection ] );
+	const filteredDesigns = useFilteredDesigns( designs, categorization );
 
 	// Pick design
 

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -8,13 +8,14 @@ import type { Design } from '../types';
 // Designs with `showFirst` are always included regardless of the selected features and subjects.
 export function filterDesigns(
 	designs: Design[],
-	categorySlug: string | null,
-	selectedDesignTier?: string
+	categorySlug: string | null | undefined,
+	selectedDesignTier: string = ''
 ): Design[] {
 	return designs.filter(
 		( design ) =>
 			( design.showFirst ||
 				isBlankCanvasDesign( design ) ||
+				! categorySlug ||
 				design.categories.find( ( { slug } ) => slug === categorySlug ) ) &&
 			( ! selectedDesignTier || design.design_tier === selectedDesignTier )
 	);
@@ -23,11 +24,11 @@ export function filterDesigns(
 export const useFilteredDesigns = ( designs: Design[], categorization?: Categorization ) => {
 	const [ searchParams ] = useSearchParams();
 
-	const selectedDesignTier = searchParams.get( 'tier' );
+	const selectedDesignTier = searchParams.get( 'tier' ) ?? '';
 
 	const filteredDesigns = useMemo( () => {
 		if ( categorization?.selection || selectedDesignTier ) {
-			return filterDesigns( designs, categorization.selection, selectedDesignTier );
+			return filterDesigns( designs, categorization?.selection, selectedDesignTier );
 		}
 
 		return designs;

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { filterDesignsByCategory } from '../utils';
+import type { Categorization } from './use-categorization';
+import type { Design } from '../types';
+
+export const useFilteredDesigns = ( designs: Design[], categorization?: Categorization ) => {
+	const filteredDesigns = useMemo( () => {
+		if ( categorization?.selection ) {
+			return filterDesignsByCategory( designs, categorization.selection );
+		}
+
+		return designs;
+	}, [ designs, categorization?.selection ] );
+
+	return filteredDesigns;
+};

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -1,16 +1,37 @@
 import { useMemo } from 'react';
-import { filterDesignsByCategory } from '../utils';
+import { useSearchParams } from 'react-router-dom';
+import { isBlankCanvasDesign } from '../utils/available-designs';
 import type { Categorization } from './use-categorization';
 import type { Design } from '../types';
 
+// Returns designs that match the features, subjects and tiers.
+// Designs with `showFirst` are always included regardless of the selected features and subjects.
+export function filterDesigns(
+	designs: Design[],
+	categorySlug: string | null,
+	selectedDesignTier?: string
+): Design[] {
+	return designs.filter(
+		( design ) =>
+			( design.showFirst ||
+				isBlankCanvasDesign( design ) ||
+				design.categories.find( ( { slug } ) => slug === categorySlug ) ) &&
+			( ! selectedDesignTier || design.design_tier === selectedDesignTier )
+	);
+}
+
 export const useFilteredDesigns = ( designs: Design[], categorization?: Categorization ) => {
+	const [ searchParams ] = useSearchParams();
+
+	const selectedDesignTier = searchParams.get( 'tier' );
+
 	const filteredDesigns = useMemo( () => {
-		if ( categorization?.selection ) {
-			return filterDesignsByCategory( designs, categorization.selection );
+		if ( categorization?.selection || selectedDesignTier ) {
+			return filterDesigns( designs, categorization.selection, selectedDesignTier );
 		}
 
 		return designs;
-	}, [ designs, categorization?.selection ] );
+	}, [ designs, categorization?.selection, selectedDesignTier ] );
 
 	return filteredDesigns;
 };

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -14,10 +14,10 @@ export function filterDesigns(
 	return designs.filter(
 		( design ) =>
 			( design.showFirst ||
-				isBlankCanvasDesign( design ) ||
 				! categorySlug ||
 				design.categories.find( ( { slug } ) => slug === categorySlug ) ) &&
-			( ! selectedDesignTier || design.design_tier === selectedDesignTier )
+			( ! selectedDesignTier || design.design_tier === selectedDesignTier ) &&
+			! isBlankCanvasDesign( design )
 	);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -833,6 +833,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-intersection-observer: "npm:^9.4.3"
+    react-router-dom: "npm:^6.23.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.3.3"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10012

## Proposed Changes

* Introduce the `useIsGoalsHoldout` hook
* Add the "Free only" toggle to the design picker
* Introduce the `useFilteredDesigns` hook to apply the "Free only" toggle to designs
* Introduce the `design-picker/goal-centric` to control the `goal-centric` related features

Note that we will handle the empty result and users with the paid plan in the follow-up PR.

**Screenshots**

![image](https://github.com/user-attachments/assets/72991989-8602-465d-b9f6-81aa4b9267f5)

![image](https://github.com/user-attachments/assets/89fb8548-7667-4b05-ad7d-ce3e4e16ba01)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to allow users to search free themes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign your account to the `control` variation of the `calypso_onboarding_goals_holdout_20241126` exp. See pbxNRc-4zR-p2.
* Create a new site
* Select any goals
* When you land on the Design Picker, make sure you CAN see the "Free only" toggle
* Enable the "Free only" toggle
* Make sure the paid themes are excluded from the result
* Switch to different categories
* Make sure the toggle still takes effect.
  * TBD: we have to handle the category without any free themes
* Assign your account to the `holdout` variation
* Make sure you CANNOT see the "Free only" toggle

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?