### PR TITLE
A4A: Add Hosting page v3 feature flag.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -13,6 +13,7 @@ import AssignLicense from './assign-license';
 import Checkout from './checkout';
 import { MARKETPLACE_TYPE_REFERRAL } from './hoc/with-marketplace-type';
 import HostingOverview from './hosting-overview';
+import HostingOverviewV3 from './hosting-overview-v3';
 import { getValidHostingSection } from './lib/hosting';
 import { getValidBrand } from './lib/product-brand';
 import PressableOverview from './pressable-overview';
@@ -62,11 +63,17 @@ export const marketplaceHostingContext: Callback = ( context, next ) => {
 
 	const section = getValidHostingSection( context.params.section );
 
+	const isV3Enabled = isEnabled( 'a4a-hosting-page-redesign-v3' );
+
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Hosting" path={ context.path } />
-			<HostingOverview defaultMarketplaceType={ purchaseType } section={ section } />
+			{ isV3Enabled ? (
+				<HostingOverviewV3 />
+			) : (
+				<HostingOverview defaultMarketplaceType={ purchaseType } section={ section } />
+			) }
 		</>
 	);
 	next();

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
@@ -1,0 +1,75 @@
+import page from '@automattic/calypso-router';
+import { useBreakpoint } from '@automattic/viewport-react';
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderActions as Actions,
+	LayoutHeaderBreadcrumb as Breadcrumb,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import PressableUsageLimitNotice from 'calypso/a8c-for-agencies/components/pressable-usage-limit-notice';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import {
+	A4A_MARKETPLACE_CHECKOUT_LINK,
+	A4A_MARKETPLACE_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import ReferralToggle from '../common/referral-toggle';
+import useShoppingCart from '../hooks/use-shopping-cart';
+import ShoppingCart from '../shopping-cart';
+
+export default function HostingOverviewV3() {
+	const translate = useTranslate();
+	const isNarrowView = useBreakpoint( '<660px' );
+
+	const { selectedCartItems, onRemoveCartItem, showCart, setShowCart, toggleCart } =
+		useShoppingCart();
+
+	return (
+		<Layout
+			className="hosting-overview-v3"
+			title={ isNarrowView ? translate( 'Hosting' ) : translate( 'Hosting Marketplace' ) }
+			wide
+			withBorder
+		>
+			<LayoutTop>
+				<PressableUsageLimitNotice />
+				<LayoutHeader>
+					<Breadcrumb
+						items={ [
+							{
+								label: translate( 'Marketplace' ),
+								href: A4A_MARKETPLACE_LINK,
+							},
+							{
+								label: translate( 'Hosting' ),
+							},
+						] }
+					/>
+
+					<Actions className="a4a-marketplace__header-actions">
+						<MobileSidebarNavigation />
+						<ReferralToggle />
+						<ShoppingCart
+							showCart={ showCart }
+							setShowCart={ setShowCart }
+							toggleCart={ toggleCart }
+							items={ selectedCartItems }
+							onRemoveItem={ onRemoveCartItem }
+							onCheckout={ () => {
+								page( A4A_MARKETPLACE_CHECKOUT_LINK );
+							} }
+						/>
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody className="hosting-overview-v3__body">
+				<QueryProductsList currency="USD" />
+				Hosting Overview V3
+				{ /* Content will go here */ }
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -41,6 +41,7 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
+		"a4a-hosting-page-redesign-v3": true,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -34,6 +34,7 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
+		"a4a-hosting-page-redesign-v3": true,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -34,6 +34,7 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
+		"a4a-hosting-page-redesign-v3": false,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -36,6 +36,7 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
+		"a4a-hosting-page-redesign-v3": false,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true,


### PR DESCRIPTION
This PR introduces a new feature flag for the Hosting page v3. In addition, it includes a new HostingOverviewV3 component to facilitate testing, which will eventually contain the new implementation.

<img width="1727" alt="Screenshot 2024-12-04 at 9 16 32 PM" src="https://github.com/user-attachments/assets/d65ebb6a-8560-430b-bc74-dbf0edac3205">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1544


## Proposed Changes

* Add `a4a-hosting-page-redesign-v3` and activate it in the **Development** and **Horizon** environments.
* Add a `HostingOverview3` component that will be loaded when the feature flag is enabled.

## Why are these changes being made?

* This is part of the **'In-product Hosting page v3'** project.

## Testing Instructions

* Use the A4A live link and go to the `/markplace/hosting` page.
* Confirm you see the empty page being loaded. See screenshot above.
* Test that when adding `?flags=-a4a-hosting-page-redesign-v3` in the URL, the current design is loaded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
