### PR TITLE
Site Migrations: Only show Jetpack features if they exist

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-feature-list.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-feature-list.tsx
@@ -72,21 +72,25 @@ export const UpgradePlanFeatureList = ( props: Props ) => {
 						</li>
 					) ) }
 
-					<li className={ clsx( 'import__upgrade-plan-feature logo' ) }>
-						<JetpackLogo size={ 16 } />
-					</li>
-					{ jetpackFeatures?.map( ( feature, i ) => (
-						<li className={ clsx( 'import__upgrade-plan-feature' ) } key={ i }>
-							<Plans2023Tooltip
-								id={ `jetpack-feature-${ i }` }
-								text={ feature?.getDescription?.() }
-								setActiveTooltipId={ setActiveTooltipId }
-								activeTooltipId={ activeTooltipId }
-							>
-								<span>{ feature?.getTitle() }</span>
-							</Plans2023Tooltip>
-						</li>
-					) ) }
+					{ jetpackFeatures && jetpackFeatures.length > 0 && (
+						<>
+							<li className={ clsx( 'import__upgrade-plan-feature logo' ) }>
+								<JetpackLogo size={ 16 } />
+							</li>
+							{ jetpackFeatures?.map( ( feature, i ) => (
+								<li className={ clsx( 'import__upgrade-plan-feature' ) } key={ i }>
+									<Plans2023Tooltip
+										id={ `jetpack-feature-${ i }` }
+										text={ feature?.getDescription?.() }
+										setActiveTooltipId={ setActiveTooltipId }
+										activeTooltipId={ activeTooltipId }
+									>
+										<span>{ feature?.getTitle() }</span>
+									</Plans2023Tooltip>
+								</li>
+							) ) }
+						</>
+					) }
 					<li className={ clsx( 'import__upgrade-plan-feature logo' ) }>
 						<strong>{ __( 'Storage' ) }</strong>
 					</li>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96415

## Proposed Changes

* In the site migration flow, if we don't have any Jetpack features, don't show the Jetpack section/logo in the plan features.

**Before**

<img width="786" alt="Screenshot 2024-12-02 at 2 45 50 PM" src="https://github.com/user-attachments/assets/088cf7e1-9c56-48ee-a0f8-d24907aa5a7c">

**After**

<img width="776" alt="Screenshot 2024-12-02 at 2 44 51 PM" src="https://github.com/user-attachments/assets/c30b8b42-6b34-4861-ab3a-ec6c5a5b0460">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p58i-iHv-p2 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/start`
* Choose import at the goals step
* Put in your website URL and choose Migrate
* Get to the plan selection step
* Click "Show all features" at the bottom of the grid
* You should not see any Jetpack logo or features listed (since we don't pass any to this component in this instance)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?