### PR TITLE
Help Center: Open chat images in a new tab

### DIFF
--- a/packages/help-center/src/components/utils.tsx
+++ b/packages/help-center/src/components/utils.tsx
@@ -109,7 +109,7 @@ export const calculateUnread = ( conversations: ZendeskConversation[] ) => {
 export const getClientId = ( conversations: ZendeskConversation[] ): string =>
 	conversations
 		.flatMap( ( conversation ) => conversation.messages )
-		.find( ( message ) => message.source.type === 'web' && message.source.id )?.source.id || '';
+		.find( ( message ) => message.source?.type === 'web' && message.source?.id )?.source?.id || '';
 
 export const getConversationsFromSupportInteractions = (
 	conversations: ZendeskConversation[],

--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -68,7 +68,9 @@ export const MessageContent = ( {
 				<div className={ messageClasses }>
 					{ message?.context?.flags?.show_ai_avatar !== false && messageHeader }
 					{ message.type === 'error' && <ErrorMessage message={ message } /> }
-					{ ( [ 'message', 'image', 'file', 'text' ].includes( message.type ) ||
+					{ ( [ 'message', 'image', 'image-placeholder', 'file', 'text' ].includes(
+						message.type
+					) ||
 						! message.type ) && (
 						<UserMessage
 							message={ markdownMessageContent }

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -133,9 +133,11 @@ export const UserMessage = ( {
 				<Markdown
 					urlTransform={ uriTransformer }
 					components={ {
-						a: ( props: React.ComponentProps< 'a' > ) => (
-							<CustomALink { ...props } target="_blank" />
-						),
+						...( message.type !== 'image' && {
+							a: ( props: React.ComponentProps< 'a' > ) => (
+								<CustomALink { ...props } target="_blank" />
+							),
+						} ),
 					} }
 				>
 					{ isRequestingHumanSupport ? displayMessage : message.content }

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -133,11 +133,9 @@ export const UserMessage = ( {
 				<Markdown
 					urlTransform={ uriTransformer }
 					components={ {
-						...( message.type !== 'image' && {
-							a: ( props: React.ComponentProps< 'a' > ) => (
-								<CustomALink { ...props } target="_blank" />
-							),
-						} ),
+						a: ( props: React.ComponentProps< 'a' > ) => (
+							<CustomALink { ...props } target="_blank" />
+						),
 					} }
 				>
 					{ isRequestingHumanSupport ? displayMessage : message.content }

--- a/packages/odie-client/src/components/send-message-input/attachment-button.tsx
+++ b/packages/odie-client/src/components/send-message-input/attachment-button.tsx
@@ -14,7 +14,7 @@ import { zendeskMessageConverter } from '../../utils';
 
 const getFileType = ( file: File ) => {
 	if ( file.type.includes( 'image' ) ) {
-		return 'image';
+		return 'image-placeholder';
 	}
 
 	return 'text';

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -217,6 +217,7 @@ export type ZendeskContentType =
 	| 'form'
 	| 'formResponse'
 	| 'image'
+	| 'image-placeholder'
 	| 'list'
 	| 'location'
 	| 'template';

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -199,7 +199,7 @@ export type ZendeskMessage = {
 	received: number;
 	role: string;
 	actions?: MessageAction[];
-	source: {
+	source?: {
 		type: 'web' | 'slack' | 'zd:surveys';
 		id: string;
 		integrationId: string;

--- a/packages/odie-client/src/utils/zendesk-message-converter.ts
+++ b/packages/odie-client/src/utils/zendesk-message-converter.ts
@@ -1,9 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { Message, MessageRole, MessageType, ZendeskMessage } from '../types';
 
-// Format markdown to support images attachments
+// Format markdown to support images attachments that open in a new tab
 function prepareMarkdownImage( imgUrl: string ): string {
-	return `![Image](${ imgUrl })`;
+	return `[![Image](${ imgUrl })](${ imgUrl })`;
 }
 
 function convertUrlsToMarkdown( text: string ): string {

--- a/packages/odie-client/src/utils/zendesk-message-converter.ts
+++ b/packages/odie-client/src/utils/zendesk-message-converter.ts
@@ -1,9 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { Message, MessageRole, MessageType, ZendeskMessage } from '../types';
 
-// Format markdown to support images attachments that open in a new tab
-function prepareMarkdownImage( imgUrl: string ): string {
-	return `[![Image](${ imgUrl })](${ imgUrl })`;
+// Format markdown to support images attachments that open in a new tab.
+function prepareMarkdownImage( imgUrl: string, isPlaceholder: boolean ): string {
+	return isPlaceholder ? `![Image](${ imgUrl })` : `[![Image](${ imgUrl })](${ imgUrl })`;
 }
 
 function convertUrlsToMarkdown( text: string ): string {
@@ -33,8 +33,12 @@ function getContentMessage( message: ZendeskMessage ): string {
 	let messageContent = '';
 	switch ( message.type ) {
 		case 'image':
+		case 'image-placeholder':
 			if ( message.mediaUrl ) {
-				messageContent = prepareMarkdownImage( message.mediaUrl );
+				messageContent = prepareMarkdownImage(
+					message.mediaUrl,
+					message.type === 'image-placeholder' ? true : false
+				);
 			}
 			break;
 		case 'text':


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/10019

## Proposed Changes

Opens the images sent in the chat in a new page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Help Center with the ?flags=help-center-experience
* Open a chat with an Happiness Engineer and send an image from the Happiness Engineer
* The image should be clickable
* You older images should be clickable
* The images you sent in the current session are still not clickable, we'll address it in the next PR

