### PR TITLE
Sunset Site Assembler: Skip Site Assembler in the assembler-first flow

### DIFF
--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -23,6 +23,8 @@ import {
 } from './internals/types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { CalypsoDispatch } from 'calypso/state/types';
+import type { AnyAction } from 'redux';
+import type { ThunkAction } from 'redux-thunk';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -90,7 +92,7 @@ const assemblerFirstFlow: Flow = {
 
 		const handleSelectSite = ( providedDependencies: ProvidedDependencies = {} ) => {
 			const selectedSiteSlug = providedDependencies?.siteSlug as string;
-			const selectedSiteId = providedDependencies?.siteId as string;
+			const selectedSiteId = providedDependencies?.siteId as number;
 			setSelectedSite( selectedSiteId );
 			setIntentOnSite( selectedSiteSlug, SiteIntent.AssemblerFirst );
 			saveSiteSettings( selectedSiteId, { launchpad_screen: 'full' } );

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -1,12 +1,14 @@
 import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
-import { getAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
+import { getAssemblerDesign } from '@automattic/design-picker';
 import { ASSEMBLER_FIRST_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
+import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { activateOrInstallThenActivate } from 'calypso/state/themes/actions';
 import { getTheme } from 'calypso/state/themes/selectors';
 import { useSiteData } from '../hooks/use-site-data';
 import { ONBOARD_STORE, SITE_STORE } from '../stores';
@@ -20,6 +22,7 @@ import {
 	ProvidedDependencies,
 } from './internals/types';
 import type { OnboardSelect } from '@automattic/data-stores';
+import type { CalypsoDispatch } from 'calypso/state/types';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -82,45 +85,21 @@ const assemblerFirstFlow: Flow = {
 		const { setPendingAction, setSelectedSite } = useDispatch( ONBOARD_STORE );
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 		const { site, siteSlug, siteId } = useSiteData();
-
-		const exitFlow = ( to: string ) => {
-			setPendingAction( () => {
-				return new Promise( () => {
-					window.location.assign( to );
-				} );
-			} );
-
-			return navigate( 'processing' );
-		};
+		const reduxDispatch = useReduxDispatch();
+		const selectedTheme = getAssemblerDesign().slug;
 
 		const handleSelectSite = ( providedDependencies: ProvidedDependencies = {} ) => {
 			const selectedSiteSlug = providedDependencies?.siteSlug as string;
 			const selectedSiteId = providedDependencies?.siteId as string;
-			const isNewSite = providedDependencies?.isNewSite === 'true';
 			setSelectedSite( selectedSiteId );
 			setIntentOnSite( selectedSiteSlug, SiteIntent.AssemblerFirst );
 			saveSiteSettings( selectedSiteId, { launchpad_screen: 'full' } );
 
-			// Check whether to go to the assembler. If not, go to the site editor directly
-			let params;
-			if ( ! isAssemblerSupported() ) {
-				params = new URLSearchParams( {
-					canvas: 'edit',
-					assembler: '1',
-				} );
+			setPendingAction(
+				enableAssemblerTheme( selectedTheme, selectedSiteId, selectedSiteSlug, reduxDispatch )
+			);
 
-				return `/site-editor/${ selectedSiteSlug }?${ params }`;
-			}
-
-			// Carry over the current search parameters
-			params = new URLSearchParams( window.location.search );
-			params.set( 'siteSlug', selectedSiteSlug );
-			params.set( 'siteId', selectedSiteId );
-			if ( isNewSite ) {
-				params.set( 'isNewSite', 'true' );
-			}
-
-			return navigate( `pattern-assembler?${ params }` );
+			navigate( 'processing' );
 		};
 
 		const submit = async (
@@ -183,12 +162,7 @@ const assemblerFirstFlow: Flow = {
 						return;
 					}
 
-					const params = new URLSearchParams( {
-						canvas: 'edit',
-						assembler: '1',
-					} );
-
-					return exitFlow( `/site-editor/${ siteSlug }?${ params }` );
+					return;
 				}
 
 				case 'pattern-assembler': {
@@ -292,5 +266,31 @@ const assemblerFirstFlow: Flow = {
 		return result;
 	},
 };
+
+function enableAssemblerTheme(
+	themeId: string,
+	siteId: number,
+	siteSlug: string,
+	reduxDispatch: CalypsoDispatch
+) {
+	const params = new URLSearchParams( {
+		canvas: 'edit',
+		assembler: '1',
+	} );
+
+	return () =>
+		Promise.resolve()
+			.then( () =>
+				reduxDispatch(
+					activateOrInstallThenActivate( themeId, siteId, { source: 'assembler' } ) as ThunkAction<
+						PromiseLike< string >,
+						any,
+						any,
+						AnyAction
+					>
+				)
+			)
+			.then( () => window.location.assign( `/site-editor/${ siteSlug }?${ params }` ) );
+}
 
 export default assemblerFirstFlow;


### PR DESCRIPTION
## Proposed Changes

In preparation of sunsetting the Site Assembler, this PR updates the assembler-first flow by skipping the Site Assembler and directly activating the Assembler theme.

Note that the assembler-first flow is still available in https://wordpress.com/patterns, which is why it cannot be deprecated yet. Also, some HEs are providing the assembler-first flow URL directly to users that ask for the Site Assembler.

We will give a heads-up before merging that this URL will no longer serve as an entry point to the Site Assembler.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sunset Site Assembler.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /setup/assembler-first.
* Select either "Select a site" or "Start a new site".
* Continue the flow and ensure that you see the processing screen, then redirected to the Site Editor.
* Go back to the Dashboard, and ensure that the site is using the theme Assembler.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
