### PR TITLE
Stats: Fix chartEnd of the forced default range by gates

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -395,9 +395,10 @@ class StatsSite extends Component {
 
 			// For StatsDateControl
 			customChartRange.daysInRange = 7;
-			customChartRange.chartEnd = momentSiteZone.format( DATE_FORMAT );
-			customChartRange.chartStart = momentSiteZone
-				.clone()
+			customChartRange.chartEnd = isNewDateFilteringEnabled
+				? momentSiteZone.clone().subtract( 1, 'days' ).format( DATE_FORMAT )
+				: momentSiteZone.format( DATE_FORMAT );
+			customChartRange.chartStart = moment( customChartRange.chartEnd )
 				.subtract( customChartRange.daysInRange - 1, 'days' )
 				.format( DATE_FORMAT );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This is the follow-up for https://github.com/Automattic/wp-calypso/pull/96869.

## Proposed Changes

* Fix the chart end date when it is determined by the forced 7 days by the feature gate.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need a complete range for all shortcuts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with Calypso Live branch.
* Navigate to Stats > Traffic page for a Simplte site created after 2024-01-09 with the feature flag: `?flags=stats/new-date-filtering`.
* Ensure the default date range is applied to the `Last 7 Days` and the selected shortcut is the same.

|Before|After|
|-|-|
|<img width="1287" alt="截圖 2024-12-04 晚上10 40 43" src="https://github.com/user-attachments/assets/70db08d5-5333-4c2e-a353-1ded1a773016">|<img width="1284" alt="截圖 2024-12-04 晚上10 40 24" src="https://github.com/user-attachments/assets/7186bc54-7b2f-4363-88e6-b17fb22e0683">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
