### PR TITLE
Global Styles: Fix unlock message and upgrade badge logic for GS variations

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -864,17 +864,31 @@ class ThemeSheet extends Component {
 	};
 
 	renderStyleVariations = () => {
-		const { isPremium, isFreePlan, isThemePurchased, shouldLimitGlobalStyles, styleVariations } =
-			this.props;
+		const {
+			isPremium,
+			isFreePlan,
+			isThemePurchased,
+			themeTier,
+			shouldLimitGlobalStyles,
+			styleVariations,
+			isExternallyManagedTheme,
+			isBundledSoftwareSet,
+		} = this.props;
 
-		const splitDefaultVariation =
-			! this.props.isExternallyManagedTheme &&
-			! this.props.isBundledSoftwareSet &&
+		const isGlobalStylesEnabled = isEnabled( 'global-styles/on-personal-plan' );
+
+		const isFreeTier = isFreePlan && themeTier?.slug === 'free';
+		const hasLimitedFeatures =
+			! isExternallyManagedTheme &&
+			! isBundledSoftwareSet &&
 			! isThemePurchased &&
+			! isGlobalStylesEnabled &&
 			! isPremium &&
 			shouldLimitGlobalStyles;
 
-		const needsUpgrade = isEnabled( 'global-styles/on-personal-plan' )
+		const shouldSplitDefaultVariation = isFreeTier || hasLimitedFeatures;
+
+		const needsUpgrade = isGlobalStylesEnabled
 			? isFreePlan
 			: shouldLimitGlobalStyles || ( isPremium && ! isThemePurchased );
 
@@ -882,7 +896,7 @@ class ThemeSheet extends Component {
 			styleVariations.length > 0 && (
 				<ThemeStyleVariations
 					description={ this.getStyleVariationDescription() }
-					splitDefaultVariation={ splitDefaultVariation }
+					splitDefaultVariation={ shouldSplitDefaultVariation }
 					selectedVariation={ this.getSelectedStyleVariation() }
 					variations={ styleVariations }
 					needsUpgrade={ needsUpgrade }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -71,7 +71,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
-import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
+import { getCurrentPlan, isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	setThemePreviewOptions,
@@ -864,7 +864,8 @@ class ThemeSheet extends Component {
 	};
 
 	renderStyleVariations = () => {
-		const { isPremium, isThemePurchased, shouldLimitGlobalStyles, styleVariations } = this.props;
+		const { isPremium, isFreePlan, isThemePurchased, shouldLimitGlobalStyles, styleVariations } =
+			this.props;
 
 		const splitDefaultVariation =
 			! this.props.isExternallyManagedTheme &&
@@ -873,7 +874,9 @@ class ThemeSheet extends Component {
 			! isPremium &&
 			shouldLimitGlobalStyles;
 
-		const needsUpgrade = shouldLimitGlobalStyles || ( isPremium && ! isThemePurchased );
+		const needsUpgrade = isEnabled( 'global-styles/on-personal-plan' )
+			? isFreePlan
+			: shouldLimitGlobalStyles || ( isPremium && ! isThemePurchased );
 
 		return (
 			styleVariations.length > 0 && (
@@ -1612,6 +1615,8 @@ export default connect(
 		const englishUrl = 'https://wordpress.com' + getThemeDetailsUrl( state, themeId );
 
 		const isAtomic = isSiteAutomatedTransfer( state, siteId );
+		const currentPlan = getCurrentPlan( state, siteId );
+		const isFreePlan = currentPlan?.productSlug === 'free_plan';
 		const isWpcomStaging = isSiteWpcomStaging( state, siteId );
 		const productionSite = getProductionSiteForWpcomStaging( state, siteId );
 		const productionSiteSlug = getSiteSlug( state, productionSite?.ID );
@@ -1649,6 +1654,7 @@ export default connect(
 			isActive: isThemeActive( state, themeId, siteId ),
 			isJetpack,
 			isAtomic,
+			isFreePlan,
 			isStandaloneJetpack,
 			isVip: isVipSite( state, siteId ),
 			isPremium: isThemePremium( state, themeId ),

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -106,13 +106,17 @@ const GlobalStylesVariations = ( {
 }: GlobalStylesVariationsProps ) => {
 	const hasEnTranslation = useHasEnTranslation();
 	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
+	splitDefaultVariation = true;
 	const upgradeToPlan = isEnabled( 'global-styles/on-personal-plan' )
 		? PLAN_PERSONAL
 		: PLAN_PREMIUM;
-	const premiumStylesDescription = translate(
-		'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
-		{ args: { planName: getPlan( upgradeToPlan )?.getTitle() ?? '' } }
-	);
+
+	const variationDescription = needsUpgrade
+		? translate(
+				'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
+				{ args: { planName: getPlan( upgradeToPlan )?.getTitle() ?? '' } }
+		  )
+		: translate( 'You can change your style at any time.' );
 
 	const baseGlobalStyles = useMemo(
 		() =>
@@ -129,7 +133,7 @@ const GlobalStylesVariations = ( {
 		[ globalStylesVariations ]
 	);
 
-	const nonDefaultStylesDescription = description ?? premiumStylesDescription;
+	const nonDefaultStylesDescription = description ?? variationDescription;
 	const nonDefaultStyles = globalStylesVariationsWithoutDefault.map(
 		( globalStylesVariation, index ) => (
 			<GlobalStylesVariation
@@ -199,11 +203,13 @@ const GlobalStylesVariations = ( {
 												count: nonDefaultStyles.length,
 										  } ) }
 								</span>
-								<PremiumBadge
-									shouldHideTooltip
-									shouldCompactWithAnimation
-									labelText={ translate( 'Upgrade' ) }
-								/>
+								{ needsUpgrade && (
+									<PremiumBadge
+										shouldHideTooltip
+										shouldCompactWithAnimation
+										labelText={ translate( 'Upgrade' ) }
+									/>
+								) }
 							</h2>
 							<p>{ nonDefaultStylesDescription }</p>
 						</div>

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -106,7 +106,6 @@ const GlobalStylesVariations = ( {
 }: GlobalStylesVariationsProps ) => {
 	const hasEnTranslation = useHasEnTranslation();
 	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
-	splitDefaultVariation = true;
 	const upgradeToPlan = isEnabled( 'global-styles/on-personal-plan' )
 		? PLAN_PERSONAL
 		: PLAN_PREMIUM;


### PR DESCRIPTION
# Fix unlock message and upgrade badge logic for GS variations

Related to:
- https://github.com/Automattic/dotcom-forge/issues/9676
- https://github.com/Automattic/wp-calypso/pull/96617#pullrequestreview-2451132354

## Proposed Changes
- Updated the logic for showing unlock message and upgrade badge based on global styles feature flag state
- Fixed when upgrade badge and message appear for Personal plan users based on feature availability

## Why are these changes being made?
When the global styles feature flag is enabled for Personal plan, users with Personal plan were still seeing the upgrade message and badge for style variations. This fix ensures that the unlock message and upgrade badge are only shown when actually needed based on the user's plan and feature flag state.

## Testing Instructions
1. Open the Calypso live link
2. Navigate to Appearance -> Themes
3. Test with different plan levels and theme tiers per table

| **Theme Type** | **Plan Level** | **Expected Behavior**                               |
|----------------|----------------|---------------------------------------------------|
| Free           | Free           | Show "Upgrade" badge         |
| Free           | Personal       | Show "Included in your plan" message, no badge    |
| Free           | Premium+       | Show "Included in your plan" message, no badge    |
| Personal       | Free           | No message, no badge                              |
| Personal       | Personal       | Show "Included in your plan" message, no badge    |
| Personal       | Premium+       | Show "Included in your plan" message, no badge    |
| Premium        | Free           | No message, no badge     |
| Premium        | Personal       | Show "Included in your plan" message, no badge    |
| Premium        | Premium+       | Show "Included in your plan" message, no badge    |


Examples with different combinations:
Free plan with free theme  | Free plan with personal theme
-------|------
<img width="672" alt="image" src="https://github.com/user-attachments/assets/6509b267-83a1-4ecb-bae6-5093d3736b29"> | <img width="674" alt="image" src="https://github.com/user-attachments/assets/473fffb0-0766-4b84-887d-4d41b91d657e">

Personal plan with free theme  | Personal plan with personal+ theme
-------|------
<img width="678" alt="image" src="https://github.com/user-attachments/assets/0079c5b4-1e16-4ff3-89c2-c9148bedd870"> | <img width="677" alt="image" src="https://github.com/user-attachments/assets/8b03063f-1152-41e4-bdb5-bd1acb4ddb06">

(Premium and Business logic behaves same as Personal)

## Pre-merge Checklist
- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?