### PR TITLE
Recommend php 8.2 as default

### DIFF
--- a/client/data/php-versions/use-php-versions.jsx
+++ b/client/data/php-versions/use-php-versions.jsx
@@ -1,18 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'calypso/state';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export const usePhpVersions = () => {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
-	// 10% of sites will have a recommended PHP version of 8.2.
-	// 237292101 is the first site of the list.
-	const is10Percent = siteId % 10 === 0 && siteId >= 237292101;
-	const recommendedValue = is10Percent ? '8.2' : '8.1';
-	const label = translate( '%s (recommended)', {
-		args: recommendedValue,
-		comment: 'PHP Version for a version switcher',
-	} );
+	const recommendedValue = '8.2';
 
 	const phpVersions = [
 		{
@@ -38,20 +28,17 @@ export const usePhpVersions = () => {
 			value: '8.1',
 		},
 		{
-			label: '8.2',
-			value: '8.2',
+			label: translate( '%s (recommended)', {
+				args: '8.2',
+				comment: 'PHP Version for a version switcher',
+			} ),
+			value: recommendedValue,
 		},
 		{
 			label: '8.3',
 			value: '8.3',
 		},
 	];
-
-	if ( is10Percent ) {
-		phpVersions[ 4 ].label = label;
-	} else {
-		phpVersions[ 3 ].label = label;
-	}
 
 	return { recommendedValue, phpVersions };
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#9626

## Proposed Changes

* Recommend PHP 8.2 to all users

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Based on the provisioned experiment, we did see a major factor that's stopping us from moving the default to PHP 8.2, so we're recommending it as default going forward.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to http://calypso.localhost:3000/sites/settings/web-server/YOUR_ATOMIC_SITE_SLUG
* Find PHP version section, and make sure it's showing PHP 8.2 with recommended string.

![Screenshot 2024-12-02 at 7 18 30 PM](https://github.com/user-attachments/assets/5057c2bd-9603-4103-91c3-be2a7b21d942)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
