### PR TITLE
Add emails and tab switching functionality in domain revamp screen

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -25,6 +25,7 @@ import {
 	domainManagementRoot,
 } from 'calypso/my-sites/domains/paths';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import DomainManagement from '.';
 
@@ -332,6 +333,7 @@ export default {
 		next();
 	},
 
+	// The domain overview page. For the All Domains view.
 	domainManagementV2( pageContext, next ) {
 		const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
 
@@ -348,8 +350,12 @@ export default {
 		next();
 	},
 
+	// The domain overview pane. Has a tabbed layout with the domain overview and email management.
 	domainManagementPaneView( feature ) {
 		return ( pageContext, next ) => {
+			const state = pageContext.store.getState();
+			const siteSlug = getSelectedSiteSlug( state );
+			const site = getSite( state, siteSlug );
 			const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
 
 			pageContext.primary = (
@@ -357,6 +363,8 @@ export default {
 					selectedDomainPreview={ pageContext.primary }
 					selectedDomain={ selectedDomainName }
 					selectedFeature={ feature }
+					siteSlug={ siteSlug }
+					site={ site }
 				/>
 			);
 

--- a/client/my-sites/domains/domain-management/domain-overview-pane/constants.ts
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/constants.ts
@@ -1,0 +1,7 @@
+export const DOMAIN_OVERVIEW = 'domain-overview';
+export const EMAIL_MANAGEMENT = 'email-management';
+
+export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
+	[ DOMAIN_OVERVIEW ]: 'domains/manage/all/overview/:domain/:site',
+	[ EMAIL_MANAGEMENT ]: 'domains/manage/all/email/:domain/:site',
+};

--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -1,10 +1,13 @@
 import page from '@automattic/calypso-router';
+import { SiteExcerptData } from '@automattic/sites';
 import { Button } from '@wordpress/components';
 import { useMergeRefs } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef } from 'react';
 import ItemPreviewPane from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import * as paths from 'calypso/my-sites/domains/paths';
+import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
+import { FEATURE_TO_ROUTE_MAP, DOMAIN_OVERVIEW, EMAIL_MANAGEMENT } from './constants';
 import type {
 	ItemData,
 	FeaturePreviewInterface,
@@ -14,7 +17,32 @@ interface Props {
 	selectedDomainPreview: React.ReactNode;
 	selectedDomain: string;
 	selectedFeature: string;
+	siteSlug: string;
+	site: SiteExcerptData;
 }
+
+export function showDomainManagementPage( route: string ) {
+	const currentParams = new URL( window.location.href ).searchParams;
+	const newUrl = new URL( route, window.location.origin );
+
+	const supportedParams = [ 'page', 'per-page', 'search', 'status' ];
+	supportedParams.forEach( ( param ) => {
+		if ( currentParams.has( param ) ) {
+			const value = currentParams.get( param );
+			if ( value ) {
+				newUrl.searchParams.set( param, value );
+			}
+		}
+	} );
+
+	page.show( newUrl.toString().replace( window.location.origin, '' ) );
+}
+
+type BtnProps = {
+	focusRef: React.RefObject< HTMLButtonElement >;
+	itemData: ItemData;
+	closeSitePreviewPane?: () => void;
+};
 
 // This is the tabbed preview pane that is used for the domain management pages.
 // Anything passed as selectedDomainPreview will be rendered in the preview pane.
@@ -23,22 +51,21 @@ const DomainOverviewPane = ( {
 	selectedDomainPreview,
 	selectedDomain,
 	selectedFeature,
+	siteSlug,
+	site,
 }: Props ) => {
 	const itemData: ItemData = {
 		title: selectedDomain,
 		subtitle: selectedDomain,
-		blogId: 12435645646456468,
-		isDotcomSite: true,
-		adminUrl: `testdomain.com/wp-admin`,
+		url: site.URL,
+		blogId: site.ID,
+		isDotcomSite: site.is_wpcom_atomic || site.is_wpcom_staging_site,
+		adminUrl: site.options?.admin_url || `${ site.URL }/wp-admin`,
 		withIcon: false,
 		hideEnvDataInHeader: true,
 	};
 
-	type BtnProps = {
-		focusRef: React.RefObject< HTMLButtonElement >;
-		itemData: ItemData;
-		closeSitePreviewPane?: () => void;
-	};
+	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( itemData.blogId );
 
 	const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane }: BtnProps ) => {
 		const adminButtonRef = useRef< HTMLButtonElement | null >( null );
@@ -51,32 +78,31 @@ const DomainOverviewPane = ( {
 				<Button
 					variant="primary"
 					className="item-preview__admin-button"
+					href={ adminUrl }
 					ref={ useMergeRefs( [ adminButtonRef, focusRef ] ) }
 				>
-					{ __( 'Manage Site' ) }
+					{ adminLabel }
 				</Button>
 			</>
 		);
 	};
-
-	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( selectedFeature );
 
 	const features: FeaturePreviewInterface[] = useMemo( () => {
 		const siteFeatures = [
 			{
 				label: __( 'Overview' ),
 				enabled: true,
-				featureIds: [ 'domain-overview' ],
+				featureIds: [ DOMAIN_OVERVIEW ],
 			},
 			{
 				label: __( 'Email' ),
 				enabled: true,
-				featureIds: [ 'email' ],
+				featureIds: [ EMAIL_MANAGEMENT ],
 			},
 		];
 
 		return siteFeatures.map( ( { label, enabled, featureIds } ) => {
-			const selected = enabled && featureIds.includes( selectedSiteFeature );
+			const selected = enabled && featureIds.includes( selectedFeature );
 			const defaultFeatureId = featureIds[ 0 ];
 			return {
 				id: defaultFeatureId,
@@ -86,7 +112,11 @@ const DomainOverviewPane = ( {
 					selected,
 					onTabClick: () => {
 						if ( enabled && ! selected ) {
-							setSelectedSiteFeature( defaultFeatureId );
+							showDomainManagementPage(
+								FEATURE_TO_ROUTE_MAP[ defaultFeatureId ]
+									.replace( ':domain', selectedDomain )
+									.replace( ':site', siteSlug )
+							);
 						}
 					},
 				},
@@ -94,7 +124,7 @@ const DomainOverviewPane = ( {
 				preview: enabled ? selectedDomainPreview : null,
 			};
 		} );
-	}, [ __, selectedDomain, selectedSiteFeature ] );
+	}, [ __, selectedDomain, selectedFeature, selectedDomainPreview ] );
 
 	return (
 		<ItemPreviewPane

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -9,8 +9,13 @@ import {
 	stagingSiteNotSupportedRedirect,
 	noSite,
 } from 'calypso/my-sites/controller';
+import emailController from '../email/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
+import {
+	DOMAIN_OVERVIEW,
+	EMAIL_MANAGEMENT,
+} from './domain-management/domain-overview-pane/constants';
 import * as paths from './paths';
 
 function registerMultiPage( { paths: givenPaths, handlers } ) {
@@ -377,7 +382,18 @@ export default function () {
 		siteSelection,
 		navigation,
 		domainManagementController.domainManagementV2,
-		domainManagementController.domainManagementPaneView( 'domain-overview' ),
+		domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
+		domainManagementController.domainDashboardLayout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.allDomainEmailManagementRoot() + '/:domain/:site',
+		siteSelection,
+		navigation,
+		emailController.emailManagement,
+		domainManagementController.domainManagementPaneView( EMAIL_MANAGEMENT ),
 		domainManagementController.domainDashboardLayout,
 		makeLayout,
 		clientRender

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -83,7 +83,11 @@ export function domainManagementAllRoot() {
 }
 
 export function allDomainManagementRoot() {
-	return '/domains/all/manage';
+	return domainManagementAllRoot() + '/overview';
+}
+
+export function allDomainEmailManagementRoot() {
+	return domainManagementAllRoot() + '/email';
 }
 
 export function domainManagementRoot() {

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -25,8 +25,8 @@ const SITE_DASHBOARD_ROUTES = {
 	'site-settings': '/sites/settings',
 
 	// Domain Management
-	'all-domain-management': '/domains/all/manage',
-	'all-email-management': '/domains/all/email',
+	'all-domain-management': '/domains/manage/all/overview',
+	'all-email-management': '/domains/manage/all/email',
 };
 
 function isInSection( sectionName: string, sectionNames: string[] ) {

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -22,7 +22,7 @@ export function domainManagementLink(
 	const isAllDomainManagementEnabled = config.isEnabled( 'calypso/all-domain-management' );
 
 	if ( isAllDomainManagementEnabled && isAllSitesView ) {
-		return `${ allDomainManagementRoot() }/${ domain }/${ siteSlug }`;
+		return `/domains/manage/all/overview/${ domain }/${ siteSlug }`;
 	}
 
 	if ( isAllSitesView ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96554

## Proposed Changes

- Added tab-switching functionality between Domains and Emails
- Added functionality to the "Close" and "Manage Site" buttons on top
- Show dynamic Domain info in the topbar
- Fixes the issue of un-attached domain not opening the layout and re-routing to the list page
- Show the as-it-is email management view (without changes)

Tests and especially E2E tests will be added in separate PRs under different cards. Switching domains will open the overview tab by default, but we'll have a separate card to open the current tab.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To revamp the domains management

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to wordpress.com/domains/manage
* Browse around, check inner functionalities, make sure you see no issues in how the table looks and works
* Open a site's wp-admin area, go to Upgrades -> Emails, browse around and make sure everything works as before
* Also click on a few domains to make sure everything is working as before.
* Now enable the feature flag by entering `window.sessionStorage.setItem('flags', 'calypso/all-domain-management')` in the browser console. Reload the page
* Now click on different domains. They should open in the new layout now.
* Check the new layout has Overview and Email tabs.
* Try switching to the Email tabs and make sure it works and it's showing the contents. Make sure you can switch back to the Overview tab too
* Try clicking on the "Close" and "My Home" button on top and make sure they work as expected

https://github.com/user-attachments/assets/82bd1ca3-0855-4f85-8055-2d4720dc52d5

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
