### PR TITLE
Align send button content

### DIFF
--- a/packages/odie-client/src/components/send-message-input/style.scss
+++ b/packages/odie-client/src/components/send-message-input/style.scss
@@ -74,6 +74,9 @@ $blueberry-color: #3858e9;
 	height: 40px;
 	width: 40px;
 
+	display: flex;
+	align-items: center;
+	justify-content: center;
 
 	&[disabled] {
 		background-color: var(--color-neutral-20) !important;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR fixes the vertical alignment of the send button icon

| Before  | After |
| ------------- | ------------- |
| <img width="409" alt="Screenshot 2024-12-02 at 16 37 45" src="https://github.com/user-attachments/assets/0a8dd26d-ae63-4bec-a65d-49797923a617">  |  <img width="412" alt="Screenshot 2024-12-02 at 16 37 14" src="https://github.com/user-attachments/assets/177ee07b-9dbd-4889-8b45-03a6cc7ae494"> |

Related to #

## Proposed Changes

* Center button content

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with and without the flag `help-center-experience`
* The send button contents should be aligned properly 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
