### PR TITLE
Add goal centric filter groups in design picker

### DIFF
--- a/packages/design-picker/src/components/design-picker-category-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/index.tsx
@@ -8,6 +8,7 @@ interface Props {
 	categories: Category[];
 	selectedSlugs: string[];
 	isMultiSelection?: boolean;
+	forceSwipe?: boolean;
 	onSelect: ( selectedSlug: string ) => void;
 }
 
@@ -16,6 +17,7 @@ export default function DesignPickerCategoryFilter( {
 	categories,
 	selectedSlugs,
 	isMultiSelection,
+	forceSwipe,
 	onSelect,
 }: Props ) {
 	const onClick = ( index: number ) => {
@@ -40,6 +42,7 @@ export default function DesignPickerCategoryFilter( {
 			initialActiveIndex={ initialActiveIndex !== -1 ? initialActiveIndex : 0 }
 			initialActiveIndexes={ initialActiveIndexes }
 			isMultiSelection={ isMultiSelection }
+			forceSwipe={ forceSwipe }
 			onClick={ onClick }
 		>
 			{ categories.map( ( category ) => (

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -29,12 +29,36 @@
 		gap: 10px;
 		margin-bottom: 24px;
 
+		@include break-small {
+			flex-direction: row;
+			align-items: flex-end;
+			gap: 30px;
+		}
+
+		.design-picker__category-group {
+			display: flex;
+			flex-direction: column;
+			&.grow {
+				flex-grow: 1;
+			}
+		}
+
+		.design-picker__category-group-label {
+			text-transform: uppercase;
+			font-size: rem(13px);
+			font-weight: 500;
+		}
+
 		.design-picker__design-your-own-button {
 			flex-shrink: 0;
 			height: 32px;
 			line-height: 14px;
-			margin-top: 9px;
-			margin-left: 10px;
+			margin-top: 8px;
+			margin-bottom: 8px;
+		}
+
+		.design-picker__tier-filter {
+			height: 48px; // match button height
 		}
 
 		.design-picker__design-your-own-button-without-categories {
@@ -49,10 +73,6 @@
 			.responsive-toolbar-group__grouped-list {
 				justify-content: flex-start;
 			}
-		}
-
-		@include break-small {
-			flex-direction: row;
 		}
 	}
 

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SHOW_ALL_SLUG } from '../constants';
 import { useFilteredDesigns } from '../hooks/use-filtered-designs';
@@ -15,7 +15,7 @@ import NoResults from './no-results';
 import PatternAssemblerCta, { usePatternAssemblerCtaData } from './pattern-assembler-cta';
 import ThemeCard from './theme-card';
 import type { Categorization } from '../hooks/use-categorization';
-import type { Category, Design, StyleVariation } from '../types';
+import type { Design, StyleVariation } from '../types';
 import type { RefCallback } from 'react';
 import './style.scss';
 
@@ -227,25 +227,20 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const filteredDesigns = useFilteredDesigns( designs, categorization );
-	const features = [ 'blog', 'magazine', 'portfolio', 'podcast', 'store' ];
-	const [ featureCategories, setFeatureCategories ] = useState< Category[] >( [] );
-	const [ subjectCategories, setSubjectCategories ] = useState< Category[] >( [] );
+	const features = [ 'blog', 'portfolio', 'podcast', 'store' ];
+	const featureCategories = useMemo(
+		() => ( categorization?.categories || [] ).filter( ( { slug } ) => features.includes( slug ) ),
+		[ categorization?.categories ]
+	);
+	const subjectCategories = useMemo(
+		() =>
+			( categorization?.categories || [] ).filter( ( { slug } ) => ! features.includes( slug ) ),
+		[ categorization?.categories ]
+	);
 
 	const assemblerCtaData = usePatternAssemblerCtaData();
 
 	const translate = useTranslate();
-
-	useEffect( () => {
-		if ( ! categorization?.categories?.length ) {
-			return;
-		}
-		setFeatureCategories(
-			categorization.categories.filter( ( { slug } ) => features.includes( slug ) )
-		);
-		setSubjectCategories(
-			categorization.categories.filter( ( { slug } ) => ! features.includes( slug ) )
-		);
-	}, [ categorization?.categories ] );
 
 	return (
 		<div>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,7 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
 import clsx from 'clsx';
-import { useCallback, useRef, useState } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SHOW_ALL_SLUG } from '../constants';
 import { useFilteredDesigns } from '../hooks/use-filtered-designs';
@@ -14,7 +15,7 @@ import NoResults from './no-results';
 import PatternAssemblerCta, { usePatternAssemblerCtaData } from './pattern-assembler-cta';
 import ThemeCard from './theme-card';
 import type { Categorization } from '../hooks/use-categorization';
-import type { Design, StyleVariation } from '../types';
+import type { Category, Design, StyleVariation } from '../types';
 import type { RefCallback } from 'react';
 import './style.scss';
 
@@ -168,6 +169,25 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 	);
 };
 
+interface DesignPickerFilterGroupProps {
+	title?: string;
+	grow?: boolean;
+	children: React.ReactNode;
+}
+
+const DesignPickerFilterGroup: React.FC< DesignPickerFilterGroupProps > = ( {
+	title,
+	grow,
+	children,
+} ) => {
+	return (
+		<div className={ clsx( 'design-picker__category-group', { grow } ) }>
+			<div className="design-picker__category-group-label">{ title }</div>
+			{ children }
+		</div>
+	);
+};
+
 interface DesignPickerProps {
 	locale: string;
 	onDesignYourOwn: ( design: Design ) => void;
@@ -207,34 +227,72 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const filteredDesigns = useFilteredDesigns( designs, categorization );
-
-	// Pick design
+	const features = [ 'blog', 'magazine', 'portfolio', 'podcast', 'store' ];
+	const [ featureCategories, setFeatureCategories ] = useState< Category[] >( [] );
+	const [ subjectCategories, setSubjectCategories ] = useState< Category[] >( [] );
 
 	const assemblerCtaData = usePatternAssemblerCtaData();
+
+	const translate = useTranslate();
+
+	useEffect( () => {
+		if ( ! categorization?.categories?.length ) {
+			return;
+		}
+		setFeatureCategories(
+			categorization.categories.filter( ( { slug } ) => features.includes( slug ) )
+		);
+		setSubjectCategories(
+			categorization.categories.filter( ( { slug } ) => ! features.includes( slug ) )
+		);
+	}, [ categorization?.categories ] );
 
 	return (
 		<div>
 			<div className="design-picker__filters">
-				{ categorization && hasCategories && (
-					<DesignPickerCategoryFilter
-						className="design-picker__category-filter"
-						categories={ categorization.categories }
-						onSelect={ categorization.onSelect }
-						selectedSlugs={ categorization.selections }
-						isMultiSelection={ isMultiFilterEnabled }
-					/>
+				{ categorization && featureCategories.length && isMultiFilterEnabled && (
+					<DesignPickerFilterGroup title={ translate( 'Features' ) }>
+						<DesignPickerCategoryFilter
+							className="design-picker__category-filter"
+							categories={ featureCategories }
+							onSelect={ categorization.onSelect }
+							selectedSlugs={ categorization.selections }
+							isMultiSelection={ isMultiFilterEnabled }
+							forceSwipe
+						/>
+					</DesignPickerFilterGroup>
+				) }
+				{ categorization && subjectCategories.length && (
+					<DesignPickerFilterGroup
+						title={ isMultiFilterEnabled ? translate( 'Subjects' ) : '' }
+						grow
+					>
+						<DesignPickerCategoryFilter
+							className="design-picker__category-filter"
+							categories={ isMultiFilterEnabled ? subjectCategories : categorization.categories }
+							onSelect={ categorization.onSelect }
+							selectedSlugs={ categorization.selections }
+							isMultiSelection={ isMultiFilterEnabled }
+						/>
+					</DesignPickerFilterGroup>
 				) }
 				{ assemblerCtaData.shouldGoToAssemblerStep && isSiteAssemblerEnabled && (
-					<Button
-						className={ clsx( 'design-picker__design-your-own-button', {
-							'design-picker__design-your-own-button-without-categories': ! hasCategories,
-						} ) }
-						onClick={ () => onClickDesignYourOwnTopButton( getAssemblerDesign() ) }
-					>
-						{ assemblerCtaData.title }
-					</Button>
+					<DesignPickerFilterGroup>
+						<Button
+							className={ clsx( 'design-picker__design-your-own-button', {
+								'design-picker__design-your-own-button-without-categories': ! hasCategories,
+							} ) }
+							onClick={ () => onClickDesignYourOwnTopButton( getAssemblerDesign() ) }
+						>
+							{ assemblerCtaData.title }
+						</Button>
+					</DesignPickerFilterGroup>
 				) }
-				{ isTierFilterEnabled && <DesignPickerTierFilter /> }
+				{ isTierFilterEnabled && (
+					<DesignPickerFilterGroup>
+						<DesignPickerTierFilter />
+					</DesignPickerFilterGroup>
+				) }
 			</div>
 
 			<div className="design-picker__grid">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10014

## Proposed Changes

* Adds filter groups `Features` and `Subjects` to the design picker
* It fallbacks to old view when `multi-selection is false`

<img width="962" alt="image" src="https://github.com/user-attachments/assets/4a3765f5-eed5-4c7f-b3cc-feb0b664190f">
<img width="374" alt="image" src="https://github.com/user-attachments/assets/60755678-e9c1-49eb-ba1e-d7a1beeef5b0">

### Note:

Buttons aren't given any background as suggested in the mocks. It will be iterated in a followup PR.
<img width="256" alt="image" src="https://github.com/user-attachments/assets/10598f06-48d4-4453-a5e8-a6cb9b1d36ec">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To enhance design filtering experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Disable the feature `design-picker/goal-centric`
* It should show default view of filters with single selection.
* Now enable `design-picker/goal-centric`
* It should now show two filter groups `Features` and `Subjects` and user should be able to select unselect any of the categories.
* Verify the UI in the small screens.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
