### PR TITLE
Performance Profiler: Pass locale to endpoints

### DIFF
--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -14,16 +14,21 @@ function mapScores( response: UrlBasicMetricsQueryResponse ) {
 	return { ...response, success: basic.success, basic: basicMetricsScored };
 }
 
-export const useUrlBasicMetricsQuery = ( url?: string, hash?: string, advance = false ) => {
+export const useUrlBasicMetricsQuery = (
+	url?: string,
+	hash?: string,
+	advance = false,
+	locale?: string | null
+) => {
 	return useQuery( {
-		queryKey: [ 'url', 'basic-metrics', url, advance ],
+		queryKey: [ 'url', 'basic-metrics', url, advance, locale ],
 		queryFn: (): Promise< UrlBasicMetricsQueryResponse > =>
 			wp.req.get(
 				{
 					path: '/site-profiler/metrics/basic',
 					apiNamespace: 'wpcom/v2',
 				},
-				{ url, ...( advance ? { advance: '1' } : {} ) }
+				{ url, ...( advance ? { advance: '1' } : {} ), locale }
 			),
 		select: mapScores,
 		meta: {

--- a/client/data/site-profiler/use-url-performance-insights.ts
+++ b/client/data/site-profiler/use-url-performance-insights.ts
@@ -6,7 +6,11 @@ function mapResult( response: UrlPerformanceInsightsQueryResponse ) {
 	return response.pagespeed;
 }
 
-export const useUrlPerformanceInsightsQuery = ( url?: string, hash?: string, locale?: string ) => {
+export const useUrlPerformanceInsightsQuery = (
+	url?: string,
+	hash?: string,
+	locale?: string | null
+) => {
 	return useQuery( {
 		queryKey: [ 'url', 'performance', url, hash, locale ],
 		queryFn: () =>

--- a/client/data/site-profiler/use-url-performance-insights.ts
+++ b/client/data/site-profiler/use-url-performance-insights.ts
@@ -6,16 +6,16 @@ function mapResult( response: UrlPerformanceInsightsQueryResponse ) {
 	return response.pagespeed;
 }
 
-export const useUrlPerformanceInsightsQuery = ( url?: string, hash?: string ) => {
+export const useUrlPerformanceInsightsQuery = ( url?: string, hash?: string, locale?: string ) => {
 	return useQuery( {
-		queryKey: [ 'url', 'performance', url, hash ],
+		queryKey: [ 'url', 'performance', url, hash, locale ],
 		queryFn: () =>
 			wp.req.get(
 				{
 					path: '/site-profiler/metrics/advanced/insights',
 					apiNamespace: 'wpcom/v2',
 				},
-				{ url, hash }
+				{ url, hash, locale }
 			),
 		meta: {
 			persist: false,

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
-import { translate } from 'i18n-calypso';
+import { translate, getLocaleSlug } from 'i18n-calypso';
 import moment from 'moment';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
@@ -53,13 +53,15 @@ const usePerformanceReport = (
 
 	const [ retestState, setRetestState ] = useState( 'idle' );
 
+	const localeSlug = getLocaleSlug();
+
 	const {
 		data: basicMetrics,
 		isError: isBasicMetricsError,
 		isFetched: isBasicMetricsFetched,
 		isLoading: isLoadingBasicMetrics,
 		refetch: requeueAdvancedMetrics,
-	} = useUrlBasicMetricsQuery( url, hash, true );
+	} = useUrlBasicMetricsQuery( url, hash, true, localeSlug );
 	const { final_url: finalUrl, token } = basicMetrics || {};
 	useEffect( () => {
 		if ( token && finalUrl ) {
@@ -80,7 +82,7 @@ const usePerformanceReport = (
 		status: insightsStatus,
 		isError: isInsightsError,
 		isLoading: isLoadingInsights,
-	} = useUrlPerformanceInsightsQuery( url, token ?? hash );
+	} = useUrlPerformanceInsightsQuery( url, token ?? hash, localeSlug );
 
 	const mobileReport =
 		typeof performanceInsights?.mobile === 'string' ? undefined : performanceInsights?.mobile;

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useRef } from 'react';
-import './style.scss';
 import DocumentHead from 'calypso/components/data/document-head';
 import { PerformanceReport } from 'calypso/data/site-profiler/types';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
@@ -16,6 +15,8 @@ import {
 import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
 import { updateQueryParams } from 'calypso/performance-profiler/utils/query-params';
 import { LoadingScreen } from '../loading-screen';
+
+import './style.scss';
 
 type PerformanceProfilerDashboardProps = {
 	url: string;
@@ -33,10 +34,10 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 		data: basicMetrics,
 		isError: isBasicMetricsError,
 		isFetched,
-	} = useUrlBasicMetricsQuery( url, hash, true );
+	} = useUrlBasicMetricsQuery( url, hash, true, translate.localeSlug );
 	const { final_url: finalUrl, token } = basicMetrics || {};
 	const { data: performanceInsights, isError: isPerformanceInsightsError } =
-		useUrlPerformanceInsightsQuery( url, hash );
+		useUrlPerformanceInsightsQuery( url, hash, translate.localeSlug );
 	const isError =
 		isBasicMetricsError ||
 		isPerformanceInsightsError ||


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/10052

## Proposed Changes

* Add a new `locale` parameter to the `/metrics/basic` and `/metrics/advanced/insights` endpoints 
* Populate that parameter with the locale of the user

|Before | After|
|-------|------|
| ![CleanShot 2024-12-04 at 16 08 25@2x](https://github.com/user-attachments/assets/fd9b32e4-cf51-4065-99c6-e1acbc97da16) |![CleanShot 2024-12-04 at 16 05 39@2x](https://github.com/user-attachments/assets/6156db35-7b03-4ef2-97dd-531d830aeda5)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To be able to use translated results from the `insights` endpoints

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In your sandbox, apply the following diff D167780-code and sandbox the API
* Change the locale to a different language than English for your user
* Go to the Speed Test tool and run a test
* Check the insights are translated. Please note that the AI-generated content will not be translated yet
* Navigate to the logged-in version of the tool
* Run a test clicking on Test again
* Check the insights are translated. Please note that the AI-generated content will not be translated yet

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?