### PR TITLE
Stats: Fix "daysInRange" of enforced  7 days range by paywall gate

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -393,7 +393,7 @@ class StatsSite extends Component {
 			customChartRange.chartEnd = momentSiteZone.format( 'YYYY-MM-DD' );
 			customChartRange.chartStart = momentSiteZone
 				.clone()
-				.subtract( 7, 'days' )
+				.subtract( customChartRange.daysInRange - 1, 'days' )
 				.format( 'YYYY-MM-DD' );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix the `daysInRange` calculation for the enforced 7-day range from the paywall gate.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The interval calculation does not fit the logic, so the selected shortcut would not be mapped.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page for a Jetpack site gated behind the commercial paywall.
* Ensure the default date range is `Last 7 Days`.
* Click on the date range picker.
* Ensure the `Last 7 Days` option is selected.

|Before|After|
|-|-|
|<img width="782" alt="截圖 2024-12-02 晚上10 43 44" src="https://github.com/user-attachments/assets/84e3558f-8c11-4e4a-9157-f1c2e53ec8af">|<img width="888" alt="截圖 2024-12-02 晚上10 43 21" src="https://github.com/user-attachments/assets/78036d25-e87d-4800-b4aa-bfad7bf96640">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
