### PR TITLE
Paid stats: add upsell on Insights page

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -8,10 +8,7 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import version_compare from 'calypso/lib/version-compare';
-import {
-	STATS_FEATURE_PAGE_INSIGHTS,
-	STATS_FEATURE_PAGE_TRAFFIC,
-} from 'calypso/my-sites/stats/constants';
+import { STATS_FEATURE_PAGE_TRAFFIC } from 'calypso/my-sites/stats/constants';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { shouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
@@ -140,13 +137,9 @@ class StatsNavigation extends Component {
 	};
 
 	isValidItem = ( item ) => {
-		const { gatedInsightsPage, isGoogleMyBusinessLocationConnected, isStore, isWordAds, siteId } =
-			this.props;
+		const { isGoogleMyBusinessLocationConnected, isStore, isWordAds, siteId } = this.props;
 
 		switch ( item ) {
-			case 'insights':
-				return ! gatedInsightsPage;
-
 			case 'wordads':
 				return isWordAds;
 
@@ -313,9 +306,6 @@ export default connect(
 			gatedTrafficPage:
 				config.isEnabled( 'stats/paid-wpcom-v3' ) &&
 				shouldGateStats( state, siteId, STATS_FEATURE_PAGE_TRAFFIC ),
-			gatedInsightsPage:
-				config.isEnabled( 'stats/paid-wpcom-v3' ) &&
-				shouldGateStats( state, siteId, STATS_FEATURE_PAGE_INSIGHTS ),
 		};
 	},
 	{ requestModuleToggles, updateModuleToggles }

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -25,6 +25,7 @@ import PostingActivity from '../../sections/posting-activity-section';
 import StatsModule from '../../stats-module';
 import PageViewTracker from '../../stats-page-view-tracker';
 import statsStrings from '../../stats-strings';
+import StatsUpsell from '../../stats-upsell';
 
 const StatsInsights = ( props ) => {
 	const { siteId, siteSlug, isOdysseyStats, isJetpack } = props;
@@ -79,7 +80,9 @@ const StatsInsights = ( props ) => {
 				></NavigationHeader>
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
 				{ shouldRendeUpsell ? (
-					<p>Upsell here</p>
+					<div id="my-stats-content" class="stats-content">
+						<StatsUpsell />
+					</div>
 				) : (
 					<>
 						<AnnualHighlightsSection siteId={ siteId } />

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -46,12 +45,8 @@ const StatsInsights = ( props ) => {
 		}
 	}, [ reduxDispatch, isPending, siteId, usageInfo ] );
 
-	// Redirect to the traffic page if the site is gated for insights
 	const shouldGateInsights = useShouldGateStats( STATS_FEATURE_PAGE_INSIGHTS );
-	if ( config.isEnabled( 'stats/paid-wpcom-v3' ) && shouldGateInsights ) {
-		page.redirect( `/stats/day/${ siteSlug }` );
-		return;
-	}
+	const shouldRendeUpsell = config.isEnabled( 'stats/paid-wpcom-v3' ) && shouldGateInsights;
 
 	const statsModuleListClass = clsx(
 		'stats__module-list--insights',
@@ -83,63 +78,69 @@ const StatsInsights = ( props ) => {
 					navigationItems={ [] }
 				></NavigationHeader>
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
-				<AnnualHighlightsSection siteId={ siteId } />
-				<AllTimeHighlightsSection siteId={ siteId } siteSlug={ siteSlug } />
-				<PostingActivity siteId={ siteId } />
-				<AllTimeViewsSection siteId={ siteId } slug={ siteSlug } />
-				<div className={ statsModuleListClass }>
-					{ isEmptyStateV2 && (
-						<StatsModuleTags
-							moduleStrings={ moduleStrings.tags }
-							hideSummaryLink
-							className={ clsx(
-								{
-									'stats__flexible-grid-item--half': isJetpack,
-									'stats__flexible-grid-item--full--large': isJetpack,
-								},
-								{
-									'stats__flexible-grid-item--full': ! isJetpack,
-								}
+				{ shouldRendeUpsell ? (
+					<p>Upsell here</p>
+				) : (
+					<>
+						<AnnualHighlightsSection siteId={ siteId } />
+						<AllTimeHighlightsSection siteId={ siteId } siteSlug={ siteSlug } />
+						<PostingActivity siteId={ siteId } />
+						<AllTimeViewsSection siteId={ siteId } slug={ siteSlug } />
+						<div className={ statsModuleListClass }>
+							{ isEmptyStateV2 && (
+								<StatsModuleTags
+									moduleStrings={ moduleStrings.tags }
+									hideSummaryLink
+									className={ clsx(
+										{
+											'stats__flexible-grid-item--half': isJetpack,
+											'stats__flexible-grid-item--full--large': isJetpack,
+										},
+										{
+											'stats__flexible-grid-item--full': ! isJetpack,
+										}
+									) }
+								/>
 							) }
-						/>
-					) }
-					{ ! isEmptyStateV2 && (
-						<StatsModule
-							path="tags-categories"
-							moduleStrings={ moduleStrings.tags }
-							statType="statsTags"
-							hideSummaryLink
-							className={ clsx(
-								{
-									'stats__flexible-grid-item--half': isJetpack,
-									'stats__flexible-grid-item--full--large': isJetpack,
-								},
-								{
-									'stats__flexible-grid-item--full': ! isJetpack,
-								}
+							{ ! isEmptyStateV2 && (
+								<StatsModule
+									path="tags-categories"
+									moduleStrings={ moduleStrings.tags }
+									statType="statsTags"
+									hideSummaryLink
+									className={ clsx(
+										{
+											'stats__flexible-grid-item--half': isJetpack,
+											'stats__flexible-grid-item--full--large': isJetpack,
+										},
+										{
+											'stats__flexible-grid-item--full': ! isJetpack,
+										}
+									) }
+								/>
 							) }
-						/>
-					) }
 
-					<StatsModuleComments
-						className={ clsx(
-							'stats__flexible-grid-item--half',
-							'stats__flexible-grid-item--full--large'
-						) }
-					/>
+							<StatsModuleComments
+								className={ clsx(
+									'stats__flexible-grid-item--half',
+									'stats__flexible-grid-item--full--large'
+								) }
+							/>
 
-					{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for all Jetpack Sites for now. */ }
-					{ ! isJetpack && (
-						<StatShares
-							siteId={ siteId }
-							className={ clsx(
-								'stats__flexible-grid-item--half',
-								'stats__flexible-grid-item--full--large'
+							{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for all Jetpack Sites for now. */ }
+							{ ! isJetpack && (
+								<StatShares
+									siteId={ siteId }
+									className={ clsx(
+										'stats__flexible-grid-item--half',
+										'stats__flexible-grid-item--full--large'
+									) }
+								/>
 							) }
-						/>
-					) }
-				</div>
-				<JetpackColophon />
+						</div>
+						<JetpackColophon />
+					</>
+				) }
 			</div>
 		</Main>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1HpG7-v6B-p2#comment-74910

## Proposed Changes

* Add upsell on Insights page
* Remove redirect and make the Insights visible again (related to: https://github.com/Automattic/wp-calypso/pull/96992)

> [!NOTE]  
> We are reusing the same upsell prompt added in https://github.com/Automattic/wp-calypso/pull/96943. We will iterate to adjust the copy and images for the different upsells in a different PR.

![CleanShot 2024-12-03 at 19 24 23@2x](https://github.com/user-attachments/assets/995c0a83-f61b-4238-ac58-df74c56e9d4c)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p1HpG7-v6B-p2#comment-74910

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso Live Branch
* Navigate to the Traffic page http://calypso.localhost:3000/stats/day/initsogarfree.wordpress.com using a free site
* Ensure the `Insights` tab is visible
* Click on `Insights` tab
* Ensure you see the upsell prompt

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?