### PR TITLE
Hide empty content in favor of Reader onboarding.

### DIFF
--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -26,6 +26,16 @@ function FollowingStream( { ...props } ) {
 		return (
 			<div className="following-stream--no-subscriptions">
 				<NavigationHeader title={ translate( 'Recent' ) } />
+				<p>
+					{ translate(
+						'{{strong}}Welcome!{{/strong}} Follow your favorite sites and their latest posts will appear here. Read, like, and comment in a distraction-free environment. Get started by selecting your interests below:',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+					) }
+				</p>
 				<ReaderOnboarding forceShow />
 			</div>
 		);

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -26,11 +26,7 @@ function FollowingStream( { ...props } ) {
 	const isLoading = isLoadingCount || isLoadingSiteSubscriptions;
 
 	const hasNonSelfSubscriptions = useMemo( () => {
-		if ( isLoading ) {
-			return true;
-		}
-
-		if ( ! subscriptionsCount?.blogs || subscriptionsCount.blogs === 0 ) {
+		if ( ! subscriptionsCount?.blogs || subscriptionsCount?.blogs === 0 ) {
 			return false;
 		}
 
@@ -43,7 +39,7 @@ function FollowingStream( { ...props } ) {
 		}
 
 		return subscriptionsCount.blogs > 0;
-	}, [ subscriptionsCount?.blogs, siteSubscriptions, isLoading ] );
+	}, [ subscriptionsCount, siteSubscriptions ] );
 
 	const viewToggle = config.isEnabled( 'reader/recent-feed-overhaul' ) ? <ViewToggle /> : null;
 

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { SubscriptionManager } from '@automattic/data-stores';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
@@ -16,13 +17,24 @@ import './style.scss';
 
 function FollowingStream( { ...props } ) {
 	const { currentView } = useFollowingView();
+	const { data: subscriptionsCount } = SubscriptionManager.useSubscriptionsCountQuery();
+	const hasSubscriptions = subscriptionsCount?.blogs && subscriptionsCount.blogs > 0;
 
 	const viewToggle = config.isEnabled( 'reader/recent-feed-overhaul' ) ? <ViewToggle /> : null;
+
+	if ( ! hasSubscriptions ) {
+		return (
+			<div className="following-stream--no-subscriptions">
+				<NavigationHeader title={ translate( 'Recent' ) } />
+				<ReaderOnboarding forceShow />
+			</div>
+		);
+	}
 
 	return (
 		<>
 			{ currentView === 'recent' && config.isEnabled( 'reader/recent-feed-overhaul' ) ? (
-				<Recent viewToggle={ viewToggle } />
+				<Recent viewToggle={ viewToggle } hasSubscriptions={ hasSubscriptions } />
 			) : (
 				<ReaderStream
 					{ ...props }

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -44,7 +44,7 @@ function FollowingStream( { ...props } ) {
 	return (
 		<>
 			{ currentView === 'recent' && config.isEnabled( 'reader/recent-feed-overhaul' ) ? (
-				<Recent viewToggle={ viewToggle } hasSubscriptions={ hasSubscriptions } />
+				<Recent viewToggle={ viewToggle } />
 			) : (
 				<ReaderStream
 					{ ...props }

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -18,14 +18,23 @@ import './style.scss';
 
 function FollowingStream( { ...props } ) {
 	const { currentView } = useFollowingView();
-	const { data: subscriptionsCount } = SubscriptionManager.useSubscriptionsCountQuery();
-	const { data: siteSubscriptions } = SubscriptionManager.useSiteSubscriptionsQuery();
+	const { data: subscriptionsCount, isLoading: isLoadingCount } =
+		SubscriptionManager.useSubscriptionsCountQuery();
+	const { data: siteSubscriptions, isLoading: isLoadingSiteSubscriptions } =
+		SubscriptionManager.useSiteSubscriptionsQuery();
+
+	const isLoading = isLoadingCount || isLoadingSiteSubscriptions;
+
 	const hasNonSelfSubscriptions = useMemo( () => {
+		if ( isLoading ) {
+			return true;
+		}
+
 		if ( ! subscriptionsCount?.blogs || subscriptionsCount.blogs === 0 ) {
 			return false;
 		}
 
-		// If we have site subscriptions data, filter out self-owned blogs
+		// If we have site subscriptions data, filter out self-owned blogs.
 		if ( siteSubscriptions?.subscriptions ) {
 			const nonSelfSubscriptions = siteSubscriptions.subscriptions.filter(
 				( sub ) => ! sub.is_owner
@@ -34,11 +43,11 @@ function FollowingStream( { ...props } ) {
 		}
 
 		return subscriptionsCount.blogs > 0;
-	}, [ subscriptionsCount?.blogs, siteSubscriptions ] );
+	}, [ subscriptionsCount?.blogs, siteSubscriptions, isLoading ] );
 
 	const viewToggle = config.isEnabled( 'reader/recent-feed-overhaul' ) ? <ViewToggle /> : null;
 
-	if ( ! hasNonSelfSubscriptions ) {
+	if ( ! isLoading && ! hasNonSelfSubscriptions ) {
 		return (
 			<div className="following-stream--no-subscriptions">
 				<NavigationHeader title={ translate( 'Recent' ) } />

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { SubscriptionManager } from '@automattic/data-stores';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -18,11 +19,26 @@ import './style.scss';
 function FollowingStream( { ...props } ) {
 	const { currentView } = useFollowingView();
 	const { data: subscriptionsCount } = SubscriptionManager.useSubscriptionsCountQuery();
-	const hasSubscriptions = subscriptionsCount?.blogs && subscriptionsCount.blogs > 0;
+	const { data: siteSubscriptions } = SubscriptionManager.useSiteSubscriptionsQuery();
+	const hasNonSelfSubscriptions = useMemo( () => {
+		if ( ! subscriptionsCount?.blogs || subscriptionsCount.blogs === 0 ) {
+			return false;
+		}
+
+		// If we have site subscriptions data, filter out self-owned blogs
+		if ( siteSubscriptions?.subscriptions ) {
+			const nonSelfSubscriptions = siteSubscriptions.subscriptions.filter(
+				( sub ) => ! sub.is_owner
+			);
+			return nonSelfSubscriptions.length > 0;
+		}
+
+		return subscriptionsCount.blogs > 0;
+	}, [ subscriptionsCount?.blogs, siteSubscriptions ] );
 
 	const viewToggle = config.isEnabled( 'reader/recent-feed-overhaul' ) ? <ViewToggle /> : null;
 
-	if ( ! hasSubscriptions ) {
+	if ( ! hasNonSelfSubscriptions ) {
 		return (
 			<div className="following-stream--no-subscriptions">
 				<NavigationHeader title={ translate( 'Recent' ) } />
@@ -50,7 +66,6 @@ function FollowingStream( { ...props } ) {
 					{ ...props }
 					className="following"
 					streamSidebar={ () => <ReaderListFollowedSites path={ window.location.pathname } /> }
-					showDefaultEmptyContentIfMissing={ false }
 				>
 					<BloganuaryHeader />
 					<NavigationHeader

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -28,6 +28,7 @@ function FollowingStream( { ...props } ) {
 					{ ...props }
 					className="following"
 					streamSidebar={ () => <ReaderListFollowedSites path={ window.location.pathname } /> }
+					showDefaultEmptyContentIfMissing={ false }
 				>
 					<BloganuaryHeader />
 					<NavigationHeader

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .is-section-reader .navigation-header.following-stream-header {
 	margin: 0 auto;
 	max-width: 600px;
@@ -190,4 +192,10 @@
 			color: var(--color-surface);
 		}
 	}
+}
+
+.following-stream--no-subscriptions {
+	max-width: $break-medium;
+	margin: 0 auto;
+	padding: 16px 24px;
 }

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -198,4 +198,8 @@
 	max-width: $break-medium;
 	margin: 0 auto;
 	padding: 16px 24px;
+
+	.navigation-header {
+		padding-bottom: 0;
+	}
 }

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -1,4 +1,3 @@
-import { SubscriptionManager } from '@automattic/data-stores';
 import { WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
@@ -14,7 +13,6 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPaginatedStream } from 'calypso/state/reader/streams/actions';
 import { viewStream } from 'calypso/state/reader-ui/actions';
-import ReaderOnboarding from '../onboarding';
 import EngagementBar from './engagement-bar';
 import RecentPostField from './recent-post-field';
 import RecentPostSkeleton from './recent-post-skeleton';
@@ -25,9 +23,10 @@ import './style.scss';
 
 interface RecentProps {
 	viewToggle?: React.ReactNode;
+	hasSubscriptions: boolean;
 }
 
-const Recent = ( { viewToggle }: RecentProps ) => {
+const Recent = ( { viewToggle, hasSubscriptions }: RecentProps ) => {
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
 	const [ selectedItem, setSelectedItem ] = useState< ReaderPost | null >( null );
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
@@ -159,93 +158,72 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 		setIsLoading( data?.isRequesting );
 	}, [ data?.isRequesting ] );
 
-	const { data: subscriptionsCount } = SubscriptionManager.useSubscriptionsCountQuery();
-	const hasSubscriptions = subscriptionsCount?.blogs && subscriptionsCount.blogs > 0;
-
 	return (
 		<div className="recent-feed">
 			<div
 				className={ `recent-feed__list-column ${
 					selectedItem && hasSubscriptions ? 'has-overlay' : ''
-				} ${ ! hasSubscriptions ? 'recent-feed--no-subscriptions' : '' }` }
+				}` }
 			>
 				<div className="recent-feed__list-column-header">
 					<NavigationHeader title={ translate( 'Recent' ) }>{ viewToggle }</NavigationHeader>
 				</div>
 				<div className="recent-feed__list-column-content">
-					{ ! hasSubscriptions ? (
-						<>
-							<p>
-								{ translate(
-									'{{strong}}Welcome!{{/strong}} Follow your favorite sites and their latest posts will appear here. Read, like, and comment in a distraction-free environment. Get started by selecting your interests below:',
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								) }
-							</p>
-							<ReaderOnboarding forceShow />
-						</>
-					) : (
-						<DataViews
-							getItemId={ ( item: ReaderPost, index = 0 ) =>
-								item.postId?.toString() ?? `item-${ index }`
-							}
-							view={ view as View }
-							fields={ fields }
-							data={ shownData }
-							onChangeView={ ( newView: View ) =>
-								setView( {
-									type: newView.type,
-									fields: newView.fields ?? [],
-									layout: view.layout,
-									perPage: newView.perPage,
-									page: newView.page,
-									search: newView.search,
-								} )
-							}
-							paginationInfo={ view.search === '' ? defaultPaginationInfo : paginationInfo }
-							defaultLayouts={ { list: {} } }
-							isLoading={ isLoading }
-							selection={ selectedItem ? [ selectedItem.postId?.toString() ] : [] }
-							onChangeSelection={ ( newSelection: string[] ) => {
-								const selectedPost = data?.items?.find(
-									( item: ReaderPost ) => item.postId?.toString() === newSelection[ 0 ]
-								);
-								setSelectedItem( selectedPost || null );
-							} }
-						/>
-					) }
+					<DataViews
+						getItemId={ ( item: ReaderPost, index = 0 ) =>
+							item.postId?.toString() ?? `item-${ index }`
+						}
+						view={ view as View }
+						fields={ fields }
+						data={ shownData }
+						onChangeView={ ( newView: View ) =>
+							setView( {
+								type: newView.type,
+								fields: newView.fields ?? [],
+								layout: view.layout,
+								perPage: newView.perPage,
+								page: newView.page,
+								search: newView.search,
+							} )
+						}
+						paginationInfo={ view.search === '' ? defaultPaginationInfo : paginationInfo }
+						defaultLayouts={ { list: {} } }
+						isLoading={ isLoading }
+						selection={ selectedItem ? [ selectedItem.postId?.toString() ] : [] }
+						onChangeSelection={ ( newSelection: string[] ) => {
+							const selectedPost = data?.items?.find(
+								( item: ReaderPost ) => item.postId?.toString() === newSelection[ 0 ]
+							);
+							setSelectedItem( selectedPost || null );
+						} }
+					/>
 				</div>
 			</div>
-			{ hasSubscriptions ? (
-				<div className={ `recent-feed__post-column ${ selectedItem ? 'overlay' : '' }` }>
-					{ ! ( selectedItem && getPostFromItem( selectedItem ) ) && isLoading && (
-						<RecentPostSkeleton />
-					) }
-					{ ! isLoading && data?.items.length === 0 && (
-						<EmptyContent
-							title={ translate( 'Nothing Posted Yet' ) }
-							line={ translate( 'This feed is currently empty.' ) }
-							illustration="/calypso/images/illustrations/illustration-empty-results.svg"
-							illustrationWidth={ 400 }
+			<div className={ `recent-feed__post-column ${ selectedItem ? 'overlay' : '' }` }>
+				{ ! ( selectedItem && getPostFromItem( selectedItem ) ) && isLoading && (
+					<RecentPostSkeleton />
+				) }
+				{ ! isLoading && data?.items.length === 0 && (
+					<EmptyContent
+						title={ translate( 'Nothing Posted Yet' ) }
+						line={ translate( 'This feed is currently empty.' ) }
+						illustration="/calypso/images/illustrations/illustration-empty-results.svg"
+						illustrationWidth={ 400 }
+					/>
+				) }
+				{ data?.items.length > 0 && selectedItem && getPostFromItem( selectedItem ) && (
+					<>
+						<AsyncLoad
+							require="calypso/blocks/reader-full-post"
+							feedId={ selectedItem.feedId }
+							postId={ selectedItem.postId }
+							onClose={ () => setSelectedItem( null ) }
+							layout="recent"
 						/>
-					) }
-					{ data?.items.length > 0 && selectedItem && getPostFromItem( selectedItem ) && (
-						<>
-							<AsyncLoad
-								require="calypso/blocks/reader-full-post"
-								feedId={ selectedItem.feedId }
-								postId={ selectedItem.postId }
-								onClose={ () => setSelectedItem( null ) }
-								layout="recent"
-							/>
-							<EngagementBar feedId={ selectedItem?.feedId } postId={ selectedItem?.postId } />
-						</>
-					) }
-				</div>
-			) : null }
+						<EngagementBar feedId={ selectedItem?.feedId } postId={ selectedItem?.postId } />
+					</>
+				) }
+			</div>
 		</div>
 	);
 };

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -23,10 +23,9 @@ import './style.scss';
 
 interface RecentProps {
 	viewToggle?: React.ReactNode;
-	hasSubscriptions: boolean;
 }
 
-const Recent = ( { viewToggle, hasSubscriptions }: RecentProps ) => {
+const Recent = ( { viewToggle }: RecentProps ) => {
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
 	const [ selectedItem, setSelectedItem ] = useState< ReaderPost | null >( null );
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
@@ -160,11 +159,7 @@ const Recent = ( { viewToggle, hasSubscriptions }: RecentProps ) => {
 
 	return (
 		<div className="recent-feed">
-			<div
-				className={ `recent-feed__list-column ${
-					selectedItem && hasSubscriptions ? 'has-overlay' : ''
-				}` }
-			>
+			<div className={ `recent-feed__list-column ${ selectedItem ? 'has-overlay' : '' }` }>
 				<div className="recent-feed__list-column-header">
 					<NavigationHeader title={ translate( 'Recent' ) }>{ viewToggle }</NavigationHeader>
 				</div>

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -148,33 +148,6 @@
 				padding: $recent-feed-spacing;
 			}
 		}
-
-		&.recent-feed--no-subscriptions {
-			max-width: none;
-
-			.recent-feed__list-column-header {
-				max-width: none;
-				margin: 0;
-				padding: 16px 24px;
-				border-bottom: 1px solid var( --studio-gray-0 );
-
-				header.navigation-header {
-					max-width: $break-medium;
-					margin: 0 auto;
-					padding: 0;
-				}
-			}
-
-			.recent-feed__list-column-content {
-				max-width: $break-medium;
-				margin: 0 auto;
-				padding: 24px 24px 0;
-			}
-
-			@media ( min-width: $break-wide ) {
-				max-width: none;
-			}
-		}
 	}
 
 	&__post-column {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Change the Scrolling Feed view to show Reader Onboarding when there are no subscriptions (like the Full Post view does now).

Before | After
---- | -----
<img width="716" alt="Screen Shot 2024-12-02 at 3 19 50 PM" src="https://github.com/user-attachments/assets/6d066c23-d695-4983-a321-634552d9ae33"> | <img width="912" alt="Screen Shot 2024-12-02 at 5 50 29 PM" src="https://github.com/user-attachments/assets/684e83fe-c68a-439f-97e2-ba7641b14eb5">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Clean up the empty content state on /read.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Remove all of your subscriptions.
* Go to /read?flags=reader/recent-feed-overhaul
* Check that you see onboarding and not the "Welcome to Reader" content. The view toggle shouldn't be visible, either.
* Go to /read without the feature flag and check that you see onboarding and not the "Welcome to Reader" content.
* Subscribe to your own site(s). Check that you still see Reader Onboarding with and without the flag.
* Complete onboarding or add a subscription to a site you don't own, and check that you see your feeds and can toggle views with the flag applied.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
