### PR TITLE
Allow primary field container to fill available space

### DIFF
--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -117,6 +117,7 @@ body.is-reader-full-post {
 
 				.components-flex {
 					align-items: center;
+					flex-grow: 1;
 				}
 
 				.dataviews-view-list__media-wrapper {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -203,7 +203,7 @@ body.is-section-reader {
 		margin-right: 8px;
 	}
 
-	/* @holdercp TODO: This can be removed once calypso/reader/stream/reader-list-followed-sites is removed */
+
 	.sidebar-streams__following-load-more {
 		color: var(--color-link);
 		cursor: pointer;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -742,7 +742,7 @@
 			line-height: 20px;
 		}
 	}
-	/* @holdercp TODO: This can be removed once calypso/reader/stream/reader-list-followed-sites is removed */
+
 	.sidebar-streams__following-load-more {
 		color: var(--color-neutral-100);
 		font-size: $font-body-small;

--- a/client/state/reader-ui/sidebar/actions.js
+++ b/client/state/reader-ui/sidebar/actions.js
@@ -53,7 +53,6 @@ export function toggleReaderSidebarFollowing() {
  * @returns The action object to dispatch.
  */
 export function selectSidebarRecentSite( { feedId } ) {
-	// @holdercp TODO: Determine if tracking is needed here
 	return {
 		type: READER_SIDEBAR_SELECT_RECENT_SITE,
 		feedId,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes  Automattic/loop#237

## Proposed Changes

Enable the post title and featured image container to fill unused space so post titles and images are aligned

| Before | After |
|--------|------|
| <img width="480" alt="image" src="https://github.com/user-attachments/assets/2b052248-0754-4c75-bbb5-3b30409a1f63"> | <img width="480" alt="image" src="https://github.com/user-attachments/assets/1c663d3f-19fb-4c50-87d6-ba4fbbea22e0"> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pe7F0s-2iv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Vist `read?flags=reader/recent-feed-overhaul`
* Select a feed where posts have featured images
* Resize screen to make sure images are always aligned to the right of the column

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
