### PR TITLE
My Home: Fix inconsistencies between the different cards on mobile

### DIFF
--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -2,15 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 
 .app-promo {
-	&.customer-home__card.card {
-		border-bottom: none;
-
-		@include break-large {
-			padding-left: 48px;
-			box-shadow: none;
-		}
-	}
-
 	.app-promo__icon {
 		display: block;
 		margin: 0 auto 6px;

--- a/client/components/blogging-prompt-card/index.jsx
+++ b/client/components/blogging-prompt-card/index.jsx
@@ -103,7 +103,7 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 		<div className="blogging-prompt">
 			<Card
 				className={ clsx( 'blogging-prompt__card', {
-					'customer-home__card': viewContext === 'home',
+					'customer-home__card is-small-hero': viewContext === 'home',
 				} ) }
 			>
 				<PromptsNavigation

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -1,6 +1,6 @@
 .blogging-prompt {
 	/* Blogging Prompt Card ------------------------ */
-	.card.blogging-prompt__card {
+	.card:not(.customer-home__card).blogging-prompt__card {
 		padding: 24px;
 	}
 	/* Blogging Prompt Header ------------------------ */

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -2,7 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 
 .quick-links.foldable-card.card {
-	box-shadow: none;
 	@include breakpoint-deprecated( ">660px" ) {
 		border-radius: 3px;
 	}

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -86,7 +86,7 @@ export const QuickLinks = ( {
 
 	return (
 		<FoldableCard
-			className="wp-for-teams-quick-links quick-links"
+			className="wp-for-teams-quick-links quick-links customer-home__card"
 			header={ translate( 'Quick Links' ) }
 			clickableHeader
 			expanded={ isExpanded }

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -228,7 +228,7 @@ export function RenderDomainUpsell( {
 	const illustrationHeader = domainSuggestionName ? domainNameSVG : null;
 
 	return (
-		<Card className="domain-upsell__card customer-home__card">
+		<Card className="domain-upsell__card customer-home__card is-large-hero">
 			<QueryProductsList />
 			<TrackComponentView eventName="calypso_my_home_domain_upsell_impression" />
 			<div>

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -2,13 +2,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-body .customer-home__layout .domain-upsell__card {
-	padding: 16px 16px 20px;
-	@include break-small {
-		padding: 32px 24px;
-	}
-}
-
 .domain-upsell__card {
 	h3 {
 		font-family: $brand-serif;

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -6,18 +6,6 @@ $card_padding_large: 24px;
 $min_results_height: 180px;
 
 .customer-home__layout .help-search {
-	&.card {
-		padding: 0;
-	}
-
-	.help-search__inner {
-		padding: 0 16px;
-
-		@include breakpoint-deprecated( ">660px" ) {
-			padding: 16px 24px 0;
-		}
-	}
-
 	.card-heading {
 		margin-bottom: 16px;
 	}
@@ -27,26 +15,17 @@ $min_results_height: 180px;
 		justify-content: space-between;
 	}
 
-	.help-search__footer {
-		margin-bottom: 30px;
-		@include breakpoint-deprecated( ">660px" ) {
-			margin-bottom: 6px;
-		}
-	}
-
 	.help-search__cta {
 		display: flex;
 		align-items: center;
-		width: 100%;
-		padding: 10px $card_padding_small;
-		color: var(--color-text);
-		line-height: 1;
-		font-size: inherit;
+		width: calc(100% + $card_padding_large * 2);
 		height: auto;
-
-		@include break-mobile {
-			padding: 10px $card_padding_large;
-		}
+		padding-left: $card_padding_large;
+		padding-right: $card_padding_large;
+		margin-left: -$card_padding_large;
+		margin-right: -$card_padding_large;
+		color: var(--color-text);
+		font-size: inherit;
 
 		&:hover,
 		&:focus {
@@ -93,8 +72,8 @@ $min_results_height: 180px;
 	}
 
 	.inline-help__search {
-		// Don't allow ellipsis items to flow outside box
-		width: 100%;
+		width: 100%; // Don't allow ellipsis items to flow outside box
+		padding: 0 0 16px 0;
 	}
 
 	.inline-help__results-item {
@@ -103,11 +82,11 @@ $min_results_height: 180px;
 
 		a {
 			text-decoration: none;
-			line-height: 1;
 			padding: 10px $card_padding_small;
 
 			// Ellipsis overflow handling
-			display: block;
+			display: flex;
+			align-items: center;
 			flex: 1;
 			white-space: nowrap;
 			overflow: hidden;
@@ -115,43 +94,23 @@ $min_results_height: 180px;
 
 			.gridicon,
 			svg {
-				margin: 0 5px -3px 0;
-				position: relative;
-				top: 2px;
+				top: 0;
 			}
 
 			&:hover,
 			&:focus {
 				cursor: pointer;
 			}
-
-			@include break-mobile {
-				padding-left: $card_padding_large;
-				padding-right: $card_padding_large;
-			}
 		}
 	}
 
 	.inline-help__results {
 		min-height: $min_results_height;
-		padding: #{$search_results_top_spacing - 1px} 0 0 0;
-		margin-left: -$card_padding_small;
-		margin-right: -$card_padding_small;
-
-		@include break-mobile {
-			margin-left: -$card_padding_large;
-			margin-right: -$card_padding_large;
-		}
 	}
 
 	.inline-help__results-title {
-		padding-left: $card_padding_small;
-		padding-right: $card_padding_small;
-
-		@include break-mobile {
-			padding-left: $card_padding_large;
-			padding-right: $card_padding_large;
-		}
+		padding-left: 0;
+		padding-right: 0;
 	}
 
 	.inline-help__empty-results {

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -87,7 +87,8 @@ const SitePreview = ( {
 	const selectedSiteName = selectedSite ? selectedSite.name : '&nbsp;';
 
 	return (
-		<div className="home-site-preview">
+		// TODO: Add the new classes only when on the home page.
+		<div className="home-site-preview customer-home__card is-full-width">
 			<ThumbnailWrapper showEditSite={ shouldShowEditSite } editSiteURL={ editSiteURL }>
 				{ shouldShowEditSite && (
 					<Button primary className="home-site-preview__thumbnail-label">

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -87,7 +87,6 @@ const SitePreview = ( {
 	const selectedSiteName = selectedSite ? selectedSite.name : '&nbsp;';
 
 	return (
-		// TODO: Add the new classes only when on the home page.
 		<div className="home-site-preview customer-home__card is-full-width">
 			<ThumbnailWrapper showEditSite={ shouldShowEditSite } editSiteURL={ editSiteURL }>
 				{ shouldShowEditSite && (

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -65,7 +65,11 @@
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;
-		padding: 16px 0 0 0;
+		padding: 32px 0 0 0;
+
+		@include break-small {
+			padding: 16px 0 0 0;
+		}
 
 		.home-site-preview__site-info {
 			display: flex;

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -2,8 +2,6 @@
 
 .stats .customer-home__card.stats__with-chart {
 	box-shadow: none;
-	border-bottom: none;
-	margin-bottom: 0;
 
 	@include breakpoint-deprecated( ">660px" ) {
 		padding: 16px 24px 0;

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -59,7 +59,7 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 	const permanentDismiss = () => dismiss( { isDismissed: true } );
 
 	return (
-		<div className="customer-home-launchpad">
+		<div className="customer-home-launchpad customer-home__card is-small-hero">
 			<div className={ headerClasses }>
 				<h2 className="customer-home-launchpad__title">{ launchpadTitle }</h2>
 				{ numberOfSteps > completedSteps ? (

--- a/client/my-sites/customer-home/cards/launchpad/style.scss
+++ b/client/my-sites/customer-home/cards/launchpad/style.scss
@@ -8,7 +8,7 @@
 	box-shadow: 0 0 0 1px var(--color-border-subtle);
 	margin-bottom: 16px;
 
-	@include break-mobile {
+	@include break-small {
 		border-radius: 3px;
 	}
 

--- a/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
@@ -25,6 +25,7 @@ const CelebrateNotice = ( {
 	const dispatch = useDispatch();
 	const { skipCurrentView } = useSkipCurrentViewMutation( siteId );
 
+	const showActions = showAction || showSkip;
 	const showNextTask = () => {
 		setIsLoading( true );
 		skipCurrentView();
@@ -64,23 +65,25 @@ const CelebrateNotice = ( {
 			<div className="celebrate-notice__text task__text">
 				<h2 className="celebrate-notice__title task__title">{ title }</h2>
 				<p className="celebrate-notice__description task__description">{ description }</p>
-				<div className="celebrate-notice__actions task__actions">
-					{ showAction && (
-						<Button
-							className="celebrate-notice__action task__action"
-							primary
-							onClick={ showNextTask }
-						>
-							{ actionText }
-						</Button>
-					) }
+				{ showActions && (
+					<div className="celebrate-notice__actions task__actions">
+						{ showAction && (
+							<Button
+								className="celebrate-notice__action task__action"
+								primary
+								onClick={ showNextTask }
+							>
+								{ actionText }
+							</Button>
+						) }
 
-					{ showSkip && (
-						<Button className="celebrate-notice__skip task__skip is-link" onClick={ skip }>
-							{ skipText }
-						</Button>
-					) }
-				</div>
+						{ showSkip && (
+							<Button className="celebrate-notice__skip task__skip is-link" onClick={ skip }>
+								{ skipText }
+							</Button>
+						) }
+					</div>
+				) }
 			</div>
 			{ isDesktop() && (
 				<div className="celebrate-notice__illustration task__illustration">

--- a/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
@@ -56,7 +56,7 @@ const CelebrateNotice = ( {
 
 	return (
 		<div
-			className={ clsx( 'celebrate-notice', 'task', 'customer-home__card', {
+			className={ clsx( 'celebrate-notice', 'task', 'customer-home__card', 'is-large-hero', {
 				'is-loading': isLoading,
 			} ) }
 		>

--- a/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx
@@ -55,7 +55,11 @@ const CelebrateNotice = ( {
 	};
 
 	return (
-		<div className={ clsx( 'celebrate-notice', 'task', { 'is-loading': isLoading } ) }>
+		<div
+			className={ clsx( 'celebrate-notice', 'task', 'customer-home__card', {
+				'is-loading': isLoading,
+			} ) }
+		>
 			{ isLoading && <Spinner /> }
 			<div className="celebrate-notice__text task__text">
 				<h2 className="celebrate-notice__title task__title">{ title }</h2>

--- a/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
@@ -16,7 +16,7 @@ const ReaderFirstPosts = () => {
 	};
 
 	return (
-		<Card className="reader-first-posts__nudge">
+		<Card className="reader-first-posts__nudge customer-home__card is-small-hero">
 			<TrackComponentView
 				eventName="calypso_my_home_reader_first_posts_nudge_view"
 				eventProperties={ {

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -7,12 +7,12 @@
 	position: relative;
 	margin-top: 0;
 	margin-bottom: 30px;
-	border-radius: 3px;
 
 	@include break-small {
 		flex-direction: row;
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
 		margin-bottom: 16px;
+		border-radius: 3px;
 	}
 
 	.task__text,

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -30,6 +30,10 @@
 		flex-direction: column;
 		margin-top: 16px;
 		align-items: flex-start;
+
+		> :last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	.task__illustration {

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -28,7 +28,6 @@
 	.task__text {
 		display: flex;
 		flex-direction: column;
-		margin-top: 16px;
 		align-items: flex-start;
 
 		> :last-child {

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -17,11 +17,8 @@
 
 	.task__text,
 	.task__illustration {
+		padding: 24px 16px;
 		box-sizing: border-box;
-
-		@include break-small {
-			padding: 24px 16px;
-		}
 
 		@include break-xlarge {
 			padding: 32px 24px;
@@ -42,7 +39,7 @@
 		margin-left: auto;
 		text-align: center;
 		margin-top: 32px;
-		
+
 		@include break-small {
 			width: 33.33%;
 			margin-top: 0;
@@ -83,7 +80,7 @@
 		font-size: $font-body;
 		line-height: 24px;
 		color: var(--color-text-subtle);
-		
+
 		@include break-medium {
 			line-height: 28px;
 			margin-bottom: 32px;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -368,12 +368,12 @@ body.is-section-home.theme-default.color-scheme {
 
 		.site-setup-list__task {
 			margin: 0;
-			padding: 32px 8px 32px 32px;
+			padding: 24px 8px 24px 24px;
 
 			// When the list switches to a single-column
 			@include breakpoint-deprecated( "<960px" ) {
 				// Less space at the top because the nav-item contributes
-				padding: 16px 32px 32px;
+				padding: 16px 24px 24px;
 			}
 		}
 	}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -294,7 +294,11 @@ body.is-section-home.theme-default.color-scheme {
 	// edges of the space with it's inner list.
 	.card,
 	.task {
-		margin: 32px;
+		margin: 32px 16px;
+
+		@include break-small {
+			margin: 32px;
+		}
 
 		@media (min-width: ($break-wide + 1)) {
 			margin: 0 32px 32px;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -125,8 +125,6 @@ body.is-section-home.theme-default.color-scheme {
 	}
 
 	.card.foldable-card {
-		padding-bottom: 16px;
-
 		.foldable-card__header {
 			padding: 0 0 8px;
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -234,6 +234,18 @@ body.is-section-home.theme-default.color-scheme {
 		}
 	}
 
+	&.task {
+		.task__text,
+		.task__illustration {
+			margin: 0;
+			padding: 0;
+		}
+
+		.task__text + .task__illustration {
+			padding-left: 48px;
+		}
+	}
+
 	.customer-home__card-subheader {
 		color: var(--color-text-subtle);
 		margin: 0 0 1rem;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -237,7 +237,6 @@ body.is-section-home.theme-default.color-scheme {
 	&.task {
 		.task__text,
 		.task__illustration {
-			margin: 0;
 			padding: 0;
 		}
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -115,6 +115,7 @@ body.is-section-home.theme-default.color-scheme {
 	.customer-home__card {
 		@include break-xlarge {
 			padding: 16px 0;
+			margin: 0;
 			box-shadow: none;
 		}
 
@@ -231,7 +232,6 @@ body.is-section-home.theme-default.color-scheme {
 		padding-top: 0;
 
 		@include break-xlarge {
-			padding: 0;
 			box-shadow: none;
 		}
 	}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -85,7 +85,7 @@ body.is-section-home.theme-default.color-scheme {
 
 .customer-home__layout {
 	@include grid-row( 4, 1 );
-	@include breakpoint-deprecated( ">1040px" ) {
+	@include break-xlarge {
 		@include grid-column( 1, 12 );
 		@include display-grid;
 		@include grid-template-columns( 12, 24px, 1fr );
@@ -94,23 +94,59 @@ body.is-section-home.theme-default.color-scheme {
 }
 
 .customer-home__layout-col-left {
-	@include breakpoint-deprecated( ">1040px" ) {
+	@include break-xlarge {
 		@include grid-column( 1, 8 );
+	}
+
+	> :first-child {
+		border-top: 1px solid var(--color-border-subtle);
+
+		@include break-small {
+			border-top: none;
+		}
 	}
 }
 
-.customer-home__layout-col-right {
-	@include breakpoint-deprecated( ">1040px" ) {
+.customer-home__main .customer-home__layout-col-right {
+	@include break-xlarge {
 		@include grid-column( 9, 4 );
 	}
 
-	.card.app-promo.customer-home__card {
-		padding-left: 16px;
-
-		@include break-large {
-			padding-left: 0;
+	.customer-home__card {
+		@include break-xlarge {
+			padding: 16px 0;
+			box-shadow: none;
 		}
 
+		&:last-child {
+			border-bottom: none;
+		}
+	}
+
+	.card.foldable-card {
+		padding-bottom: 16px;
+
+		.foldable-card__header {
+			padding: 0 0 8px;
+
+			.foldable-card__action {
+				top: -4px;
+				width: auto;
+				margin-right: 0;
+			}
+		}
+
+		.foldable-card__content {
+			padding-right: 0;
+
+			.quick-links__action-box {
+				padding-left: 0;
+				padding-right: 0;
+			}
+		}
+	}
+
+	.card.app-promo {
 		.app-promo__icon {
 			margin: 0 0 6px;
 		}
@@ -132,39 +168,16 @@ body.is-section-home.theme-default.color-scheme {
 		}
 	}
 
-	@include break-mobile {
-		> .card,
-		> .card.quick-links,
-		> .card.app-promo {
-			padding: 16px 0;
+	.home-site-preview {
+		.home-site-preview__thumbnail-wrapper {
+			margin: 0 -24px;
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
 
-			.foldable-card__header {
-				padding: 16px 0 14px;
-
-				.foldable-card__action {
-					width: auto;
-					margin-right: 0;
-				}
+			@include break-xlarge {
+				margin: 0;
+				border-radius: 3px;
 			}
-
-			.foldable-card__content {
-				padding-right: 0;
-				.quick-links__action-box {
-					padding-left: 0;
-					padding-right: 0;
-				}
-			}
-		}
-	}
-
-	& > .card,
-	& > .foldable-card.card,
-	& > .foldable-card.card.is-expanded {
-		margin-bottom: 30px;
-		margin-top: 0;
-
-		@include breakpoint-deprecated( ">660px" ) {
-			margin-bottom: 16px;
 		}
 	}
 }
@@ -184,23 +197,48 @@ body.is-section-home.theme-default.color-scheme {
 }
 
 .customer-home__main .customer-home__card {
-	padding: 0 16px 30px;
-	margin-top: 0;
-	margin-bottom: 24px;
+	padding: 32px 16px;
+	margin: 0;
 	border-bottom: 1px solid var(--color-border-subtle);
 	box-shadow: none;
 
-	@include breakpoint-deprecated( ">660px" ) {
+	@include break-small {
 		border-radius: 3px;
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
 		border-bottom: none;
 		padding: 16px 24px;
-		margin: 0 0 16px;
+		margin-bottom: 16px;
 	}
 
 	&.is-compact {
 		margin: 0 0 1px;
 		padding: 16px 24px;
+	}
+
+	&.is-small-hero {
+		@include break-small {
+			padding: 24px;
+		}
+	}
+
+	&.is-large-hero {
+		@include break-small {
+			padding: 32px 24px;
+		}
+	}
+
+	&.is-full-width {
+		padding-top: 0;
+
+		@include break-xlarge {
+			padding: 0;
+			box-shadow: none;
+		}
+	}
+
+	.customer-home__card-subheader {
+		color: var(--color-text-subtle);
+		margin: 0 0 1rem;
 	}
 }
 
@@ -217,11 +255,6 @@ body.is-section-home.theme-default.color-scheme {
 
 .customer-home__main .blogging-prompt .blogging-prompt__card .blogging-prompt__prompt-text {
 	font-size: $font-body-large;
-}
-
-.customer-home__card-subheader {
-	color: var(--color-text-subtle);
-	margin: 0 0 1rem;
 }
 
 .customer-home__main .vertical-nav {
@@ -247,7 +280,12 @@ body.is-section-home.theme-default.color-scheme {
 	display: flex;
 	flex-direction: column;
 	padding: 0;
-	margin-bottom: 16px;
+
+	@include break-small {
+		margin-bottom: 16px;
+		box-shadow: 0 0 0 1px var(--color-border-subtle);
+		border-radius: 3px;
+	}
 
 	// We add margin here to the direct children and strip it away from the
 	// outer edges of child elements.
@@ -266,12 +304,6 @@ body.is-section-home.theme-default.color-scheme {
 	// Extend the checklist to the edge of the primary content area
 	.site-setup-list__nav {
 		margin: 0;
-	}
-
-	border-radius: 3px;
-
-	@include breakpoint-deprecated( ">660px" ) {
-		box-shadow: 0 0 0 1px var(--color-border-subtle);
 	}
 
 	.dot-pager__controls {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #97066

## Proposed Changes

* Fix _some_ styling inconsistencies for the cards on the My Home screen, focusing mostly on mobile.
* Refactor the code and move the generic styling to an already existing class - `customer-home__card`. This is for `cards` only. `Tasks` (another card variant) have a more specific styling so I've skipped those.
* Use consistent breakpoints and switch to a mobile-first approach by refactoring the `breakpoint-deprecated` calls.
* Slightly update the style of the "Get Help" card to make it more consistent with the others.
* Fix some `tasks` having no padding on mobile (potentially related to https://github.com/Automattic/wp-calypso/issues/96936).



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Because once you see these issues, it's hard to unsee them. 🙂

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch and go to http://calypso.localhost:3000/home/YOUR-DOMAIN
* Compare the cards with http://wordpress.com/home/YOUR-DOMAIN and make sure there is an improvement (not aiming for perfection 🙂) in the paddings and style consistency on tablet and mobile. The desktop version should be mostly the same with very slight changes (mostly the "Get Help" card).
* To test cards/tasks from other views, sandbox `public-api.wordpress.com`, and update the `get_view` function in the `wp-content/lib/home/views.php` file to return another view. You could use the following snippet as an example:
```php
$views = VIEWS_SIMPLE_AND_ATOMIC_TIME_SENSITIVE;
foreach ( $views as $view ) {
	return get_cards_for_view( maybe_inject_high_priority_promos( $view ), $blog_id, $user_id, $dev );
} 
```
* Test the other view defined at the beginning (lines 43-94) of the `wp-content/lib/home/views.php` file.
* Test on different browsers.

## Screenshots

### [Mobile Portrait] BEFORE

<img width="591" alt="SCR-20241205-qxpe" src="https://github.com/user-attachments/assets/b7329466-6a6e-453d-a832-35e4a08eb72c">

---

### [Mobile Portrait] AFTER

<img width="591" alt="SCR-20241205-qzsv" src="https://github.com/user-attachments/assets/30029222-10e3-44c9-a9b8-c3bdedf210fc">

---

### [Mobile Landscape] BEFORE

![SCR-20241205-qxwv](https://github.com/user-attachments/assets/a5293615-385e-4850-aa40-b998a9bd14fa)

---

### [Mobile Landscape] AFTER

![SCR-20241205-raak](https://github.com/user-attachments/assets/76f43653-427b-4910-8f12-acb841713f77)

---

### [Mobile Task Card] BEFORE

<img width="596" alt="SCR-20241205-rcng" src="https://github.com/user-attachments/assets/01275e0f-bf66-4d3e-9e4b-22892cb05cf2">

---

### [Mobile Task Card] AFTER

<img width="598" alt="SCR-20241205-rcgk" src="https://github.com/user-attachments/assets/5dc17a96-e47c-40c0-b3f9-307c55d2101c">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
