### PR TITLE
Change the chart colours to the accent colour

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -27,10 +27,10 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 	const [ width, setWidth ] = useState( DEFAULT_DIMENSIONS.width );
 	const hourly = resolution === ChartResolution.Hour;
 
-	const primaryColor = getComputedStyle( document.body )
-		.getPropertyValue( '--color-primary' )
+	const accentColour = getComputedStyle( document.body )
+		.getPropertyValue( '--color-accent' )
 		.trim();
-	const primaryRGB = hexToRgb( primaryColor );
+	const primaryRGB = hexToRgb( accentColour );
 
 	const updateWidth = () => {
 		const wrapperElement = document.querySelector(
@@ -124,7 +124,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 				},
 				{
 					label: _.capitalize( source ),
-					stroke: primaryColor,
+					stroke: accentColour,
 					width: 3,
 					fill: ( self: uPlot ) => {
 						const { r, g, b } = primaryRGB;
@@ -162,7 +162,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 				},
 			],
 		};
-	}, [ width, source, primaryColor, formatDate, hourly, primaryRGB ] );
+	}, [ width, source, accentColour, formatDate, hourly, primaryRGB ] );
 
 	return (
 		<div style={ { position: 'relative' } }>

--- a/client/my-sites/promote-post-i2/components/location-charts/style.scss
+++ b/client/my-sites/promote-post-i2/components/location-charts/style.scss
@@ -34,7 +34,7 @@
 
 		&__progress-bar-filled {
 			height: 100%;
-			background-color: var(--color-primary);
+			background-color: var(--color-accent);
 			border-radius: 4px;
 		}
 
@@ -46,7 +46,7 @@
 		}
 
 		&__show-more-button {
-			color: var(--color-primary);
+			color: var(--color-accent);
 			font-weight: 500;
 			text-align: center;
 			margin-top: 12px;


### PR DESCRIPTION
## Proposed Changes

* We had cases where using primary colour was not optimal for the chart colours. Primary colour is usually the same as accent, but not always,   By using accent it will always match the button styles/

## Testing Instructions

- Check a running or completed campaign e.g. `/advertising/campaigns/123/site.uk`
- Try changing your theme from `Users -> Profile` 
- Refresh the stats page.

I have attached examples here of all the colour schemes so that you don't have to :)

![Screenshot 2024-12-03 at 11 13 00](https://github.com/user-attachments/assets/a219d947-3e87-4a1e-a4c6-40a207e3a299)
![Screenshot 2024-12-03 at 11 13 17](https://github.com/user-attachments/assets/42ce4d29-8b1b-466a-9054-3bfa0db056d6)
![Screenshot 2024-12-03 at 11 13 30](https://github.com/user-attachments/assets/d83295be-e525-45c7-a0e2-4e92fb83a14e)
![Screenshot 2024-12-03 at 11 13 43](https://github.com/user-attachments/assets/88190b96-a050-4693-a5c8-4df2391d61ea)
![Screenshot 2024-12-03 at 11 13 54](https://github.com/user-attachments/assets/55657961-9137-4a16-9c3e-142f4aeafceb)
![Screenshot 2024-12-03 at 11 14 12](https://github.com/user-attachments/assets/c07735f3-737e-49ee-977d-746cc6667dc8)
![Screenshot 2024-12-03 at 11 14 23](https://github.com/user-attachments/assets/da04bd38-1a04-46e6-8f27-e615e789df4c)
![Screenshot 2024-12-03 at 11 14 35](https://github.com/user-attachments/assets/afd89ed7-32dd-4113-97b6-3f7c6d07932b)
![Screenshot 2024-12-03 at 11 14 48](https://github.com/user-attachments/assets/d525c857-bd99-40f4-9dec-ec39f0315ffc)
![Screenshot 2024-12-03 at 11 15 04](https://github.com/user-attachments/assets/ba168eef-5d99-466c-b453-7086c4259c90)
![Screenshot 2024-12-03 at 11 15 15](https://github.com/user-attachments/assets/801791f0-1832-4c88-ba7e-ed371dcd4810)
![Screenshot 2024-12-03 at 11 15 27](https://github.com/user-attachments/assets/4f425738-cfcd-45ec-9b04-e2d4e57fce82)
![Screenshot 2024-12-03 at 11 15 38](https://github.com/user-attachments/assets/bc035e43-e3db-4476-b87f-79bb29daf4e5)
![Screenshot 2024-12-03 at 11 15 49](https://github.com/user-attachments/assets/3c655997-b7cc-4208-82a4-96b19a842c98)
![Screenshot 2024-12-03 at 11 16 00](https://github.com/user-attachments/assets/df713e72-6e96-4f8d-9155-19fe408d7e0d)
![Screenshot 2024-12-03 at 11 16 12](https://github.com/user-attachments/assets/6ae95fd4-6166-4a73-9c4c-a280ff49aac9)
![Screenshot 2024-12-03 at 11 16 23](https://github.com/user-attachments/assets/d939cbf1-cb79-43f7-9fdb-754508425128)
![Screenshot 2024-12-03 at 11 16 33](https://github.com/user-attachments/assets/b413e9d0-cbb1-4cd8-8cb6-a41c08570815)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
