### PR TITLE
Recent Feed Overhaul - Remove extra padding in mobile view

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -22,13 +22,14 @@ body.is-section-reader {
 	}
 
 	@media only screen and (max-width: 781px) {
-		div.layout.is-global-sidebar-visible {
-			.main {
-				padding: 0;
-			}
-			.layout__primary {
-				overflow-x: auto;
-			}
+		div.layout.is-global-sidebar-visible .layout__primary {
+			overflow-x: auto;
+		}
+	}
+
+	@media only screen and (max-width: 600px) {
+		div.layout.is-global-sidebar-visible .main {
+			padding: 24px 0;
 		}
 	}
 }

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -23,6 +23,9 @@ body.is-section-reader {
 
 	@media only screen and (max-width: 781px) {
 		div.layout.is-global-sidebar-visible {
+			.main {
+				padding: 0;
+			}
 			.layout__primary {
 				overflow-x: auto;
 			}


### PR DESCRIPTION
## Description

Some additional padding snuck in that was affecting the mobile view. I've removed it in this PR.

## Before

![before](https://github.com/user-attachments/assets/4d9dd493-5781-4bba-8c89-c3502b3a8c10)

## After

![after](https://github.com/user-attachments/assets/2e77970e-b9cc-49b9-866d-a918d5a9adf6)

## Testing

- Apply this PR
- Head to http://calypso.localhost:3000/read?flags=reader/recent-feed-overhaul
- Resize your screen