### PR TITLE
Stats: Upsell to personal instead of premium

### DIFF
--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
-import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Gridicon, PlanPrice } from '@automattic/components';
 import { Plans } from '@automattic/data-stores';
@@ -25,14 +25,16 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const plans = Plans.usePlans( { coupon: undefined } );
-	const plan = plans?.data?.[ PLAN_PREMIUM ];
+	const planKey = isEnabled( 'stats/paid-wpcom-v3' ) ? PLAN_PERSONAL : PLAN_PREMIUM;
+	const plan = plans?.data?.[ planKey ];
 	const pricing = Plans.usePricingMetaForGridPlans( {
-		planSlugs: [ PLAN_PREMIUM ],
+		planSlugs: [ planKey ],
 		siteId: selectedSiteId,
 		coupon: undefined,
 		useCheckPlanAvailabilityForPurchase,
 		storageAddOns: null,
-	} )?.[ PLAN_PREMIUM ];
+	} )?.[ planKey ];
+	const planSlug = plan?.pathSlug ?? planKey;
 	const isLoading = plans.isLoading || ! pricing;
 	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
 	const eventPrefix = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
@@ -53,12 +55,12 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 		} );
 		if ( isSimpleClassic ) {
 			const checkoutProductUrl = new URL(
-				`https://wordpress.com/checkout/${ siteSlug }/${ PLAN_PREMIUM }`
+				`https://wordpress.com/checkout/${ siteSlug }/${ planSlug }`
 			);
 			checkoutProductUrl.searchParams.set( 'redirect_to', window.location.href );
 			window.open( checkoutProductUrl, '_self' );
 		} else {
-			page( `/checkout/${ siteSlug }/${ plan?.pathSlug ?? 'premium' }` );
+			page( `/checkout/${ siteSlug }/${ planSlug }` );
 		}
 	};
 

--- a/client/my-sites/stats/stats-upsell/index.tsx
+++ b/client/my-sites/stats/stats-upsell/index.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
-import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { Plans, HelpCenter } from '@automattic/data-stores';
@@ -25,14 +25,16 @@ export default function StatsUpsell( { siteId }: { siteId: number } ) {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const plans = Plans.usePlans( { coupon: undefined } );
-	const plan = plans?.data?.[ PLAN_PREMIUM ];
+	const planKey = isEnabled( 'stats/paid-wpcom-v3' ) ? PLAN_PERSONAL : PLAN_PREMIUM;
+	const plan = plans?.data?.[ planKey ];
 	const pricing = Plans.usePricingMetaForGridPlans( {
-		planSlugs: [ PLAN_PREMIUM ],
+		planSlugs: [ planKey ],
 		siteId: selectedSiteId,
 		coupon: undefined,
 		useCheckPlanAvailabilityForPurchase,
 		storageAddOns: null,
-	} )?.[ PLAN_PREMIUM ];
+	} )?.[ planKey ];
+	const planSlug = plan?.pathSlug ?? planKey;
 	const isLoading = plans.isLoading || ! pricing;
 	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
 	const eventPrefix = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
@@ -47,11 +49,11 @@ export default function StatsUpsell( { siteId }: { siteId: number } ) {
 		} );
 		if ( isOdysseyStats ) {
 			const checkoutProductUrl = new URL(
-				`https://wordpress.com/checkout/${ siteSlug }/${ PLAN_PREMIUM }`
+				`https://wordpress.com/checkout/${ siteSlug }/${ planSlug }`
 			);
 			window.open( checkoutProductUrl, '_self' );
 		} else {
-			page( `/checkout/${ siteSlug }/${ plan?.pathSlug ?? 'premium' }` );
+			page( `/checkout/${ siteSlug }/${ planSlug }` );
 		}
 	};
 


### PR DESCRIPTION
Related to #

## Proposed Changes

- Changes the upsell to target the personal plan instead of the premium plan.

The modal upsell also needs to choose the plan dependent on the stats feature and the calypso flag. Being able to do this requires https://github.com/Automattic/wp-calypso/pull/97041 so I'll tackle that  as a follow up.

## Testing Instructions

Test with and without the flag,

- With: http://calypso.localhost:3000/stats/day/testingcalypso16.wordpress.com
- Without: http://calypso.localhost:3000/stats/day/testingcalypso16.wordpress.com?flags=-stats/paid-wpcom-v3

Ensure the upsell targets personal plans when the flag is present.

Before

![Screenshot(155)](https://github.com/user-attachments/assets/c2713d9d-b525-437e-8838-efc3d0f5c39d)

After (note both upsells are updated)

![Screenshot(154)](https://github.com/user-attachments/assets/ee2bbe5f-1095-4129-9300-66a9010422da)
