### PR TITLE
Stats: improve the code that handle video module toggling based on the "feature enable" flag

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -87,7 +87,7 @@ class StatsNavigation extends Component {
 	};
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
-		const availableModuleToggles = AVAILABLE_PAGE_MODULES[ nextProps.selectedItem ].map(
+		const availableModuleToggles = ( AVAILABLE_PAGE_MODULES[ nextProps.selectedItem ] || [] ).map(
 			( toggleItem ) => {
 				// disable the "videos" toggle on sites that do not have VideoPress enabled
 				// the toggle will be disabled (grayed out and non interactive)
@@ -100,6 +100,11 @@ class StatsNavigation extends Component {
 				};
 			}
 		);
+
+		// toggle the visibility of video module itself
+		if ( ! nextProps.hasVideoPress ) {
+			nextProps.pageModuleToggles.videos = false;
+		}
 
 		if (
 			prevState.pageModules !== nextProps.pageModuleToggles ||

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -83,11 +83,29 @@ class StatsNavigation extends Component {
 				};
 			} )
 		),
+		availableModuleToggles: [],
 	};
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
-		if ( prevState.pageModules !== nextProps.pageModuleToggles ) {
-			return { pageModules: nextProps.pageModuleToggles };
+		const availableModuleToggles = AVAILABLE_PAGE_MODULES[ nextProps.selectedItem ].map(
+			( toggleItem ) => {
+				// disable the "videos" toggle on sites that do not have VideoPress enabled
+				// the toggle will be disabled (grayed out and non interactive)
+				const shouldDisableVideoToggle = ! nextProps.hasVideoPress && toggleItem.key === 'videos';
+
+				return {
+					...toggleItem,
+					disabled: shouldDisableVideoToggle,
+					defaultValue: shouldDisableVideoToggle === false,
+				};
+			}
+		);
+
+		if (
+			prevState.pageModules !== nextProps.pageModuleToggles ||
+			prevState.availableModuleToggles !== nextProps.availableModuleToggles
+		) {
+			return { availableModuleToggles, pageModules: nextProps.pageModuleToggles };
 		}
 
 		return null;
@@ -159,9 +177,8 @@ class StatsNavigation extends Component {
 			showLock,
 			hideModuleSettings,
 			delayTooltipPresentation,
-			hasVideoPress,
 		} = this.props;
-		const { pageModules, isPageSettingsTooltipDismissed } = this.state;
+		const { pageModules, isPageSettingsTooltipDismissed, availableModuleToggles } = this.state;
 		const { label, showIntervals, path } = navItems[ selectedItem ];
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ path }/{{ interval }}${ slugPath }`;
@@ -230,19 +247,7 @@ class StatsNavigation extends Component {
 					AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] &&
 					! hideModuleSettings && (
 						<PageModuleToggler
-							availableModules={ AVAILABLE_PAGE_MODULES[ this.props.selectedItem ].map(
-								( toggleItem ) => {
-									// disable the "videos" toggle on sites that do not have VideoPress enabled
-									// the toggle will be disabled (grayed out and non interactive)
-									const shouldDisableVideoToggle = ! hasVideoPress && toggleItem.key === 'videos';
-
-									return {
-										...toggleItem,
-										disabled: shouldDisableVideoToggle,
-										defaultValue: shouldDisableVideoToggle === false,
-									};
-								}
-							) }
+							availableModuleToggles={ availableModuleToggles }
 							pageModules={ pageModules }
 							onToggleModule={ this.onToggleModule }
 							isTooltipShown={

--- a/client/blocks/stats-navigation/page-module-toggler.tsx
+++ b/client/blocks/stats-navigation/page-module-toggler.tsx
@@ -6,7 +6,7 @@ import { useState, useRef, useCallback } from 'react';
 import { ModuleToggleItem } from './constants';
 
 type PageModuleTogglerProps = {
-	availableModules: ModuleToggleItem[];
+	availableModuleToggles: ModuleToggleItem[];
 	pageModules: { [ name: string ]: boolean };
 	onToggleModule: ( module: string, isShow: boolean ) => void;
 	isTooltipShown: boolean;
@@ -14,7 +14,7 @@ type PageModuleTogglerProps = {
 };
 
 export default function PageModuleToggler( {
-	availableModules,
+	availableModuleToggles,
 	pageModules,
 	onToggleModule,
 	isTooltipShown,
@@ -73,7 +73,7 @@ export default function PageModuleToggler( {
 			>
 				<div>{ translate( 'Modules visibility' ) }</div>
 				<div className="page-modules-settings-toggle-wrapper">
-					{ availableModules.map( ( toggleItem: ModuleToggleItem ) => {
+					{ availableModuleToggles.map( ( toggleItem: ModuleToggleItem ) => {
 						return (
 							<div key={ toggleItem.key } className="page-modules-settings-toggle">
 								<Icon className="gridicon" icon={ toggleItem.icon } />

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -310,7 +310,7 @@ class StatsSite extends Component {
 			supportUserFeedback,
 			momentSiteZone,
 			wpcomShowUpsell,
-			isVideoPress,
+			hasVideoPress,
 		} = this.props;
 		const isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' ) || isInternal;
 		let defaultPeriod = PAST_SEVEN_DAYS;
@@ -670,7 +670,7 @@ class StatsSite extends Component {
 									className={ halfWidthModuleClasses }
 								/>
 
-								{ isVideoPress && ! this.isModuleHidden( 'videos' ) && (
+								{ hasVideoPress && ! this.isModuleHidden( 'videos' ) && (
 									<StatsModuleVideos
 										moduleStrings={ moduleStrings.videoplays }
 										period={ this.props.period }
@@ -845,7 +845,7 @@ export default connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
 		const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-		const isVideoPress = siteHasFeature( state, siteId, 'videopress' );
+		const hasVideoPress = siteHasFeature( state, siteId, 'videopress' );
 
 		// Odyssey Stats: This UX is not possible in Odyssey as this page would not be able to render in the first place.
 		const showEnableStatsModule =
@@ -908,7 +908,7 @@ export default connect(
 			shouldForceDefaultDateRange,
 			momentSiteZone: getMomentSiteZone( state, siteId ),
 			wpcomShowUpsell,
-			isVideoPress,
+			hasVideoPress,
 		};
 	},
 	{

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -44,7 +44,6 @@ import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-ro
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getJetpackStatsAdminVersion, isJetpackSite } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { requestModuleSettings } from 'calypso/state/stats/module-settings/actions';
@@ -310,7 +309,6 @@ class StatsSite extends Component {
 			supportUserFeedback,
 			momentSiteZone,
 			wpcomShowUpsell,
-			hasVideoPress,
 		} = this.props;
 		const isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' ) || isInternal;
 		let defaultPeriod = PAST_SEVEN_DAYS;
@@ -670,7 +668,7 @@ class StatsSite extends Component {
 									className={ halfWidthModuleClasses }
 								/>
 
-								{ hasVideoPress && ! this.isModuleHidden( 'videos' ) && (
+								{ ! this.isModuleHidden( 'videos' ) && (
 									<StatsModuleVideos
 										moduleStrings={ moduleStrings.videoplays }
 										period={ this.props.period }
@@ -845,7 +843,6 @@ export default connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
 		const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-		const hasVideoPress = siteHasFeature( state, siteId, 'videopress' );
 
 		// Odyssey Stats: This UX is not possible in Odyssey as this page would not be able to render in the first place.
 		const showEnableStatsModule =
@@ -908,7 +905,6 @@ export default connect(
 			shouldForceDefaultDateRange,
 			momentSiteZone: getMomentSiteZone( state, siteId ),
 			wpcomShowUpsell,
-			hasVideoPress,
 		};
 	},
 	{


### PR DESCRIPTION
Related to #96894.

## Proposed Changes

*

## Why are these changes being made?

This PR addresses the remaining points from @Initsogar [code review](https://github.com/Automattic/wp-calypso/pull/96894#discussion_r1863810462) in #96894 and [makes use of the `getDerivedStateFromProps`](https://react.dev/reference/react/Component#static-getderivedstatefromprops) to evaluate the `availableModuleToggles` state.

## Testing Instructions

TBA / basically follow the testing instructions from #96894 - check for any regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
