### PR TITLE
Update Woo rebrand auth signin and magic link pages

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -106,9 +106,7 @@ export default function ContinueAsUser( {
 						busy={ validatingPath }
 						href={ validatedPath || '/' }
 					>
-						{ `${ translate( 'Continue as', {
-							context: 'Continue as an existing WordPress.com user',
-						} ) } ${ userName }` }
+						{ translate( 'Continue' ) }
 					</Button>
 				</div>
 			);

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -482,8 +482,8 @@ class Login extends Component {
 					headerText = <h3>{ translate( 'Log in to your account' ) }</h3>;
 					const poweredByWpCom = (
 						<>
-							{ translate( 'Log in with your WordPress.com account.' ) }
-							<br />
+							{ translate( 'Log in with your WordPress.com account.' ) }{ ' ' }
+							<br className="hide-on-desktop" />
 						</>
 					);
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -349,6 +349,12 @@ $breakpoint-mobile: 660px;
 		@media (max-width: $break-mobile) {
 			text-align: left;
 		}
+
+		@media (min-width: $break-large) {
+			br.hide-on-desktop {
+				display: none;
+			}
+		}
 	}
 
 	.magic-login__form-action {
@@ -2123,6 +2129,7 @@ $breakpoint-mobile: 660px;
 
 .woo.feature-flag-woocommerce-rebrand-2-0,
 .woo.feature-flag-woocommerce-rebrand-2-0.is-woo-passwordless {
+	--woo-purple-0: #F2EDFF;
 	--woo-purple-40: #873EFF;
 	--woo-purple-50: #720EEC;
 	--woo-purple-60: #6108CE;
@@ -2169,7 +2176,8 @@ $breakpoint-mobile: 660px;
 	.magic-login.is-white-login .magic-login__form-action .button.is-primary:not([disabled]) {
 		background-color: var(--woo-purple-40);
 
-		&:hover {
+		&:hover,
+		&:focus {
 			background-color: var(--woo-purple-60);
 		}
 	}
@@ -2180,7 +2188,8 @@ $breakpoint-mobile: 660px;
 		text-decoration: underline;
 		text-underline-offset: 4px;
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: var(--woo-purple-60);
 		}
 	}
@@ -2190,7 +2199,8 @@ $breakpoint-mobile: 660px;
 		text-decoration: underline;
 		text-underline-offset: 4px;
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: var(--woo-purple-60);
 		}
 	}
@@ -2198,7 +2208,8 @@ $breakpoint-mobile: 660px;
 	.continue-as-user__change-user-link {
 		color: var(--woo-purple-50);
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: var(--woo-purple-70);
 		}
 	}
@@ -2206,12 +2217,24 @@ $breakpoint-mobile: 660px;
 	.magic-login__footer a {
 		color: var(--woo-purple-50);
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: var(--woo-purple-40);
 		}
 	}
 
 	.auth-form__social-buttons-tos a {
 		text-underline-offset: 2px;
+	}
+
+	.login__lost-password-link {
+		color: var(--woo-purple-40);
+		padding: 12px 24px;
+		border-radius: 8px; /* stylelint-disable-line scales/radii */
+		&:hover,
+		&:focus {
+			color: var(--woo-purple-60);
+			background-color: var(--woo-purple-0);
+		}
 	}
 }

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -6,6 +6,87 @@
 
 $breakpoint-mobile: 660px;
 
+@mixin button-primary {
+	background-color: var(--woo-purple-40);
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+
+	&:hover,
+	&:focus {
+		background-color: var(--woo-purple-60);
+	}
+
+	&:disabled {
+		background-color: var(--studio-gray-5);
+		color: var(--studio-gray-50);
+	}
+}
+
+@mixin button-secondary {
+	border: 2px solid var(--woo-purple-40);
+	background-color: transparent;
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+
+	&:hover,
+	&:focus {
+		background-color: var(--woo-purple-70);
+	}
+
+	&:disabled {
+		background-color: var(--studio-gray-5);
+		color: var(--studio-gray-50);
+	}
+}
+
+@mixin button-tertiary {
+	background-color: transparent;
+	color: var(--woo-purple-40);
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+
+	&:hover,
+	&:focus {
+		background-color: var(--woo-purple-0);
+		color: var(--woo-purple-60);
+	}
+
+	&:disabled {
+		background-color: transparent;
+		color: var(--studio-gray-50);
+	}
+}
+
+@mixin button-size-small {
+	padding: 5.5px 16px;
+	font-weight: 500;
+	font-size: rem(14px);
+	line-height: 21px;
+}
+
+@mixin button-size-base {
+	padding: 12px 24px;
+	font-weight: 500;
+	font-size: rem(16px);
+	line-height: 24px;
+}
+
+@mixin button-size-large {
+	padding: 14.5px 24px;
+	font-weight: 500;
+	font-size: rem(18px);
+	line-height: 27px;
+}
+
+@mixin link-woo {
+	color: var(--woo-purple-40);
+	text-decoration: underline;
+	text-underline-offset: 4px;
+	font-weight: 400;
+
+	&:hover,
+	&:focus {
+		color: var(--woo-purple-60);
+	}
+}
+
 .woo {
 	--woo-purple-40: #966ccf;
 	--woo-purple-50: #7f54b3;
@@ -1687,6 +1768,7 @@ $breakpoint-mobile: 660px;
 
 				strong {
 					font-weight: 600;
+					display: inline-block;
 				}
 			}
 
@@ -2139,13 +2221,7 @@ $breakpoint-mobile: 660px;
 		.security-key-form__help-text,
 		.formatted-header__subtitle {
 			a {
-				color: var(--woo-purple-40);
-				text-decoration: underline;
-				text-underline-offset: 4px;
-
-				&:hover {
-					color: var(--woo-purple-60);
-				}
+				@include link-woo;
 			}
 		}
 	}
@@ -2174,53 +2250,25 @@ $breakpoint-mobile: 660px;
 	.button.is-primary,
 	.login .button.is-primary,
 	.magic-login.is-white-login .magic-login__form-action .button.is-primary:not([disabled]) {
-		background-color: var(--woo-purple-40);
-
-		&:hover,
-		&:focus {
-			background-color: var(--woo-purple-60);
-		}
+		@include button-primary;
 	}
 
 	.notice__text a,
 	.notice__text a:visited {
-		color: var(--woo-purple-40);
-		text-decoration: underline;
-		text-underline-offset: 4px;
-
-		&:hover,
-		&:focus {
-			color: var(--woo-purple-60);
-		}
+		@include link-woo;
 	}
 
 	.login__header-subtitle a {
-		color: var(--woo-purple-40);
-		text-decoration: underline;
-		text-underline-offset: 4px;
-
-		&:hover,
-		&:focus {
-			color: var(--woo-purple-60);
-		}
+		@include link-woo;
 	}
 
 	.continue-as-user__change-user-link {
-		color: var(--woo-purple-50);
-
-		&:hover,
-		&:focus {
-			color: var(--woo-purple-70);
-		}
+		@include button-tertiary;
+		@include button-size-small;
 	}
 
 	.magic-login__footer a {
-		color: var(--woo-purple-50);
-
-		&:hover,
-		&:focus {
-			color: var(--woo-purple-40);
-		}
+		@include link-woo;
 	}
 
 	.auth-form__social-buttons-tos a {
@@ -2228,13 +2276,6 @@ $breakpoint-mobile: 660px;
 	}
 
 	.login__lost-password-link {
-		color: var(--woo-purple-40);
-		padding: 12px 24px;
-		border-radius: 8px; /* stylelint-disable-line scales/radii */
-		&:hover,
-		&:focus {
-			color: var(--woo-purple-60);
-			background-color: var(--woo-purple-0);
-		}
+		@include link-woo;
 	}
 }


### PR DESCRIPTION
Related to #96945, #96947, #97056

## Proposed Changes

* Update Woo branding for sign in, sign in (while logged in), email magic link, and post-email magic link
* Remove user name from `Continue as user name` button in sign in (while logged in) page
* Add mobile responsiveness for some copies
* Add mixins into SCSS

## Testing Instructions

* In your [`development.json`](https://github.com/Automattic/wp-calypso/blob/c470b69f28f940f90221730605717d06622639c7/config/development.json#L251), set `woocommerce/rebrand-2-0` to `true`
* Run `yarn start`

#### Sign in page

* In an incognito window, go to [this URL](http://calypso.localhost:3000/start/wpcc/oauth2-user?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252Fwoocommerce%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26client_source%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1&oauth2_client_id=50916)
* Observe the changes match with Figma tp2u3Nk9arcpeNMZcylNG4-fi-271_8254
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/897a4ca5-d944-43b7-8711-39511762ea68">

#### Email magic link

* Continuing from above instructions, click on `Email me a login link`
* Observe the changes match with screenshot (No Figma available)
* Try entering an email and observe the button UI changes, matching with tp2u3Nk9arcpeNMZcylNG4-fi-112_6447

<img width="1398" alt="image" src="https://github.com/user-attachments/assets/9c057d67-7f9d-4240-b65f-924a83381433">

#### Post-email magic link

* Continuing from above instructions, enter an email and click on `Send link`
* Observe the changes match with Figma tp2u3Nk9arcpeNMZcylNG4-fi-271_8309
* Try entering an email and observe the button UI changes, matching with tp2u3Nk9arcpeNMZcylNG4-fi-112_6447

<img width="1399" alt="image" src="https://github.com/user-attachments/assets/853bc31d-09b3-42a7-86de-e6a38513b6a2">

#### Sign in page (while signed in)

* Using a window where WordPress.com is logged in, go to [this URL](http://calypso.localhost:3000/start/wpcc/oauth2-user?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252Fwoocommerce%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26client_source%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1&oauth2_client_id=50916)
* tp2u3Nk9arcpeNMZcylNG4-fi-271_8267

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/29a05fc5-8ee8-4e92-87f4-3d375b409127">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?