### PR TITLE
Add missing Server Performance chart legend

### DIFF
--- a/client/sites/tools/monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/sites/tools/monitoring/components/site-monitoring-line-chart/index.tsx
@@ -37,6 +37,7 @@ interface SeriesProp {
 	scale?: string;
 	unit?: string;
 	showInLegend?: boolean;
+	showInTooltip?: boolean;
 }
 
 export function formatChartHour( date: Date ): string {

--- a/client/sites/tools/monitoring/components/site-monitoring.tsx
+++ b/client/sites/tools/monitoring/components/site-monitoring.tsx
@@ -587,6 +587,8 @@ export const SiteMonitoring = ( { className }: { className?: string } ) => {
 						fill: colorToAlpha( 'WordPress Blue 50', 0.1 ),
 						label: __( 'Requests per minute' ),
 						stroke: colorStudio.colors[ 'WordPress Blue 50' ],
+						showInLegend: true,
+						showInTooltip: true,
 					},
 					{
 						fill: colorToAlpha( 'Yellow 30', 0.2 ),
@@ -594,6 +596,8 @@ export const SiteMonitoring = ( { className }: { className?: string } ) => {
 						stroke: colorStudio.colors[ 'Yellow 30' ],
 						scale: 'average-response-time',
 						unit: 'ms',
+						showInLegend: true,
+						showInTooltip: true,
 					},
 				] }
 				isLoading={ isLoadingLineChart }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9965

## Proposed Changes

I propose to add a missing legend for the Server Performance chart on the site's Monitoring page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The legend is missing for the Server Performance line chart but is available for other charts.



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Calypso locally or use a Calypso Live link
2. Navigate to the `/sites` page
3. Locate a Business site with enabled Hosting features
4. Open the site's card and click the Monitoring tab
5. Confirm that Server Performance chart has legend displayed

| **Before** | **After** |
|---|---|
| ![Screenshot 2024-12-02 at 11 16 40](https://github.com/user-attachments/assets/0c1ac87e-d7ba-4cc4-83af-2faf9d6436f0) | ![Screenshot 2024-12-02 at 11 17 35](https://github.com/user-attachments/assets/bcd8c040-2d18-4b15-a371-0517d2d743f2) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
