### PR TITLE
fix the header color in dsp widget

### DIFF
--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -20,7 +20,7 @@ $heading-font-body-small: 15px;
 		padding: 0 rem(24px);
 		position: fixed;
 		width: calc(100% - 3rem);
-		background: var(--theme-text-color);
+		background: var(--studio-white);
 		z-index: 1000;
 
 		@include break-large {


### PR DESCRIPTION


## Proposed Changes

this is a minor fix for the DSP client widget

I noticed that then the widget loads we have the theme color for the header bar

<img width="422" alt="Screenshot 2024-12-05 at 12 31 18 PM" src="https://github.com/user-attachments/assets/70dbd173-49d8-4769-b842-8dc5e7caaa09">

this doesn't look that good depending on the theme selected

after version will always be white

<img width="635" alt="Screenshot 2024-12-05 at 12 33 14 PM" src="https://github.com/user-attachments/assets/079be154-2782-4971-8bc8-6f93d8fee874">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

just CR is enough I think

if you want to test it just fire up the branch and change your theme (Users-> profile) I have classic bright selected

open up the advertising-> create campaign to load the DSP widget

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
