### PR TITLE
Performance Profiler: Avoid refreshing personalized recommendations

### DIFF
--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -96,7 +96,7 @@ export const InsightsSection = forwardRef(
 				</div>
 				{ filteredAudits.map( ( key, index ) => (
 					<MetricsInsight
-						key={ `insight-${ index }` }
+						key={ key }
 						insight={ { ...audits[ key ], id: key } }
 						fullPageScreenshot={ fullPageScreenshot }
 						index={ index }

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -19,7 +19,7 @@ export const useSupportChatLLMQuery = (
 ) => {
 	return useQuery( {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps
-		queryKey: [ 'support', 'chat', insight.title, is_wpcom ],
+		queryKey: [ 'support', 'chat', hash, insight.title, is_wpcom ],
 		queryFn: () =>
 			wp.req.post(
 				{
@@ -31,13 +31,11 @@ export const useSupportChatLLMQuery = (
 					is_wpcom,
 				}
 			),
-		meta: {
-			persist: false,
-		},
 		select: mapResult,
 		enabled: !! insight.title && enable,
 		retry: false,
 		refetchOnWindowFocus: false,
+		staleTime: 1000 * 60 * 5, // 5 minutes
 	} );
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9673

## Proposed Changes

* Add a caching time of 5 minutes to the query
* Add the hash to the `queryKey` so it re-runs for different reports
* It also changes the `key` of the list to avoid using the index, please see Pitfall [here](https://react.dev/learn/rendering-lists#why-does-react-need-keys)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid fetching multiple times the same data from the server

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch and run a test or open an existing report, e.g. `/speed-test-tool?url=https://www.atliq.com/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MjM1NzV9._LVu56m6pZx6q3Fy9A4wMDdIqXKx5P-BykRuW4tDn1s`
* Open the Network tab in the Developer Tools and filter by `performance-profiler`
* Scroll down and open one Insight
* Check that there is one network call
* Use the dropdown filter to open other recommendations and select again the `All recommendations` so the opened item is removed and added again to the list
* Check there are no additional network calls
* Additionally, [In the linked task](https://github.com/Automattic/dotcom-forge/issues/9673) there is a video showing the steps

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
