### PR TITLE
Make the tracks events for domain suggestion better

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -102,6 +102,8 @@ class DomainRegistrationSuggestion extends Component {
 				rec_result: `${ this.props.suggestion.domain_name }${ resultSuffix }`,
 				fetch_query: this.props.query,
 				domain_type: this.props.suggestion.is_premium ? 'premium' : 'standard',
+				tld: getTld( this.props.suggestion.domain_name ),
+				flow_name: this.props.flowName,
 			} );
 		}
 	}

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -193,7 +193,8 @@ class MapDomainStep extends Component {
 	registerSuggestedDomain = () => {
 		this.props.recordAddDomainButtonClickInMapDomain(
 			this.state.suggestion.domain_name,
-			this.props.analyticsSection
+			this.props.analyticsSection,
+			this.props.flowName
 		);
 
 		return this.props.onRegisterDomain( this.state.suggestion );

--- a/client/components/domains/register-domain-step/analytics.js
+++ b/client/components/domains/register-domain-step/analytics.js
@@ -7,24 +7,32 @@ import {
 
 const noop = () => {};
 
-export const recordMapDomainButtonClick = ( section ) =>
+export const recordMapDomainButtonClick = ( section, flowName ) =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Clicked "Map it" Button' ),
-		recordTracksEvent( 'calypso_domain_search_results_mapping_button_click', { section } )
+		recordTracksEvent( 'calypso_domain_search_results_mapping_button_click', {
+			section,
+			flow_name: flowName,
+		} )
 	);
 
-export const recordTransferDomainButtonClick = ( section, source ) =>
+export const recordTransferDomainButtonClick = ( section, source, flowName ) =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Clicked "Use a Domain I own" Button' ),
-		recordTracksEvent( 'calypso_domain_search_results_transfer_button_click', { section, source } )
+		recordTracksEvent( 'calypso_domain_search_results_transfer_button_click', {
+			section,
+			source,
+			flow_name: flowName,
+		} )
 	);
 
-export const recordUseYourDomainButtonClick = ( section, source ) =>
+export const recordUseYourDomainButtonClick = ( section, source, flowName ) =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Clicked "Use a Domain I own" Button' ),
 		recordTracksEvent( 'calypso_domain_search_results_use_my_domain_button_click', {
 			section,
 			source,
+			flow_name: flowName,
 		} )
 	);
 
@@ -33,7 +41,8 @@ export const recordSearchFormSubmit = (
 	section,
 	timeDiffFromLastSearch,
 	count,
-	vendor
+	vendor,
+	flowName
 ) =>
 	composeAnalytics(
 		recordGoogleEvent(
@@ -48,13 +57,14 @@ export const recordSearchFormSubmit = (
 			search_count: count,
 			search_vendor: vendor,
 			section,
+			flow_name: flowName,
 		} )
 	);
 
-export const recordSearchFormView = ( section ) =>
+export const recordSearchFormView = ( section, flowName ) =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Landed on Search' ),
-		recordTracksEvent( 'calypso_domain_search_pageview', { section } )
+		recordTracksEvent( 'calypso_domain_search_pageview', { section, flow_name: flowName } )
 	);
 
 export const recordSearchResultsReceive = (
@@ -62,7 +72,8 @@ export const recordSearchResultsReceive = (
 	searchResults,
 	responseTimeInMs,
 	resultCount,
-	section
+	section,
+	flowName
 ) =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Receive Results', 'Response Time', responseTimeInMs ),
@@ -72,6 +83,7 @@ export const recordSearchResultsReceive = (
 			response_time_ms: responseTimeInMs,
 			result_count: resultCount,
 			section,
+			flow_name: flowName,
 		} )
 	);
 
@@ -79,7 +91,8 @@ export const recordDomainAvailabilityReceive = (
 	searchQuery,
 	availableStatus,
 	responseTimeInMs,
-	section
+	section,
+	flowName
 ) =>
 	composeAnalytics(
 		recordGoogleEvent(
@@ -93,10 +106,16 @@ export const recordDomainAvailabilityReceive = (
 			available_status: availableStatus,
 			response_time: responseTimeInMs,
 			section,
+			flow_name: flowName,
 		} )
 	);
 
-export const recordDomainAddAvailabilityPreCheck = ( domain, unavailableStatus, section ) =>
+export const recordDomainAddAvailabilityPreCheck = (
+	domain,
+	unavailableStatus,
+	section,
+	flowName
+) =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Search',
@@ -108,16 +127,18 @@ export const recordDomainAddAvailabilityPreCheck = ( domain, unavailableStatus, 
 			domain: domain,
 			unavailable_status: unavailableStatus,
 			section,
+			flow_name: flowName,
 		} )
 	);
 
-export function recordShowMoreResults( searchQuery, pageNumber, section ) {
+export function recordShowMoreResults( searchQuery, pageNumber, section, flowName ) {
 	return composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Show More Results' ),
 		recordTracksEvent( 'calypso_domain_search_show_more_results', {
 			search_query: searchQuery,
 			page_number: pageNumber,
 			section,
+			flow_name: flowName,
 		} )
 	);
 }
@@ -130,22 +151,24 @@ function processFiltersForAnalytics( filters ) {
 	return convertArraysToCSV( prepareKeys( filters ) );
 }
 
-export function recordFiltersReset( filters, keysToReset, section ) {
+export function recordFiltersReset( filters, keysToReset, section, flowName ) {
 	return composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Filters Reset' ),
 		recordTracksEvent( 'calypso_domain_search_filters_reset', {
 			keys_to_reset: keysToReset.join( ',' ),
 			section,
+			flow_name: flowName,
 			...processFiltersForAnalytics( filters ),
 		} )
 	);
 }
 
-export function recordFiltersSubmit( filters, section ) {
+export function recordFiltersSubmit( filters, section, flowName ) {
 	return composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Filters Submit' ),
 		recordTracksEvent( 'calypso_domain_search_filters_submit', {
 			section,
+			flow_name: flowName,
 			...processFiltersForAnalytics( filters ),
 		} )
 	);
@@ -186,7 +209,7 @@ function processSearchStatQueue() {
 	}
 }
 
-function reportSearchStats( { query, section, timestamp, vendor } ) {
+function reportSearchStats( { query, section, timestamp, vendor, flowName } ) {
 	let timeDiffFromLastSearchInSeconds = 0;
 	if ( lastSearchTimestamp ) {
 		timeDiffFromLastSearchInSeconds = Math.floor( ( timestamp - lastSearchTimestamp ) / 1000 );
@@ -198,6 +221,7 @@ function reportSearchStats( { query, section, timestamp, vendor } ) {
 		section,
 		timeDiffFromLastSearchInSeconds,
 		searchCount,
-		vendor
+		vendor,
+		flowName
 	);
 }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1796,7 +1796,11 @@ class RegisterDomainStep extends Component {
 	goToUseYourDomainStep = ( event ) => {
 		event.preventDefault();
 
-		this.props.recordUseYourDomainButtonClick( this.props.analyticsSection, this.props.flowName );
+		this.props.recordUseYourDomainButtonClick(
+			this.props.analyticsSection,
+			null,
+			this.props.flowName
+		);
 
 		page( this.getUseYourDomainUrl() );
 	};

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -348,7 +348,7 @@ class RegisterDomainStep extends Component {
 			this.save();
 		}
 		this._isMounted = true;
-		this.props.recordSearchFormView( this.props.analyticsSection );
+		this.props.recordSearchFormView( this.props.analyticsSection, this.props.flowName );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -925,7 +925,12 @@ class RegisterDomainStep extends Component {
 	};
 
 	onFiltersReset = ( ...keysToReset ) => {
-		this.props.recordFiltersReset( this.state.filters, keysToReset, this.props.analyticsSection );
+		this.props.recordFiltersReset(
+			this.state.filters,
+			keysToReset,
+			this.props.analyticsSection,
+			this.props.flowName
+		);
 		const filters = {
 			...this.state.filters,
 			...( Array.isArray( keysToReset ) && keysToReset.length > 0
@@ -940,7 +945,11 @@ class RegisterDomainStep extends Component {
 	};
 
 	onFiltersSubmit = () => {
-		this.props.recordFiltersSubmit( this.state.filters, this.props.analyticsSection );
+		this.props.recordFiltersSubmit(
+			this.state.filters,
+			this.props.analyticsSection,
+			this.props.flowName
+		);
 		this.repeatSearch( { pageNumber: 1 } );
 	};
 
@@ -1199,7 +1208,8 @@ class RegisterDomainStep extends Component {
 						domain,
 						status,
 						timeDiff,
-						this.props.analyticsSection
+						this.props.analyticsSection,
+						this.props.flowName
 					);
 
 					this.props.onDomainsAvailabilityChange( true );
@@ -1245,7 +1255,8 @@ class RegisterDomainStep extends Component {
 					analyticsResults,
 					timeDiff,
 					domainSuggestions.length,
-					this.props.analyticsSection
+					this.props.analyticsSection,
+					this.props.flowName
 				);
 
 				return domainSuggestions;
@@ -1270,7 +1281,8 @@ class RegisterDomainStep extends Component {
 					analyticsResults,
 					timeDiff,
 					-1,
-					this.props.analyticsSection
+					this.props.analyticsSection,
+					this.props.flowName
 				);
 				throw error;
 			} );
@@ -1374,7 +1386,8 @@ class RegisterDomainStep extends Component {
 			analyticsResults,
 			timeDiff,
 			subdomainSuggestions.length,
-			this.props.analyticsSection
+			this.props.analyticsSection,
+			this.props.flowName
 		);
 
 		// This part handles the other end of the condition handled by the line 282:
@@ -1412,7 +1425,8 @@ class RegisterDomainStep extends Component {
 			analyticsResults,
 			timeDiff,
 			-1,
-			this.props.analyticsSection
+			this.props.analyticsSection,
+			this.props.flowName
 		);
 
 		this.setState( {
@@ -1442,7 +1456,12 @@ class RegisterDomainStep extends Component {
 		}
 
 		enqueueSearchStatReport(
-			{ query: searchQuery, section: this.props.analyticsSection, vendor: this.props.vendor },
+			{
+				query: searchQuery,
+				section: this.props.analyticsSection,
+				vendor: this.props.vendor,
+				flowName: this.props.flowName,
+			},
 			this.props.recordSearchFormSubmit
 		);
 
@@ -1483,7 +1502,8 @@ class RegisterDomainStep extends Component {
 		this.props.recordShowMoreResults(
 			this.state.lastQuery,
 			pageNumber,
-			this.props.analyticsSection
+			this.props.analyticsSection,
+			this.props.flowName
 		);
 
 		this.setState( { pageNumber, pageSize: PAGE_SIZE }, this.save );
@@ -1560,7 +1580,8 @@ class RegisterDomainStep extends Component {
 					this.props.recordDomainAddAvailabilityPreCheck(
 						domain,
 						status,
-						this.props.analyticsSection
+						this.props.analyticsSection,
+						this.props.flowName
 					);
 
 					const skipAvailabilityErrors =
@@ -1753,7 +1774,7 @@ class RegisterDomainStep extends Component {
 	goToMapDomainStep = ( event ) => {
 		event.preventDefault();
 
-		this.props.recordMapDomainButtonClick( this.props.analyticsSection );
+		this.props.recordMapDomainButtonClick( this.props.analyticsSection, this.props.flowName );
 
 		page( this.getMapDomainUrl() );
 	};
@@ -1763,7 +1784,11 @@ class RegisterDomainStep extends Component {
 
 		const source = event.currentTarget.dataset.tracksButtonClickSource;
 
-		this.props.recordTransferDomainButtonClick( this.props.analyticsSection, source );
+		this.props.recordTransferDomainButtonClick(
+			this.props.analyticsSection,
+			source,
+			this.props.flowName
+		);
 
 		page( this.getTransferDomainUrl() );
 	};
@@ -1771,7 +1796,7 @@ class RegisterDomainStep extends Component {
 	goToUseYourDomainStep = ( event ) => {
 		event.preventDefault();
 
-		this.props.recordUseYourDomainButtonClick( this.props.analyticsSection );
+		this.props.recordUseYourDomainButtonClick( this.props.analyticsSection, this.props.flowName );
 
 		page( this.getUseYourDomainUrl() );
 	};

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -471,7 +471,8 @@ class TransferDomainStep extends Component {
 	registerSuggestedDomain = () => {
 		this.props.recordAddDomainButtonClickInTransferDomain(
 			this.state.suggestion.domain_name,
-			this.props.analyticsSection
+			this.props.analyticsSection,
+			this.props.flowName
 		);
 
 		return this.props.onRegisterDomain( this.state.suggestion );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -232,7 +232,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			},
 		} );
 
-		dispatch( recordAddDomainButtonClickInTransferDomain( domain, getAnalyticsSection() ) );
+		dispatch( recordAddDomainButtonClickInTransferDomain( domain, getAnalyticsSection(), flow ) );
 
 		setDomainCartItem( domainCartItem );
 
@@ -242,7 +242,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 	const handleAddMapping = ( domain: string ) => {
 		const domainCartItem = domainMapping( { domain } );
 
-		dispatch( recordAddDomainButtonClickInMapDomain( domain, getAnalyticsSection() ) );
+		dispatch( recordAddDomainButtonClickInMapDomain( domain, getAnalyticsSection(), flow ) );
 
 		setDomainCartItem( domainCartItem );
 
@@ -255,7 +255,8 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 				suggestion.domain_name,
 				getAnalyticsSection(),
 				position,
-				suggestion?.is_premium
+				suggestion?.is_premium,
+				flow
 			)
 		);
 

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -201,7 +201,7 @@ class DomainSearch extends Component< DomainSearchProps > {
 			is_premium: isPremium,
 		} = suggestion;
 
-		this.props.recordAddDomainButtonClick( domain, 'domains', position, isPremium, 'domains' );
+		this.props.recordAddDomainButtonClick( domain, 'domains', position, isPremium, 'domains/add' );
 
 		let registration = domainRegistration( {
 			domain,

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -85,7 +85,8 @@ type DomainSearchProps = {
 		domainName: string,
 		section: string,
 		position: number,
-		isPremium?: boolean
+		isPremium?: boolean,
+		flowName?: string
 	) => void;
 	recordRemoveDomainButtonClick: ( domainName: string ) => void;
 	isSiteOnFreePlan?: boolean;
@@ -200,7 +201,7 @@ class DomainSearch extends Component< DomainSearchProps > {
 			is_premium: isPremium,
 		} = suggestion;
 
-		this.props.recordAddDomainButtonClick( domain, 'domains', position, isPremium );
+		this.props.recordAddDomainButtonClick( domain, 'domains', position, isPremium, 'domains' );
 
 		let registration = domainRegistration( {
 			domain,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -226,7 +226,8 @@ export class RenderDomainsStep extends Component {
 			suggestion.domain_name,
 			this.getAnalyticsSection(),
 			position,
-			suggestion?.is_premium
+			suggestion?.is_premium,
+			this.props.flowName
 		);
 
 		await this.props.saveSignupStep( stepData );
@@ -476,7 +477,11 @@ export class RenderDomainsStep extends Component {
 			? { useThemeHeadstart: shouldUseThemeAnnotation }
 			: {};
 
-		this.props.recordAddDomainButtonClickInMapDomain( domain, this.getAnalyticsSection() );
+		this.props.recordAddDomainButtonClickInMapDomain(
+			domain,
+			this.getAnalyticsSection(),
+			this.props.flowName
+		);
 
 		this.props.submitSignupStep(
 			Object.assign(
@@ -519,7 +524,11 @@ export class RenderDomainsStep extends Component {
 			? { useThemeHeadstart: shouldUseThemeAnnotation }
 			: {};
 
-		this.props.recordAddDomainButtonClickInTransferDomain( domain, this.getAnalyticsSection() );
+		this.props.recordAddDomainButtonClickInTransferDomain(
+			domain,
+			this.getAnalyticsSection(),
+			this.props.flowName
+		);
 
 		this.props.submitSignupStep(
 			Object.assign(

--- a/client/state/domains/actions.js
+++ b/client/state/domains/actions.js
@@ -6,7 +6,13 @@ import {
 
 import 'calypso/state/domains/init';
 
-export const recordAddDomainButtonClick = ( domainName, section, position, isPremium = false ) =>
+export const recordAddDomainButtonClick = (
+	domainName,
+	section,
+	position,
+	isPremium = false,
+	flowName = ''
+) =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Search',
@@ -19,10 +25,11 @@ export const recordAddDomainButtonClick = ( domainName, section, position, isPre
 			position,
 			section,
 			is_premium: isPremium,
+			flow_name: flowName,
 		} )
 	);
 
-export const recordAddDomainButtonClickInMapDomain = ( domainName, section ) =>
+export const recordAddDomainButtonClickInMapDomain = ( domainName, section, flowName = '' ) =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Search',
@@ -33,10 +40,11 @@ export const recordAddDomainButtonClickInMapDomain = ( domainName, section ) =>
 		recordTracksEvent( 'calypso_map_domain_step_add_domain_click', {
 			domain_name: domainName,
 			section,
+			flow_name: flowName,
 		} )
 	);
 
-export const recordAddDomainButtonClickInTransferDomain = ( domainName, section ) =>
+export const recordAddDomainButtonClickInTransferDomain = ( domainName, section, flowName = '' ) =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Search',
@@ -47,6 +55,7 @@ export const recordAddDomainButtonClickInTransferDomain = ( domainName, section 
 		recordTracksEvent( 'calypso_transfer_domain_step_add_domain_click', {
 			domain_name: domainName,
 			section,
+			flow_name: flowName,
 		} )
 	);
 


### PR DESCRIPTION
We need to gather some data and that turned out to be a painful experience since we didn't have the flow name in any of the events we wanted to query so we had to make some super complicated funnel like queries to get some of the results we were interested in. We can add the flow_name in the tracks events to gather that information easy next time

## Proposed Changes

* Add flow_name in the register-domain-step component tracks events
* Add flow_name in the traintracks events in the domain suggestion component
* Add tld in the trantracks events too

## Why are these changes being made?

* We need to be able to segment the data for domain suggestion searches, results and etc by the different flows

## Testing Instructions

* Test going through the different flows like /start/domains or go and try to add a domain to a site and make sure that there is a flow_name in the `t.gif` request query params for those events

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
