### PR TITLE
Reduce axes width to better use space

### DIFF
--- a/client/sites/tools/monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/sites/tools/monitoring/components/site-monitoring-line-chart/index.tsx
@@ -104,7 +104,7 @@ function addExtraScaleIfDefined( series: Array< SeriesProp > ) {
 			{
 				scale: serie.scale,
 				side: 1,
-				size: 70,
+				size: 60,
 				grid: {
 					show: false,
 				},
@@ -183,7 +183,7 @@ export const SiteMonitoringLineChart = ( {
 					// y-axis
 					gap: 8,
 					space: 40,
-					size: 50,
+					size: 40,
 					stroke: '#787C82',
 					grid: {
 						stroke: '#DCDCDE',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9966

## Proposed Changes

I propose slightly reducing the width of the left and right axes to optimize the space used for the chart.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There is too much padding on the left side of the chart and we would like to better ruse that space.

The PR reduces both axes width by 10px so it gives more room for the chart itself.

It's still not ideal on the left side for low numbers. It's caused by how the chart library is implemented internally - it uses a fixed width for the axis and then aligns the text to the axis itself.

It looks for short labels as follows now:

| **Desktop** | **Mobile** |
|---|---|
| ![Screenshot 2024-12-02 at 16 23 35](https://github.com/user-attachments/assets/04eb09d1-2517-4065-a1c5-28773eae2d16) | ![Screenshot 2024-12-02 at 16 23 55](https://github.com/user-attachments/assets/efccf2aa-3ee6-4060-907c-fac44da8d11d) |

| **Desktop** | **Mobile** |
|---|---|
| ![Screenshot 2024-12-02 at 16 23 10](https://github.com/user-attachments/assets/3a4cfe06-376b-4d5f-bcf0-45f22e78a8e3) | ![Screenshot 2024-12-02 at 16 22 58](https://github.com/user-attachments/assets/58679614-6203-4c9f-a168-0ae17826b8f9) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Calypso locally or use a Calypso Live link
2. Navigate to the `/sites` page
3. Locate a Business site with enabled Hosting features
4. Open the site's card and click the Monitoring tab
5. Confirm that the Server Performance chart has better y-axis labels spacing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
