### PR TITLE
Point plugins link to wp-admin for Jetpack sites

### DIFF
--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -436,7 +436,8 @@ export function useActions( {
 					const wpAdminUrl = getSiteAdminUrl( site );
 					const adminInterface = getAdminInterface( site );
 					const isWpAdminInterface = adminInterface === 'wp-admin';
-					if ( isWpAdminInterface ) {
+					const isSelfHostedJetpack = isNotAtomicJetpack( site );
+					if ( isWpAdminInterface || isSelfHostedJetpack ) {
 						window.location.href = `${ wpAdminUrl }plugins.php`;
 					} else {
 						page( getPluginsUrl( site.slug ) );


### PR DESCRIPTION
Related to pekYwv-4QE-p2#comment-4365

## Proposed Changes

- Changes the plugins link to wp-admin when site is a self hosted Jetpack site.

## Testings

- View the actions menu on /sites for a self hosted jetpack site

![Screenshot_2024-12-05_09-03-18](https://github.com/user-attachments/assets/b63ce3a1-a539-42dd-8b0b-d942d3eb1ee6)
