### PR TITLE
Site Migration: Update "View Sites dashboard" button to point to site overview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -131,7 +131,7 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 		<div className="migration-message__cta-wrapper">
 			<Button
 				className="migration-message__cta"
-				href="/sites"
+				href={ '/sites/overview/' + siteSlug }
 				variant="primary"
 				onClick={ () =>
 					recordTracksEvent( 'calypso_migration_message_view_sites_dashboard_click' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/96418

## Proposed Changes

* Instead of going to `/sites`, go to `/sites/overview/siteSlug` so users see the overview for their specific new site. Helpful for users who have more than one site and might get lost in the all sites view.

<img width="788" alt="Screenshot 2024-12-02 at 1 34 49 PM" src="https://github.com/user-attachments/assets/3129d8ea-f72e-4625-ab6c-568614bb5f16">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p58i-iHv-p2 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Create a new site from `/start`
* Choose import/migrate on the goals step
* Go through the migration flow and choose "Do it for me"
* Put in credentials or a migration file (you can input any URL for the migration file to work around this)
* On the final page, the "View Sites dashboard" button should point to `/sites/overview/yoursiteslug`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?