### PR TITLE
Stats: Use hour digits for hourly view X-axis labels

### DIFF
--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -11,7 +11,7 @@ export function formatDate( date, period ) {
 	const momentizedDate = moment( date );
 	switch ( period ) {
 		case 'hour':
-			return momentizedDate.format( 'HH:mm' );
+			return momentizedDate.format( 'MMM D' );
 		case 'day':
 			return momentizedDate.format( 'LL' );
 		default:
@@ -57,10 +57,13 @@ export const buildChartData = memoizeLast( ( activeLegend, chartTab, data, perio
 function addTooltipData( chartTab, item, period ) {
 	const tooltipData = [];
 	const label = ( () => {
+		const formatedDate = formatDate( item.data.period, period );
+
 		if ( 'hour' === period ) {
-			return item.label;
+			return `${ formatedDate } ${ item.label }`;
 		}
-		return formatDate( item.data.period, period );
+
+		return formatedDate;
 	} )();
 
 	tooltipData.push( {

--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -57,13 +57,13 @@ export const buildChartData = memoizeLast( ( activeLegend, chartTab, data, perio
 function addTooltipData( chartTab, item, period ) {
 	const tooltipData = [];
 	const label = ( () => {
-		const formatedDate = formatDate( item.data.period, period );
+		const formattedDate = formatDate( item.data.period, period );
 
 		if ( 'hour' === period ) {
-			return `${ formatedDate } ${ item.label }`;
+			return `${ formattedDate } ${ item.label }`;
 		}
 
-		return formatedDate;
+		return formattedDate;
 	} )();
 
 	tooltipData.push( {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -168,7 +168,7 @@ export function getChartLabels( unit, date, localizedDate ) {
 		const isWeekend = 'day' === unit && ( 6 === dayOfWeek || 0 === dayOfWeek );
 		const labelName = `label${ unit.charAt( 0 ).toUpperCase() + unit.slice( 1 ) }`;
 		const formats = {
-			hour: translate( 'MMM D HH:mm', {
+			hour: translate( 'HH:mm', {
 				context: 'momentjs format string (hour)',
 				comment: 'This specifies an hour for the stats x-axis label.',
 			} ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/300

## Proposed Changes

* Update the function `getChartLabels` for hourly chart labels in hour-digit format.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because the hourly view data is about the same date, the chart X-axis label would only need to display hour digits.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page with the feature flag: `?flags=stats/new-date-filtering`.
* Click on the chart bar to navigate to the one-day hourly view.
* Ensure the X-axis labels are all in hour-digit format.

<img width="1278" alt="截圖 2024-12-05 晚上8 35 14" src="https://github.com/user-attachments/assets/4af1e3ff-06d8-46a2-a577-887b2f766909">

* Navigate to Stats > Subscribers page.
* Click on any item in the `Emails` module to navigate to the Email Detail page.
* Toggle the chart period to `Hours`.
* Ensure the chart X-axis labels also show in hour-digit format and the tooltip still shows in the previous format.

<img width="1282" alt="截圖 2024-12-05 晚上9 42 55" src="https://github.com/user-attachments/assets/5ff6c88d-fac9-46cc-abd4-c73403877895">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
