### PR TITLE
Help Center: Add support for WP Support 3 tab component

### DIFF
--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -455,9 +455,7 @@
 				}
 			}
 
-			// Originally hidden with context: https://github.com/Automattic/wp-calypso/issues/87340#issuecomment-1937424710
-			// New CSS changes: Show the tab component for the WP Support 3 tab component
-
+			// Show the tab component for the WP Support 3 tab component
 			.wp-block-wpsupport3-tabs {
 
 				.aligncenter {

--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -477,8 +477,7 @@
 						padding: 8px 0;
 			
 						color: var( --blue-blue-50, #0675c4 );
-						/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-						font-size: 16px;
+						font-size: $font-body;
 						line-height: 24px;
 						border: none;
 						background: none;

--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -455,10 +455,70 @@
 				}
 			}
 
-			// Hide the tablist for the WP Support 3 tab component
-			// Context: https://github.com/Automattic/wp-calypso/issues/87340#issuecomment-1937424710
-			.wpsupport3-tab__tablist {
+			// Originally hidden with context: https://github.com/Automattic/wp-calypso/issues/87340#issuecomment-1937424710
+			// New CSS changes: Show the tab component for the WP Support 3 tab component
+
+			.wp-block-wpsupport3-tabs {
+
+				.aligncenter {
+					margin-left: auto;
+					margin-right: auto;
+				}
+				
+				.wpsupport3-tab__tablist {
+					display: flex;
+					align-items: center;
+					gap: 24px;
+					white-space: nowrap;
+					overflow-x: auto;
+					border-bottom: 1px solid var( --wp--preset--color--border-light-gray, #eee );
+
+					.wpsupport3-tab__title {
+						padding: 8px 0;
+			
+						color: var( --blue-blue-50, #0675c4 );
+						/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+						font-size: 16px;
+						line-height: 24px;
+						border: none;
+						background: none;
+						border-bottom: 1px solid transparent;
+						transition: border-bottom 0.3s;
+
+						&:focus {
+							outline: none;
+						}
+
+						&:hover {
+							text-decoration: none;
+						}
+			
+						&[aria-selected='true'] {
+							color: var( --gray-gray-100, #101517 );
+							border-bottom: 1px solid var( --gray-gray-100, #101517 );
+						}
+					}
+				}
+			}
+			
+			.wp-block-wpsupport3-tab {
+				margin-top: 32px;
 				display: none;
+				
+				&:not( [aria-hidden='true'] ) {
+					display: block;
+					animation: fadeIn 0.5s;
+				}
+			
+				@keyframes fadeIn {
+					from {
+						opacity: 0;
+					}
+			
+					to {
+						opacity: 1;
+					}
+				}
 			}
 		}
 	}

--- a/packages/help-center/src/components/help-center-article.tsx
+++ b/packages/help-center/src/components/help-center-article.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useEffect, createInterpolateElement } from '@wordpress/element';
+import { useEffect, createInterpolateElement, useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { usePostByUrl } from '../hooks';
 import { BackToTopButton } from './back-to-top-button';
@@ -12,7 +12,9 @@ import './help-center-article.scss';
 export const HelpCenterArticle = () => {
 	const [ searchParams ] = useSearchParams();
 	const { sectionName } = useHelpCenterContext();
-
+	const location = useLocation();
+	const navigate = useNavigate();
+	const [ tabHash, setTabHash ] = useState( '' );
 	const postUrl = searchParams.get( 'link' ) || '';
 	const query = searchParams.get( 'query' );
 
@@ -52,6 +54,66 @@ export const HelpCenterArticle = () => {
 				: recordTracksEvent( 'calypso_helpcenter_article_viewed', tracksData );
 		}
 	}, [ post, query, sectionName ] );
+
+	const toggleTab = ( element: Element, show: boolean ) => {
+		( element as HTMLElement ).style.display = show ? 'block' : 'none';
+		element.setAttribute( 'aria-hidden', show ? 'false' : 'true' );
+	};
+
+	const toggleTabTitle = ( element: Element, show: boolean ) => {
+		element.setAttribute( 'aria-selected', show ? 'true' : 'false' );
+	};
+
+	const activateTab = useCallback( () => {
+		const hash = tabHash;
+
+		const tabs = Array.from( document.querySelectorAll( '.wp-block-wpsupport3-tabs' ) );
+
+		tabs.forEach( ( tab ) => {
+			const titles = Array.from( tab.querySelectorAll( '.wpsupport3-tab__title' ) );
+			const bodies = Array.from(
+				tab.querySelectorAll( '.wp-block-wpsupport3-tab:not(.invisible_tabpanel)' )
+			);
+
+			const match = titles.findIndex( ( titles ) => titles.id === hash?.substring( 1 ) );
+
+			// Reset selection
+			titles.forEach( ( title ) => toggleTabTitle( title, false ) );
+			bodies.forEach( ( body ) => toggleTab( body, false ) );
+
+			if ( hash && match !== -1 ) {
+				toggleTabTitle( titles[ match ], true );
+				toggleTab( bodies[ match ], true );
+			} else {
+				// If the first tab is invisible from the editor, we set the first tab as active.
+				toggleTabTitle( titles[ 0 ], true );
+				toggleTab( bodies[ 0 ], true );
+			}
+		} );
+	}, [ tabHash ] );
+
+	useEffect( () => {
+		if ( tabHash || post ) {
+			activateTab();
+		}
+	}, [ activateTab, tabHash, post ] );
+
+	useEffect( () => {
+		if ( post ) {
+			const titles = Array.from(
+				document.querySelectorAll( '.wp-block-wpsupport3-tabs .wpsupport3-tab__title' )
+			);
+			titles.forEach( ( title ) => {
+				title.addEventListener( 'click', ( e ) => {
+					e.preventDefault();
+					setTabHash( `#${ title?.id }` );
+					setTimeout( () => {
+						window.scroll( 0, document.documentElement.scrollTop );
+					} );
+				} );
+			} );
+		}
+	}, [ location.pathname, location.search, navigate, post ] );
 
 	return (
 		<div className="help-center-article">

--- a/packages/help-center/src/components/help-center-article.tsx
+++ b/packages/help-center/src/components/help-center-article.tsx
@@ -1,9 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useEffect, createInterpolateElement, useCallback, useState } from '@wordpress/element';
+import { useEffect, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { usePostByUrl } from '../hooks';
+import { useHelpCenterArticleTabComponent } from '../hooks/use-help-center-article-tab-component';
 import { BackToTopButton } from './back-to-top-button';
 import ArticleContent from './help-center-article-content';
 
@@ -12,13 +13,11 @@ import './help-center-article.scss';
 export const HelpCenterArticle = () => {
 	const [ searchParams ] = useSearchParams();
 	const { sectionName } = useHelpCenterContext();
-	const location = useLocation();
-	const navigate = useNavigate();
-	const [ tabHash, setTabHash ] = useState( '' );
 	const postUrl = searchParams.get( 'link' ) || '';
 	const query = searchParams.get( 'query' );
 
 	const { data: post, isLoading, error } = usePostByUrl( postUrl );
+	useHelpCenterArticleTabComponent( post?.content );
 
 	useEffect( () => {
 		//If a url includes an anchor, let's scroll this into view!
@@ -54,66 +53,6 @@ export const HelpCenterArticle = () => {
 				: recordTracksEvent( 'calypso_helpcenter_article_viewed', tracksData );
 		}
 	}, [ post, query, sectionName ] );
-
-	const toggleTab = ( element: Element, show: boolean ) => {
-		( element as HTMLElement ).style.display = show ? 'block' : 'none';
-		element.setAttribute( 'aria-hidden', show ? 'false' : 'true' );
-	};
-
-	const toggleTabTitle = ( element: Element, show: boolean ) => {
-		element.setAttribute( 'aria-selected', show ? 'true' : 'false' );
-	};
-
-	const activateTab = useCallback( () => {
-		const hash = tabHash;
-
-		const tabs = Array.from( document.querySelectorAll( '.wp-block-wpsupport3-tabs' ) );
-
-		tabs.forEach( ( tab ) => {
-			const titles = Array.from( tab.querySelectorAll( '.wpsupport3-tab__title' ) );
-			const bodies = Array.from(
-				tab.querySelectorAll( '.wp-block-wpsupport3-tab:not(.invisible_tabpanel)' )
-			);
-
-			const match = titles.findIndex( ( titles ) => titles.id === hash?.substring( 1 ) );
-
-			// Reset selection
-			titles.forEach( ( title ) => toggleTabTitle( title, false ) );
-			bodies.forEach( ( body ) => toggleTab( body, false ) );
-
-			if ( hash && match !== -1 ) {
-				toggleTabTitle( titles[ match ], true );
-				toggleTab( bodies[ match ], true );
-			} else {
-				// If the first tab is invisible from the editor, we set the first tab as active.
-				toggleTabTitle( titles[ 0 ], true );
-				toggleTab( bodies[ 0 ], true );
-			}
-		} );
-	}, [ tabHash ] );
-
-	useEffect( () => {
-		if ( tabHash || post ) {
-			activateTab();
-		}
-	}, [ activateTab, tabHash, post ] );
-
-	useEffect( () => {
-		if ( post ) {
-			const titles = Array.from(
-				document.querySelectorAll( '.wp-block-wpsupport3-tabs .wpsupport3-tab__title' )
-			);
-			titles.forEach( ( title ) => {
-				title.addEventListener( 'click', ( e ) => {
-					e.preventDefault();
-					setTabHash( `#${ title?.id }` );
-					setTimeout( () => {
-						window.scroll( 0, document.documentElement.scrollTop );
-					} );
-				} );
-			} );
-		}
-	}, [ location.pathname, location.search, navigate, post ] );
 
 	return (
 		<div className="help-center-article">

--- a/packages/help-center/src/hooks/use-help-center-article-tab-component.tsx
+++ b/packages/help-center/src/hooks/use-help-center-article-tab-component.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState } from '@wordpress/element';
+
+export const useHelpCenterArticleTabComponent = ( postContent: string | undefined ) => {
+	const [ tabHash, setTabHash ] = useState( '' );
+
+	const toggleTab = ( element: Element, show: boolean ) => {
+		( element as HTMLElement ).style.display = show ? 'block' : 'none';
+		element.setAttribute( 'aria-hidden', show ? 'false' : 'true' );
+	};
+
+	const toggleTabTitle = ( element: Element, show: boolean ) => {
+		element.setAttribute( 'aria-selected', show ? 'true' : 'false' );
+	};
+
+	const activateTab = useCallback( () => {
+		const hash = tabHash;
+
+		const tabs = Array.from( document.querySelectorAll( '.wp-block-wpsupport3-tabs' ) );
+
+		tabs.forEach( ( tab ) => {
+			const titles = Array.from( tab.querySelectorAll( '.wpsupport3-tab__title' ) );
+			const bodies = Array.from(
+				tab.querySelectorAll( '.wp-block-wpsupport3-tab:not(.invisible_tabpanel)' )
+			);
+
+			const match = titles.findIndex( ( titles ) => titles.id === hash?.substring( 1 ) );
+
+			// Reset selection
+			titles.forEach( ( title ) => toggleTabTitle( title, false ) );
+			bodies.forEach( ( body ) => toggleTab( body, false ) );
+
+			if ( hash && match !== -1 ) {
+				toggleTabTitle( titles[ match ], true );
+				toggleTab( bodies[ match ], true );
+			} else {
+				// If the first tab is invisible from the editor, we set the first tab as active.
+				toggleTabTitle( titles[ 0 ], true );
+				toggleTab( bodies[ 0 ], true );
+			}
+		} );
+	}, [ tabHash ] );
+
+	useEffect( () => {
+		if ( tabHash || postContent ) {
+			activateTab();
+		}
+	}, [ activateTab, tabHash, postContent ] );
+
+	useEffect( () => {
+		if ( postContent ) {
+			const titles = Array.from(
+				document.querySelectorAll( '.wp-block-wpsupport3-tabs .wpsupport3-tab__title' )
+			);
+			titles.forEach( ( title ) => {
+				title.addEventListener( 'click', ( e ) => {
+					e.preventDefault();
+					setTabHash( `#${ title?.id }` );
+					setTimeout( () => {
+						window.scroll( 0, document.documentElement.scrollTop );
+					} );
+				} );
+			} );
+		}
+	}, [ postContent ] );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/9818

## Proposed Changes

* Add support for WPSupport 3 Tab component

<img width="416" alt="CleanShot 2024-12-02 at 13 48 55@2x" src="https://github.com/user-attachments/assets/4fcd4c9c-c78c-41dc-bcc6-c139043bf184">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* WPSupport3 tab component is currently hidden. These changes add its functionality and make it appear on support docs  within Help Center.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout trunk or use live link
* Navigate to `home?flags=help-center-experience` and open the Help Center
* Find a support doc that uses the wpsupport3 tab component (Example articles to search for: `Upload a theme`, `Get more storage space`, `Set the homepage`.
* Test its functionality
* Bonus: Find more support docs with this components and try to break it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
