### PR TITLE
Reader: remove subscribe label in sidebar

### DIFF
--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -136,7 +136,3 @@
 .stream__right-column .reader-feed-header__follow-and-settings {
 	margin-bottom: 24px;
 }
-
-.stream__right-column .reader-subscription-list-item .follow-button__label {
-	display: none;
-}

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -136,3 +136,7 @@
 .stream__right-column .reader-feed-header__follow-and-settings {
 	margin-bottom: 24px;
 }
+
+.stream__right-column .reader-subscription-list-item .follow-button__label {
+	display: none;
+}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -860,6 +860,10 @@
 		margin-bottom: 24px;
 	}
 
+	.reader-subscription-list-item .follow-button__label {
+		display: none;
+	}
+
 	@include breakpoint-deprecated( "<660px" ) {
 		margin: 24px 16px 0;
 

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -130,6 +130,9 @@
 
 	.stream__two-column .stream__right-column {
 		margin-top: 0;
+		.reader-subscription-list-item .follow-button__label {
+			display: none;
+		}
 	}
 
 	.reader-sidebar-site_link {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/235

## Proposed Changes

* Hides the 'Subscribe' label when showing list of sites to follow in the Reader right sidebar

## Before
<img width="1469" alt="Screenshot 2024-12-04 at 18 46 16" src="https://github.com/user-attachments/assets/c5ffd393-e529-4923-8a10-651a7d2a0dd6">

## After
<img width="1475" alt="Screenshot 2024-12-04 at 18 45 58" src="https://github.com/user-attachments/assets/9978e213-efcb-4108-baf1-e4ab38fc2dae">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tidy up UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/read` on calypso live and confirm the subscribe button is not showing the label in the right sidebar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
