### PR TITLE
Stats: put yesterday as ending date behind feature flag

### DIFF
--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -29,7 +29,9 @@ export const getShortcuts = createSelector(
 		const siteToday = getMomentSiteZone( state, siteId );
 		const siteTodayStr = siteToday.format( DATE_FORMAT );
 		const siteYesterday = siteToday.clone().subtract( 1, 'days' );
-		const yesterdayStr = siteYesterday.format( DATE_FORMAT );
+		const yesterdayStr = isNewDateFilteringEnabled
+			? siteYesterday.format( DATE_FORMAT )
+			: siteTodayStr;
 
 		const supportedShortcutList = [
 			{

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -338,7 +338,9 @@ class StatsSite extends Component {
 			customChartRange = { chartEnd };
 		} else {
 			customChartRange = {
-				chartEnd: momentSiteZone.clone().subtract( 1, 'days' ).format( DATE_FORMAT ),
+				chartEnd: isNewDateFilteringEnabled
+					? momentSiteZone.clone().subtract( 1, 'days' ).format( DATE_FORMAT )
+					: momentSiteZone.format( DATE_FORMAT ),
 			};
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1733265057494329-slack-C03TY6J1A

## Proposed Changes

* Gate the feature before we release the project as users don't have a way to easily view the data for today.


## Testing Instructions

* Open a non a8c with Calypso Live `/stats/day/:yourSite`
* Ensure the default ending date is Today



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?