### PR TITLE
Add experimental UI for site identification step in the migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { StepContainer, Title, SubTitle, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { Icon, next, published, shield } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { type FC, useEffect, useState, useCallback } from 'react';
+import { type FC, ReactElement, useEffect, useState, useCallback } from 'react';
 import CaptureInput from 'calypso/blocks/import/capture/capture-input';
 import ScanningStep from 'calypso/blocks/import/scanning';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -19,12 +19,19 @@ import type { UrlData } from 'calypso/blocks/import/types';
 import './style.scss';
 
 interface HostingDetailsProps {
-	items: { title?: string; icon?: ReactElement; description: string }[];
+	items: { title: string; description: string }[];
+}
+
+interface HostingDetailsWithIconsProps {
+	items: {
+		icon: ReactElement;
+		description: string;
+	}[];
 }
 
 const isMigrationExperimentEnabled = config.isEnabled( 'migration-flow/experiment' );
 
-const HostingDetailsWithIcons: FC< HostingDetailsProps > = ( { items } ) => {
+const HostingDetailsWithIcons: FC< HostingDetailsWithIconsProps > = ( { items } ) => {
 	const translate = useTranslate();
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,4 +1,6 @@
+import config from '@automattic/calypso-config';
 import { StepContainer, Title, SubTitle, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
+import { Icon, next, published, shield } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { type FC, useEffect, useState, useCallback } from 'react';
 import CaptureInput from 'calypso/blocks/import/capture/capture-input';
@@ -17,8 +19,36 @@ import type { UrlData } from 'calypso/blocks/import/types';
 import './style.scss';
 
 interface HostingDetailsProps {
-	items: { title: string; description: string }[];
+	items: { title?: string; icon?: ReactElement; description: string }[];
 }
+
+const isMigrationExperimentEnabled = config.isEnabled( 'migration-flow/experiment' );
+
+const HostingDetailsWithIcons: FC< HostingDetailsProps > = ( { items } ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="import__site-identify-hosting-details-experiment">
+			<p className="import__site-identify-hosting-details-experiment-title">
+				{ translate( 'Why should you host with us?' ) }
+			</p>
+			<ul className="import__site-identify-hosting-details-experiment-list">
+				{ items.map( ( item, index ) => (
+					<li key={ index } className="import__site-identify-hosting-details-experiment-list-item">
+						<Icon
+							className="import__site-identify-hosting-details-experiment-icon"
+							icon={ item.icon }
+							size={ 24 }
+						/>
+						<p className="import__site-identify-hosting-details-experiment-description">
+							{ item.description }
+						</p>
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+};
 
 const HostingDetails: FC< HostingDetailsProps > = ( { items } ) => {
 	const translate = useTranslate();
@@ -69,26 +99,49 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 		return <ScanningStep />;
 	}
 
-	const hostingDetailItems = {
-		'unmatched-uptime': {
-			title: translate( 'Unmatched Reliability and Uptime' ),
-			description: translate(
-				"Our infrastructure's 99.99% uptime, combined with our automatic update system, ensures your site remains accessible and secure."
-			),
-		},
-		'effortless-customization': {
-			title: translate( 'Effortless Customization' ),
-			description: translate(
-				'Our tools and options let you easily design a website to meet your needs, whether you’re a beginner or an expert.'
-			),
-		},
-		'blazing-fast-speed': {
-			title: translate( 'Blazing Fast Page Speed' ),
-			description: translate(
-				'Our global CDN with 28+ locations delivers lightning-fast load times for a seamless visitor experience.'
-			),
-		},
-	};
+	let hostingDetailItems;
+
+	if ( isMigrationExperimentEnabled ) {
+		hostingDetailItems = {
+			'blazing-fast-speed': {
+				icon: next,
+				description: translate(
+					'Blazing fast speeds with lightning-fast load times for a seamless experience.'
+				),
+			},
+			'unmatched-uptime': {
+				icon: published,
+				description: translate(
+					'Unmatched reliability with 99.999% uptime and unmetered traffic.'
+				),
+			},
+			security: {
+				icon: shield,
+				description: translate( 'Round-the-clock security monitoring and DDoS protection.' ),
+			},
+		};
+	} else {
+		hostingDetailItems = {
+			'unmatched-uptime': {
+				title: translate( 'Unmatched Reliability and Uptime' ),
+				description: translate(
+					"Our infrastructure's 99.99% uptime, combined with our automatic update system, ensures your site remains accessible and secure."
+				),
+			},
+			'effortless-customization': {
+				title: translate( 'Effortless Customization' ),
+				description: translate(
+					'Our tools and options let you easily design a website to meet your needs, whether you’re a beginner or an expert.'
+				),
+			},
+			'blazing-fast-speed': {
+				title: translate( 'Blazing Fast Page Speed' ),
+				description: translate(
+					'Our global CDN with 28+ locations delivers lightning-fast load times for a seamless visitor experience.'
+				),
+			},
+		};
+	}
 
 	return (
 		<div className="import__capture-wrapper">
@@ -116,7 +169,11 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 					nextLabelText={ translate( 'Check my site' ) }
 				/>
 			</div>
-			<HostingDetails items={ Object.values( hostingDetailItems ) } />
+			{ isMigrationExperimentEnabled ? (
+				<HostingDetailsWithIcons items={ Object.values( hostingDetailItems ) } />
+			) : (
+				<HostingDetails items={ Object.values( hostingDetailItems ) } />
+			) }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,4 +1,3 @@
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, Title, SubTitle, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { type FC, useEffect, useState, useCallback } from 'react';
@@ -52,27 +51,7 @@ interface Props {
 
 export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLink = false } ) => {
 	const translate = useTranslate();
-	const hasEnTranslation = useHasEnTranslation();
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
-
-	// TODO: Remove extra steps for non-English locales once we have translations -- title.
-	const titleInUse = hasEnTranslation( 'Let’s find your site' )
-		? translate( 'Let’s find your site' )
-		: translate( 'Let’s import your content' );
-
-	// TODO: Remove extra steps for non-English locales once we have translations -- subtitle.
-	const subtitleInUse = hasEnTranslation(
-		"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
-	)
-		? translate(
-				"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
-		  )
-		: translate( 'Drop your current site address below to get started.' );
-
-	// TODO: Remove extra steps for non-English locales once we have translations -- CTA text.
-	const nextLabelText = hasEnTranslation( 'Check my site' ) ? translate( 'Check my site' ) : false;
-	const nextLabelProp = nextLabelText ? { nextLabelText } : {}; // If we don't pass anything, the default label 'Continue' will be used.
-
 	const {
 		data: siteInfo,
 		isError: hasError,
@@ -90,46 +69,36 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 		return <ScanningStep />;
 	}
 
-	// TODO: Remove extra steps and properties for non-English locales once we have translations -- hosting details.
 	const hostingDetailItems = {
 		'unmatched-uptime': {
 			title: translate( 'Unmatched Reliability and Uptime' ),
-			titleString: 'Unmatched Reliability and Uptime', // Temporary string for non-English locales. Remove once we have translations.
 			description: translate(
 				"Our infrastructure's 99.99% uptime, combined with our automatic update system, ensures your site remains accessible and secure."
 			),
-			descriptionString:
-				"Our infrastructure's 99.99% uptime, combined with our automatic update system, ensures your site remains accessible and secure.", // Temporary string for non-English locales. Remove once we have translations.
 		},
 		'effortless-customization': {
 			title: translate( 'Effortless Customization' ),
-			titleString: 'Effortless Customization',
 			description: translate(
 				'Our tools and options let you easily design a website to meet your needs, whether you’re a beginner or an expert.'
 			),
-			descriptionString:
-				'Our tools and options let you easily design a website to meet your needs, whether you’re a beginner or an expert.',
 		},
 		'blazing-fast-speed': {
 			title: translate( 'Blazing Fast Page Speed' ),
-			titleString: 'Blazing Fast Page Speed',
 			description: translate(
 				'Our global CDN with 28+ locations delivers lightning-fast load times for a seamless visitor experience.'
 			),
-			descriptionString:
-				'Our global CDN with 28+ locations delivers lightning-fast load times for a seamless visitor experience.',
 		},
 	};
-
-	const hasTranslationsForAllItems = Object.values( hostingDetailItems ).every(
-		( item ) => hasEnTranslation( item.titleString ) && hasEnTranslation( item.descriptionString )
-	);
 
 	return (
 		<div className="import__capture-wrapper">
 			<div className="import__heading import__heading-center">
-				<Title>{ titleInUse }</Title>
-				<SubTitle>{ subtitleInUse }</SubTitle>
+				<Title>{ translate( 'Let’s find your site' ) }</Title>
+				<SubTitle>
+					{ translate(
+						"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
+					) }
+				</SubTitle>
 			</div>
 			<div className="import__capture-container">
 				<CaptureInput
@@ -144,12 +113,10 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 						'Or <button>pick your current platform from a list</button>'
 					) }
 					hideImporterListLink={ hideImporterListLink }
-					{ ...nextLabelProp }
+					nextLabelText={ translate( 'Check my site' ) }
 				/>
 			</div>
-			{ hasTranslationsForAllItems && (
-				<HostingDetails items={ Object.values( hostingDetailItems ) } />
-			) }
+			<HostingDetails items={ Object.values( hostingDetailItems ) } />
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -158,6 +158,7 @@
 	&-icon {
 		background-color: #dcdcde;
 		border: 2px solid #dcdcde;
+		border-radius: 4px;
 		display: flex;
 		fill: var(--studio-gray-70);
 		flex: 0 0 24px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -124,3 +124,48 @@
 		}
 	}
 }
+
+.import__site-identify-hosting-details-experiment {
+	margin: 40px auto 0 auto;
+	max-width: 350px;
+
+	&-title {
+		color: var(--studio-gray-100);
+		font-size: 1.25rem;
+		font-weight: 500;
+		margin-bottom: 0.5rem;
+		text-align: center;
+	}
+
+	&-list {
+		background-color: #f6f7f7;
+		font-size: 0.75rem;
+		list-style: none;
+		margin: 0;
+		padding: 2rem;
+
+		&-item {
+			display: flex;
+			gap: 0.5rem;
+			margin-bottom: 1rem;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+	}
+
+	&-icon {
+		background-color: #dcdcde;
+		border: 2px solid #dcdcde;
+		display: flex;
+		fill: var(--studio-gray-70);
+		flex: 0 0 24px;
+		padding: 4px;
+	}
+
+	&-description {
+		color: var(--studio-black);
+		line-height: 1.66666667;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import config, { isEnabled } from '@automattic/calypso-config';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
@@ -39,11 +40,23 @@ const API_RESPONSE_WITH_OTHER_PLATFORM: UrlData = {
 };
 
 const MOCK_WORDPRESS_SITE_SLUG = 'test-example.wordpress.com';
-
 const getInput = () => screen.getByLabelText( /Enter your site address/ );
+
+const isMigrationExperimentEnabled = isEnabled( 'migration-flow/experiment' );
+
+const restoreIsMigrationExperimentEnabled = () => {
+	if ( isMigrationExperimentEnabled ) {
+		config.enable( 'migration-flow/experiment' );
+	} else {
+		config.disable( 'migration-flow/experiment' );
+	}
+};
 
 describe( 'SiteMigrationIdentify', () => {
 	beforeAll( () => nock.disableNetConnect() );
+	afterEach( () => {
+		restoreIsMigrationExperimentEnabled();
+	} );
 
 	it( 'continues the flow and saves the migration domain when the platform is wordpress', async () => {
 		useSiteSlug.mockReturnValue( MOCK_WORDPRESS_SITE_SLUG );
@@ -156,6 +169,8 @@ describe( 'SiteMigrationIdentify', () => {
 	} );
 
 	it( 'shows why host with us points', async () => {
+		config.disable( 'migration-flow/experiment' );
+
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10025.
Resolves #96413.

## Proposed Changes

- Updates the "Why should you host with us?" section of the site identification step in the migration flow. These changes are currently behind a feature flag and will be launched as part of a future experiment.
- Removes translation checks for some strings as those have now been translated.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Browse to the "Let’s find your site" step of the migration flow.
* Ensure the UI is the same as it was before:

![Screenshot 2024-12-04 at 12 14 19 PM](https://github.com/user-attachments/assets/9be5925e-776a-40bb-a279-205ebf6e5379)
* Enable the `migration-flow/experiment` feature flag in `config/development.json`.
* Ensure the UI matches the new design (ay0fZYgdXxPDbZbgPlz3hu-fi-1_3446):

![Screenshot 2024-12-05 at 8 34 20 AM](https://github.com/user-attachments/assets/d05712c9-6c84-4163-93ce-9a721d5cfa66)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?