### PR TITLE
Reader Recent Feed: Fix flash of onboarding when loading

### DIFF
--- a/client/reader/following/use-site-subscriptions.ts
+++ b/client/reader/following/use-site-subscriptions.ts
@@ -27,7 +27,8 @@ export function useSiteSubscriptions() {
 		}
 
 		// If we have site subscriptions data, filter out self-owned blogs.
-		if ( siteSubscriptions?.subscriptions ) {
+		// Self-owned blogs are not returned in the feed.
+		if ( siteSubscriptions?.subscriptions.length > 0 ) {
 			const nonSelfSubscriptions = siteSubscriptions.subscriptions.filter(
 				( sub ) => ! sub.is_owner
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/96988

## Proposed Changes

* When the feed is loading there's sometimes a flash of onboarding, and the onboarding viewed Tracks event is being fired incorrectly. I realized I need to check for `siteSubscriptions?.subscriptions.length`, not just the existence of `siteSubscriptions?.subscriptions`. Otherwise we can have `subscriptionsCount` greater than 0, but no actual subscriptions to check.

Before:

https://github.com/user-attachments/assets/e9b7f230-ab8b-4438-8be9-3f5055c0e51b

After:

https://github.com/user-attachments/assets/3c1817e3-f60d-43e2-9a49-075dd6aefcc7


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the UX and the accuracy of the Tracks event.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load or reload /read
* If you have subscriptions to sites that aren't your own, you should not see a flash of onboarding and `calypso_reader_onboarding_viewed` should not be fired.
* Otherwise, you should see onboarding and `calypso_reader_onboarding_viewed` should be sent to Tracks.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
