### PR TITLE
Site Migration: Add source site domain to site overview

### DIFF
--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -14,7 +14,7 @@ export const MigrationStartedDIFM = ( { site }: { site?: SiteDetails } ) => {
 		"Sit back as {{strong}}%(siteName)s{{/strong}} transfers to its new home. Here's what you can expect.",
 		{
 			components: { strong: <strong /> },
-			args: { siteName: migrationSourceSiteDomain ?? translate( 'your site' ) },
+			args: { siteName: migrationSourceSiteDomain },
 		}
 	) as string;
 

--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -11,10 +11,10 @@ export const MigrationStartedDIFM = ( { site }: { site?: SiteDetails } ) => {
 
 	const title = translate( 'Your migration is underway' );
 	const subTitle = translate(
-		"Sit back as {{strong}}%(siteUrl)s{{/strong}} transfers to its new home. Here's what you can expect.",
+		"Sit back as {{strong}}%(siteName)s{{/strong}} transfers to its new home. Here's what you can expect.",
 		{
 			components: { strong: <strong /> },
-			args: { siteUrl: migrationSourceSiteDomain ?? translate( 'your site' ) },
+			args: { siteName: migrationSourceSiteDomain ?? translate( 'your site' ) },
 		}
 	) as string;
 

--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -7,10 +7,10 @@ export const MigrationStartedDIFM = ( { site }: { site?: SiteDetails } ) => {
 	const translate = useTranslate();
 	const title = translate( 'Your migration is underway' );
 	const subTitle = translate(
-		"Sit back as {{strong}}%(siteName)s{{/strong}} transfers to its new home. Here's what you can expect.",
+		"Sit back as {{strong}}%(siteUrl)s{{/strong}} transfers to its new home. Here's what you can expect.",
 		{
 			components: { strong: <strong /> },
-			args: { siteName: site?.name ?? translate( 'your site' ) },
+			args: { siteUrl: site?.migration_source_site_domain ?? translate( 'your site' ) },
 		}
 	) as string;
 

--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -5,7 +5,10 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 export const MigrationStartedDIFM = ( { site }: { site?: SiteDetails } ) => {
 	const translate = useTranslate();
-	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain;
+	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain?.replace(
+		/^https?:\/\/|\/+$/g,
+		''
+	);
 	const title = translate( 'Your migration is underway' );
 	const subTitle = translate(
 		"Sit back as {{strong}}%(siteUrl)s{{/strong}} transfers to its new home. Here's what you can expect.",

--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -5,10 +5,10 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 export const MigrationStartedDIFM = ( { site }: { site?: SiteDetails } ) => {
 	const translate = useTranslate();
-	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain?.replace(
-		/^https?:\/\/|\/+$/g,
-		''
-	);
+	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain
+		? site?.options?.migration_source_site_domain?.replace( /^https?:\/\/|\/+$/g, '' )
+		: translate( 'your site' );
+
 	const title = translate( 'Your migration is underway' );
 	const subTitle = translate(
 		"Sit back as {{strong}}%(siteUrl)s{{/strong}} transfers to its new home. Here's what you can expect.",

--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -5,12 +5,13 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 export const MigrationStartedDIFM = ( { site }: { site?: SiteDetails } ) => {
 	const translate = useTranslate();
+	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain;
 	const title = translate( 'Your migration is underway' );
 	const subTitle = translate(
 		"Sit back as {{strong}}%(siteUrl)s{{/strong}} transfers to its new home. Here's what you can expect.",
 		{
 			components: { strong: <strong /> },
-			args: { siteUrl: site?.migration_source_site_domain ?? translate( 'your site' ) },
+			args: { siteUrl: migrationSourceSiteDomain ?? translate( 'your site' ) },
 		}
 	) as string;
 

--- a/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
@@ -5,11 +5,12 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 export const MigrationStartedDIY = ( { site }: { site: SiteDetails } ) => {
 	const title = translate( 'Your migration is underway' );
+	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain;
 	const subTitle = translate(
 		'Sit back as {{strong}}%(siteUrl)s{{/strong}} transfers to its new home. Get ready for unmatched WordPress hosting.',
 		{
 			components: { strong: <strong /> },
-			args: { siteUrl: site.migration_source_site_domain ?? translate( 'your site' ) },
+			args: { siteUrl: migrationSourceSiteDomain ?? translate( 'your site' ) },
 		}
 	) as string;
 

--- a/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
@@ -5,7 +5,11 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 export const MigrationStartedDIY = ( { site }: { site: SiteDetails } ) => {
 	const title = translate( 'Your migration is underway' );
-	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain;
+	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain?.replace(
+		/^https?:\/\/|\/+$/g,
+		''
+	);
+
 	const subTitle = translate(
 		'Sit back as {{strong}}%(siteUrl)s{{/strong}} transfers to its new home. Get ready for unmatched WordPress hosting.',
 		{

--- a/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
@@ -5,16 +5,15 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 export const MigrationStartedDIY = ( { site }: { site: SiteDetails } ) => {
 	const title = translate( 'Your migration is underway' );
-	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain?.replace(
-		/^https?:\/\/|\/+$/g,
-		''
-	);
+	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain
+		? site?.options?.migration_source_site_domain?.replace( /^https?:\/\/|\/+$/g, '' )
+		: translate( 'your site' );
 
 	const subTitle = translate(
 		'Sit back as {{strong}}%(siteUrl)s{{/strong}} transfers to its new home. Get ready for unmatched WordPress hosting.',
 		{
 			components: { strong: <strong /> },
-			args: { siteUrl: migrationSourceSiteDomain ?? translate( 'your site' ) },
+			args: { siteUrl: migrationSourceSiteDomain },
 		}
 	) as string;
 

--- a/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
@@ -6,10 +6,10 @@ import type { SiteDetails } from '@automattic/data-stores';
 export const MigrationStartedDIY = ( { site }: { site: SiteDetails } ) => {
 	const title = translate( 'Your migration is underway' );
 	const subTitle = translate(
-		'Sit back as {{strong}}%(siteName)s{{/strong}} transfers to its new home. Get ready for unmatched WordPress hosting.',
+		'Sit back as {{strong}}%(siteUrl)s{{/strong}} transfers to its new home. Get ready for unmatched WordPress hosting.',
 		{
 			components: { strong: <strong /> },
-			args: { siteName: site.name ?? translate( 'your site' ) },
+			args: { siteUrl: site.migration_source_site_domain ?? translate( 'your site' ) },
 		}
 	) as string;
 

--- a/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
@@ -10,10 +10,10 @@ export const MigrationStartedDIY = ( { site }: { site: SiteDetails } ) => {
 		: translate( 'your site' );
 
 	const subTitle = translate(
-		'Sit back as {{strong}}%(siteUrl)s{{/strong}} transfers to its new home. Get ready for unmatched WordPress hosting.',
+		'Sit back as {{strong}}%(siteName)s{{/strong}} transfers to its new home. Get ready for unmatched WordPress hosting.',
 		{
 			components: { strong: <strong /> },
-			args: { siteUrl: migrationSourceSiteDomain },
+			args: { siteName: migrationSourceSiteDomain },
 		}
 	) as string;
 

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -85,6 +85,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'theme_slug',
 	'launchpad_screen',
 	'launchpad_checklist_tasks_statuses',
+	'migration_source_site_domain',
 	'wpcom_production_blog_id',
 	'wpcom_staging_blog_ids',
 	'can_blaze',

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -164,6 +164,7 @@ export interface SiteDetails {
 
 	// Migration
 	site_migration?: SourceSiteMigrationBase;
+	migration_source_site_domain?: string;
 }
 
 export enum SiteCapabilities {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -164,7 +164,6 @@ export interface SiteDetails {
 
 	// Migration
 	site_migration?: SourceSiteMigrationBase;
-	migration_source_site_domain?: string;
 }
 
 export enum SiteCapabilities {
@@ -293,6 +292,7 @@ export interface SiteDetailsOptions {
 	wordads?: boolean;
 	launchpad_screen?: false | 'off' | 'full' | 'minimized';
 	launchpad_checklist_tasks_statuses?: LaunchPadCheckListTasksStatuses;
+	migration_source_site_domain?: string;
 	wpcom_production_blog_id?: number;
 	wpcom_staging_blog_ids?: number[];
 	can_blaze?: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96422

## Proposed Changes

* On the site overview screen, instead of showing the site title for the destination site, show the site URL from the source site (if we have it)
* This is dependent on the work in https://github.com/Automattic/jetpack/pull/40552 which adds the new option to the sites API

**Before**

<img width="955" alt="Screenshot 2024-12-10 at 4 40 56 PM" src="https://github.com/user-attachments/assets/1d1f2632-3bb3-493c-ab7f-77a6636b035f">

**After**

<img width="952" alt="Screenshot 2024-12-10 at 4 40 42 PM" src="https://github.com/user-attachments/assets/73ff0994-e94a-4ad8-95ef-23242528c098">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p58i-iHv-p2 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com` and apply https://github.com/Automattic/jetpack/pull/40552 to your sandbox
* Switch to this PR
* Navigate to `/start` and go through the migration flow (choose Import at the goals step)
* Input your URL
* Choose "Do it for me"
* Pay for the plan
* Input your credentials or a random link for the backup file
* Don't forget to close out the ZenDesk ticket or add a note asking for it to be closed :)
* Click on the "Visit Site Dashboard" button to go to the site overview screen
* You should see the changes to the heading copy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?