### PR TITLE
Stats: Release new date filtering to production

### DIFF
--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -28,6 +28,8 @@ $custom-stats-tab-mobile-break: $break-medium;
 		width: 100%;
 		padding: 24px 0 16px;
 		border: 0;
+		// Use border radius of its parent; otherwise it'd break the parent corner.
+		border-radius: 4px;
 		box-sizing: border-box;
 
 		display: flex;
@@ -108,6 +110,7 @@ $custom-stats-tab-mobile-break: $break-medium;
 					grid-template-columns: 2fr 2fr 3fr;
 					align-items: center;
 					justify-content: space-between;
+					border-radius: 0;
 				}
 
 				&:hover {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -169,8 +169,10 @@ class StatsSite extends Component {
 	}
 
 	getAvailableLegend() {
+		const { period } = this.props.period;
 		const activeTab = getActiveTab( this.props.chartTab );
-		return activeTab.legendOptions || [];
+		// TODO: remove this when we support hourly visitors.
+		return period !== 'hour' ? activeTab.legendOptions || [] : [];
 	}
 
 	navigationFromChartBar = ( periodStartDate, period ) => {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -162,7 +162,8 @@ class StatsSite extends Component {
 		if ( activeTab !== state.activeTab ) {
 			return {
 				activeTab,
-				activeLegend: activeTab.legendOptions || [],
+				// TODO: remove this when we support hourly visitors.
+				activeLegend: props.period !== 'hour' ? activeTab.legendOptions || [] : [],
 			};
 		}
 		return null;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -310,7 +310,7 @@ class StatsSite extends Component {
 			momentSiteZone,
 			wpcomShowUpsell,
 		} = this.props;
-		const isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' ) || isInternal;
+		const isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' );
 		let defaultPeriod = PAST_SEVEN_DAYS;
 
 		const shouldShowUpsells = isOdysseyStats && ! isAtomic;

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -127,18 +127,21 @@ function addTooltipData( chartTab, item, period, customRange = {} ) {
 				className: 'is-views',
 				icon: <Icon className="gridicon" icon={ eye } />,
 			} );
-			tooltipData.push( {
-				label: translate( 'Visitors' ),
-				value: numberFormat( item.data.visitors ),
-				className: 'is-visitors',
-				icon: <Icon className="gridicon" icon={ people } />,
-			} );
-			tooltipData.push( {
-				label: translate( 'Views Per Visitor' ),
-				value: numberFormat( item.data.views / item.data.visitors, { decimals: 2 } ),
-				className: 'is-views-per-visitor',
-				icon: <Icon className="gridicon" icon={ chevronRight } />,
-			} );
+
+			if ( Number.isFinite( item.data.visitors ) ) {
+				tooltipData.push( {
+					label: translate( 'Visitors' ),
+					value: numberFormat( item.data.visitors ),
+					className: 'is-visitors',
+					icon: <Icon className="gridicon" icon={ people } />,
+				} );
+				tooltipData.push( {
+					label: translate( 'Views Per Visitor' ),
+					value: numberFormat( item.data.views / item.data.visitors, { decimals: 2 } ),
+					className: 'is-views-per-visitor',
+					icon: <Icon className="gridicon" icon={ chevronRight } />,
+				} );
+			}
 
 			if ( item.data.post_titles && item.data.post_titles.length ) {
 				// only show two post titles

--- a/config/development.json
+++ b/config/development.json
@@ -222,7 +222,7 @@
 		"ssr/prefetch-timebox": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": false,
+		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -145,7 +145,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": false,
+		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/production.json
+++ b/config/production.json
@@ -193,7 +193,7 @@
 		"ssr/sample-log-cache-misses": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": false,
+		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -189,7 +189,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": false,
+		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,

--- a/config/test.json
+++ b/config/test.json
@@ -137,7 +137,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": false,
+		"stats/new-date-filtering": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -185,7 +185,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": false,
+		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -62,10 +62,6 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 			await statsPage.clickTab( 'Traffic' );
 		} );
 
-		it( 'View 30-day highlights', async function () {
-			await statsPage.selectHighlightPeriod( '30-day' );
-		} );
-
 		it( 'Select "Months" stats period', async function () {
 			await statsPage.selectStatsPeriodFromDropdown( 'Months' );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/274

## Proposed Changes

* Enable the feature flag `stats/new-date-filtering` for all environments.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Release the date filtering project by flipping the feature flag.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page for any site.
* Ensure the Traffic page applies the new design and date filtering functionalities.

<img width="1280" alt="截圖 2024-12-04 晚上10 20 58" src="https://github.com/user-attachments/assets/bf249ae9-0af0-4ed7-92ae-e82a2a5cb511">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
