### PR TITLE
Themes: Lazy load screenshots

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -204,6 +204,7 @@ export class Theme extends Component {
 
 		return (
 			<img
+				loading="lazy"
 				alt={ isScreenshotLoaded ? decodeEntities( description ) : '' }
 				className="theme__img"
 				src={ themeImgSrc }

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -19,6 +19,7 @@ exports[`Theme rendering should match snapshot 1`] = `
         <img
           alt=""
           class="theme__img"
+          loading="lazy"
           src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
           srcset="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
         />


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/95248

## Proposed Changes

Defers the loading of the theme screenshots in the theme showcase until the user scrolls near them with a `loading='lazy'` attribute, effectively decreasing the initial data load from 35MB to 2.5MB (-92%).

**Before**

https://github.com/user-attachments/assets/81827735-8731-41e1-90c3-a0f0c055d939

**After**

https://github.com/user-attachments/assets/4c896747-df8d-44b0-a848-01ce31c51457




## Why are these changes being made?

To optimize the data transferred over network.

## Testing Instructions

- Use the Calypso live link below
- Open the browser devtools and select the Network tab
- Filter by `screenshot` requests
- Go to `/themes/:site`
- Make sure that the screenshot requests are lazy loaded (off-screen images are loaded when you scroll near them)
- Repeat with `/themes` while logged in and logged out