### PR TITLE
Restrict Site Transfer Input to Email Addresses

### DIFF
--- a/client/my-sites/people/team-members-site-transfer/index.tsx
+++ b/client/my-sites/people/team-members-site-transfer/index.tsx
@@ -29,7 +29,7 @@ function TeamMembersSiteTransfer( props: Props ) {
 	}
 
 	function onClick( user: Member ) {
-		props.onClick( user.login );
+		props.onClick( user.email as string );
 	}
 
 	function renderPerson( user: Member ) {

--- a/client/sites/settings/administration/tools/transfer-site/site-owner-user-search.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/site-owner-user-search.tsx
@@ -87,9 +87,9 @@ const SiteOwnerTransferEligibility = ( {
 		checkSiteTransferEligibility( { newSiteOwner: tempSiteOwner } );
 	};
 
-	function onUserClick( userLogin: string ) {
-		onRecipientChange( userLogin );
-		checkSiteTransferEligibility( { newSiteOwner: userLogin } );
+	function onUserClick( userEmail: string ) {
+		onRecipientChange( userEmail );
+		checkSiteTransferEligibility( { newSiteOwner: userEmail } );
 	}
 
 	function onRecipientChange( recipient: string ) {
@@ -102,7 +102,7 @@ const SiteOwnerTransferEligibility = ( {
 		<form onSubmit={ handleFormSubmit }>
 			<FormText>
 				{ translate(
-					"Ready to transfer {{strong}}%(siteSlug)s{{/strong}} and its associated purchases? Simply enter the new owner's email or WordPress.com username below, or choose an existing user to start the transfer process.",
+					"Ready to transfer {{strong}}%(siteSlug)s{{/strong}} and its associated purchases? Simply enter the new owner's email below, or choose an existing user to start the transfer process.",
 					{
 						args: { siteSlug },
 						components: { strong: <Strong /> },
@@ -111,13 +111,13 @@ const SiteOwnerTransferEligibility = ( {
 			</FormText>
 
 			<FormFieldset>
-				<FormLabel>{ translate( 'Email or WordPress.com username' ) }</FormLabel>
+				<FormLabel>{ translate( 'Email' ) }</FormLabel>
 				<FormTextInput
 					id="recipient"
 					name="recipient"
 					value={ tempSiteOwner }
 					isError={ recipientError }
-					placeholder="@"
+					placeholder="example@example.com"
 					onChange={ ( e: ChangeEvent< HTMLInputElement > ) => onRecipientChange( e.target.value ) }
 				/>
 				{ recipientError && (
@@ -144,7 +144,7 @@ const SiteOwnerTransferEligibility = ( {
 				<TeamMembersSiteTransfer
 					search={ tempSiteOwner }
 					usersQuery={ usersQuery }
-					onClick={ ( userLogin: string ) => onUserClick( userLogin ) }
+					onClick={ ( userEmail: string ) => onUserClick( userEmail ) }
 				/>
 			) }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/87001, D137375-code, D167877-code

## Proposed Changes

This PR modifies the site transfer functionality to restrict the transfer input field to only accept email addresses, disallowing usernames. 

- This also resolves p1733387208740199/1733361636.672369-slack-CRWCHQGUB indirectly. 
- Site members can still be searched by username (the value being sent will be the email). I believe this approach provides good enough usability.
- Users can transfer Jetpack-connected sites via /settings/manage-connection/:siteSlug. This process is already safe because the recipient is selected from a list of site administrators, eliminating the user-input field. 

UI changes;
| before | after |
|--------|--------|
| <img width="752" alt="Screenshot 2024-12-06 at 11 46 52" src="https://github.com/user-attachments/assets/b2dd9490-3cbb-4dbd-a8b9-6a46ce2f0b05"> | <img width="759" alt="Screenshot 2024-12-06 at 11 46 56" src="https://github.com/user-attachments/assets/cb629a1e-c7b3-40ac-b347-399199ba22bc"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This change addresses an issue where users might mistakenly enter a username instead of an email address, causing transfer emails to be sent to unintended recipients. https://github.com/Automattic/dotcom-forge/issues/8540

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch D167877-code to your sandbox
* Go to `/settings/start-site-transfer/<site>?flags=-untangling/hosting-menu`

Transfer to a non-member of your site;

* Input a username
* Click "Continue"
* Observe the error: "The specified email is not a valid email address."
* Input an email
* Click "Continue"
* Observe the UI is redirected to "Confirm site transfer"
* Accept statements and click "Start transfer"
* Observe the email is sent to the user

Transfer to a member of your site;

* Input a username
* Observe the user is displayed
* Click "Continue"
* Observe the error: "The specified email is not a valid email address."
* Click "Transfer ownership"
* Observe the UI is redirected to "Confirm site transfer"
* Accept statements and click "Start transfer"
* Observe the email is sent to the user

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?