### PR TITLE
Site logs: hide unexpected pagination numbers

### DIFF
--- a/client/sites/tools/logs/components/site-logs.tsx
+++ b/client/sites/tools/logs/components/site-logs.tsx
@@ -20,6 +20,8 @@ import { SiteLogsTable } from './site-logs-table';
 import { SiteLogsToolbar } from './site-logs-toolbar';
 import type { Moment } from 'moment';
 
+import './style.scss';
+
 export type LogType = 'php' | 'web';
 
 const DEFAULT_PAGE_SIZE = 50;

--- a/client/sites/tools/logs/components/style.scss
+++ b/client/sites/tools/logs/components/style.scss
@@ -1,0 +1,7 @@
+.site-logs-container {
+	// The logging API doesn't allow us to jump directly to a page, so hide page buttons.
+	.pagination__page-number,
+	.pagination__ellipsis {
+		display: none;
+	}
+}

--- a/client/sites/tools/monitoring/components/style.scss
+++ b/client/sites/tools/monitoring/components/style.scss
@@ -90,23 +90,6 @@ div.is-section-site-monitoring:not(.is-global-sidebar-visible) {
 
 .site-monitoring {
 	position: relative;
-
-	// The logging API doesn't allow us to jump directly to a page, so hide page buttons.
-	.pagination__page-number,
-	.pagination__ellipsis {
-		display: none;
-	}
-
-	&.is-loading {
-		.site-logs__monitoring-text {
-			opacity: 0.5;
-		}
-
-		.site-logs__monitoring-click-guard {
-			pointer-events: none;
-			opacity: 0.5;
-		}
-	}
 }
 
 .site-monitoring .components-tab-panel__tab-content,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/92668

## Proposed Changes

This PR restores the behavior of the original PR that introduced the pagination for site logs:

- https://github.com/Automattic/wp-calypso/pull/74935

The pagination is supposed to only show Prev and Next buttons, without any page numbers, due to the limitation of the backend endpoint. The above PR does that by hiding the page numbers via CSS. I believe, we broke that CSS somehow when we moved the feature to the Hosting Dashboard.

|Before|After|
|-|-|
|<img width="443" alt="image" src="https://github.com/user-attachments/assets/9e62f0f8-438d-4b93-8c30-1a6e6339df27">|<img width="273" alt="image" src="https://github.com/user-attachments/assets/e9a8b561-063c-4a8e-bd6f-d867221cdf57">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes a regression.

## Testing Instructions

1. Go to /sites?flags=-untangling/hosting-menu
2. Click an Atomic site.
3. Click Logs tab.
4. Click the Web server subtab (so that you can see bunch of logs already)
5. Scroll down and check that the Prev/Next pagination controls are working.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
