### PR TITLE
Fix delete domain dialog width and CTA

### DIFF
--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -257,7 +257,7 @@ class RemoveDomainDialog extends Component {
 		return (
 			<Dialog
 				buttons={ buttons }
-				className="remove-domain-dialog__dialog"
+				additionalClassNames="remove-domain-dialog"
 				isVisible={ this.props.isDialogVisible }
 				onClose={ this.close }
 				leaveTimeout={ 0 }

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -17,6 +17,11 @@
 		vertical-align: middle;
 	}
 }
+.remove-domain-dialog {
+	&.dialog.card {
+		max-width: 565px;
+	}
+}
 .dialog__button--domains-remove {
 	> .dialog__button-label {
 		display: flex;

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .remove-purchase__card,
 .auto-renew-toggle__card {
 	margin: 10px auto;
@@ -19,13 +22,18 @@
 }
 .remove-domain-dialog {
 	&.dialog.card {
-		max-width: 565px;
+		max-width: 90%;
+
+		@include break-small {
+			max-width: 565px;
+		}
 	}
 }
 .dialog__button--domains-remove {
 	> .dialog__button-label {
 		display: flex;
 		align-items: center;
+		justify-content: center;
 		column-gap: 7px;
 
 		> svg {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9788

## Proposed Changes

I propose to fix delete domain dialog width as it's too wide. Also, I fixed the primary action button on mobile, as the button content was not centered correctly.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To improve UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Calypso locally or use a Calypso Live link
2. Navigate to the `/domains/manage` page
3. Locate a domain and click it
4. Click the 'Delete' button
5. Confirm that dialog is no longer too wide
6. Change browser width to mobile view
7. Confirm that dialog is 90% wide and that text on ll buttons is centered

Mobile

| **Before** | **After** |
|---|---|
| ![Screenshot 2024-12-02 at 18 24 17](https://github.com/user-attachments/assets/a6ef6ece-b7b6-4fd1-9e8b-5d289b5d4f3b) | ![Screenshot 2024-12-02 at 18 18 44](https://github.com/user-attachments/assets/aad57ee2-f340-4e66-9515-765960bce68f) |

Desktop

| **Before** | **After** |
|---|---|
| ![Screenshot 2024-12-02 at 18 24 32](https://github.com/user-attachments/assets/b0356f4e-e5f7-4517-adae-54f41ce02e72) | ![Screenshot 2024-12-02 at 18 19 13](https://github.com/user-attachments/assets/40a097a5-5a41-4786-931c-84eb064e5bd3) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
