### PR TITLE
DO NOT MERGE: Add new translations for the remove domain dialog changes

### DIFF
--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -63,6 +63,7 @@ class RemoveDomainDialog extends Component {
 						}
 					) }
 				</p>
+				<p>{ translate( 'Do you still want to continue with deleting your domain?' ) }</p>
 			</Fragment>
 		);
 	}
@@ -224,7 +225,7 @@ class RemoveDomainDialog extends Component {
 			{
 				action: 'cancel',
 				disabled: this.props.isRemoving,
-				label: this.state.step === 3 ? translate( 'Nevermind' ) : translate( 'Cancel' ),
+				label: this.state.step === 3 ? translate( 'Never mind' ) : translate( 'Cancel' ),
 			},
 			{
 				action: 'remove',


### PR DESCRIPTION
This pull request is just here to add the "String Freeze" label to the new translations from https://github.com/Automattic/wp-calypso/pull/96701 (apparently that label doesn't work when added to pull requests by non-Automatticians).

This should not be merged.

Here are screenshots of what the newly-translated text will look like within the context of the above pull request:

**First step:**

![step-1](https://github.com/user-attachments/assets/8140db52-fd5b-48ed-9c02-9fe2ea6e7560)

**Second step:**

![step-2](https://github.com/user-attachments/assets/1ef847e4-fdc4-4fa4-87f3-7a874df4ef96)
