### PR TITLE
e2e: fix correct title tag

### DIFF
--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -74,7 +74,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	it( 'Template content loads into editor', async function () {
 		const editorCanvas = await editorPage.getEditorCanvas();
-		await editorCanvas.locator( `h1.wp-block:text-is('${ pageTemplateToSelect }')` ).waitFor();
+
+		await editorCanvas.locator( `h2.wp-block:text-is('${ pageTemplateToSelect }')` ).waitFor();
 	} );
 
 	it( 'Open setting sidebar', async function () {


### PR DESCRIPTION

## Proposed Changes
After switching to Gutenberg 19.8.0 we have incorrect selector for title. I checked it and it's indeed should be h2, since we have h1 as the main title

<img width="1258" alt="Screenshot 2024-12-04 at 17 13 00" src="https://github.com/user-attachments/assets/ae41b660-8fac-4460-be4a-48db51a4d342">


## Testing Instructions
Visual review should suffice