### PR TITLE
Stats: add learn more button on StatsUpsell pointing to Jetpack Stats Help Center

### DIFF
--- a/client/my-sites/stats/stats-upsell/style.scss
+++ b/client/my-sites/stats/stats-upsell/style.scss
@@ -119,4 +119,9 @@
 			}
 		}
 	}
+
+	.stats-upsell__buttons {
+		display: flex;
+		gap: 16px;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1733119153796319-slack-C068X5XJT3J

## Proposed Changes

* Add `Learn more` button in the new stats upsell prompt
* Open up Jetpack Stats Help Center when clicking on it

https://github.com/user-attachments/assets/38a1c5a6-cf3f-408c-9763-84a40a155a5b

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p1HpG7-v6B-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso Live Branch
* Navigate to the Traffic page http://calypso.localhost:3000/stats/day/initsogarfree.wordpress.com using a free site
* Ensure the `Learn more` button is visible on the upsell prompt at the bottom of the page
* Ensure clicking on it open up the **Help Center** pointing to the Jetpack Stat section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?