### PR TITLE
Stats: Fix applying the custom range shortcut without dates

### DIFF
--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -30,7 +30,7 @@ const DateRangePickerShortcuts = ( {
 	isNewDateFilteringEnabled = false,
 }: {
 	currentShortcut?: string;
-	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment, shortcutId: string ) => void;
+	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment ) => void;
 	onShortcutClick?: ( shortcut: DateRangePickerShortcut ) => void;
 	locked?: boolean;
 	startDate?: MomentOrNull;
@@ -59,7 +59,9 @@ const DateRangePickerShortcuts = ( {
 
 	const handleClick = ( shortcut: DateRangePickerShortcut ) => {
 		! locked &&
-			onClick( moment( shortcut.startDate ), moment( shortcut.endDate ), shortcut.id || '' );
+			shortcut.startDate &&
+			shortcut.endDate &&
+			onClick( moment( shortcut.startDate ), moment( shortcut.endDate ) );
 
 		// Call the onShortcutClick if provided
 		onShortcutClick && onShortcutClick( shortcut );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/303

## Proposed Changes

* Prevent clicking on the `Custom Range` shortcut that doesn't have corresponding start and end dates.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `Custom Range` shortcut should be used to display the selected range rather than being clickable to apply the start and end dates.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Launch the date range picker.
* Click on the `Custom Range` shortcut.
* Ensure the `Custom Range` shortcut is not clickable and does not apply any values to the `From` and `To` inputs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
