### PR TITLE
In progress: Don't recommend transferring unsupported domain and don't connect unregistered domains

### DIFF
--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -335,7 +335,7 @@ function ConnectDomainStep( {
 			return <div className={ baseClassName + '__sidebar-placeholder' }></div>;
 		}
 
-		if ( ! isStepStart ) {
+		if ( ! isStepStart || ! domainSetupInfo?.data?.is_supported_tld ) {
 			return null;
 		}
 

--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -8,7 +8,7 @@ export function getAvailabilityErrorMessage( { availabilityData, domainName, sel
 	const { status, mappable, maintenance_end_time, other_site_domain, other_site_domain_only } =
 		availabilityData;
 
-	if ( domainAvailability.AVAILABLE === status ) {
+	if ( [ status, mappable ].includes( domainAvailability.AVAILABLE ) ) {
 		if ( selectedSite ) {
 			const searchPageLink = domainAddNew( selectedSite.slug, domainName );
 			return createInterpolateElement(


### PR DESCRIPTION
Introduces logic to hide the recommendation to transfer an unsupported domain to wp.com

related to code-D166359

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Hides suggestion to transfer when the tld is not supported
 
![image](https://github.com/user-attachments/assets/6257346b-4059-4a20-a22a-d997f9ef6586)

- Don't continue forward to the Transfer/Connect step at all if the domain is not Registered
![image](https://github.com/user-attachments/assets/23ec2359-7da2-4a2c-9dc0-3f5ee74202ae)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid asking customers to do things that are unsupported, giving a false impression

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff
* Apply this backend diff: 170089-ghe-Automattic/wpcom
* Build and proxy Calypso
* Proxy for Sandbox
* Navigate to a site you own
* Navigate to Upgrades > Domains
* Select 'Use a Domain I Own' from the dropdown
* ![image](https://github.com/user-attachments/assets/3be4291b-c563-4c42-9118-11937d5e034c)

TEST CASE 1 - Unsupported, Registered Domain:
- Enter 'google.pl', or another UNSUPPORTED TLD that is definitely registered (elsewhere)
- On the next page, ensure the "Transfer [Recommended]" side banner is not shown

TEST CASE 2 - Unsupported, Unregistered Domain:
- Enter 'veryfakedomain12345.pl' or another Unsupported TLD that is certainly not registered here or anywhere
- You should see the same error that you would see with 'veryfakedomain12345.com' (a supported tld), suggesting you seek further answers on the Domain Search page

TEST CASE 3 - Supported Unregistered Domain:
- Enter 'veryfakedomain12345.com' or another Supported TLD that is unequivocally  not registered here or anywhere
- You should see the same error from Test Case 2, this is the current experience and should be unchanged

TEST CASE  - Supported Registered Domain:
- Enter 'google.com' or another supported TLD that is unquestionably registered elsewhere
- On the next page, ensure the "Transfer [Recommended]" side banner IS shown, as per the current (and unchanged) functionality


