### PR TITLE
Marketplace: removes themes/display-thank-you-page-for-bundle flag.

### DIFF
--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Onboard, getThemeIdFromStylesheet } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch } from 'calypso/state';
@@ -148,11 +147,7 @@ const pluginBundleFlow: Flow = {
 
 			if ( siteDetails?.options?.theme_slug ) {
 				const themeId = getThemeIdFromStylesheet( siteDetails?.options?.theme_slug );
-				if ( isEnabled( 'themes/display-thank-you-page-for-bundle' ) ) {
-					defaultExitDest = `/marketplace/thank-you/${ siteSlug }?themes=${ themeId }`;
-				} else {
-					defaultExitDest = `/theme/${ themeId }/${ siteSlug }`;
-				}
+				defaultExitDest = `/marketplace/thank-you/${ siteSlug }?themes=${ themeId }`;
 			}
 
 			if ( 'checkForPlugins' === currentStep ) {

--- a/config/development.json
+++ b/config/development.json
@@ -231,7 +231,6 @@
 		"subscription-gifting": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
-		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": true,
 		"themes/text-search-lots": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -154,7 +154,6 @@
 		"subscription-gifting": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
-		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,

--- a/config/production.json
+++ b/config/production.json
@@ -202,7 +202,6 @@
 		"subscription-gifting": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
-		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -198,7 +198,6 @@
 		"subscription-gifting": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
-		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -195,7 +195,6 @@
 		"subscription-gifting": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
-		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Removed `themes/display-thank-you-page-for-bundle` flag since it's now shipped to all environments.
