### PR TITLE
Fixes whole campaign not being fetched

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -278,9 +278,12 @@ export default function CampaignItemDetails( props: Props ) {
 
 	const activeDays = getCampaignActiveDays( start_date, end_date );
 
-	const [ selectedDateRange, setSelectedDateRange ] = useState< ChartSourceDateRanges >(
-		activeDays >= 7 ? ChartSourceDateRanges.LAST_7_DAYS : ChartSourceDateRanges.WHOLE_CAMPAIGN
-	);
+	const initialRange =
+		activeDays < 7 ? ChartSourceDateRanges.WHOLE_CAMPAIGN : ChartSourceDateRanges.LAST_7_DAYS;
+	const initialResolution = activeDays < 3 ? ChartResolution.Hour : ChartResolution.Day;
+
+	const [ selectedDateRange, setSelectedDateRange ] =
+		useState< ChartSourceDateRanges >( initialRange );
 
 	const getChartStartDate = ( dateRange: ChartSourceDateRanges ) => {
 		const effectiveEndDate = getEffectiveEndDate();
@@ -310,18 +313,18 @@ export default function CampaignItemDetails( props: Props ) {
 	};
 
 	const [ chartParams, setChartParams ] = useState( {
-		startDate: getChartStartDate( ChartSourceDateRanges.LAST_7_DAYS ),
+		startDate: getChartStartDate( initialRange ),
 		endDate: getEffectiveEndDate().toISOString().split( 'T' )[ 0 ],
-		resolution: ChartResolution.Day,
+		resolution: initialResolution,
 	} );
 
 	const updateChartParams = ( newDateRange: ChartSourceDateRanges ) => {
 		// These shorter time frames can show hourly data, we can show up to 30 days of hourly data (max days stored in Druid)
-		const newResolution = [ ChartSourceDateRanges.TODAY, ChartSourceDateRanges.YESTERDAY ].includes(
-			newDateRange
-		)
-			? ChartResolution.Hour
-			: ChartResolution.Day;
+		const newResolution =
+			[ ChartSourceDateRanges.TODAY, ChartSourceDateRanges.YESTERDAY ].includes( newDateRange ) ||
+			activeDays < 3
+				? ChartResolution.Hour
+				: ChartResolution.Day;
 
 		const newStartDate = getChartStartDate( newDateRange );
 
@@ -343,7 +346,7 @@ export default function CampaignItemDetails( props: Props ) {
 	const { isLoading: campaignsStatsIsLoading } = campaignStatsQuery;
 	const { data: campaignStats } = campaignStatsQuery;
 	const getCampaignStatsChart = (
-		data: CampaignChartSeriesData[],
+		data: CampaignChartSeriesData[] | null,
 		source: ChartSourceOptions,
 		isLoading = false
 	) => {
@@ -356,7 +359,8 @@ export default function CampaignItemDetails( props: Props ) {
 				</div>
 			);
 		}
-		if ( ! data || data.length === 0 ) {
+
+		if ( ! data ) {
 			return null;
 		}
 
@@ -507,7 +511,7 @@ export default function CampaignItemDetails( props: Props ) {
 
 	// The controls that are always shown
 	chartControls.push( {
-		onClick: () => setSelectedDateRange( ChartSourceDateRanges.WHOLE_CAMPAIGN ),
+		onClick: () => updateChartParams( ChartSourceDateRanges.WHOLE_CAMPAIGN ),
 		title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.WHOLE_CAMPAIGN ],
 		isDisabled: selectedDateRange === ChartSourceDateRanges.WHOLE_CAMPAIGN,
 	} );
@@ -875,7 +879,7 @@ export default function CampaignItemDetails( props: Props ) {
 														label={ chartSource }
 													/>
 													{ getCampaignStatsChart(
-														campaignStats?.series[ chartSource ] ?? [],
+														campaignStats?.series[ chartSource ] ?? null,
 														chartSource,
 														campaignsStatsIsLoading
 													) }

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -279,7 +279,7 @@ export default function CampaignItemDetails( props: Props ) {
 	const activeDays = getCampaignActiveDays( start_date, end_date );
 
 	const initialRange =
-		activeDays < 7 ? ChartSourceDateRanges.WHOLE_CAMPAIGN : ChartSourceDateRanges.LAST_7_DAYS;
+		activeDays <= 7 ? ChartSourceDateRanges.WHOLE_CAMPAIGN : ChartSourceDateRanges.LAST_7_DAYS;
 	const initialResolution = activeDays < 3 ? ChartResolution.Hour : ChartResolution.Day;
 
 	const [ selectedDateRange, setSelectedDateRange ] =

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -63,7 +63,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 
 	const formatDate = ( date: Date, hourly: boolean ) => {
 		const options: Intl.DateTimeFormatOptions = hourly
-			? { hour: 'numeric', minute: 'numeric' }
+			? { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' }
 			: { month: 'short', day: 'numeric' };
 		return new Intl.DateTimeFormat( locale, options ).format( date );
 	};


### PR DESCRIPTION
## Proposed Changes

* When switching to the "whole campaign" it was not re-fetching data
* Whole campaign was loading 7 days by default, not the actual campaign dates
* Switch data to hourly when the campaign is less than a 3 days old
* Switch hourly labelling to include date, since it could now be multi-day

## Testing Instructions



https://github.com/user-attachments/assets/aa4e365b-8b38-4ddd-a1c6-42c4836797a2



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
