### PR TITLE
AP: Apply the design updates

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/components/authorization.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/components/authorization.tsx
@@ -1,8 +1,17 @@
 import { NextButton } from '@automattic/onboarding';
-import { check, Icon } from '@wordpress/icons';
+import { Icon, loop, backup, shield } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 
-const AuthorizationBenefits = ( { benefits }: { benefits: string[] } ) => {
+interface AuthorizationBenefitsItem {
+	icon: React.ReactElement;
+	text: string;
+}
+
+interface AuthorizationBenefitsProps {
+	benefits: AuthorizationBenefitsItem[];
+}
+
+const AuthorizationBenefits = ( { benefits }: AuthorizationBenefitsProps ) => {
 	return (
 		<div className="site-migration-application-password-authorization__benefits">
 			{ benefits.map( ( benefit, index ) => (
@@ -11,9 +20,9 @@ const AuthorizationBenefits = ( { benefits }: { benefits: string[] } ) => {
 					key={ index }
 				>
 					<div className="site-migration-application-password-authorization__benefits-item-icon">
-						<Icon icon={ check } size={ 20 } />
+						<Icon icon={ benefit.icon } size={ 20 } />
 					</div>
-					<span>{ benefit }</span>
+					<span>{ benefit.text }</span>
 				</div>
 			) ) }
 		</div>
@@ -47,9 +56,20 @@ const Authorization = ( { onShareCredentialsClick, onAuthorizationClick }: Autho
 				<h3>{ translate( "Here's what else you're getting" ) }</h3>
 				<AuthorizationBenefits
 					benefits={ [
-						translate( 'Uninterrupted service throughout the entire migration experience.' ),
-						translate( 'Unmatched reliability with 99.999% uptime and unmetered traffic.' ),
-						translate( 'Round-the-clock security monitoring and DDoS protection.' ),
+						{
+							icon: loop,
+							text: translate(
+								'Uninterrupted service throughout the entire migration experience.'
+							),
+						},
+						{
+							icon: backup,
+							text: translate( 'Unmatched reliability with 99.999% uptime and unmetered traffic.' ),
+						},
+						{
+							icon: shield,
+							text: translate( 'Round-the-clock security monitoring and DDoS protection.' ),
+						},
 					] }
 				/>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -5,6 +5,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -68,15 +69,14 @@ const SiteMigrationApplicationPasswordsAuthorization: Step = function ( { naviga
 	let notice = undefined;
 	if ( isStoreApplicationPasswordError ) {
 		notice = (
-			<Notice status="is-error" showDismiss={ false }>
-				{ translate( "We couldn't complete the authorization." ) }
-				<button
-					className="button navigation-link step-container__navigation-link has-underline is-borderless site-migration-application-password-authorization__contact-me-button"
-					type="button"
-					onClick={ contactMe }
-				>
-					{ translate( 'Please contact me.' ) }
-				</button>
+			<Notice
+				status="is-warning"
+				showDismiss={ false }
+				text={ translate(
+					'We ran into a problem connecting to your site. Please try again or let us know so we can help you out.'
+				) }
+			>
+				<NoticeAction onClick={ contactMe }>{ translate( 'Get help' ) }</NoticeAction>
 			</Notice>
 		);
 	} else if ( isAuthorizationRejected ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/style.scss
@@ -38,14 +38,14 @@
 		.site-migration-application-password-authorization__benefits-item-icon {
 			width: 42px;
 			height: 42px;
-			background-color: var(--studio-wordpress-blue-10);
+			background-color: var(--studio-gray-5);
 			border-radius: 4px;
 			display: flex;
 			align-items: center;
 			justify-content: center;
 			flex-shrink: 0;
 			svg {
-				fill: var(--studio-wordpress-blue-50);
+				fill: var(--studio-gray-70);
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/test/index.tsx
@@ -79,7 +79,7 @@ describe( 'SiteMigrationApplicationPasswordAuthorization', () => {
 		const initialEntry = `/step?from=${ sourceUrl }&authorizationUrl=${ encodedAuthorizationUrl }&user_login=test&password=test`;
 		render( {}, { initialEntry } );
 
-		const errorMessage = await findByText( /We couldn't complete the authorization./ );
+		const errorMessage = await findByText( /Get help/ );
 
 		await waitFor( () => {
 			expect( errorMessage ).toBeVisible();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #97082

## Proposed Changes

* Fix the icons on the Authorization Step.
* Fix the error message in case we can store the Credentials.

![Captura de Tela 2024-12-04 às 17 12 03](https://github.com/user-attachments/assets/33b7963e-a3be-41f8-be42-9b9e1813fb66)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There were a few outstanding design issues that we needed to tackle separately, beyond that we collected feedback to the new error we introduced.
* p1733342097901209/1733315236.570409-slack-C0Q664T29

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calypso live to avoid the SSL error when trying to authenticate.
* Go through the migration process until you reach the Credentials step.
* Then update the URL to point to the `/setup/site-migration/site-migration-application-password-authorization` path. Keep the current parameters, and add the `authorizationUrl`, which could be a valid authorization URL for the Application Passwords: `https://example.com/wp-admin/authorize-application.php&app_id=1083d914-d9f8-47ec-b49b-55d206104730&app_name=Test`
* You should see the default view, inviting the user to Authorize. Click on the "Authorize" button.
* You should be redirected to your test site.
* Approve the new Application Password.
* You should be redirected to the Authorization step and should see a loading state.
* After the loading state, you'll probably see the Authorization step with an error message, because the endpoint that stores the Password will fail because you don't have the ticket.
* So far this should be enough to test.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?