### PR TITLE
Photos picker: Integrate GooglePhotos connection upgrade

### DIFF
--- a/client/data/media/with-google-photos-picker-session.js
+++ b/client/data/media/with-google-photos-picker-session.js
@@ -20,7 +20,9 @@ export const withGooglePhotosPickerSession = createHigherOrderComponent( ( Wrapp
 		);
 		const photosPickerSession = useSelector( ( state ) => getGooglePhotosPickerSession( state ) );
 
-		const { data: cachedSession } = useGooglePhotosPickerSessionQuery( cachedSessionId );
+		const { data: cachedSession } = useGooglePhotosPickerSessionQuery( cachedSessionId, {
+			enabled: !! photosPickerApiEnabled,
+		} );
 		const { createSession, isPending } = useCreateGooglePhotosPickerSessionMutation();
 		const { mutate: deletePickerSession } = useDeleteGooglePhotosPickerSessionMutation();
 

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -21,7 +21,6 @@ import {
 	MEDIA_IMAGE_THUMBNAIL,
 	SCALE_TOUCH_GRID,
 } from 'calypso/lib/media/constants';
-import GooglePhotosPickerButton from 'calypso/my-sites/media-library/google-photos-picker-button';
 import InlineConnection from 'calypso/sites/marketing/connections/inline-connection';
 import { pauseGuidedTour, resumeGuidedTour } from 'calypso/state/guided-tours/actions';
 import { getGuidedTourState } from 'calypso/state/guided-tours/selectors';
@@ -37,6 +36,8 @@ import {
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MediaLibraryExternalHeader from './external-media-header';
+import GooglePhotosAuthUpgrade from './google-photos-auth-upgrade';
+import GooglePhotosPickerButton from './google-photos-picker-button';
 import MediaLibraryHeader from './header';
 import MediaLibraryList from './list';
 import './content.scss';
@@ -140,6 +141,12 @@ export class MediaLibraryContent extends Component {
 		}
 
 		return false;
+	}
+
+	hasGoogleInvalidConnection( props ) {
+		const { googleConnection, source } = props;
+
+		return source === 'google_photos' && googleConnection && googleConnection.status === 'invalid';
 	}
 
 	renderErrors() {
@@ -407,6 +414,10 @@ export class MediaLibraryContent extends Component {
 					mediaScale={ this.props.mediaScale }
 				/>
 			);
+		}
+
+		if ( this.hasGoogleInvalidConnection( this.props ) ) {
+			return <GooglePhotosAuthUpgrade connection={ this.props.googleConnection } />;
 		}
 
 		if ( this.needsToBeConnected() ) {

--- a/client/my-sites/media-library/google-photos-auth-upgrade.tsx
+++ b/client/my-sites/media-library/google-photos-auth-upgrade.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
+import type { Connection } from 'calypso/sites/marketing/connections/types';
+
+interface Props {
+	connection: Connection;
+}
+const GooglePhotosAutUpgrade = ( props: Props ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const { connection } = props;
+	const [ isDisconnecting, setIsDisconnecting ] = useState( false );
+
+	return (
+		<div className="media-library__connect-message">
+			<p>
+				<img
+					src="/calypso/images/sharing/google-photos-logo-text.svg?v=20241124"
+					width="400"
+					alt={ translate( 'Google Photos' ) }
+				/>
+			</p>
+			<p>
+				{ translate(
+					"We've updated our Google Photos service. You will need to disconnect and reconnect to continue accessing your photos."
+				) }
+			</p>
+
+			<Button
+				variant="secondary"
+				isBusy={ isDisconnecting }
+				onClick={ () => {
+					dispatch( deleteStoredKeyringConnection( connection ) );
+					setIsDisconnecting( true );
+				} }
+			>
+				{ translate( 'Disconnect from Google Photos' ) }
+			</Button>
+		</div>
+	);
+};
+
+export default GooglePhotosAutUpgrade;

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -33,10 +33,14 @@ const isConnected = ( state, source ) =>
 	! sourceNeedsKeyring( source ) ||
 	some( getKeyringConnections( state ), { type: 'other', status: 'ok', service: source } );
 
-const needsKeyring = ( state, source ) =>
-	sourceNeedsKeyring( source ) &&
-	! isKeyringConnectionsFetching( state ) &&
-	! some( getKeyringConnections( state ), { type: 'other', status: 'ok' } );
+const needsKeyring = ( state, source ) => {
+	return (
+		sourceNeedsKeyring( source ) &&
+		! isKeyringConnectionsFetching( state ) &&
+		( ! some( getKeyringConnections( state ), { type: 'other', status: 'ok' } ) ||
+			! some( getKeyringConnections( state ), { type: 'other', status: 'invalid' } ) )
+	);
+};
 
 class MediaLibrary extends Component {
 	static propTypes = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/40416

## Proposed Changes

* Created google photos auth upgrade component
* Integrated upgrade screen
* Improve picker session fetching; don't trigger it if the feature flag is not there

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* With these changes we are covering Google Photos <-> Google Photos Picker connection transitions avoiding having 2 parallel connections

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Media Library page
* Establish conenction
* Go to your sandbox and turn the feature ON/OFF
* Go to the Media Library page and check if there is an Upgrade screen
* Try both scenarios: Google Photos <-> Google Photos

<img width="1143" alt="Screenshot 2024-12-05 at 14 43 46" src="https://github.com/user-attachments/assets/4c85e809-9716-4c0a-88be-0ecab52f2837">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
