### PR TITLE
Design Picker: Map goals to multi taxonomies

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -1,14 +1,57 @@
 import { Onboard } from '@automattic/data-stores';
 import { Category } from '@automattic/design-picker';
 
-const CATEGORY_BLOG = 'blog';
-const CATEGORY_STORE = 'store';
-const CATEGORY_BUSINESS = 'business';
-const CATEGORY_COMMUNITY_NON_PROFIT = 'community-non-profit';
-const CATEGORY_PORTFOLIO = 'portfolio';
-const CATEGORY_AUTHORS_WRITERS = 'authors-writers';
-const CATEGORY_EDUCATION = 'education';
-const CATEGORY_ENTERTAINMENT = 'entertainment';
+const CATEGORIES = {
+	/**
+	 * Features
+	 */
+	BLOG: 'blog',
+	NEWSLETTER: 'newsletter',
+	PORTFOLIO: 'portfolio',
+	PODCAST: 'podcast',
+	STORE: 'store',
+
+	/**
+	 * Subjects
+	 */
+	BUSINESS: 'business',
+	COMMUNITY_NON_PROFIT: 'community-non-profit',
+	AUTHORS_WRITERS: 'authors-writers',
+	EDUCATION: 'education',
+	ENTERTAINMENT: 'entertainment',
+	EVENTS: 'events',
+	LINK_IN_BIO: 'link-in-bio',
+};
+
+const GOALS_TO_CATEGORIES: { [ key in Onboard.SiteGoal ]: string[] } = {
+	[ Onboard.SiteGoal.Write ]: [ CATEGORIES.BLOG, CATEGORIES.NEWSLETTER ],
+	[ Onboard.SiteGoal.Courses ]: [ CATEGORIES.EDUCATION ],
+	[ Onboard.SiteGoal.AnnounceEvents ]: [ CATEGORIES.EVENTS ],
+	[ Onboard.SiteGoal.Porfolio ]: [ CATEGORIES.PORTFOLIO ],
+	[ Onboard.SiteGoal.PaidSubscribers ]: [ CATEGORIES.NEWSLETTER, CATEGORIES.BLOG ],
+	[ Onboard.SiteGoal.Promote ]: [ CATEGORIES.BUSINESS, CATEGORIES.LINK_IN_BIO ],
+	[ Onboard.SiteGoal.CollectDonations ]: [ CATEGORIES.COMMUNITY_NON_PROFIT ],
+	[ Onboard.SiteGoal.Newsletter ]: [ CATEGORIES.NEWSLETTER, CATEGORIES.BLOG ],
+	[ Onboard.SiteGoal.Engagement ]: [
+		CATEGORIES.PODCAST,
+		CATEGORIES.BLOG,
+		CATEGORIES.NEWSLETTER,
+		CATEGORIES.LINK_IN_BIO,
+	],
+	[ Onboard.SiteGoal.SellPhysical ]: [ CATEGORIES.STORE ],
+	[ Onboard.SiteGoal.Videos ]: [ CATEGORIES.PORTFOLIO ],
+	[ Onboard.SiteGoal.ContactForm ]: [ CATEGORIES.BUSINESS ],
+	[ Onboard.SiteGoal.BuildNonprofit ]: [ CATEGORIES.COMMUNITY_NON_PROFIT, CATEGORIES.EDUCATION ],
+	[ Onboard.SiteGoal.SellDigital ]: [ CATEGORIES.STORE, CATEGORIES.BUSINESS ],
+
+	// The following goals are deprecated. They are no longer availabe in the goals
+	// signup step, but existing sites still use them.
+	[ Onboard.SiteGoal.Sell ]: [ CATEGORIES.STORE ],
+	[ Onboard.SiteGoal.DIFM ]: [ CATEGORIES.BUSINESS ],
+	[ Onboard.SiteGoal.Import ]: [ CATEGORIES.BUSINESS ],
+	[ Onboard.SiteGoal.ImportSubscribers ]: [ CATEGORIES.BUSINESS ],
+	[ Onboard.SiteGoal.Other ]: [ CATEGORIES.BUSINESS ],
+};
 
 /**
  * Ensures the category appears at the top of the design category list
@@ -29,17 +72,20 @@ function makeSortCategoryToTop( slugs: string[] ) {
 	};
 }
 
-const sortBlogToTop = makeSortCategoryToTop( [ CATEGORY_BLOG ] );
-const sortStoreToTop = makeSortCategoryToTop( [ CATEGORY_STORE ] );
-const sortBusinessToTop = makeSortCategoryToTop( [ CATEGORY_BUSINESS ] );
+const sortBlogToTop = makeSortCategoryToTop( [ CATEGORIES.BLOG ] );
+const sortStoreToTop = makeSortCategoryToTop( [ CATEGORIES.STORE ] );
+const sortBusinessToTop = makeSortCategoryToTop( [ CATEGORIES.BUSINESS ] );
 
 export function getCategorizationOptions(
 	intent: string,
 	goals: Onboard.SiteGoal[],
-	useGoals: boolean
+	options: {
+		useGoals?: boolean;
+		isMultiSelection?: boolean;
+	} = {}
 ) {
-	if ( useGoals ) {
-		return getCategorizationFromGoals( goals );
+	if ( options.useGoals ) {
+		return getCategorizationFromGoals( goals, options.isMultiSelection );
 	}
 	return getCategorizationFromIntent( intent );
 }
@@ -56,19 +102,19 @@ function getCategorizationFromIntent( intent: string ) {
 		case 'write':
 			return {
 				...result,
-				defaultSelections: [ CATEGORY_BLOG ],
+				defaultSelections: [ CATEGORIES.BLOG ],
 				sort: sortBlogToTop,
 			};
 		case 'sell':
 			return {
 				...result,
-				defaultSelections: [ CATEGORY_STORE ],
+				defaultSelections: [ CATEGORIES.STORE ],
 				sort: sortStoreToTop,
 			};
 		case 'build':
 			return {
 				...result,
-				defaultSelections: [ CATEGORY_BUSINESS ],
+				defaultSelections: [ CATEGORIES.BUSINESS ],
 				sort: sortBusinessToTop,
 			};
 		default:
@@ -79,35 +125,44 @@ function getCategorizationFromIntent( intent: string ) {
 	}
 }
 
-function getCategorizationFromGoals( goals: Onboard.SiteGoal[] ) {
+function getCategorizationFromGoals(
+	goals: Onboard.SiteGoal[],
+	isMultiSelection: boolean = false
+) {
 	// Sorted according to which theme category makes the most consequential impact
 	// on the user's site e.g. if you want a store, then choosing a Woo compatible
 	// theme is more important than choosing a theme that is good for blogging.
 	// Missing categories are treated as equally inconsequential.
 	const mostConsequentialDesignCategories = [
-		CATEGORY_STORE,
-		CATEGORY_EDUCATION,
-		CATEGORY_COMMUNITY_NON_PROFIT,
-		CATEGORY_ENTERTAINMENT,
-		CATEGORY_PORTFOLIO,
-		CATEGORY_BLOG,
-		CATEGORY_AUTHORS_WRITERS,
+		CATEGORIES.STORE,
+		CATEGORIES.EDUCATION,
+		CATEGORIES.COMMUNITY_NON_PROFIT,
+		CATEGORIES.ENTERTAINMENT,
+		CATEGORIES.PORTFOLIO,
+		CATEGORIES.BLOG,
+		CATEGORIES.AUTHORS_WRITERS,
 	];
 
-	const defaultSelections = goals.flatMap( getGoalsPreferredCategory ).sort( ( a, b ) => {
-		let aIndex = mostConsequentialDesignCategories.indexOf( a );
-		let bIndex = mostConsequentialDesignCategories.indexOf( b );
+	const defaultSelections = goals
+		.map( ( goal ) => {
+			const preferredCategories = getGoalsPreferredCategories( goal );
+			return isMultiSelection ? preferredCategories : preferredCategories.slice( 0, 1 );
+		} )
+		.flat()
+		.sort( ( a, b ) => {
+			let aIndex = mostConsequentialDesignCategories.indexOf( a );
+			let bIndex = mostConsequentialDesignCategories.indexOf( b );
 
-		// If the category is not in the list, it should be sorted to the end.
-		if ( aIndex === -1 ) {
-			aIndex = mostConsequentialDesignCategories.length;
-		}
-		if ( bIndex === -1 ) {
-			bIndex = mostConsequentialDesignCategories.length;
-		}
+			// If the category is not in the list, it should be sorted to the end.
+			if ( aIndex === -1 ) {
+				aIndex = mostConsequentialDesignCategories.length;
+			}
+			if ( bIndex === -1 ) {
+				bIndex = mostConsequentialDesignCategories.length;
+			}
 
-		return aIndex - bIndex;
-	} ) ?? [ CATEGORY_BUSINESS ];
+			return aIndex - bIndex;
+		} ) ?? [ CATEGORIES.BUSINESS ];
 
 	return {
 		defaultSelections,
@@ -115,43 +170,6 @@ function getCategorizationFromGoals( goals: Onboard.SiteGoal[] ) {
 	};
 }
 
-function getGoalsPreferredCategory( goal: Onboard.SiteGoal ): string[] {
-	switch ( goal ) {
-		case Onboard.SiteGoal.Write:
-			return [ CATEGORY_BLOG ];
-
-		case Onboard.SiteGoal.CollectDonations:
-		case Onboard.SiteGoal.BuildNonprofit:
-			return [ CATEGORY_COMMUNITY_NON_PROFIT ];
-
-		case Onboard.SiteGoal.Porfolio:
-			return [ CATEGORY_PORTFOLIO ];
-
-		case Onboard.SiteGoal.Newsletter:
-		case Onboard.SiteGoal.PaidSubscribers:
-			return [ CATEGORY_AUTHORS_WRITERS ];
-
-		case Onboard.SiteGoal.SellDigital:
-		case Onboard.SiteGoal.SellPhysical:
-		case Onboard.SiteGoal.Sell:
-			return [ CATEGORY_STORE ];
-
-		case Onboard.SiteGoal.Courses:
-			return [ CATEGORY_EDUCATION ];
-
-		case Onboard.SiteGoal.Videos:
-		case Onboard.SiteGoal.AnnounceEvents:
-			return [ CATEGORY_ENTERTAINMENT ];
-
-		case Onboard.SiteGoal.Engagement:
-		case Onboard.SiteGoal.Promote:
-		case Onboard.SiteGoal.ContactForm:
-		case Onboard.SiteGoal.Import:
-		case Onboard.SiteGoal.ImportSubscribers:
-		case Onboard.SiteGoal.Other:
-		case Onboard.SiteGoal.DIFM:
-			return [ CATEGORY_BUSINESS ];
-		default:
-			return [];
-	}
+function getGoalsPreferredCategories( goal: Onboard.SiteGoal ): string[] {
+	return GOALS_TO_CATEGORIES[ goal ] || [];
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -229,11 +229,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		}
 	}, [ hasTrackedView, designs ] );
 
-	const categorizationOptions = getCategorizationOptions(
-		intent,
-		goals,
-		addedGoalsExpAssignment?.variationName === 'treatment'
-	);
+	const categorizationOptions = getCategorizationOptions( intent, goals, {
+		useGoals: addedGoalsExpAssignment?.variationName === 'treatment',
+		isMultiSelection: isGoalCentricFeature,
+	} );
 	const categorization = useCategorization( allDesigns?.filters?.subject || EMPTY_OBJECT, {
 		...categorizationOptions,
 		isMultiSelection: isGoalCentricFeature,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10015

## Proposed Changes

* Map goals to multi taxonomies. Will improve the sorting in the follow-up PR.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Select goals on the Goals screen
* On the Design Picker screen, ensure the default selected categories match the https://github.com/Automattic/dotcom-forge/issues/10015 if the category is there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
