### PR TITLE
Fix spacing around domain transfer lock icon

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/style.scss
@@ -34,7 +34,7 @@
 
 				svg {
 					fill: var(--studio-gray-50);
-					margin: 0 8px 0 3px;
+					margin: 0 3px 0 0;
 				}
 			}
 		}

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -272,7 +272,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 			<span className="transfer-page__transfer-lock-label">
 				{ isDomainLocked ? (
 					<>
-						<Icon icon={ lock } size={ 15 } viewBox="4 0 18 20" />
+						<Icon icon={ lock } size={ 16 } viewBox="0 0 22 22" />
 						{ enabledLockLabel }
 					</>
 				) : (

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -101,7 +101,7 @@
 		color: var(--studio-gray-80);
 
 		svg {
-			margin-right: 8px;
+			margin-right: 3px;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9789

## Proposed Changes

I propose to fix the spacing around the domain transfer lock icon on the manage domain page and in the transfer form.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The spacing between the icon and text is incorrect.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Calypso locally or use a Calypso Live link
2. Navigate to the `/domains/manage` page
3. Locate a domain and click it
4. Confirm that spacing is fixed

|**Before**|**After**|
|---|---|
| ![Screenshot 2024-12-02 at 17 43 22](https://github.com/user-attachments/assets/7b220860-187c-45f0-a8b9-077fbf2057fb) | ![Screenshot 2024-12-02 at 17 42 23](https://github.com/user-attachments/assets/95133b81-c965-42ab-917b-c33d18de701d) |

| **Before** | **After** |
|---|---|
| ![Screenshot 2024-12-02 at 17 43 30](https://github.com/user-attachments/assets/e0af102c-0852-4fc9-9dc9-f694257bd542) | ![Screenshot 2024-12-02 at 17 42 33](https://github.com/user-attachments/assets/aab640f3-3689-4c44-972d-8e1523965fab) |


## Pre-merge Checklist

<!--

Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
 - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
