### PR TITLE
Update support card description

### DIFF
--- a/client/sites/overview/components/support-card/index.js
+++ b/client/sites/overview/components/support-card/index.js
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
@@ -25,6 +26,7 @@ function trackNavigateGetHelpClick() {
 const HELP_CENTER_STORE = HelpCenter.register();
 
 export default function SupportCard() {
+	const hasEnTranslation = useHasEnTranslation();
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
@@ -38,7 +40,15 @@ export default function SupportCard() {
 
 	return (
 		<HostingCard className="support-card" title={ translate( 'Need some help?' ) }>
-			<p>{ translate( 'Our AI assistant can help, or connect you to our support team.' ) }</p>
+			<p>
+				{ hasEnTranslation(
+					'Our AI assistant can answer your questions and connect you to our Happiness Engineers for further assistance.'
+				)
+					? translate(
+							'Our AI assistant can answer your questions and connect you to our Happiness Engineers for further assistance.'
+					  )
+					: translate( 'Our AI assistant can help, or connect you to our support team.' ) }
+			</p>
 			<Button onClick={ onClick }>{ translate( 'Get help' ) }</Button>
 		</HostingCard>
 	);


### PR DESCRIPTION
## Proposed Changes

As suggested in p1733238866947139-slack-C06DN6QQVAQ (internal ref), this PR updates the support card description text from "Our AI assistant can help or connect you to our support team." to "Our AI assistant can answer your questions and connect you to our Happiness Engineers for further assistance."

| Before | After |
| --- | --- |
| ![Screenshot 2024-12-04 at 2 48 31 PM](https://github.com/user-attachments/assets/ad4d8143-f356-4d68-bd5b-27e8aca92993) | ![Screenshot 2024-12-04 at 2 48 15 PM](https://github.com/user-attachments/assets/abad2688-9708-4d3c-8c6b-4a855f5d747b) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WP.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Head to /sites
2. Click any site to display the Site Management Panel
3. Ensure that the support card description text is updated as above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?