### PR TITLE
A4A: fix sites Dataviews monitor switch errors

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
@@ -25,7 +25,8 @@ export default function useToggleActivateMonitor(
 	const queryClient = useQueryClient();
 	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
 
-	const { dataViewsState, showOnlyFavorites } = useContext( SitesDashboardContext );
+	const { dataViewsState, showOnlyFavorites, showOnlyDevelopmentSites } =
+		useContext( SitesDashboardContext );
 
 	const agencyId = useSelector( getActiveAgencyId );
 
@@ -37,6 +38,7 @@ export default function useToggleActivateMonitor(
 				{
 					issueTypes: getSelectedFilters( dataViewsState.filters ),
 					showOnlyFavorites: showOnlyFavorites || false,
+					showOnlyDevelopmentSites: showOnlyDevelopmentSites || false,
 				},
 				dataViewsState.sort,
 				dataViewsState.perPage,
@@ -60,15 +62,17 @@ export default function useToggleActivateMonitor(
 			await queryClient.cancelQueries( {
 				queryKey,
 			} );
-
 			// Update to the new value
-			queryClient.setQueryData( queryKey, ( oldSites: any ) => {
+			// If there are issues with updating the query data, check if queryKey is the same
+			// as in client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+			await queryClient.setQueryData( queryKey, ( oldSites: any ) => {
 				return {
 					...oldSites,
-					sites: oldSites?.sites.map( ( site: Site ) => {
+					sites: oldSites?.sites?.map( ( site: Site ) => {
 						if ( site.blog_id === siteId ) {
 							return {
 								...site,
+								monitor_active: params.monitor_active,
 								monitor_settings: {
 									...site.monitor_settings,
 									monitor_active: params.monitor_active,

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
@@ -28,7 +28,8 @@ export default function useUpdateMonitorSettings(
 	const queryClient = useQueryClient();
 	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
 
-	const { dataViewsState, showOnlyFavorites } = useContext( SitesDashboardContext );
+	const { dataViewsState, showOnlyFavorites, showOnlyDevelopmentSites } =
+		useContext( SitesDashboardContext );
 
 	const agencyId = useSelector( getActiveAgencyId );
 
@@ -40,6 +41,7 @@ export default function useUpdateMonitorSettings(
 				{
 					issueTypes: getSelectedFilters( dataViewsState.filters ),
 					showOnlyFavorites: showOnlyFavorites || false,
+					showOnlyDevelopmentSites: showOnlyDevelopmentSites || false,
 				},
 				dataViewsState.sort,
 				dataViewsState.perPage,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1491

## Proposed Changes

During deep investigation it appears that `queryKey` was changed to facilitate new development sites in our query, which broke the logic inside toggle action (we were trying to update query that was non-existant).
This diff updates queryKey to proper value and adds a comment to help navigate the solution in the future if the similar fix would be needed.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `/sites` tab
- If you don't have any sites available, create one with https://jurassic.ninja/ , and connect to A4A by installing 'Automattic for Agencies Client' plugin
- On the `/sites` page, try to enable/disable Monitor for your site. Check that it works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
