### PR TITLE
Checkout - fixing additional promo for 2 year Jetpack plans

### DIFF
--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -91,6 +91,7 @@ const useCalculatedDiscounts = () => {
 	const originalPrice = current.priceBeforeDiscounts * 2;
 	const introductoryOfferDiscount = biennial.priceBeforeDiscounts - biennial.priceInteger;
 	const multiYearDiscount = originalPrice - biennial.priceBeforeDiscounts;
+	const additionalDiscount = introductoryOfferDiscount;
 
 	const priceBreakdown: PriceBreakdown[] = [];
 
@@ -128,6 +129,14 @@ const useCalculatedDiscounts = () => {
 		priceBreakdown.push( {
 			label: __( 'Multi-year discount' ),
 			priceInteger: multiYearDiscount,
+			isDiscount: true,
+		} );
+	}
+
+	if ( additionalDiscount > 0 ) {
+		priceBreakdown.push( {
+			label: __( 'Additional discount' ),
+			priceInteger: additionalDiscount,
 			isDiscount: true,
 		} );
 	}

--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -91,7 +91,9 @@ const useCalculatedDiscounts = () => {
 	const originalPrice = current.priceBeforeDiscounts * 2;
 	const introductoryOfferDiscount = biennial.priceBeforeDiscounts - biennial.priceInteger;
 	const multiYearDiscount = originalPrice - biennial.priceBeforeDiscounts;
-	const additionalDiscount = introductoryOfferDiscount;
+	const additionalDiscount = product.introductory_offer_terms?.enabled
+		? 0
+		: biennial.priceBeforeDiscounts - biennial.priceInteger; // additional discount for events like Black Friday
 
 	const priceBreakdown: PriceBreakdown[] = [];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-marketing/issues/1106

## Proposed Changes

* Show all discounts for the two year introductory offer, including additional promotions like Black Friday

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* to avoiding showing a price without discount

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* checkout live branch
* apply this URL - `/checkout/jetpack/jetpack_stats_yearly:-q-10000?source=jetpack-plans&checkoutBackUrl=http%3A%2F%2Fjetpack.cloud.localhost%3A3000%2Fpricing%23jetpack_stats_yearly`
* verify that the amount on the two year upsell shows an additional discount and the prices match the dropdown (screenshot below)
* repeat the same check for a bundle and verify that the additional discount is not showing up for items with an introductory offer (and the final price matches the dropdown price)

<img width="844" alt="SCR-20241203-mwew" src="https://github.com/user-attachments/assets/71270454-50a1-4e4c-b4e8-61bdb4e4fbfe">


## Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
