### PR TITLE
Untangling: fire calypso_page_view event on global view page load

### DIFF
--- a/client/hosting/overview/controller.tsx
+++ b/client/hosting/overview/controller.tsx
@@ -3,11 +3,17 @@ import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import HostingActivate from 'calypso/hosting/server-settings/hosting-activate';
 import Hosting from 'calypso/hosting/server-settings/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import HostingOverview from 'calypso/sites/overview/components/hosting-overview';
 import { successNotice } from 'calypso/state/notices/actions';
 
 export function hostingOverview( context: PageJSContext, next: () => void ) {
-	context.primary = <HostingOverview />;
+	context.primary = (
+		<>
+			<PageViewTracker path="/overview/:site" title="Site Overview" />
+			<HostingOverview />
+		</>
+	);
 	next();
 }
 

--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -1,7 +1,6 @@
 import { translate } from 'i18n-calypso';
 import { FC } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { isNotAtomicJetpack, isMigrationInProgress } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -30,7 +29,6 @@ const HostingOverview: FC = () => {
 
 	return (
 		<div className="hosting-overview">
-			<PageViewTracker path="/overview/:site" title="Site Overview" />
 			<NavigationHeader
 				className="hosting-overview__navigation-header"
 				title={ translate( 'Overview' ) }

--- a/client/sites/overview/controller.tsx
+++ b/client/sites/overview/controller.tsx
@@ -1,7 +1,14 @@
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getRouteFromContext } from 'calypso/utils';
 import HostingOverview from './components/hosting-overview';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
 export function overview( context: PageJSContext, next: () => void ) {
-	context.primary = <HostingOverview />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Sites > Overview" path={ getRouteFromContext( context ) } />
+			<HostingOverview />
+		</>
+	);
 	next();
 }

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getRouteFromContext } from 'calypso/utils';
 import { SidebarItem, Sidebar, PanelWithSidebar } from '../components/panel-sidebar';
 import AdministrationSettings from './administration';
 import useIsAdministrationSettingSupported from './administration/hooks/use-is-administration-setting-supported';
@@ -37,6 +39,7 @@ export function SettingsSidebar() {
 export function siteSettings( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker title="Sites > Settings > Site" path={ getRouteFromContext( context ) } />
 			<SettingsSidebar />
 			<SiteSettings />
 		</PanelWithSidebar>
@@ -47,6 +50,10 @@ export function siteSettings( context: PageJSContext, next: () => void ) {
 export function administrationSettings( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Settings > Administration"
+				path={ getRouteFromContext( context ) }
+			/>
 			<SettingsSidebar />
 			<AdministrationSettings />
 		</PanelWithSidebar>
@@ -57,6 +64,10 @@ export function administrationSettings( context: PageJSContext, next: () => void
 export function administrationToolResetSite( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Settings > Administration > Reset site"
+				path={ getRouteFromContext( context ) }
+			/>
 			<SettingsSidebar />
 			<ResetSite />
 		</PanelWithSidebar>
@@ -67,6 +78,10 @@ export function administrationToolResetSite( context: PageJSContext, next: () =>
 export function administrationToolTransferSite( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Settings > Administration > Transfer site"
+				path={ getRouteFromContext( context ) }
+			/>
 			<SettingsSidebar />
 			<TransferSite />
 		</PanelWithSidebar>
@@ -77,6 +92,10 @@ export function administrationToolTransferSite( context: PageJSContext, next: ()
 export function administrationToolDeleteSite( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Settings > Administration > Delete site"
+				path={ getRouteFromContext( context ) }
+			/>
 			<SettingsSidebar />
 			<DeleteSite />
 		</PanelWithSidebar>
@@ -87,6 +106,7 @@ export function administrationToolDeleteSite( context: PageJSContext, next: () =
 export function cachingSettings( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker title="Sites > Settings > Caching" path={ getRouteFromContext( context ) } />
 			<SettingsSidebar />
 			<CachingSettings />
 		</PanelWithSidebar>
@@ -97,6 +117,10 @@ export function cachingSettings( context: PageJSContext, next: () => void ) {
 export function webServerSettings( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Settings > Web server"
+				path={ getRouteFromContext( context ) }
+			/>
 			<SettingsSidebar />
 			<WebServerSettings />
 		</PanelWithSidebar>

--- a/client/sites/tools/controller.tsx
+++ b/client/sites/tools/controller.tsx
@@ -1,8 +1,10 @@
 import page, { Context as PageJSContext } from '@automattic/calypso-router';
 import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import HostingFeatures from 'calypso/sites/hosting-features/components/hosting-features';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getRouteFromContext } from 'calypso/utils';
 import { SidebarItem, Sidebar, PanelWithSidebar } from '../components/panel-sidebar';
 import { areHostingFeaturesSupported } from '../hosting-features/features';
 import Database from './database/page';
@@ -49,13 +51,22 @@ export function tools( context: PageJSContext, next: () => void ) {
 		return page.redirect( `/sites/tools/staging-site/${ site?.slug }` );
 	}
 
-	context.primary = <HostingFeatures showAsTools />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Sites > Advanced Tools" path={ getRouteFromContext( context ) } />
+			<HostingFeatures showAsTools />
+		</>
+	);
 	next();
 }
 
 export function stagingSite( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Advanced Tools > Staging site"
+				path={ getRouteFromContext( context ) }
+			/>
 			<ToolsSidebar />
 			<StagingSite />
 		</PanelWithSidebar>
@@ -66,6 +77,10 @@ export function stagingSite( context: PageJSContext, next: () => void ) {
 export function deployments( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Advanced Tools > Deployments"
+				path={ getRouteFromContext( context ) }
+			/>
 			<ToolsSidebar />
 			<Deployments />
 		</PanelWithSidebar>
@@ -76,6 +91,10 @@ export function deployments( context: PageJSContext, next: () => void ) {
 export function deploymentCreation( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Advanced Tools > Deployments > Create"
+				path={ getRouteFromContext( context ) }
+			/>
 			<ToolsSidebar />
 			<DeploymentCreation />
 		</PanelWithSidebar>
@@ -94,6 +113,10 @@ export function deploymentManagement( context: PageJSContext, next: () => void )
 
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Advanced Tools > Deployments > Manage"
+				path={ getRouteFromContext( context ) }
+			/>
 			<ToolsSidebar />
 			<DeploymentManagement codeDeploymentId={ codeDeploymentId } />
 		</PanelWithSidebar>
@@ -112,6 +135,10 @@ export function deploymentRunLogs( context: PageJSContext, next: () => void ) {
 
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Advanced Tools > Deployments > Run logs"
+				path={ getRouteFromContext( context ) }
+			/>
 			<ToolsSidebar />
 			<DeploymentRunLogs codeDeploymentId={ codeDeploymentId } />
 		</PanelWithSidebar>
@@ -122,6 +149,10 @@ export function deploymentRunLogs( context: PageJSContext, next: () => void ) {
 export function monitoring( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Advanced Tools > Monitoring"
+				path={ getRouteFromContext( context ) }
+			/>
 			<ToolsSidebar />
 			<Monitoring />
 		</PanelWithSidebar>
@@ -132,6 +163,10 @@ export function monitoring( context: PageJSContext, next: () => void ) {
 export function phpErrorLogs( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Advanced Tools > Logs > PHP"
+				path={ getRouteFromContext( context ) }
+			/>
 			<ToolsSidebar />
 			<Logs logType="php" />
 		</PanelWithSidebar>
@@ -142,6 +177,10 @@ export function phpErrorLogs( context: PageJSContext, next: () => void ) {
 export function webServerLogs( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Advanced Tools > Logs > Web"
+				path={ getRouteFromContext( context ) }
+			/>
 			<ToolsSidebar />
 			<Logs logType="web" />
 		</PanelWithSidebar>
@@ -152,6 +191,10 @@ export function webServerLogs( context: PageJSContext, next: () => void ) {
 export function sftpSsh( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Advanced Tools > SFTP/SSH"
+				path={ getRouteFromContext( context ) }
+			/>
 			<ToolsSidebar />
 			<SftpSsh />
 		</PanelWithSidebar>
@@ -162,6 +205,10 @@ export function sftpSsh( context: PageJSContext, next: () => void ) {
 export function database( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<PanelWithSidebar>
+			<PageViewTracker
+				title="Sites > Advanced Tools > Database"
+				path={ getRouteFromContext( context ) }
+			/>
 			<ToolsSidebar />
 			<Database />
 		</PanelWithSidebar>

--- a/client/utils.ts
+++ b/client/utils.ts
@@ -1,3 +1,4 @@
+import { Context } from '@automattic/calypso-router';
 import { addQueryArgs } from 'calypso/lib/url';
 // Adapts route paths to also include wildcard
 // subroutes under the root level section.
@@ -49,4 +50,14 @@ export function isEligibleForProductSampling( userId: number, percentage: number
 	const userSegment = userId % 100;
 
 	return userSegment < percentage;
+}
+
+export function getRouteFromContext( context: Context ) {
+	let route = context.path;
+	for ( const [ key, value ] of Object.entries( context.params ) ) {
+		if ( key !== '0' ) {
+			route = route.replace( value, ':' + key );
+		}
+	}
+	return route;
 }


### PR DESCRIPTION
## Proposed Changes

This PR adds Tracks event (`calypso_page_view`) when hosting dashboard pages are loaded in the new IA.

(Except Marketing pages, since it seems we want to revert them (?))

## Why are these changes being made?

pbxlJb-6ye-p2

## Testing Instructions

1. Go to /sites.
2. Click a site.
3. Click around the tabs/subtabs (except Marketing).
4. Verify you see the `calypso_page_view` event with the correct path, e.g.

<img width="580" alt="image" src="https://github.com/user-attachments/assets/9ef7d679-884e-42ac-9f62-daa2ad4d562d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?