### PR TITLE
Adds a tooltip to the campaign details chart

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -1305,16 +1305,14 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 
 	&__chart-tooltip-date {
 		color: var(--studio-gray-20);
-		font-size: 0.875rem;
+		font-size: 0.75rem;
 		font-style: normal;
-		font-weight: 400;
 		letter-spacing: -0.15px;
 	}
 
 	&__chart-tooltip-data {
 		color: var(--color-text-white);
-		font-size: 1.25rem;
-		font-style: normal;
+		font-size: 0.875rem;
 		font-weight: 500;
 		letter-spacing: -0.15px;
 	}

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -1297,11 +1297,15 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 
 .campaign-item-details {
 
-	//&__uplot-chart {
-	//	.u-over {
-	//		cursor: none;
-	//	}
-	//}
+	&__chart-tooltip {
+		position: absolute;
+		pointer-events: none;
+		background: var( --color-black );
+		color: var( --color-text-white );
+		padding: 8px 10px;
+		border-radius: 4px;
+		display: none;
+	}
 
 	&__chart-tooltip-date {
 		color: var(--studio-gray-20);

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -1294,3 +1294,36 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 .location-chart__show-more-button {
 	cursor: pointer;
 }
+
+.campaign-item-details {
+
+	&__uplot-chart {
+		.u-over {
+			cursor: none;
+		}
+	}
+
+	&__chart-tooltip-date {
+		color: var(--studio-gray-20);
+		font-size: 0.875rem;
+		font-style: normal;
+		font-weight: 400;
+		letter-spacing: -0.15px;
+	}
+
+	&__chart-tooltip-data {
+		color: var(--color-text-white);
+		font-size: 1.25rem;
+		font-style: normal;
+		font-weight: 500;
+		letter-spacing: -0.15px;
+	}
+
+	&__chart-tooltip-divider {
+		background: var(--studio-gray-90);
+		height: 1px;
+		width: 100%;
+		display: block;
+		margin: 4px 0;
+	}
+}

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -1300,8 +1300,8 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 	&__chart-tooltip {
 		position: absolute;
 		pointer-events: none;
-		background: var( --color-black );
-		color: var( --color-text-white );
+		background: var( --studio-black );
+		color: var( --studio-white );
 		padding: 8px 10px;
 		border-radius: 4px;
 		display: none;

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -1305,6 +1305,7 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 		padding: 8px 10px;
 		border-radius: 4px;
 		display: none;
+		text-align: center;
 	}
 
 	&__chart-tooltip-date {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -1297,11 +1297,11 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 
 .campaign-item-details {
 
-	&__uplot-chart {
-		.u-over {
-			cursor: none;
-		}
-	}
+	//&__uplot-chart {
+	//	.u-over {
+	//		cursor: none;
+	//	}
+	//}
 
 	&__chart-tooltip-date {
 		color: var(--studio-gray-20);

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -29,10 +29,8 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 	const tooltipRef = useRef< HTMLDivElement | null >( null );
 	const lineRef = useRef< HTMLDivElement | null >( null );
 
-	const accentColour = getComputedStyle( document.body )
-		.getPropertyValue( '--color-accent' )
-		.trim();
-	const primaryRGB = hexToRgb( accentColour );
+	const accentColor = getComputedStyle( document.body ).getPropertyValue( '--color-accent' ).trim();
+	const chartColor = hexToRgb( accentColor );
 
 	const updateWidth = () => {
 		const wrapperElement = document.querySelector(
@@ -218,6 +216,11 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 			legend: {
 				show: false, // This will hide the legend
 			},
+			scales: {
+				y: {
+					range: ( self: uPlot, min: number, max: number ) => [ min, max + ( max - min ) * 0.4 ], // Add x% padding at the top to allow space for the tooltip
+				},
+			},
 			series: [
 				{
 					label: 'Date',
@@ -230,10 +233,10 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 				},
 				{
 					label: _.capitalize( source ),
-					stroke: accentColour,
+					stroke: accentColor,
 					width: 3,
 					fill: ( self: uPlot ) => {
-						const { r, g, b } = primaryRGB;
+						const { r, g, b } = chartColor;
 
 						//Get the height so we can create a gradient
 						const height = self?.bbox?.height;
@@ -252,7 +255,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 						return linear?.()( u, seriesIdx, idx0, idx1 ) || null;
 					},
 					points: {
-						show: false,
+						show: true,
 					},
 					value: ( self: uPlot, rawValue: number ) => {
 						return formatValue( rawValue );
@@ -261,7 +264,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 			],
 			plugins: [ tooltipPlugin ],
 		};
-	}, [ width, source, accentColour, formatDate, hourly, primaryRGB ] );
+	}, [ width, source, accentColor, formatDate, hourly, chartColor ] );
 
 	return (
 		<div style={ { position: 'relative' } }>

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -10,6 +10,7 @@ import {
 } from 'calypso/data/promote-post/use-campaign-chart-stats-query';
 import { ChartSourceOptions } from 'calypso/my-sites/promote-post-i2/components/campaign-item-details';
 import 'uplot/dist/uPlot.min.css';
+import { tooltip } from 'calypso/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/tooltip';
 import { formatCents } from 'calypso/my-sites/promote-post-i2/utils';
 
 const DEFAULT_DIMENSIONS = {
@@ -27,7 +28,6 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 	const [ width, setWidth ] = useState( DEFAULT_DIMENSIONS.width );
 	const hourly = resolution === ChartResolution.Hour;
 	const tooltipRef = useRef< HTMLDivElement | null >( null );
-	const lineRef = useRef< HTMLDivElement | null >( null );
 
 	const accentColor = getComputedStyle( document.body ).getPropertyValue( '--color-accent' ).trim();
 	const chartColor = hexToRgb( accentColor );
@@ -59,116 +59,31 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 
 	// Convert to uPlot's AlignedData format
 	const uplotData: uPlot.AlignedData = [ new Float64Array( labels ), new Float64Array( values ) ];
+
 	const locale = useLocale();
 
-	const formatDate = ( date: Date, hourly: boolean ) => {
-		const options: Intl.DateTimeFormatOptions = hourly
-			? { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' }
-			: { month: 'short', day: 'numeric' };
-		return new Intl.DateTimeFormat( locale, options ).format( date );
-	};
-
-	const tooltipPlugin = {
-		hooks: {
-			init: ( u: uPlot ) => {
-				if ( ! tooltipRef.current ) {
-					tooltipRef.current = document.createElement( 'div' );
-					tooltipRef.current.className = 'campaign-item-details__chart-tooltip';
-					tooltipRef.current.style.position = 'absolute';
-					tooltipRef.current.style.pointerEvents = 'none';
-					tooltipRef.current.style.background = 'black';
-					tooltipRef.current.style.color = 'white';
-					tooltipRef.current.style.padding = '8px 10px';
-					tooltipRef.current.style.borderRadius = '4px';
-					tooltipRef.current.style.display = 'none';
-					u.over.parentNode?.appendChild( tooltipRef.current );
-				}
-
-				if ( ! lineRef.current ) {
-					lineRef.current = document.createElement( 'div' );
-					lineRef.current.className = 'campaign-item-details__chart-tooltip-line';
-					lineRef.current.style.position = 'absolute';
-					lineRef.current.style.width = '2px';
-					lineRef.current.style.background = 'rgba(0, 0, 0, 0.12)';
-					lineRef.current.style.top = '0';
-					lineRef.current.style.bottom = '50px';
-					lineRef.current.style.display = 'none';
-					u.over.parentNode?.appendChild( lineRef.current );
-				}
-
-				u.over.addEventListener( 'mousemove', ( e ) => {
-					if ( ! tooltipRef.current || ! lineRef.current ) {
-						return;
-					}
-					const { left } = u.over.getBoundingClientRect();
-					const mouseLeft = e.clientX - left;
-
-					const idx = u.posToIdx( mouseLeft );
-					if ( idx >= 0 && idx < u.data[ 0 ].length ) {
-						const date = u.data[ 0 ][ idx ];
-						const value = u.data[ 1 ][ idx ];
-						if ( value != null ) {
-							tooltipRef.current.style.display = 'block';
-							tooltipRef.current.style.left = mouseLeft + 'px';
-							tooltipRef.current.style.top = '0';
-							tooltipRef.current.innerHTML = `
-								<div class="campaign-item-details__chart-tooltip-date"><strong>${ formatDate(
-									new Date( date * 1000 ),
-									hourly
-								) }</strong></div>
-								<div class="campaign-item-details__chart-tooltip-divider"></div>
-								<div class="campaign-item-details__chart-tooltip-data">${ formatValue( value ) }</div>
-							`;
-
-							lineRef.current.style.display = 'block';
-
-							lineRef.current.style.left = mouseLeft + tooltipRef.current.offsetWidth / 2 + 'px';
-							lineRef.current.style.top = '0';
-						} else {
-							tooltipRef.current.style.display = 'none';
-							lineRef.current.style.display = 'none';
-						}
-					} else {
-						tooltipRef.current.style.display = 'none';
-						lineRef.current.style.display = 'none';
-					}
-				} );
-
-				u.over.addEventListener( 'mouseleave', () => {
-					if ( tooltipRef.current ) {
-						tooltipRef.current.style.display = 'none';
-					}
-					if ( lineRef.current ) {
-						lineRef.current.style.display = 'none';
-					}
-				} );
-			},
-			destroy: () => {
-				if ( tooltipRef.current && tooltipRef.current.parentNode ) {
-					tooltipRef.current.parentNode.removeChild( tooltipRef.current );
-					tooltipRef.current = null;
-				}
-				if ( lineRef.current && lineRef.current.parentNode ) {
-					lineRef.current.parentNode.removeChild( lineRef.current );
-					lineRef.current = null;
-				}
-			},
-		},
-	};
-
-	function formatValue( rawValue: number ) {
-		if ( rawValue == null ) {
-			return '-';
-		}
-
-		if ( source === ChartSourceOptions.Spend ) {
-			return `$${ formatCents( rawValue, 2 ) }`;
-		}
-
-		return rawValue.toLocaleString();
-	}
-
 	const options = useMemo( () => {
+		const formatDate = ( date: Date, hourly: boolean ) => {
+			const options: Intl.DateTimeFormatOptions = hourly
+				? { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' }
+				: { month: 'short', day: 'numeric' };
+			return new Intl.DateTimeFormat( locale, options ).format( date );
+		};
+
+		const tooltipPlugin = tooltip( tooltipRef, formatDate, hourly, formatValue );
+
+		function formatValue( rawValue: number ) {
+			if ( rawValue == null ) {
+				return '-';
+			}
+
+			if ( source === ChartSourceOptions.Spend ) {
+				return `$${ formatCents( rawValue, 2 ) }`;
+			}
+
+			return rawValue.toLocaleString();
+		}
+
 		return {
 			class: 'campaign-item-details__uplot-chart',
 			width: width,
@@ -240,7 +155,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 					fill: ( self: uPlot ) => {
 						const { r, g, b } = chartColor;
 
-						//Get the height so we can create a gradient
+						// Get the height so we can create a gradient
 						const height = self?.bbox?.height;
 						if ( ! height || ! isFinite( height ) ) {
 							return `rgba(${ r }, ${ g }, ${ b }, 0.1)`;
@@ -266,7 +181,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 			],
 			plugins: [ tooltipPlugin ],
 		};
-	}, [ width, source, accentColor, formatDate, hourly, chartColor ] );
+	}, [ hourly, width, source, accentColor, locale, chartColor ] );
 
 	return (
 		<div style={ { position: 'relative' } }>

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -27,6 +27,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 	const [ width, setWidth ] = useState( DEFAULT_DIMENSIONS.width );
 	const hourly = resolution === ChartResolution.Hour;
 	const tooltipRef = useRef< HTMLDivElement | null >( null );
+	const lineRef = useRef< HTMLDivElement | null >( null );
 
 	const accentColour = getComputedStyle( document.body )
 		.getPropertyValue( '--color-accent' )
@@ -85,8 +86,20 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 					u.over.parentNode?.appendChild( tooltipRef.current );
 				}
 
+				if ( ! lineRef.current ) {
+					lineRef.current = document.createElement( 'div' );
+					lineRef.current.className = 'campaign-item-details__chart-tooltip-line';
+					lineRef.current.style.position = 'absolute';
+					lineRef.current.style.width = '2px';
+					lineRef.current.style.background = 'rgba(0, 0, 0, 0.12)';
+					lineRef.current.style.top = '0';
+					lineRef.current.style.bottom = '0';
+					lineRef.current.style.display = 'none';
+					u.over.parentNode?.appendChild( lineRef.current );
+				}
+
 				u.over.addEventListener( 'mousemove', ( e ) => {
-					if ( ! tooltipRef.current ) {
+					if ( ! tooltipRef.current || ! lineRef.current ) {
 						return;
 					}
 					const { left, top } = u.over.getBoundingClientRect();
@@ -109,11 +122,18 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 								<div class="campaign-item-details__chart-tooltip-divider"></div>
 								<div class="campaign-item-details__chart-tooltip-data">${ value.toLocaleString() }</div>
 							`;
+
+							lineRef.current.style.display = 'block';
+
+							lineRef.current.style.left = mouseLeft + tooltipRef.current.offsetWidth / 2 + 'px';
+							lineRef.current.style.top = mouseTop - 20 + 'px';
 						} else {
 							tooltipRef.current.style.display = 'none';
+							lineRef.current.style.display = 'none';
 						}
 					} else {
 						tooltipRef.current.style.display = 'none';
+						lineRef.current.style.display = 'none';
 					}
 				} );
 
@@ -121,12 +141,19 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 					if ( tooltipRef.current ) {
 						tooltipRef.current.style.display = 'none';
 					}
+					if ( lineRef.current ) {
+						lineRef.current.style.display = 'none';
+					}
 				} );
 			},
 			destroy: () => {
 				if ( tooltipRef.current && tooltipRef.current.parentNode ) {
 					tooltipRef.current.parentNode.removeChild( tooltipRef.current );
 					tooltipRef.current = null;
+				}
+				if ( lineRef.current && lineRef.current.parentNode ) {
+					lineRef.current.parentNode.removeChild( lineRef.current );
+					lineRef.current = null;
 				}
 			},
 		},

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -100,9 +100,8 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 					if ( ! tooltipRef.current || ! lineRef.current ) {
 						return;
 					}
-					const { left, top } = u.over.getBoundingClientRect();
+					const { left } = u.over.getBoundingClientRect();
 					const mouseLeft = e.clientX - left;
-					const mouseTop = e.clientY - top;
 
 					const idx = u.posToIdx( mouseLeft );
 					if ( idx >= 0 && idx < u.data[ 0 ].length ) {
@@ -111,7 +110,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 						if ( value != null ) {
 							tooltipRef.current.style.display = 'block';
 							tooltipRef.current.style.left = mouseLeft + 'px';
-							tooltipRef.current.style.top = mouseTop + 'px';
+							tooltipRef.current.style.top = '0';
 							tooltipRef.current.innerHTML = `
 								<div class="campaign-item-details__chart-tooltip-date"><strong>${ formatDate(
 									new Date( date * 1000 ),
@@ -124,7 +123,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 							lineRef.current.style.display = 'block';
 
 							lineRef.current.style.left = mouseLeft + tooltipRef.current.offsetWidth / 2 + 'px';
-							lineRef.current.style.top = mouseTop + 50 + 'px';
+							lineRef.current.style.top = '0';
 						} else {
 							tooltipRef.current.style.display = 'none';
 							lineRef.current.style.display = 'none';
@@ -218,7 +217,10 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 			},
 			scales: {
 				y: {
-					range: ( self: uPlot, min: number, max: number ) => [ min, max + ( max - min ) * 0.4 ], // Add x% padding at the top to allow space for the tooltip
+					range: ( self: uPlot, min: number, max: number ): [ number, number ] => [
+						min,
+						max + ( max - min ) * 0.4,
+					],
 				},
 			},
 			series: [

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -1,6 +1,6 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { hexToRgb } from '@automattic/onboarding';
-import _ from 'lodash';
+import _, { debounce } from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
@@ -42,16 +42,18 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 		}
 	};
 
+	const debouncedUpdateWidth = debounce( updateWidth, 200 );
+
 	useEffect( () => {
 		// Set initial width
 		updateWidth();
-		window.addEventListener( 'resize', updateWidth );
+		window.addEventListener( 'resize', debouncedUpdateWidth );
 
 		return () => {
 			// Remove on unmount
-			window.removeEventListener( 'resize', updateWidth );
+			window.removeEventListener( 'resize', debouncedUpdateWidth );
 		};
-	}, [] );
+	}, [ debouncedUpdateWidth ] );
 
 	// Convert ISO date string to Unix timestamp
 	const labels = data.map( ( entry ) => new Date( entry.date_utc ).getTime() / 1000 );

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -215,6 +215,9 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 					fill: '#fff',
 				},
 			},
+			legend: {
+				show: false, // This will hide the legend
+			},
 			series: [
 				{
 					label: 'Date',

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -93,7 +93,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 					lineRef.current.style.width = '2px';
 					lineRef.current.style.background = 'rgba(0, 0, 0, 0.12)';
 					lineRef.current.style.top = '0';
-					lineRef.current.style.bottom = '0';
+					lineRef.current.style.bottom = '50px';
 					lineRef.current.style.display = 'none';
 					u.over.parentNode?.appendChild( lineRef.current );
 				}
@@ -113,20 +113,20 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 						if ( value != null ) {
 							tooltipRef.current.style.display = 'block';
 							tooltipRef.current.style.left = mouseLeft + 'px';
-							tooltipRef.current.style.top = mouseTop - 40 + 'px';
+							tooltipRef.current.style.top = mouseTop + 'px';
 							tooltipRef.current.innerHTML = `
 								<div class="campaign-item-details__chart-tooltip-date"><strong>${ formatDate(
 									new Date( date * 1000 ),
 									hourly
 								) }</strong></div>
 								<div class="campaign-item-details__chart-tooltip-divider"></div>
-								<div class="campaign-item-details__chart-tooltip-data">${ value.toLocaleString() }</div>
+								<div class="campaign-item-details__chart-tooltip-data">${ formatValue( value ) }</div>
 							`;
 
 							lineRef.current.style.display = 'block';
 
 							lineRef.current.style.left = mouseLeft + tooltipRef.current.offsetWidth / 2 + 'px';
-							lineRef.current.style.top = mouseTop - 20 + 'px';
+							lineRef.current.style.top = mouseTop + 50 + 'px';
 						} else {
 							tooltipRef.current.style.display = 'none';
 							lineRef.current.style.display = 'none';
@@ -158,6 +158,18 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 			},
 		},
 	};
+
+	function formatValue( rawValue: number ) {
+		if ( rawValue == null ) {
+			return '-';
+		}
+
+		if ( source === ChartSourceOptions.Spend ) {
+			return `$${ formatCents( rawValue, 2 ) }`;
+		}
+
+		return rawValue.toLocaleString();
+	}
 
 	const options = useMemo( () => {
 		return {
@@ -240,15 +252,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 						show: false,
 					},
 					value: ( self: uPlot, rawValue: number ) => {
-						if ( rawValue == null ) {
-							return '-';
-						}
-
-						if ( source === ChartSourceOptions.Spend ) {
-							return `$${ formatCents( rawValue, 2 ) }`;
-						}
-
-						return rawValue.toLocaleString();
+						return formatValue( rawValue );
 					},
 				},
 			],

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -136,7 +136,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 				y: {
 					range: ( self: uPlot, min: number, max: number ): [ number, number ] => [
 						min,
-						max + ( max - min ) * 0.4,
+						max + ( max - min ) * 0.4, // Increase the scale by 40%, this allows extra space for the tooltip
 					],
 				},
 			},

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -1,7 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { hexToRgb } from '@automattic/onboarding';
 import _ from 'lodash';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
 import {
@@ -26,6 +26,7 @@ type GraphProps = {
 const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 	const [ width, setWidth ] = useState( DEFAULT_DIMENSIONS.width );
 	const hourly = resolution === ChartResolution.Hour;
+	const tooltipRef = useRef< HTMLDivElement | null >( null );
 
 	const accentColour = getComputedStyle( document.body )
 		.getPropertyValue( '--color-accent' )
@@ -68,9 +69,72 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 		return new Intl.DateTimeFormat( locale, options ).format( date );
 	};
 
+	const tooltipPlugin = {
+		hooks: {
+			init: ( u: uPlot ) => {
+				if ( ! tooltipRef.current ) {
+					tooltipRef.current = document.createElement( 'div' );
+					tooltipRef.current.className = 'campaign-item-details__chart-tooltip';
+					tooltipRef.current.style.position = 'absolute';
+					tooltipRef.current.style.pointerEvents = 'none';
+					tooltipRef.current.style.background = 'black';
+					tooltipRef.current.style.color = 'white';
+					tooltipRef.current.style.padding = '8px 10px';
+					tooltipRef.current.style.borderRadius = '4px';
+					tooltipRef.current.style.display = 'none';
+					u.over.parentNode?.appendChild( tooltipRef.current );
+				}
+
+				u.over.addEventListener( 'mousemove', ( e ) => {
+					if ( ! tooltipRef.current ) {
+						return;
+					}
+					const { left, top } = u.over.getBoundingClientRect();
+					const mouseLeft = e.clientX - left;
+					const mouseTop = e.clientY - top;
+
+					const idx = u.posToIdx( mouseLeft );
+					if ( idx >= 0 && idx < u.data[ 0 ].length ) {
+						const date = u.data[ 0 ][ idx ];
+						const value = u.data[ 1 ][ idx ];
+						if ( value != null ) {
+							tooltipRef.current.style.display = 'block';
+							tooltipRef.current.style.left = mouseLeft + 'px';
+							tooltipRef.current.style.top = mouseTop - 40 + 'px';
+							tooltipRef.current.innerHTML = `
+								<div class="campaign-item-details__chart-tooltip-date"><strong>${ formatDate(
+									new Date( date * 1000 ),
+									hourly
+								) }</strong></div>
+								<div class="campaign-item-details__chart-tooltip-divider"></div>
+								<div class="campaign-item-details__chart-tooltip-data">${ value.toLocaleString() }</div>
+							`;
+						} else {
+							tooltipRef.current.style.display = 'none';
+						}
+					} else {
+						tooltipRef.current.style.display = 'none';
+					}
+				} );
+
+				u.over.addEventListener( 'mouseleave', () => {
+					if ( tooltipRef.current ) {
+						tooltipRef.current.style.display = 'none';
+					}
+				} );
+			},
+			destroy: () => {
+				if ( tooltipRef.current && tooltipRef.current.parentNode ) {
+					tooltipRef.current.parentNode.removeChild( tooltipRef.current );
+					tooltipRef.current = null;
+				}
+			},
+		},
+	};
+
 	const options = useMemo( () => {
 		return {
-			class: 'blaze-stats-line-chart',
+			class: 'campaign-item-details__uplot-chart',
 			width: width,
 			height: DEFAULT_DIMENSIONS.height,
 			tzDate: ( ts: number ) => new Date( ts * 1000 ),
@@ -161,6 +225,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 					},
 				},
 			],
+			plugins: [ tooltipPlugin ],
 		};
 	}, [ width, source, accentColour, formatDate, hourly, primaryRGB ] );
 

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/tooltip.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/tooltip.tsx
@@ -1,3 +1,4 @@
+import { debounce } from 'lodash';
 import React from 'react';
 import uPlot from 'uplot';
 
@@ -16,7 +17,8 @@ export function tooltip(
 					u.over.parentNode?.appendChild( tooltipRef.current );
 				}
 
-				u.over.addEventListener( 'mousemove', ( e ) => {
+				// Debounce the mouse move, to reduce the number of updates
+				const handleMouseMove = debounce( ( e ) => {
 					if ( ! tooltipRef?.current ) {
 						return;
 					}
@@ -25,15 +27,19 @@ export function tooltip(
 					const mouseLeft = e.clientX - left;
 					const activePoint = u.posToIdx( mouseLeft );
 
-					if ( activePoint && tooltipRef.current ) {
+					if ( activePoint >= 0 && tooltipRef.current ) {
 						window.requestAnimationFrame( () => {
 							if ( ! tooltipRef.current ) {
 								return;
 							}
 
 							// Get the highlighted point
-							const xPoint = u.data[ 0 ][ activePoint ] ?? 0;
-							const yPoint = u.data[ 1 ][ activePoint ] ?? 0;
+							const xPoint = u.data[ 0 ][ activePoint ];
+							const yPoint = u.data[ 1 ][ activePoint ];
+							if ( xPoint == null || yPoint == null ) {
+								tooltipRef.current.style.display = 'none';
+								return;
+							}
 
 							// Find where that is on the page
 							const xPos = Math.round( u.valToPos( xPoint, 'x', true ) );
@@ -45,11 +51,13 @@ export function tooltip(
 
 							// If we have a value, put the tooltip just above it.
 							if ( value != null ) {
-								tooltipRef.current.style.display = 'block';
-								tooltipRef.current.style.left = `${ xPos - tooltipRef.current.offsetWidth / 2 }px`;
-								tooltipRef.current.style.top = `${ yPos - 16 - tooltipRef.current.offsetHeight }px`;
+								const tooltip = tooltipRef.current;
+								tooltip.style.display = 'block';
+								tooltip.style.left = `${ xPos - tooltip.offsetWidth / 2 }px`;
+								tooltip.style.top = `${ yPos - 16 - tooltip.offsetHeight }px`;
 
-								tooltipRef.current.innerHTML = `
+								// Only update the content if it has changed to avoid unnecessary reflows
+								const newTooltipContent = `
 									<div class="campaign-item-details__chart-tooltip-date">
 										<strong>${ formatDate( new Date( date * 1000 ), hourly ) }</strong>
 									</div>
@@ -58,8 +66,21 @@ export function tooltip(
 										${ formatValue( value ) }
 									</div>
 								`;
+
+								if ( tooltip.innerHTML !== newTooltipContent ) {
+									tooltip.innerHTML = newTooltipContent;
+								}
 							}
 						} );
+					} else if ( tooltipRef.current ) {
+						tooltipRef.current.style.display = 'none';
+					}
+				}, 8 ); // 120mhz (1000/120 = 8.333ms)
+
+				u.over.addEventListener( 'mousemove', handleMouseMove );
+				u.over.addEventListener( 'mouseleave', () => {
+					if ( tooltipRef.current ) {
+						tooltipRef.current.style.display = 'none';
 					}
 				} );
 			},

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/tooltip.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/tooltip.tsx
@@ -11,22 +11,25 @@ export function tooltip(
 	return {
 		hooks: {
 			init: ( u: uPlot ) => {
+				// Create the tooltip element
 				if ( ! tooltipRef.current ) {
 					tooltipRef.current = document.createElement( 'div' );
 					tooltipRef.current.className = 'campaign-item-details__chart-tooltip';
 					u.over.parentNode?.appendChild( tooltipRef.current );
 				}
 
-				// Debounce the mouse move, to reduce the number of updates
+				// Wrap mouse move in a Debounce to reduce the number of updates
 				const handleMouseMove = debounce( ( e ) => {
 					if ( ! tooltipRef?.current ) {
 						return;
 					}
 
+					// Get the mouse position relative to the chart
 					const { left } = u.over.getBoundingClientRect();
 					const mouseLeft = e.clientX - left;
 					const activePoint = u.posToIdx( mouseLeft );
 
+					// If a point is active, update the tooltip
 					if ( activePoint >= 0 && tooltipRef.current ) {
 						window.requestAnimationFrame( () => {
 							if ( ! tooltipRef.current ) {

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/tooltip.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/tooltip.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import uPlot from 'uplot';
+
+export function tooltip(
+	tooltipRef: React.MutableRefObject< HTMLDivElement | null >,
+	formatDate: ( date: Date, hourly: boolean ) => string,
+	hourly: boolean,
+	formatValue: ( rawValue: number ) => string
+) {
+	return {
+		hooks: {
+			init: ( u: uPlot ) => {
+				if ( ! tooltipRef.current ) {
+					tooltipRef.current = document.createElement( 'div' );
+					tooltipRef.current.className = 'campaign-item-details__chart-tooltip';
+					u.over.parentNode?.appendChild( tooltipRef.current );
+				}
+
+				u.over.addEventListener( 'mousemove', ( e ) => {
+					if ( ! tooltipRef?.current ) {
+						return;
+					}
+
+					const { left } = u.over.getBoundingClientRect();
+					const mouseLeft = e.clientX - left;
+					const activePoint = u.posToIdx( mouseLeft );
+
+					if ( activePoint && tooltipRef.current ) {
+						window.requestAnimationFrame( () => {
+							if ( ! tooltipRef.current ) {
+								return;
+							}
+
+							// Get the highlighted point
+							const xPoint = u.data[ 0 ][ activePoint ] ?? 0;
+							const yPoint = u.data[ 1 ][ activePoint ] ?? 0;
+
+							// Find where that is on the page
+							const xPos = Math.round( u.valToPos( xPoint, 'x', true ) );
+							const yPos = Math.round( u.valToPos( yPoint, 'y', true ) );
+
+							// Get the date / data value
+							const date = u.data[ 0 ][ activePoint ];
+							const value = u.data[ 1 ][ activePoint ];
+
+							// If we have a value, put the tooltip just above it.
+							if ( value != null ) {
+								tooltipRef.current.style.display = 'block';
+								tooltipRef.current.style.left = `${ xPos - tooltipRef.current.offsetWidth / 2 }px`;
+								tooltipRef.current.style.top = `${ yPos - 16 - tooltipRef.current.offsetHeight }px`;
+
+								tooltipRef.current.innerHTML = `
+									<div class="campaign-item-details__chart-tooltip-date">
+										<strong>${ formatDate( new Date( date * 1000 ), hourly ) }</strong>
+									</div>
+									<div class="campaign-item-details__chart-tooltip-divider"></div>
+									<div class="campaign-item-details__chart-tooltip-data">
+										${ formatValue( value ) }
+									</div>
+								`;
+							}
+						} );
+					}
+				} );
+			},
+			destroy: () => {
+				if ( tooltipRef.current && tooltipRef.current.parentNode ) {
+					tooltipRef.current.parentNode.removeChild( tooltipRef.current );
+					tooltipRef.current = null;
+				}
+			},
+		},
+	};
+}


### PR DESCRIPTION
## Proposed Changes

Here are the original designs.
<img width="729" alt="Screenshot 2024-12-04 at 18 19 05" src="https://github.com/user-attachments/assets/99eb04fd-37b4-4b02-855e-0f5ee4541fe3">

However, we discussed some changes with @bartoszbak 
- Snap to the selected point - so the tooltip reflects the data point
- Sit the tooltip 16px above the point
- Show the points permanently - but with a highlighted state
- I've removed the grey line as it was causing an issue with the tooltip mouse position, but also no longer needed now the tooltip is fixed just above the point.




## Testing Instructions

* Hit the campaign details page and hover over the charts, here is an example:

https://github.com/user-attachments/assets/c704dfe1-0b66-423b-9d32-08a341edd159




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
