### PR TITLE
Paid subscriber import: enable for Jetpack sites, hide content step

### DIFF
--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -68,17 +68,16 @@ export default function NewsletterImporter( {
 	const [ autoFetchData, setAutoFetchData ] = useState( false );
 	const [ shouldResetImport, setShouldResetImport ] = useState( step === 'reset' );
 
+	if ( step === 'reset' ) {
+		step = 'content';
+	}
+
 	const { data: paidNewsletterData } = usePaidNewsletterQuery(
 		engine,
 		step,
 		selectedSite?.ID,
 		autoFetchData
 	);
-
-	// Set initial step on reset, let it be "subscribers" when content step is hidden for Jetpack sites.
-	if ( step === 'reset' ) {
-		step = paidNewsletterData?.steps?.content ? 'content' : 'subscribers';
-	}
 
 	useEffect( () => {
 		if (

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -68,15 +68,17 @@ export default function NewsletterImporter( {
 	const [ autoFetchData, setAutoFetchData ] = useState( false );
 	const [ shouldResetImport, setShouldResetImport ] = useState( step === 'reset' );
 
-	if ( step === 'reset' ) {
-		step = 'content';
-	}
 	const { data: paidNewsletterData } = usePaidNewsletterQuery(
 		engine,
 		step,
 		selectedSite?.ID,
 		autoFetchData
 	);
+
+	// Set initial step on reset, let it be "subscribers" when content step is hidden for Jetpack sites.
+	if ( step === 'reset' ) {
+		step = paidNewsletterData?.steps?.content ? 'content' : 'subscribers';
+	}
 
 	useEffect( () => {
 		if (
@@ -162,7 +164,7 @@ export default function NewsletterImporter( {
 	const shouldShowConfettiRef = useRef( false );
 	const [ showConfetti, setShowConfetti ] = useState( false );
 	const importerStatus = getImporterStatus(
-		paidNewsletterData?.steps?.content.status,
+		paidNewsletterData?.steps?.content?.status,
 		paidNewsletterData?.steps?.subscribers.status
 	);
 

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -50,7 +50,7 @@ export default function ConnectStripe( {
 			<p>
 				{ createInterpolateElement(
 					__(
-						"To migrate your <strong>paid subscribers</strong> to WordPress.com, make sure you're connecting the <strong>same</strong> Stripe account you use with Substack."
+						"To migrate your <strong>paid subscribers</strong>, make sure you're connecting the <strong>same</strong> Stripe account you use with Substack."
 					),
 					{
 						strong: <strong />,
@@ -64,7 +64,7 @@ export default function ConnectStripe( {
 					onClick={ () => {
 						recordTracksEvent( 'calypso_paid_importer_connect_stripe' );
 					} }
-					ariaLabel={ __( 'Connect Stripe' ) }
+					aria-label={ __( 'Connect Stripe' ) }
 				>
 					{ createInterpolateElement( __( 'Connect <StripeLogo />' ), {
 						StripeLogo: (

--- a/client/my-sites/importer/newsletter/subscribers/step-done.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-done.tsx
@@ -11,7 +11,7 @@ export default function StepDone( { cardData, nextStepUrl }: SubscribersStepProp
 
 	return (
 		<Card>
-			<h2>{ __( 'Import your subscribers to WordPress.com' ) }</h2>
+			<h2>{ __( 'Import your subscribers' ) }</h2>
 			<Notice status="success" className="importer__notice" isDismissible={ false }>
 				{ sprintf(
 					// Translators: %d is number of subscribers.

--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -65,7 +65,7 @@ export default function StepInitial( {
 				{ __( 'Open Substack subscribers' ) }
 			</Button>
 			<hr />
-			<h2>{ __( 'Step 2: Import your subscribers to WordPress.com' ) }</h2>
+			<h2>{ __( 'Step 2: Import your subscribers' ) }</h2>
 			{ selectedSite.ID && (
 				<SubscriberUploadForm
 					siteId={ selectedSite.ID }

--- a/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/upload-form.tsx
@@ -1,7 +1,7 @@
 import { FormInputValidation } from '@automattic/components';
 import { Subscriber } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { ProgressBar } from '@wordpress/components';
+import { ProgressBar, ExternalLink } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -11,7 +11,9 @@ import { useCallback, useState, FormEvent, useEffect } from 'react';
 import DropZone from 'calypso/components/drop-zone';
 import FilePicker from 'calypso/components/file-picker';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../../importer-action-buttons/container';
 import ImportSubscribersError from './import-subscribers-error';
@@ -53,6 +55,7 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 		},
 		[ selectedFile, importCsvSubscribers, siteId ]
 	);
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 
 	const onFileSelect = useCallback( ( files: Array< File > ) => {
 		const file = files[ 0 ];
@@ -125,11 +128,14 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextSte
 							'By clicking "Continue," you represent that you\'ve obtained the appropriate consent to email each person. <learnMoreLink>Learn more</learnMoreLink>.'
 						),
 						{
-							learnMoreLink: (
+							learnMoreLink: isJetpack ? (
+								// @ts-expect-error Used in createInterpolateElement doesn't need children.
+								<ExternalLink href="https://jetpack.com/support/newsletter/import-subscribers/" />
+							) : (
 								<InlineSupportLink
 									showIcon={ false }
 									supportLink={ localizeUrl(
-										'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'
+										'https://wordpress.com/support/import-subscribers-to-a-newsletter/'
 									) }
 									supportPostId={ 220199 }
 								/>

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -15,6 +15,7 @@ import { useEffect, useState } from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import Notice from 'calypso/components/notice';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { isBusinessTrialSite } from 'calypso/sites-dashboard/utils';
 import './style.scss';
@@ -95,7 +96,13 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 		recordTracksEvent( `calypso_subscribers_add_question`, {
 			method: 'substack',
 		} );
-		page( `/import/newsletter/substack/${ site?.slug || site?.ID || '' }` );
+		if ( isJetpackCloud() ) {
+			window.location.href = `https://wordpress.com/import/newsletter/substack/${
+				site?.slug || site?.ID || ''
+			}`;
+		} else {
+			page( `/import/newsletter/substack/${ site?.slug || site?.ID || '' }` );
+		}
 	};
 
 	const renderLearnMoreLink = ( isJetpack: boolean | null ) => {

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -172,7 +172,11 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 							<FlowQuestion
 								icon={ reusableBlock }
 								title={ translate( 'Import from Substack' ) }
-								text={ translate( 'Quickly bring your subscribers (and even your content!).' ) }
+								text={
+									isJetpack
+										? translate( 'Quickly bring your free and paid subscribers.' )
+										: translate( 'Quickly bring your subscribers (and even your content!).' )
+								}
 								onClick={ importFromSubstack }
 							/>
 						) }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -84,7 +84,8 @@
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,
-		"bulk-plugin-management": true
+		"bulk-plugin-management": true,
+		"importers/newsletter": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -77,7 +77,8 @@
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,
-		"bulk-plugin-management": true
+		"bulk-plugin-management": true,
+		"importers/newsletter": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -40,7 +40,7 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"i18n/community-translator": false,
-		"importers/newsletter": false,
+		"importers/newsletter": true,
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -81,7 +81,8 @@
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,
-		"bulk-plugin-management": true
+		"bulk-plugin-management": true,
+		"importers/newsletter": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Depends on backend change: D167682-code


## Proposed Changes

* Enables paid subscriber importer for Jetpack sites

Differences from WP.com version:
- Hides "Content" step; the content importer on Jetpack site works significantly differently [via .org plugin](https://wordpress.org/plugins/substack-importer/) so for Jetpack sites we need to focus on free and paid subscribers.
- No "View content" final CTA
- Point to Jetpack docs instead of WP.com docs

Not in PR though good follow ups:
- See if we need step counter at all
- Hide "skip" since there's no point skipping a single step
- URL initially has `content` bit instead of `subscribers`

### Before

<img width="1135" alt="Screenshot 2024-12-03 at 12 03 32" src="https://github.com/user-attachments/assets/48a3ec79-6cc2-485f-9e24-d02891a7065b">

<img width="833" alt="image" src="https://github.com/user-attachments/assets/8e96ea90-c76a-40e3-b267-ec4a1a0d607e">

### After

<img width="1286" alt="image" src="https://github.com/user-attachments/assets/5ef2e698-2333-42ed-933d-ee76ad996190">
<img width="1195" alt="Screenshot 2024-12-03 at 13 19 04" src="https://github.com/user-attachments/assets/688e6659-b081-4bb7-aba7-ce81b1ca4c41">
<img width="1192" alt="Screenshot 2024-12-03 at 13 19 19" src="https://github.com/user-attachments/assets/28022914-f910-482d-9c5d-7a1d04702c81">
<img width="1190" alt="Screenshot 2024-12-03 at 13 19 40" src="https://github.com/user-attachments/assets/0b3cac78-5eef-4341-a50f-a9318eb0fe85">
<img width="1194" alt="Screenshot 2024-12-03 at 13 20 47" src="https://github.com/user-attachments/assets/42b6c858-c0ce-4616-afd1-6b5bcc60d099">
<img width="441" alt="Screenshot 2024-12-03 at 14 28 34" src="https://github.com/user-attachments/assets/0f63a5a7-2ff0-470d-8efb-0ac7fc45f987">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test the modal:

* Go https://cloud.jetpack.com/subscribers but localhost or [Live version](https://github.com/Automattic/wp-calypso/pull/97005#issuecomment-2514327887)
* Click "Add subscribers"; you should see Substack option

To test the importer in Calypso:

* Apply D167682-code and sandbox public api
* Open `/import/newsletter/substack/JETPACK_SITE_SLUG` in localhost Calypso or [Live version](https://github.com/Automattic/wp-calypso/pull/97005#issuecomment-2514327887)
* Go through importing substack subscribers process

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?