### PR TITLE
Stats: Show feedback prompts to sites with 10k+ visitors per month

### DIFF
--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -19,6 +19,7 @@ import 'animate.css';
 
 import './style.scss';
 
+const TRACKS_EVENT_DID_PRESENT_FEEDBACK_CARD = 'stats_feedback_action_present_persistent_section';
 const TRACKS_EVENT_LEAVE_REVIEW_FROM_CARD =
 	'stats_feedback_action_redirect_to_plugin_review_page_from_persistent_section';
 const TRACKS_EVENT_SEND_FEEDBACK_FROM_CARD =
@@ -167,6 +168,10 @@ interface FeedbackCardProps {
 }
 
 function FeedbackCard( { onLeaveReview, onSendFeedback }: FeedbackCardProps ) {
+	useEffect( () => {
+		trackStatsAnalyticsEvent( TRACKS_EVENT_DID_PRESENT_FEEDBACK_CARD );
+	}, [] );
+
 	const handleLeaveReviewFromCard = () => {
 		trackStatsAnalyticsEvent( TRACKS_EVENT_LEAVE_REVIEW_FROM_CARD );
 		onLeaveReview();

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -3,7 +3,7 @@ import { Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
 import {
@@ -268,7 +268,9 @@ function StatsFeedbackPresentor( { siteId }: FeedbackPresentorProps ) {
 	const { data, isSuccess } = useFetchTrafficHook( siteId );
 
 	const visitors = data?.past_thirty_days.visitors ?? 0;
-	const isHighTrafficSite = isSuccess && visitors > getHighTrafficThreshold();
+	const highTrafficThreshold = useMemo( () => getHighTrafficThreshold(), [] );
+
+	const isHighTrafficSite = isSuccess && visitors > highTrafficThreshold;
 	logFeedbackPresentationStatus( 'StatsHighTrafficSite', isHighTrafficSite );
 
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -272,10 +272,10 @@ function StatsFeedbackPresentor( { siteId }: FeedbackPresentorProps ) {
 	const { supportCommercialUse } = useStatsPurchases( siteId );
 	const { data, isSuccess } = useFetchTrafficHook( siteId );
 
-	const visitors = data?.past_thirty_days.visitors ?? 0;
+	const views = data?.past_thirty_days.views ?? 0;
 	const highTrafficThreshold = useMemo( () => getHighTrafficThreshold(), [] );
 
-	const isHighTrafficSite = isSuccess && visitors > highTrafficThreshold;
+	const isHighTrafficSite = isSuccess && views > highTrafficThreshold;
 	logFeedbackPresentationStatus( 'StatsHighTrafficSite', isHighTrafficSite );
 
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -244,7 +244,20 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 	);
 }
 
+function logFeedbackPresentationStatus( key: string, value: boolean ) {
+	const isCalypsoLive = window.location.host === 'calypso.live';
+	const isCalypsoLocalhost = window.location.host.startsWith( 'calypso.localhost' );
+	if ( isCalypsoLive || isCalypsoLocalhost ) {
+		localStorage.setItem( key, value ? 'true' : 'false' );
+	}
+}
+
 const FEEDBACK_HIGH_TRAFFIC_SITE_THRESHOLD = 10000;
+
+function getHighTrafficThreshold() {
+	const value = Number( localStorage.getItem( 'StatsHighTrafficThreshold' ) );
+	return value !== 0 ? value : FEEDBACK_HIGH_TRAFFIC_SITE_THRESHOLD;
+}
 
 interface FeedbackPresentorProps {
 	siteId: number;
@@ -255,7 +268,8 @@ function StatsFeedbackPresentor( { siteId }: FeedbackPresentorProps ) {
 	const { data, isSuccess } = useFetchTrafficHook( siteId );
 
 	const visitors = data?.past_thirty_days.visitors ?? 0;
-	const isHighTrafficSite = isSuccess && visitors > FEEDBACK_HIGH_TRAFFIC_SITE_THRESHOLD;
+	const isHighTrafficSite = isSuccess && visitors > getHighTrafficThreshold();
+	logFeedbackPresentationStatus( 'StatsHighTrafficSite', isHighTrafficSite );
 
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const presentForHighTrafficSite = isOdysseyStats && isHighTrafficSite;

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -6,6 +5,8 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
+import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	NOTICES_KEY_SHOW_FLOATING_USER_FEEDBACK_PANEL,
 	useNoticeVisibilityQuery,
@@ -278,8 +279,10 @@ function StatsFeedbackPresentor( { siteId }: FeedbackPresentorProps ) {
 	const isHighTrafficSite = isSuccess && views > highTrafficThreshold;
 	logFeedbackPresentationStatus( 'StatsHighTrafficSite', isHighTrafficSite );
 
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	const presentForHighTrafficSite = isOdysseyStats && isHighTrafficSite;
+	const isJetpackNotAtomic = useSelector(
+		( state ) => !! isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
+	const presentForHighTrafficSite = isJetpackNotAtomic && isHighTrafficSite;
 
 	if ( ! supportCommercialUse && ! presentForHighTrafficSite ) {
 		return null;

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -11,6 +12,7 @@ import {
 } from '../hooks/use-notice-visibility-query';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import FeedbackModal from './modal';
+import useFetchTrafficHook from './use-fetch-traffic-hook';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import 'animate.css';
@@ -188,19 +190,17 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 	const [ isFeedbackModalOpen, setIsFeedbackModalOpen ] = useState( false );
 	const [ isFloatingPanelOpen, setIsFloatingPanelOpen ] = useState( false );
 
-	const { supportCommercialUse } = useStatsPurchases( siteId );
-
 	const { isPending, isError, shouldShowFeedbackPanel, updateFeedbackPanelHibernationDelay } =
 		useNoticeVisibilityHooks( siteId );
 
 	useEffect( () => {
-		if ( ! isPending && ! isError && shouldShowFeedbackPanel && supportCommercialUse ) {
+		if ( ! isPending && ! isError && shouldShowFeedbackPanel ) {
 			setTimeout( () => {
 				setIsFloatingPanelOpen( true );
 				trackStatsAnalyticsEvent( TRACKS_EVENT_VIEW_FLOATING_PANEL );
 			}, FEEDBACK_PANEL_PRESENTATION_DELAY );
 		}
-	}, [ isPending, isError, shouldShowFeedbackPanel, supportCommercialUse ] );
+	}, [ isPending, isError, shouldShowFeedbackPanel ] );
 
 	const dismissPanelWithDelay = () => {
 		// Allows the animation to run first.
@@ -228,10 +228,6 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 		setIsFeedbackModalOpen( false );
 	};
 
-	if ( ! supportCommercialUse ) {
-		return null;
-	}
-
 	return (
 		<div className="stats-feedback-container">
 			<FeedbackCard onLeaveReview={ handleLeaveReview } onSendFeedback={ handleSendFeedback } />
@@ -248,4 +244,27 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 	);
 }
 
-export default StatsFeedbackController;
+const FEEDBACK_HIGH_TRAFFIC_SITE_THRESHOLD = 10000;
+
+interface FeedbackPresentorProps {
+	siteId: number;
+}
+
+function StatsFeedbackPresentor( { siteId }: FeedbackPresentorProps ) {
+	const { supportCommercialUse } = useStatsPurchases( siteId );
+	const { data, isSuccess } = useFetchTrafficHook( siteId );
+
+	const visitors = data?.past_thirty_days.visitors ?? 0;
+	const isHighTrafficSite = isSuccess && visitors > FEEDBACK_HIGH_TRAFFIC_SITE_THRESHOLD;
+
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const presentForHighTrafficSite = isOdysseyStats && isHighTrafficSite;
+
+	if ( ! supportCommercialUse && ! presentForHighTrafficSite ) {
+		return null;
+	}
+
+	return <StatsFeedbackController siteId={ siteId } />;
+}
+
+export default StatsFeedbackPresentor;

--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -80,7 +80,7 @@ interface FeedbackContentProps {
 function FeedbackContent( { onLeaveReview, onSendFeedback }: FeedbackContentProps ) {
 	const translate = useTranslate();
 
-	const ctaText = translate( 'How do you rate your overall experience with Jetpack Stats?' );
+	const ctaText = translate( 'How would you rate your overall experience with Jetpack?' );
 	const primaryButtonText = translate( 'Love it? Leave a review ↗' );
 	const secondaryButtonText = translate( 'Not a fan? Help us improve' );
 

--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -126,12 +126,12 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 			/>
 			<div className="stats-feedback-modal__wrapper">
 				<h1 className="stats-feedback-modal__title">
-					{ translate( 'Help us make Jetpack Stats better' ) }
+					{ translate( 'Help us make Jetpack better' ) }
 				</h1>
 
 				<div className="stats-feedback-modal__text">
 					{ translate(
-						'We value your opinion and would love to hear more about your experience. Please share any specific thoughts or suggestions you have to improve Jetpack Stats.'
+						'We value your opinion and would love to hear more about your experience. Please share any specific thoughts or suggestions you have to improve Jetpack.'
 					) }
 				</div>
 				<TextareaControl

--- a/client/my-sites/stats/feedback/use-fetch-traffic-hook.ts
+++ b/client/my-sites/stats/feedback/use-fetch-traffic-hook.ts
@@ -3,7 +3,7 @@ import wpcom from 'calypso/lib/wp';
 
 // TODO: Update stale time before release.
 // Probably good enough to call this one per 24 hours.
-const FETCH_TRAFFIC_STALE_TIME = 5 * 1000; // 5 seconds
+const FETCH_TRAFFIC_STALE_TIME = 24 * 60 * 60 * 1000; // 24 hours
 
 async function fetchHighlights( siteId: number ) {
 	const response = await wpcom.req.get(

--- a/client/my-sites/stats/feedback/use-fetch-traffic-hook.ts
+++ b/client/my-sites/stats/feedback/use-fetch-traffic-hook.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+// TODO: Update stale time before release.
+// Probably good enough to call this one per 24 hours.
+const FETCH_TRAFFIC_STALE_TIME = 5 * 1000; // 5 seconds
+
+async function fetchHighlights( siteId: number ) {
+	const response = await wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/stats/highlights`,
+		},
+		{
+			source: 'stats-feedback',
+		}
+	);
+
+	return response;
+}
+
+function useHighlightsQuery( siteId: number ) {
+	const response = useQuery( {
+		queryKey: [ 'fetchHighlights', siteId ],
+		queryFn: () => fetchHighlights( siteId ),
+		staleTime: FETCH_TRAFFIC_STALE_TIME,
+	} );
+
+	return response;
+}
+
+// Wrapping this for the sake of readatbility at the call site.
+function useFetchTrafficHook( siteId: number ) {
+	return useHighlightsQuery( siteId );
+}
+
+export default useFetchTrafficHook;

--- a/client/my-sites/stats/feedback/use-fetch-traffic-hook.ts
+++ b/client/my-sites/stats/feedback/use-fetch-traffic-hook.ts
@@ -1,9 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-// TODO: Update stale time before release.
-// Probably good enough to call this one per 24 hours.
-const FETCH_TRAFFIC_STALE_TIME = 24 * 60 * 60 * 1000; // 24 hours
+// Limit this lookup to once per 24 hours.
+const FETCH_TRAFFIC_STALE_TIME = 24 * 60 * 60 * 1000;
 
 async function fetchHighlights( siteId: number ) {
 	const response = await wpcom.req.get(
@@ -28,7 +27,7 @@ function useHighlightsQuery( siteId: number ) {
 	return response;
 }
 
-// Wrapping this for the sake of readatbility at the call site.
+// Wrapping this for the sake of readability at the call site.
 function useFetchTrafficHook( siteId: number ) {
 	return useHighlightsQuery( siteId );
 }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -431,10 +431,6 @@ class StatsSite extends Component {
 			'stats__flexible-grid-item--full--medium'
 		);
 
-		// Temporarily move the feedback card to the top of the page.
-		const feedbackOnTop = true;
-		const feedbackOnBottom = false;
-
 		return (
 			<div className="stats">
 				{ ! isOdysseyStats && (
@@ -467,7 +463,6 @@ class StatsSite extends Component {
 					isOdysseyStats={ isOdysseyStats }
 					statsPurchaseSuccess={ context.query.statsPurchaseSuccess }
 				/>
-				{ feedbackOnTop && <StatsFeedbackPresentor siteId={ siteId } /> }
 				{ ! isNewDateFilteringEnabled && (
 					// @TODO: remove highlight section completely once flag is released
 					<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
@@ -732,7 +727,7 @@ class StatsSite extends Component {
 				{ ! config.isEnabled( 'stats/paid-wpcom-v3' ) && (
 					<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
 				) }
-				{ feedbackOnBottom && supportUserFeedback && <StatsFeedbackPresentor siteId={ siteId } /> }
+				{ supportUserFeedback && <StatsFeedbackPresentor siteId={ siteId } /> }
 				<JetpackColophon />
 				<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
 				{ this.props.upsellModalView && <StatsUpsellModal siteId={ siteId } /> }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -64,7 +64,7 @@ import StatsModuleSearch from './features/modules/stats-search';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
 import StatsModuleUTM, { StatsModuleUTMOverlay } from './features/modules/stats-utm';
 import StatsModuleVideos from './features/modules/stats-videos';
-import StatsFeedbackController from './feedback';
+import StatsFeedbackPresentor from './feedback';
 import HighlightsSection from './highlights-section';
 import { shouldGateStats } from './hooks/use-should-gate-stats';
 import MiniCarousel from './mini-carousel';
@@ -431,6 +431,10 @@ class StatsSite extends Component {
 			'stats__flexible-grid-item--full--medium'
 		);
 
+		// Temporarily move the feedback card to the top of the page.
+		const feedbackOnTop = true;
+		const feedbackOnBottom = false;
+
 		return (
 			<div className="stats">
 				{ ! isOdysseyStats && (
@@ -463,6 +467,7 @@ class StatsSite extends Component {
 					isOdysseyStats={ isOdysseyStats }
 					statsPurchaseSuccess={ context.query.statsPurchaseSuccess }
 				/>
+				{ feedbackOnTop && <StatsFeedbackPresentor siteId={ siteId } /> }
 				{ ! isNewDateFilteringEnabled && (
 					// @TODO: remove highlight section completely once flag is released
 					<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
@@ -727,7 +732,7 @@ class StatsSite extends Component {
 				{ ! config.isEnabled( 'stats/paid-wpcom-v3' ) && (
 					<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
 				) }
-				{ supportUserFeedback && <StatsFeedbackController siteId={ siteId } /> }
+				{ feedbackOnBottom && supportUserFeedback && <StatsFeedbackPresentor siteId={ siteId } /> }
 				<JetpackColophon />
 				<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
 				{ this.props.upsellModalView && <StatsUpsellModal siteId={ siteId } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/red-team/issues/259

## Proposed Changes

Expands the audience for the feedback prompts to includes sites with 10k+ visitors/month.

Of note, the UI will be shown at the top of the page (for my own sanity while testing). Will move it back down below before shipping these changes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See Project Thread here:

pejTkB-1Lb-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Quick logic test:

* Launch the Calypso Live site.
* Visit the Traffic page for a site with 10k+ visits in the last month.
* Check local storage for the `StatsHighTrafficSite` value.
* Odyssey would show the feedback UI when `true` and skip it when `false`.
* Set the traffic threshold via the `StatsHighTrafficThreshold` value in local storage.

Option 2:

* Build Odyssey Stats locally per: PCYsg-Pp7-p2
* Get 10k visitors on your test site…
* Or set the traffic threshold via the `StatsHighTrafficThreshold` value in local storage.
* Confirm the UI for the inline card is displayed **at the top** of the Traffic page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?