### PR TITLE
Plugin Install URL: default to Calypso if WP Admin would redirect back to Calypso.

### DIFF
--- a/client/state/selectors/get-plugin-install-url.ts
+++ b/client/state/selectors/get-plugin-install-url.ts
@@ -1,8 +1,16 @@
+import { FEATURE_INSTALL_PLUGINS } from '@automattic/calypso-products';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteAdminUrl, getSiteSlug, isAdminInterfaceWPAdmin } from '../sites/selectors';
 import type { AppState } from 'calypso/types';
 
 export default function getPluginInstallUrl( state: AppState, siteId?: number | null ) {
-	if ( ! isAdminInterfaceWPAdmin( state, siteId ) ) {
+	const hasInstallPlugins = siteHasFeature( state, siteId, FEATURE_INSTALL_PLUGINS );
+	const isWPCOMAtomicSite = isAtomicSite( state, siteId );
+
+	// If the site doesn't have the install plugins feature, isn't Atomic, or is not using the WP Admin interface,
+	// avoid redirecting to the WP Admin plugins page.
+	if ( ! isAdminInterfaceWPAdmin( state, siteId ) || ! hasInstallPlugins || ! isWPCOMAtomicSite ) {
 		const siteSlug = getSiteSlug( state, siteId );
 		return `/plugins/${ siteSlug }`;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/96907

## Proposed Changes

* In cases where core WP Admin `/wp-admin/plugins.php` isn't available for that site, we should avoid redirecting WP Admin and just redirect users to Calypso `/plugins` page where they would probably need to upgrade their plan OR transfer it to Atomic.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On non Atomic site ( eg Business simple ), or a free site
* Go to `http://calypso.localhost:3000/sites/overview/[site]`
* Click "Install Plugins"
* You should be redirected to Calypso `/plugins/[site]`
* Change the Admin interface style to `WP Admin` by running the following in your sandbox 
```
wpsh
update_blog_option( blog_id, 'wpcom_admin_interface', 'wp-admin' );
```
* Test again that you are still redirected to Calypso `/plugins`

* On an Atomic site with a biz or ecom plan
* Go to `http://calypso.localhost:3000/sites/overview/[site]`
* Click "Install Plugins"
* You should be redirected to Calypso `/plugins/[site]` 
* Change the Admin interface style to `WP Admin` by running the following in your sandbox 
 ```
wpsh
update_blog_option( blog_id, 'wpcom_admin_interface', 'wp-admin' );
```
* Test that you are redirected to WP Admin `/wp-admin/plugins.php`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
