### PR TITLE
HC: Add external link navigation above header

### DIFF
--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -23,21 +23,16 @@
 		flex-direction: column;
 
 		.help-center-article-content__header {
-			h1.help-center-article-content__header-title {
-				margin: 0;
 
-				> a {
-					text-decoration: none;
-					clear: none;
-					color: var(--color-neutral-70);
-					-webkit-font-smoothing: antialiased;
-					-moz-osx-font-smoothing: grayscale;
-					font-size: $font-title-medium;
-					font-weight: 600;
-					line-height: 32px;
-					margin: 56px 0 0;
-					max-width: 750px;
-				}
+			.help-center-article-content__header-link {
+				color: var(--color-neutral-70);
+			}
+
+			h1.help-center-article-content__header-title {
+				margin: 8px 0 0 0;
+				color: var(--color-neutral-70);
+				font-size: $font-title-medium;
+				font-weight: 600;
 			}
 		}
 

--- a/packages/help-center/src/components/help-center-support-article-header.tsx
+++ b/packages/help-center/src/components/help-center-support-article-header.tsx
@@ -15,15 +15,16 @@ export const SupportArticleHeader = ( {
 		</div>
 	) : (
 		<div className="help-center-article-content__header">
+			<ExternalLink
+				className="help-center-article-content__header-link"
+				href={ post.URL }
+				target="_blank"
+				icon
+			>
+				Open support page
+			</ExternalLink>
 			<h1 className="help-center-article-content__header-title">
-				<ExternalLink
-					className="help-center-article-content__header-title-link"
-					href={ post.URL }
-					target="_blank"
-					icon={ false }
-				>
-					{ decodeEntities( post.title ) }
-				</ExternalLink>
+				{ decodeEntities( post.title ) }
 			</h1>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

| Before  | After |
| ------------- | ------------- |
|  <img width="407" alt="Screenshot 2024-12-03 at 11 09 53" src="https://github.com/user-attachments/assets/ec339cb1-7b4c-49fd-ae57-edb43c1feecd"> |  <img width="422" alt="Screenshot 2024-12-03 at 11 09 42" src="https://github.com/user-attachments/assets/281c41a8-11f2-4075-b0ec-42e2a6047f00"> |

Fixes https://github.com/Automattic/wp-calypso/issues/96396

## Proposed Changes

* Add external link nav above header

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Better navigation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open articles in the help center
* Test the link above the header
