### PR TITLE
Help Center: Add editor type to tracking

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useState, useReducer } from '@wordpress/element
 import { registerPlugin } from '@wordpress/plugins';
 import ReactDOM from 'react-dom';
 import { useCanvasMode } from './hooks/use-canvas-mode';
+import { getEditorType } from './utils';
 import './help-center.scss';
 
 const queryClient = new QueryClient();
@@ -29,6 +30,7 @@ function HelpCenterContent() {
 			force_site_id: true,
 			location: 'help-center',
 			section: 'gutenberg-editor',
+			editor_type: getEditorType(),
 			canvas_mode: canvasMode,
 		} );
 

--- a/apps/help-center/utils.js
+++ b/apps/help-center/utils.js
@@ -21,3 +21,23 @@ export const getUnlock = () => {
 		return undefined;
 	}
 };
+
+export const getEditorType = () => {
+	if ( document.querySelector( '#editor .edit-post-layout' ) ) {
+		return 'post';
+	}
+
+	if ( document.querySelector( '#site-editor' ) ) {
+		return 'site';
+	}
+
+	if ( document.querySelector( '#widgets-editor' ) ) {
+		return 'widgets';
+	}
+
+	if ( document.querySelector( '#customize-controls .customize-widgets__sidebar-section.open' ) ) {
+		return 'customize-widgets';
+	}
+
+	return undefined;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

In `calypso_inlinehelp_show` (and close) we know when we are in the editor by the value of the `section` property (`gutenberg-editor`), but we don't know if we're editing the site or a post.

This PR introduce a `editor_type` property to the event.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync the changes to your website and sandbox widgets.wordpress.com
* Open the site editor and click on Help Center
* You should see the value in Tracks Vigilante
* Do the same for a post

