### PR TITLE
Stats: use today as shortcut ending date / default ending date

### DIFF
--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -29,38 +29,36 @@ export const getShortcuts = createSelector(
 		const siteId = getSelectedSiteId( state );
 		const siteToday = getMomentSiteZone( state, siteId );
 		const siteTodayStr = siteToday.format( DATE_FORMAT );
-		const siteYesterday = isNewDateFilteringEnabled
-			? siteToday.clone().subtract( 1, 'days' )
-			: siteToday.clone();
+		const siteYesterday = siteToday.clone().subtract( 1, 'days' );
 		const yesterdayStr = siteYesterday.format( DATE_FORMAT );
 
 		const supportedShortcutList = [
 			{
 				id: 'last_7_days',
 				label: translateFunction( 'Last 7 Days' ),
-				startDate: siteYesterday.clone().subtract( 6, 'days' ).format( DATE_FORMAT ),
-				endDate: yesterdayStr,
+				startDate: siteToday.clone().subtract( 6, 'days' ).format( DATE_FORMAT ),
+				endDate: siteTodayStr,
 				period: DATERANGE_PERIOD.DAY,
 			},
 			{
 				id: 'last_30_days',
 				label: translateFunction( 'Last 30 Days' ),
-				startDate: siteYesterday.clone().subtract( 29, 'days' ).format( DATE_FORMAT ),
-				endDate: yesterdayStr,
+				startDate: siteToday.clone().subtract( 29, 'days' ).format( DATE_FORMAT ),
+				endDate: siteTodayStr,
 				period: DATERANGE_PERIOD.DAY,
 			},
 			{
 				id: 'last_3_months',
 				label: translateFunction( 'Last 90 Days' ),
-				startDate: siteYesterday.clone().subtract( 89, 'days' ).format( DATE_FORMAT ),
-				endDate: yesterdayStr,
+				startDate: siteToday.clone().subtract( 89, 'days' ).format( DATE_FORMAT ),
+				endDate: siteTodayStr,
 				period: DATERANGE_PERIOD.WEEK,
 			},
 			{
 				id: 'last_year',
 				label: translateFunction( 'Last Year' ),
-				startDate: siteYesterday.clone().subtract( 364, 'days' ).format( DATE_FORMAT ),
-				endDate: yesterdayStr,
+				startDate: siteToday.clone().subtract( 364, 'days' ).format( DATE_FORMAT ),
+				endDate: siteTodayStr,
 				period: DATERANGE_PERIOD.MONTH,
 			},
 			{

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -338,9 +338,7 @@ class StatsSite extends Component {
 			customChartRange = { chartEnd };
 		} else {
 			customChartRange = {
-				chartEnd: isNewDateFilteringEnabled
-					? momentSiteZone.clone().subtract( 1, 'days' ).format( DATE_FORMAT )
-					: momentSiteZone.format( DATE_FORMAT ),
+				chartEnd: momentSiteZone.format( DATE_FORMAT ),
 			};
 		}
 
@@ -395,9 +393,7 @@ class StatsSite extends Component {
 
 			// For StatsDateControl
 			customChartRange.daysInRange = 7;
-			customChartRange.chartEnd = isNewDateFilteringEnabled
-				? momentSiteZone.clone().subtract( 1, 'days' ).format( DATE_FORMAT )
-				: momentSiteZone.format( DATE_FORMAT );
+			customChartRange.chartEnd = momentSiteZone.format( DATE_FORMAT );
 			customChartRange.chartStart = moment( customChartRange.chartEnd )
 				.subtract( customChartRange.daysInRange - 1, 'days' )
 				.format( DATE_FORMAT );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -356,7 +356,7 @@ class StatsSite extends Component {
 			// (e.g. months defaulting to 30 days and showing one point)
 			customChartRange.chartStart = momentSiteZone
 				.clone()
-				.subtract( daysInRange, 'days' )
+				.subtract( daysInRange - 1, 'days' )
 				.format( DATE_FORMAT );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1733354174044339-slack-C0438NHCLSY

## Proposed Changes

* Make Last x days end yesterday makes a lot of sense if the highlight cards are still up at the top of the page. But now that they respect the date range, then incomplete periods shouldn't be a problem anymore, because users are aware today hasn't ended yet.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live for a p2 `/stats/day/your-site.com`
* Ensure the default date range ending today
* Click some of the date range shortcuts
* Ensure the ranges end today as well
* Apply the range
* Ensure everything looks okay 

<img width="1207" alt="image" src="https://github.com/user-attachments/assets/c5c4b547-a7c3-4d2a-b015-6f9dd9e5eda2">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?