### PR TITLE
Onboarding: Fix going back from Checkout to Stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -3,18 +3,13 @@ import { useStepPersistedState } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { localize } from 'i18n-calypso';
 import { isEmpty } from 'lodash';
-import { useRef, useCallback, useEffect } from 'react';
+import { useRef, useCallback } from 'react';
 import { connect } from 'react-redux';
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
 import { planItem } from 'calypso/lib/cart-values/cart-items';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { RenderDomainsStep, submitDomainStepSelection } from 'calypso/signup/steps/domains';
-import {
-	wasSignupCheckoutPageUnloaded,
-	retrieveSignupDestination,
-	getSignupCompleteFlowName,
-} from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import {
@@ -100,18 +95,6 @@ export default function DomainsStep( props: StepProps ) {
 		},
 		[ stepState, setStepState ]
 	);
-	useEffect( () => {
-		// This will automatically submit the domains step when navigating back from checkout
-		// It will redirect the user to plans step. The idea is to achieve the same behavior as /start.
-		const signupDestinationCookieExists = retrieveSignupDestination();
-		const isReEnteringFlow = getSignupCompleteFlowName() === props.flow;
-		const isManageSiteFlow = Boolean(
-			wasSignupCheckoutPageUnloaded() && signupDestinationCookieExists && isReEnteringFlow
-		);
-		if ( isManageSiteFlow ) {
-			props.navigation.submit?.( stepState );
-		}
-	}, [ stepState, props.navigation, props.flow ] );
 
 	return (
 		<CalypsoShoppingCartProvider>

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -159,7 +159,7 @@ const onboarding: Flow = {
 						}
 					}
 					setSignupCompleteFlowName( flowName );
-					return navigate( 'create-site', undefined, true );
+					return navigate( 'create-site', undefined, false );
 				}
 				case 'create-site':
 					return navigate( 'processing', undefined, true );


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/96888

Reverts https://github.com/Automattic/wp-calypso/pull/95244/files#diff-d6bc20bcdcb4a999ce96bb33bf6f986392311a3800680220300a7477733748f7R101-R112.

## Proposed Changes

This corrects a mistake in the onboarding flow that replaces the plans route when navigating to create-site route.

## Why are these changes being made?
So that going back from checkout to /plans works in the onboarding flow.

## Testing Instructions

- Make sure you can't reproduce https://github.com/Automattic/wp-calypso/issues/96888.
- Make sure going back to plans then re-selecting a plan yields the correct plan and domain in checkout.
- Make sure going back to domain, clicking Continue, then re-selecting a plan yields the correct plan and domain in checkout.