### PR TITLE
Change over the accent colour of the filtering buttons

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -333,7 +333,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				margin-bottom: 16px;
 			}
 			.components-dropdown .components-button {
-				color: var(--color-primary);
+				color: var(--color-accent);
 				font-weight: 500;
 				font-size: 0.875rem;
 				border-radius: 4px;


### PR DESCRIPTION
## Proposed Changes

* Matches Last X days . clicks buttons above the charts  to the chart colour

![Screenshot 2024-12-04 at 10 44 16](https://github.com/user-attachments/assets/c7ab43ab-f1bc-4b17-bb74-8223f6b9830b)

## Why are these changes being made?

- This commit was supposed to happen in #97002 but failed to push

## Testing Instructions

* Ensure the buttons above match the chart colours`/advertising/campaigns/123/site.com`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
