### PR TITLE
e2e: fix About pattern name to About (Page)

### DIFF
--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -67,7 +67,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Patterns', function () {
-		const patternName = 'About';
+		const patternName = 'About (Page)';
 
 		it( `Add ${ patternName } pattern`, async function () {
 			await editorPage.addPatternFromSidebar( patternName );


### PR DESCRIPTION
## Proposed Changes

`About` pattern was renamed to `About (Page)`, that's why we have e2e failed:
<img width="1516" alt="Screenshot 2024-12-05 at 12 10 02" src="https://github.com/user-attachments/assets/c1fcbc62-aa09-4b92-9d7b-200721b99dd3">


## Testing Instructions

Visual review should suffice