### PR TITLE
Linear charts & remove duplicate days buttons

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -467,7 +467,7 @@ export default function CampaignItemDetails( props: Props ) {
 			],
 		},
 		{
-			condition: activeDays >= 7,
+			condition: activeDays > 7,
 			controls: [
 				{
 					onClick: () => updateChartParams( ChartSourceDateRanges.LAST_7_DAYS ),
@@ -477,7 +477,7 @@ export default function CampaignItemDetails( props: Props ) {
 			],
 		},
 		{
-			condition: activeDays >= 14,
+			condition: activeDays > 14,
 			controls: [
 				{
 					onClick: () => updateChartParams( ChartSourceDateRanges.LAST_14_DAYS ),
@@ -487,7 +487,7 @@ export default function CampaignItemDetails( props: Props ) {
 			],
 		},
 		{
-			condition: activeDays >= 30,
+			condition: activeDays > 30,
 			controls: [
 				{
 					onClick: () => updateChartParams( ChartSourceDateRanges.LAST_30_DAYS ),

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -142,8 +142,8 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 						return gradient;
 					},
 					paths: ( u: uPlot, seriesIdx: number, idx0: number, idx1: number ) => {
-						const { spline } = uPlot.paths;
-						return spline?.()( u, seriesIdx, idx0, idx1 ) || null;
+						const { linear } = uPlot.paths;
+						return linear?.()( u, seriesIdx, idx0, idx1 ) || null;
 					},
 					points: {
 						show: false,


### PR DESCRIPTION
## Proposed Changes

* Fixes DSP issues 2899 & 2890

- Don't show the last X days button if X is equal to "whole campaign" - means we have 2 buttons that do the same thing.
- Make the line chart linear, this should more accurately represent the data than the previous curved lines

## Testing Instructions

Code review should be adequate

- Find a 7-day campaign
- It should only show the "whole campaign" and not "last 7 days" button 
- It can show "today/yesterday" if it is still active
- Charts should be linear

![Screenshot 2024-12-05 at 11 03 55](https://github.com/user-attachments/assets/8f58140b-b8d4-43b3-a602-7731355b4742)


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
