### PR TITLE
Design Picker: Allow users to select multiple taxonomies

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -46,9 +46,9 @@ export function getCategorizationOptions(
 
 function getCategorizationFromIntent( intent: string ) {
 	const result = {
-		defaultSelections: null,
+		defaultSelections: [] as string[],
 	} as {
-		defaultSelections: string[] | null;
+		defaultSelections: string[];
 		sort: ( a: Category, b: Category ) => 0 | 1 | -1;
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -24,6 +24,7 @@ function makeSortCategoryToTop( slugs: string[] ) {
 		} else if ( slugsSet.has( b.slug ) ) {
 			return 1;
 		}
+
 		return 0;
 	};
 }
@@ -93,23 +94,20 @@ function getCategorizationFromGoals( goals: Onboard.SiteGoal[] ) {
 		CATEGORY_AUTHORS_WRITERS,
 	];
 
-	const defaultSelections =
-		goals
-			.flatMap( getGoalsPreferredCategory )
-			.sort( ( a, b ) => {
-				let aIndex = mostConsequentialDesignCategories.indexOf( a );
-				let bIndex = mostConsequentialDesignCategories.indexOf( b );
+	const defaultSelections = goals.flatMap( getGoalsPreferredCategory ).sort( ( a, b ) => {
+		let aIndex = mostConsequentialDesignCategories.indexOf( a );
+		let bIndex = mostConsequentialDesignCategories.indexOf( b );
 
-				// If the category is not in the list, it should be sorted to the end.
-				if ( aIndex === -1 ) {
-					aIndex = mostConsequentialDesignCategories.length;
-				}
-				if ( bIndex === -1 ) {
-					bIndex = mostConsequentialDesignCategories.length;
-				}
+		// If the category is not in the list, it should be sorted to the end.
+		if ( aIndex === -1 ) {
+			aIndex = mostConsequentialDesignCategories.length;
+		}
+		if ( bIndex === -1 ) {
+			bIndex = mostConsequentialDesignCategories.length;
+		}
 
-				return aIndex - bIndex;
-			} ) ?? [ CATEGORY_BUSINESS ];
+		return aIndex - bIndex;
+	} ) ?? [ CATEGORY_BUSINESS ];
 
 	return {
 		defaultSelections,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -14,22 +14,23 @@ const CATEGORY_ENTERTAINMENT = 'entertainment';
  * Ensures the category appears at the top of the design category list
  * (directly below the Show All filter).
  */
-function makeSortCategoryToTop( slug: string ) {
+function makeSortCategoryToTop( slugs: string[] ) {
+	const slugsSet = new Set( slugs );
 	return ( a: Category, b: Category ) => {
 		if ( a.slug === b.slug ) {
 			return 0;
-		} else if ( a.slug === slug ) {
+		} else if ( slugsSet.has( a.slug ) ) {
 			return -1;
-		} else if ( b.slug === slug ) {
+		} else if ( slugsSet.has( b.slug ) ) {
 			return 1;
 		}
 		return 0;
 	};
 }
 
-const sortBlogToTop = makeSortCategoryToTop( CATEGORY_BLOG );
-const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
-const sortBusinessToTop = makeSortCategoryToTop( CATEGORY_BUSINESS );
+const sortBlogToTop = makeSortCategoryToTop( [ CATEGORY_BLOG ] );
+const sortStoreToTop = makeSortCategoryToTop( [ CATEGORY_STORE ] );
+const sortBusinessToTop = makeSortCategoryToTop( [ CATEGORY_BUSINESS ] );
 
 export function getCategorizationOptions(
 	intent: string,
@@ -44,9 +45,9 @@ export function getCategorizationOptions(
 
 function getCategorizationFromIntent( intent: string ) {
 	const result = {
-		defaultSelection: null,
+		defaultSelections: null,
 	} as {
-		defaultSelection: string | null;
+		defaultSelections: string[] | null;
 		sort: ( a: Category, b: Category ) => 0 | 1 | -1;
 	};
 
@@ -54,19 +55,19 @@ function getCategorizationFromIntent( intent: string ) {
 		case 'write':
 			return {
 				...result,
-				defaultSelection: CATEGORY_BLOG,
+				defaultSelections: [ CATEGORY_BLOG ],
 				sort: sortBlogToTop,
 			};
 		case 'sell':
 			return {
 				...result,
-				defaultSelection: CATEGORY_STORE,
+				defaultSelections: [ CATEGORY_STORE ],
 				sort: sortStoreToTop,
 			};
 		case 'build':
 			return {
 				...result,
-				defaultSelection: CATEGORY_BUSINESS,
+				defaultSelections: [ CATEGORY_BUSINESS ],
 				sort: sortBusinessToTop,
 			};
 		default:
@@ -92,9 +93,9 @@ function getCategorizationFromGoals( goals: Onboard.SiteGoal[] ) {
 		CATEGORY_AUTHORS_WRITERS,
 	];
 
-	const defaultSelection =
+	const defaultSelections =
 		goals
-			.map( getGoalsPreferredCategory )
+			.flatMap( getGoalsPreferredCategory )
 			.sort( ( a, b ) => {
 				let aIndex = mostConsequentialDesignCategories.indexOf( a );
 				let bIndex = mostConsequentialDesignCategories.indexOf( b );
@@ -108,42 +109,41 @@ function getCategorizationFromGoals( goals: Onboard.SiteGoal[] ) {
 				}
 
 				return aIndex - bIndex;
-			} )
-			.shift() ?? CATEGORY_BUSINESS;
+			} ) ?? [ CATEGORY_BUSINESS ];
 
 	return {
-		defaultSelection,
-		sort: makeSortCategoryToTop( defaultSelection ),
+		defaultSelections,
+		sort: makeSortCategoryToTop( defaultSelections ),
 	};
 }
 
-function getGoalsPreferredCategory( goal: Onboard.SiteGoal ): string {
+function getGoalsPreferredCategory( goal: Onboard.SiteGoal ): string[] {
 	switch ( goal ) {
 		case Onboard.SiteGoal.Write:
-			return CATEGORY_BLOG;
+			return [ CATEGORY_BLOG ];
 
 		case Onboard.SiteGoal.CollectDonations:
 		case Onboard.SiteGoal.BuildNonprofit:
-			return CATEGORY_COMMUNITY_NON_PROFIT;
+			return [ CATEGORY_COMMUNITY_NON_PROFIT ];
 
 		case Onboard.SiteGoal.Porfolio:
-			return CATEGORY_PORTFOLIO;
+			return [ CATEGORY_PORTFOLIO ];
 
 		case Onboard.SiteGoal.Newsletter:
 		case Onboard.SiteGoal.PaidSubscribers:
-			return CATEGORY_AUTHORS_WRITERS;
+			return [ CATEGORY_AUTHORS_WRITERS ];
 
 		case Onboard.SiteGoal.SellDigital:
 		case Onboard.SiteGoal.SellPhysical:
 		case Onboard.SiteGoal.Sell:
-			return CATEGORY_STORE;
+			return [ CATEGORY_STORE ];
 
 		case Onboard.SiteGoal.Courses:
-			return CATEGORY_EDUCATION;
+			return [ CATEGORY_EDUCATION ];
 
 		case Onboard.SiteGoal.Videos:
 		case Onboard.SiteGoal.AnnounceEvents:
-			return CATEGORY_ENTERTAINMENT;
+			return [ CATEGORY_ENTERTAINMENT ];
 
 		case Onboard.SiteGoal.Engagement:
 		case Onboard.SiteGoal.Promote:
@@ -152,6 +152,8 @@ function getGoalsPreferredCategory( goal: Onboard.SiteGoal ): string {
 		case Onboard.SiteGoal.ImportSubscribers:
 		case Onboard.SiteGoal.Other:
 		case Onboard.SiteGoal.DIFM:
-			return CATEGORY_BUSINESS;
+			return [ CATEGORY_BUSINESS ];
+		default:
+			return [];
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -961,6 +961,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
 			showActiveThemeBadge={ intent !== 'build' }
 			isTierFilterEnabled={ isGoalCentricFeature }
+			isMultiFilterEnabled={ isGoalCentricFeature }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -119,6 +119,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const isGoalsHoldout = useIsGoalsHoldout( stepName );
 
+	const isGoalCentricFeature = isEnabled( 'design-picker/goal-centric' ) && ! isGoalsHoldout;
+
 	const queryParams = useQuery();
 	const { goBack, submit, exitFlow } = navigation;
 
@@ -232,10 +234,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		goals,
 		addedGoalsExpAssignment?.variationName === 'treatment'
 	);
-	const categorization = useCategorizationFromApi(
-		allDesigns?.filters?.subject || EMPTY_OBJECT,
-		categorizationOptions
-	);
+	const categorization = useCategorizationFromApi( allDesigns?.filters?.subject || EMPTY_OBJECT, {
+		...categorizationOptions,
+		isMultiSelection: isGoalCentricFeature,
+	} );
 
 	// ********** Logic for selecting a design and style variation
 	const {
@@ -297,7 +299,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				intent,
 				design,
 			} ),
-			category: categorization.selection,
+			category: categorization.selections.join( ',' ),
 			...( design.recipe?.pattern_ids && { pattern_ids: design.recipe.pattern_ids.join( ',' ) } ),
 			...( design.recipe?.header_pattern_ids && {
 				header_pattern_ids: design.recipe.header_pattern_ids.join( ',' ),
@@ -673,7 +675,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			handleSubmit(
 				{
 					selectedDesign: _selectedDesign,
-					selectedSiteCategory: categorization.selection,
+					selectedSiteCategory: categorization.selections.join( ',' ),
 				},
 				{ ...( positionIndex >= 0 && { position_index: positionIndex } ) }
 			);
@@ -703,7 +705,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 			handleSubmit( {
 				selectedDesign: _selectedDesign,
-				selectedSiteCategory: categorization.selection,
+				selectedSiteCategory: categorization.selections.join( ',' ),
 				shouldGoToAssembler,
 			} );
 		} else {
@@ -937,7 +939,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	if ( isDesignFirstFlow ) {
 		categorization.categories = [];
-		categorization.selection = 'blog';
+		categorization.selections = [ 'blog' ];
 	}
 
 	const stepContent = (
@@ -958,7 +960,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
 			siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
 			showActiveThemeBadge={ intent !== 'build' }
-			isTierFilterEnabled={ isEnabled( 'design-picker/goal-centric' ) && ! isGoalsHoldout }
+			isTierFilterEnabled={ isGoalCentricFeature }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -17,7 +17,7 @@ import {
 } from '@automattic/data-stores';
 import {
 	UnifiedDesignPicker,
-	useCategorizationFromApi,
+	useCategorization,
 	getDesignPreviewUrl,
 	isAssemblerDesign,
 	isAssemblerSupported,
@@ -234,7 +234,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		goals,
 		addedGoalsExpAssignment?.variationName === 'treatment'
 	);
-	const categorization = useCategorizationFromApi( allDesigns?.filters?.subject || EMPTY_OBJECT, {
+	const categorization = useCategorization( allDesigns?.filters?.subject || EMPTY_OBJECT, {
 		...categorizationOptions,
 		isMultiSelection: isGoalCentricFeature,
 	} );
@@ -299,7 +299,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				intent,
 				design,
 			} ),
-			category: categorization.selections.join( ',' ),
+			category: categorization.selections?.join( ',' ),
 			...( design.recipe?.pattern_ids && { pattern_ids: design.recipe.pattern_ids.join( ',' ) } ),
 			...( design.recipe?.header_pattern_ids && {
 				header_pattern_ids: design.recipe.header_pattern_ids.join( ',' ),
@@ -331,7 +331,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	function trackAllDesignsView() {
 		recordTracksEvent( 'calypso_signup_design_scrolled_to_end', {
 			intent,
-			category: categorization?.selection,
+			category: categorization?.selections?.join( ',' ),
 		} );
 	}
 
@@ -675,7 +675,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			handleSubmit(
 				{
 					selectedDesign: _selectedDesign,
-					selectedSiteCategory: categorization.selections.join( ',' ),
+					selectedSiteCategory: categorization.selections?.join( ',' ),
 				},
 				{ ...( positionIndex >= 0 && { position_index: positionIndex } ) }
 			);
@@ -705,7 +705,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 			handleSubmit( {
 				selectedDesign: _selectedDesign,
-				selectedSiteCategory: categorization.selections.join( ',' ),
+				selectedSiteCategory: categorization.selections?.join( ',' ),
 				shouldGoToAssembler,
 			} );
 		} else {

--- a/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
+++ b/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
@@ -43,7 +43,7 @@ export default function DropdownGroup( {
 
 	const defaultActiveIndexes = useMemo( () => {
 		if ( isMultiSelection ) {
-			return initialActiveIndexes;
+			return initialActiveIndexes || [];
 		}
 
 		return initialActiveIndex !== -1 ? [ initialActiveIndex ] : [];
@@ -253,10 +253,10 @@ export default function DropdownGroup( {
 				{ maybeRenderMore( true ) }
 			</ToolbarGroup>
 			<ToolbarGroup
-				className={ clsx(
-					'responsive-toolbar-group__grouped-list',
-					calculatedOnce ? 'is-visible' : ''
-				) }
+				className={ clsx( 'responsive-toolbar-group__grouped-list', {
+					'is-visible': calculatedOnce,
+					'is-multi': isMultiSelection,
+				} ) }
 			>
 				{ renderChildren() }
 				{ maybeRenderMore() }

--- a/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
+++ b/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
@@ -10,7 +10,7 @@ import {
 import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState, useMemo } from 'react';
 
 import './style.scss';
 
@@ -26,6 +26,8 @@ export default function DropdownGroup( {
 	rootMargin = '0px',
 	onClick = () => null,
 	initialActiveIndex = -1,
+	initialActiveIndexes,
+	isMultiSelection,
 }: {
 	children: ReactNode[];
 	className?: string;
@@ -34,15 +36,43 @@ export default function DropdownGroup( {
 	rootMargin?: string;
 	onClick?: ( index: number ) => void;
 	initialActiveIndex?: number;
+	initialActiveIndexes?: number[];
+	isMultiSelection?: boolean;
 } ) {
 	const classes = clsx( 'responsive-toolbar-group__dropdown', className );
 
+	const defaultActiveIndexes = useMemo( () => {
+		if ( isMultiSelection ) {
+			return initialActiveIndexes;
+		}
+
+		return initialActiveIndex !== -1 ? [ initialActiveIndex ] : [];
+	}, [ isMultiSelection, initialActiveIndex, initialActiveIndexes ] );
+
 	const containerRef = useRef< HTMLDivElement >( null );
 	const [ calculatedOnce, setCalculatedOnce ] = useState< boolean >( false );
-	const [ activeIndex, setActiveIndex ] = useState< number >( initialActiveIndex );
+	const [ activeIndexes, setActiveIndexes ] = useState< Set< number > >(
+		new Set( defaultActiveIndexes )
+	);
 	const [ groupedIndexes, setGroupedIndexes ] = useState< GroupedIndexStore >( {} );
 	const { current: shadowListItems } = useRef< HTMLButtonElement[] >( [] );
 	const translate = useTranslate();
+
+	const onSelect = ( index: number ) => {
+		setActiveIndexes( ( currentActiveIndexes: Set< number > ) => {
+			if ( ! isMultiSelection ) {
+				return new Set( [ index ] );
+			}
+
+			if ( ! currentActiveIndexes.has( index ) ) {
+				currentActiveIndexes.add( index );
+			} else if ( currentActiveIndexes.size > 1 ) {
+				currentActiveIndexes.delete( index );
+			}
+
+			return currentActiveIndexes;
+		} );
+	};
 
 	const assignRef = ( index: number, element: HTMLButtonElement ) => {
 		shadowListItems[ index ] = element;
@@ -73,9 +103,9 @@ export default function DropdownGroup( {
 			.map( ( { index, child } ) => (
 				<ToolbarButton
 					key={ `button-item-${ index }` }
-					isActive={ activeIndex === parseInt( index ) }
+					isActive={ activeIndexes.has( parseInt( index ) ) }
 					onClick={ () => {
-						setActiveIndex( parseInt( index ) );
+						onSelect( parseInt( index ) );
 						onClick( parseInt( index ) );
 					} }
 					className="responsive-toolbar-group__button-item"
@@ -100,7 +130,9 @@ export default function DropdownGroup( {
 									'responsive-toolbar-group__more-item',
 									'responsive-toolbar-group__button-item'
 								) }
-								isActive={ groupedIndexes[ activeIndex ] }
+								isActive={ Array.from( activeIndexes ).some(
+									( index ) => groupedIndexes[ index ]
+								) }
 								onClick={ () => {
 									onToggle();
 								} }
@@ -117,13 +149,13 @@ export default function DropdownGroup( {
 										<MenuItem
 											key={ `menu-item-${ index }` }
 											onClick={ () => {
-												setActiveIndex( parseInt( index ) );
+												onSelect( parseInt( index ) );
 												onClick( parseInt( index ) );
 												onClose();
 											} }
 											className={ clsx(
 												'responsive-toolbar-group__menu-item',
-												activeIndex === parseInt( index ) ? 'is-selected' : ''
+												activeIndexes.has( parseInt( index ) ) ? 'is-selected' : ''
 											) }
 										>
 											{ child }
@@ -211,8 +243,8 @@ export default function DropdownGroup( {
 
 	// Reset active on prop change from above
 	useEffect( () => {
-		setActiveIndex( initialActiveIndex );
-	}, [ initialActiveIndex ] );
+		setActiveIndexes( new Set( defaultActiveIndexes ) );
+	}, [ defaultActiveIndexes ] );
 
 	return (
 		<div className={ classes } ref={ containerRef }>

--- a/packages/components/src/responsive-toolbar-group/index.tsx
+++ b/packages/components/src/responsive-toolbar-group/index.tsx
@@ -14,10 +14,12 @@ const ResponsiveToolbarGroup = ( {
 	rootMargin = '0px',
 	onClick = () => null,
 	initialActiveIndex = -1,
+	initialActiveIndexes,
 	swipeBreakpoint = '<660px',
 	hrefList = [],
 	forceSwipe = false,
 	swipeEnabled = true,
+	isMultiSelection = false,
 }: {
 	children: ReactNode[];
 	className?: string;
@@ -26,6 +28,7 @@ const ResponsiveToolbarGroup = ( {
 	rootMargin?: string;
 	onClick?: ( index: number ) => void;
 	initialActiveIndex?: number;
+	initialActiveIndexes?: number[];
 	swipeBreakpoint?: string;
 
 	/**
@@ -42,6 +45,11 @@ const ResponsiveToolbarGroup = ( {
 	 * When false completely disables swipe at all breakpoints.
 	 */
 	swipeEnabled?: boolean;
+
+	/**
+	 * Whether to allow multiple selection.
+	 */
+	isMultiSelection?: boolean;
 } ) => {
 	const classes = clsx( 'responsive-toolbar-group', className );
 	const isWithinBreakpoint = useBreakpoint( swipeBreakpoint );
@@ -51,8 +59,10 @@ const ResponsiveToolbarGroup = ( {
 			<SwipeGroup
 				className={ classes }
 				initialActiveIndex={ initialActiveIndex }
+				initialActiveIndexes={ initialActiveIndexes }
 				onClick={ onClick }
 				hrefList={ hrefList }
+				isMultiSelection={ isMultiSelection }
 			>
 				{ children }
 			</SwipeGroup>
@@ -63,10 +73,12 @@ const ResponsiveToolbarGroup = ( {
 		<DropdownGroup
 			className={ classes }
 			initialActiveIndex={ initialActiveIndex }
+			initialActiveIndexes={ initialActiveIndexes }
 			onClick={ onClick }
 			hideRatio={ hideRatio }
 			showRatio={ showRatio }
 			rootMargin={ rootMargin }
+			isMultiSelection={ isMultiSelection }
 		>
 			{ children }
 		</DropdownGroup>

--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -44,6 +44,12 @@
 		opacity: 1;
 	}
 
+	.is-multi {
+		.responsive-toolbar-group__menu-item:not(:first-child) {
+			margin-top: 8px;
+		}
+	}
+
 	.responsive-toolbar-group__full-list {
 		overflow: hidden;
 		position: absolute;

--- a/packages/components/src/responsive-toolbar-group/swipe-group.tsx
+++ b/packages/components/src/responsive-toolbar-group/swipe-group.tsx
@@ -1,6 +1,6 @@
 import { ToolbarGroup, ToolbarButton as BaseToolbarButton } from '@wordpress/components';
 import clsx from 'clsx';
-import { ReactNode, useState, useRef, useEffect } from 'react';
+import { ReactNode, useState, useRef, useEffect, useMemo } from 'react';
 import type { Button } from '@wordpress/components';
 
 import './style.scss';
@@ -15,22 +15,36 @@ export default function SwipeGroup( {
 	className = '',
 	onClick = () => null,
 	initialActiveIndex = -1,
+	initialActiveIndexes,
+	isMultiSelection,
 	hrefList = [],
 }: {
 	children: ReactNode[];
 	className?: string;
 	onClick?: ( index: number ) => void;
 	initialActiveIndex?: number;
+	initialActiveIndexes?: number[];
+	isMultiSelection?: boolean;
 	hrefList?: string[];
 } ) {
 	const classes = clsx( 'responsive-toolbar-group__swipe', className );
 
-	const [ activeIndex, setActiveIndex ] = useState< number >( initialActiveIndex );
+	const defaultActiveIndexes = useMemo( () => {
+		if ( isMultiSelection ) {
+			return initialActiveIndexes;
+		}
+
+		return initialActiveIndex !== -1 ? [ initialActiveIndex ] : [];
+	}, [ isMultiSelection, initialActiveIndex, initialActiveIndexes ] );
+
+	const [ activeIndexes, setActiveIndexes ] = useState< Set< number > >(
+		new Set( defaultActiveIndexes )
+	);
 
 	// Set active on prop change from above
 	useEffect( () => {
-		setActiveIndex( initialActiveIndex );
-	}, [ initialActiveIndex ] );
+		setActiveIndexes( new Set( defaultActiveIndexes ) );
+	}, [ defaultActiveIndexes ] );
 	const ref = useRef< HTMLAnchorElement >( null );
 
 	// Scroll to category on load
@@ -40,12 +54,12 @@ export default function SwipeGroup( {
 		}
 	}, [] );
 
-	// Scroll to the beginning when activeIndex changes to 0. This indicates a state reset.
+	// Scroll to the beginning when activeIndexes changes to 0. This indicates a state reset.
 	useEffect( () => {
-		if ( ref.current && activeIndex === 0 ) {
+		if ( ref.current ) {
 			ref.current.scrollIntoView( { block: 'end', inline: 'center' } );
 		}
-	}, [ activeIndex ] );
+	}, [ activeIndexes ] );
 
 	return (
 		<div className={ classes }>
@@ -54,11 +68,23 @@ export default function SwipeGroup( {
 					<ToolbarButton
 						key={ `button-item-${ index }` }
 						id={ `button-item-${ index }` }
-						isActive={ activeIndex === index }
+						isActive={ activeIndexes.has( index ) }
 						href={ hrefList[ index ] }
-						ref={ activeIndex === index ? ref : null }
+						ref={ activeIndexes.has( index ) ? ref : null }
 						onClick={ ( event: React.MouseEvent ) => {
-							setActiveIndex( index );
+							setActiveIndexes( ( currentActiveIndexes: Set< number > ) => {
+								if ( ! isMultiSelection ) {
+									return new Set( [ index ] );
+								}
+
+								if ( ! currentActiveIndexes.has( index ) ) {
+									currentActiveIndexes.add( index );
+								} else if ( currentActiveIndexes.size > 1 ) {
+									currentActiveIndexes.delete( index );
+								}
+
+								return currentActiveIndexes;
+							} );
 							onClick( index );
 
 							if ( typeof hrefList[ index ] === 'string' ) {

--- a/packages/components/src/responsive-toolbar-group/swipe-group.tsx
+++ b/packages/components/src/responsive-toolbar-group/swipe-group.tsx
@@ -31,7 +31,7 @@ export default function SwipeGroup( {
 
 	const defaultActiveIndexes = useMemo( () => {
 		if ( isMultiSelection ) {
-			return initialActiveIndexes;
+			return initialActiveIndexes || [];
 		}
 
 		return initialActiveIndex !== -1 ? [ initialActiveIndex ] : [];

--- a/packages/design-picker/src/components/design-picker-category-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/index.tsx
@@ -6,9 +6,9 @@ import './style.scss';
 interface Props {
 	className: string;
 	categories: Category[];
-	selectedSlugs: string[] | null;
+	selectedSlugs: string[];
 	isMultiSelection?: boolean;
-	onSelect: ( selectedSlug: string | null ) => void;
+	onSelect: ( selectedSlug: string ) => void;
 }
 
 export default function DesignPickerCategoryFilter( {
@@ -20,12 +20,13 @@ export default function DesignPickerCategoryFilter( {
 }: Props ) {
 	const onClick = ( index: number ) => {
 		const category = categories[ index ];
+		if ( category?.slug ) {
+			recordTracksEvent( 'calypso_signup_unified_design_select_category', {
+				category: category?.slug,
+			} );
 
-		recordTracksEvent( 'calypso_signup_unified_design_select_category', {
-			category: category?.slug,
-		} );
-
-		onSelect( category?.slug );
+			onSelect( category.slug );
+		}
 	};
 
 	const selectedSlugsSet = new Set( selectedSlugs );

--- a/packages/design-picker/src/components/design-picker-category-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/index.tsx
@@ -7,14 +7,16 @@ interface Props {
 	className: string;
 	categories: Category[];
 	selectedSlugs: string[] | null;
+	isMultiSelection?: boolean;
 	onSelect: ( selectedSlug: string | null ) => void;
 }
 
 export default function DesignPickerCategoryFilter( {
 	className,
 	categories,
-	onSelect,
 	selectedSlugs,
+	isMultiSelection,
+	onSelect,
 }: Props ) {
 	const onClick = ( index: number ) => {
 		const category = categories[ index ];
@@ -28,10 +30,15 @@ export default function DesignPickerCategoryFilter( {
 
 	const selectedSlugsSet = new Set( selectedSlugs );
 	const initialActiveIndex = categories.findIndex( ( { slug } ) => selectedSlugsSet.has( slug ) );
+	const initialActiveIndexes = categories
+		.map( ( { slug }, index ) => ( selectedSlugsSet.has( slug ) ? index : -1 ) )
+		.filter( ( index ) => index >= 0 );
 	return (
 		<ResponsiveToolbarGroup
 			className={ className }
 			initialActiveIndex={ initialActiveIndex !== -1 ? initialActiveIndex : 0 }
+			initialActiveIndexes={ initialActiveIndexes }
+			isMultiSelection={ isMultiSelection }
 			onClick={ onClick }
 		>
 			{ categories.map( ( category ) => (

--- a/packages/design-picker/src/components/design-picker-category-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/index.tsx
@@ -6,7 +6,7 @@ import './style.scss';
 interface Props {
 	className: string;
 	categories: Category[];
-	selectedSlug: string | null;
+	selectedSlugs: string[] | null;
 	onSelect: ( selectedSlug: string | null ) => void;
 }
 
@@ -14,7 +14,7 @@ export default function DesignPickerCategoryFilter( {
 	className,
 	categories,
 	onSelect,
-	selectedSlug,
+	selectedSlugs,
 }: Props ) {
 	const onClick = ( index: number ) => {
 		const category = categories[ index ];
@@ -25,7 +25,9 @@ export default function DesignPickerCategoryFilter( {
 
 		onSelect( category?.slug );
 	};
-	const initialActiveIndex = categories.findIndex( ( { slug } ) => slug === selectedSlug );
+
+	const selectedSlugsSet = new Set( selectedSlugs );
+	const initialActiveIndex = categories.findIndex( ( { slug } ) => selectedSlugsSet.has( slug ) );
 	return (
 		<ResponsiveToolbarGroup
 			className={ className }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -218,7 +218,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						className="design-picker__category-filter"
 						categories={ categorization.categories }
 						onSelect={ categorization.onSelect }
-						selectedSlug={ categorization.selection }
+						selectedSlugs={ categorization.selections }
 					/>
 				) }
 				{ assemblerCtaData.shouldGoToAssemblerStep && isSiteAssemblerEnabled && (
@@ -239,7 +239,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					return (
 						<DesignCard
 							key={ design.recipe?.slug ?? design.slug ?? index }
-							category={ categorization?.selection }
+							category={ categorization?.selections.join( ',' ) }
 							design={ design }
 							locale={ locale }
 							isPremiumThemeAvailable={ isPremiumThemeAvailable }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -184,6 +184,7 @@ interface DesignPickerProps {
 	siteActiveTheme?: string | null;
 	showActiveThemeBadge?: boolean;
 	isTierFilterEnabled?: boolean;
+	isMultiFilterEnabled?: boolean;
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -202,6 +203,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	siteActiveTheme = null,
 	showActiveThemeBadge = false,
 	isTierFilterEnabled = false,
+	isMultiFilterEnabled = false,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const filteredDesigns = useFilteredDesigns( designs, categorization );
@@ -219,6 +221,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						categories={ categorization.categories }
 						onSelect={ categorization.onSelect }
 						selectedSlugs={ categorization.selections }
+						isMultiSelection={ isMultiFilterEnabled }
 					/>
 				) }
 				{ assemblerCtaData.shouldGoToAssemblerStep && isSiteAssemblerEnabled && (
@@ -279,6 +282,7 @@ export interface UnifiedDesignPickerProps {
 	siteActiveTheme?: string | null;
 	showActiveThemeBadge?: boolean;
 	isTierFilterEnabled?: boolean;
+	isMultiFilterEnabled?: boolean;
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -299,6 +303,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	siteActiveTheme = null,
 	showActiveThemeBadge = false,
 	isTierFilterEnabled = false,
+	isMultiFilterEnabled = false,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 
@@ -336,6 +341,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					siteActiveTheme={ siteActiveTheme }
 					showActiveThemeBadge={ showActiveThemeBadge }
 					isTierFilterEnabled={ isTierFilterEnabled }
+					isMultiFilterEnabled={ isMultiFilterEnabled }
 				/>
 				{ bottomAnchorContent }
 			</div>

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -2,18 +2,18 @@ import { useEffect, useMemo, useState, useCallback } from 'react';
 import { Category } from '../types';
 
 export interface Categorization {
-	selections: string[] | null;
-	onSelect: ( selectedSlug: string | null ) => void;
+	selections: string[];
+	onSelect: ( selectedSlug: string ) => void;
 	categories: Category[];
 }
 
 interface UseCategorizationOptions {
-	defaultSelections: string[] | null;
+	defaultSelections: string[];
 	isMultiSelection?: boolean;
 	sort?: ( a: Category, b: Category ) => number;
 }
 
-export function useCategorizationFromApi(
+export function useCategorization(
 	categoryMap: Record< string, Category >,
 	{ defaultSelections, isMultiSelection, sort }: UseCategorizationOptions
 ): Categorization {
@@ -27,14 +27,14 @@ export function useCategorizationFromApi(
 		return result.sort( sort );
 	}, [ categoryMap, sort ] );
 
-	const [ selections, setSelections ] = useState< string[] | null >(
+	const [ selections, setSelections ] = useState< string[] >(
 		chooseDefaultSelections( categories, defaultSelections )
 	);
 
 	const onSelect = useCallback(
 		( value: string ) => {
-			setSelections( ( currentSelections: string[] | null ) => {
-				if ( ! currentSelections || ! isMultiSelection ) {
+			setSelections( ( currentSelections: string[] ) => {
+				if ( ! isMultiSelection ) {
 					return [ value ];
 				}
 
@@ -43,6 +43,7 @@ export function useCategorizationFromApi(
 					return [ ...currentSelections, value ];
 				}
 
+				// The selections should at least have one.
 				return currentSelections.length > 1
 					? [ ...currentSelections.slice( 0, index ), ...currentSelections.slice( index + 1 ) ]
 					: currentSelections;
@@ -73,10 +74,10 @@ export function useCategorizationFromApi(
  */
 function shouldSetToDefaultSelections(
 	categories: Category[],
-	currentSelections: string[] | null
+	currentSelections: string[]
 ): boolean {
-	// For an empty list, `null` selection is the only correct one.
-	if ( categories.length === 0 && currentSelections === null ) {
+	// For an empty list, the empty selections is the only correct one.
+	if ( categories.length === 0 && currentSelections.length === 0 ) {
 		return false;
 	}
 
@@ -92,14 +93,11 @@ function shouldSetToDefaultSelections(
  * @param defaultSelections use this category as the default selections if possible
  * @returns the default category or null if none is available
  */
-function chooseDefaultSelections(
-	categories: Category[],
-	defaultSelections: string[] | null
-): string[] | null {
+function chooseDefaultSelections( categories: Category[], defaultSelections: string[] ): string[] {
 	const defaultSelectionsSet = new Set( defaultSelections );
 	if ( defaultSelections && categories.find( ( { slug } ) => defaultSelectionsSet.has( slug ) ) ) {
 		return defaultSelections;
 	}
 
-	return categories[ 0 ]?.slug ? [ categories[ 0 ]?.slug ] : null;
+	return categories[ 0 ]?.slug ? [ categories[ 0 ]?.slug ] : [];
 }

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -25,7 +25,7 @@ export function useCategorizationFromApi(
 		} ) );
 
 		return result.sort( sort );
-	}, [ categoryMap ] );
+	}, [ categoryMap, sort ] );
 
 	const [ selections, setSelections ] = useState< string[] | null >(
 		chooseDefaultSelections( categories, defaultSelections )
@@ -33,20 +33,19 @@ export function useCategorizationFromApi(
 
 	const onSelect = useCallback(
 		( value: string ) => {
-			setSelections( ( currentSelections: string[] ) => {
-				if ( ! isMultiSelection ) {
+			setSelections( ( currentSelections: string[] | null ) => {
+				if ( ! currentSelections || ! isMultiSelection ) {
 					return [ value ];
 				}
 
 				const index = currentSelections.findIndex( ( selection ) => selection === value );
-				if ( index !== -1 ) {
-					return [
-						...currentSelections.slice( 0, index ),
-						...currentSelections.slice( index + 1 ),
-					];
+				if ( index === -1 ) {
+					return [ ...currentSelections, value ];
 				}
 
-				return [ ...currentSelections, value ];
+				return currentSelections.length > 1
+					? [ ...currentSelections.slice( 0, index ), ...currentSelections.slice( index + 1 ) ]
+					: currentSelections;
 			} );
 		},
 		[ isMultiSelection, setSelections ]

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -1,21 +1,21 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import { Category } from '../types';
 
 export interface Categorization {
-	selection: string | null;
+	selections: string[] | null;
 	onSelect: ( selectedSlug: string | null ) => void;
 	categories: Category[];
 }
 
 interface UseCategorizationOptions {
-	defaultSelection: string | null;
-	showAllFilter?: boolean;
+	defaultSelections: string[] | null;
+	isMultiSelection?: boolean;
 	sort?: ( a: Category, b: Category ) => number;
 }
 
 export function useCategorizationFromApi(
 	categoryMap: Record< string, Category >,
-	{ defaultSelection, sort }: UseCategorizationOptions
+	{ defaultSelections, isMultiSelection, sort }: UseCategorizationOptions
 ): Categorization {
 	const categories = useMemo( () => {
 		const categoryMapKeys = Object.keys( categoryMap ) || [];
@@ -27,56 +27,80 @@ export function useCategorizationFromApi(
 		return result.sort( sort );
 	}, [ categoryMap ] );
 
-	const [ selection, onSelect ] = useState< string | null >(
-		chooseDefaultSelection( categories, defaultSelection )
+	const [ selections, setSelections ] = useState< string[] | null >(
+		chooseDefaultSelections( categories, defaultSelections )
+	);
+
+	const onSelect = useCallback(
+		( value: string ) => {
+			setSelections( ( currentSelections: string[] ) => {
+				if ( ! isMultiSelection ) {
+					return [ value ];
+				}
+
+				const index = currentSelections.findIndex( ( selection ) => selection === value );
+				if ( index !== -1 ) {
+					return [
+						...currentSelections.slice( 0, index ),
+						...currentSelections.slice( index + 1 ),
+					];
+				}
+
+				return [ ...currentSelections, value ];
+			} );
+		},
+		[ isMultiSelection, setSelections ]
 	);
 
 	useEffect( () => {
-		if ( shouldSetToDefaultSelection( categories, selection ) ) {
-			onSelect( chooseDefaultSelection( categories, defaultSelection ) );
+		if ( shouldSetToDefaultSelections( categories, selections ) ) {
+			setSelections( chooseDefaultSelections( categories, defaultSelections ) );
 		}
-	}, [ categories, defaultSelection, selection ] );
+	}, [ categories, defaultSelections, selections ] );
 
 	return {
 		categories,
-		selection,
+		selections,
 		onSelect,
 	};
 }
 
 /**
- *	Check that the current selection still matches one of the category slugs,
- *	and if it doesn't reset the current selection to the default selection.
+ *	Check that the current selections still match one of the category slugs,
+ *	and if it doesn't reset the current selections to the default selections.
  *	@param categories the list of available categories
- *	@param currentSelection the slug of the current selected category
- *	@returns whether the current selection should be set to the default selection
+ *	@param currentSelections the slugs of the current selected category
+ *	@returns whether the current selections should be set to the default selections
  */
-function shouldSetToDefaultSelection(
+function shouldSetToDefaultSelections(
 	categories: Category[],
-	currentSelection: string | null
+	currentSelections: string[] | null
 ): boolean {
 	// For an empty list, `null` selection is the only correct one.
-	if ( categories.length === 0 && currentSelection === null ) {
+	if ( categories.length === 0 && currentSelections === null ) {
 		return false;
 	}
-	return ! categories.some( ( { slug } ) => slug === currentSelection );
+
+	const currentSelectionsSet = new Set( currentSelections );
+	return ! categories.some( ( { slug } ) => currentSelectionsSet.has( slug ) );
 }
 
 /**
  * Chooses which category is the one that should be used by default.
- * If `defaultSelection` is a valid category slug then it'll be used, otherwise it'll be whichever
+ * If `defaultSelections` is a valid category slug then it'll be used, otherwise it'll be whichever
  * category appears first in the list.
  * @param categories the categories from which the default will be selected
- * @param defaultSelection use this category as the default selection if possible
+ * @param defaultSelections use this category as the default selections if possible
  * @returns the default category or null if none is available
  */
-function chooseDefaultSelection(
+function chooseDefaultSelections(
 	categories: Category[],
-	defaultSelection: string | null
-): string | null {
-	if ( defaultSelection && categories.find( ( { slug } ) => slug === defaultSelection ) ) {
-		return defaultSelection;
+	defaultSelections: string[] | null
+): string[] | null {
+	const defaultSelectionsSet = new Set( defaultSelections );
+	if ( defaultSelections && categories.find( ( { slug } ) => defaultSelectionsSet.has( slug ) ) ) {
+		return defaultSelections;
 	}
 
-	return categories[ 0 ]?.slug ?? null;
+	return categories[ 0 ]?.slug ? [ categories[ 0 ]?.slug ] : null;
 }

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -4,22 +4,52 @@ import { isBlankCanvasDesign } from '../utils/available-designs';
 import type { Categorization } from './use-categorization';
 import type { Design } from '../types';
 
+const getDesignSlug = ( design: Design ) => design.recipe?.slug ?? design.slug;
+
 // Returns designs that match the features, subjects and tiers.
 // Designs with `showFirst` are always included regardless of the selected features and subjects.
-export function filterDesigns(
+export const filterDesigns = (
 	designs: Design[],
-	categorySlug: string | null | undefined,
+	categorySlugs: string[] | null | undefined,
 	selectedDesignTier: string = ''
-): Design[] {
-	return designs.filter(
+): Design[] => {
+	const categorySlugsSet = new Set( categorySlugs || [] );
+	const filteredDesigns = designs.filter(
 		( design ) =>
 			( design.showFirst ||
-				! categorySlug ||
-				design.categories.find( ( { slug } ) => slug === categorySlug ) ) &&
+				categorySlugsSet.size === 0 ||
+				design.categories.find( ( { slug } ) => categorySlugsSet.has( slug ) ) ) &&
 			( ! selectedDesignTier || design.design_tier === selectedDesignTier ) &&
 			! isBlankCanvasDesign( design )
 	);
-}
+
+	if ( categorySlugsSet.size > 1 ) {
+		const scores: { [ key: string ]: number } = filteredDesigns.reduce(
+			( result, design ) => ( {
+				...result,
+				[ getDesignSlug( design ) ]: design.categories.reduce(
+					( sum, { slug } ) => sum + ( categorySlugsSet.has( slug ) ? 1 : 0 ),
+					0
+				),
+			} ),
+			{}
+		);
+
+		filteredDesigns.sort( ( a: Design, b: Design ) => {
+			const aScore = scores[ getDesignSlug( a ) ];
+			const bScore = scores[ getDesignSlug( b ) ];
+
+			if ( aScore > bScore ) {
+				return -1;
+			} else if ( aScore < bScore ) {
+				return 1;
+			}
+			return 0;
+		} );
+	}
+
+	return filteredDesigns;
+};
 
 export const useFilteredDesigns = ( designs: Design[], categorization?: Categorization ) => {
 	const [ searchParams ] = useSearchParams();
@@ -27,12 +57,12 @@ export const useFilteredDesigns = ( designs: Design[], categorization?: Categori
 	const selectedDesignTier = searchParams.get( 'tier' ) ?? '';
 
 	const filteredDesigns = useMemo( () => {
-		if ( categorization?.selection || selectedDesignTier ) {
-			return filterDesigns( designs, categorization?.selection, selectedDesignTier );
+		if ( categorization?.selections || selectedDesignTier ) {
+			return filterDesigns( designs, categorization?.selections, selectedDesignTier );
 		}
 
 		return designs;
-	}, [ designs, categorization?.selection, selectedDesignTier ] );
+	}, [ designs, categorization?.selections, selectedDesignTier ] );
 
 	return filteredDesigns;
 };

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -33,5 +33,5 @@ export type {
 	StyleVariationPreviewColorPalette,
 	StyleVariationStylesColor,
 } from './types';
-export { useCategorizationFromApi } from './hooks/use-categorization';
+export { useCategorization } from './hooks/use-categorization';
 export { useThemeDesignsQuery } from './hooks/use-theme-designs-query';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10013

## Proposed Changes

* Make the `ResponsiveToolbarGroup` component support multiple active elements
* Make the `DesignPicker` support multiple category selection
* Order the designs by the number of the matched categories

Note that we'll work on the new UI in the follow-up PR

**Demo**

https://github.com/user-attachments/assets/839b6c55-0b72-415b-8550-9157c6514c59

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allow users to select multiple categories in the Design Picker

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Select goals on the Goals screen
* Select multiple categories on the Design Picker screen
  * Ensure you can select the multiple categories
  * Ensure the UI indicates all selected categories correctly
  * Ensure there is at least one selected category
  * Ensure the order of designs changes according to the selected categories
* Assign yourself to the holdout experiment. See pbxNRc-4zR-p2
  * Ensure the existing behavior still works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?