### PR TITLE
Design Picker: Sort the selected categories to the top and keep the order between them unchanged

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -58,19 +58,14 @@ const GOALS_TO_CATEGORIES: { [ key in Onboard.SiteGoal ]: string[] } = {
  * (directly below the Show All filter).
  */
 function makeSortCategoryToTop( slugs: string[] ) {
-	const slugsMap: { [ key: string ]: number } = slugs.reduce(
-		( result, slug, index ) => ( {
-			...result,
-			[ slug ]: index + 1,
-		} ),
-		{}
-	);
+	const slugsSet = new Set( slugs );
+
 	return ( a: Category, b: Category ) => {
-		if ( slugsMap[ a.slug ] && slugsMap[ b.slug ] ) {
-			return slugsMap[ a.slug ] - slugsMap[ b.slug ];
-		} else if ( slugsMap[ a.slug ] ) {
+		if ( slugsSet.has( a.slug ) && slugsSet.has( b.slug ) ) {
+			return 0;
+		} else if ( slugsSet.has( a.slug ) ) {
 			return -1;
-		} else if ( slugsMap[ b.slug ] ) {
+		} else if ( slugsSet.has( b.slug ) ) {
 			return 1;
 		}
 
@@ -145,37 +140,6 @@ function getCategorizationFromGoals(
 				.flat() ?? [ CATEGORIES.BUSINESS ]
 		)
 	);
-
-	if ( ! isMultiSelection ) {
-		// Sorted according to which theme category makes the most consequential impact
-		// on the user's site e.g. if you want a store, then choosing a Woo compatible
-		// theme is more important than choosing a theme that is good for blogging.
-		// Missing categories are treated as equally inconsequential.
-		const mostConsequentialDesignCategories = [
-			CATEGORIES.STORE,
-			CATEGORIES.EDUCATION,
-			CATEGORIES.COMMUNITY_NON_PROFIT,
-			CATEGORIES.ENTERTAINMENT,
-			CATEGORIES.PORTFOLIO,
-			CATEGORIES.BLOG,
-			CATEGORIES.AUTHORS_WRITERS,
-		];
-
-		defaultSelections.sort( ( a, b ) => {
-			let aIndex = mostConsequentialDesignCategories.indexOf( a );
-			let bIndex = mostConsequentialDesignCategories.indexOf( b );
-
-			// If the category is not in the list, it should be sorted to the end.
-			if ( aIndex === -1 ) {
-				aIndex = mostConsequentialDesignCategories.length;
-			}
-			if ( bIndex === -1 ) {
-				bIndex = mostConsequentialDesignCategories.length;
-			}
-
-			return aIndex - bIndex;
-		} );
-	}
 
 	return {
 		defaultSelections,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -58,13 +58,19 @@ const GOALS_TO_CATEGORIES: { [ key in Onboard.SiteGoal ]: string[] } = {
  * (directly below the Show All filter).
  */
 function makeSortCategoryToTop( slugs: string[] ) {
-	const slugsSet = new Set( slugs );
+	const slugsMap: { [ key: string ]: number } = slugs.reduce(
+		( result, slug, index ) => ( {
+			...result,
+			[ slug ]: index + 1,
+		} ),
+		{}
+	);
 	return ( a: Category, b: Category ) => {
-		if ( a.slug === b.slug ) {
-			return 0;
-		} else if ( slugsSet.has( a.slug ) ) {
+		if ( slugsMap[ a.slug ] && slugsMap[ b.slug ] ) {
+			return slugsMap[ a.slug ] - slugsMap[ b.slug ];
+		} else if ( slugsMap[ a.slug ] ) {
 			return -1;
-		} else if ( slugsSet.has( b.slug ) ) {
+		} else if ( slugsMap[ b.slug ] ) {
 			return 1;
 		}
 
@@ -129,27 +135,33 @@ function getCategorizationFromGoals(
 	goals: Onboard.SiteGoal[],
 	isMultiSelection: boolean = false
 ) {
-	// Sorted according to which theme category makes the most consequential impact
-	// on the user's site e.g. if you want a store, then choosing a Woo compatible
-	// theme is more important than choosing a theme that is good for blogging.
-	// Missing categories are treated as equally inconsequential.
-	const mostConsequentialDesignCategories = [
-		CATEGORIES.STORE,
-		CATEGORIES.EDUCATION,
-		CATEGORIES.COMMUNITY_NON_PROFIT,
-		CATEGORIES.ENTERTAINMENT,
-		CATEGORIES.PORTFOLIO,
-		CATEGORIES.BLOG,
-		CATEGORIES.AUTHORS_WRITERS,
-	];
+	const defaultSelections = Array.from(
+		new Set(
+			goals
+				.map( ( goal ) => {
+					const preferredCategories = getGoalsPreferredCategories( goal );
+					return isMultiSelection ? preferredCategories : preferredCategories.slice( 0, 1 );
+				} )
+				.flat() ?? [ CATEGORIES.BUSINESS ]
+		)
+	);
 
-	const defaultSelections = goals
-		.map( ( goal ) => {
-			const preferredCategories = getGoalsPreferredCategories( goal );
-			return isMultiSelection ? preferredCategories : preferredCategories.slice( 0, 1 );
-		} )
-		.flat()
-		.sort( ( a, b ) => {
+	if ( ! isMultiSelection ) {
+		// Sorted according to which theme category makes the most consequential impact
+		// on the user's site e.g. if you want a store, then choosing a Woo compatible
+		// theme is more important than choosing a theme that is good for blogging.
+		// Missing categories are treated as equally inconsequential.
+		const mostConsequentialDesignCategories = [
+			CATEGORIES.STORE,
+			CATEGORIES.EDUCATION,
+			CATEGORIES.COMMUNITY_NON_PROFIT,
+			CATEGORIES.ENTERTAINMENT,
+			CATEGORIES.PORTFOLIO,
+			CATEGORIES.BLOG,
+			CATEGORIES.AUTHORS_WRITERS,
+		];
+
+		defaultSelections.sort( ( a, b ) => {
 			let aIndex = mostConsequentialDesignCategories.indexOf( a );
 			let bIndex = mostConsequentialDesignCategories.indexOf( b );
 
@@ -162,7 +174,8 @@ function getCategorizationFromGoals(
 			}
 
 			return aIndex - bIndex;
-		} ) ?? [ CATEGORIES.BUSINESS ];
+		} );
+	}
 
 	return {
 		defaultSelections,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -84,7 +84,7 @@ const GoalsStep: Step = ( { navigation } ) => {
 			...commonEventProps,
 			intent,
 			goals: serializeGoals( goals ),
-			combo: goals.sort().join( ',' ),
+			combo: goals.slice().sort().join( ',' ),
 			total: goals.length,
 			is_goals_big_sky_eligible: isGoalsBigSkyEligible( goals ),
 		};

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -353,7 +353,7 @@ const progressTitle: Reducer< string | undefined, OnboardAction > = ( state, act
 
 const goals: Reducer< SiteGoal[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'SET_GOALS' ) {
-		return action.goals;
+		return [ ...action.goals ];
 	}
 	if ( action.type === 'CLEAR_IMPORT_GOAL' ) {
 		return state.filter( ( goal ) => goal !== SiteGoal.Import );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10015

## Proposed Changes

* Sort the selected categories to the top and keep the order between them unchanged (the same as the API response by D167989-code) regardless of the order of selected goals.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* On the Goals screen, select "Sell services or digital goods" first and then "Publish a blog"
* On the Design Picker screen, ensure the order of selected categories are "Blog, Business, Store" (The feature & subject will be separated after we update the UI)
* Go back to the Goals screen
* Reverse the selected order. That is,  select "Publish a blog" first and then "Sell services or digital goods"
* On the Design Picker screen, ensure the order of selected categories are still "Blog, Business, Store"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?