### PR TITLE
Stats: Check partial period date label with customRange

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -280,7 +280,14 @@ const connectComponent = connect(
 		}
 
 		const counts = getCountRecords( state, siteId, query.date, query.period, query.quantity );
-		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
+		const chartData = buildChartData(
+			activeLegend,
+			chartTab,
+			counts,
+			period,
+			queryDate,
+			isNewDateFilteringEnabled ? customRange : {}
+		);
 		const loadingTabs = getLoadingTabs( state, siteId, query.date, query.period, query.quantity );
 		const isActiveTabLoading = loadingTabs.includes( chartTab ) || chartData.length < quantity;
 

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -14,9 +14,11 @@ import moment from 'moment';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { rangeOfPeriod } from 'calypso/state/stats/lists/utils';
 
-export function formatDate( date, period ) {
+export function formatDate( date, period, chartStart = null, chartEnd = null ) {
 	// NOTE: Consider localizing the dates, especially for the 'week' case.
 	const momentizedDate = moment( date );
+	const endDate = momentizedDate.clone().add( 6, 'days' );
+
 	switch ( period ) {
 		case 'hour':
 			// TODO: align the time format with email stats.
@@ -24,6 +26,18 @@ export function formatDate( date, period ) {
 		case 'day':
 			return momentizedDate.format( 'LL' );
 		case 'week':
+			// Make partial period display with correct start and end dates.
+			if ( chartStart && momentizedDate.isBefore( chartStart ) ) {
+				return (
+					moment( chartStart ).format( 'LL' ) +
+					' - ' +
+					momentizedDate.add( 6, 'days' ).format( 'LL' )
+				);
+			}
+			if ( chartEnd && endDate.isAfter( chartEnd ) ) {
+				return momentizedDate.format( 'LL' ) + ' - ' + moment( chartEnd ).format( 'LL' );
+			}
+
 			return momentizedDate.format( 'LL' ) + ' - ' + momentizedDate.add( 6, 'days' ).format( 'LL' );
 		case 'month':
 			return momentizedDate.format( 'MMMM YYYY' );
@@ -47,39 +61,42 @@ export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
 }
 
 const EMPTY_RESULT = [];
-export const buildChartData = memoizeLast( ( activeLegend, chartTab, data, period, queryDate ) => {
-	if ( ! data ) {
-		return EMPTY_RESULT;
-	}
-	return data.map( ( record ) => {
-		const nestedValue = activeLegend.length ? record[ activeLegend[ 0 ] ] : null;
+export const buildChartData = memoizeLast(
+	( activeLegend, chartTab, data, period, queryDate, customRange ) => {
+		if ( ! data ) {
+			return EMPTY_RESULT;
+		}
+		return data.map( ( record ) => {
+			const nestedValue = activeLegend.length ? record[ activeLegend[ 0 ] ] : null;
 
-		const recordClassName =
-			record.classNames && record.classNames.length ? record.classNames.join( ' ' ) : null;
-		const className = clsx( recordClassName, {
-			'is-selected': record.period === queryDate,
+			const recordClassName =
+				record.classNames && record.classNames.length ? record.classNames.join( ' ' ) : null;
+			const className = clsx( recordClassName, {
+				'is-selected': record.period === queryDate,
+			} );
+
+			const item = addTooltipData(
+				chartTab,
+				{
+					label: record[ `label${ capitalize( period ) }` ],
+					value: record[ chartTab ],
+					data: record,
+					nestedValue,
+					className,
+				},
+				period,
+				customRange
+			);
+
+			return item;
 		} );
+	}
+);
 
-		const item = addTooltipData(
-			chartTab,
-			{
-				label: record[ `label${ capitalize( period ) }` ],
-				value: record[ chartTab ],
-				data: record,
-				nestedValue,
-				className,
-			},
-			period
-		);
-
-		return item;
-	} );
-} );
-
-function addTooltipData( chartTab, item, period ) {
+function addTooltipData( chartTab, item, period, customRange = {} ) {
 	const tooltipData = [];
 	tooltipData.push( {
-		label: formatDate( item.data.period, period ),
+		label: formatDate( item.data.period, period, customRange.chartStart, customRange.chartEnd ),
 		className: 'is-date-label',
 		value: null,
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/286

## Proposed Changes

* Compare chart starts and end dates with the partial `week` period date label for accurate data range on the tooltip.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make the partial `week` bar have a more accurate tooltip date label.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page with the feature flag: `?flags=stats/new-date-filtering`.
* Pick a date range and apply the period `Weeks`.
* Hover on the first and last bars on the chart.
* Ensure the date label starts or ends with the applied date range.

<img width="1298" alt="截圖 2024-12-04 晚上11 45 30" src="https://github.com/user-attachments/assets/f6a3862c-5d55-4ff8-9f4e-ce4a587f8cc6">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
