### PR TITLE
Fix broken 'Add site' link on the list of domains

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table-site-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-site-cell.tsx
@@ -1,6 +1,7 @@
 import { SiteDetails } from '@automattic/data-stores';
 import { useI18n } from '@wordpress/react-i18n';
 import { domainOnlySiteCreationLink } from '../utils/paths';
+import type { MouseEvent } from 'react';
 
 interface DomainsTableSiteCellProps {
 	site: Pick< SiteDetails, 'ID' | 'name' >;
@@ -20,6 +21,7 @@ export const DomainsTableSiteCell = ( {
 			<a
 				className="domains-table__add-site-link"
 				href={ domainOnlySiteCreationLink( siteSlug, site.ID ) }
+				onClick={ ( e: MouseEvent ) => e.stopPropagation() }
 			>
 				{ __( 'Add site' ) }
 			</a>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9785

## Proposed Changes

I propose fixing a broken 'Add site' link in the list of domains. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The table row on the Domains page points to the page that allows managing a domain. The 'Add site' link on the grid should point to a new site flow, similar to the CTA on the domain manage page.

Currently, due to a bug, when users click 'Add site' on the list of domains, the link action is ignored and they are navigated to manage domain form.

I propose to fix the issue by adding an onclick handler to stop the propagation. A similar approach was followed in other places.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Calypso locally or use a Calypso Live link
2. Navigate to the `/domains/manage` page
3. Locate a domain that is not attached to a site
4. Click the 'Add site' link and confirm it points to a new site flow
5. Navigate back and confirm that the domain row still points to the domain manage page

![Screenshot 2024-12-02 at 12 33 38](https://github.com/user-attachments/assets/f4fccfcd-76cc-45c5-858a-008a751782c7)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
 - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
