### PR TITLE
Fix incorrect height of logs date filter in Safari

### DIFF
--- a/client/sites/tools/logs/components/site-logs-toolbar/style.scss
+++ b/client/sites/tools/logs/components/site-logs-toolbar/style.scss
@@ -36,6 +36,8 @@
 		}
 
 		input[type="datetime-local"] {
+			display: flex;
+			justify-content: center;
 			cursor: text;
 			&::-webkit-calendar-picker-indicator {
 				cursor: pointer;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9963

## Proposed Changes

I propose to fix the issue with the incorrect height of the date filter in the site Logs tab, which happens only in Safari.

| **Before** | **After** |
|---|---|
| ![safari-before](https://github.com/user-attachments/assets/115bd8b1-e786-4a9a-aa1c-8a7edc810d46) | ![safari-after](https://github.com/user-attachments/assets/855a9afb-b345-458c-ab20-17e630876335)|



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make UI consistent across different browsers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Calypso locally or use a Calypso Live link in Safari
2. Navigate to the `/sites` page
3. Locate a Business site with enabled Hosting features
4. Open the site's card and click the Logs tab
5. Confirm that the height of date filters looks as expected
6. Repeat the steps in Chrome and confirm that no issue was introduced

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
