### PR TITLE
Stats: Fix sticky header for Odyssey Stats

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -19,8 +19,8 @@ const commonDefaultProps = {
 	minLimit: false,
 };
 
-export function calculateOffset() {
-	const headerEl = document.getElementById( 'header' );
+export function calculateOffset( headerId ) {
+	const headerEl = document.getElementById( headerId ?? 'header' );
 	// Offset to account for Masterbar if it is fixed position
 	if ( headerEl && getComputedStyle( headerEl ).position === 'fixed' ) {
 		return headerEl.getBoundingClientRect().height;
@@ -28,10 +28,10 @@ export function calculateOffset() {
 	return 0;
 }
 
-export function getBlockStyle( state ) {
+export function getBlockStyle( state, headerId ) {
 	if ( state.isSticky ) {
 		return {
-			top: calculateOffset(),
+			top: calculateOffset( headerId ),
 			width: state.blockWidth,
 		};
 	}
@@ -59,7 +59,7 @@ function renderStickyPanel( props, state ) {
 
 	return (
 		<div className={ classes } ref={ state._ref }>
-			<div className="sticky-panel__content" style={ getBlockStyle( state ) }>
+			<div className="sticky-panel__content" style={ getBlockStyle( state, props.headerId ) }>
 				{ props.children }
 			</div>
 			<div

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -472,7 +472,7 @@ class StatsSite extends Component {
 				) }
 				{ isNewDateFilteringEnabled && (
 					// moves date range block into new location
-					<StickyPanel>
+					<StickyPanel headerId={ isOdysseyStats ? 'wpadminbar' : 'header' }>
 						<StatsPeriodHeader>
 							<StatsPeriodNavigation
 								date={ date }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Allow passing of header Id to allow Odyssey Stats to get correct header height

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bugfix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test Odyssey Stats locally following option 1 here - PCYsg-Pp7-p2#option-1
* Open the Traffic page and scroll down
* Ensure the header sticks below the wp admin header


|Before|After|
|---|---|
|<img width="935" alt="image" src="https://github.com/user-attachments/assets/7a750de0-edf4-4bf0-96aa-818e0f65f334">|<img width="940" alt="image" src="https://github.com/user-attachments/assets/01989058-1e2b-484e-b124-67e6f038d510">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?