### PR TITLE
stats-authors: toggle the "authors" module when there is only one to be displayed

### DIFF
--- a/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
+++ b/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
@@ -12,6 +12,7 @@ import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
 } from 'calypso/state/stats/lists/selectors';
+import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
 import { SUPPORT_URL, JETPACK_SUPPORT_URL_TRAFFIC } from '../../../const';
@@ -44,6 +45,14 @@ const StatAuthors: React.FC< StatsDefaultModuleProps > = ( {
 	const data = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, query )
 	) as [ id: number, label: string ];
+
+	// toggle the module if it's going to show just a single author
+	const isSingleAuthor = data?.length === 1;
+
+	useSelector( ( state ) => {
+		const pageModuleToggles = getModuleToggles( state, siteId, [ 'traffic' ] );
+		pageModuleToggles.authors = ! isSingleAuthor;
+	} );
 
 	return (
 		<>


### PR DESCRIPTION
Resolves #80534

## Proposed Changes

* This PR toggles the stats "Authors" module when only a single author statistic can be rendered there.


## Testing Instructions

Find a site with just a single author active and a site with more active authors:

* http://calypso.localhost:3000/stats/day/farerskiekadry.pl
* http://calypso.localhost:3000/stats/week/`<your team's P2 domain>`?chartStart=2024-09-05&chartEnd=2024-12-03

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
